### PR TITLE
feat(activation): tighten NPI-to-packet conversion flow

### DIFF
--- a/apps/web/__tests__/live-path-regression.test.tsx
+++ b/apps/web/__tests__/live-path-regression.test.tsx
@@ -581,7 +581,7 @@ describe('live path regression hardening', () => {
     const view = await renderNode(<LiveTrustConsole onPreviewReady={onPreviewReady} />);
 
     await setInputValue(view.container, 'NPI number', '1234567890');
-    await clickByText(view.container, 'See readiness');
+    await clickByText(view.container, 'Start with NPI lookup');
     await flush();
     await advance(260);
     await flush();
@@ -598,9 +598,9 @@ describe('live path regression hardening', () => {
     expect(onPreviewReady).toHaveBeenCalledWith('1234567890', 'Ada Lovelace');
     expect(trackedEventNames()).toEqual(expect.arrayContaining([
       'page_loaded',
-      'npi_submit',
-      'loader_started',
-      'preview_visible',
+      'npi_submit_attempt',
+      'source_check_started',
+      'readiness_revealed',
     ]));
 
     await view.unmount();
@@ -611,17 +611,17 @@ describe('live path regression hardening', () => {
     const view = await renderNode(<LiveTrustConsole />);
 
     await setInputValue(view.container, 'NPI number', '1234');
-    await clickByText(view.container, 'See readiness');
+    await clickByText(view.container, 'Start with NPI lookup');
     await flush();
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(textContent(view.container)).toContain('Enter a valid 10-digit NPI to build a live or demo snapshot.');
 
-    const previewErrorCall = trackUxEventMock.mock.calls
+    // PR #79: invalid NPI now fires npi_invalid event (not preview_error)
+    const npiInvalidCall = trackUxEventMock.mock.calls
       .map((call) => call[0])
-      .find((event) => event?.event_name === 'preview_error');
-    expect(previewErrorCall?.metadata).toMatchObject({
-      error_type: 'invalid_npi',
+      .find((event) => event?.event_name === 'npi_invalid');
+    expect(npiInvalidCall?.metadata).toMatchObject({
       interaction_result: 'cancel',
       source_mode: 'live',
     });
@@ -643,7 +643,7 @@ describe('live path regression hardening', () => {
     const view = await renderNode(<LiveTrustConsole />);
 
     await setInputValue(view.container, 'NPI number', '1234567890');
-    await clickByText(view.container, 'See readiness');
+    await clickByText(view.container, 'Start with NPI lookup');
     await flush();
     await advance(260);
     await flush();
@@ -653,7 +653,7 @@ describe('live path regression hardening', () => {
 
     const previewVisibleCall = trackUxEventMock.mock.calls
       .map((call) => call[0])
-      .find((event) => event?.event_name === 'preview_visible');
+      .find((event) => event?.event_name === 'readiness_revealed');
     const previewErrorCall = trackUxEventMock.mock.calls
       .map((call) => call[0])
       .find((event) => event?.event_name === 'preview_error');

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -135,9 +135,10 @@ describe('post-release truth cleanup', () => {
     const reviewMarkup = renderToStaticMarkup(<ReviewLandingPage />);
     const sdkMarkup = renderToStaticMarkup(<SdkDocsPage />);
 
-    expect(interviewMarkup).toContain('packet preview');
-    expect(interviewMarkup).toContain('source-backed readiness snapshot');
+    // PR #79: InterviewBlockedState component renders title/description props
+    expect(interviewMarkup).toContain('homepage NPI lookup');
     expect(interviewMarkup).not.toContain('real verified readiness');
+    expect(interviewMarkup).not.toContain('verified readiness');
 
     expect(reviewMarkup).toContain('Open a shared packet preview');
     expect(reviewMarkup).toContain('share when a real packet exists');

--- a/apps/web/app/interview/InterviewBlockedState.tsx
+++ b/apps/web/app/interview/InterviewBlockedState.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { UX_EVENTS } from '@/lib/analytics/ux-events';
+import { trackUxEvent } from '@/lib/telemetry/ux-tracker';
+
+interface InterviewBlockedStateProps {
+  title: string;
+  description: string;
+  telemetryReason?: string;
+}
+
+export default function InterviewBlockedState({
+  title,
+  description,
+  telemetryReason,
+}: InterviewBlockedStateProps) {
+  const trackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!telemetryReason || trackedRef.current) {
+      return;
+    }
+
+    trackUxEvent({
+      event_name: UX_EVENTS.INTERVIEW_BLOCKED_VIEW,
+      component_id: 'interview_entry',
+      metadata: {
+        blocked_reason: telemetryReason,
+      },
+    });
+
+    trackedRef.current = true;
+  }, [telemetryReason]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ background: '#080e1a' }}>
+      <div className="w-full max-w-sm space-y-5 text-center">
+        <p className="text-white/58 text-base leading-relaxed">{title}</p>
+        <p className="text-white/32 text-sm leading-relaxed">{description}</p>
+        <Link
+          href="/"
+          className="block w-full rounded-xl bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-semibold py-4 transition-all text-center"
+        >
+          Start with NPI lookup
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/interview/page.tsx
+++ b/apps/web/app/interview/page.tsx
@@ -11,9 +11,13 @@
  * Status is conveyed through opacity, not color.
  */
 
-import Link from 'next/link';
 import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  getStatusDisplayLabel,
+  getTrustStatusLabel,
+} from '@/lib/trust/status-language';
 import InterviewClient from './InterviewClient';
+import InterviewBlockedState from './InterviewBlockedState';
 
 const B =
   process.env.BACKEND_URL ||
@@ -43,28 +47,18 @@ export default async function InterviewPage({
   searchParams: Promise<{ entityId?: string; npi?: string; contextId?: string }>;
 }) {
   const { entityId, npi, contextId } = await searchParams;
+  const checkedLabel = getTrustStatusLabel('checked');
+  const pendingLabel = getTrustStatusLabel('pending');
+  const unavailableLabel = getTrustStatusLabel('unavailable');
+  const previewOnlyLabel = getStatusDisplayLabel('demo', 'Preview only');
 
   if (!entityId && !npi) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ background: '#080e1a' }}>
-        <div className="w-full max-w-sm space-y-5 text-center">
-          <p className="text-white/50 text-base leading-relaxed">
-            Interview mode turns your source-backed readiness snapshot into a packet preview.
-          </p>
-          <p className="text-white/30 text-sm">
-            Enter your NPI first to open a packet preview.
-          </p>
-          <Link
-            href="/"
-            className="block w-full rounded-xl bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-semibold py-4 transition-all text-center"
-          >
-            Start with NPI lookup
-          </Link>
-          <Link href="/" className="block text-white/20 hover:text-white/40 text-xs transition-colors">
-            Back to home
-          </Link>
-        </div>
-      </div>
+      <InterviewBlockedState
+        title="Interview mode needs a homepage NPI lookup before it can open."
+        description="This route does not have NPI lookup context yet. Start from the homepage lookup, then continue from the readiness snapshot once the current source states are visible."
+        telemetryReason="missing_npi_context"
+      />
     );
   }
 
@@ -76,25 +70,10 @@ export default async function InterviewPage({
 
   if (!passport) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ background: '#080e1a' }}>
-        <div className="w-full max-w-sm space-y-5 text-center">
-          <p className="text-white/50 text-base leading-relaxed">
-            VitalCV could not build a packet preview from that input yet.
-          </p>
-          <p className="text-white/30 text-sm">
-            Start from your NPI lookup so the packet preview is anchored to a real passport object.
-          </p>
-          <Link
-            href="/"
-            className="block w-full rounded-xl bg-emerald-500 hover:bg-emerald-400 text-white text-sm font-semibold py-4 transition-all text-center"
-          >
-            Start with NPI lookup
-          </Link>
-          <Link href="/" className="block text-white/20 hover:text-white/40 text-xs transition-colors">
-            Back to home
-          </Link>
-        </div>
-      </div>
+      <InterviewBlockedState
+        title="VitalCV could not load a source-backed interview packet for that NPI yet."
+        description={`Run the homepage lookup again to confirm which sections are ${checkedLabel}, ${pendingLabel}, ${unavailableLabel}, or ${previewOnlyLabel} before you continue.`}
+      />
     );
   }
 

--- a/apps/web/components/hero/LiveTrustConsole.tsx
+++ b/apps/web/components/hero/LiveTrustConsole.tsx
@@ -24,8 +24,12 @@ import { useEffect, useRef, useState } from 'react';
 import { useRoleContext } from '@/components/auth/RoleContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { TrustStatusBadge } from '@/components/ui/trust-status-badge';
+import {
+  getTrustStatusDescriptor,
+  TrustStatusBadge,
+} from '@/components/ui/trust-status-badge';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
+import { UX_EVENTS } from '@/lib/analytics/ux-events';
 import {
   LIVE_PATH_NPI_RE,
   LIVE_PATH_PREVIEW_NOTICE,
@@ -33,6 +37,10 @@ import {
   resolveLivePathSourceMode,
 } from '@/lib/live-path/contracts';
 import { trackUxEvent } from '@/lib/telemetry/ux-tracker';
+import {
+  getStatusDisplayLabel,
+  getTrustStatusLabel,
+} from '@/lib/trust/status-language';
 import { ReadinessPreview, type ClinicianTrustState } from './ReadinessPreview';
 
 type Phase = 'idle' | 'loading' | 'preview';
@@ -130,6 +138,41 @@ function resolveLoadingCopy(stages: SourceStage[], isDemo: boolean): string {
   return 'Resolving readiness…';
 }
 
+const FLOW_STEPS = [
+  'Enter NPI',
+  'Review readiness',
+  'Share intent',
+] as const;
+
+function resolveFlowStepState(
+  phase: Phase,
+  stepIndex: number,
+): 'complete' | 'active' | 'upcoming' {
+  if (phase === 'idle') {
+    return stepIndex === 0 ? 'active' : 'upcoming';
+  }
+
+  if (phase === 'loading') {
+    if (stepIndex === 0) return 'complete';
+    return stepIndex === 1 ? 'active' : 'upcoming';
+  }
+
+  if (stepIndex <= 1) return 'complete';
+  return stepIndex === 2 ? 'active' : 'upcoming';
+}
+
+function flowStepClassName(state: 'complete' | 'active' | 'upcoming'): string {
+  switch (state) {
+    case 'complete':
+      return 'border-white/8 bg-white/[0.03] text-white/58';
+    case 'active':
+      return 'border-white/12 bg-white/[0.06] text-white/78';
+    case 'upcoming':
+    default:
+      return 'border-white/6 bg-black/10 text-white/34';
+  }
+}
+
 // ── Ingest response shape (subset) ───────────────────────────
 
 interface IngestSourceResult {
@@ -202,7 +245,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
     if (previewTrackedSubmitIdRef.current === submitId) return;
 
     trackUxEvent({
-      event_name: 'preview_visible',
+      event_name: UX_EVENTS.READINESS_REVEALED,
       component_id: 'homepage_npi_flow',
       duration_ms: submitStartedAtRef.current === null
         ? null
@@ -273,10 +316,32 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
     if (phase !== 'idle') return;
 
     const trimmed = npi.trim();
-    if (!LIVE_PATH_NPI_RE.test(trimmed)) {
+    const isValidNpi = LIVE_PATH_NPI_RE.test(trimmed);
+
+    trackUxEvent({
+      event_name: UX_EVENTS.NPI_SUBMIT_ATTEMPT,
+      component_id: 'homepage_npi_flow',
+      metadata: {
+        auth_state: authState,
+        npi_length: trimmed.length,
+        source_mode: 'live',
+        validation_state: isValidNpi ? 'valid' : 'invalid',
+      },
+    });
+
+    if (!isValidNpi) {
       setFormMessage(INVALID_NPI_MESSAGE);
       inputRef.current?.focus({ preventScroll: true });
-      trackPreviewError('invalid_npi');
+      trackUxEvent({
+        event_name: UX_EVENTS.NPI_INVALID,
+        component_id: 'homepage_npi_flow',
+        metadata: {
+          auth_state: authState,
+          interaction_result: 'cancel',
+          npi_length: trimmed.length,
+          source_mode: 'live',
+        },
+      });
       return;
     }
 
@@ -295,20 +360,10 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
     submitStartedAtRef.current = performance.now();
     setFormMessage(null);
 
-    trackUxEvent({
-      event_name: 'npi_submit',
-      component_id: 'homepage_npi_flow',
-      metadata: {
-        auth_state: authState,
-        npi_length: trimmed.length,
-        source_mode: 'live',
-      },
-    });
-
     setPhase('loading');
     resetPreviewState();
     trackUxEvent({
-      event_name: 'loader_started',
+      event_name: UX_EVENTS.SOURCE_CHECK_STARTED,
       component_id: 'homepage_npi_flow',
       metadata: {
         auth_state: authState,
@@ -433,11 +488,27 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
     const dest = LIVE_PATH_NPI_RE.test(trimmed)
       ? `/interview?npi=${trimmed}`
       : '/passport';
+
+    trackUxEvent({
+      event_name: UX_EVENTS.SHARE_INTENT,
+      component_id: 'homepage_npi_flow',
+      metadata: {
+        auth_state: authState,
+        npi_length: trimmed.length,
+        source_mode: sourceMode,
+      },
+    });
+
     router.push(dest);
   }
 
   const isPreviewPhase = phase === 'preview';
   const loadingCopy = resolveLoadingCopy(stages, isDemo);
+  const checkedLabel = getTrustStatusLabel('checked');
+  const pendingLabel = getTrustStatusLabel('pending');
+  const accessRequiredLabel = getTrustStatusLabel('access_required');
+  const unavailableLabel = getTrustStatusLabel('unavailable');
+  const previewOnlyLabel = getStatusDisplayLabel('demo', 'Preview only');
 
   return (
     <section className="relative" style={{ background: '#080e1a' }}>
@@ -449,6 +520,23 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
       />
 
       <div className={`relative z-10 mx-auto w-full max-w-xl px-4 sm:px-6 ${isPreviewPhase ? 'pt-5 sm:pt-10 pb-6 sm:pb-10' : 'pt-12 sm:pt-20 pb-10 sm:pb-18'}`}>
+        <div className="mb-5 grid gap-2 sm:grid-cols-3">
+          {FLOW_STEPS.map((step, index) => {
+            const stepState = resolveFlowStepState(phase, index);
+
+            return (
+              <div
+                key={step}
+                className={`rounded-2xl border px-4 py-3 transition-colors ${flowStepClassName(stepState)}`}
+              >
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-white/28">
+                  Step {index + 1}
+                </p>
+                <p className="mt-1 text-xs font-medium">{step}</p>
+              </div>
+            );
+          })}
+        </div>
 
         {!isPreviewPhase ? (
           <>
@@ -459,7 +547,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
               See your readiness snapshot in <span className="text-emerald-400">about 10 seconds.</span>
             </h1>
             <p className="mb-6 text-sm leading-relaxed text-white/50 sm:text-base">
-              VitalCV resolves your public NPI identity first, runs connected sources, and clearly labels anything missing, blocked, or preview-only.
+              VitalCV starts with your NPI, then labels each lane as {checkedLabel}, {pendingLabel}, {accessRequiredLabel}, {unavailableLabel}, or {previewOnlyLabel} before you move forward.
             </p>
           </>
         ) : (
@@ -469,7 +557,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
                 Readiness snapshot
               </p>
               <p className="mt-1 text-xs text-white/40 sm:text-sm">
-                Source-backed where available. Explicit when preview-only.
+                Step 2 is visible. Step 3 keeps this snapshot honest in interview mode.
               </p>
             </div>
             {isDemo && (
@@ -509,7 +597,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
               disabled={phase === 'loading'}
               className="h-14 w-full shrink-0 whitespace-nowrap rounded-xl px-5 text-sm font-semibold sm:w-auto"
             >
-              <span aria-live="polite">{phase === 'loading' ? loadingCopy : 'See readiness'}</span>
+              <span aria-live="polite">{phase === 'loading' ? loadingCopy : 'Start with NPI lookup'}</span>
             </Button>
           </form>
         )}
@@ -534,6 +622,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
                 <div className="space-y-2">
                   {stages.map((stage, index) => {
                     const badge = stageBadge(stage);
+                    const statusDescriptor = getTrustStatusDescriptor(badge.status, badge.label);
 
                     return (
                       <div
@@ -541,7 +630,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
                         className="flex items-center justify-between gap-3 rounded-xl border border-white/6 bg-black/10 px-3 py-2.5"
                         style={{ animation: `vcv-stage-in 150ms ease-out ${index * 140}ms both` }}
                       >
-                        <div className="flex items-center gap-2.5">
+                        <div className="flex items-start gap-2.5">
                           {stage.status === 'loading' ? (
                             <span className="h-3.5 w-3.5 rounded-full border border-sky-300/50 border-t-transparent animate-spin" />
                           ) : (
@@ -549,11 +638,18 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
                               {STAGE_SYMBOL[stage.status]}
                             </span>
                           )}
-                          <span className={`text-xs transition-colors duration-150 ${
-                            stage.status === 'loading' ? 'text-white/72' : stage.status === 'waiting' ? 'text-white/25' : 'text-white/52'
-                          }`}>
-                            {stage.label}
-                          </span>
+                          <div>
+                            <span className={`text-xs transition-colors duration-150 ${
+                              stage.status === 'loading' ? 'text-white/72' : stage.status === 'waiting' ? 'text-white/25' : 'text-white/52'
+                            }`}>
+                              {stage.label}
+                            </span>
+                            {statusDescriptor ? (
+                              <p className="mt-1 text-[10px] leading-relaxed text-white/24">
+                                {statusDescriptor}
+                              </p>
+                            ) : null}
+                          </div>
                         </div>
                         <TrustStatusBadge
                           status={badge.status}

--- a/apps/web/components/hero/ReadinessPreview.tsx
+++ b/apps/web/components/hero/ReadinessPreview.tsx
@@ -31,7 +31,15 @@ import { ProofDetailsList } from '@/components/trust/ProofDetailsList';
 import { EvidenceDisclosureCard } from '@/components/trust/EvidenceDisclosureCard';
 import { getDemoProfile, type DemoProfile } from '@/lib/demo/demoProfiles';
 import { formatCompactProofDate } from '@/lib/trust/proof-language';
-import { TrustStatusBadge } from '@/components/ui/trust-status-badge';
+import {
+  getStatusDisplayLabel,
+  getTrustStatusLabel,
+  resolveTrustUiStatus,
+} from '@/lib/trust/status-language';
+import {
+  getTrustStatusDescriptor,
+  TrustStatusBadge,
+} from '@/components/ui/trust-status-badge';
 
 // ── Real trust-state shape (matches trustStateEngine output) ─
 
@@ -488,6 +496,14 @@ interface Props {
 }
 
 export function ReadinessPreview({ npi, realState, isDemo, visible, onContinue }: Props) {
+  const checkedLabel = getTrustStatusLabel('checked');
+  const clearLabel = getTrustStatusLabel('clear');
+  const pendingLabel = getTrustStatusLabel('pending');
+  const accessRequiredLabel = getTrustStatusLabel('access_required');
+  const reviewRequiredLabel = getTrustStatusLabel('review_required');
+  const unavailableLabel = getTrustStatusLabel('unavailable');
+  const previewOnlyLabel = getStatusDisplayLabel('demo', 'Preview only');
+  const demoDescriptor = getTrustStatusDescriptor('demo', previewOnlyLabel);
 
   // ── Real-data path ───────────────────────────────────────
   if (realState && !isDemo) {
@@ -595,12 +611,19 @@ export function ReadinessPreview({ npi, realState, isDemo, visible, onContinue }
           </CardContent>
 
           <CardFooter className="border-t border-white/6 px-5 py-4">
-            <div className="w-full">
+            <div className="w-full rounded-2xl border border-white/6 bg-black/15 p-4">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-white/24">Next step</p>
+                <p className="mt-1 text-sm font-medium text-white/72">Carry this snapshot into interview mode.</p>
+                <p className="mt-1 text-xs leading-relaxed text-white/38">
+                  {checkedLabel} or {clearLabel} sections stay attached. {pendingLabel}, {accessRequiredLabel}, {reviewRequiredLabel}, and {unavailableLabel} sections remain visible.
+                </p>
+              </div>
               <Button
                 type="button"
                 variant="success"
                 onClick={onContinue}
-                className="h-14 w-full rounded-xl px-5 text-sm font-semibold"
+                className="mt-4 h-14 w-full rounded-xl px-5 text-sm font-semibold"
               >
                 Continue to packet preview
               </Button>
@@ -635,7 +658,12 @@ export function ReadinessPreview({ npi, realState, isDemo, visible, onContinue }
               <p className="text-lg font-bold leading-tight text-white">{demo.name}</p>
               <p className="text-sm text-white/45">{demo.specialty}</p>
             </div>
-            <TrustStatusBadge status="demo" label="Preview only" size="sm" />
+            <div className="space-y-2 text-right">
+              <TrustStatusBadge status="demo" label={previewOnlyLabel} size="sm" />
+              {demoDescriptor ? (
+                <p className="text-[10px] leading-relaxed text-white/24">{demoDescriptor}</p>
+              ) : null}
+            </div>
           </div>
         </CardHeader>
 
@@ -711,17 +739,24 @@ export function ReadinessPreview({ npi, realState, isDemo, visible, onContinue }
         </CardContent>
 
         <CardFooter className="border-t border-white/6 px-5 py-4">
-          <div className="w-full">
+          <div className="w-full rounded-2xl border border-white/6 bg-black/15 p-4">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-white/24">Next step</p>
+              <p className="mt-1 text-sm font-medium text-white/72">Carry this example into interview mode.</p>
+              <p className="mt-1 text-xs leading-relaxed text-white/38">
+                This route stays {previewOnlyLabel} until a live run returns {checkedLabel} source results.
+              </p>
+            </div>
             <Button
               type="button"
               variant="success"
               onClick={onContinue}
-              className="h-14 w-full rounded-xl px-5 text-sm font-semibold"
+              className="mt-4 h-14 w-full rounded-xl px-5 text-sm font-semibold"
             >
               Share in your next interview
             </Button>
             <p className="mt-2 text-center text-[10px] text-white/20">
-              Demo preview only · live data appears after a real source run
+              {previewOnlyLabel} only - live data appears after a real source run
             </p>
           </div>
         </CardFooter>

--- a/apps/web/components/trust/SourceCoverageRow.tsx
+++ b/apps/web/components/trust/SourceCoverageRow.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { TrustStatusBadge, type TrustBadgeStatus } from '@/components/ui/trust-status-badge';
+import {
+  getTrustStatusDescriptor,
+  TrustStatusBadge,
+  type TrustBadgeStatus,
+} from '@/components/ui/trust-status-badge';
 import { formatProofDate } from '@/lib/trust/proof-language';
 import {
   sourceCoverageBadgeLabel,
@@ -40,6 +44,7 @@ function resolveCoverageBadge(check: PassportSourceCoverageCheck): {
 export function SourceCoverageRow({ check }: SourceCoverageRowProps) {
   const decisionGrade = check.state === 'live';
   const badge = resolveCoverageBadge(check);
+  const statusDescriptor = getTrustStatusDescriptor(badge.status, badge.label);
 
   return (
     <div className="flex items-start justify-between gap-4 py-3">
@@ -53,6 +58,9 @@ export function SourceCoverageRow({ check }: SourceCoverageRowProps) {
             {decisionGrade ? 'Decision grade' : 'Not decision grade'}
           </Badge>
         </div>
+        {statusDescriptor ? (
+          <p className="text-[11px] leading-relaxed text-white/28">{statusDescriptor}</p>
+        ) : null}
         <p className="text-xs leading-relaxed text-white/42">{check.reason}</p>
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-white/24">
           <span>{check.checkedAt ? `Checked ${formatProofDate(check.checkedAt)}` : 'Not yet checked'}</span>

--- a/apps/web/components/ui/trust-status-badge.tsx
+++ b/apps/web/components/ui/trust-status-badge.tsx
@@ -54,6 +54,14 @@ const CANONICAL_TRUST_BADGE_STATUSES = new Set<TrustUiStatus>([
   'demo',
 ]);
 
+const TRUST_STATUS_DESCRIPTORS: Record<string, string> = {
+  checked: 'Confirmed in this run from the source',
+  'access required': 'This source requires institutional access',
+  pending: 'Not yet checked in this session',
+  'preview only': 'Example data - not from a live source run',
+  demo: 'Example data - not from a live source run',
+};
+
 interface TrustStatusBadgeProps {
   status: TrustBadgeStatus;
   label?: string;
@@ -61,13 +69,15 @@ interface TrustStatusBadgeProps {
   className?: string;
 }
 
-function TrustStatusBadge({
-  status,
-  label,
-  size = 'md',
-  className,
-}: TrustStatusBadgeProps) {
-  const meta = CANONICAL_TRUST_BADGE_STATUSES.has(status as TrustUiStatus)
+function normalizeDescriptorKey(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function resolveTrustBadgeMeta(
+  status: TrustBadgeStatus,
+  label?: string,
+): { className: string; label: string } {
+  return CANONICAL_TRUST_BADGE_STATUSES.has(status as TrustUiStatus)
     ? {
         className: getTrustStatusBadgeClassName(status as TrustUiStatus),
         label: getStatusDisplayLabel(status as TrustUiStatus, label),
@@ -76,6 +86,24 @@ function TrustStatusBadge({
         className: VDS_STATUS_META[status as SupplementalVdsTrustStatus].className,
         label: label ?? VDS_STATUS_META[status as SupplementalVdsTrustStatus].label,
       };
+}
+
+export function getTrustStatusDescriptor(
+  status: TrustBadgeStatus,
+  label?: string,
+): string | null {
+  const descriptor = TRUST_STATUS_DESCRIPTORS[normalizeDescriptorKey(resolveTrustBadgeMeta(status, label).label)];
+
+  return descriptor ?? null;
+}
+
+function TrustStatusBadge({
+  status,
+  label,
+  size = 'md',
+  className,
+}: TrustStatusBadgeProps) {
+  const meta = resolveTrustBadgeMeta(status, label);
 
   return (
     <Badge

--- a/apps/web/lib/analytics/ux-events.ts
+++ b/apps/web/lib/analytics/ux-events.ts
@@ -7,13 +7,17 @@
  */
 
 export const UX_EVENTS = {
-  NPI_SUBMITTED: 'npi_submitted',
+  NPI_SUBMITTED: 'npi_submit_attempt',
+  NPI_SUBMIT_ATTEMPT: 'npi_submit_attempt',
+  NPI_INVALID: 'npi_invalid',
   SOURCE_CHECK_STARTED: 'source_check_started',
   READINESS_REVEALED: 'readiness_revealed',
   ACCORDION_EXPANDED: 'accordion_expanded',
   EVIDENCE_VIEWER_OPENED: 'evidence_viewer_opened',
-  SHARE_CTA_CLICKED: 'share_cta_clicked',
+  SHARE_CTA_CLICKED: 'share_intent',
+  SHARE_INTENT: 'share_intent',
   EMPLOYER_ACTION_CLICKED: 'employer_action_clicked',
+  INTERVIEW_BLOCKED_VIEW: 'interview_blocked_view',
   PAGE_LOAD_TIMING: 'page_load_timing',
   DEAD_END_REACHED: 'dead_end_reached',
   NAV_ITEM_CLICKED: 'nav_item_clicked',

--- a/apps/web/lib/pilot-ops/client.ts
+++ b/apps/web/lib/pilot-ops/client.ts
@@ -24,12 +24,16 @@ export type PilotMetricEventType =
   | 'route_failure'
   // UX-8: UX friction telemetry events
   | 'npi_submitted'
+  | 'npi_submit_attempt'
+  | 'npi_invalid'
   | 'source_check_started'
   | 'readiness_revealed'
   | 'accordion_expanded'
   | 'evidence_viewer_opened'
   | 'share_cta_clicked'
+  | 'share_intent'
   | 'employer_action_clicked'
+  | 'interview_blocked_view'
   | 'page_load_timing'
   | 'dead_end_reached'
   | 'nav_item_clicked';


### PR DESCRIPTION
## What Changed
- Tightened homepage activation around the NPI-first wedge.
- Clarified preview/demo/live next-step language.
- Improved interview packet conversion copy without overstating readiness.
- Hardened source-state comprehension and CTA telemetry.