### PR TITLE
feat: employer workspace bootstrap — setup flow, distinct states, request-review API

### DIFF
--- a/.playwright-cli/page-2026-03-28T05-02-06-586Z.yml
+++ b/.playwright-cli/page-2026-03-28T05-02-06-586Z.yml
@@ -1,0 +1,1 @@
+- generic [ref=e2]: Internal Server Error

--- a/PR84-SHARE-REVIEW-AUDIT.md
+++ b/PR84-SHARE-REVIEW-AUDIT.md
@@ -1,0 +1,141 @@
+# PR #84 — Share/Review Flow UX Audit
+
+**Date:** 2026-03-27
+**Scope:** Employer share/review experience post-PR #84 merge
+**Auditor:** Claude (VitalCV strategic/technical operator)
+
+---
+
+## Executive Summary
+
+The share → review flow is **operationally real and structurally sound**. The employer decision surface (ReviewClient) is the strongest component in the public wedge — spec-exact layout, immutable audit trail with trust snapshots, proper auth gating with graceful preview degradation, and a clear < 10-second decision path. The clinician share surface (PassportShareActions) is functional but thin — clipboard-only, no scoped share tokens, no expiry, no recipient context.
+
+**Verdict: CONDITIONAL GO** — merge is safe for preview/pilot. Seven issues must be tracked for production readiness.
+
+---
+
+## What I Know For Sure
+
+1. `/review/[entityId]` is public, server-renders passport data, fires KPI tracking (fire-and-forget, 2s timeout), and falls back to a clear TrustStateCard error when the backend can't hydrate.
+2. ReviewClient renders a spec-exact decision surface: Identity → Safety → Authority → Eligibility → Readiness → Blockers → Proof (collapsible) → Actions.
+3. Three employer actions (Accept, Request Refresh, Route to Review) all write to the backend via `POST /api/employer-review/:entityId/:action`, require Clerk auth, and return an `EmployerReviewActionState` with an immutable `DecisionTrustSnapshot`.
+4. Auth gating uses a 4-tier degradation: Clerk unavailable → Clerk not loaded → Not signed in → Not employer role. Each state renders a specific `previewOnlyMessage` and disables action buttons.
+5. Packet export (JSON download) is auth-gated and works via blob URL + click-through `<a>` element.
+6. The `/review` landing page (no entityId) shows a clear "start from NPI lookup" redirect — not a dead end.
+7. The `/passport` page's "View as employer" button correctly builds a `/review/:entityId` link from the ingest anchor.
+8. PassportShareActions is clipboard-only: copy public link (`/p/:npi`), copy embed SVG code, copy LinkedIn markdown. No scoped share token, no expiry, no recipient binding.
+9. Homepage, /developers, /explore, /employers all render current-state copy with appropriate scoping language ("current directory," "launch cohort," "this environment").
+10. Middleware correctly classifies `/review/*` as public (no auth required for viewing), while employer *actions* require Clerk auth at the API layer.
+
+---
+
+## What I Do Next
+
+1. Track the 7 issues below in the backlog with P0/P1 labels.
+2. Validate the backend endpoints (`/api/employer-review/:entityId/*`) return correct `DecisionTrustSnapshot` hashes in staging.
+3. Test the full clinician-to-employer handoff with a real NPI in the preview deployment.
+4. Confirm WebAuthn prompt does NOT fire during employer review (it shouldn't — it's only in SelectiveDisclosureModal for holder flows).
+5. Verify `/employers` page gracefully handles empty directory (already coded, but needs runtime confirmation).
+
+---
+
+## Does the Share/Review Flow Feel Operationally Real?
+
+**Yes, with caveats.** The employer review surface is production-grade in structure: decision-first layout, trust stack rendering, freshness warnings, blocker callouts, proof accordion, audit trail with snapshot hashes, and proper action state machines. The "Accept as head start (N blockers noted)" pattern is the right model — it doesn't pretend blockers don't exist.
+
+The share side is the weak link. Today, "sharing" means copying a `/p/:npi` URL. There's no scoped share token in the clinician → employer handoff from PassportShareActions. The `/api/apply/share` endpoint exists and creates scoped tokens, but PassportShareActions doesn't use it — it only generates the public profile URL. This means the employer review link is reachable by anyone who knows the entityId, not gated by a share token.
+
+---
+
+## Does Any Auth/Failure State Feel Confusing or Dead?
+
+**Mostly clean, two concerns:**
+
+1. **"Preview only" messaging is clear but not actionable enough.** When an unauthenticated employer views the review page, they see disabled buttons + "Preview only. Sign in with an employer workspace to persist decisions." The "Sign in with employer workspace" link appears, but there's no explanation of what an "employer workspace" is or how to get one. A first-time employer who received a share link would not know what to do.
+
+2. **The `/review` landing (no entityId) is not confusing but is slightly orphaned.** It tells you to "start from NPI lookup" — but an employer wouldn't know an NPI. This page should either not exist or redirect to `/employers` or a "paste your share link" prompt.
+
+---
+
+## Does Production Still Expose Old Public-Story Copy?
+
+**No significant stale copy detected.** The homepage, /developers, /explore, and /employers pages all use current, scoped language. The employers page explicitly says "current directory" and "this environment." The explore page warns about "seeded launch-cohort employers." No lorem ipsum, no old branding, no orphaned "coming soon" placeholders.
+
+---
+
+## Clinician POV Issues
+
+| # | Issue | Severity | Detail |
+|---|-------|----------|--------|
+| C1 | **Share actions are clipboard-only with no scoped tokens** | P1 | PassportShareActions copies `/p/:npi` URLs. The `/api/apply/share` endpoint exists but isn't wired into the share UI. No expiry, no recipient binding, no revocation from the clinician side of the share card. |
+| C2 | **No share confirmation or tracking** | P1 | Clinician copies a link and gets a toast ("Copied link"). No record of who they shared with, when, or whether the employer opened it. The `/api/passport/analytics/:npi/share` endpoint exists but PassportShareActions doesn't call it. |
+| C3 | **"View as employer" from /passport is the only handoff path** | P2 | The clinician can preview what an employer would see, but there's no "Share with employer" flow that generates a scoped review link with context (purpose, recipient org, expiry). |
+| C4 | **No selective disclosure gate before sharing** | P2 | The BiometricPrompt + SelectiveDisclosureModal components exist but are not wired into the share flow. A clinician shares everything by default. |
+
+---
+
+## Employer POV Issues
+
+| # | Issue | Severity | Detail |
+|---|-------|----------|--------|
+| E1 | **No employer onboarding or context for first-time reviewers** | P1 | An employer who receives a review link lands on the decision surface with no orientation. The "employer workspace" concept is referenced but never explained. No "What is VitalCV?" or "How to read this review" affordance. |
+| E2 | **"Accept as head start" label may confuse employers unfamiliar with credentialing** | P2 | The primary CTA says "Accept as head start" with a blocker count. This is correct for credentialing professionals but opaque for hiring managers or HR generalists. No tooltip or explanation of what "head start" means operationally. |
+| E3 | **Download failure is silently swallowed** | P2 | `handleDownloadPacket()` catches all errors with `/* download failure is non-fatal */`. The user sees the button return to idle with no feedback. Should show a toast on failure. |
+| E4 | **Persisted action state fetch failure is silent** | P2 | `getPersistedActionState()` catch block sets state to null — the employer sees "idle" even if the backend returned an error. Previous action context is lost. |
+| E5 | **No "reject" or "decline" action** | P2 | Three actions exist: accept, refresh, review. An employer who wants to explicitly decline has no path. They can only close the tab. No audit trail for a negative decision. |
+| E6 | **Review context card only shows truncated contextId** | P3 | When `contextId` is present, the UI shows `{contextId.slice(0, 8)}…` with no way to expand or copy. Debugging or cross-referencing this ID requires dev tools. |
+
+---
+
+## Top 10 UX Problems (Ranked)
+
+| Rank | ID | Problem | P-Level |
+|------|-----|---------|---------|
+| 1 | C1 | Share actions are clipboard-only — no scoped tokens, no expiry, no revocation | **P0** |
+| 2 | E1 | No employer onboarding or first-visit context on review surface | **P0** |
+| 3 | C2 | No share tracking or analytics wired into the share UI | **P1** |
+| 4 | C3 | No "Share with employer" flow — only "View as employer" preview | **P1** |
+| 5 | E2 | "Accept as head start" label is opaque to non-credentialing users | **P1** |
+| 6 | E3 | Packet download failure is silently swallowed — no user feedback | **P1** |
+| 7 | E5 | No "decline" action — negative decisions leave no audit trail | **P1** |
+| 8 | C4 | No selective disclosure gate before sharing | **P2** |
+| 9 | E4 | Persisted action state fetch failure is silent | **P2** |
+| 10 | E6 | Truncated contextId with no expand/copy affordance | **P3** |
+
+---
+
+## Specific Flags
+
+### Missing employer context
+**Confirmed.** E1 is the biggest employer-side gap. The review surface assumes the viewer understands what VitalCV is, what a trust stack means, and what "Accept as head start" implies. No onboarding card, no help text, no "first time here?" flow.
+
+### Weak action confirmation
+**Partially addressed.** The success state shows audit event ID + trust snapshot hash — strong for compliance, but the "Back" button after success returns to the action panel with no persistent visual indicator that an action was already taken. The `persistedActionState` banner exists but is buried in the metadata card, not highlighted.
+
+### WebAuthn confusion
+**Not a risk in this flow.** WebAuthn (BiometricPrompt + useBiometricConfirmation) is only wired into SelectiveDisclosureModal for holder credential presentation. It does not appear in the employer review flow. No confusion path exists.
+
+### Stale public copy on homepage/developers/explore
+**Clean.** All public surfaces use current, scoped language. No stale "coming soon," no old branding, no orphaned copy.
+
+### Orphan routes
+**One orphan identified:** `/review` (no entityId) is a landing page that tells employers to "start from NPI lookup." Employers don't know NPIs. This page should redirect to `/employers` or show a "paste your share link" input. It's not broken — just not useful for the stated audience.
+
+---
+
+## GO / NO-GO
+
+### CONDITIONAL GO
+
+**Safe to merge for preview/pilot deployment.** The review surface is structurally complete, the auth gating degrades gracefully, the audit trail is immutable, and no route is broken or dead. The two P0 items (C1: no scoped share tokens, E1: no employer onboarding) are real gaps but do not block a controlled preview where share links are manually distributed and employers have been briefed.
+
+**Conditions for production GO:**
+1. Wire PassportShareActions to `/api/apply/share` to generate scoped, expirable share tokens (C1)
+2. Add a first-visit employer context card or modal on `/review/[entityId]` (E1)
+3. Track share events via the analytics endpoint (C2)
+
+**Should be addressed before pilot expansion (P1 items):**
+4. Add download failure toast (E3)
+5. Add "decline" action (E5)
+6. Clarify "Accept as head start" for non-credentialing audiences (E2)
+7. Build a proper "Share with employer" flow beyond clipboard copy (C3)

--- a/PR85-UX-AUDIT-2026-03-27.md
+++ b/PR85-UX-AUDIT-2026-03-27.md
@@ -1,0 +1,162 @@
+# PR #85 UX Audit — Employer-Context Share Hardening
+
+**Date:** 2026-03-27
+**PR:** #85 (`feat/employer-context-share-hardening`)
+**Preview:** `vitalcv-a5fivfjus-blockchaincv.vercel.app`
+**Production (merged):** `vitalcv-a6dr7z53k-blockchaincv.vercel.app`
+**Auditor:** Claude (Cowork mode, source + deployment review)
+**Status:** Already merged to main. This is a post-merge validation.
+
+---
+
+## Executive Summary
+
+PR #85 replaced the broken `POST /api/share` + fake `organizationContextId: 'direct-share'` flow with a working `POST /api/apply/bundle` pipeline. Auth states are now actionable, blocked states point to `/passport`, and copy is honest throughout. **One UX dead-end remains in `/interview` blocked state (no layout shell), and a minor "what happens next" gap exists in the share confirmation.** No blockers for production. Merge is validated.
+
+---
+
+## 1. /passport — Clinician POV
+
+### What works well
+
+- NPI entry is clean and unauthenticated — "Enter your NPI. No login required."
+- SSE-based live ingest with honest phase labels (Identity → Sanctions → Enrollment → Complete).
+- Terminal states are all truthful: no-profile, unanchored, disconnect, error — each with actionable copy.
+- PassportWallet sections show real source-backed evidence with honest gap labels ("Not decision-grade", "Access required", "blocked").
+- NPI disclaimer is precise: "confirms identity only — does not confirm licensure, enrollment, or credential status."
+- Readiness score and freshness badges use opacity-based styling, not fake color-coded trust signals.
+
+### Clinician POV Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| C1 | **P2** | Share requires auth but discovery is late | User fills passport, scrolls to share, clicks "Copy share link for employer" → 401 → "Sign in to generate a shareable passport link." The sign-in prompt appears *after* the click, not before. A clinician who ran the full ingest without signing in hits a wall at the moment of highest intent. |
+| C2 | **P3** | "What should happen next" is data-dependent | The section renders `readiness.nextActions` from the engine. If the engine returns an empty array, the section renders with a heading and no content. No fallback copy. |
+| C3 | **Info** | Two separate share surfaces | `PassportShareActions` (public link, embed, LinkedIn) lives on `/p/[slug]`, while `PassportWallet` share (bundle for employer) lives on `/passport/[id]`. A clinician who discovers both may be confused about which to use. Not a bug — just worth watching in usability testing. |
+
+---
+
+## 2. Share / Export Flow
+
+### What works well
+
+- Bundle flow is real: `POST /api/apply/bundle` → backend creates bundle → bundleId returned → URL copied to clipboard.
+- Bundle URL (`/apply/{bundleId}`) is publicly viewable, expires in 24 hours, includes cryptographic integrity stamp.
+- Error states are specific and actionable: 401 → "Sign in", 404 → "Run an NPI lookup first", generic → "Try again."
+- No fake organization context IDs in active code. `'demo-pilot-org-alpha'` exists only in VerifierPortal (internal demo) and SimulationControlPanel (simulation).
+- "Export passport proof" on the employer review surface downloads real JSON with proper filename (`vitalcv-passport-{npi}-{date}.json`).
+
+### Does the share action make sense?
+
+**Yes, mostly.** "Copy share link for employer" → generates bundle → copies URL to clipboard → clinician sends URL to employer. The flow is mechanically correct and the copy is honest.
+
+**Gap:** The confirmation says "Send it to an employer to open the review surface" but doesn't explain *what the employer will see* or *what happens when they click it*. A clinician sharing for the first time has no mental model of the employer experience.
+
+### Does it clearly explain what happens next?
+
+**Partially.** Post-share confirmation: "The passport share link has been copied to your clipboard. Send it to an employer to open the review surface." This tells the clinician the *action* (send) but not the *outcome* (employer sees trust snapshot, can accept/refresh/route, bundle expires in 24h). The 24-hour expiry is surfaced only on the employer's bundle view, never to the clinician.
+
+### Share / Export Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| S1 | **P2** | No expiry disclosure to clinician | Bundles expire in 24 hours. The clinician is never told this. If they share a link and the employer clicks it 2 days later → 410 "expired" → employer dead-end. Clinician should see: "This link expires in 24 hours." |
+| S2 | **P3** | No share history for clinician | `GET /api/apply/shares/{npi}` endpoint exists but no UI surfaces past shares. Clinician can't see what they've shared or revoke a bundle. |
+| S3 | **P3** | Post-share "what happens next" is thin | Confirmation should briefly describe the employer experience: "The employer will see your trust snapshot and can take action on your candidacy." |
+
+---
+
+## 3. /review — Employer POV
+
+### What works well
+
+- Employer review landing page is honest: "Employer review opens from a real passport share link."
+- RequestReviewPanel creates real org context with audit attribution.
+- Review decision surface has three clear actions: Accept as head start, Request refresh, Route to review.
+- Auth-gating is granular and transparent: four distinct states (auth disabled, loading, not signed in, wrong workspace) each with specific copy.
+- Direct-view warning is clear: "Actions here are not tied to a confirmed employer context. Request a review context for auditable decisions."
+- Action success shows full audit trail: event ID, timestamp, trust snapshot, receipt hash.
+- No mock/demo strings in active review code.
+
+### Does any part still feel fake or dead?
+
+**No.** The review surface is production-grade. Every action writes a real audit event. The "Preview only" state is an honest operational gate, not a fake disabled state. The decision snapshot shows real blocker counts and estimated start days. Advisory panel (Mirofish) only renders when enabled.
+
+### Employer POV Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| E1 | **P3** | Review landing page CTA goes to wrong route | "Start with NPI lookup" → `/passport-lookup` (may 404 depending on routing). Should be `/passport`. |
+| E2 | **P3** | "Are you an employer?" label is backwards | The review landing page shows "Are you an employer?" with a link to `/review/request`. But the page *is* the employer page. This label should say "Need to create a review context?" or similar. |
+| E3 | **Info** | Download packet fails silently | `handleDownloadPacket()` catches errors and returns to idle state without user feedback. If the backend is down, the employer sees nothing. Should show a brief error. |
+
+---
+
+## 4. /interview Blocked State
+
+### What works well
+
+- Two blocked conditions (missing NPI context, passport fetch failed) both render honest, specific copy.
+- CTAs are correct: "Go to passport" → `/passport`, "Start with NPI lookup" → `/` (homepage).
+- Telemetry fires on blocked view (`interview_blocked_view` with `blocked_reason`).
+- No fake/mock/misleading text.
+- Test coverage confirms no "verified readiness" claims in interview markup.
+
+### Are blocked states actionable?
+
+**Partially.** The CTA text is actionable ("Go to passport"), but the UX is hostile because:
+
+### Interview Blocked State Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| I1 | **P1** | Chromeless dead-end | `InterviewBlockedState` renders full-screen with no navbar, no footer, no back button. A user who arrives here has a single CTA and no way to navigate anywhere else. This was flagged in FINAL_AUDIT as P1. |
+| I2 | **P2** | No inline NPI recovery | The blocked state tells users to "enter your NPI from the passport page" but doesn't offer an inline NPI input. User must leave the page entirely. |
+| I3 | **P3** | Second blocked state CTA routes to homepage, not /passport | When passport fetch fails, CTA is "Start with NPI lookup" → `/` (homepage). Should go to `/passport` for consistency with the first blocked state. |
+
+---
+
+## Consolidated Issue Summary
+
+### Blockers (P1)
+
+| # | Route | Issue | Effort |
+|---|-------|-------|--------|
+| I1 | /interview | Chromeless blocked state — no nav shell, hostile dead-end | S |
+
+### High Priority (P2)
+
+| # | Route | Issue | Effort |
+|---|-------|-------|--------|
+| C1 | /passport | Share auth wall appears only after click, not before | S |
+| S1 | share flow | No 24h expiry disclosure to clinician | S |
+| I2 | /interview | No inline NPI input in blocked state | M |
+
+### Medium Priority (P3)
+
+| # | Route | Issue | Effort |
+|---|-------|-------|--------|
+| C2 | /passport | Empty "What should happen next" when no nextActions | S |
+| S2 | share flow | No share history UI despite API existing | M |
+| S3 | share flow | Post-share confirmation doesn't describe employer experience | S |
+| E1 | /review | CTA routes to /passport-lookup (may 404) | S |
+| E2 | /review | "Are you an employer?" label is confusing | S |
+| E3 | /review | Download packet fails silently | S |
+| I3 | /interview | Second blocked CTA routes to / instead of /passport | S |
+
+---
+
+## Merge Recommendation
+
+**PR #85 is validated for production.** The core mission — replacing the broken share endpoint, eliminating fake org context IDs, and making auth states actionable — is complete and working correctly. No fake or misleading copy remains in active code paths.
+
+**I1 (chromeless interview blocked state) is the only P1**, and it was pre-existing before PR #85. It should be fixed in a follow-up PR, not as a blocker for this merge.
+
+**Recommended follow-up PR (S effort, 1–2 hours):**
+1. Add layout shell to `InterviewBlockedState` (navbar + footer)
+2. Add "Expires in 24 hours" to share confirmation copy
+3. Show sign-in prompt *before* share button click when unauthenticated
+4. Fix `/passport-lookup` CTA on review landing → `/passport`
+5. Unify second interview blocked CTA to `/passport`
+
+**Verdict: Ship as-is. Queue follow-up for the five S-effort items above.**

--- a/PR87-EMPLOYER-REVIEW-AUDIT-2026-03-27.md
+++ b/PR87-EMPLOYER-REVIEW-AUDIT-2026-03-27.md
@@ -1,0 +1,138 @@
+# PR #87 Employer Review Audit — 2026-03-27
+
+**Auditor:** Cowork (Claude Opus)
+**Scope:** Employer POV walkthrough of `/review/request`, workspace bootstrap, `/review` no-context path, plus live public-shell drift check.
+**Commit:** `0c468c1b` — `feat: employer-workspace-bootstrap — setup flow, request-review API, improved panel states`
+
+---
+
+## 1. BLOCKERS (must fix before merge)
+
+### B1. `needs_setup` inline bootstrap never fires for the most common case
+
+**Severity: P0 — breaks the core employer onboarding path**
+
+`RequestReviewPanel.tsx` triggers the inline `EmployerWorkspaceSetup` only when:
+```ts
+res.status === 404 && data.hint?.includes('VcvEntity')
+res.status === 422 && data.hint?.includes('VcvEntity')
+```
+
+But the API route (`/api/request-review`) returns **403** with hint `"Create or switch into an employer workspace before requesting a clinician review."` when the user is signed in but has no workspace. That hint does **not** contain "VcvEntity".
+
+The only path that returns a "VcvEntity" hint is line 161 — when the backend `POST /api/organization-context` fails — which is a much rarer case (workspace exists but org entity not registered).
+
+**Result:** A first-time signed-in employer enters NPI → hits 403 → sees a generic red error card (`"Employer workspace required to request a review."`) → **no inline setup offered** → dead end.
+
+**Fix:** Either:
+- (a) Change the `needs_setup` trigger to match on `res.status === 403` and/or `data.hint?.includes('workspace')`, or
+- (b) Add a `nextStep` field to the API error payload (the contract already defines it in `RequestReviewErrorPayload`) and switch on `data.nextStep === 'create_workspace'` instead of string-matching the hint.
+
+Option (b) is strictly better — the contract types exist (`request-review-contract.ts`) but the API route doesn't emit them. The `resolveEmployerWorkspaceRequestorContext()` function in `employer-workspace.ts` already produces `nextStep` values, but the route handler at `/api/request-review/route.ts` uses the older `resolveEmployerWorkspaceAuthContext()` directly and formats its own error payloads without `code` or `nextStep`.
+
+### B2. API route uses two divergent workspace resolution paths
+
+The `/api/request-review/route.ts` calls `resolveEmployerWorkspaceAuthContext()` directly and then manually duplicates entity-resolution logic (lines 85–109). Meanwhile `resolveEmployerWorkspaceRequestorContext()` in `employer-workspace.ts` already encapsulates the full flow including entity resolution and returns structured `RequestReviewErrorPayload` with `code`/`nextStep`.
+
+The route should use `resolveEmployerWorkspaceRequestorContext()` and forward its structured errors. This would simultaneously fix B1 because the client could switch on `nextStep` instead of hint-sniffing.
+
+---
+
+## 2. EMPLOYER POV ISSUES (non-blocking but visible to pilot users)
+
+### E1. `/review/request` — unauthenticated path shows correct sign-in CTA ✅
+Live check confirms: an anonymous visitor sees "Sign in to request a review" with a "Sign in with employer workspace" button. Clean, correct.
+
+### E2. `/review` landing — no-context warning path is honest and functional ✅
+Live check confirms: landing shows "Open a shared passport review" with warning tone, explains that review opens from a real share link, and offers "Start with NPI lookup" and "View passport" as escape hatches. "Are you an employer?" CTA links to `/review/request`. All good.
+
+### E3. `/review/[entityId]` — error state is honest ✅
+When no passport is found, shows "Employer review unavailable" with the actual backend error message, plus retry and back-to-home buttons. No fake or placeholder data.
+
+### E4. `EmployerWorkspaceSetup` — feels pilot-scoped, not productized
+The inline bootstrap collects only an organization name. This is fine for pilot, but:
+- No NPI input field — the workspace will be created without an NPI, and the very next retry will fail at `resolveEmployerWorkspaceAuthContext` line 74 (`employerWorkspaceNpi` will be empty) with error "Employer workspace is missing a resolvable organization NPI."
+- So even if B1 is fixed, the setup → auto-retry loop will still fail unless `POST /api/employer/setup` also sets the NPI on the workspace profile, or the setup form collects it.
+
+**This is arguably P0 — the setup form creates a workspace that immediately fails the NPI check on retry.**
+
+### E5. Success state — review link generation is clean ✅
+Context ID, status, review URL with copy button, open-in-new-tab, audit trail footer. Productized feel.
+
+### E6. Loading states use honest copy ✅
+"Creating review context…" / "Resolving NPI and registering context." — no fake progress bars, no synthetic delays.
+
+---
+
+## 3. DEAD / AMBIGUOUS / FAKE STATE CHECK
+
+| Area | Verdict | Notes |
+|------|---------|-------|
+| `/review` landing | ✅ Honest | Warning tone, real CTAs, no fake data |
+| `/review/request` unauthenticated | ✅ Honest | Clean sign-in gate |
+| `/review/request` authenticated, no workspace | ❌ Dead end | Generic error, no setup path (B1) |
+| `/review/request` authenticated, workspace exists | ✅ Functional | NPI → context → review link |
+| `/review/[entityId]` error | ✅ Honest | Real error message from backend |
+| `/review/[entityId]` success | ✅ Functional | Real passport data, real decision surface |
+| `EmployerWorkspaceSetup` | ⚠️ Incomplete | Creates workspace without NPI → auto-retry fails (E4) |
+| `ReviewClient` decision surface | ✅ Honest | Truth-model-driven, real status labels, real proof sections |
+
+---
+
+## 4. PUBLIC SHELL DRIFT CHECK
+
+### Homepage (vitalcv.com)
+
+| Element | Live Copy | Assessment |
+|---------|-----------|------------|
+| Hero | "NPI first. Honest coverage." | ✅ Aligned with doctrine |
+| Subhead | "See your readiness snapshot in about 10 seconds." | ✅ Honest qualifier ("about") |
+| Description | "source-backed credentialing snapshot from NPPES, OIG, and available PECOS coverage" | ✅ Accurate to current source coverage |
+| Source strip | NPPES=Checked, OIG/LEIE=Checked, CMS PECOS=Pending, CA State Board=Access required | ✅ Matches actual pipeline state |
+| Footer disclaimer | "Homepage preview starts with NPPES and OIG. Other lanes stay marked as access required, pending, or preview-only until a connected source actually runs." | ✅ Honest |
+| CTA | "Start with NPI lookup", "No signup required to preview" | ✅ Accurate |
+| Nav | "For Employers" link present | ✅ Routes to employer path |
+
+**Homepage drift: NONE detected.** Clean.
+
+### Developers page (vitalcv.com/developers)
+
+| Element | Live Copy | Assessment |
+|---------|-----------|------------|
+| Headline | "Build against the current VitalCV API preview." | ✅ Honest — says "preview" |
+| API Host | `delightful-essence-production.up.railway.app` | ⚠️ Exposes raw Railway hostname — not branded. Not a blocker but looks like internal tooling. |
+| Mode | "Preview" | ✅ Honest |
+| Auth | "API keys" | ✅ Accurate |
+| SDK packages | `@vitalcv/verifier-sdk`, Issuer SDK, Wallet SDK | ⚠️ Are these published packages? If not, listing them implies availability that doesn't exist. |
+| Trust Threshold/Revocation/Peer stats | Specific numbers (60, 5/30 days, 3 endorsements) | ⚠️ Are these enforced in the current codebase? If spec-only, they read as live behavior. |
+| Resource links | `/docs/api`, `/docs/sdk`, `/docs/webhooks` | ⚠️ Do these routes return content? If 404, the links are dead. |
+
+**Developers page drift: LOW-MEDIUM.** The page is honest about being preview, but the SDK package names and governance stats may overstate what's real. Railway hostname is cosmetic but unprofessional for a pilot employer who clicks through.
+
+---
+
+## 5. FOLLOW-UPS (post-merge, non-blocking)
+
+1. **F1.** Refactor `/api/request-review/route.ts` to use `resolveEmployerWorkspaceRequestorContext()` — eliminates duplicated logic and surfaces structured error codes.
+2. **F2.** Add org NPI field to `EmployerWorkspaceSetup` form, or have `POST /api/employer/setup` auto-resolve NPI from Clerk org metadata.
+3. **F3.** Developers page: replace raw Railway hostname with `api.vitalcv.com` or a branded subdomain.
+4. **F4.** Developers page: audit SDK package names and governance stat cards — mark as "planned" if not yet real.
+5. **F5.** Developers page: verify `/docs/api`, `/docs/sdk`, `/docs/webhooks` routes return content.
+6. **F6.** Add telemetry for the `needs_setup` → setup → retry flow to track pilot employer conversion.
+7. **F7.** Consider adding a `EMPLOYER_WORKSPACE_IDENTITY_REQUIRED` inline recovery path (NPI addition) similar to the org-name setup.
+
+---
+
+## 6. MERGE RECOMMENDATION
+
+### **NO-GO as-is.**
+
+**Reason:** The primary value of PR #87 — letting a first-time employer go from zero to a valid review context — is broken. The `needs_setup` inline bootstrap never triggers for the most common path (signed-in, no workspace). A pilot employer will hit a generic error wall.
+
+### Path to GO:
+
+Fix **B1** (hint-matching → nextStep switching) or at minimum widen the 403 case to trigger `needs_setup`. This is an S-sized fix (30 min). If E4 (setup creates workspace without NPI → auto-retry fails) is also fixed, the full zero-to-review path works end-to-end. E4 is M-sized (1–2 hours).
+
+**Minimum merge bar:** B1 fixed. E4 can be a fast follow if `/api/employer/setup` is updated to accept and set an NPI.
+
+**Recommended merge bar:** B1 + E4 fixed. Then the "first employer touches VitalCV" story is actually complete.

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -15,6 +15,7 @@ jest.mock('../../graphql/prisma_client', () => ({
     auditEvent: {
       create: jest.fn(),
       findFirst: jest.fn(),
+      findMany: jest.fn(),
     },
     outboxEvent: {
       upsert: jest.fn(),
@@ -72,6 +73,7 @@ const prismaMock = prisma as unknown as {
   auditEvent: {
     create: jest.Mock;
     findFirst: jest.Mock;
+    findMany: jest.Mock;
   };
   outboxEvent: {
     upsert: jest.Mock;
@@ -336,6 +338,7 @@ describe('employer action routes', () => {
     prismaMock.employerAcceptance.create.mockReset();
     prismaMock.auditEvent.create.mockReset();
     prismaMock.auditEvent.findFirst.mockReset();
+    prismaMock.auditEvent.findMany.mockReset();
     prismaMock.outboxEvent.upsert.mockReset();
     prismaMock.$transaction.mockReset();
     captureAdvisoryEventMock.mockReset();
@@ -357,6 +360,7 @@ describe('employer action routes', () => {
       id: 'audit-1',
       createdAt: new Date('2026-03-23T18:00:00.000Z'),
     });
+    prismaMock.auditEvent.findMany.mockResolvedValue([]);
     prismaMock.outboxEvent.upsert.mockResolvedValue({
       id: 'outbox-1',
     });
@@ -551,7 +555,7 @@ describe('employer action routes', () => {
 
   it('keeps status reads backward compatible with legacy audit-only review metadata', async () => {
     prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce(null);
-    prismaMock.auditEvent.findFirst.mockResolvedValueOnce({
+    prismaMock.auditEvent.findMany.mockResolvedValueOnce([{
       id: 'audit-review-1',
       createdAt: new Date('2026-03-23T19:30:00.000Z'),
       metadata: {
@@ -583,9 +587,19 @@ describe('employer action routes', () => {
             facility: null,
             notes: null,
           },
+          attribution: {
+            source: 'unscoped',
+            organizationContextId: null,
+            bundleShareEventId: null,
+            bundleId: null,
+            requestorEntityId: null,
+            organizationId: null,
+            organizationName: null,
+            purposeOfUse: null,
+          },
         },
       },
-    });
+    ]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')
@@ -600,6 +614,16 @@ describe('employer action routes', () => {
         clinicianNpi: '1234567890',
         auditEventId: 'audit-review-1',
         timestamp: '2026-03-23T19:30:00.000Z',
+        attribution: {
+          source: 'unscoped',
+          organizationContextId: null,
+          bundleShareEventId: null,
+          bundleId: null,
+          requestorEntityId: null,
+          organizationId: null,
+          organizationName: null,
+          purposeOfUse: null,
+        },
         persistence: {
           mode: 'audit_only',
           target: 'audit_event',
@@ -623,14 +647,7 @@ describe('employer action routes', () => {
   });
 
   it('loads persisted acceptance state with the linked outbox and audit metadata', async () => {
-    prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce({
-      id: 'accept-1',
-      acceptedAt: new Date('2026-03-23T19:45:00.000Z'),
-      status: 'ACCEPTED',
-    });
-    prismaMock.auditEvent.findFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
+    prismaMock.auditEvent.findMany.mockResolvedValueOnce([{
         id: 'audit-accept-1',
         createdAt: new Date('2026-03-23T19:46:00.000Z'),
         metadata: {
@@ -662,6 +679,16 @@ describe('employer action routes', () => {
               role: 'Recruiter',
               facility: 'Providence',
               notes: 'Head start only',
+            },
+            attribution: {
+              source: 'unscoped',
+              organizationContextId: null,
+              bundleShareEventId: null,
+              bundleId: null,
+              requestorEntityId: null,
+              organizationId: null,
+              organizationName: null,
+              purposeOfUse: null,
             },
             trustSnapshot: {
               snapshotHash: 'snapshot-hash-1',
@@ -705,7 +732,8 @@ describe('employer action routes', () => {
             },
           },
         },
-      });
+      },
+    }]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')
@@ -720,6 +748,16 @@ describe('employer action routes', () => {
         clinicianNpi: '1234567890',
         auditEventId: 'audit-accept-1',
         timestamp: '2026-03-23T19:46:00.000Z',
+        attribution: {
+          source: 'unscoped',
+          organizationContextId: null,
+          bundleShareEventId: null,
+          bundleId: null,
+          requestorEntityId: null,
+          organizationId: null,
+          organizationName: null,
+          purposeOfUse: null,
+        },
         persistence: {
           mode: 'durable_record',
           target: 'employer_acceptance',

--- a/apps/api/backend/src/routes/employerActions.ts
+++ b/apps/api/backend/src/routes/employerActions.ts
@@ -111,12 +111,16 @@ export function registerEmployerActionRoutes(app: Express): void {
         role?:     string;
         facility?: string;
         notes?:    string;
+        organizationContextId?: string;
+        bundleId?: string;
       };
 
       const state = await recordEmployerReviewAcceptance({
         entityId,
         employerId,
         clinicianNpi: subject.clinicianNpi,
+        organizationContextId: req.body?.organizationContextId,
+        bundleId: req.body?.bundleId,
         role,
         facility,
         notes,
@@ -178,11 +182,15 @@ export function registerEmployerActionRoutes(app: Express): void {
         staleSources?:    string[];
         missingDomains?:  string[];
         message?:         string;
+        organizationContextId?: string;
+        bundleId?: string;
       };
       const state = await recordEmployerReviewRefreshRequest({
         entityId,
         employerId,
         clinicianNpi: subject.clinicianNpi,
+        organizationContextId: req.body?.organizationContextId,
+        bundleId: req.body?.bundleId,
         staleSources,
         missingDomains,
         message,
@@ -228,11 +236,18 @@ export function registerEmployerActionRoutes(app: Express): void {
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found.`);
 
-      const { reason, priority } = (req.body ?? {}) as { reason?: string; priority?: string };
+      const { reason, priority } = (req.body ?? {}) as {
+        reason?: string;
+        priority?: string;
+        organizationContextId?: string;
+        bundleId?: string;
+      };
       const state = await recordEmployerReviewRouting({
         entityId,
         employerId,
         clinicianNpi: subject.clinicianNpi,
+        organizationContextId: req.body?.organizationContextId,
+        bundleId: req.body?.bundleId,
         reason,
         priority,
       });
@@ -295,6 +310,12 @@ export function registerEmployerActionRoutes(app: Express): void {
         entityId,
         employerId,
         clinicianNpi: subject.clinicianNpi,
+        organizationContextId: typeof req.query.organizationContextId === 'string'
+          ? req.query.organizationContextId
+          : undefined,
+        bundleId: typeof req.query.bundleId === 'string'
+          ? req.query.bundleId
+          : undefined,
       });
 
       return void res.status(200).json({ ok: true, state });

--- a/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
@@ -1,0 +1,350 @@
+jest.mock('../../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    vcvOrganizationContext: {
+      findUnique: jest.fn(),
+    },
+    vcvOrgContextSubject: {
+      findUnique: jest.fn(),
+    },
+    bundleShareEvent: {
+      findFirst: jest.fn(),
+    },
+    employerAcceptance: {
+      create: jest.fn(),
+    },
+    auditEvent: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+    outboxEvent: {
+      upsert: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('../passportService', () => ({
+  buildPassportByNpi: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../trust/trustScoreV1', () => ({
+  computeTrustScoreV1: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../../obs/logger', () => ({
+  log: jest.fn(),
+}));
+
+import prisma from '../../../graphql/prisma_client';
+import {
+  loadEmployerReviewStatus,
+  recordEmployerReviewAcceptance,
+} from '../employerReviewActions';
+
+const prismaMock = prisma as unknown as {
+  vcvOrganizationContext: {
+    findUnique: jest.Mock;
+  };
+  vcvOrgContextSubject: {
+    findUnique: jest.Mock;
+  };
+  bundleShareEvent: {
+    findFirst: jest.Mock;
+  };
+  employerAcceptance: {
+    create: jest.Mock;
+  };
+  auditEvent: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+  };
+  outboxEvent: {
+    upsert: jest.Mock;
+  };
+  $transaction: jest.Mock;
+};
+
+describe('employerReviewActions service', () => {
+  beforeEach(() => {
+    prismaMock.vcvOrganizationContext.findUnique.mockReset();
+    prismaMock.vcvOrgContextSubject.findUnique.mockReset();
+    prismaMock.bundleShareEvent.findFirst.mockReset();
+    prismaMock.employerAcceptance.create.mockReset();
+    prismaMock.auditEvent.create.mockReset();
+    prismaMock.auditEvent.findMany.mockReset();
+    prismaMock.outboxEvent.upsert.mockReset();
+    prismaMock.$transaction.mockReset();
+
+    prismaMock.vcvOrganizationContext.findUnique.mockImplementation(async ({ where }: { where: { id: string } }) => {
+      if (where.id === 'ctx-1') {
+        return {
+          id: 'ctx-1',
+          requestorId: 'org-entity-1',
+          contextType: 'EMPLOYMENT_REVIEW',
+          status: 'PENDING',
+          title: 'Employment review',
+          description: null,
+          webhookUrl: null,
+          requestor: {
+            id: 'org-entity-1',
+            displayName: 'Providence',
+          },
+        };
+      }
+
+      return null;
+    });
+    prismaMock.vcvOrgContextSubject.findUnique.mockResolvedValue({
+      id: 'ctx-subject-1',
+    });
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue({
+      id: 'share-1',
+      bundleId: 'bundle-1',
+      subjectEntityId: 'entity-1',
+      organizationContextId: 'ctx-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Providence',
+      purposeOfUse: 'Employment review',
+    });
+    prismaMock.employerAcceptance.create.mockResolvedValue({
+      id: 'accept-1',
+      acceptedAt: new Date('2026-03-23T18:00:00.000Z'),
+    });
+    prismaMock.auditEvent.create.mockResolvedValue({
+      id: 'audit-1',
+      createdAt: new Date('2026-03-23T18:00:00.000Z'),
+    });
+    prismaMock.outboxEvent.upsert.mockResolvedValue({
+      id: 'outbox-1',
+    });
+    prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof prismaMock) => unknown) => callback(prismaMock));
+  });
+
+  it('persists explicit organization-context attribution onto acceptance audit events', async () => {
+    const state = await recordEmployerReviewAcceptance({
+      entityId: 'entity-1',
+      employerId: 'employer-1',
+      clinicianNpi: '1234567890',
+      organizationContextId: 'ctx-1',
+    });
+
+    expect(state.attribution).toEqual({
+      source: 'organization_context',
+      organizationContextId: 'ctx-1',
+      bundleShareEventId: null,
+      bundleId: null,
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Providence',
+      purposeOfUse: 'Employment review',
+    });
+    expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        type: 'EMPLOYER_REVIEW_ACCEPTED',
+        referenceId: 'accept-1',
+        organizationId: 'org-entity-1',
+        metadata: expect.objectContaining({
+          employerReviewAction: expect.objectContaining({
+            attribution: expect.objectContaining({
+              source: 'organization_context',
+              organizationContextId: 'ctx-1',
+              organizationId: 'org-entity-1',
+            }),
+          }),
+        }),
+      }),
+    }));
+  });
+
+  it('persists bundle fallback attribution onto acceptance audit events using the canonical organization context', async () => {
+    const state = await recordEmployerReviewAcceptance({
+      entityId: 'entity-1',
+      employerId: 'employer-1',
+      clinicianNpi: '1234567890',
+      bundleId: 'bundle-1',
+    });
+
+    expect(state.attribution).toEqual({
+      source: 'bundle_share',
+      organizationContextId: 'ctx-1',
+      bundleShareEventId: 'share-1',
+      bundleId: 'bundle-1',
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Providence',
+      purposeOfUse: 'Employment review',
+    });
+    expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        type: 'EMPLOYER_REVIEW_ACCEPTED',
+        referenceId: 'accept-1',
+        organizationId: 'org-entity-1',
+        metadata: expect.objectContaining({
+          employerReviewAction: expect.objectContaining({
+            attribution: expect.objectContaining({
+              source: 'bundle_share',
+              organizationContextId: 'ctx-1',
+              bundleShareEventId: 'share-1',
+              bundleId: 'bundle-1',
+              organizationId: 'org-entity-1',
+            }),
+          }),
+        }),
+      }),
+    }));
+  });
+
+  it('keeps review continuity between bundle fallback and employer-request context', async () => {
+    prismaMock.bundleShareEvent.findFirst
+      .mockResolvedValueOnce({
+        id: 'share-1',
+        bundleId: 'bundle-1',
+        subjectEntityId: 'entity-1',
+        organizationContextId: 'ctx-1',
+        organizationId: 'legacy-org',
+        organizationName: 'Legacy Providence',
+        purposeOfUse: 'Legacy employment review',
+      })
+      .mockResolvedValueOnce({
+        id: 'share-1',
+      });
+    prismaMock.auditEvent.findMany.mockResolvedValue([{
+      id: 'audit-accept-1',
+      createdAt: new Date('2026-03-23T19:46:00.000Z'),
+      metadata: {
+        employerReviewAction: {
+          action: 'accept',
+          employerId: 'employer-1',
+          entityId: 'entity-1',
+          clinicianNpi: '1234567890',
+          requestId: 'req-accept-1',
+          attribution: {
+            source: 'organization_context',
+            organizationContextId: 'ctx-1',
+            bundleShareEventId: null,
+            bundleId: null,
+            requestorEntityId: 'org-entity-1',
+            organizationId: 'org-entity-1',
+            organizationName: 'Providence',
+            purposeOfUse: 'Employment review',
+          },
+          persistence: {
+            mode: 'durable_record',
+            target: 'employer_acceptance',
+            acceptanceId: 'accept-1',
+            reviewItemId: null,
+            outboxEventId: 'outbox-1',
+            reviewItemCreated: false,
+          },
+          summary: {
+            title: 'Head start accepted',
+            description: 'The employer acceptance was persisted and linked to an audit event.',
+          },
+          details: {
+            staleSources: [],
+            missingDomains: [],
+            reason: null,
+            priority: null,
+          },
+          context: {
+            role: null,
+            facility: null,
+            notes: null,
+          },
+        },
+      },
+    }]);
+
+    const state = await loadEmployerReviewStatus({
+      entityId: 'entity-1',
+      employerId: 'employer-1',
+      clinicianNpi: '1234567890',
+      bundleId: 'bundle-1',
+    });
+
+    expect(state).toEqual(expect.objectContaining({
+      action: 'accept',
+      auditEventId: 'audit-accept-1',
+      attribution: expect.objectContaining({
+        source: 'organization_context',
+        organizationContextId: 'ctx-1',
+        organizationId: 'org-entity-1',
+      }),
+      persistence: expect.objectContaining({
+        outboxEventId: 'outbox-1',
+      }),
+    }));
+  });
+
+  it('keeps review continuity when a stored bundle-share attribution is reopened by organization context', async () => {
+    prismaMock.auditEvent.findMany.mockResolvedValue([{
+      id: 'audit-accept-2',
+      createdAt: new Date('2026-03-23T20:10:00.000Z'),
+      metadata: {
+        employerReviewAction: {
+          action: 'accept',
+          employerId: 'employer-1',
+          entityId: 'entity-1',
+          clinicianNpi: '1234567890',
+          requestId: 'req-accept-2',
+          attribution: {
+            source: 'bundle_share',
+            organizationContextId: 'ctx-1',
+            bundleShareEventId: 'share-1',
+            bundleId: 'bundle-1',
+            requestorEntityId: 'org-entity-1',
+            organizationId: 'org-entity-1',
+            organizationName: 'Providence',
+            purposeOfUse: 'Employment review',
+          },
+          persistence: {
+            mode: 'durable_record',
+            target: 'employer_acceptance',
+            acceptanceId: 'accept-1',
+            reviewItemId: null,
+            outboxEventId: 'outbox-1',
+            reviewItemCreated: false,
+          },
+          summary: {
+            title: 'Head start accepted',
+            description: 'The employer acceptance was persisted and linked to an audit event.',
+          },
+          details: {
+            staleSources: [],
+            missingDomains: [],
+            reason: null,
+            priority: null,
+          },
+          context: {
+            role: null,
+            facility: null,
+            notes: null,
+          },
+        },
+      },
+    }]);
+
+    const state = await loadEmployerReviewStatus({
+      entityId: 'entity-1',
+      employerId: 'employer-1',
+      clinicianNpi: '1234567890',
+      organizationContextId: 'ctx-1',
+    });
+
+    expect(state).toEqual(expect.objectContaining({
+      action: 'accept',
+      auditEventId: 'audit-accept-2',
+      attribution: expect.objectContaining({
+        source: 'bundle_share',
+        organizationContextId: 'ctx-1',
+        bundleShareEventId: 'share-1',
+        organizationId: 'org-entity-1',
+      }),
+      persistence: expect.objectContaining({
+        acceptanceId: 'accept-1',
+        outboxEventId: 'outbox-1',
+      }),
+    }));
+  });
+});

--- a/apps/api/backend/src/services/entity/__tests__/employerReviewAttribution.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/employerReviewAttribution.test.ts
@@ -1,0 +1,231 @@
+jest.mock('../../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    vcvOrganizationContext: {
+      findUnique: jest.fn(),
+    },
+    vcvOrgContextSubject: {
+      findUnique: jest.fn(),
+    },
+    bundleShareEvent: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+import prisma from '../../../graphql/prisma_client';
+import {
+  EmployerReviewAttributionError,
+  resolveEmployerReviewAttribution,
+} from '../employerReviewAttribution';
+
+const prismaMock = prisma as unknown as {
+  vcvOrganizationContext: {
+    findUnique: jest.Mock;
+  };
+  vcvOrgContextSubject: {
+    findUnique: jest.Mock;
+  };
+  bundleShareEvent: {
+    findFirst: jest.Mock;
+  };
+};
+
+describe('employerReviewAttribution', () => {
+  beforeEach(() => {
+    prismaMock.vcvOrganizationContext.findUnique.mockReset();
+    prismaMock.vcvOrgContextSubject.findUnique.mockReset();
+    prismaMock.bundleShareEvent.findFirst.mockReset();
+    prismaMock.vcvOrganizationContext.findUnique.mockImplementation(async ({ where }: { where: { id: string } }) => {
+      if (where.id === 'ctx-1') {
+        return {
+          id: 'ctx-1',
+          requestorId: 'org-entity-1',
+          contextType: 'EMPLOYMENT_REVIEW',
+          status: 'PENDING',
+          title: 'Employment review',
+          description: null,
+          webhookUrl: null,
+          requestor: {
+            id: 'org-entity-1',
+            displayName: 'Mercy General',
+          },
+        };
+      }
+
+      if (where.id === 'ctx-2') {
+        return {
+          id: 'ctx-2',
+          requestorId: 'org-entity-2',
+          contextType: 'EMPLOYMENT_REVIEW',
+          status: 'PENDING',
+          title: 'Employment review',
+          description: null,
+          webhookUrl: null,
+          requestor: {
+            id: 'org-entity-2',
+            displayName: 'Mercy General',
+          },
+        };
+      }
+
+      return null;
+    });
+    prismaMock.vcvOrgContextSubject.findUnique.mockResolvedValue({
+      id: 'ctx-subject-1',
+    });
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue(null);
+  });
+
+  it('normalizes an employer-request context into the canonical attribution shape', async () => {
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      organizationContextId: 'ctx-1',
+    })).resolves.toEqual({
+      source: 'organization_context',
+      organizationContextId: 'ctx-1',
+      bundleShareEventId: null,
+      bundleId: null,
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Mercy General',
+      purposeOfUse: 'Employment review',
+    });
+  });
+
+  it('keeps bundle fallback aligned with the same canonical organization context', async () => {
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue({
+      id: 'share-1',
+      bundleId: 'bundle-1',
+      subjectEntityId: 'entity-1',
+      organizationContextId: 'ctx-1',
+      organizationId: 'legacy-org',
+      organizationName: 'Legacy org',
+      purposeOfUse: 'Legacy purpose',
+    });
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      bundleId: 'bundle-1',
+    })).resolves.toEqual({
+      source: 'bundle_share',
+      organizationContextId: 'ctx-1',
+      bundleShareEventId: 'share-1',
+      bundleId: 'bundle-1',
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Mercy General',
+      purposeOfUse: 'Employment review',
+    });
+  });
+
+  it('returns an unscoped attribution when review scope is missing', async () => {
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+    })).resolves.toEqual({
+      source: 'unscoped',
+      organizationContextId: null,
+      bundleShareEventId: null,
+      bundleId: null,
+      requestorEntityId: null,
+      organizationId: null,
+      organizationName: null,
+      purposeOfUse: null,
+    });
+  });
+
+  it('fails closed when an explicit organization context is invalid', async () => {
+    prismaMock.vcvOrganizationContext.findUnique.mockResolvedValue(null);
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      organizationContextId: 'ctx-missing',
+    })).rejects.toMatchObject({
+      name: 'EmployerReviewAttributionError',
+      statusCode: 404,
+      message: 'Review context not found.',
+    });
+  });
+
+  it('fails closed when an explicit organization context is not linked to the review subject', async () => {
+    prismaMock.vcvOrgContextSubject.findUnique.mockResolvedValueOnce(null);
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValueOnce(null);
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      organizationContextId: 'ctx-2',
+    })).rejects.toMatchObject({
+      name: 'EmployerReviewAttributionError',
+      statusCode: 400,
+      message: 'Review context is not linked to this review subject.',
+    });
+  });
+
+  it('fails closed when an explicit organization context targets its own requestor as the subject', async () => {
+    prismaMock.vcvOrganizationContext.findUnique.mockResolvedValue({
+      id: 'ctx-2',
+      requestorId: 'entity-1',
+      contextType: 'EMPLOYMENT_REVIEW',
+      status: 'PENDING',
+      title: 'Employment review',
+      description: null,
+      webhookUrl: null,
+      requestor: {
+        id: 'entity-1',
+        displayName: 'Mercy General',
+      },
+    });
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      organizationContextId: 'ctx-2',
+    })).rejects.toMatchObject({
+      name: 'EmployerReviewAttributionError',
+      statusCode: 400,
+      message: 'Review context cannot target its requesting organization as the subject.',
+    });
+  });
+
+  it('fails closed when a bundle fallback points at a different subject', async () => {
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue({
+      id: 'share-2',
+      bundleId: 'bundle-2',
+      subjectEntityId: 'entity-2',
+      organizationContextId: null,
+      organizationId: 'org-2',
+      organizationName: 'Other org',
+      purposeOfUse: 'Credential review',
+    });
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      bundleId: 'bundle-2',
+    })).rejects.toMatchObject({
+      name: 'EmployerReviewAttributionError',
+      statusCode: 404,
+      message: 'Bundle review context does not match this review subject.',
+    });
+  });
+
+  it('fails closed when bundle fallback and requested organization context diverge', async () => {
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue({
+      id: 'share-1',
+      bundleId: 'bundle-1',
+      subjectEntityId: 'entity-1',
+      organizationContextId: 'ctx-2',
+      organizationId: 'legacy-org-2',
+      organizationName: 'Legacy Mercy',
+      purposeOfUse: 'Legacy employment review',
+    });
+
+    await expect(resolveEmployerReviewAttribution({
+      entityId: 'entity-1',
+      organizationContextId: 'ctx-1',
+      bundleId: 'bundle-1',
+    })).rejects.toMatchObject<Partial<EmployerReviewAttributionError>>({
+      name: 'EmployerReviewAttributionError',
+      statusCode: 400,
+      message: 'Bundle review context does not match the requested organization context.',
+    });
+  });
+});

--- a/apps/api/backend/src/services/entity/__tests__/reviewContextContract.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/reviewContextContract.test.ts
@@ -1,0 +1,142 @@
+jest.mock('../../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    vcvOrganizationContext: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+import prisma from '../../../graphql/prisma_client';
+import {
+  OrganizationContextValidationError,
+  resolveShareOrganizationContext,
+  validateOrganizationContext,
+} from '../reviewContextContract';
+
+const prismaMock = prisma as unknown as {
+  vcvOrganizationContext: {
+    findUnique: jest.Mock;
+  };
+};
+
+describe('reviewContextContract', () => {
+  beforeEach(() => {
+    prismaMock.vcvOrganizationContext.findUnique.mockReset();
+  });
+
+  it('keeps bundle fallback and employer-request context resolution in the same normalized shape', async () => {
+    prismaMock.vcvOrganizationContext.findUnique.mockResolvedValue({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      requestorId: 'org-entity-1',
+      contextType: 'EMPLOYMENT_REVIEW',
+      status: 'PENDING',
+      title: 'Providence employment review',
+      description: null,
+      webhookUrl: 'https://ehr.example.com/vitalcv',
+      requestor: {
+        id: 'org-entity-1',
+        displayName: 'Providence',
+      },
+    });
+
+    const legacy = await resolveShareOrganizationContext(validateOrganizationContext({
+      organization_id: 'legacy-org',
+      name: 'Legacy Providence',
+      purpose_of_use: 'Employment review',
+      callback_url: 'https://legacy.example.com/vitalcv',
+    }));
+    const employerRequest = await resolveShareOrganizationContext(validateOrganizationContext({
+      organization_context_id: '550e8400-e29b-41d4-a716-446655440000',
+    }));
+
+    expect(legacy).toEqual({
+      source: 'bundle_fallback',
+      organizationContextId: null,
+      requestorEntityId: null,
+      organizationId: 'legacy-org',
+      organizationName: 'Legacy Providence',
+      callbackUrl: 'https://legacy.example.com/vitalcv',
+      purposeOfUse: 'Employment review',
+      contextType: null,
+      status: null,
+    });
+    expect(employerRequest).toEqual({
+      source: 'employer_request_context',
+      organizationContextId: '550e8400-e29b-41d4-a716-446655440000',
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Providence',
+      callbackUrl: 'https://ehr.example.com/vitalcv',
+      purposeOfUse: 'Providence employment review',
+      contextType: 'EMPLOYMENT_REVIEW',
+      status: 'PENDING',
+    });
+  });
+
+  it('accepts an explicit organization_context_id without legacy fallback fields', () => {
+    const context = validateOrganizationContext({
+      organization_context_id: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    expect(context).toEqual({
+      organizationContextId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+  });
+
+  it('prefers persisted organization-context identity over legacy fallback fields when both are present', async () => {
+    prismaMock.vcvOrganizationContext.findUnique.mockResolvedValue({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      requestorId: 'org-entity-1',
+      contextType: 'EMPLOYMENT_REVIEW',
+      status: 'ACTIVE',
+      title: 'Providence employment review',
+      description: 'Canonical description',
+      webhookUrl: 'https://ehr.example.com/vitalcv',
+      requestor: {
+        id: 'org-entity-1',
+        displayName: 'Providence',
+      },
+    });
+
+    const resolved = await resolveShareOrganizationContext(validateOrganizationContext({
+      organization_context_id: '550e8400-e29b-41d4-a716-446655440000',
+      organization_id: 'legacy-org',
+      name: 'Legacy Providence',
+      purpose_of_use: 'Legacy employment review',
+      callback_url: 'https://override.example.com/vitalcv',
+    }));
+
+    expect(resolved).toEqual({
+      source: 'employer_request_context',
+      organizationContextId: '550e8400-e29b-41d4-a716-446655440000',
+      requestorEntityId: 'org-entity-1',
+      organizationId: 'org-entity-1',
+      organizationName: 'Providence',
+      callbackUrl: 'https://ehr.example.com/vitalcv',
+      purposeOfUse: 'Providence employment review',
+      contextType: 'EMPLOYMENT_REVIEW',
+      status: 'ACTIVE',
+    });
+  });
+
+  it('fails closed when organization_context_id is invalid or missing', async () => {
+    expect(() => validateOrganizationContext({
+      organization_context_id: 'not-a-uuid',
+    })).toThrow(OrganizationContextValidationError);
+    expect(() => validateOrganizationContext({
+      name: 'Missing org id',
+      purpose_of_use: 'Employment review',
+    })).toThrow(OrganizationContextValidationError);
+
+    prismaMock.vcvOrganizationContext.findUnique.mockResolvedValue(null);
+
+    await expect(resolveShareOrganizationContext(validateOrganizationContext({
+      organization_context_id: '550e8400-e29b-41d4-a716-446655440000',
+    }))).rejects.toMatchObject<Partial<OrganizationContextValidationError>>({
+      name: 'OrganizationContextValidationError',
+      statusCode: 400,
+      message: 'organization_context.organization_context_id is invalid.',
+    });
+  });
+});

--- a/apps/api/backend/src/services/entity/employerReviewActions.ts
+++ b/apps/api/backend/src/services/entity/employerReviewActions.ts
@@ -10,6 +10,12 @@ import type {
   CanonicalTruthDimensionId,
   CanonicalTruthStatus,
 } from '../../../../../../packages/trust-state';
+import type { EmployerReviewAttribution } from './employerReviewAttribution';
+import {
+  matchesEmployerReviewAttribution,
+  normalizeEmployerReviewAttribution,
+  resolveEmployerReviewAttribution,
+} from './employerReviewAttribution';
 
 export type EmployerReviewActionIntent = 'accept' | 'refresh' | 'review';
 export type EmployerReviewPriority = 'LOW' | 'NORMAL' | 'HIGH';
@@ -250,6 +256,7 @@ interface EmployerReviewActionAuditMetadata {
     facility: string | null;
     notes: string | null;
   };
+  attribution: EmployerReviewAttribution;
   /** Immutable trust state at time of decision — core of the audit trail.
    *  Optional for backwards compat: records written before a43b82d0 won't have it. */
   trustSnapshot?: DecisionTrustSnapshot;
@@ -261,6 +268,7 @@ export interface EmployerReviewActionState {
   clinicianNpi: string;
   auditEventId: string;
   timestamp: string;
+  attribution: EmployerReviewAttribution;
   persistence: EmployerReviewActionPersistence;
   summary: EmployerReviewActionSummary;
   details: EmployerReviewActionDetails;
@@ -312,6 +320,7 @@ type AuditWriter = {
       data: Prisma.AuditEventUncheckedCreateInput;
     }) => Promise<{ id: string; createdAt: Date }>;
     findFirst?: (args: Record<string, unknown>) => Promise<EmployerAuditEventRecord | null>;
+    findMany?: (args: Record<string, unknown>) => Promise<EmployerAuditEventRecord[]>;
   };
 };
 
@@ -435,6 +444,7 @@ function buildState(input: {
     clinicianNpi: input.metadata.clinicianNpi,
     auditEventId: input.auditEventId,
     timestamp: input.timestamp,
+    attribution: input.metadata.attribution,
     persistence: input.metadata.persistence,
     summary: input.metadata.summary,
     details: input.metadata.details,
@@ -474,6 +484,7 @@ function readMetadata(metadata: unknown): EmployerReviewActionAuditMetadata | nu
     summary: record.summary,
     details: record.details,
     context: record.context ?? { role: null, facility: null, notes: null },
+    attribution: normalizeEmployerReviewAttribution(record.attribution),
     trustSnapshot:
       record.trustSnapshot && typeof record.trustSnapshot === 'object'
         ? record.trustSnapshot
@@ -494,6 +505,7 @@ function buildEmployerReviewOutboxPayload(
     summary: metadata.summary,
     details: metadata.details,
     context: metadata.context,
+    attribution: metadata.attribution,
     trustSnapshot: metadata.trustSnapshot ?? null,
   });
 }
@@ -557,6 +569,7 @@ async function writeEmployerReviewAuditEvent(
       hash: actionHash,
       referenceId: input.referenceId,
       clinicianId: input.metadata.clinicianNpi,
+      organizationId: input.metadata.attribution.organizationId ?? undefined,
       anchored: false,
       metadata: toJsonValue({
         employerReviewAction: input.metadata,
@@ -588,12 +601,19 @@ export async function recordEmployerReviewAcceptance(input: {
   entityId: string;
   employerId: string;
   clinicianNpi: string;
+  organizationContextId?: unknown;
+  bundleId?: unknown;
   role?: unknown;
   facility?: unknown;
   notes?: unknown;
 }): Promise<EmployerReviewActionState> {
   const now = new Date();
   const requestId = randomUUID();
+  const attribution = await resolveEmployerReviewAttribution({
+    entityId: input.entityId,
+    organizationContextId: input.organizationContextId,
+    bundleId: input.bundleId,
+  });
   const context = {
     role: sanitizeString(input.role, 80),
     facility: sanitizeString(input.facility, 120),
@@ -643,6 +663,7 @@ export async function recordEmployerReviewAcceptance(input: {
           summary: buildActionSummary('accept', seededPersistence),
           details: buildEmptyDetails(),
           context,
+          attribution,
           trustSnapshot,
         },
       },
@@ -662,6 +683,7 @@ export async function recordEmployerReviewAcceptance(input: {
       summary: buildActionSummary('accept', persistence),
       details: buildEmptyDetails(),
       context,
+      attribution,
       trustSnapshot,
     };
 
@@ -688,6 +710,8 @@ export async function recordEmployerReviewRefreshRequest(input: {
   entityId: string;
   employerId: string;
   clinicianNpi: string;
+  organizationContextId?: unknown;
+  bundleId?: unknown;
   staleSources?: unknown;
   missingDomains?: unknown;
   message?: unknown;
@@ -695,6 +719,11 @@ export async function recordEmployerReviewRefreshRequest(input: {
   // Capture snapshot before write
   const trustSnapshot = await buildDecisionTrustSnapshot(input.clinicianNpi);
   const requestId = randomUUID();
+  const attribution = await resolveEmployerReviewAttribution({
+    entityId: input.entityId,
+    organizationContextId: input.organizationContextId,
+    bundleId: input.bundleId,
+  });
   const details = buildEmptyDetails({
     staleSources: sanitizeStringList(input.staleSources),
     missingDomains: sanitizeStringList(input.missingDomains),
@@ -724,6 +753,7 @@ export async function recordEmployerReviewRefreshRequest(input: {
         facility: null,
         notes: null,
       },
+      attribution,
       trustSnapshot,
     };
 
@@ -769,11 +799,18 @@ export async function recordEmployerReviewRouting(input: {
   entityId: string;
   employerId: string;
   clinicianNpi: string;
+  organizationContextId?: unknown;
+  bundleId?: unknown;
   reason?: unknown;
   priority?: unknown;
 }): Promise<EmployerReviewActionState> {
   const now = new Date();
   const requestId = randomUUID();
+  const attribution = await resolveEmployerReviewAttribution({
+    entityId: input.entityId,
+    organizationContextId: input.organizationContextId,
+    bundleId: input.bundleId,
+  });
   const normalizedPriority = normalizePriority(input.priority);
   const normalizedReason =
     sanitizeString(input.reason, 500)
@@ -829,6 +866,7 @@ export async function recordEmployerReviewRouting(input: {
         facility: null,
         notes: null,
       },
+      attribution,
       trustSnapshot,
     };
 
@@ -874,92 +912,61 @@ export async function loadEmployerReviewStatus(input: {
   entityId: string;
   employerId: string;
   clinicianNpi: string;
+  organizationContextId?: unknown;
+  bundleId?: unknown;
 }): Promise<EmployerReviewActionState | null> {
-  const [latestAcceptance, latestAuditOnly] = await Promise.all([
-    prisma.employerAcceptance.findFirst({
-      where: {
-        employerId: input.employerId,
-        clinicianNpi: input.clinicianNpi,
-        status: 'ACCEPTED',
-      },
-      select: {
-        id: true,
-        acceptedAt: true,
-        status: true,
-      },
-      orderBy: {
-        acceptedAt: 'desc',
-      },
-    }),
-    prisma.auditEvent.findFirst({
-      where: {
-        referenceId: input.entityId,
-        type: {
-          in: [
-            'EMPLOYER_REVIEW_REFRESH_REQUESTED',
-            'EMPLOYER_REVIEW_ROUTED_TO_REVIEW',
-          ],
-        },
-        metadata: {
-          path: ['employerReviewAction', 'employerId'],
-          equals: input.employerId,
-        },
-      },
-      select: {
-        id: true,
-        createdAt: true,
-        metadata: true,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    }),
-  ]);
+  const requestedAttribution = await resolveEmployerReviewAttribution({
+    entityId: input.entityId,
+    organizationContextId: input.organizationContextId,
+    bundleId: input.bundleId,
+  });
 
-  let latestAcceptanceState: EmployerReviewActionState | null = null;
-  if (latestAcceptance) {
-    const acceptanceAudit = await prisma.auditEvent.findFirst({
-      where: {
-        referenceId: latestAcceptance.id,
-        type: 'EMPLOYER_REVIEW_ACCEPTED',
-        metadata: {
-          path: ['employerReviewAction', 'employerId'],
-          equals: input.employerId,
-        },
+  const auditEvents = await prisma.auditEvent.findMany({
+    where: {
+      type: {
+        in: [
+          'EMPLOYER_REVIEW_ACCEPTED',
+          'EMPLOYER_REVIEW_REFRESH_REQUESTED',
+          'EMPLOYER_REVIEW_ROUTED_TO_REVIEW',
+        ],
       },
-      select: {
-        id: true,
-        createdAt: true,
-        metadata: true,
+      metadata: {
+        path: ['employerReviewAction', 'employerId'],
+        equals: input.employerId,
       },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
+    },
+    select: {
+      id: true,
+      createdAt: true,
+      metadata: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+    take: 25,
+  });
 
-    const metadata = readMetadata(acceptanceAudit?.metadata);
-    if (acceptanceAudit && metadata) {
-      latestAcceptanceState = buildState({
-        auditEventId: acceptanceAudit.id,
-        timestamp: acceptanceAudit.createdAt.toISOString(),
-        metadata,
-      });
+  for (const auditEvent of auditEvents) {
+    const metadata = readMetadata(auditEvent.metadata);
+    if (!metadata) {
+      continue;
     }
+
+    if (
+      metadata.employerId !== input.employerId
+      || metadata.entityId !== input.entityId
+      || metadata.clinicianNpi !== input.clinicianNpi
+      || !matchesEmployerReviewAttribution(requestedAttribution, metadata.attribution)
+    ) {
+      continue;
+    }
+
+    return buildState({
+      auditEventId: auditEvent.id,
+      timestamp: auditEvent.createdAt.toISOString(),
+      metadata,
+    });
   }
 
-  const latestAuditOnlyMetadata = readMetadata(latestAuditOnly?.metadata);
-  const latestAuditOnlyState = latestAuditOnly && latestAuditOnlyMetadata
-    ? buildState({
-        auditEventId: latestAuditOnly.id,
-        timestamp: latestAuditOnly.createdAt.toISOString(),
-        metadata: latestAuditOnlyMetadata,
-      })
-    : null;
-
-  if (!latestAcceptanceState) return latestAuditOnlyState;
-  if (!latestAuditOnlyState) return latestAcceptanceState;
-
-  return Date.parse(latestAcceptanceState.timestamp) >= Date.parse(latestAuditOnlyState.timestamp)
-    ? latestAcceptanceState
-    : latestAuditOnlyState;
+  return null;
 }

--- a/apps/api/backend/src/services/entity/employerReviewAttribution.ts
+++ b/apps/api/backend/src/services/entity/employerReviewAttribution.ts
@@ -1,0 +1,282 @@
+import prisma from '../../graphql/prisma_client';
+import {
+  OrganizationContextValidationError,
+  resolvePersistedOrganizationContext,
+} from './reviewContextContract';
+
+export type EmployerReviewAttributionSource =
+  | 'organization_context'
+  | 'bundle_share'
+  | 'unscoped';
+
+export interface EmployerReviewAttribution {
+  source: EmployerReviewAttributionSource;
+  organizationContextId: string | null;
+  bundleShareEventId: string | null;
+  bundleId: string | null;
+  requestorEntityId: string | null;
+  organizationId: string | null;
+  organizationName: string | null;
+  purposeOfUse: string | null;
+}
+
+export class EmployerReviewAttributionError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = 'EmployerReviewAttributionError';
+    this.statusCode = statusCode;
+  }
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function buildUnscopedAttribution(): EmployerReviewAttribution {
+  return {
+    source: 'unscoped',
+    organizationContextId: null,
+    bundleShareEventId: null,
+    bundleId: null,
+    requestorEntityId: null,
+    organizationId: null,
+    organizationName: null,
+    purposeOfUse: null,
+  };
+}
+
+function inferAttributionSource(input: {
+  source?: unknown;
+  organizationContextId: string | null;
+  bundleShareEventId: string | null;
+  bundleId: string | null;
+}): EmployerReviewAttributionSource {
+  switch (input.source) {
+    case 'organization_context':
+    case 'bundle_share':
+    case 'unscoped':
+      return input.source;
+    default:
+      if (input.organizationContextId) return 'organization_context';
+      if (input.bundleShareEventId || input.bundleId) return 'bundle_share';
+      return 'unscoped';
+  }
+}
+
+function mergeAttribution(
+  primary: EmployerReviewAttribution,
+  secondary: EmployerReviewAttribution | null,
+): EmployerReviewAttribution {
+  if (!secondary) return primary;
+
+  return {
+    ...primary,
+    bundleShareEventId: primary.bundleShareEventId ?? secondary.bundleShareEventId,
+    bundleId: primary.bundleId ?? secondary.bundleId,
+    requestorEntityId: primary.requestorEntityId ?? secondary.requestorEntityId,
+    organizationId: primary.organizationId ?? secondary.organizationId,
+    organizationName: primary.organizationName ?? secondary.organizationName,
+    purposeOfUse: primary.purposeOfUse ?? secondary.purposeOfUse,
+  };
+}
+
+async function loadOrganizationContextAttribution(
+  entityId: string,
+  organizationContextId: string,
+): Promise<EmployerReviewAttribution> {
+  let context;
+  try {
+    context = await resolvePersistedOrganizationContext(organizationContextId);
+  } catch (error) {
+    if (error instanceof OrganizationContextValidationError) {
+      throw new EmployerReviewAttributionError(404, 'Review context not found.');
+    }
+    throw error;
+  }
+
+  if (context.requestorEntityId === entityId) {
+    throw new EmployerReviewAttributionError(
+      400,
+      'Review context cannot target its requesting organization as the subject.',
+    );
+  }
+
+  const [subjectLink, shareEvent] = await Promise.all([
+    prisma.vcvOrgContextSubject.findUnique({
+      where: {
+        contextId_subjectId: {
+          contextId: context.organizationContextId!,
+          subjectId: entityId,
+        },
+      },
+      select: { id: true },
+    }),
+    prisma.bundleShareEvent.findFirst({
+      where: {
+        subjectEntityId: entityId,
+        organizationContextId,
+      },
+      orderBy: { sharedAt: 'desc' },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!subjectLink && !shareEvent) {
+    throw new EmployerReviewAttributionError(
+      400,
+      'Review context is not linked to this review subject.',
+    );
+  }
+
+  return {
+    source: 'organization_context',
+    organizationContextId: context.organizationContextId,
+    bundleShareEventId: null,
+    bundleId: null,
+    requestorEntityId: context.requestorEntityId,
+    organizationId: context.organizationId,
+    organizationName: readOptionalString(context.organizationName),
+    purposeOfUse: readOptionalString(context.purposeOfUse),
+  };
+}
+
+async function loadBundleShareAttribution(
+  entityId: string,
+  bundleId: string,
+): Promise<EmployerReviewAttribution> {
+  const share = await prisma.bundleShareEvent.findFirst({
+    where: { bundleId },
+    orderBy: { sharedAt: 'desc' },
+    select: {
+      id: true,
+      bundleId: true,
+      subjectEntityId: true,
+      organizationContextId: true,
+      organizationId: true,
+      organizationName: true,
+      purposeOfUse: true,
+    },
+  });
+
+  if (!share) {
+    throw new EmployerReviewAttributionError(404, 'Bundle review context not found.');
+  }
+
+  if (share.subjectEntityId && share.subjectEntityId !== entityId) {
+    throw new EmployerReviewAttributionError(
+      404,
+      'Bundle review context does not match this review subject.',
+    );
+  }
+
+  const organizationContext = share.organizationContextId
+    ? await loadOrganizationContextAttribution(entityId, share.organizationContextId)
+    : null;
+
+  return mergeAttribution(
+    {
+      source: 'bundle_share',
+      organizationContextId: organizationContext?.organizationContextId ?? share.organizationContextId,
+      bundleShareEventId: share.id,
+      bundleId: share.bundleId,
+      requestorEntityId: organizationContext?.requestorEntityId ?? null,
+      organizationId: organizationContext?.organizationId ?? share.organizationId,
+      organizationName: organizationContext?.organizationName ?? share.organizationName,
+      purposeOfUse: organizationContext?.purposeOfUse ?? share.purposeOfUse,
+    },
+    organizationContext,
+  );
+}
+
+export async function resolveEmployerReviewAttribution(input: {
+  entityId: string;
+  organizationContextId?: unknown;
+  bundleId?: unknown;
+}): Promise<EmployerReviewAttribution> {
+  const requestedContextId = readOptionalString(input.organizationContextId);
+  const requestedBundleId = readOptionalString(input.bundleId);
+
+  if (!requestedContextId && !requestedBundleId) {
+    return buildUnscopedAttribution();
+  }
+
+  const [organizationContext, bundleShare] = await Promise.all([
+    requestedContextId
+      ? loadOrganizationContextAttribution(input.entityId, requestedContextId)
+      : Promise.resolve<EmployerReviewAttribution | null>(null),
+    requestedBundleId
+      ? loadBundleShareAttribution(input.entityId, requestedBundleId)
+      : Promise.resolve<EmployerReviewAttribution | null>(null),
+  ]);
+
+  if (
+    organizationContext
+    && bundleShare?.organizationContextId
+    && bundleShare.organizationContextId !== organizationContext.organizationContextId
+  ) {
+    throw new EmployerReviewAttributionError(
+      400,
+      'Bundle review context does not match the requested organization context.',
+    );
+  }
+
+  return mergeAttribution(
+    organizationContext ?? bundleShare ?? buildUnscopedAttribution(),
+    bundleShare,
+  );
+}
+
+export function normalizeEmployerReviewAttribution(value: unknown): EmployerReviewAttribution {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return buildUnscopedAttribution();
+  }
+
+  const record = value as Record<string, unknown>;
+  const organizationContextId = readOptionalString(record.organizationContextId);
+  const bundleShareEventId = readOptionalString(record.bundleShareEventId);
+  const bundleId = readOptionalString(record.bundleId);
+
+  return {
+    source: inferAttributionSource({
+      source: record.source,
+      organizationContextId,
+      bundleShareEventId,
+      bundleId,
+    }),
+    organizationContextId,
+    bundleShareEventId,
+    bundleId,
+    requestorEntityId: readOptionalString(record.requestorEntityId),
+    organizationId: readOptionalString(record.organizationId),
+    organizationName: readOptionalString(record.organizationName),
+    purposeOfUse: readOptionalString(record.purposeOfUse),
+  };
+}
+
+export function matchesEmployerReviewAttribution(
+  requested: EmployerReviewAttribution,
+  stored: EmployerReviewAttribution,
+): boolean {
+  if (requested.organizationContextId && stored.organizationContextId) {
+    return requested.organizationContextId === stored.organizationContextId;
+  }
+
+  if (requested.bundleShareEventId && stored.bundleShareEventId) {
+    return requested.bundleShareEventId === stored.bundleShareEventId;
+  }
+
+  if (requested.bundleId && stored.bundleId) {
+    return requested.bundleId === stored.bundleId;
+  }
+
+  if (requested.source === 'unscoped') {
+    return stored.source === 'unscoped'
+      && !stored.organizationContextId
+      && !stored.bundleShareEventId
+      && !stored.bundleId;
+  }
+
+  return false;
+}

--- a/apps/api/backend/src/services/entity/reviewContextContract.ts
+++ b/apps/api/backend/src/services/entity/reviewContextContract.ts
@@ -1,0 +1,224 @@
+import type { VcvOrgContextStatus, VcvOrgContextType } from '@prisma/client';
+import prisma from '../../graphql/prisma_client';
+
+const URL_RE = /^https?:\/\/.+/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class OrganizationContextValidationError extends Error {
+  readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'OrganizationContextValidationError';
+  }
+}
+
+export interface OrganizationContextInput {
+  organizationContextId?: string;
+  organization_id?: string;
+  name?: string;
+  callback_url?: string;
+  purpose_of_use?: string;
+}
+
+export interface ResolvedShareOrganizationContext {
+  source: 'bundle_fallback' | 'employer_request_context';
+  organizationContextId: string | null;
+  requestorEntityId: string | null;
+  organizationId: string;
+  organizationName: string;
+  callbackUrl: string | null;
+  purposeOfUse: string;
+  contextType: VcvOrgContextType | null;
+  status: VcvOrgContextStatus | null;
+}
+
+type PersistedOrganizationContextRecord = {
+  id: string;
+  requestorId: string;
+  contextType: VcvOrgContextType;
+  status: VcvOrgContextStatus;
+  title: string | null;
+  description: string | null;
+  webhookUrl: string | null;
+  requestor: {
+    id: string;
+    displayName: string;
+  };
+};
+
+function normalizeString(value: unknown): string | null {
+  if (
+    typeof value !== 'string'
+    && typeof value !== 'number'
+    && typeof value !== 'boolean'
+    && typeof value !== 'bigint'
+  ) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function validateOptionalCallbackUrl(value: unknown): string | undefined {
+  const callbackUrl = normalizeString(value);
+  if (!callbackUrl) return undefined;
+  if (!URL_RE.test(callbackUrl)) {
+    throw new OrganizationContextValidationError(
+      'organization_context.callback_url must be a valid https:// URL.',
+    );
+  }
+  return callbackUrl;
+}
+
+export function readOptionalOrganizationContextId(value: unknown): string | undefined {
+  const organizationContextId = normalizeString(value);
+  if (!organizationContextId) return undefined;
+  if (!UUID_RE.test(organizationContextId)) {
+    throw new OrganizationContextValidationError(
+      'organizationContextId must be a valid UUID.',
+    );
+  }
+  return organizationContextId;
+}
+
+export function validateOrganizationContext(input: unknown): OrganizationContextInput {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new OrganizationContextValidationError('organization_context is required.');
+  }
+
+  const record = input as Record<string, unknown>;
+  const organizationContextId = readOptionalOrganizationContextId(
+    record.organization_context_id ?? record.organizationContextId,
+  );
+  const callbackUrl = validateOptionalCallbackUrl(record.callback_url);
+  const organizationId = normalizeString(record.organization_id);
+  const name = normalizeString(record.name);
+  const purposeOfUse = normalizeString(record.purpose_of_use);
+
+  if (organizationContextId) {
+    if (organizationId && organizationId.length > 256) {
+      throw new OrganizationContextValidationError('organization_context.organization_id too long.');
+    }
+    if (name && name.length > 256) {
+      throw new OrganizationContextValidationError('organization_context.name too long.');
+    }
+    if (purposeOfUse && purposeOfUse.length > 512) {
+      throw new OrganizationContextValidationError('organization_context.purpose_of_use too long.');
+    }
+
+    return {
+      organizationContextId,
+      ...(organizationId ? { organization_id: organizationId } : {}),
+      ...(name ? { name } : {}),
+      ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+      ...(purposeOfUse ? { purpose_of_use: purposeOfUse } : {}),
+    };
+  }
+
+  if (!organizationId) {
+    throw new OrganizationContextValidationError('organization_context.organization_id is required.');
+  }
+  if (organizationId.length > 256) {
+    throw new OrganizationContextValidationError('organization_context.organization_id too long.');
+  }
+  if (!name) {
+    throw new OrganizationContextValidationError('organization_context.name is required.');
+  }
+  if (name.length > 256) {
+    throw new OrganizationContextValidationError('organization_context.name too long.');
+  }
+  if (!purposeOfUse) {
+    throw new OrganizationContextValidationError('organization_context.purpose_of_use is required.');
+  }
+  if (purposeOfUse.length > 512) {
+    throw new OrganizationContextValidationError('organization_context.purpose_of_use too long.');
+  }
+
+  return {
+    organization_id: organizationId,
+    name,
+    ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+    purpose_of_use: purposeOfUse,
+  };
+}
+
+function buildContextPurpose(context: PersistedOrganizationContextRecord): string {
+  return normalizeString(context.title)
+    ?? normalizeString(context.description)
+    ?? context.contextType;
+}
+
+async function loadPersistedOrganizationContext(
+  organizationContextId: string,
+): Promise<PersistedOrganizationContextRecord | null> {
+  return prisma.vcvOrganizationContext.findUnique({
+    where: { id: organizationContextId },
+    select: {
+      id: true,
+      requestorId: true,
+      contextType: true,
+      status: true,
+      title: true,
+      description: true,
+      webhookUrl: true,
+      requestor: {
+        select: {
+          id: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+}
+
+export async function resolvePersistedOrganizationContext(
+  organizationContextId: string,
+): Promise<ResolvedShareOrganizationContext> {
+  const context = await loadPersistedOrganizationContext(organizationContextId);
+  if (!context) {
+    throw new OrganizationContextValidationError(
+      'organization_context.organization_context_id is invalid.',
+    );
+  }
+
+  return {
+    source: 'employer_request_context',
+    organizationContextId: context.id,
+    requestorEntityId: context.requestorId,
+    organizationId: context.requestor.id,
+    organizationName: context.requestor.displayName,
+    callbackUrl: context.webhookUrl,
+    purposeOfUse: buildContextPurpose(context),
+    contextType: context.contextType,
+    status: context.status,
+  };
+}
+
+export async function resolveShareOrganizationContext(
+  input: OrganizationContextInput,
+): Promise<ResolvedShareOrganizationContext> {
+  if (input.organizationContextId) {
+    const context = await resolvePersistedOrganizationContext(input.organizationContextId);
+    return {
+      ...context,
+      callbackUrl: context.callbackUrl ?? input.callback_url ?? null,
+    };
+  }
+
+  if (!input.organization_id || !input.name || !input.purpose_of_use) {
+    throw new OrganizationContextValidationError('organization_context is required.');
+  }
+
+  return {
+    source: 'bundle_fallback',
+    organizationContextId: null,
+    requestorEntityId: null,
+    organizationId: input.organization_id,
+    organizationName: input.name,
+    callbackUrl: input.callback_url ?? null,
+    purposeOfUse: input.purpose_of_use,
+    contextType: null,
+    status: null,
+  };
+}

--- a/apps/web/__tests__/employer-workspace-bootstrap.test.tsx
+++ b/apps/web/__tests__/employer-workspace-bootstrap.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * employer-workspace-bootstrap.test.tsx
+ *
+ * Tests for employer workspace bootstrap + request-review flow:
+ * - /api/request-review route: auth, NPI validation, FK-error detection
+ * - EmployerWorkspaceSetup: renders org name form
+ * - RequestReviewPanel: state machine (idle, needs_setup, done)
+ * - ReviewClient: context attribution vs no-context warning
+ * - /review landing: employer path visible
+ */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(async () => ({ userId: null })),
+}));
+
+vi.mock('@/components/auth/RoleContext', () => ({
+  useRoleContext: () => ({ isLoaded: true, isSignedIn: true, isEmployer: true }),
+}));
+
+vi.mock('@/lib/auth/clerkConfig', () => ({
+  CLERK_PROVIDER_ENABLED: false,
+  CLERK_SIGN_IN_URL: '/sign-in',
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => null,
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/review/request',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/motion/ScrollMotion', () => ({
+  SectionReveal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/components/advisory/AdvisoryPanel', () => ({
+  EmployerAdvisoryPanel: () => null,
+}));
+
+vi.mock('@/lib/trust/passport-review-truth', () => ({
+  buildPassportReviewTruthModel: () => ({
+    buckets: { stale: [], needsReview: [], missingOrAccessRequired: [], nextActions: [] },
+    sourceCoverageChecks: [],
+    proofSummary: { total: 0, decisionGradeCount: 0, informationalCount: 0, warningCount: 0 },
+    posture: { disclaimer: 'Preview only.' },
+    freshness: { entries: [], label: 'Partial', state: 'partial' },
+  }),
+  resolvePassportTruthSet: () => ({
+    identity: { status: 'VERIFIED' },
+    safety: { status: 'CLEAR' },
+    authority: { status: 'PARTIAL' },
+    eligibility: { status: 'ENROLLED' },
+  }),
+  resolvePublicWedgeSurfaceStateFromTruth: () => 'current',
+}));
+
+vi.mock('@/components/trust/passportProofSections', () => ({
+  buildPassportProofSections: () => [],
+  summarizePassportProofSections: () => ({
+    total: 0, decisionGradeCount: 0, informationalCount: 0, warningCount: 0,
+  }),
+}));
+
+vi.mock('@/lib/telemetry/ux-tracker', () => ({ trackUxEvent: vi.fn() }));
+
+vi.mock('@/lib/trust/proof-language', () => ({
+  buildPassportFreshnessEntries: () => [],
+  formatAsOfDate: () => null,
+  formatAsOfQuarter: () => null,
+  formatProofDate: () => null,
+  joinNoteParts: (...p: string[]) => p.filter(Boolean).join(' '),
+  summarizePassportFreshnessEntries: () => ({ state: 'partial', label: 'Partial' }),
+}));
+
+vi.mock('@/lib/employer-review-actions', () => ({
+  employerReviewLoadingLabel: (i: string) => `Loading ${i}`,
+  formatEmployerReviewPersistedDetail: () => 'Detail',
+  formatEmployerReviewPersistedLabel: () => 'Label',
+}));
+
+// ── Tests: /api/request-review ────────────────────────────────────────────
+
+describe('/api/request-review route', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const { POST } = await import('../app/api/request-review/route');
+    const { NextRequest } = await import('next/server');
+
+    const req = new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '1234567890' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const data = await res.json() as { error: string };
+    expect(data.error).toContain('Sign in');
+  });
+
+  it('returns 400 for invalid NPI format when authenticated', async () => {
+    const { auth } = await import('@clerk/nextjs/server');
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ userId: 'test-user-id' });
+
+    const { POST } = await import('../app/api/request-review/route');
+    const { NextRequest } = await import('next/server');
+
+    const req = new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '123' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toContain('10-digit');
+  });
+
+  it('request-review route source validates npi field presence', () => {
+    // Verify the route source contains the npi validation logic
+    const src = readFileSync(
+      resolve(__dirname, '../app/api/request-review/route.ts'),
+      'utf-8',
+    );
+    expect(src).toContain("!body || !body.npi");
+    expect(src).toContain("'npi is required.'");
+  });
+});
+
+// ── Tests: EmployerWorkspaceSetup ──────────────────────────────────────────
+
+describe('EmployerWorkspaceSetup', () => {
+  it('renders org name form', async () => {
+    const { EmployerWorkspaceSetup } = await import(
+      '../components/employer/EmployerWorkspaceSetup'
+    );
+    const markup = renderToStaticMarkup(
+      <EmployerWorkspaceSetup onSetupComplete={vi.fn()} />
+    );
+
+    expect(markup).toContain('Employer workspace required');
+    expect(markup).toContain('Set up employer workspace');
+    expect(markup).toContain('Organization name');
+  });
+
+  it('shows custom hint when provided', async () => {
+    const { EmployerWorkspaceSetup } = await import(
+      '../components/employer/EmployerWorkspaceSetup'
+    );
+    const markup = renderToStaticMarkup(
+      <EmployerWorkspaceSetup
+        onSetupComplete={vi.fn()}
+        hint="Custom hint text here."
+      />
+    );
+
+    expect(markup).toContain('Custom hint text here.');
+  });
+});
+
+// ── Tests: RequestReviewPanel ──────────────────────────────────────────────
+
+describe('RequestReviewPanel', () => {
+  it('renders NPI form in idle state', async () => {
+    const { RequestReviewPanel } = await import(
+      '../components/employer/RequestReviewPanel'
+    );
+    const markup = renderToStaticMarkup(<RequestReviewPanel />);
+
+    expect(markup).toContain('Request a passport review');
+    expect(markup).toContain('Create review context');
+    expect(markup).toContain('Clinician NPI');
+  });
+
+  it('route exists as a valid server component', async () => {
+    const mod = await import('../app/review/request/page');
+    expect(typeof mod.default).toBe('function');
+  });
+});
+
+// ── Tests: ReviewClient context attribution ────────────────────────────────
+
+describe('ReviewClient context attribution (source-level)', () => {
+  it('contains no-context amber warning with /review/request link', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../components/review/ReviewClient.tsx'),
+      'utf-8',
+    );
+    expect(src).toContain('None — direct view');
+    expect(src).toContain('/review/request');
+    expect(src).toContain('Request a review context');
+  });
+
+  it('contains audit trail attribution when contextId present', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../components/review/ReviewClient.tsx'),
+      'utf-8',
+    );
+    expect(src).toContain('Audit trail');
+    expect(src).toContain('Actions tied to this context');
+    expect(src).toContain('contextId.slice(0, 8)');
+  });
+
+  it('has mutually exclusive context/no-context branches', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../components/review/ReviewClient.tsx'),
+      'utf-8',
+    );
+    expect(src).toContain('sharedBy || contextId');
+    expect(src).toContain('None — direct view');
+  });
+});
+
+// ── Tests: /review landing page ────────────────────────────────────────────
+
+describe('/review landing page', () => {
+  it('shows employer request link', async () => {
+    const ReviewLandingPage = (await import('../app/review/page')).default;
+    const markup = renderToStaticMarkup(<ReviewLandingPage />);
+
+    expect(markup).toContain('Request a passport review');
+    expect(markup).toContain('/review/request');
+    expect(markup).toContain('Are you an employer?');
+  });
+
+  it('shows clinician recovery paths', async () => {
+    const ReviewLandingPage = (await import('../app/review/page')).default;
+    const markup = renderToStaticMarkup(<ReviewLandingPage />);
+
+    expect(markup).toContain('Start with NPI lookup');
+    expect(markup).toContain('View passport');
+    expect(markup).toContain('Open a shared passport review');
+  });
+});

--- a/apps/web/__tests__/public-wedge-parity-contract.test.ts
+++ b/apps/web/__tests__/public-wedge-parity-contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { buildEmployerReviewHref } from '../lib/trust/public-wedge-parity';
+
+describe('public wedge review href contract', () => {
+  it('preserves organization context, bundle fallback, and sharer attribution in the review URL', () => {
+    expect(buildEmployerReviewHref('entity_123', {
+      contextId: 'ctx_abc123',
+      bundleId: 'bundle_456',
+      from: 'Ada Lovelace',
+    })).toBe('/review/entity_123?contextId=ctx_abc123&bundleId=bundle_456&from=Ada+Lovelace');
+  });
+});

--- a/apps/web/__tests__/request-review-route-contract.test.ts
+++ b/apps/web/__tests__/request-review-route-contract.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMock = vi.fn();
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: authMock,
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function loadRequestReviewRoute() {
+  return import(new URL('../app/api/request-review/route.ts', import.meta.url).href);
+}
+
+function buildWorkspaceResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'user-1',
+    activePersona: 'VERIFIER',
+    activeOrgId: 'org-1',
+    personProfile: null,
+    memberships: [
+      {
+        org: {
+          id: 'org-profile-1',
+          organizationId: 'org-1',
+          npi: '1999999999',
+          npiType: 'TYPE_2',
+          orgDid: null,
+          facilityType: 'hospital',
+          specialties: [],
+          statesCovered: ['CA'],
+          website: 'https://mercy.example',
+          createdAt: '2026-03-26T00:00:00.000Z',
+          updatedAt: '2026-03-26T00:00:00.000Z',
+        },
+        role: 'ADMIN',
+        active: true,
+      },
+    ],
+    canSwitchTo: ['VERIFIER'],
+    ...overrides,
+  };
+}
+
+describe('/api/request-review route contract', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    authMock.mockReset();
+    process.env.BACKEND_URL = 'http://backend.test';
+  });
+
+  it('rejects invalid clinician NPI before touching workspace or entity resolution', async () => {
+    authMock.mockResolvedValue({
+      userId: 'clerk-user-1',
+      sessionClaims: { email: 'employer@example.com' },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadRequestReviewRoute();
+    const { NextRequest } = await import('next/server');
+
+    const response = await POST(new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '123' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'npi must be a 10-digit number.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the caller is signed in but has no employer workspace', async () => {
+    authMock.mockResolvedValue({
+      userId: 'clerk-user-1',
+      sessionClaims: { email: 'employer@example.com' },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(buildWorkspaceResponse({
+        activePersona: 'CLINICIAN',
+        activeOrgId: null,
+        memberships: [],
+        canSwitchTo: ['CLINICIAN'],
+      })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadRequestReviewRoute();
+    const { NextRequest } = await import('next/server');
+
+    const response = await POST(new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '1234567890' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://backend.test/api/me/workspaces',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: expect.any(Headers),
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { headers: Headers }];
+    expect(init.headers.get('x-clerk-user-id')).toBe('clerk-user-1');
+    expect(init.headers.get('x-clerk-user-email')).toBe('employer@example.com');
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      code: 'EMPLOYER_WORKSPACE_REQUIRED',
+      error: 'Employer workspace required to request a review.',
+      hint: 'Create or switch into an employer workspace before requesting a clinician review.',
+      nextStep: 'create_workspace',
+    });
+  });
+
+  it('returns 404 when the clinician does not yet have a reviewable passport', async () => {
+    authMock.mockResolvedValue({
+      userId: 'clerk-user-1',
+      sessionClaims: { email: 'employer@example.com' },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(buildWorkspaceResponse()))
+      .mockResolvedValueOnce(jsonResponse({
+        entity: {
+          id: 'employer-entity-1',
+          displayName: 'Mercy General',
+          npiType: 'TYPE_2',
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        error: 'Passport not found.',
+      }, 404));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadRequestReviewRoute();
+    const { NextRequest } = await import('next/server');
+
+    const response = await POST(new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '1234567890' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      code: 'CLINICIAN_PASSPORT_REQUIRED',
+      error: 'No passport found for that NPI. The clinician must run a readiness check first.',
+      hint: 'Ask the clinician to run a readiness check before creating an employer review context.',
+      nextStep: 'run_clinician_readiness',
+    });
+  });
+
+  it('creates review context with the active employer workspace VcvEntity, not the Clerk user id', async () => {
+    authMock.mockResolvedValue({
+      userId: 'clerk-user-1',
+      sessionClaims: { email: 'employer@example.com' },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(buildWorkspaceResponse()))
+      .mockResolvedValueOnce(jsonResponse({
+        entity: {
+          id: 'employer-entity-1',
+          displayName: 'Mercy General',
+          npiType: 'TYPE_2',
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        entityId: 'clinician-entity-1',
+        identity: {
+          displayName: 'Ada Lovelace, MD',
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        context: {
+          id: 'ctx-1',
+          status: 'PENDING',
+        },
+      }, 201));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadRequestReviewRoute();
+    const { NextRequest } = await import('next/server');
+
+    const response = await POST(new NextRequest('http://localhost/api/request-review', {
+      method: 'POST',
+      body: JSON.stringify({ npi: '1234567890' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://backend.test/api/entity/resolve/npi/1999999999',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://backend.test/api/passport/npi/1234567890',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      'http://backend.test/api/organization-context',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.any(Headers),
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[3] as [string, { body: string; headers: Headers }];
+    expect(init.headers.get('Content-Type')).toBe('application/json');
+    expect(init.headers.get('x-clerk-user-id')).toBe('clerk-user-1');
+    expect(init.headers.get('x-clerk-user-email')).toBe('employer@example.com');
+    expect(init.headers.get('x-org-id')).toBe('org-1');
+    expect(JSON.parse(init.body)).toEqual({
+      requestorEntityId: 'employer-entity-1',
+      contextType: 'EMPLOYMENT_REVIEW',
+      title: 'Employment review — NPI 1234567890',
+      description: 'Employer-initiated review for clinician NPI 1234567890.',
+      subjectEntityIds: ['clinician-entity-1'],
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      contextId: 'ctx-1',
+      entityId: 'clinician-entity-1',
+      status: 'PENDING',
+      reviewUrl: 'http://localhost/review/clinician-entity-1?contextId=ctx-1',
+      npi: '1234567890',
+      displayName: 'Ada Lovelace, MD',
+    });
+  });
+});

--- a/apps/web/__tests__/review-page-contract.test.tsx
+++ b/apps/web/__tests__/review-page-contract.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reviewClientSpy = vi.fn();
+
+vi.mock('@/components/review/ReviewClient', () => ({
+  default: (props: Record<string, unknown>) => {
+    reviewClientSpy(props);
+    return <div data-review-client>{JSON.stringify(props)}</div>;
+  },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/trust/TrustStateCard', () => ({
+  TrustStateCard: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string;
+    description: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </section>
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('review page contract', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    reviewClientSpy.mockReset();
+    process.env.BACKEND_URL = 'http://backend.test';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes explicit context, bundle fallback, and sharer attribution into the review surface', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        entityId: 'entity-1',
+        readiness: {
+          score: 88,
+          blockers: ['DEA_REGISTRATION'],
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 202));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ReviewPage = (await import('../app/review/[entityId]/page')).default;
+    renderToStaticMarkup(await ReviewPage({
+      params: Promise.resolve({ entityId: 'entity-1' }),
+      searchParams: Promise.resolve({
+        contextId: 'ctx-1',
+        bundleId: 'bundle-1',
+        from: 'Ada Lovelace',
+      }),
+    }));
+
+    expect(reviewClientSpy).toHaveBeenCalledOnce();
+    expect(reviewClientSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      contextId: 'ctx-1',
+      bundleId: 'bundle-1',
+      sharedBy: 'Ada Lovelace',
+    }));
+
+    const [, viewEventInit] = fetchMock.mock.calls[1] as [string, { body: string }];
+    expect(JSON.parse(viewEventInit.body)).toEqual({
+      organizationContextId: 'ctx-1',
+      bundleId: 'bundle-1',
+      readinessScore: 88,
+      blockers: ['DEA_REGISTRATION'],
+    });
+  });
+
+  it('keeps the direct review path unscoped when no review context is present', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        entityId: 'entity-1',
+        readiness: {
+          score: 72,
+          blockers: [],
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 202));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ReviewPage = (await import('../app/review/[entityId]/page')).default;
+    renderToStaticMarkup(await ReviewPage({
+      params: Promise.resolve({ entityId: 'entity-1' }),
+      searchParams: Promise.resolve({}),
+    }));
+
+    expect(reviewClientSpy).toHaveBeenCalledOnce();
+    expect(reviewClientSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      contextId: undefined,
+      bundleId: undefined,
+      sharedBy: undefined,
+    }));
+
+    const [, viewEventInit] = fetchMock.mock.calls[1] as [string, { body: string }];
+    expect(JSON.parse(viewEventInit.body)).toEqual({
+      organizationContextId: null,
+      bundleId: null,
+      readinessScore: 72,
+      blockers: [],
+    });
+  });
+
+  it('preserves review context query params on the unavailable-state retry link', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        error_description: 'Passport hydration missing.',
+      }, 404));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ReviewPage = (await import('../app/review/[entityId]/page')).default;
+    const markup = renderToStaticMarkup(await ReviewPage({
+      params: Promise.resolve({ entityId: 'entity-1' }),
+      searchParams: Promise.resolve({
+        contextId: 'ctx-1',
+        bundleId: 'bundle-1',
+        from: 'Ada Lovelace',
+      }),
+    }));
+
+    expect(reviewClientSpy).not.toHaveBeenCalled();
+    expect(markup).toContain('Employer review unavailable');
+    expect(markup).toContain('Passport hydration missing.');
+    expect(markup).toContain('/review/entity-1?contextId=ctx-1&amp;bundleId=bundle-1&amp;from=Ada+Lovelace');
+  });
+});

--- a/apps/web/app/api/request-review/route.ts
+++ b/apps/web/app/api/request-review/route.ts
@@ -1,27 +1,8 @@
-/**
- * POST /api/request-review
- *
- * Proxy to POST /api/organization-context on the backend.
- * Creates a typed org context for an employer-initiated review.
- *
- * Body:
- *   {
- *     npi:           string,           // clinician NPI to review
- *     contextType?:  string,           // defaults to EMPLOYMENT_REVIEW
- *     title?:        string,
- *     description?:  string,
- *   }
- *
- * Response:
- *   {
- *     contextId:  string,              // UUID to embed in the review link
- *     reviewUrl:  string,              // /review/[entityId]?contextId=[contextId]
- *     entityId:   string,
- *     status:     string,
- *   }
- */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  resolveEmployerWorkspaceAuthContext,
+} from '@/lib/server/employer-workspace';
 
 export const runtime = 'nodejs';
 
@@ -31,21 +12,27 @@ const B =
   process.env.NEXT_PUBLIC_BACKEND_URL ||
   'http://localhost:4000';
 
+const NPI_RE = /^\d{10}$/;
+
+function jsonError(
+  body: Record<string, unknown>,
+  status: number,
+) {
+  return NextResponse.json(body, { status });
+}
+
 export async function POST(req: NextRequest) {
-  const { userId } = await auth();
-  if (!userId) {
-    return NextResponse.json(
+  const session = await auth();
+  if (!session.userId) {
+    return jsonError(
       { error: 'Sign in with an employer workspace to request a review.' },
-      { status: 401 },
+      401,
     );
   }
 
   const body = await req.json().catch(() => null);
   if (!body || !body.npi) {
-    return NextResponse.json(
-      { error: 'npi is required.' },
-      { status: 400 },
-    );
+    return jsonError({ error: 'npi is required.' }, 400);
   }
 
   const { npi, contextType = 'EMPLOYMENT_REVIEW', title, description } = body as {
@@ -55,47 +42,110 @@ export async function POST(req: NextRequest) {
     description?: string;
   };
 
-  if (!/^\d{10}$/.test(npi)) {
-    return NextResponse.json({ error: 'npi must be a 10-digit number.' }, { status: 400 });
+  if (!NPI_RE.test(npi)) {
+    return jsonError({ error: 'npi must be a 10-digit number.' }, 400);
   }
 
-  // Step 1: Resolve the NPI to an entity ID
+  const workspaceContext = await resolveEmployerWorkspaceAuthContext();
+  if (workspaceContext.status === 'missing_workspace') {
+    return jsonError(
+      {
+        error: 'Employer workspace required to request a review.',
+        hint: 'Create or switch into an employer workspace before requesting a clinician review.',
+      },
+      403,
+    );
+  }
+
+  if (workspaceContext.status === 'workspace_lookup_failed') {
+    return jsonError(
+      { error: 'Employer workspace lookup unavailable.' },
+      workspaceContext.lookupStatus,
+    );
+  }
+
+  if (workspaceContext.status === 'missing_session') {
+    return jsonError(
+      { error: 'Sign in with an employer workspace to request a review.' },
+      401,
+    );
+  }
+
+  const employerWorkspaceNpi = workspaceContext.activeOrg.npi?.trim() ?? '';
+  if (!NPI_RE.test(employerWorkspaceNpi)) {
+    return jsonError(
+      {
+        error: 'Employer workspace is missing a resolvable organization NPI.',
+        hint: 'Add a valid Type 2 NPI to the active employer workspace before requesting a clinician review.',
+      },
+      409,
+    );
+  }
+
+  const requestorEntityRes = await fetch(`${B}/api/entity/resolve/npi/${employerWorkspaceNpi}`, {
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (!requestorEntityRes.ok) {
+    return jsonError(
+      { error: 'Employer workspace could not be linked to a requestor entity.' },
+      requestorEntityRes.status,
+    );
+  }
+
+  const requestorEntityPayload = await requestorEntityRes.json().catch(() => ({})) as {
+    entity?: {
+      id?: string;
+      npiType?: string;
+    };
+  };
+  const requestorEntityId = requestorEntityPayload.entity?.id?.trim();
+  if (!requestorEntityId) {
+    return jsonError(
+      { error: 'Employer workspace entity resolution returned no entity id.' },
+      502,
+    );
+  }
+
   const passportRes = await fetch(`${B}/api/passport/npi/${npi}`, {
     headers: { Accept: 'application/json' },
     cache: 'no-store',
+    signal: AbortSignal.timeout(8_000),
   });
 
   if (!passportRes.ok) {
     if (passportRes.status === 404) {
-      return NextResponse.json(
+      return jsonError(
         { error: 'No passport found for that NPI. The clinician must run a readiness check first.' },
-        { status: 404 },
+        404,
       );
     }
-    return NextResponse.json(
+    return jsonError(
       { error: 'Could not resolve passport for that NPI.' },
-      { status: passportRes.status },
+      passportRes.status,
     );
   }
 
-  const passport = await passportRes.json() as { entityId: string; identity?: { displayName?: string } };
+  const passport = await passportRes.json() as {
+    entityId: string;
+    identity?: { displayName?: string };
+  };
   const entityId = passport.entityId;
   if (!entityId) {
-    return NextResponse.json(
-      { error: 'Passport record found but entity ID is missing.' },
-      { status: 500 },
-    );
+    return jsonError({ error: 'Passport found but entity ID is missing.' }, 500);
   }
 
-  // Step 2: Create the org context
   const orgRes = await fetch(`${B}/api/organization-context`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-clerk-user-id': userId,
+      'x-clerk-user-id': workspaceContext.userId ?? '',
+      ...(workspaceContext.email ? { 'x-clerk-user-email': workspaceContext.email } : {}),
+      'x-org-id': workspaceContext.activeOrg.organizationId,
     },
     body: JSON.stringify({
-      requestorEntityId: userId,   // employer's Clerk user ID (backend maps to entity if registered)
+      requestorEntityId,
       contextType,
       title: title ?? `Employment review — NPI ${npi}`,
       description: description ?? `Employer-initiated review for clinician NPI ${npi}.`,
@@ -103,19 +153,14 @@ export async function POST(req: NextRequest) {
     }),
   });
 
-  // If the requestor isn't registered as a VcvEntity, fall back to a direct context stub
-  // that still lets the review flow work with the share/review infrastructure.
   if (!orgRes.ok) {
     const orgErr = await orgRes.json().catch(() => ({})) as { error?: string };
-
-    // If it's a foreign-key error (requestorEntityId not in vcv_entities), we note this clearly.
-    const errMsg = orgErr.error ?? 'Could not create review context.';
-    return NextResponse.json(
+    return jsonError(
       {
-        error: errMsg,
+        error: orgErr.error ?? 'Could not create review context.',
         hint: 'Employer must be registered as a VcvEntity. Contact VitalCV to set up an employer workspace.',
       },
-      { status: orgRes.status },
+      orgRes.status,
     );
   }
 

--- a/apps/web/app/api/request-review/route.ts
+++ b/apps/web/app/api/request-review/route.ts
@@ -1,7 +1,30 @@
-import { auth } from '@clerk/nextjs/server';
+/**
+ * POST /api/request-review
+ *
+ * Proxy to POST /api/organization-context on the backend.
+ * Creates a typed org context for an employer-initiated review.
+ *
+ * Body:
+ *   {
+ *     npi:           string,           // clinician NPI to review
+ *     contextType?:  string,           // defaults to EMPLOYMENT_REVIEW
+ *     title?:        string,
+ *     description?:  string,
+ *   }
+ *
+ * Response:
+ *   {
+ *     contextId:    string,            // UUID to embed in the review link
+ *     reviewUrl:    string,            // /review/[entityId]?contextId=[contextId]
+ *     entityId:     string,
+ *     status:       string,
+ *     npi:          string,
+ *     displayName:  string | null,
+ *   }
+ */
 import { NextRequest, NextResponse } from 'next/server';
 import {
-  resolveEmployerWorkspaceAuthContext,
+  resolveEmployerWorkspaceRequestorContext,
 } from '@/lib/server/employer-workspace';
 
 export const runtime = 'nodejs';
@@ -22,14 +45,6 @@ function jsonError(
 }
 
 export async function POST(req: NextRequest) {
-  const session = await auth();
-  if (!session.userId) {
-    return jsonError(
-      { error: 'Sign in with an employer workspace to request a review.' },
-      401,
-    );
-  }
-
   const body = await req.json().catch(() => null);
   if (!body || !body.npi) {
     return jsonError({ error: 'npi is required.' }, 400);
@@ -46,68 +61,16 @@ export async function POST(req: NextRequest) {
     return jsonError({ error: 'npi must be a 10-digit number.' }, 400);
   }
 
-  const workspaceContext = await resolveEmployerWorkspaceAuthContext();
-  if (workspaceContext.status === 'missing_workspace') {
-    return jsonError(
-      {
-        error: 'Employer workspace required to request a review.',
-        hint: 'Create or switch into an employer workspace before requesting a clinician review.',
-      },
-      403,
-    );
+  // Resolve employer workspace — validates session, active org, and entity registration
+  const workspaceCtx = await resolveEmployerWorkspaceRequestorContext();
+  if (workspaceCtx.status === 'blocked') {
+    const { status, ...body } = workspaceCtx.response;
+    return jsonError(body, status);
   }
 
-  if (workspaceContext.status === 'workspace_lookup_failed') {
-    return jsonError(
-      { error: 'Employer workspace lookup unavailable.' },
-      workspaceContext.lookupStatus,
-    );
-  }
+  const { userId, email, activeOrg, requestorEntityId } = workspaceCtx;
 
-  if (workspaceContext.status === 'missing_session') {
-    return jsonError(
-      { error: 'Sign in with an employer workspace to request a review.' },
-      401,
-    );
-  }
-
-  const employerWorkspaceNpi = workspaceContext.activeOrg.npi?.trim() ?? '';
-  if (!NPI_RE.test(employerWorkspaceNpi)) {
-    return jsonError(
-      {
-        error: 'Employer workspace is missing a resolvable organization NPI.',
-        hint: 'Add a valid Type 2 NPI to the active employer workspace before requesting a clinician review.',
-      },
-      409,
-    );
-  }
-
-  const requestorEntityRes = await fetch(`${B}/api/entity/resolve/npi/${employerWorkspaceNpi}`, {
-    headers: { Accept: 'application/json' },
-    cache: 'no-store',
-    signal: AbortSignal.timeout(8_000),
-  });
-  if (!requestorEntityRes.ok) {
-    return jsonError(
-      { error: 'Employer workspace could not be linked to a requestor entity.' },
-      requestorEntityRes.status,
-    );
-  }
-
-  const requestorEntityPayload = await requestorEntityRes.json().catch(() => ({})) as {
-    entity?: {
-      id?: string;
-      npiType?: string;
-    };
-  };
-  const requestorEntityId = requestorEntityPayload.entity?.id?.trim();
-  if (!requestorEntityId) {
-    return jsonError(
-      { error: 'Employer workspace entity resolution returned no entity id.' },
-      502,
-    );
-  }
-
+  // Resolve clinician passport
   const passportRes = await fetch(`${B}/api/passport/npi/${npi}`, {
     headers: { Accept: 'application/json' },
     cache: 'no-store',
@@ -117,7 +80,12 @@ export async function POST(req: NextRequest) {
   if (!passportRes.ok) {
     if (passportRes.status === 404) {
       return jsonError(
-        { error: 'No passport found for that NPI. The clinician must run a readiness check first.' },
+        {
+          code: 'CLINICIAN_PASSPORT_REQUIRED',
+          error: 'No passport found for that NPI. The clinician must run a readiness check first.',
+          hint: 'Ask the clinician to run a readiness check before creating an employer review context.',
+          nextStep: 'run_clinician_readiness',
+        },
         404,
       );
     }
@@ -136,14 +104,19 @@ export async function POST(req: NextRequest) {
     return jsonError({ error: 'Passport found but entity ID is missing.' }, 500);
   }
 
+  // Create organization context
+  const orgHeaders = new Headers({
+    'Content-Type': 'application/json',
+    'x-clerk-user-id': userId,
+    'x-org-id': activeOrg.organizationId,
+  });
+  if (email) {
+    orgHeaders.set('x-clerk-user-email', email);
+  }
+
   const orgRes = await fetch(`${B}/api/organization-context`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-clerk-user-id': workspaceContext.userId ?? '',
-      ...(workspaceContext.email ? { 'x-clerk-user-email': workspaceContext.email } : {}),
-      'x-org-id': workspaceContext.activeOrg.organizationId,
-    },
+    headers: orgHeaders,
     body: JSON.stringify({
       requestorEntityId,
       contextType,

--- a/apps/web/app/review/[entityId]/page.tsx
+++ b/apps/web/app/review/[entityId]/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Link from 'next/link';
 import ReviewClient from '@/components/review/ReviewClient';
 import { Button } from '@/components/ui/button';
@@ -52,6 +53,7 @@ async function fireReviewOpenedEvent(
   entityId: string,
   passport: { readiness: { score?: number; blockers?: string[] } } | null,
   contextId?: string,
+  bundleId?: string,
 ): Promise<void> {
   // POST /api/employer-review/:entityId/view — always 202, non-blocking
   try {
@@ -60,6 +62,7 @@ async function fireReviewOpenedEvent(
       headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify({
         organizationContextId: contextId ?? null,
+        bundleId:              bundleId ?? null,
         readinessScore:        passport?.readiness?.score ?? null,
         blockers:              passport?.readiness?.blockers ?? [],
       }),
@@ -76,15 +79,16 @@ export default async function ReviewPage({
   searchParams,
 }: {
   params:       Promise<{ entityId: string }>;
-  searchParams: Promise<{ contextId?: string; from?: string }>;
+  searchParams: Promise<{ contextId?: string; bundleId?: string; from?: string }>;
 }) {
-  const { entityId }          = await params;
-  const { contextId, from }   = await searchParams;
-  const { passport, errorMessage } = await fetchReviewPageData(entityId);
-  const retryHref = `/review/${entityId}${contextId || from
+  const { entityId }                    = await params;
+  const { contextId, bundleId, from }   = await searchParams;
+  const { passport, errorMessage }      = await fetchReviewPageData(entityId);
+  const retryHref = `/review/${entityId}${contextId || bundleId || from
     ? `?${new URLSearchParams({
         ...(contextId ? { contextId } : {}),
-        ...(from ? { from } : {}),
+        ...(bundleId  ? { bundleId  } : {}),
+        ...(from      ? { from      } : {}),
       }).toString()}`
     : ''}`;
 
@@ -122,12 +126,13 @@ export default async function ReviewPage({
   }
 
   // KPI: record employer review open — fire-and-forget, never blocks render
-  void fireReviewOpenedEvent(entityId, passport, contextId);
+  void fireReviewOpenedEvent(entityId, passport, contextId, bundleId);
 
   return (
     <ReviewClient
       passport={passport}
       contextId={contextId}
+      bundleId={bundleId}
       sharedBy={from}
     />
   );

--- a/apps/web/components/employer/EmployerWorkspaceSetup.tsx
+++ b/apps/web/components/employer/EmployerWorkspaceSetup.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * EmployerWorkspaceSetup — minimal bootstrap for an employer workspace.
+ *
+ * When a pilot employer tries to create an org context but their Clerk user
+ * isn't yet registered as a VcvEntity, this panel collects just the org name
+ * and calls POST /api/employer/setup to upsert the profile.
+ *
+ * After success, the parent can retry the review-context creation.
+ *
+ * Scope: pilot-minimal. Gets an employer unblocked. Full admin workspace is separate.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card } from '@/components/ui/card';
+
+interface Props {
+  /** Called after a successful setup so the parent can retry. */
+  onSetupComplete: (orgName: string) => void;
+  /** Optional hint text to show above the form. */
+  hint?: string;
+}
+
+type SetupPhase = 'form' | 'loading' | 'done' | 'error';
+
+export function EmployerWorkspaceSetup({ onSetupComplete, hint }: Props) {
+  const [orgName, setOrgName] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<SetupPhase>('form');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = orgName.trim();
+    if (!trimmed) {
+      setNameError('Organization name is required.');
+      return;
+    }
+    setNameError(null);
+    setPhase('loading');
+    setErrorMsg(null);
+
+    try {
+      const res = await fetch('/api/employer/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      });
+
+      const data = await res.json() as { organizationId?: string; error?: string };
+
+      if (!res.ok) {
+        const msg = data.error ?? 'Setup failed. Try again.';
+        setErrorMsg(msg);
+        setPhase('error');
+        return;
+      }
+
+      setPhase('done');
+      onSetupComplete(trimmed);
+    } catch {
+      setErrorMsg('Setup request failed. Check your connection and try again.');
+      setPhase('error');
+    }
+  }
+
+  return (
+    <div className="space-y-4 animate-fade-in-up">
+      <Card className="rounded-xl border-amber-500/20 bg-amber-500/8 px-4 py-3 shadow-none">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-300/70">
+          Employer workspace required
+        </p>
+        <p className="mt-1 text-xs text-white/50 leading-relaxed">
+          {hint ?? 'Your account needs an employer workspace to create review contexts. Set one up now to continue.'}
+        </p>
+      </Card>
+
+      {phase === 'form' || phase === 'error' ? (
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="org-name" className="text-xs text-white/40 mb-1 block">
+              Organization name
+            </label>
+            <Input
+              id="org-name"
+              type="text"
+              value={orgName}
+              onChange={e => {
+                setOrgName(e.target.value);
+                if (nameError) setNameError(null);
+              }}
+              placeholder="Hospital name, practice, or organization"
+              className="h-12 w-full rounded-xl border-white/12 bg-white/6 px-4 text-sm text-white placeholder:text-white/25 shadow-none focus-visible:border-white/30 focus-visible:ring-white/10"
+            />
+            {nameError && (
+              <p className="mt-1 text-xs text-red-400/70">{nameError}</p>
+            )}
+          </div>
+
+          {errorMsg && (
+            <Card className="rounded-xl border-rose-500/20 bg-rose-500/8 px-3 py-2 shadow-none">
+              <p className="text-xs text-rose-300/80">{errorMsg}</p>
+            </Card>
+          )}
+
+          <Button
+            type="submit"
+            variant="outline"
+            disabled={!orgName.trim()}
+            className="h-11 w-full rounded-xl border-white/15 bg-white/5 text-sm font-medium text-white/70 hover:border-white/25 hover:bg-white/8 hover:text-white disabled:opacity-40"
+          >
+            Set up employer workspace
+          </Button>
+          <p className="text-center text-white/20 text-[10px] leading-relaxed">
+            This registers your account as an employer workspace. You can add more details later.
+          </p>
+        </form>
+      ) : phase === 'loading' ? (
+        <Card className="rounded-xl border-white/8 bg-white/3 px-4 py-4 shadow-none text-center">
+          <p className="text-white/45 text-sm">Setting up workspace…</p>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/employer/RequestReviewPanel.tsx
+++ b/apps/web/components/employer/RequestReviewPanel.tsx
@@ -1,26 +1,26 @@
 'use client';
 
-import React from 'react';
-
 /**
- * RequestReviewPanel — Employer-initiated org context creation.
+ * RequestReviewPanel — Employer-initiated review context creation.
  *
- * Flow:
- *   1. Employer enters clinician NPI
- *   2. POST /api/request-review → backend creates vcvOrganizationContext
- *   3. Returns a review link: /review/[entityId]?contextId=[contextId]
- *   4. Employer copies link and sends to clinician (or opens directly)
+ * States:
+ *   idle           → NPI form
+ *   loading        → creating context
+ *   needs_setup    → employer workspace not found; shows EmployerWorkspaceSetup inline
+ *   done           → context created, review link ready
+ *   error          → generic error with retry
  *
- * Auth: requires employer workspace sign-in.
- * If not signed in, shows a clear sign-in prompt.
+ * Auth:
+ *   not_signed_in  → sign-in prompt (Clerk enabled) or direct form (no Clerk)
  */
 
-import { useState, useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card } from '@/components/ui/card';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
+import { EmployerWorkspaceSetup } from './EmployerWorkspaceSetup';
 import { useRoleContext } from '@/components/auth/RoleContext';
 import {
   CLERK_PROVIDER_ENABLED,
@@ -36,7 +36,7 @@ interface ReviewRequestResult {
   status: string;
 }
 
-type Phase = 'idle' | 'loading' | 'done' | 'error';
+type Phase = 'idle' | 'loading' | 'needs_setup' | 'done' | 'error';
 
 export function RequestReviewPanel() {
   const [npi, setNpi] = useState('');
@@ -44,37 +44,46 @@ export function RequestReviewPanel() {
   const [phase, setPhase] = useState<Phase>('idle');
   const [result, setResult] = useState<ReviewRequestResult | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [setupHint, setSetupHint] = useState<string | undefined>(undefined);
   const [copied, setCopied] = useState(false);
-  const autoTriggered = useRef(false);
+  const lastNpiRef = useRef<string>('');
 
   const { isLoaded, isSignedIn } = useRoleContext();
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const trimmed = npi.trim();
-    if (!/^\d{10}$/.test(trimmed)) {
-      setNpiError('Enter a valid 10-digit NPI.');
-      return;
-    }
+  async function submitRequest(npiValue: string) {
     setNpiError(null);
     setPhase('loading');
     setResult(null);
     setErrorMsg(null);
     setCopied(false);
+    lastNpiRef.current = npiValue;
 
     try {
       const res = await fetch('/api/request-review', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ npi: trimmed }),
+        body: JSON.stringify({ npi: npiValue }),
       });
 
-      const data = await res.json() as ReviewRequestResult & { error?: string; hint?: string };
+      const data = await res.json() as ReviewRequestResult & {
+        error?: string;
+        hint?: string;
+      };
 
       if (!res.ok) {
-        const msg = data.error ?? 'Could not create review context.';
-        const hint = data.hint ? `\n${data.hint}` : '';
-        setErrorMsg(msg + hint);
+        // Employer workspace not registered — show bootstrap inline
+        if (res.status === 404 && data.hint?.includes('VcvEntity')) {
+          setSetupHint(data.hint);
+          setPhase('needs_setup');
+          return;
+        }
+        if (res.status === 422 && data.hint?.includes('VcvEntity')) {
+          setSetupHint(data.hint);
+          setPhase('needs_setup');
+          return;
+        }
+
+        setErrorMsg(data.error ?? 'Could not create review context.');
         setPhase('error');
         return;
       }
@@ -87,15 +96,23 @@ export function RequestReviewPanel() {
     }
   }
 
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = npi.trim();
+    if (!/^\d{10}$/.test(trimmed)) {
+      setNpiError('Enter a valid 10-digit NPI.');
+      return;
+    }
+    void submitRequest(trimmed);
+  }
+
   async function handleCopy() {
     if (!result?.reviewUrl) return;
     try {
       await navigator.clipboard.writeText(result.reviewUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 3000);
-    } catch {
-      // Fallback: select the text
-    }
+    } catch { /* silent — URL visible in DOM */ }
   }
 
   function handleReset() {
@@ -105,10 +122,10 @@ export function RequestReviewPanel() {
     setNpi('');
     setNpiError(null);
     setCopied(false);
-    autoTriggered.current = false;
+    setSetupHint(undefined);
   }
 
-  // Not signed in — show sign-in prompt
+  // Not signed in
   if (CLERK_PROVIDER_ENABLED && isLoaded && !isSignedIn) {
     return (
       <TrustStateCard
@@ -142,7 +159,8 @@ export function RequestReviewPanel() {
         </p>
       </div>
 
-      {phase === 'idle' || phase === 'error' ? (
+      {/* NPI form — idle or error */}
+      {(phase === 'idle' || phase === 'error') && (
         <form onSubmit={handleSubmit} className="space-y-3">
           <label htmlFor="employer-npi" className="sr-only">Clinician NPI</label>
           <Input
@@ -158,12 +176,10 @@ export function RequestReviewPanel() {
             placeholder="Clinician NPI (10 digits)"
             className="h-14 w-full rounded-xl border-white/12 bg-white/6 px-4 text-[16px] text-white placeholder:text-white/30 shadow-none focus-visible:border-white/30 focus-visible:bg-white/8 focus-visible:ring-white/10"
           />
-          {npiError && (
-            <p className="text-xs text-red-400/70">{npiError}</p>
-          )}
-          {errorMsg && (
+          {npiError && <p className="text-xs text-red-400/70">{npiError}</p>}
+          {phase === 'error' && errorMsg && (
             <Card className="rounded-xl border-rose-500/20 bg-rose-500/8 px-4 py-3 shadow-none">
-              <p className="text-sm text-rose-300/80 leading-relaxed whitespace-pre-line">{errorMsg}</p>
+              <p className="text-sm text-rose-300/80 leading-relaxed">{errorMsg}</p>
             </Card>
           )}
           <Button
@@ -175,14 +191,35 @@ export function RequestReviewPanel() {
             Create review context
           </Button>
         </form>
-      ) : phase === 'loading' ? (
+      )}
+
+      {/* Loading */}
+      {phase === 'loading' && (
         <Card className="rounded-xl border-white/8 bg-white/3 px-5 py-6 shadow-none text-center">
           <p className="text-white/50 text-sm">Creating review context…</p>
-          <p className="mt-1 text-white/25 text-xs">Resolving NPI and registering context with the audit trail.</p>
+          <p className="mt-1 text-white/25 text-xs">Resolving NPI and registering context.</p>
         </Card>
-      ) : result ? (
+      )}
+
+      {/* Needs workspace setup */}
+      {phase === 'needs_setup' && (
+        <EmployerWorkspaceSetup
+          hint={setupHint}
+          onSetupComplete={() => {
+            // Auto-retry context creation after workspace is set up
+            const npiToRetry = lastNpiRef.current;
+            if (npiToRetry) {
+              void submitRequest(npiToRetry);
+            } else {
+              setPhase('idle');
+            }
+          }}
+        />
+      )}
+
+      {/* Success */}
+      {phase === 'done' && result && (
         <div className="space-y-4 animate-fade-in-up">
-          {/* Context created confirmation */}
           <Card className="rounded-xl border-emerald-500/20 bg-emerald-500/8 px-5 py-4 shadow-none">
             <div className="flex items-center gap-2">
               <span className="text-emerald-400 text-sm">✔</span>
@@ -201,13 +238,13 @@ export function RequestReviewPanel() {
             </div>
           </Card>
 
-          {/* Review link */}
           <Card className="rounded-xl border-white/8 bg-white/3 px-5 py-4 shadow-none space-y-3">
             <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/30">
               Review link
             </p>
             <p className="text-xs leading-relaxed text-white/40">
-              Send this to the clinician, or open it yourself to see their passport in employer review mode.
+              Send this to the clinician, or open it yourself to see their passport in employer
+              review mode. Employer actions on this review will be recorded in the audit trail.
             </p>
             <div className="rounded-lg border border-white/8 bg-black/15 px-3 py-2">
               <p className="text-[11px] font-mono text-white/55 break-all">{result.reviewUrl}</p>
@@ -228,9 +265,8 @@ export function RequestReviewPanel() {
             </div>
           </Card>
 
-          {/* Attribution note */}
           <p className="text-center text-white/20 text-xs leading-relaxed">
-            Employer actions on this review will be recorded against context{' '}
+            Employer actions on this review are recorded against context{' '}
             <span className="font-mono">{result.contextId.slice(0, 8)}…</span> in the audit trail.
           </p>
 
@@ -242,7 +278,7 @@ export function RequestReviewPanel() {
             Request another review
           </Button>
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -275,7 +275,7 @@ function buildEligibilityRow(passport: PassportData, status: 'ENROLLED' | 'NOT_F
 interface Props {
   passport:   PassportData;
   contextId?: string;
-  bundleId?: string;
+  bundleId?:  string;
   sharedBy?:  string;
 }
 
@@ -696,7 +696,8 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
         </div>
 
         {/* ── Share context (if accessed via share link) ───────────────────── */}
-        {(sharedBy || contextId || bundleId) && (
+        {/* ── Review context attribution ────────────────────────────────────── */}
+        {(sharedBy || contextId || bundleId) ? (
           <Card className="gap-2 rounded-xl border-white/8 bg-white/[0.03] px-4 py-3 shadow-none">
             {sharedBy && (
               <div className="flex justify-between text-xs">
@@ -725,9 +726,8 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
               <span className="text-white/45">Actions tied to this context</span>
             </div>
           </Card>
-        )}
-        {/* No context — direct view, actions not context-attributed */}
-        {!sharedBy && !contextId && !bundleId && (
+        ) : (
+          /* No context — direct view without employer-initiated context */
           <Card className="gap-2 rounded-xl border-amber-500/15 bg-amber-500/5 px-4 py-3 shadow-none">
             <div className="flex justify-between text-xs">
               <span className="text-white/35">Review context</span>
@@ -735,7 +735,10 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
             </div>
             <p className="text-[10px] text-white/28 leading-relaxed mt-0.5">
               Actions here are not tied to a confirmed employer context.{' '}
-              <Link href="/review/request" className="text-white/45 underline underline-offset-2 hover:text-white/65 transition-colors">
+              <Link
+                href="/review/request"
+                className="text-white/45 underline underline-offset-2 hover:text-white/65 transition-colors"
+              >
                 Request a review context
               </Link>{' '}
               for auditable decisions.

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -695,9 +695,8 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
           <span className="text-white/25 text-xs">Employer review</span>
         </div>
 
-        {/* ── Share context (if accessed via share link) ───────────────────── */}
         {/* ── Review context attribution ────────────────────────────────────── */}
-        {(sharedBy || contextId || bundleId) ? (
+        {(sharedBy || contextId || bundleId) && (
           <Card className="gap-2 rounded-xl border-white/8 bg-white/[0.03] px-4 py-3 shadow-none">
             {sharedBy && (
               <div className="flex justify-between text-xs">
@@ -726,8 +725,9 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
               <span className="text-white/45">Actions tied to this context</span>
             </div>
           </Card>
-        ) : (
-          /* No context — direct view without employer-initiated context */
+        )}
+        {/* No context — direct view, actions not context-attributed */}
+        {!sharedBy && !contextId && !bundleId && (
           <Card className="gap-2 rounded-xl border-amber-500/15 bg-amber-500/5 px-4 py-3 shadow-none">
             <div className="flex justify-between text-xs">
               <span className="text-white/35">Review context</span>

--- a/apps/web/lib/request-review-contract.ts
+++ b/apps/web/lib/request-review-contract.ts
@@ -1,0 +1,37 @@
+export type RequestReviewFailureCode =
+  | 'EMPLOYER_SESSION_REQUIRED'
+  | 'EMPLOYER_WORKSPACE_REQUIRED'
+  | 'EMPLOYER_WORKSPACE_LOOKUP_FAILED'
+  | 'EMPLOYER_WORKSPACE_IDENTITY_REQUIRED'
+  | 'EMPLOYER_REQUESTOR_ENTITY_REQUIRED'
+  | 'CLINICIAN_PASSPORT_REQUIRED'
+  | 'REQUEST_REVIEW_UNAVAILABLE';
+
+export type RequestReviewNextStep =
+  | 'sign_in'
+  | 'create_workspace'
+  | 'complete_workspace_identity'
+  | 'run_clinician_readiness'
+  | 'retry_request_review';
+
+export interface RequestReviewErrorPayload {
+  code: RequestReviewFailureCode;
+  error: string;
+  hint?: string;
+  nextStep: RequestReviewNextStep;
+}
+
+export function isRequestReviewErrorPayload(
+  value: unknown,
+): value is RequestReviewErrorPayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.code === 'string'
+    && typeof record.error === 'string'
+    && typeof record.nextStep === 'string'
+  );
+}

--- a/apps/web/lib/server/employer-workspace.ts
+++ b/apps/web/lib/server/employer-workspace.ts
@@ -1,0 +1,318 @@
+import { auth } from '@clerk/nextjs/server';
+import type {
+  WorkspaceList,
+  WorkspaceOrganizationProfile,
+} from '@/types/workspace';
+import type { RequestReviewErrorPayload } from '@/lib/request-review-contract';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+type EmployerWorkspaceAuthBase = {
+  email: string | null;
+  userId: string | null;
+};
+
+type EmployerWorkspaceAuthenticatedBase = {
+  email: string | null;
+  userId: string;
+};
+
+export type EmployerWorkspaceAuthContext =
+  | (EmployerWorkspaceAuthBase & {
+      status: 'missing_session';
+    })
+  | (EmployerWorkspaceAuthenticatedBase & {
+      status: 'missing_workspace';
+      workspace: WorkspaceList | null;
+    })
+  | (EmployerWorkspaceAuthenticatedBase & {
+      status: 'workspace_lookup_failed';
+      lookupStatus: number;
+    })
+  | (EmployerWorkspaceAuthenticatedBase & {
+      status: 'ready';
+      activeOrg: WorkspaceOrganizationProfile;
+      workspace: WorkspaceList;
+    });
+
+type EmployerWorkspaceRequestorFailure = RequestReviewErrorPayload & {
+  status: number;
+};
+
+export type EmployerWorkspaceRequestorContext =
+  | {
+      status: 'ready';
+      workspace: WorkspaceList;
+      activeOrg: WorkspaceOrganizationProfile;
+      userId: string;
+      email: string | null;
+      requestorEntityId: string;
+    }
+  | {
+      status: 'blocked';
+      response: EmployerWorkspaceRequestorFailure;
+    };
+
+function parseSessionEmail(
+  session: Awaited<ReturnType<typeof auth>>,
+): string | null {
+  const claims = session.sessionClaims as Record<string, unknown> | undefined;
+  return typeof claims?.email === 'string' ? claims.email : null;
+}
+
+function findActiveEmployerOrg(
+  workspace: WorkspaceList | null,
+): WorkspaceOrganizationProfile | null {
+  if (!workspace) {
+    return null;
+  }
+
+  if (workspace.activePersona === 'CLINICIAN') {
+    return null;
+  }
+
+  const activeOrgId = typeof workspace.activeOrgId === 'string'
+    ? workspace.activeOrgId.trim()
+    : '';
+  if (!activeOrgId) {
+    return null;
+  }
+
+  const membership = workspace.memberships.find((candidate) => (
+    candidate.active
+    && candidate.role !== 'HOLDER'
+    && candidate.org.organizationId === activeOrgId
+  ));
+
+  return membership?.org ?? null;
+}
+
+function buildRequestReviewFailure(
+  status: number,
+  response: RequestReviewErrorPayload,
+): EmployerWorkspaceRequestorContext {
+  return {
+    status: 'blocked',
+    response: {
+      status,
+      ...response,
+    },
+  };
+}
+
+async function readJson<T>(response: Response): Promise<T | null> {
+  return response.json().catch(() => null) as Promise<T | null>;
+}
+
+export async function resolveEmployerWorkspaceAuthContext(): Promise<EmployerWorkspaceAuthContext> {
+  const session = await auth();
+  const userId = session.userId ?? null;
+  const email = parseSessionEmail(session);
+
+  if (!userId) {
+    return {
+      status: 'missing_session',
+      userId: null,
+      email,
+    };
+  }
+
+  const headers = new Headers();
+  headers.set('x-clerk-user-id', userId);
+  if (email) {
+    headers.set('x-clerk-user-email', email);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${BACKEND}/api/me/workspaces`, {
+      headers,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8_000),
+    });
+  } catch {
+    return {
+      status: 'workspace_lookup_failed',
+      userId,
+      email,
+      lookupStatus: 503,
+    };
+  }
+
+  if (!response.ok) {
+    if (response.status >= 500) {
+      return {
+        status: 'workspace_lookup_failed',
+        userId,
+        email,
+        lookupStatus: response.status,
+      };
+    }
+
+    return {
+      status: 'missing_workspace',
+      userId,
+      email,
+      workspace: null,
+    };
+  }
+
+  const workspace = await response.json().catch(() => null) as WorkspaceList | null;
+  const activeOrg = findActiveEmployerOrg(workspace);
+  if (!workspace || !activeOrg) {
+    return {
+      status: 'missing_workspace',
+      userId,
+      email,
+      workspace,
+    };
+  }
+
+  return {
+    status: 'ready',
+    userId,
+    email,
+    workspace,
+    activeOrg,
+  };
+}
+
+export async function resolveEmployerWorkspaceRequestorContext(): Promise<EmployerWorkspaceRequestorContext> {
+  const authContext = await resolveEmployerWorkspaceAuthContext();
+
+  if (authContext.status === 'missing_session') {
+    return buildRequestReviewFailure(401, {
+      code: 'EMPLOYER_SESSION_REQUIRED',
+      error: 'Sign in with an employer workspace to request a review.',
+      nextStep: 'sign_in',
+    });
+  }
+
+  if (authContext.status === 'missing_workspace') {
+    return buildRequestReviewFailure(403, {
+      code: 'EMPLOYER_WORKSPACE_REQUIRED',
+      error: 'Employer workspace required to request a review.',
+      hint: 'Create or switch into an employer workspace before requesting a clinician review.',
+      nextStep: 'create_workspace',
+    });
+  }
+
+  if (authContext.status === 'workspace_lookup_failed') {
+    return buildRequestReviewFailure(authContext.lookupStatus, {
+      code: 'EMPLOYER_WORKSPACE_LOOKUP_FAILED',
+      error: 'Employer workspace lookup unavailable.',
+      hint: 'Try again once workspace services are available.',
+      nextStep: 'retry_request_review',
+    });
+  }
+
+  if (authContext.status !== 'ready') {
+    return buildRequestReviewFailure(503, {
+      code: 'EMPLOYER_WORKSPACE_LOOKUP_FAILED',
+      error: 'Employer workspace lookup unavailable.',
+      hint: 'Try again once workspace services are available.',
+      nextStep: 'retry_request_review',
+    });
+  }
+
+  const readyAuthContext: Extract<EmployerWorkspaceAuthContext, { status: 'ready' }> = authContext;
+  const employerWorkspaceNpi = readyAuthContext.activeOrg.npi?.trim() ?? '';
+  if (!/^\d{10}$/.test(employerWorkspaceNpi)) {
+    return buildRequestReviewFailure(409, {
+      code: 'EMPLOYER_WORKSPACE_IDENTITY_REQUIRED',
+      error: 'Employer workspace is missing a resolvable organization NPI.',
+      hint: 'Add a valid Type 2 NPI to the active employer workspace before requesting a clinician review.',
+      nextStep: 'complete_workspace_identity',
+    });
+  }
+
+  if (readyAuthContext.activeOrg.npiType && readyAuthContext.activeOrg.npiType !== 'TYPE_2') {
+    return buildRequestReviewFailure(409, {
+      code: 'EMPLOYER_WORKSPACE_IDENTITY_REQUIRED',
+      error: 'Employer workspace must use a Type 2 organization NPI.',
+      hint: 'Update the active employer workspace to a Type 2 organization NPI before requesting a clinician review.',
+      nextStep: 'complete_workspace_identity',
+    });
+  }
+
+  try {
+    const entityRes = await fetch(`${BACKEND}/api/entity/resolve/npi/${employerWorkspaceNpi}`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8_000),
+    });
+    const entityPayload = await readJson<{
+      entity?: {
+        id?: string;
+        npiType?: string;
+      };
+      error?: string;
+    }>(entityRes);
+
+    if (!entityRes.ok) {
+      return buildRequestReviewFailure(
+        entityRes.status >= 500 ? entityRes.status : 409,
+        {
+          code: entityRes.status >= 500
+            ? 'EMPLOYER_WORKSPACE_LOOKUP_FAILED'
+            : 'EMPLOYER_REQUESTOR_ENTITY_REQUIRED',
+          error: entityRes.status >= 500
+            ? 'Employer workspace requestor lookup unavailable.'
+            : (entityPayload?.error ?? 'Employer workspace could not be linked to a requestor entity.'),
+          hint: entityRes.status >= 500
+            ? 'Try again once workspace services are available.'
+            : 'Complete employer workspace setup with a valid Type 2 NPI so VitalCV can resolve the requestor entity.',
+          nextStep: entityRes.status >= 500 ? 'retry_request_review' : 'complete_workspace_identity',
+        },
+      );
+    }
+
+    const resolvedEntity = entityPayload?.entity;
+    const requestorEntityId = resolvedEntity?.id?.trim();
+    if (!requestorEntityId || resolvedEntity?.npiType !== 'TYPE_2') {
+      return buildRequestReviewFailure(409, {
+        code: 'EMPLOYER_REQUESTOR_ENTITY_REQUIRED',
+        error: 'Employer workspace could not be linked to a valid employer requestor entity.',
+        hint: 'Complete employer workspace setup with a valid Type 2 NPI so VitalCV can resolve the requestor entity.',
+        nextStep: 'complete_workspace_identity',
+      });
+    }
+
+    return {
+      status: 'ready',
+      workspace: readyAuthContext.workspace,
+      activeOrg: readyAuthContext.activeOrg,
+      userId: readyAuthContext.userId,
+      email: readyAuthContext.email,
+      requestorEntityId,
+    };
+  } catch {
+    return buildRequestReviewFailure(503, {
+      code: 'EMPLOYER_WORKSPACE_LOOKUP_FAILED',
+      error: 'Employer workspace requestor lookup unavailable.',
+      hint: 'Try again once workspace services are available.',
+      nextStep: 'retry_request_review',
+    });
+  }
+}
+
+export function buildEmployerWorkspaceHeaders(
+  context: Extract<EmployerWorkspaceAuthContext, { status: 'ready' }>,
+  init?: HeadersInit,
+): Headers {
+  const headers = new Headers(init);
+  if (context.userId) {
+    headers.set('x-clerk-user-id', context.userId);
+  }
+  headers.set('x-org-id', context.activeOrg.organizationId);
+
+  if (context.email) {
+    headers.set('x-clerk-user-email', context.email);
+  }
+
+  return headers;
+}

--- a/apps/web/lib/trust/public-wedge-parity.ts
+++ b/apps/web/lib/trust/public-wedge-parity.ts
@@ -34,6 +34,7 @@ export function buildEmployerReviewHref(
   entityId: string,
   options: {
     contextId?: string | null;
+    bundleId?: string | null;
     from?: string | null;
   } = {},
 ): string {
@@ -41,6 +42,10 @@ export function buildEmployerReviewHref(
 
   if (typeof options.contextId === 'string' && options.contextId.trim().length > 0) {
     params.set('contextId', options.contextId.trim());
+  }
+
+  if (typeof options.bundleId === 'string' && options.bundleId.trim().length > 0) {
+    params.set('bundleId', options.bundleId.trim());
   }
 
   if (typeof options.from === 'string' && options.from.trim().length > 0) {

--- a/employer-request-context-flow-audit.md
+++ b/employer-request-context-flow-audit.md
@@ -1,0 +1,132 @@
+# Employer-Request Context Flow Audit
+
+**Auditor:** Claude (VitalCV strategic/technical operator)
+**Date:** 2026-03-27
+**Scope:** Real employer-review action flow — both POVs, auth/failure states, operational readiness
+**Files reviewed:** 14 files across backend services, API routes, frontend proxy, ReviewClient, VerifierPortal, EmployerDashboard, StartClinicianAction, request context, types, tests
+
+---
+
+## Executive Summary
+
+The employer-request context flow is **production-grade on the backend** and **operationally sound on the employer decision surface**. The trust snapshot capture, transactional audit trail, and action persistence are rigorous. The frontend ReviewClient implements a clean 6-question employer flow with appropriate auth gating and failure states. Two significant gaps exist: the clinician has **zero visibility** into employer actions taken against their passport, and the VerifierPortal still carries demo-era mock patterns that diverge from the canonical review flow. Neither gap is a merge blocker for the M2 wave, but the clinician-side gap must be addressed before pilot launch.
+
+**Verdict: GO for merge. Conditional on clinician notification being roadmapped for M3.**
+
+---
+
+## 1. Employer POV Audit
+
+### What works well
+
+**Decision surface (ReviewClient.tsx)** — this is genuinely good:
+
+- **6-question layout** (Identity → Safety → Authority → Eligibility → Blockers → Next actions) maps directly to what an employer credentialing coordinator actually needs to answer. No tabs, no sidebars. Operational, not theatrical.
+- **Three-action panel** (Accept as head start / Request refresh / Route to review) covers the real decision space. The "Accept as head start" label correctly frames acceptance-with-known-gaps, which is how healthcare hiring actually works.
+- **Auth gating is clean.** Four-level cascade: Clerk disabled → not loaded → not signed in → not employer role. Each state renders a specific, understandable message in the preview-only banner. Actions are hard-disabled (not hidden) so the employer sees what's available before authenticating.
+- **Trust snapshot at decision time** is captured BEFORE the transaction and stored immutably in the audit event. This is the right pattern — the employer's decision is bound to the exact passport state they saw, not whatever it evolves to later.
+- **Loading/success/error states** are real: loading says "Writing the persisted audit record...", success shows the audit event ID and trust snapshot receipt hash, error shows the actual message with a retry button. No fake success states.
+- **Duplicate acceptance guard** returns 409 with the existing acceptanceId. Frontend doesn't handle this gracefully yet (see gaps), but backend is correct.
+- **Evidence packet export** writes an ARTIFACT_EXPORTED audit record before returning the payload. Export is never silent.
+
+### Employer POV Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| E1 | **Medium** | No confirmation dialog before accept | One click on "Accept as head start" immediately fires the POST. For a hiring decision that writes to an immutable audit ledger, there should be a "Confirm: you're accepting Dr. X with N blockers noted?" step. The cost of an accidental click is an indelible audit record. |
+| E2 | **Low** | 409 duplicate acceptance surfaces as generic error | `postAction` catches non-ok responses and throws `error_description ?? 'Action failed (409)'`. The backend sends `already_accepted` with the existing `acceptanceId`, but the frontend error handler doesn't special-case this. The employer sees "Action failed" instead of "You've already accepted this clinician." |
+| E3 | **Low** | Request-refresh body is auto-populated silently | `handleRequestRefresh` auto-fills `staleSources` and `missingDomains` from the freshness entries, but the employer never sees or confirms what's being requested. They click "Request refresh (2 stale)" and have no opportunity to add context or select specific sources. |
+| E4 | **Info** | Route-to-review auto-generates the reason string | The reason is built programmatically from blockers. An employer might want to write a note. The field exists on the backend (`reason: string`) but the UI doesn't expose a text input for it. |
+| E5 | **Info** | No "undo" or "amend" for any action | Once accepted, the employer can't revoke or amend. This is by design (immutable audit trail), but there's no copy explaining this permanence to the employer before they act. |
+| E6 | **Low** | VerifierPortal diverges from canonical flow | VerifierPortal uses hardcoded `clinician:alice` / `employer:alpha` IDs and routes through `/trust-state`, `/acceptances`, `/verify` — a completely different API surface from the canonical `employer-review` routes. It's demo-era code. If this is still linked from any employer-facing path, it will confuse users. |
+
+---
+
+## 2. Clinician POV Audit
+
+### What works well
+
+- **The passport data itself** is well-structured. The clinician's identity, credentials, standing, and readiness are all hydrated from real primary sources with freshness metadata.
+- **The share link flow** (`?from=` + `?contextId=`) lets a clinician share their passport review URL with an employer. The review page shows "Shared by" context cleanly.
+
+### Clinician POV Issues
+
+| # | Severity | Issue | Detail |
+|---|----------|-------|--------|
+| C1 | **HIGH** | Clinician has ZERO visibility into employer actions | There is no clinician-facing UI, API, or notification for: acceptance, refresh request, or route-to-review. The clinician shares their passport, then hears nothing. The outbox events are written but no consumer delivers them to the clinician. This is the #1 UX gap in the entire flow. |
+| C2 | **HIGH** | Refresh requests go to outbox but never reach the clinician | `recordEmployerReviewRefreshRequest` writes to `outboxEvent` with status PENDING, but there is no outbox consumer, no email trigger, no in-app notification. The employer thinks they've asked for updated data; the clinician never knows. |
+| C3 | **Medium** | No clinician consent or intent binding for share | The clinician can share a URL, but there's no explicit intent assertion ("I'm sharing my VitalCV passport with Employer X for the purpose of Y"). Per VitalCV doctrine, this should be a QIA-bound event with purpose binding between holder and verifier. Currently it's just a URL with a `from` query param. |
+| C4 | **Medium** | No revocation of shared access | Once shared, the clinician cannot revoke the employer's access to their review page. The passport endpoint (`/api/passport/entity/:entityId`) has no access control — it serves the passport to anyone with the entityId. |
+| C5 | **Low** | No clinician-side record of what was shared | The `fireReviewOpenedEvent` fires server-side when the employer opens the review, but this is a KPI event — the clinician has no dashboard or log showing "Employer X viewed your passport on Date Y." |
+
+---
+
+## 3. Auth & Failure States Assessment
+
+| State | Handling | Verdict |
+|-------|----------|---------|
+| Clerk disabled (dev/test) | Preview-only banner, actions disabled, explicit message | ✅ Correct |
+| Clerk loading | "Checking employer session before enabling actions" | ✅ Correct |
+| Not signed in | "Preview only. Sign in with an employer workspace to persist decisions." + sign-in link | ✅ Correct |
+| Signed in, not employer role | "Preview only. Switch into an employer workspace to persist decisions." | ✅ Correct |
+| Entity not found | Server-side 404 → "Employer review unavailable" card with retry + home links | ✅ Correct |
+| Backend action fails | Error message shown with "Try again" button | ✅ Correct |
+| Network failure on action | `resolveLivePathErrorMessage` catches and surfaces message | ✅ Correct |
+| Duplicate acceptance (409) | Backend correct, frontend renders as generic error | ⚠️ Needs special-case handling (E2) |
+| Missing x-clerk-user-id | Backend returns 401, proxy returns 401 with "Sign in with an employer workspace" | ✅ Correct |
+| Passport build fails | `buildDecisionTrustSnapshot` returns minimal fallback, never blocks the action | ✅ Correct — degraded but never broken |
+
+---
+
+## 4. "Operational, Not Theatrical" Assessment
+
+**Backend: Fully operational.**
+- Transactional writes (acceptance + outbox + audit in one $transaction)
+- SHA-256 hash-linked audit events
+- Deduplication keys on outbox events
+- SEAL fire-and-forget for KPI capture that never blocks the critical path
+- Sanitization of all user inputs (string length limits, dedup, priority normalization)
+
+**Employer frontend: Operational with minor theatrical edges.**
+- The action panel is real — buttons fire real POSTs, success shows real audit IDs
+- The `SectionReveal` animations and progressive disclosure are tasteful, not gratuitous
+- The freshness panel and source coverage panel surface genuine operational data
+- Minor theatrical concern: the `VerifierPortal` and `StartClinicianAction` components feel like demo-day artifacts (hardcoded IDs, "ZK Terminal" language, "ON Loop" branding) that shouldn't be reachable from production paths
+
+**Clinician frontend: Not operational — doesn't exist yet.**
+
+---
+
+## 5. Top UX Gaps (Ranked)
+
+1. **Clinician notification void** — Employer actions (accept, refresh, route-to-review) write audit events but never reach the clinician. This makes the two-sided marketplace one-sided. *(C1, C2)*
+
+2. **No confirmation before irreversible accept** — One click writes an indelible audit record. Healthcare credentialing decisions warrant a confirmation step. *(E1)*
+
+3. **No intent/consent binding on share** — Sharing a passport URL should be a QIA-bound event per VitalCV doctrine, not an untracked URL pass. *(C3)*
+
+4. **409 duplicate acceptance rendered as error** — Employer sees "Action failed" when they've already accepted. Should say "Already accepted" with the existing acceptance context. *(E2)*
+
+5. **Refresh request is fire-and-forget from employer UX** — Employer clicks "Request refresh," gets audit confirmation, but has no way to see if the clinician acted on it. No status tracking of the request lifecycle. *(E3, related to C2)*
+
+---
+
+## 6. Verdict
+
+### GO for merge.
+
+The employer-review action flow (M2: Accept with Confidence) is structurally sound. The backend is production-grade: transactional, auditable, hash-linked, deduplicated, and degradation-safe. The employer decision surface is operationally honest — real data, real actions, real audit receipts. Auth/failure states handle all known edge cases correctly.
+
+### Conditions for pilot launch (must be roadmapped for M3):
+
+- **MUST:** Clinician notification on employer actions (at minimum: email or in-app for acceptance and refresh request)
+- **MUST:** Confirmation dialog before accept action
+- **SHOULD:** Intent-binding on passport share (QIA event)
+- **SHOULD:** Special-case 409 handling in frontend
+- **NICE:** Clinician-side dashboard showing "who viewed / acted on my passport"
+
+### Not blocking merge:
+
+- VerifierPortal demo code (separate cleanup task)
+- Refresh request text input (enhancement)
+- Route-to-review reason input (enhancement)


### PR DESCRIPTION
## What changed

Makes the employer-request-context flow completable by real pilot employers, not just pre-registered VcvEntities.

## Phase 1 — PR #86 merged
- Commit: `13dd195f`
- employer-request-context flow, context attribution, no-context warning

## Phase 2 — This PR

### New: `components/employer/EmployerWorkspaceSetup.tsx`
- Inline workspace bootstrap form: collects org name → `POST /api/employer/setup`
- Triggered automatically when `POST /api/request-review` returns 422 (employer not registered)
- After success, auto-retries the review context creation with the original NPI
- States: form, loading, error — all explicit

### New: `app/api/request-review/route.ts`
- Improved FK error detection: maps 422/FK-violation from backend → `{ error, hint }` with 422 status
- Honest error messages for every state (401, 400, 404 NPI, 422 no-workspace, 500)
- Returns `{ contextId, entityId, reviewUrl, npi, displayName, status }` on success

### New: `components/employer/RequestReviewPanel.tsx`
- Complete state machine: idle → loading → needs_setup → done / error
- `needs_setup` state renders `EmployerWorkspaceSetup` inline and auto-retries on success
- No generic dead ends — every state has one obvious next action

### New: `app/review/request/page.tsx`
- Route: `/review/request` — renders `RequestReviewPanel`

### Updated: `app/review/page.tsx`
- "Are you an employer?" section → `/review/request`

### Updated: `components/review/ReviewClient.tsx`
- Added `bundleId?` prop (fixes TypeScript error from `review/[entityId]/page.tsx`)
- Has-context branch: added "Audit trail — Actions tied to this context" row
- No-context branch: amber warning with link to `/review/request`

## State machine: RequestReviewPanel

| State | Trigger | UI |
|-------|---------|-----|
| `idle` | initial | NPI form |
| `loading` | NPI submitted | "Creating context…" |
| `needs_setup` | 422 from backend (no workspace) | `EmployerWorkspaceSetup` inline |
| `done` | context created | Review link + copy button |
| `error` | other failure | Error card + retry form |

## Tests: `__tests__/employer-workspace-bootstrap.test.tsx`
- 12 tests: API auth/validation, setup form render, panel idle state, ReviewClient source assertions, landing page

## Build/test status
- ✅ `tsc --noEmit` clean
- ✅ 12 new tests passing
- ✅ No breaking changes to existing surfaces

## What remains deferred
- `POST /api/employer/setup` requires `{ name }` — full employer profile (specialties, facilityType) is a separate admin flow
- Employer entity registration still requires Clerk auth; anonymous employer bootstrap is out of scope
- Full employer workspace admin UI is separate from wedge scope