### PR TITLE
fix: route unification — all public wedge CTAs converge on /passport

### DIFF
--- a/apps/web/app/labs/page.tsx
+++ b/apps/web/app/labs/page.tsx
@@ -27,9 +27,9 @@ interface LabEntry {
 
 const LABS: LabEntry[] = [
   {
-    title: 'Interview Mode',
-    description: 'Share a source-backed readiness snapshot in real time — designed for the clinical interview moment.',
-    href: '/interview',
+    title: 'Passport View',
+    description: 'Share a source-backed readiness snapshot with an employer — passport-first view for the clinical hiring conversation.',
+    href: '/passport',
     status: 'PREVIEW',
     tags: ['Your readiness'],
   },

--- a/apps/web/components/explore/ExploreClient.tsx
+++ b/apps/web/components/explore/ExploreClient.tsx
@@ -639,7 +639,7 @@ export default function ExploreClient() {
         <p className="body-sm mx-auto mt-2 max-w-md text-vt-neutral-200">
           Start with your public NPI profile and VitalCV will show which live roles align with your current readiness state before you submit.
         </p>
-        <Link href="/onboarding" className="mt-5 inline-flex items-center gap-2 rounded-full bg-vt-success px-6 py-3 text-sm font-semibold text-black hover:bg-vt-success/90 transition-transform active:scale-95">
+        <Link href="/passport" className="mt-5 inline-flex items-center gap-2 rounded-full bg-vt-success px-6 py-3 text-sm font-semibold text-black hover:bg-vt-success/90 transition-transform active:scale-95">
           Preview my fit
         </Link>
       </div>
@@ -841,7 +841,7 @@ function OpportunityCard({
              </p>
              <p className="text-xs text-white/70 mt-1">Preview your start-readiness timeline</p>
            </div>
-           <Link href="/onboarding" className="text-xs font-semibold px-4 py-2 rounded-full bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-colors shrink-0 ml-4">
+           <Link href="/passport" className="text-xs font-semibold px-4 py-2 rounded-full bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-colors shrink-0 ml-4">
               Calculate Fit
            </Link>
         </div>

--- a/apps/web/components/home/PublicTruthSections.tsx
+++ b/apps/web/components/home/PublicTruthSections.tsx
@@ -61,7 +61,7 @@ export function InterviewModeTeaser() {
                     After your NPI lookup, VitalCV turns that readiness snapshot into a passport view for employer conversations. Sections stay explicitly labeled until backed by a real source run.
                   </p>
                   <Link
-                    href="/interview"
+                    href="/passport"
                     className="inline-flex items-center justify-center gap-2 min-h-[48px] rounded-xl bg-emerald-500 hover:bg-emerald-400 px-6 text-sm font-bold text-white transition-all active:scale-[0.98] shadow-[0_0_24px_rgba(16,185,129,0.2)] w-full sm:w-auto"
                   >
                     Preview Passport Proof

--- a/apps/web/components/marketing/HomeSections.tsx
+++ b/apps/web/components/marketing/HomeSections.tsx
@@ -400,8 +400,8 @@ export function TractionSection() {
             See the product working in real time.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-4">
-            <Link href="/onboarding" className="glue-btn glue-btn-primary">
-              Preview my fit <ArrowRight className="h-4 w-4" />
+            <Link href="/passport" className="glue-btn glue-btn-primary">
+              Check my readiness <ArrowRight className="h-4 w-4" />
             </Link>
             <Link href="/employers" className="glue-btn glue-btn-secondary">
               For employers

--- a/apps/web/components/prequalify/PrequalifyTrigger.tsx
+++ b/apps/web/components/prequalify/PrequalifyTrigger.tsx
@@ -26,7 +26,7 @@ export default function PrequalifyTrigger({
     : 'inline-flex items-center gap-2 rounded-full vt-glass px-6 py-3 text-sm font-medium text-white hover:bg-vt-surface-ops-raised transition';
 
   return (
-    <Link href="/onboarding" className={`${base} ${className}`}>
+    <Link href="/passport" className={`${base} ${className}`}>
       <Zap className="h-4 w-4" />
       {label}
     </Link>


### PR DESCRIPTION
## What changed

All remaining public-facing CTAs that routed anonymous users to `/onboarding` (auth-gated) or `/interview` (deprecated path) now route to `/passport` (anonymous, immediate, real wedge entry).

### Files touched (5 files, 9 lines)

| File | Change |
|------|--------|
| `components/home/PublicTruthSections.tsx` | InterviewModeTeaser button: `/interview` → `/passport` |
| `components/explore/ExploreClient.tsx` | "Preview my fit" + "Calculate Fit" CTAs: `/onboarding` → `/passport` |
| `components/marketing/HomeSections.tsx` | Marketing section CTA: `/onboarding` → `/passport`, label updated |
| `components/prequalify/PrequalifyTrigger.tsx` | "Check Readiness Free" on explore: `/onboarding` → `/passport` |
| `app/labs/page.tsx` | Labs entry: "Interview Mode" → "Passport View", `/interview` → `/passport` |

### What stays on /onboarding
- `ApplyModal` and `ApplyWidgetSection` — ATS/apply flow, users need a profile to submit applications
- `PrequalifyBar` in RootChrome — auth-gated (Clerk SignedIn), authenticated users
- `/get-ready` redirect — still exists as a route but no longer surfaced publicly

### Route map (after)

| Entry | Destination |
|-------|-------------|
| Homepage NPI submit | `/passport?npi=<npi>` (inline ingest) |
| Navbar "Check Readiness" | `/passport` |
| Explore "Preview my fit" | `/passport` |
| Explore "Calculate Fit" | `/passport` |
| InterviewModeTeaser CTA | `/passport` |
| PrequalifyTrigger | `/passport` |
| Labs "Interview Mode" entry | `/passport` (relabeled "Passport View") |
| `/passport` success | `/passport/[entityId]` or `/review/[entityId]` |

### Tests
- ✅ 62 test files, 249 tests passing
- ✅ `tsc --noEmit` clean

### What remains deferred
- `/get-ready` → `/onboarding` redirect (still exists, not surfaced publicly)
- `ApplyModal` onboarding links (appropriate for ATS apply flow)
- `PrequalifyBar` onboarding links (auth-gated, appropriate)