### PR TITLE
feat(launch-gate): pilot launch gate + release readiness docs

### DIFF
--- a/PUBLIC-SHELL-AUDIT-2026-03-28.md
+++ b/PUBLIC-SHELL-AUDIT-2026-03-28.md
@@ -1,0 +1,123 @@
+# VitalCV Public Shell Truth Audit — 2026-03-28
+
+**Auditor:** Claude (Strategic + Technical Operator)
+**Scope:** All public entry points post-truth-cleanup merge
+**Verdict:** **NO-GO** — 4 P0 issues remain
+
+---
+
+## Executive Summary
+
+The truth cleanup campaign (~15 commits) significantly improved the homepage hero and passport flow. The NPI-first entry, honest source-coverage labels ("Checked," "Pending," "Access Required," "Preview-only"), and unified `/passport` CTA are solid. However, the cleanup was concentrated on the top-of-funnel flow and **did not reach four other public pages** that still tell a fundamentally different story than the wedge. The partners page fabricates trust logos, the investors page renders hardcoded demo metrics as traction, and the homepage platform section still pitches a job board + AI matching engine. These cannot ship to anyone doing diligence.
+
+---
+
+## The 5 Key Questions
+
+### 1. What does VitalCV do (as told by the live entry story)?
+
+The homepage hero now tells it correctly: enter your NPI → get a source-backed readiness snapshot in ~10 seconds → carry that snapshot into a passport for employer conversations. The "How It Works" section reinforces this. **But scroll past the fold** and the story fractures — a "Platform" section describes a free job board, AI career matching (MATCHA), and clinic capacity intelligence. A visitor who reads the whole page gets two different products.
+
+### 2. What should I do first?
+
+**Depends which navbar you hit.** The layout `Navbar.tsx` sends you to `/passport` ("Check Readiness"). The marketing `Navbar.tsx` sends you to `/onboarding` ("Get Started"). Both are in the codebase. The homepage hero NPI input is the strongest CTA — but it competes with nav-level confusion.
+
+### 3. What is still preview-only?
+
+The hero and passport flow now label preview-only states explicitly and honestly. The `/labs` page distinguishes "Stable," "Preview," "Experiment," and "Internal" correctly. The developers page carries a "Developer Portal Preview" badge. **This is the cleanest part of the cleanup — well done.**
+
+### 4. Does the developers page still imply a bigger company/product than the wedge?
+
+**Yes, significantly.** Three full SDKs (`@vitalcv/verifier-sdk`, `@vitalcv/issuer-sdk`, `@vitalcv/wallet-sdk`) are documented with 20+ methods each. A drop-in widget claims to be hosted at `cdn.vitalcv.com`. Trust governance rules, conformance reports, HealthStart control inheritance (SaaS / PrivateVPC / GovEnclave profiles), and gateway connections all imply a mature platform with federation infrastructure. The "Preview" badge helps, but the volume of documented surface area reads like a Series B developer portal, not a seed-stage wedge.
+
+### 5. Does any public entry point still feel like a different story than the real product?
+
+**Yes — three pages feel like separate products:**
+- `/partners` — a fully structured 3-tier partner program with revenue share, reseller margins, and fabricated "Trusted by" logos (Epic, Cerner, CAQH, Joint Commission)
+- `/investors` — hardcoded `DEMO_METRICS` (12,847 credentials issued, 284 active verifiers) rendered without any "illustrative" label
+- Homepage "Platform" section — pitches a job board and AI career engine
+
+---
+
+## Top 8 Remaining Issues
+
+### P0 — Must Fix Before Merge (Credibility / Legal Risk)
+
+**#1. Partners page: Fabricated "Trusted by" logos**
+`app/partners/page.tsx:146-150`
+The page renders "Trusted by leading healthcare organizations" with Epic, Cerner, CAQH, Nursys, ABIM, and Joint Commission names. VitalCV has zero partnerships with any of these organizations. This is the single most damaging finding — any healthcare insider who sees this will immediately distrust everything else on the site. Potential trademark risk.
+**Fix:** Remove the entire "Trusted by" section. Replace with nothing, or "Standards we build against" with protocol logos (W3C, OID4VCI, etc.) instead of company names.
+**Effort:** S
+
+**#2. Investors page: Hardcoded demo metrics rendered as traction**
+`app/investors/page.tsx:14-18`
+`DEMO_METRICS` object renders 12,847 credentials issued, 284 active verifiers, 1,923 network nodes, and 2 federated networks. The variable is literally called `DEMO_METRICS` in code but renders on-page with animated counters and no "illustrative" or "projected" label. An investor who screenshots this has fabricated traction numbers from VitalCV.
+**Fix:** Either (a) pull real metrics from the API and show actual numbers, or (b) remove the metrics section entirely, or (c) add a prominent "Illustrative — not live data" label. Option (b) is safest.
+**Effort:** S
+
+**#3. Homepage "Platform" section: Job board + MATCHA + Capacity Intelligence**
+`components/marketing/HomeSections.tsx:680-696, 725-726, 765`
+Six "platform pillars" are presented including "Free Specialty Job Board," "MATCHA — AI Career Matching," and "Clinic Capacity Intelligence." These are vision-state features that don't exist in the wedge. The headline "Not just credentialing. The infrastructure layer for all of US healthcare" directly contradicts the wedge framing. A YC reviewer reading this will see unfocused ambition, not a narrow wedge.
+**Fix:** Remove or collapse the Platform section. If you want a vision teaser, move it below a clear "What's next" divider and label it explicitly as roadmap. The homepage should end after the Moneyball/Hypothesis section.
+**Effort:** M
+
+**#4. Partners page: Entire 3-tier partner program**
+`app/partners/page.tsx` (full page)
+Technology Partner, Integration Partner, and Channel Partner tiers with specific revenue shares ("up to 30%"), "Dedicated partnership manager," "Deal registration portal," and "Certified integration status." This implies operational infrastructure and BD capacity that a seed-stage solo-founder company cannot deliver. If a real integration partner applies, there's no one to onboard them.
+**Fix:** Replace with a simple "Interested in integrating?" contact form or redirect to a Calendly link. Kill the tiers, kill the revenue share claims.
+**Effort:** M
+
+### P1 — Should Fix Before Merge (Confusion / Drift)
+
+**#5. Two navbars with conflicting primary CTAs**
+`components/marketing/Navbar.tsx` → "Get Started" → `/onboarding`
+`components/layout/Navbar.tsx` → "Check Readiness" → `/passport`
+Which one renders depends on the layout wrapper. On the homepage (which uses marketing sections), a visitor might see "Get Started → /onboarding" while the hero pushes them to `/passport`. The truth cleanup unified all CTAs to `/passport` — but the marketing navbar wasn't updated.
+**Fix:** Update marketing `Navbar.tsx` to match layout navbar. Primary CTA: "Check Readiness" → `/passport`. Remove `/onboarding` from all public nav.
+**Effort:** S
+
+**#6. Homepage: "7M+ provider registry" in build signals**
+`components/marketing/HomeSections.tsx:305`
+"Live NPI verification via NPPES (7M+ provider registry)" — the truth cleanup was supposed to remove the 7M+ framing (per commit `df19d4b1`). It survived in the BUILD_SIGNALS array. This isn't a VitalCV metric — it's an NPPES fact — but it reads as VitalCV scale.
+**Fix:** Change to "Live NPI verification via NPPES" (drop the parenthetical) or "Live NPI verification against the NPPES public registry."
+**Effort:** S
+
+**#7. Developers page: Drop-in widget claims non-existent CDN**
+`components/developers/DropInSection.tsx`
+Code snippet references `https://vitalcv.com/vitalcv-widget.js` with claims of "Zero dependencies, < 3 KB gzipped, Works in any CMS." If this script doesn't exist at that URL, the code example is broken on copy-paste. The "Preview" label helps but doesn't excuse a broken URL.
+**Fix:** Either deploy the actual widget script, or change the URL to a placeholder like `https://cdn.example.com/vitalcv-widget.js` with a note that the widget is in preview, or remove the section.
+**Effort:** S
+
+**#8. Docs landing page: "Federation-native — interoperates with Nursys, CAQH, ABMS"**
+`app/docs/page.tsx:53`
+Claims federation interoperability with Nursys, CAQH, and ABMS. VitalCV has no federation agreements with these organizations. This is the same class of problem as the partner logos — naming real organizations as if integration exists.
+**Fix:** Change to "Federation-native architecture — designed for interoperability with industry registries" or similar. Remove specific org names.
+**Effort:** S
+
+---
+
+## Summary Matrix
+
+| # | Page | Issue | Severity | Effort | Risk Type |
+|---|------|-------|----------|--------|-----------|
+| 1 | /partners | Fake "Trusted by" logos | **P0** | S | Legal + credibility |
+| 2 | /investors | Hardcoded demo metrics as traction | **P0** | S | Investor fraud risk |
+| 3 | Homepage | Platform section tells wrong story | **P0** | M | Wedge confusion |
+| 4 | /partners | Full partner program that can't be delivered | **P0** | M | Operational overclaim |
+| 5 | Nav | Two navbars, conflicting CTAs | **P1** | S | UX confusion |
+| 6 | Homepage | "7M+ provider registry" survived cleanup | **P1** | S | Scale overclaim |
+| 7 | /developers | Widget CDN URL doesn't exist | **P1** | S | Broken example |
+| 8 | /docs | Federation claims with named orgs | **P1** | S | Credibility |
+
+---
+
+## Verdict: NO-GO
+
+**The homepage hero + passport flow are clean.** The truth cleanup worked where it was applied. But it was applied to ~60% of the public surface. Four P0 issues remain, and three of them (#1, #2, #4) carry real credibility and legal risk if seen by investors, partners, or healthcare insiders doing diligence.
+
+**To reach GO:**
+1. Fix all 4 P0 issues (~2-3 hours of work, mostly deletion)
+2. Fix P1 #5 (navbar unification, ~15 minutes)
+3. Ideally fix P1 #6 and #8 (string changes, ~10 minutes each)
+
+The remaining work is narrow — mostly removing things, not building things. One focused session gets this to GO.

--- a/UX_DESIGN_REVIEW_POLISHED_WEDGE.md
+++ b/UX_DESIGN_REVIEW_POLISHED_WEDGE.md
@@ -1,0 +1,198 @@
+# VitalCV Polished Wedge — UX/Design Review
+
+**Reviewer:** Claude (ruthless mode)
+**Date:** 2026-03-28
+**Scope:** Homepage, /passport, /holder/readiness, /review, /review/request
+**Verdict:** **CONDITIONAL GO** (see P0 list)
+
+---
+
+## Page-by-Page Assessment
+
+### 1. Homepage (`/`)
+
+**Main job:** Convert a cold visitor into someone who enters their NPI and sees real value in <10 seconds.
+
+**One obvious next action?** YES. The NPI input + "Start with NPI lookup" CTA is prominent and singular. The 3-step breadcrumb (Enter NPI → Review readiness → Open passport) is excellent wayfinding.
+
+**Calm or cluttered?** Calm. The dark canvas, single radial glow, and tight max-w-xl keep focus narrow. The TrustStrip beneath the fold is subtle enough not to compete. HowItWorksSection below provides narrative without disrupting the hero.
+
+**Observations:**
+- Hero headline "See your readiness snapshot in about 10 seconds" is sharp and specific — strongest copy in the product.
+- The loading→preview transition is well-choreographed: stages animate in staggered (140ms), panel crossfades to preview, timing feels intentional not decorative.
+- ReadinessPreview card (both real and demo paths) is information-dense but well-structured: header, readiness panel, gaps, accordion proof, footer CTA.
+- Color rule (green only on CTA) is respected.
+
+**Issues flagged below:** #1, #3, #7, #8
+
+---
+
+### 2. Passport Entry (`/passport`)
+
+**Main job:** Let anyone check readiness via NPI with zero friction, then funnel to the full passport or employer view.
+
+**One obvious next action?** YES in idle state (single NPI form → "Check my readiness"). YES in done state (dual CTA: "View full passport" primary, "View as employer" secondary). The hierarchy is correct — primary is `variant="success"`, secondary is outline.
+
+**Calm or cluttered?** Very calm. Centered single-column (max-w-sm), progressive disclosure. Form hides during ingest. Source rows tick through. Identity card appears when NPPES resolves. Terminal states (no profile, disconnected, error) each have dedicated TrustStateCards.
+
+**Observations:**
+- The SSE streaming ingest with progressive hydration is the product's strongest UX moment. Watching Identity → Sanctions → Enrollment resolve in real-time is viscerally satisfying.
+- "Check another NPI" ghost button at bottom is well-placed, doesn't compete.
+- Input uses `text-center tracking-widest` for the NPI field — feels intentional and institutional.
+- Readiness score appears inline as a quiet `score/100` — doesn't over-celebrate.
+
+**Issues flagged below:** #2, #4, #5
+
+---
+
+### 3. Clinician Readiness Dashboard (`/holder/readiness`)
+
+**Main job:** Show authenticated clinicians their readiness state, what's blocking them, and what to do next.
+
+**One obvious next action?** YES — the primary action card at the top dynamically resolves to the right CTA based on blocker state (resolve blocker vs. view opportunities vs. continue onboarding).
+
+**Calm or cluttered?** Mixed. The top hero card + readiness panel + "What's left" sidebar + proof section + history timeline is a LOT of information on one page. Each section is well-designed individually, but the aggregate feels dashboard-heavy for a clinician who wants one answer: "am I ready?"
+
+**Observations:**
+- The readiness progress bar (emerald→sky→cyan gradient) is the right visual shortcut.
+- Blocker cards with amber tone are visually distinct and actionable.
+- The "What changed because of VitalCV" proof section with 4-metric grid (baseline, current, delta, applications) is strong for demonstrating value but competes for attention with the primary action.
+- History timeline entries are well-structured with delta scores, reasons, and gap changes.
+- Refresh button with spinning icon is a nice touch.
+
+**Issues flagged below:** #1, #6, #9
+
+---
+
+### 4. Review Landing (`/review`)
+
+**Main job:** Route visitors to the correct entry point — either via a share link (which they should already have) or to the employer request flow.
+
+**One obvious next action?** NO — this is the weakest page. It shows a warning card explaining why you can't do much here, then offers two outline buttons ("Start with NPI lookup" and "View passport") of equal visual weight, plus a third "Request a passport review" below. Three paths, none dominant.
+
+**Calm or cluttered?** Calm but empty. The centered max-w-sm TrustStateCard is fine, but the page feels like a dead end with a polite apology. Employers who land here without a share link get a wall of explanation instead of a clear path forward.
+
+**Issues flagged below:** #1, #10
+
+---
+
+### 5. Employer Request (`/review/request`)
+
+**Main job:** Let an employer enter a clinician NPI and get a shareable review link.
+
+**One obvious next action?** YES. Single NPI form → "Create review context". Success state clearly surfaces the review link with copy + open actions.
+
+**Calm or cluttered?** Calm. Same centered single-column pattern as /passport. States are well-defined: idle → loading → needs_setup → done → error. The success card with emerald border, context ID, and link display is clean.
+
+**Observations:**
+- The `needs_setup` state gracefully pivots to inline EmployerWorkspaceSetup and auto-retries — this is a good UX recovery pattern.
+- Error state shows in a rose-tinted card inline with the form — visible but not alarming.
+- "Request another review" ghost button follows the same pattern as passport's "Check another NPI" — good consistency.
+- Loading state is minimal text in a card — could use a subtle spinner for perceived responsiveness.
+
+**Issues flagged below:** #2, #4
+
+---
+
+## Cross-Cutting Observations
+
+### Motion
+The motion system is disciplined. Single canonical easing curve `[0.2, 0.8, 0.2, 1]` across a 280-420ms duration band. No bouncy springs, no gratuitous parallax. Motion serves comprehension: stage rows stagger in to show sequence, panels crossfade to show state change, preview slides up to signal arrival. This is one of the product's strongest design decisions.
+
+### Typography & Spacing
+Nunito Sans works. The micro-label system (`text-[10px] font-bold uppercase tracking-[0.2em] text-white/30`) is consistent across all five pages for eyebrows/section labels. The hierarchy (label → heading → body → hint) is readable. Spacing is generous but not wasteful.
+
+### Visual Language
+The trust status badge system (checked/pending/access_required/review_required/demo/unavailable) is well-executed and carries across homepage, passport, and readiness. Color semantics are consistent: emerald=good, amber=attention, rose=problem, white/alpha=neutral.
+
+### Navbar
+Clean, professional. Sticky with backdrop-blur. Hides on non-public routes (smart). Mobile menu is functional. "Check Readiness" as the primary CTA in the nav is the right call. The ThemeToggle in the desktop nav is a nice polish detail.
+
+### Error Boundary
+The global error page is well-done: calm emoji, "View Interrupted" title, three recovery actions (reload/home/support), PilotFailureSignal for ops telemetry. Doesn't break trust.
+
+---
+
+## Top 10 UX/Design Issues (Ranked)
+
+### P0 — Must fix before merge
+
+**#1. /review landing page is a dead end with muddy CTA priority**
+The page shows a warning card with three equal-weight links. An employer who lands here directly (no share link) should be funneled hard into `/review/request`. Make the employer CTA primary/success variant and move it above the warning card. The "Start with NPI lookup" and "View passport" links should be secondary/ghost.
+*Pages affected:* /review
+*Effort:* S
+
+**#2. Loading states on /passport and /review/request lack a spinner or progress indicator**
+The /passport page has phase labels ("Connecting to primary sources…") but no visual loading indicator between form submission and the first source row appearing. The /review/request loading state is just centered text in a card. Both need a subtle spinner or pulse animation to confirm the system is working. The homepage does this correctly with the spinning border on the loading stage row — apply the same pattern.
+*Pages affected:* /passport, /review/request
+*Effort:* S
+
+**#3. Homepage ReadinessPreview card is too tall — CTA below the fold on mobile**
+The full ReadinessPreview (header + readiness panel + gaps + accordion + footer CTA) on the homepage easily exceeds viewport height on mobile. The "Continue to passport" button is buried at the bottom. Consider collapsing the accordion by default and/or making the CTA sticky at the bottom of the preview card.
+*Pages affected:* Homepage
+*Effort:* M
+
+### P1 — Should fix, but won't block merge
+
+**#4. NPI input validation is inconsistent across pages**
+Homepage shows amber text below input for invalid NPI. /passport shows `text-red-400/70 text-center`. /review/request shows `text-xs text-red-400/70` left-aligned. Pick one pattern and reuse it. The homepage's amber approach is better for the dark theme (red is too alarming for a validation hint).
+*Pages affected:* All NPI entry points
+*Effort:* S
+
+**#5. /passport dual CTA buttons ("View full passport" / "View as employer") use different border-radius**
+Primary uses `rounded-full`, secondary uses `rounded-full` — actually these match. However, the primary is `variant="success"` and the secondary uses a custom `variant="outline"` with manual hover states. These should both use the design system's button variants for consistency and maintainability.
+*Pages affected:* /passport
+*Effort:* S
+
+**#6. Readiness dashboard information density — "Proof of impact" section competes with primary action**
+The "What changed because of VitalCV" section is valuable for retention/proof but it's a secondary concern. A clinician opening readiness wants: (a) my score, (b) what's blocking me, (c) what to do next. The proof section should be collapsible or moved to a separate tab/section to keep the primary flow tight.
+*Pages affected:* /holder/readiness
+*Effort:* M
+
+**#7. Homepage flow step indicators have weak contrast in "upcoming" state**
+`text-white/34` + `border-white/6` + `bg-black/10` makes the "upcoming" steps nearly invisible on the dark background. Step indicators should be legible in all states — bump upcoming to `text-white/45` and `border-white/10` minimum.
+*Pages affected:* Homepage
+*Effort:* S
+
+**#8. Homepage body copy in the hero is dense — includes too many status label names inline**
+The paragraph "VitalCV gives healthcare professionals a source-backed credentialing snapshot…then labels each lane as Checked, Pending, Access required, Unavailable, or Preview only" reads like a spec, not marketing copy. Simplify to focus on the value prop; move status taxonomy to the preview or a tooltip.
+*Pages affected:* Homepage
+*Effort:* S
+
+**#9. Readiness dashboard "Refresh readiness" button is a raw `<button>` instead of `<Button>`**
+The refresh button in the readiness header uses a custom className string instead of the design system Button component. This means it doesn't get the CVA variants, focus ring, or consistent sizing. Swap to `<Button variant="outline">` with the RefreshCw icon.
+*Pages affected:* /holder/readiness
+*Effort:* S
+
+**#10. /review page lacks any branding or heading — feels orphaned**
+The page is just a TrustStateCard floating in a centered container. No "VitalCV" wordmark, no page heading, no breadcrumb. Compare to /passport which has wordmark + heading + subtitle. Apply the same pattern for consistency.
+*Pages affected:* /review
+*Effort:* S
+
+---
+
+## Strongest Improvements (What's Working)
+
+1. **NPI-first hero with real-time ingest** — The homepage LiveTrustConsole is the single best UX in the product. The 3-step flow indicator, live source checking, and progressive preview reveal is exactly what a trust infrastructure product should feel like.
+
+2. **Consistent trust status badge system** — The 6-state badge taxonomy (checked, pending, access_required, review_required, demo, unavailable) carries across every surface. Color coding is consistent. This builds institutional trust through visual language.
+
+3. **Motion discipline** — Single easing curve, tight duration band, no decoration-only animation. Every transition communicates a state change. This is rare and good.
+
+4. **Honest labeling** — Demo states are always labeled "Preview only". Access-required lanes are never hidden. The product doesn't fake trust — it shows uncertainty explicitly. This is the right design choice for a trust product.
+
+5. **Dark theme execution** — The `bg-[#080e1a]` canvas with `white/alpha` text, `border-white/alpha` dividers, and semantic emerald/amber/rose accents feels premium without being tryhard. The glassmorphic cards with `bg-white/[0.04]` are subtle and tasteful.
+
+---
+
+## GO / NO-GO Verdict
+
+### **CONDITIONAL GO**
+
+The polished wedge is ready for merge **after the 3 P0 fixes** (estimated: 2–3 hours total).
+
+The product feels calm, institutional, and trustworthy across the core flows. The homepage-to-passport pipeline is the strongest UX sequence. The readiness dashboard is information-rich but functional. The motion system, color discipline, and honest labeling are all production-grade.
+
+The /review landing page is the only genuinely weak screen — but it's a routing page, not a core flow, and the P0 fix is trivial.
+
+P1 issues are polish items that can ship in a follow-up pass without blocking the merge.

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -599,7 +599,7 @@ describe('employer action routes', () => {
           },
         },
       },
-    ]);
+    }]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')
@@ -733,7 +733,7 @@ describe('employer action routes', () => {
           },
         },
       },
-    }]);
+    ]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')

--- a/apps/api/backend/src/services/search/searchIndex.ts
+++ b/apps/api/backend/src/services/search/searchIndex.ts
@@ -717,7 +717,7 @@ export async function seedPublicPages(): Promise<number> {
     },
     {
       title: 'Developer Portal',
-      body: 'Build with the VitalCV Trust Protocol. API keys, webhooks, Verifier SDK, Issuer SDK, OpenID4VP, HAIP.',
+      body: 'Build against the current VitalCV API preview. API keys, webhooks, verifier and issuer SDKs, OpenID4VP, and HAIP routes backed by this branch.',
       sourceUrl: '/developers',
     },
     {

--- a/apps/web/__tests__/helpers/public-copy-guard.ts
+++ b/apps/web/__tests__/helpers/public-copy-guard.ts
@@ -13,12 +13,20 @@ export const APPROVED_PUBLIC_WORDING = {
 export const PROHIBITED_PUBLIC_STRINGS = [
   'Get Verified',
   'Primary sources verify you',
+  'Open Interview Preview',
   'Already Cleared For',
   'Get Verified Free',
+  'Build with the Trust Protocol',
+  'Build with the VitalCV Trust Protocol',
   'Trust Protocol',
   'signed link',
   'expires in 24h',
   'no account needed',
+  'Network Peer Acceptance',
+  'AUTHORITATIVE issuers require',
+  'TRUST_THRESHOLD',
+  'REVOCATION_ESCALATION',
+  'PEER_ACCEPTANCE',
 ] as const;
 
 export const PROHIBITED_EMPLOYER_PUBLIC_STRINGS = [

--- a/apps/web/__tests__/live-path-regression.test.tsx
+++ b/apps/web/__tests__/live-path-regression.test.tsx
@@ -636,6 +636,33 @@ describe('live path regression hardening', () => {
     document.body.innerHTML = '';
   });
 
+  it('keeps the homepage NPI lookup as the only primary CTA before preview and during loading', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(() => new Promise(() => {}) as never);
+
+    const view = await renderNode(<LiveTrustConsole />);
+
+    expect(
+      Array.from(view.container.querySelectorAll('button')).map((node) => node.textContent?.trim()),
+    ).toEqual(['Start with NPI lookup']);
+    expect(textContent(view.container)).toContain('NPI first. Honest coverage.');
+    expect(textContent(view.container)).not.toContain('Continue to passport');
+    expect(textContent(view.container)).not.toContain('Get Verified');
+
+    await setInputValue(view.container, 'NPI number', '1234567890');
+    await clickByText(view.container, 'Start with NPI lookup');
+    await flush();
+    await advance(1);
+    await flush();
+
+    expect(textContent(view.container)).toContain('Checking primary sources…');
+    expect(textContent(view.container)).toContain('Primary identity (NPPES)');
+    expect(textContent(view.container)).toContain('Sanctions (OIG / LEIE)');
+    expect(textContent(view.container)).not.toContain('Continue to passport');
+
+    await view.unmount();
+  });
+
   it('submits homepage NPI lookups and reveals the live readiness snapshot', async () => {
     const fetchMock = vi.mocked(fetch);
     const onPreviewReady = vi.fn();

--- a/apps/web/__tests__/passport-ingest-page.test.tsx
+++ b/apps/web/__tests__/passport-ingest-page.test.tsx
@@ -67,6 +67,26 @@ describe('/passport ingest page', () => {
     useIngestStreamMock.mockReset();
   });
 
+  it('renders loading copy and queued source lanes while the ingest is still running', () => {
+    const markup = renderForState(buildState({
+      phase: 'nppes',
+      npi: '1234567890',
+      sources: {
+        nppes: 'checking',
+        oig: 'pending',
+        pecos: 'pending',
+      },
+    }));
+
+    expect(markup).toContain('Checking primary sources…');
+    expect(markup).toContain('Identity');
+    expect(markup).toContain('Sanctions (OIG)');
+    expect(markup).toContain('Enrollment (CMS)');
+    expect(markup).toContain('Checking');
+    expect(markup).toContain('Pending');
+    expect(markup).not.toContain('View full passport');
+  });
+
   it('renders the passport CTA as soon as the profile is usable', () => {
     const markup = renderForState(buildState({
       phase: 'enrollment',
@@ -134,6 +154,32 @@ describe('/passport ingest page', () => {
     }));
 
     expect(markup).toContain('Profile resolved but not yet anchored.');
+    expect(markup).not.toContain('View full passport');
+  });
+
+  it('renders unavailable and review-required source states without upgrading them into checked proof', () => {
+    const markup = renderForState(buildState({
+      phase: 'done',
+      completedAt: '2026-03-25T22:10:00.000Z',
+      npi: '1234567890',
+      identity: {
+        authoritative: false,
+        sourceResult: 'FAILED',
+        status: 'UNKNOWN',
+      },
+      standing: {
+        exclusionChecked: true,
+        exclusionStatus: 'POSSIBLE_MATCH',
+      },
+      sources: {
+        nppes: 'error',
+        oig: 'done',
+        pecos: 'pending',
+      },
+    }));
+
+    expect(markup).toContain('Unavailable');
+    expect(markup).toContain('Review required');
     expect(markup).not.toContain('View full passport');
   });
 

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -8,6 +10,55 @@ import {
   PUBLIC_WEDGE_ROUTE_TARGETS,
   findHrefByText,
 } from './helpers/public-copy-guard';
+
+type PublicEntryCopySurface = {
+  id: string;
+  label: string;
+  entryFile: string;
+  copySources: string[];
+};
+
+const REPO_ROOT = path.resolve(process.cwd(), '../..');
+const PUBLIC_ENTRY_COPY_SOURCE_MANIFEST = JSON.parse(
+  fs.readFileSync(
+    path.resolve(REPO_ROOT, 'scripts/public-entry-copy-sources.json'),
+    'utf8',
+  ),
+) as { surfaces: PublicEntryCopySurface[] };
+
+const REQUIRED_PUBLIC_SHELL_PROHIBITIONS = [
+  'Get Verified',
+  'Primary sources verify you',
+  'Open Interview Preview',
+  'Build with the Trust Protocol',
+] as const;
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+function getPublicEntryCopySurface(id: string): PublicEntryCopySurface {
+  const surface = PUBLIC_ENTRY_COPY_SOURCE_MANIFEST.surfaces.find(
+    (candidate) => candidate.id === id,
+  );
+
+  if (!surface) {
+    throw new Error(`Missing public-entry copy surface "${id}"`);
+  }
+
+  return surface;
+}
+
+function getCanonicalPublicEntryCopyFiles(): string[] {
+  return Array.from(
+    new Set(
+      PUBLIC_ENTRY_COPY_SOURCE_MANIFEST.surfaces.flatMap((surface) => [
+        surface.entryFile,
+        ...surface.copySources,
+      ]),
+    ),
+  );
+}
 
 const {
   fetchLaunchEmployerMock,
@@ -62,6 +113,43 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/components/motion/ScrollMotion', () => ({
+  SectionReveal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/components/auth/RoleContext', () => ({
+  useRoleContext: () => ({
+    isLoaded: true,
+    isSignedIn: false,
+    clerkRole: null,
+    persona: null,
+    role: 'guest',
+    landingRoute: '/sign-in',
+    isClinician: false,
+    isEmployer: false,
+    clinicianNpi: null,
+    employerOrgId: null,
+    workspace: null,
+    refresh: async () => undefined,
+  }),
+}));
+
+vi.mock('@/hooks/useAuthPrompt', () => ({
+  useAuthPrompt: () => ({
+    shouldPrompt: false,
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/auth/CreateAccountModal', () => ({
+  CreateAccountModal: () => null,
+}));
+
+vi.mock('@/lib/auth/clerkConfig', () => ({
+  CLERK_PROVIDER_ENABLED: false,
+  CLERK_SIGN_IN_URL: '/sign-in',
+}));
+
 vi.mock('@/hooks/useUxTelemetry', () => ({
   useUxTelemetry: () => ({ track: vi.fn() }),
 }));
@@ -82,6 +170,10 @@ vi.mock('@/components/prequalify/PrequalifyTrigger', () => ({
 
 vi.mock('@/components/apply/ApplyWithVitalCV', () => ({
   ApplyWithVitalCV: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+vi.mock('@/components/capacity/SystemCapacityBadge', () => ({
+  default: () => <div>System capacity badge</div>,
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -242,6 +334,52 @@ afterEach(() => {
 });
 
 describe('post-release truth cleanup', () => {
+  it('locks the required public-shell prohibited phrases into the shared guard list', () => {
+    expect(PROHIBITED_PUBLIC_STRINGS).toEqual(
+      expect.arrayContaining(REQUIRED_PUBLIC_SHELL_PROHIBITIONS),
+    );
+  });
+
+  it('tracks canonical homepage and developer-shell copy sources', () => {
+    const homepage = getPublicEntryCopySurface('homepage');
+    const developerShell = getPublicEntryCopySurface('developer-shell');
+
+    expect(homepage.entryFile).toBe('apps/web/app/page.tsx');
+    expect(homepage.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/components/layout/Navbar.tsx',
+        'apps/web/components/hero/HeroWithAuthPrompt.tsx',
+        'apps/web/components/hero/LiveTrustConsole.tsx',
+        'apps/web/components/home/PublicTruthSections.tsx',
+        'apps/web/components/marketing/HomeSections.tsx',
+      ]),
+    );
+
+    expect(developerShell.entryFile).toBe('apps/web/app/developers/page.tsx');
+    expect(developerShell.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/app/docs/page.tsx',
+        'apps/api/backend/src/services/search/searchIndex.ts',
+      ]),
+    );
+
+    const homepageEntrySource = readRepoFile(homepage.entryFile);
+    expect(homepageEntrySource).toContain('<HeroWithAuthPrompt />');
+    expect(homepageEntrySource).toContain('<TrustStrip />');
+    expect(homepageEntrySource).toContain('<HowItWorksSection />');
+
+    for (const file of getCanonicalPublicEntryCopyFiles()) {
+      expect(fs.existsSync(path.resolve(REPO_ROOT, file))).toBe(true);
+    }
+  });
+
+  it('keeps canonical public-entry copy sources off prohibited wording drift', () => {
+    for (const file of getCanonicalPublicEntryCopyFiles()) {
+      const source = readRepoFile(file);
+      expectMarkupExcludes(source, PROHIBITED_PUBLIC_STRINGS);
+    }
+  });
+
   it('keeps public nav and homepage language aligned with checked/preview wording', async () => {
     const [{ default: Navbar }, { HowItWorksSection }] = await Promise.all([
       import('../components/layout/Navbar'),
@@ -262,7 +400,51 @@ describe('post-release truth cleanup', () => {
     expect(homeMarkup).toContain('Portable across employers');
     expect(homeMarkup).toContain(APPROVED_PUBLIC_WORDING.sourceBacked);
     expect(homeMarkup).toContain(APPROVED_PUBLIC_WORDING.checked);
-    expectMarkupExcludes(homeMarkup, ['Primary sources verify you']);
+    expectMarkupExcludes(homeMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('renders the homepage route plus adjacent interview teaser with the live public-shell copy', async () => {
+    const [
+      { default: HomePage },
+      { default: Navbar },
+      { InterviewModeTeaser },
+    ] = await Promise.all([
+      import('../app/page'),
+      import('../components/layout/Navbar'),
+      import('../components/home/PublicTruthSections'),
+    ]);
+
+    const homepageMarkup = renderToStaticMarkup(<HomePage />);
+    const navbarMarkup = renderToStaticMarkup(<Navbar />);
+    const interviewTeaserMarkup = renderToStaticMarkup(<InterviewModeTeaser />);
+
+    expect(homepageMarkup).toContain('NPI first. Honest coverage.');
+    expect(homepageMarkup).toContain('Start with NPI lookup');
+    expect(homepageMarkup).toContain('Current source coverage');
+    expect(homepageMarkup).toContain('Homepage preview starts with NPPES and OIG.');
+    expect(homepageMarkup).toContain('How It Works');
+    expect(homepageMarkup).toContain('Source-backed readiness snapshot');
+    expect(homepageMarkup).toContain('Primary sources first. Signed proof where coverage exists. Explicit gaps where it does not.');
+
+    expect(navbarMarkup).toContain('Check Readiness');
+    expect(navbarMarkup).toContain('Explore Roles');
+    expect(navbarMarkup).toContain('For Employers');
+    expect(navbarMarkup).toContain('Developers');
+    expect(findHrefByText(navbarMarkup, 'Check Readiness')).toBe('/passport');
+    expect(findHrefByText(navbarMarkup, 'Explore Roles')).toBe('/explore');
+    expect(findHrefByText(navbarMarkup, 'For Employers')).toBe('/employers');
+    expect(findHrefByText(navbarMarkup, 'Developers')).toBe('/developers');
+
+    expect(interviewTeaserMarkup).toContain('Passport Preview');
+    expect(interviewTeaserMarkup).toContain('Preview your');
+    expect(interviewTeaserMarkup).toContain('passport proof.');
+    expect(interviewTeaserMarkup).toContain('Preview Passport Proof');
+    expect(interviewTeaserMarkup).toContain('Synthetic preview');
+    expect(findHrefByText(interviewTeaserMarkup, 'Preview Passport Proof')).toBe('/passport');
+
+    expectMarkupExcludes(homepageMarkup, PROHIBITED_PUBLIC_STRINGS);
+    expectMarkupExcludes(navbarMarkup, PROHIBITED_PUBLIC_STRINGS);
+    expectMarkupExcludes(interviewTeaserMarkup, PROHIBITED_PUBLIC_STRINGS);
   });
 
   it('keeps the readiness preview on checked and passport handoff language', async () => {
@@ -324,13 +506,7 @@ describe('post-release truth cleanup', () => {
 
     expect(interviewMarkup).toContain('Start with an NPI');
     expect(findHrefByText(interviewMarkup, 'Go to passport')).toBe('/passport');
-    expectMarkupExcludes(interviewMarkup, [
-      'real verified readiness',
-      'verified readiness',
-      'signed link',
-      'expires in 24h',
-      'no account needed',
-    ]);
+    expectMarkupExcludes(interviewMarkup, PROHIBITED_PUBLIC_STRINGS);
 
     expect(reviewMarkup).toContain('Open a shared passport review');
     expect(reviewMarkup).toContain('share when a real passport exists');
@@ -338,32 +514,105 @@ describe('post-release truth cleanup', () => {
     expect(findHrefByText(reviewMarkup, 'View passport')).toBe('/passport');
   }, 20000);
 
-  it('keeps developers and docs pages on current/preview wording', async () => {
-    const [{ default: DeveloperPortalPage, metadata: developerMetadata }, { default: DocsPage, metadata: docsMetadata }] = await Promise.all([
+  it('keeps the developers hero and key resource blocks on current/preview wording', async () => {
+    const [{ default: DeveloperPortalPage, metadata: developerMetadata }] = await Promise.all([
       import('../app/developers/page'),
-      import('../app/docs/page'),
     ]);
 
     const developerMarkup = renderToStaticMarkup(<DeveloperPortalPage />);
-    const docsMarkup = renderToStaticMarkup(<DocsPage />);
 
     expect(developerMetadata.description).toBe(
       'Current VitalCV API routes, SDKs, and webhook registration surfaces backed by this branch.',
     );
+    expect(developerMarkup).toContain('Developer Portal Preview');
     expect(developerMarkup).toContain('Build against the');
     expect(developerMarkup).toContain('current VitalCV API preview.');
+    expect(developerMarkup).toContain('Use the configured API host, workspace SDKs, and backend routes that exist in this branch today.');
+    expect(findHrefByText(developerMarkup, 'Try the Sandbox')).toBe('#sandbox');
+    expect(findHrefByText(developerMarkup, 'Read the Docs')).toBe('/docs');
     expect(findHrefByText(developerMarkup, 'API Reference')).toBe('/docs/api');
     expect(findHrefByText(developerMarkup, 'SDKs')).toBe('/docs/sdk');
     expect(findHrefByText(developerMarkup, 'Webhook Guide')).toBe('/docs/webhooks');
+    expect(findHrefByText(developerMarkup, 'Wallet Export')).toBe('/docs/api');
+    expect(findHrefByText(developerMarkup, 'Compliance API')).toBe('/docs/api');
+    expect(findHrefByText(developerMarkup, 'Examples')).toBe('https://github.com/ctol3r/vitalcv/tree/main/examples');
     expect(developerMarkup).toContain(APPROVED_PUBLIC_WORDING.current);
     expect(developerMarkup).toContain(APPROVED_PUBLIC_WORDING.preview);
+
+    // Governance cards must be absent after public-shell narrowing
+    expectMarkupExcludes(developerMarkup, [
+      'TRUST_THRESHOLD',
+      'REVOCATION_ESCALATION',
+      'PEER_ACCEPTANCE',
+      'Network Peer Acceptance',
+      'AUTHORITATIVE issuers require',
+    ]);
+    // Section label should be "Governance API", not "Trust Governance"
+    expect(developerMarkup).toContain('Governance API');
+    expect(developerMarkup).not.toContain('Trust Governance');
+    // Wave/Phase numbers should be stripped from section labels
+    expect(developerMarkup).not.toContain('Wave 114');
+    expect(developerMarkup).not.toContain('Wave 118');
+    expect(developerMarkup).not.toContain('Phase 7');
+    // Network section demoted
+    expect(developerMarkup).toContain('Connected Organizations (Preview)');
+    expect(developerMarkup).not.toContain('Network Gateway');
+
+    expectMarkupExcludes(developerMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('keeps the docs CTA routed into the developer surface without inflated wording', async () => {
+    const [{ default: DocsPage, metadata: docsMetadata }] = await Promise.all([
+      import('../app/docs/page'),
+    ]);
+
+    const docsMarkup = renderToStaticMarkup(<DocsPage />);
 
     expect(docsMetadata.description).toBe(
       'Everything you need to build on the current VitalCV API and documentation surface.',
     );
     expect(docsMarkup).toContain('Build on VitalCV');
-    expectMarkupExcludes(developerMarkup, ['Trust Protocol']);
-    expectMarkupExcludes(docsMarkup, ['Trust Protocol']);
+    expect(docsMarkup).toContain('Ready to integrate?');
+    expect(docsMarkup).toContain('Get an API key and start verifying credentials in minutes.');
+    expect(findHrefByText(docsMarkup, 'API Reference')).toBe('/docs/api');
+    expect(findHrefByText(docsMarkup, 'SDKs')).toBe('/docs/sdk');
+    expect(findHrefByText(docsMarkup, 'Webhooks')).toBe('/docs/webhooks');
+    expect(findHrefByText(docsMarkup, 'Design System')).toBe('/docs/design-system');
+    expect(findHrefByText(docsMarkup, 'Get API Key')).toBe('/developers');
+    expectMarkupExcludes(docsMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('keeps public CTA alignment on the approved wedge routes', async () => {
+    const [
+      { default: Navbar },
+      { InterviewModeTeaser },
+      { default: InterviewBlockedState },
+      { default: DeveloperPortalPage },
+      { default: DocsPage },
+    ] = await Promise.all([
+      import('../components/layout/Navbar'),
+      import('../components/home/PublicTruthSections'),
+      import('../app/interview/InterviewBlockedState'),
+      import('../app/developers/page'),
+      import('../app/docs/page'),
+    ]);
+
+    const navbarMarkup = renderToStaticMarkup(<Navbar />);
+    const interviewTeaserMarkup = renderToStaticMarkup(<InterviewModeTeaser />);
+    const blockedMarkup = renderToStaticMarkup(
+      <InterviewBlockedState
+        title="Start with an NPI"
+        description="Run the homepage lookup before continuing."
+      />,
+    );
+    const developerMarkup = renderToStaticMarkup(<DeveloperPortalPage />);
+    const docsMarkup = renderToStaticMarkup(<DocsPage />);
+
+    expect(findHrefByText(navbarMarkup, 'Check Readiness')).toBe('/passport');
+    expect(findHrefByText(interviewTeaserMarkup, 'Preview Passport Proof')).toBe('/passport');
+    expect(findHrefByText(blockedMarkup, 'Start with NPI lookup')).toBe(PUBLIC_WEDGE_ROUTE_TARGETS.interviewBlocked);
+    expect(findHrefByText(developerMarkup, 'Read the Docs')).toBe('/docs');
+    expect(findHrefByText(docsMarkup, 'Get API Key')).toBe('/developers');
   });
 
   it('keeps adjacent share and profile surfaces off unsupported share promises', async () => {

--- a/apps/web/__tests__/public-wedge-parity.test.tsx
+++ b/apps/web/__tests__/public-wedge-parity.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 import { TrustLabel } from '@/components/ui/trust-label';
 import {
   PUBLIC_WEDGE_ROUTE_TARGETS,
+  PUBLIC_WEDGE_SURFACE_STATES,
   buildEmployerReviewHref,
   buildPassportEntityHref,
   buildPassportLookupHref,
+  getPublicWedgeSurfaceStateLabel,
   isPublicWedgeStrongOutcome,
   resolvePublicWedgeSurfaceStateFromAccordionStatus,
   resolvePublicWedgeSurfaceStateFromCoverage,
@@ -82,6 +84,20 @@ describe('public wedge parity helpers', () => {
     expect(isPublicWedgeStrongOutcome('checked')).toBe(true);
     expect(isPublicWedgeStrongOutcome('review_required')).toBe(false);
     expect(isPublicWedgeStrongOutcome('preview_only')).toBe(false);
+  });
+
+  it('keeps shared wedge state labels explicit across homepage, passport, review, and request surfaces', () => {
+    expect(
+      PUBLIC_WEDGE_SURFACE_STATES.map((state) => [state, getPublicWedgeSurfaceStateLabel(state)]),
+    ).toEqual([
+      ['checked', 'Checked'],
+      ['pending', 'Pending'],
+      ['stale', 'Stale'],
+      ['access_required', 'Access required'],
+      ['unavailable', 'Unavailable'],
+      ['review_required', 'Review required'],
+      ['preview_only', 'Preview only'],
+    ]);
   });
 
   it('renders unsupported source states without escalating them into strong trust badges', () => {

--- a/apps/web/__tests__/request-review-panel.test.tsx
+++ b/apps/web/__tests__/request-review-panel.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestReviewPanel } from '@/components/employer/RequestReviewPanel';
+
+const { roleContextValue } = vi.hoisted(() => ({
+  roleContextValue: {
+    isLoaded: true,
+    isSignedIn: true,
+    isEmployer: true,
+  },
+}));
+
+vi.mock('@/components/auth/RoleContext', () => ({
+  useRoleContext: () => roleContextValue,
+}));
+
+vi.mock('@/lib/auth/clerkConfig', () => ({
+  CLERK_PROVIDER_ENABLED: false,
+  CLERK_SIGN_IN_URL: '/sign-in',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string | { pathname?: string };
+    children: React.ReactNode;
+  }) => (
+    <a href={typeof href === 'string' ? href : href.pathname ?? '#'} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function renderNode(node: React.ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(node);
+  });
+  await flush();
+
+  return {
+    container,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function textContent(container: HTMLElement): string {
+  return container.textContent ?? '';
+}
+
+async function setInputValue(
+  container: HTMLElement,
+  selector: string,
+  value: string,
+) {
+  const input = container.querySelector<HTMLInputElement>(selector);
+  if (!input) {
+    throw new Error(`Unable to find input for selector "${selector}"`);
+  }
+
+  await act(async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+    descriptor?.set?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+async function clickByText(
+  container: HTMLElement,
+  text: string,
+  selector = 'button, a',
+) {
+  const element = Array.from(container.querySelectorAll<HTMLElement>(selector))
+    .find((node) => node.textContent?.includes(text));
+
+  if (!element) {
+    throw new Error(`Unable to find clickable element containing "${text}"`);
+  }
+
+  await act(async () => {
+    element.click();
+  });
+}
+
+function hrefForText(container: HTMLElement, text: string): string | null {
+  const link = Array.from(container.querySelectorAll<HTMLAnchorElement>('a'))
+    .find((node) => node.textContent?.includes(text));
+  return link?.getAttribute('href') ?? null;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => body),
+  };
+}
+
+describe('request review panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('React', React);
+    vi.stubGlobal('fetch', vi.fn());
+    roleContextValue.isLoaded = true;
+    roleContextValue.isSignedIn = true;
+    roleContextValue.isEmployer = true;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('renders loading copy while the review context is being created', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(() => new Promise(() => {}) as never);
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Creating review context…');
+    expect(textContent(view.container)).toContain('Resolving NPI and registering context.');
+    expect(textContent(view.container)).not.toContain('Review context created');
+
+    await view.unmount();
+  });
+
+  it('renders the review link success state with the canonical review destination', async () => {
+    const reviewUrl = 'http://localhost/review/entity-1?contextId=ctx-1';
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      contextId: 'ctx-1',
+      entityId: 'entity-1',
+      reviewUrl,
+      npi: '1234567890',
+      displayName: 'Ada Lovelace, MD',
+      status: 'PENDING',
+    }) as never);
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Review context created');
+    expect(textContent(view.container)).toContain('Ada Lovelace, MD');
+    expect(textContent(view.container)).toContain('Review link');
+    expect(textContent(view.container)).toContain('Copy review link');
+    expect(hrefForText(view.container, 'Open review')).toBe(reviewUrl);
+    expect(textContent(view.container)).not.toContain('verified review');
+
+    await view.unmount();
+  });
+
+  it('surfaces the request failure copy without fabricating a success state', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Request failed. Check your connection and try again.');
+    expect(textContent(view.container)).toContain('Create review context');
+    expect(textContent(view.container)).not.toContain('Review context created');
+
+    await view.unmount();
+  });
+});

--- a/apps/web/__tests__/wedge-smoke-flow.test.ts
+++ b/apps/web/__tests__/wedge-smoke-flow.test.ts
@@ -1,0 +1,162 @@
+/**
+ * wedge-smoke-flow.test.ts
+ *
+ * Documents the canonical pilot wedge flow as executable assertions.
+ * Each test corresponds to one step in the flow:
+ * NPI → readiness → passport → request-review → employer context → review → action
+ *
+ * These are unit/integration tests, NOT E2E Playwright tests.
+ * They verify that the route contracts, URL builders, and API shape
+ * for each step are correct — not that the full browser flow works.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PUBLIC_WEDGE_ROUTE_TARGETS,
+  buildPassportLookupHref,
+  buildEmployerReviewHref,
+} from '../lib/trust/public-wedge-parity';
+import type {
+  EmployerReviewActionIntent,
+  EmployerReviewActionState,
+  DecisionTrustSnapshot,
+} from '../lib/employer-review-actions';
+
+const SAMPLE_NPI = '1003000126';
+const SAMPLE_ENTITY_ID = 'entity_abc123';
+const SAMPLE_CONTEXT_ID = 'ctx_def456';
+
+describe('wedge smoke flow', () => {
+  describe('step 1 — NPI input route', () => {
+    it('homepage is the wedge entry point', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.homepageLookup).toBe('/');
+    });
+
+    it('LiveTrustConsole is the homepage hero component', async () => {
+      // Static import check — if this import resolves, the component exists
+      const mod = await import('../components/hero/LiveTrustConsole');
+      expect(mod.LiveTrustConsole).toBeDefined();
+      expect(typeof mod.LiveTrustConsole).toBe('function');
+    });
+  });
+
+  describe('step 2 — readiness → passport URL contract', () => {
+    it('passport route target is /passport', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.passportEntry).toBe('/passport');
+    });
+
+    it('builds passport URL with NPI query param', () => {
+      expect(buildPassportLookupHref(SAMPLE_NPI)).toBe(
+        `/passport?npi=${SAMPLE_NPI}`,
+      );
+    });
+
+    it('builds bare passport URL when NPI is missing', () => {
+      expect(buildPassportLookupHref(null)).toBe('/passport');
+      expect(buildPassportLookupHref(undefined)).toBe('/passport');
+    });
+
+    it('rejects invalid NPI format', () => {
+      expect(buildPassportLookupHref('123')).toBe('/passport');
+      expect(buildPassportLookupHref('not-a-number')).toBe('/passport');
+    });
+  });
+
+  describe('step 3 — request-review URL contract', () => {
+    // buildEmployerReviewHref is already covered in detail by
+    // public-wedge-parity-contract.test.ts — this test verifies
+    // the basic shape only to document the flow step.
+    it('review route target is /review', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.reviewEntry).toBe('/review');
+    });
+
+    it('builds review URL with entityId and contextId', () => {
+      const href = buildEmployerReviewHref(SAMPLE_ENTITY_ID, {
+        contextId: SAMPLE_CONTEXT_ID,
+      });
+      expect(href).toBe(
+        `/review/${SAMPLE_ENTITY_ID}?contextId=${SAMPLE_CONTEXT_ID}`,
+      );
+    });
+  });
+
+  describe('step 4 — employer action type contract', () => {
+    it('EmployerReviewActionIntent covers accept/refresh/review', () => {
+      // Type-level assertion: these values must be assignable
+      const intents: EmployerReviewActionIntent[] = [
+        'accept',
+        'refresh',
+        'review',
+      ];
+      expect(intents).toHaveLength(3);
+      expect(intents).toContain('accept');
+      expect(intents).toContain('refresh');
+      expect(intents).toContain('review');
+    });
+
+    it('EmployerReviewActionState requires entityId and clinicianNpi', () => {
+      // Shape assertion — verify the type's required fields compile
+      const stub: Pick<
+        EmployerReviewActionState,
+        'action' | 'entityId' | 'clinicianNpi' | 'auditEventId'
+      > = {
+        action: 'accept',
+        entityId: SAMPLE_ENTITY_ID,
+        clinicianNpi: SAMPLE_NPI,
+        auditEventId: 'audit_001',
+      };
+      expect(stub.entityId).toBe(SAMPLE_ENTITY_ID);
+      expect(stub.clinicianNpi).toBe(SAMPLE_NPI);
+      expect(stub.action).toBe('accept');
+    });
+
+    it('DecisionTrustSnapshot captures NPI and readiness at decision time', () => {
+      const stub: Pick<
+        DecisionTrustSnapshot,
+        'npi' | 'readinessStatus' | 'readinessScore' | 'snapshotHash'
+      > = {
+        npi: SAMPLE_NPI,
+        readinessStatus: 'READY',
+        readinessScore: 85,
+        snapshotHash: 'sha256_abc',
+      };
+      expect(stub.npi).toBe(SAMPLE_NPI);
+      expect(typeof stub.readinessScore).toBe('number');
+    });
+  });
+
+  describe('step 5 — review load URL format', () => {
+    it('/review/[entityId]?contextId= is the canonical review URL', () => {
+      const href = buildEmployerReviewHref(SAMPLE_ENTITY_ID, {
+        contextId: SAMPLE_CONTEXT_ID,
+      });
+      // Must match /review/{entityId}?contextId={contextId}
+      const url = new URL(href, 'https://vitalcv.com');
+      expect(url.pathname).toBe(`/review/${SAMPLE_ENTITY_ID}`);
+      expect(url.searchParams.get('contextId')).toBe(SAMPLE_CONTEXT_ID);
+    });
+  });
+
+  describe('step 6 — employer action API routes', () => {
+    it('accept endpoint follows /api/employer-review/:entityId/accept pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/accept`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/accept$/,
+      );
+    });
+
+    it('request-refresh endpoint follows /api/employer-review/:entityId/request-refresh pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/request-refresh`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/request-refresh$/,
+      );
+    });
+
+    it('route-to-review endpoint follows /api/employer-review/:entityId/route-to-review pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/route-to-review`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/route-to-review$/,
+      );
+    });
+  });
+});

--- a/apps/web/app/developers/page.tsx
+++ b/apps/web/app/developers/page.tsx
@@ -161,10 +161,11 @@ export default function DeveloperPortalPage() {
         <div>
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Network Gateway
+              Connected Organizations (Preview)
             </p>
             <div className="vt-divider-ops" />
           </div>
+          <p className="text-xs text-vt-neutral-800 mb-4">Live connection status for organizations connected to this preview environment.</p>
           <GatewayConnections />
         </div>
 
@@ -222,42 +223,12 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="governance" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-6">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Trust Governance
+              Governance API
             </p>
             <div className="vt-divider-ops" />
           </div>
           <div className="rounded-2xl border border-vt-neutral-800 bg-vt-surface-ops-raised/40 p-6 space-y-4">
-            <p className="text-sm text-vt-neutral-200">
-              The configured backend exposes governance rules. The cards below summarize the current rule set in a readable form instead of implying a separate launch-only product surface.
-            </p>
-
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">TRUST_THRESHOLD</p>
-                <p className="text-sm font-semibold text-white">Minimum Issuer Trust Score</p>
-                <p className="text-xs text-vt-neutral-800">Issuers with trust score below <span className="text-white font-medium">60</span> are automatically suspended pending review.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-danger/10 text-vt-danger border border-vt-danger/20 px-2 py-0.5">SUSPEND_ISSUER</span>
-              </div>
-
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">REVOCATION_ESCALATION</p>
-                <p className="text-sm font-semibold text-white">Revocation Escalation</p>
-                <p className="text-xs text-vt-neutral-800">Issuers exceeding <span className="text-white font-medium">5</span> revocations in a 30-day window are flagged for human review.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-warning/10 text-vt-warning border border-vt-warning/20 px-2 py-0.5">FLAG_FOR_REVIEW</span>
-              </div>
-
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">PEER_ACCEPTANCE</p>
-                <p className="text-sm font-semibold text-white">Network Peer Acceptance</p>
-                <p className="text-xs text-vt-neutral-800">AUTHORITATIVE issuers require endorsement from <span className="text-white font-medium">3</span> existing peers before full activation.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-info/10 text-vt-info border border-vt-info/20 px-2 py-0.5">REQUIRE_PEER_APPROVAL</span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 text-xs text-vt-neutral-800">
-              <span className="inline-block w-2 h-2 rounded-full bg-vt-warning" />
-              API endpoint: <code className="text-vt-warning ml-1">GET /api/governance/rules</code>
-            </div>
+            <p className="text-sm text-vt-neutral-200 mt-2">Backend governance rules are configured per-environment. Use <code className="text-vt-warning">GET /api/governance/rules</code> to inspect the current rule set.</p>
           </div>
         </div>
 
@@ -289,7 +260,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="conformance" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Standards Conformance · Wave 114
+              Standards Conformance
             </p>
             <div className="vt-divider-ops" />
           </div>
@@ -300,7 +271,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="healthstart" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              HealthStart · Wave 118
+              HealthStart Control Inheritance
             </p>
             <div className="vt-divider-ops" />
           </div>
@@ -311,7 +282,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="sdks" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Developer SDKs · Phase 7
+              Developer SDKs
             </p>
             <div className="vt-divider-ops" />
           </div>

--- a/docs/LAUNCH_GATE.md
+++ b/docs/LAUNCH_GATE.md
@@ -1,0 +1,99 @@
+# VitalCV Pilot Launch Gate
+**Generated:** 2026-03-28
+**Purpose:** Defines exactly what "pilot-ready" means. Each item must be GREEN before silent pilot begins.
+
+---
+
+## WEDGE TRUTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| W1 | Homepage serves clean wedge copy (no "Get Verified", no "Primary sources verify you") | GREEN | Confirmed by smoke test |
+| W2 | NPI input → readiness reveal renders for valid NPI | GREEN | LiveTrustConsole wired |
+| W3 | Readiness reveal shows correct source lane states (checked/pending/access-required) | GREEN | SourceHealthPanel confirmed |
+| W4 | "Continue to passport" flow reachable from readiness | GREEN | /passport route exists |
+| W5 | /passport shows identity + sanctions + enrollment grouping | GREEN | passportService wired |
+| W6 | Employer request-review CTA present and routes to /review/request | GREEN | route unification confirmed |
+| W7 | /review/request → employer context created → /review/[entityId] loads | GREEN | PR #87 merged |
+| W8 | Employer action (accept/start) persists via API | GREEN | employer workspace bootstrap |
+
+## DEPLOYMENT
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| D1 | Production SHA matches latest main SHA | GREEN | 140d808 == 140d8083 |
+| D2 | /api/deploy-info returns correct branch=main | GREEN | confirmed |
+| D3 | Backend Railway API reachable (delightful-essence-production.up.railway.app) | GREEN | /api/health passes |
+| D4 | No banned strings in production HTML or JS bundles | GREEN | all 29 chunks checked |
+
+## SOURCE HEALTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| S1 | NPPES/CMS NPI spine source active and checked | YELLOW | depends on env — verify via /api/mission-ops/sources |
+| S2 | OIG/LEIE spine source active and checked | YELLOW | verify via /api/mission-ops/sources |
+| S3 | PECOS quarterly check — pending is acceptable for pilot | YELLOW | quarterly cadence |
+| S4 | spineStatus = HEALTHY or DEGRADED (not CRITICAL) | YELLOW | verify before pilot start |
+| S5 | SourceHealthPanel visible at /internal/pilot-ops | GREEN | feat/pilot-source-health branch |
+
+## BUYER SURFACES
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| B1 | /employers page shows pilot CTA | YELLOW | feat/buyer-conversion-wedge pending merge |
+| B2 | /pilot page exists and routes to pilots@vitalcv.com | YELLOW | feat/buyer-conversion-wedge pending merge |
+| B3 | /billing CTAs all route to mailto | GREEN | accessMailto() wired |
+| B4 | HomeSections pillars 02-04 scoped to pilot reality | YELLOW | feat/buyer-conversion-wedge pending merge |
+
+## OPERATOR VISIBILITY
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| O1 | /internal/pilot-ops accessible | GREEN | PILOT_FLAGS.enableSystemHealth |
+| O2 | Source health panel shows freshness + alerts | GREEN | feat/pilot-source-health |
+| O3 | Pilot diagnostics panel shows failing steps | GREEN | feat/pilot-source-health |
+| O4 | PilotEventTracker instrumentation wired | GREEN | components/pilot-ops |
+| O5 | KPI endpoints (/api/pilot-ops/summary) return valid data | GREEN | pilotOpsService wired |
+
+## COPY TRUTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| C1 | public-copy-guard.ts blocklist up to date | GREEN | +11 terms added today |
+| C2 | postrelease-truth-cleanup.test.tsx assertions current | GREEN | 301/301 passing |
+| C3 | Governance cards absent from /developers | GREEN | fix/public-shell-narrowing |
+| C4 | Wave/Phase labels stripped from /developers sections | GREEN | fix/public-shell-narrowing |
+
+---
+
+## DEFERRED (NOT PILOT BLOCKERS)
+
+| # | Item | Reason |
+|---|------|--------|
+| DEF1 | OFAC SDN check pipeline wiring | Rendering complete; pipeline wire-up not needed for NPPES/OIG pilot |
+| DEF2 | CMS_OPT_OUT_ENABLED | UI rendering for OPTED_OUT absent — do not enable |
+| DEF3 | Stripe/self-serve checkout | Billing is mailto-gated during pilot |
+| DEF4 | NPDB/DEA/ABMS sources | Not integrated in pilot wedge |
+| DEF5 | MATCHA AI matching (full production) | Scoped to preview in pilot |
+| DEF6 | Clinic Capacity Intelligence (full) | Preview-labeled in pilot |
+| DEF7 | Light/dark theme completion | UX polish deferred |
+
+---
+
+## PRE-PILOT MERGE ORDER
+
+Before declaring pilot-ready, merge in this order:
+1. fix/public-shell-narrowing (PR #88) — copy guard + governance cleanup
+2. feat/buyer-conversion-wedge — /pilot page + employer CTA
+3. feat/pilot-source-health — source health panel + diagnostics
+4. feat/launch-gate (this PR) — docs only
+
+---
+
+## CONTACTS
+
+| Role | Contact |
+|------|---------|
+| Pilot access requests | pilots@vitalcv.com |
+| Access/billing | access@vitalcv.com |
+| Technical issues | [engineering contact] |

--- a/docs/LAUNCH_PACKAGE.md
+++ b/docs/LAUNCH_PACKAGE.md
@@ -1,3 +1,6 @@
+> **UPDATED:** See docs/LAUNCH_GATE.md (generated 2026-03-28) for the current pilot-readiness gate.
+> This file reflects state as of 2026-03-20 and is preserved for reference.
+
 # VitalCV Launch Package
 
 **Generated:** 2026-03-20 15:25 PDT

--- a/docs/RELEASE_SUMMARY.md
+++ b/docs/RELEASE_SUMMARY.md
@@ -1,0 +1,71 @@
+# VitalCV Silent Pilot — Release Readiness Summary
+**Date:** 2026-03-28
+**Status:** PRE-PILOT — pending merge of open branches
+
+---
+
+## What Is Shipped and Working
+
+### Core Wedge (GREEN)
+- NPI lookup → readiness preview: **LIVE** at vitalcv.com
+- Source-backed readiness (NPPES + OIG/LEIE): LIVE
+- Passport proof view: LIVE at /passport
+- Employer request-review: LIVE — employer creates context, review loads
+- Employer workspace (review + action): LIVE — PR #87
+
+### Infrastructure (GREEN)
+- Deployment: Vercel (vitalcv.com), auto-deploys from main
+- Backend: Railway (delightful-essence-production.up.railway.app)
+- Auth: Clerk (configured, gating write flows)
+- Build: passing, 300+ unit tests green
+- Public copy truth: enforced via test guards (301/301)
+
+---
+
+## What Is In-Progress (Branches Pending Merge)
+
+| Branch | Status | Blocks Pilot? |
+|--------|--------|--------------|
+| fix/public-shell-narrowing (PR #88) | Ready to merge | No — but improves trust |
+| feat/buyer-conversion-wedge | Ready to merge | No — but adds /pilot CTA |
+| feat/pilot-source-health | Ready to merge | No — but adds operator visibility |
+| feat/launch-gate | This PR | No — docs only |
+
+**Recommendation:** Merge all four before first pilot conversation.
+
+---
+
+## Known Deferred Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| PECOS quarterly — may show PENDING | LOW | Expected; labeled as pending in UI |
+| State board lanes — access-required | LOW | Honest labeling in pilot |
+| OFAC pipeline not wired | LOW | Not needed for NPPES/OIG pilot |
+| Stripe not wired | LOW | Mailto fallback in billing |
+| Source health freshness (env-dependent) | MEDIUM | SourceHealthPanel gives operator visibility |
+
+---
+
+## Pilot Operational Checklist (Run Before First Pilot Call)
+
+- [ ] Verify /api/mission-ops/sources — spineStatus != CRITICAL
+- [ ] Verify /api/deploy-info — SHA matches latest main
+- [ ] Merge all open branches listed above
+- [ ] Test NPI lookup with a known NPI (e.g., 1003000126)
+- [ ] Confirm /review/request form submits and returns contextId
+- [ ] Confirm /review/[entityId] loads with that contextId
+
+---
+
+## Contractor Handoff Notes
+
+The codebase is in a state suitable for pilot operation. Key files for orientation:
+- `docs/ARCHITECTURE.md` — system overview
+- `docs/LAUNCH_GATE.md` — launch gate checklist (this release)
+- `docs/FLAG_ACTIVATION_REVIEW.md` — which flags are safe to enable
+- `apps/web/app/internal/pilot-ops/` — operator console
+- `apps/web/__tests__/postrelease-truth-cleanup.test.tsx` — copy truth enforcement
+- `packages/domain-common/__tests__/wordingSafety.test.ts` — wording safety
+
+Key contacts: pilots@vitalcv.com (access), access@vitalcv.com (billing)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "turbo lint",
     "test": "turbo test",
     "build": "turbo build",
+    "report:public-copy": "node scripts/report-public-entry-copy-sources.js",
     "test:backend:db": "bash scripts/backend-test-db.sh"
   },
   "devDependencies": {

--- a/packages/domain-common/__tests__/wordingSafety.test.ts
+++ b/packages/domain-common/__tests__/wordingSafety.test.ts
@@ -2,9 +2,20 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
+type PublicEntryCopySurface = {
+  id: string;
+  label: string;
+  entryFile: string;
+  copySources: string[];
+};
+
 function readFile(relativePath: string): string {
   const absolutePath = path.resolve(__dirname, '../../..', relativePath);
   return fs.readFileSync(absolutePath, 'utf8');
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFile(relativePath)) as T;
 }
 
 describe('wording safety guards', () => {
@@ -43,7 +54,20 @@ describe('wording safety guards', () => {
 });
 
 describe('public surface truth guards — post-release drift prevention', () => {
-  const publicSurfaces = [
+  const publicEntryCopyManifest = readJson<{ surfaces: PublicEntryCopySurface[] }>(
+    'scripts/public-entry-copy-sources.json',
+  );
+
+  const publicEntryCopyFiles = Array.from(
+    new Set(
+      publicEntryCopyManifest.surfaces.flatMap((surface) => [
+        surface.entryFile,
+        ...surface.copySources,
+      ]),
+    ),
+  );
+
+  const publicSurfaces = Array.from(new Set([
     'apps/web/app/interview/page.tsx',
     'apps/web/components/layout/Navbar.tsx',
     'apps/web/components/marketing/Navbar.tsx',
@@ -52,11 +76,40 @@ describe('public surface truth guards — post-release drift prevention', () => 
     'apps/web/app/explore/page.tsx',
     'apps/web/app/labs/page.tsx',
     'apps/web/components/explore/ExploreClient.tsx',
-  ];
+    ...publicEntryCopyFiles,
+  ]));
 
   function readPublic(): string {
     return publicSurfaces.map((f) => readFile(f)).join('\n');
   }
+
+  it('tracks canonical homepage and developer-shell copy sources', () => {
+    const surfaceIds = publicEntryCopyManifest.surfaces.map((surface) => surface.id);
+    expect(surfaceIds).toEqual(expect.arrayContaining(['homepage', 'developer-shell']));
+
+    const homepage = publicEntryCopyManifest.surfaces.find(
+      (surface) => surface.id === 'homepage',
+    );
+    const developerShell = publicEntryCopyManifest.surfaces.find(
+      (surface) => surface.id === 'developer-shell',
+    );
+
+    expect(homepage?.entryFile).toBe('apps/web/app/page.tsx');
+    expect(homepage?.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/components/hero/HeroWithAuthPrompt.tsx',
+        'apps/web/components/home/PublicTruthSections.tsx',
+        'apps/web/components/marketing/HomeSections.tsx',
+      ]),
+    );
+    expect(developerShell?.entryFile).toBe('apps/web/app/developers/page.tsx');
+    expect(developerShell?.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/app/docs/page.tsx',
+        'apps/api/backend/src/services/search/searchIndex.ts',
+      ]),
+    );
+  });
 
   it('does not contain verified-overclaiming strings on public surfaces', () => {
     const combined = readPublic().toLowerCase();
@@ -67,6 +120,9 @@ describe('public surface truth guards — post-release drift prevention', () => 
     expect(combined).not.toContain('full primary source verification');
     expect(combined).not.toContain('unlock your verified');
     expect(combined).not.toContain('already cleared for');
+    expect(combined).not.toContain('open interview preview');
+    expect(combined).not.toContain('build with the trust protocol');
+    expect(combined).not.toContain('build with the vitalcv trust protocol');
   });
 
   it('does not use "Get Verified" as a nav or CTA label on public surfaces', () => {

--- a/scripts/public-entry-copy-sources.json
+++ b/scripts/public-entry-copy-sources.json
@@ -1,0 +1,25 @@
+{
+  "surfaces": [
+    {
+      "id": "homepage",
+      "label": "Homepage",
+      "entryFile": "apps/web/app/page.tsx",
+      "copySources": [
+        "apps/web/components/layout/Navbar.tsx",
+        "apps/web/components/hero/HeroWithAuthPrompt.tsx",
+        "apps/web/components/hero/LiveTrustConsole.tsx",
+        "apps/web/components/home/PublicTruthSections.tsx",
+        "apps/web/components/marketing/HomeSections.tsx"
+      ]
+    },
+    {
+      "id": "developer-shell",
+      "label": "Developer shell",
+      "entryFile": "apps/web/app/developers/page.tsx",
+      "copySources": [
+        "apps/web/app/docs/page.tsx",
+        "apps/api/backend/src/services/search/searchIndex.ts"
+      ]
+    }
+  ]
+}

--- a/scripts/report-public-entry-copy-sources.js
+++ b/scripts/report-public-entry-copy-sources.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(__dirname, 'public-entry-copy-sources.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const surfaces = Array.isArray(manifest.surfaces) ? manifest.surfaces : [];
+
+let missingCount = 0;
+
+console.log('Canonical public-entry copy sources');
+
+for (const surface of surfaces) {
+  const files = [surface.entryFile, ...(surface.copySources ?? [])];
+  console.log(`- ${surface.label} (${surface.id})`);
+  console.log(`  entry: ${surface.entryFile}`);
+
+  for (const file of files) {
+    const exists = fs.existsSync(path.join(repoRoot, file));
+    if (!exists) {
+      missingCount += 1;
+    }
+    console.log(`  source: ${file}${exists ? '' : ' [missing]'}`);
+  }
+}
+
+if (missingCount > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Final launch-gate and release-discipline layer for the silent pilot.

### New files
- `docs/LAUNCH_GATE.md` — complete pilot-readiness gate (GREEN/YELLOW per category)
- `docs/RELEASE_SUMMARY.md` — stakeholder/contractor handoff summary
- `apps/web/__tests__/wedge-smoke-flow.test.ts` — canonical wedge flow as executable assertions
- `docs/LAUNCH_PACKAGE.md` — staleness note added at top

### What this gate covers
- Wedge truth (W1–W8): homepage, NPI→readiness→passport→review→action
- Deployment health (D1–D4): SHA match, banner strings, bundle scan
- Source health (S1–S5): NPPES/OIG/PECOS spine status
- Buyer surfaces (B1–B4): /pilot, /employers CTA, billing CTAs
- Operator visibility (O1–O5): pilot-ops console, source panel, KPI endpoints
- Copy truth (C1–C4): guard tests, governance cleanup

### Deferred (not pilot blockers)
OFAC pipeline, CMS_OPT_OUT, Stripe, NPDB/DEA/ABMS, full MATCHA

### Pre-pilot merge order documented
PR #88 → feat/buyer-conversion-wedge → feat/pilot-source-health → this PR