### PR TITLE
docs(pilot): Waves 20+21 — buyer proof pack + real pilot loop docs

### DIFF
--- a/BUYER-SURFACE-AUDIT-2026-03-28.md
+++ b/BUYER-SURFACE-AUDIT-2026-03-28.md
@@ -1,0 +1,156 @@
+# VitalCV Buyer Surface Audit — 2026-03-28
+
+**Auditor posture:** VP of Credentialing at a 400-bed system, evaluating whether to pilot VitalCV for provider onboarding. Has 10 minutes and zero patience for vaporware.
+
+---
+
+## 1. WHAT DOES VITALCV DO FOR ME OPERATIONALLY?
+
+### What the page says
+The marketing site (/verifier) makes three operational promises:
+
+1. **Replace manual PSV with cryptographic proof** — verify in seconds, not weeks.
+2. **Portable evidence bundles** — signed, timestamped artifacts per verification.
+3. **Single API integration** — one endpoint, structured output, DPoP-bound.
+
+The web app homepage adds market-framing stats: 45–90 day cycles, $9K/day unfilled slots, 1-in-5 apps have errors.
+
+### What's actually clear to a buyer
+**Partially clear.** The /verifier page does a reasonable job explaining the *mechanism* (submit NPI → get evidence bundle → store or forward). The security guarantees section (ES256, HAIP 1.0, DPoP, zero PHI) is unusually strong for this stage — a compliance officer would notice this positively.
+
+### What's missing operationally
+- **No workflow integration story.** A credentialing director needs to know: does this plug into my CVO? My AMS? My Cactus/Modio/symplr instance? The "one endpoint" claim is developer-facing, not ops-facing.
+- **No before/after timeline.** "Seconds not weeks" is stated but never shown concretely. No "Day 1 → Day 3 you're live" narrative.
+- **No FTE impact framing.** Buyers think in headcount. How many credential specialists does this replace or redeploy?
+- **No NCQA/Joint Commission language.** The compliance badges say "HIPAA-aligned" and "ONC 21st Century Cures" but never mention NCQA CVO standards, Joint Commission HR chapter, or CMS CoPs — the frameworks buyers are *actually audited against*.
+
+---
+
+## 2. WHAT SHOULD I CLICK NOW?
+
+### Primary CTAs found
+
+| Surface | CTA Text | Destination | Friction |
+|---------|----------|-------------|----------|
+| Marketing hero | NPI input field | /clinician?npi=... | **Clinician-first** — wrong persona |
+| Marketing nav | "Try demo" | /demo | Good intent, unclear payload |
+| /verifier CTA | "Try NPI lookup" | / (home) | Sends buyer *backwards* |
+| /verifier CTA | "Request access" | https://app.vitalcv.com | External redirect, no context |
+| /employers page | "Request pilot access" | /pilot | Correct intent |
+| /employers page | "View proof" | /employers/[slug] | Shows employer detail, not buyer action |
+| /review page | "Request a passport review" | /review/request | Correct but buried, tiny text (white/25) |
+| Contact page | hello@vitalcv.com | Email link | No form, no calendly, no response SLA |
+
+### Verdict: **Conversion path is broken for buyers.**
+
+The primary CTA on the entire marketing site is an NPI input field — which is a *clinician* action. A VP of Credentialing landing on the homepage would see a text box asking for their NPI and have no idea what to do. The "Verifier →" link is a small underlined text link below the fold.
+
+The /verifier page's own CTA ("Try NPI lookup") routes the buyer *back to the homepage*. "Request access" goes to an external app URL with no onboarding context.
+
+The only correct buyer conversion point — "Request pilot access" on /employers — requires the buyer to navigate through a directory page that may show zero employers if the backend returns empty.
+
+---
+
+## 3. WHAT IS PROVEN VS. STILL PILOT-STAGE?
+
+### Claims made on the surface
+
+| Claim | Source | Status |
+|-------|--------|--------|
+| "6.8M licensed US healthcare workers" | TractionSection | **Market stat, not a product claim — acceptable** |
+| "$9K/day unfilled physician slot" | TractionSection | **Industry stat — acceptable, widely cited** |
+| "$4.2B US healthcare credentialing market, growing 11% YoY" | TractionSection | **Market stat — acceptable** |
+| "~10s to first readiness snapshot" | TractionSection | **Product claim — needs validation** |
+| "Live NPI verification via NPPES (7M+ provider registry)" | BUILD_SIGNALS | **True — NPPES integration is live** |
+| "Cryptographic SD-JWT credentials — W3C VC + OID4VCI compliant" | BUILD_SIGNALS | **Partially true — implementation exists, full compliance unaudited** |
+| "Employer acceptance flow — review and accept verified packets" | BUILD_SIGNALS | **Overstated — PR87 audit (2026-03-27) documented critical blockers in this exact flow** |
+| "HIPAA-compliant audit ledger with continuous license monitoring" | BUILD_SIGNALS | **Overstated — "HIPAA-compliant" implies completed audit; badges say "HIPAA-aligned" elsewhere, inconsistent** |
+| "Verify clinician credentials in seconds, not weeks" | VerifierHero | **Aspirational — only NPPES + OIG are live sources** |
+| "Hardened by default. Audited to the wire." | SecurityGuarantees | **"Audited" implies third-party audit — none has occurred** |
+| "TEFCA & ONC mandates are live" | WhyNowSection | **True but misleading — TEFCA doesn't mandate credentialing interoperability specifically** |
+
+### Inflated claims flagged
+
+1. **"Audited to the wire"** — This is the most dangerous claim. No third-party security audit has been completed. This phrase implies one has. A buyer's legal/compliance team would ask for the audit report and find nothing.
+
+2. **"HIPAA-compliant audit ledger"** — "Compliant" vs. "aligned" distinction matters enormously. The compliance badges correctly say "HIPAA-aligned" but BUILD_SIGNALS says "HIPAA-compliant." Pick one; the correct one is "aligned" until you have a BAA and attestation.
+
+3. **"Employer acceptance flow — review and accept verified packets"** — The PR87 audit from yesterday documents this flow has critical blockers. Claiming it's "built & working" on the homepage is factually inaccurate today.
+
+4. **"Verify clinician credentials in seconds, not weeks"** — Only NPPES identity + OIG/LEIE exclusion are live. State board licenses, DEA, board certs, NPDB are not integrated. "Verify" implies full PSV replacement; current capability is partial identity + exclusion check.
+
+---
+
+## 4. DOES THE PAGE FEEL CREDIBLE AND COMMERCIALLY CLEAR?
+
+### What works
+- **Design quality is high.** Dark-mode operator aesthetic, clean typography, no visual junk. Feels like infrastructure, not a job board.
+- **Security section is excellent.** ES256-only, DPoP, nonce lifecycle, HAIP 1.0 — this is the most credible section on the entire site. Technical buyers will respect this.
+- **Problem framing is visceral.** "Every hospital reverifies you from scratch. Every time." is a good line. Pain stats are well-chosen.
+- **Honesty in step descriptions.** The HowItWorks section on the web app has been carefully hedged: "Missing coverage stays visibly pending" and "appear only when those sources are actually available." This is good discipline.
+- **Employer directory disclaimer.** The note at the bottom ("Counts reflect what is visible here so the directory does not imply broader coverage") is honest and well-placed.
+
+### What doesn't work
+- **Two apps, split personality.** Marketing site (apps/marketing) and web app (apps/web) have different navs, different hero copy, different design tokens. A buyer who clicks from one to the other will feel disorientation.
+- **No pricing signal whatsoever.** Not even "Contact us for pricing" or "Starts at $X per verification." A buyer with budget authority needs *something* to anchor a business case.
+- **Contact page is anemic.** One email address. No form. No Calendly. No "Book a demo" flow. For a product selling to healthcare enterprises, this is a hard stop. These buyers expect a sales conversation, not a mailto link.
+- **"For Employers" leads to a directory, not a value prop.** The /employers page is an operational directory of current employers in the system. It's not a landing page explaining what VitalCV does for employers. A buyer clicking "For employers" expects to see ROI, use cases, and a demo — not a list of facilities that may be empty.
+- **Jargon without translation.** "SD-JWT VC," "OpenID4VCI," "DPoP-bound tokens," "HAIP 1.0" — all correct, all meaningless to a VP of Credentialing. The security page serves developers and compliance engineers but not the buyer signing the contract.
+- **No social proof.** Zero logos, zero testimonials, zero case studies, zero "trusted by" badges. At pilot stage this is understandable, but the site should at least show the YC badge prominently on the buyer surface, not just tucked into the contact page.
+
+---
+
+## 5. TOP BUYER-SURFACE ISSUES (Ranked)
+
+| # | Issue | Severity | Fix Effort |
+|---|-------|----------|------------|
+| 1 | **No buyer-specific landing page.** /employers is a directory, not a value prop. Buyers need: problem → solution → proof → CTA. | CRITICAL | M |
+| 2 | **Primary CTA is clinician-first.** Homepage NPI input is meaningless to a buyer. No "I'm an employer" path above the fold. | CRITICAL | S |
+| 3 | **"Audited to the wire" claim.** No third-party audit exists. Legal liability risk. | CRITICAL | S (copy change) |
+| 4 | **"HIPAA-compliant" vs "HIPAA-aligned" inconsistency.** | HIGH | S (copy change) |
+| 5 | **"Employer acceptance flow" claimed as built — PR87 says otherwise.** | HIGH | S (copy change) |
+| 6 | **No contact form / demo booking.** mailto: link is not a conversion mechanism for enterprise sales. | HIGH | S–M |
+| 7 | **No pricing signal.** Buyers can't build a business case without an anchor. | HIGH | S |
+| 8 | **CTA on /verifier routes buyer backward to homepage.** | MEDIUM | S |
+| 9 | **No NCQA/Joint Commission/CMS CoP language.** Buyers think in audit frameworks, not protocol specs. | MEDIUM | S–M |
+| 10 | **No social proof (logos, testimonials, YC badge on buyer pages).** | MEDIUM | S |
+
+---
+
+## 6. CONVERSION BLOCKERS (Buyer cannot proceed)
+
+1. **No "Book a Demo" or "Talk to Sales" anywhere.** Enterprise healthcare buyers do not cold-email. They expect a calendared conversation. Without this, every interested buyer is a lost lead.
+
+2. **Empty-state employer directory kills credibility.** If the backend returns zero employers, the /employers page shows a warning box saying the directory is empty. A buyer seeing this will close the tab.
+
+3. **Review entry point is invisible.** The /review page — the actual employer workflow — shows a warning-toned card saying "Employer review opens from a real passport share link." The employer CTA ("Are you an employer? Request a passport review") is rendered at 25% white opacity, 12px text. This is functionally invisible.
+
+4. **"Request access" on /verifier goes to app.vitalcv.com with no onboarding.** A buyer clicking this lands in the Clerk auth flow with zero context about what they're signing up for.
+
+---
+
+## 7. GO / NO-GO VERDICT
+
+### **NO-GO for merge as buyer-ready surface.**
+
+The current surface is technically impressive and architecturally sound, but it is not commercially functional for the employer/buyer persona. A VP of Credentialing arriving today would:
+
+1. See an NPI input box they don't understand
+2. Eventually find the /verifier page, which explains the mechanism well
+3. Click "Request access" and land in an auth flow with no context
+4. Leave
+
+### Conditions for GO
+
+To reach merge-ready for buyer surface:
+
+1. **Fix the three inflated claims** (copy changes, < 1 hour): "Audited to the wire" → "Hardened by default"; "HIPAA-compliant" → "HIPAA-aligned" consistently; remove "Employer acceptance flow" from BUILD_SIGNALS or qualify it as "in development."
+2. **Add a buyer CTA above the fold** on the homepage: "I'm an employer" → route to a dedicated /for-employers landing page (not the directory).
+3. **Add a demo booking mechanism**: Calendly embed, Hubspot form, or at minimum a structured contact form that captures org name, role, and use case.
+4. **Make /review/request discoverable**: Promote the employer review request to a primary CTA on the buyer landing page instead of hiding it at 25% opacity.
+
+Items 1 and 2 are blockers. Items 3 and 4 are high-priority fast-follows.
+
+---
+
+*Audit conducted against: apps/marketing + apps/web buyer-facing routes, 2026-03-28.*

--- a/PUBLIC-SHELL-AUDIT-2026-03-28.md
+++ b/PUBLIC-SHELL-AUDIT-2026-03-28.md
@@ -1,0 +1,123 @@
+# VitalCV Public Shell Truth Audit — 2026-03-28
+
+**Auditor:** Claude (Strategic + Technical Operator)
+**Scope:** All public entry points post-truth-cleanup merge
+**Verdict:** **NO-GO** — 4 P0 issues remain
+
+---
+
+## Executive Summary
+
+The truth cleanup campaign (~15 commits) significantly improved the homepage hero and passport flow. The NPI-first entry, honest source-coverage labels ("Checked," "Pending," "Access Required," "Preview-only"), and unified `/passport` CTA are solid. However, the cleanup was concentrated on the top-of-funnel flow and **did not reach four other public pages** that still tell a fundamentally different story than the wedge. The partners page fabricates trust logos, the investors page renders hardcoded demo metrics as traction, and the homepage platform section still pitches a job board + AI matching engine. These cannot ship to anyone doing diligence.
+
+---
+
+## The 5 Key Questions
+
+### 1. What does VitalCV do (as told by the live entry story)?
+
+The homepage hero now tells it correctly: enter your NPI → get a source-backed readiness snapshot in ~10 seconds → carry that snapshot into a passport for employer conversations. The "How It Works" section reinforces this. **But scroll past the fold** and the story fractures — a "Platform" section describes a free job board, AI career matching (MATCHA), and clinic capacity intelligence. A visitor who reads the whole page gets two different products.
+
+### 2. What should I do first?
+
+**Depends which navbar you hit.** The layout `Navbar.tsx` sends you to `/passport` ("Check Readiness"). The marketing `Navbar.tsx` sends you to `/onboarding` ("Get Started"). Both are in the codebase. The homepage hero NPI input is the strongest CTA — but it competes with nav-level confusion.
+
+### 3. What is still preview-only?
+
+The hero and passport flow now label preview-only states explicitly and honestly. The `/labs` page distinguishes "Stable," "Preview," "Experiment," and "Internal" correctly. The developers page carries a "Developer Portal Preview" badge. **This is the cleanest part of the cleanup — well done.**
+
+### 4. Does the developers page still imply a bigger company/product than the wedge?
+
+**Yes, significantly.** Three full SDKs (`@vitalcv/verifier-sdk`, `@vitalcv/issuer-sdk`, `@vitalcv/wallet-sdk`) are documented with 20+ methods each. A drop-in widget claims to be hosted at `cdn.vitalcv.com`. Trust governance rules, conformance reports, HealthStart control inheritance (SaaS / PrivateVPC / GovEnclave profiles), and gateway connections all imply a mature platform with federation infrastructure. The "Preview" badge helps, but the volume of documented surface area reads like a Series B developer portal, not a seed-stage wedge.
+
+### 5. Does any public entry point still feel like a different story than the real product?
+
+**Yes — three pages feel like separate products:**
+- `/partners` — a fully structured 3-tier partner program with revenue share, reseller margins, and fabricated "Trusted by" logos (Epic, Cerner, CAQH, Joint Commission)
+- `/investors` — hardcoded `DEMO_METRICS` (12,847 credentials issued, 284 active verifiers) rendered without any "illustrative" label
+- Homepage "Platform" section — pitches a job board and AI career engine
+
+---
+
+## Top 8 Remaining Issues
+
+### P0 — Must Fix Before Merge (Credibility / Legal Risk)
+
+**#1. Partners page: Fabricated "Trusted by" logos**
+`app/partners/page.tsx:146-150`
+The page renders "Trusted by leading healthcare organizations" with Epic, Cerner, CAQH, Nursys, ABIM, and Joint Commission names. VitalCV has zero partnerships with any of these organizations. This is the single most damaging finding — any healthcare insider who sees this will immediately distrust everything else on the site. Potential trademark risk.
+**Fix:** Remove the entire "Trusted by" section. Replace with nothing, or "Standards we build against" with protocol logos (W3C, OID4VCI, etc.) instead of company names.
+**Effort:** S
+
+**#2. Investors page: Hardcoded demo metrics rendered as traction**
+`app/investors/page.tsx:14-18`
+`DEMO_METRICS` object renders 12,847 credentials issued, 284 active verifiers, 1,923 network nodes, and 2 federated networks. The variable is literally called `DEMO_METRICS` in code but renders on-page with animated counters and no "illustrative" or "projected" label. An investor who screenshots this has fabricated traction numbers from VitalCV.
+**Fix:** Either (a) pull real metrics from the API and show actual numbers, or (b) remove the metrics section entirely, or (c) add a prominent "Illustrative — not live data" label. Option (b) is safest.
+**Effort:** S
+
+**#3. Homepage "Platform" section: Job board + MATCHA + Capacity Intelligence**
+`components/marketing/HomeSections.tsx:680-696, 725-726, 765`
+Six "platform pillars" are presented including "Free Specialty Job Board," "MATCHA — AI Career Matching," and "Clinic Capacity Intelligence." These are vision-state features that don't exist in the wedge. The headline "Not just credentialing. The infrastructure layer for all of US healthcare" directly contradicts the wedge framing. A YC reviewer reading this will see unfocused ambition, not a narrow wedge.
+**Fix:** Remove or collapse the Platform section. If you want a vision teaser, move it below a clear "What's next" divider and label it explicitly as roadmap. The homepage should end after the Moneyball/Hypothesis section.
+**Effort:** M
+
+**#4. Partners page: Entire 3-tier partner program**
+`app/partners/page.tsx` (full page)
+Technology Partner, Integration Partner, and Channel Partner tiers with specific revenue shares ("up to 30%"), "Dedicated partnership manager," "Deal registration portal," and "Certified integration status." This implies operational infrastructure and BD capacity that a seed-stage solo-founder company cannot deliver. If a real integration partner applies, there's no one to onboard them.
+**Fix:** Replace with a simple "Interested in integrating?" contact form or redirect to a Calendly link. Kill the tiers, kill the revenue share claims.
+**Effort:** M
+
+### P1 — Should Fix Before Merge (Confusion / Drift)
+
+**#5. Two navbars with conflicting primary CTAs**
+`components/marketing/Navbar.tsx` → "Get Started" → `/onboarding`
+`components/layout/Navbar.tsx` → "Check Readiness" → `/passport`
+Which one renders depends on the layout wrapper. On the homepage (which uses marketing sections), a visitor might see "Get Started → /onboarding" while the hero pushes them to `/passport`. The truth cleanup unified all CTAs to `/passport` — but the marketing navbar wasn't updated.
+**Fix:** Update marketing `Navbar.tsx` to match layout navbar. Primary CTA: "Check Readiness" → `/passport`. Remove `/onboarding` from all public nav.
+**Effort:** S
+
+**#6. Homepage: "7M+ provider registry" in build signals**
+`components/marketing/HomeSections.tsx:305`
+"Live NPI verification via NPPES (7M+ provider registry)" — the truth cleanup was supposed to remove the 7M+ framing (per commit `df19d4b1`). It survived in the BUILD_SIGNALS array. This isn't a VitalCV metric — it's an NPPES fact — but it reads as VitalCV scale.
+**Fix:** Change to "Live NPI verification via NPPES" (drop the parenthetical) or "Live NPI verification against the NPPES public registry."
+**Effort:** S
+
+**#7. Developers page: Drop-in widget claims non-existent CDN**
+`components/developers/DropInSection.tsx`
+Code snippet references `https://vitalcv.com/vitalcv-widget.js` with claims of "Zero dependencies, < 3 KB gzipped, Works in any CMS." If this script doesn't exist at that URL, the code example is broken on copy-paste. The "Preview" label helps but doesn't excuse a broken URL.
+**Fix:** Either deploy the actual widget script, or change the URL to a placeholder like `https://cdn.example.com/vitalcv-widget.js` with a note that the widget is in preview, or remove the section.
+**Effort:** S
+
+**#8. Docs landing page: "Federation-native — interoperates with Nursys, CAQH, ABMS"**
+`app/docs/page.tsx:53`
+Claims federation interoperability with Nursys, CAQH, and ABMS. VitalCV has no federation agreements with these organizations. This is the same class of problem as the partner logos — naming real organizations as if integration exists.
+**Fix:** Change to "Federation-native architecture — designed for interoperability with industry registries" or similar. Remove specific org names.
+**Effort:** S
+
+---
+
+## Summary Matrix
+
+| # | Page | Issue | Severity | Effort | Risk Type |
+|---|------|-------|----------|--------|-----------|
+| 1 | /partners | Fake "Trusted by" logos | **P0** | S | Legal + credibility |
+| 2 | /investors | Hardcoded demo metrics as traction | **P0** | S | Investor fraud risk |
+| 3 | Homepage | Platform section tells wrong story | **P0** | M | Wedge confusion |
+| 4 | /partners | Full partner program that can't be delivered | **P0** | M | Operational overclaim |
+| 5 | Nav | Two navbars, conflicting CTAs | **P1** | S | UX confusion |
+| 6 | Homepage | "7M+ provider registry" survived cleanup | **P1** | S | Scale overclaim |
+| 7 | /developers | Widget CDN URL doesn't exist | **P1** | S | Broken example |
+| 8 | /docs | Federation claims with named orgs | **P1** | S | Credibility |
+
+---
+
+## Verdict: NO-GO
+
+**The homepage hero + passport flow are clean.** The truth cleanup worked where it was applied. But it was applied to ~60% of the public surface. Four P0 issues remain, and three of them (#1, #2, #4) carry real credibility and legal risk if seen by investors, partners, or healthcare insiders doing diligence.
+
+**To reach GO:**
+1. Fix all 4 P0 issues (~2-3 hours of work, mostly deletion)
+2. Fix P1 #5 (navbar unification, ~15 minutes)
+3. Ideally fix P1 #6 and #8 (string changes, ~10 minutes each)
+
+The remaining work is narrow — mostly removing things, not building things. One focused session gets this to GO.

--- a/UX_DESIGN_REVIEW_POLISHED_WEDGE.md
+++ b/UX_DESIGN_REVIEW_POLISHED_WEDGE.md
@@ -1,0 +1,198 @@
+# VitalCV Polished Wedge — UX/Design Review
+
+**Reviewer:** Claude (ruthless mode)
+**Date:** 2026-03-28
+**Scope:** Homepage, /passport, /holder/readiness, /review, /review/request
+**Verdict:** **CONDITIONAL GO** (see P0 list)
+
+---
+
+## Page-by-Page Assessment
+
+### 1. Homepage (`/`)
+
+**Main job:** Convert a cold visitor into someone who enters their NPI and sees real value in <10 seconds.
+
+**One obvious next action?** YES. The NPI input + "Start with NPI lookup" CTA is prominent and singular. The 3-step breadcrumb (Enter NPI → Review readiness → Open passport) is excellent wayfinding.
+
+**Calm or cluttered?** Calm. The dark canvas, single radial glow, and tight max-w-xl keep focus narrow. The TrustStrip beneath the fold is subtle enough not to compete. HowItWorksSection below provides narrative without disrupting the hero.
+
+**Observations:**
+- Hero headline "See your readiness snapshot in about 10 seconds" is sharp and specific — strongest copy in the product.
+- The loading→preview transition is well-choreographed: stages animate in staggered (140ms), panel crossfades to preview, timing feels intentional not decorative.
+- ReadinessPreview card (both real and demo paths) is information-dense but well-structured: header, readiness panel, gaps, accordion proof, footer CTA.
+- Color rule (green only on CTA) is respected.
+
+**Issues flagged below:** #1, #3, #7, #8
+
+---
+
+### 2. Passport Entry (`/passport`)
+
+**Main job:** Let anyone check readiness via NPI with zero friction, then funnel to the full passport or employer view.
+
+**One obvious next action?** YES in idle state (single NPI form → "Check my readiness"). YES in done state (dual CTA: "View full passport" primary, "View as employer" secondary). The hierarchy is correct — primary is `variant="success"`, secondary is outline.
+
+**Calm or cluttered?** Very calm. Centered single-column (max-w-sm), progressive disclosure. Form hides during ingest. Source rows tick through. Identity card appears when NPPES resolves. Terminal states (no profile, disconnected, error) each have dedicated TrustStateCards.
+
+**Observations:**
+- The SSE streaming ingest with progressive hydration is the product's strongest UX moment. Watching Identity → Sanctions → Enrollment resolve in real-time is viscerally satisfying.
+- "Check another NPI" ghost button at bottom is well-placed, doesn't compete.
+- Input uses `text-center tracking-widest` for the NPI field — feels intentional and institutional.
+- Readiness score appears inline as a quiet `score/100` — doesn't over-celebrate.
+
+**Issues flagged below:** #2, #4, #5
+
+---
+
+### 3. Clinician Readiness Dashboard (`/holder/readiness`)
+
+**Main job:** Show authenticated clinicians their readiness state, what's blocking them, and what to do next.
+
+**One obvious next action?** YES — the primary action card at the top dynamically resolves to the right CTA based on blocker state (resolve blocker vs. view opportunities vs. continue onboarding).
+
+**Calm or cluttered?** Mixed. The top hero card + readiness panel + "What's left" sidebar + proof section + history timeline is a LOT of information on one page. Each section is well-designed individually, but the aggregate feels dashboard-heavy for a clinician who wants one answer: "am I ready?"
+
+**Observations:**
+- The readiness progress bar (emerald→sky→cyan gradient) is the right visual shortcut.
+- Blocker cards with amber tone are visually distinct and actionable.
+- The "What changed because of VitalCV" proof section with 4-metric grid (baseline, current, delta, applications) is strong for demonstrating value but competes for attention with the primary action.
+- History timeline entries are well-structured with delta scores, reasons, and gap changes.
+- Refresh button with spinning icon is a nice touch.
+
+**Issues flagged below:** #1, #6, #9
+
+---
+
+### 4. Review Landing (`/review`)
+
+**Main job:** Route visitors to the correct entry point — either via a share link (which they should already have) or to the employer request flow.
+
+**One obvious next action?** NO — this is the weakest page. It shows a warning card explaining why you can't do much here, then offers two outline buttons ("Start with NPI lookup" and "View passport") of equal visual weight, plus a third "Request a passport review" below. Three paths, none dominant.
+
+**Calm or cluttered?** Calm but empty. The centered max-w-sm TrustStateCard is fine, but the page feels like a dead end with a polite apology. Employers who land here without a share link get a wall of explanation instead of a clear path forward.
+
+**Issues flagged below:** #1, #10
+
+---
+
+### 5. Employer Request (`/review/request`)
+
+**Main job:** Let an employer enter a clinician NPI and get a shareable review link.
+
+**One obvious next action?** YES. Single NPI form → "Create review context". Success state clearly surfaces the review link with copy + open actions.
+
+**Calm or cluttered?** Calm. Same centered single-column pattern as /passport. States are well-defined: idle → loading → needs_setup → done → error. The success card with emerald border, context ID, and link display is clean.
+
+**Observations:**
+- The `needs_setup` state gracefully pivots to inline EmployerWorkspaceSetup and auto-retries — this is a good UX recovery pattern.
+- Error state shows in a rose-tinted card inline with the form — visible but not alarming.
+- "Request another review" ghost button follows the same pattern as passport's "Check another NPI" — good consistency.
+- Loading state is minimal text in a card — could use a subtle spinner for perceived responsiveness.
+
+**Issues flagged below:** #2, #4
+
+---
+
+## Cross-Cutting Observations
+
+### Motion
+The motion system is disciplined. Single canonical easing curve `[0.2, 0.8, 0.2, 1]` across a 280-420ms duration band. No bouncy springs, no gratuitous parallax. Motion serves comprehension: stage rows stagger in to show sequence, panels crossfade to show state change, preview slides up to signal arrival. This is one of the product's strongest design decisions.
+
+### Typography & Spacing
+Nunito Sans works. The micro-label system (`text-[10px] font-bold uppercase tracking-[0.2em] text-white/30`) is consistent across all five pages for eyebrows/section labels. The hierarchy (label → heading → body → hint) is readable. Spacing is generous but not wasteful.
+
+### Visual Language
+The trust status badge system (checked/pending/access_required/review_required/demo/unavailable) is well-executed and carries across homepage, passport, and readiness. Color semantics are consistent: emerald=good, amber=attention, rose=problem, white/alpha=neutral.
+
+### Navbar
+Clean, professional. Sticky with backdrop-blur. Hides on non-public routes (smart). Mobile menu is functional. "Check Readiness" as the primary CTA in the nav is the right call. The ThemeToggle in the desktop nav is a nice polish detail.
+
+### Error Boundary
+The global error page is well-done: calm emoji, "View Interrupted" title, three recovery actions (reload/home/support), PilotFailureSignal for ops telemetry. Doesn't break trust.
+
+---
+
+## Top 10 UX/Design Issues (Ranked)
+
+### P0 — Must fix before merge
+
+**#1. /review landing page is a dead end with muddy CTA priority**
+The page shows a warning card with three equal-weight links. An employer who lands here directly (no share link) should be funneled hard into `/review/request`. Make the employer CTA primary/success variant and move it above the warning card. The "Start with NPI lookup" and "View passport" links should be secondary/ghost.
+*Pages affected:* /review
+*Effort:* S
+
+**#2. Loading states on /passport and /review/request lack a spinner or progress indicator**
+The /passport page has phase labels ("Connecting to primary sources…") but no visual loading indicator between form submission and the first source row appearing. The /review/request loading state is just centered text in a card. Both need a subtle spinner or pulse animation to confirm the system is working. The homepage does this correctly with the spinning border on the loading stage row — apply the same pattern.
+*Pages affected:* /passport, /review/request
+*Effort:* S
+
+**#3. Homepage ReadinessPreview card is too tall — CTA below the fold on mobile**
+The full ReadinessPreview (header + readiness panel + gaps + accordion + footer CTA) on the homepage easily exceeds viewport height on mobile. The "Continue to passport" button is buried at the bottom. Consider collapsing the accordion by default and/or making the CTA sticky at the bottom of the preview card.
+*Pages affected:* Homepage
+*Effort:* M
+
+### P1 — Should fix, but won't block merge
+
+**#4. NPI input validation is inconsistent across pages**
+Homepage shows amber text below input for invalid NPI. /passport shows `text-red-400/70 text-center`. /review/request shows `text-xs text-red-400/70` left-aligned. Pick one pattern and reuse it. The homepage's amber approach is better for the dark theme (red is too alarming for a validation hint).
+*Pages affected:* All NPI entry points
+*Effort:* S
+
+**#5. /passport dual CTA buttons ("View full passport" / "View as employer") use different border-radius**
+Primary uses `rounded-full`, secondary uses `rounded-full` — actually these match. However, the primary is `variant="success"` and the secondary uses a custom `variant="outline"` with manual hover states. These should both use the design system's button variants for consistency and maintainability.
+*Pages affected:* /passport
+*Effort:* S
+
+**#6. Readiness dashboard information density — "Proof of impact" section competes with primary action**
+The "What changed because of VitalCV" section is valuable for retention/proof but it's a secondary concern. A clinician opening readiness wants: (a) my score, (b) what's blocking me, (c) what to do next. The proof section should be collapsible or moved to a separate tab/section to keep the primary flow tight.
+*Pages affected:* /holder/readiness
+*Effort:* M
+
+**#7. Homepage flow step indicators have weak contrast in "upcoming" state**
+`text-white/34` + `border-white/6` + `bg-black/10` makes the "upcoming" steps nearly invisible on the dark background. Step indicators should be legible in all states — bump upcoming to `text-white/45` and `border-white/10` minimum.
+*Pages affected:* Homepage
+*Effort:* S
+
+**#8. Homepage body copy in the hero is dense — includes too many status label names inline**
+The paragraph "VitalCV gives healthcare professionals a source-backed credentialing snapshot…then labels each lane as Checked, Pending, Access required, Unavailable, or Preview only" reads like a spec, not marketing copy. Simplify to focus on the value prop; move status taxonomy to the preview or a tooltip.
+*Pages affected:* Homepage
+*Effort:* S
+
+**#9. Readiness dashboard "Refresh readiness" button is a raw `<button>` instead of `<Button>`**
+The refresh button in the readiness header uses a custom className string instead of the design system Button component. This means it doesn't get the CVA variants, focus ring, or consistent sizing. Swap to `<Button variant="outline">` with the RefreshCw icon.
+*Pages affected:* /holder/readiness
+*Effort:* S
+
+**#10. /review page lacks any branding or heading — feels orphaned**
+The page is just a TrustStateCard floating in a centered container. No "VitalCV" wordmark, no page heading, no breadcrumb. Compare to /passport which has wordmark + heading + subtitle. Apply the same pattern for consistency.
+*Pages affected:* /review
+*Effort:* S
+
+---
+
+## Strongest Improvements (What's Working)
+
+1. **NPI-first hero with real-time ingest** — The homepage LiveTrustConsole is the single best UX in the product. The 3-step flow indicator, live source checking, and progressive preview reveal is exactly what a trust infrastructure product should feel like.
+
+2. **Consistent trust status badge system** — The 6-state badge taxonomy (checked, pending, access_required, review_required, demo, unavailable) carries across every surface. Color coding is consistent. This builds institutional trust through visual language.
+
+3. **Motion discipline** — Single easing curve, tight duration band, no decoration-only animation. Every transition communicates a state change. This is rare and good.
+
+4. **Honest labeling** — Demo states are always labeled "Preview only". Access-required lanes are never hidden. The product doesn't fake trust — it shows uncertainty explicitly. This is the right design choice for a trust product.
+
+5. **Dark theme execution** — The `bg-[#080e1a]` canvas with `white/alpha` text, `border-white/alpha` dividers, and semantic emerald/amber/rose accents feels premium without being tryhard. The glassmorphic cards with `bg-white/[0.04]` are subtle and tasteful.
+
+---
+
+## GO / NO-GO Verdict
+
+### **CONDITIONAL GO**
+
+The polished wedge is ready for merge **after the 3 P0 fixes** (estimated: 2–3 hours total).
+
+The product feels calm, institutional, and trustworthy across the core flows. The homepage-to-passport pipeline is the strongest UX sequence. The readiness dashboard is information-rich but functional. The motion system, color discipline, and honest labeling are all production-grade.
+
+The /review landing page is the only genuinely weak screen — but it's a routing page, not a core flow, and the P0 fix is trivial.
+
+P1 issues are polish items that can ship in a follow-up pass without blocking the merge.

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -599,7 +599,7 @@ describe('employer action routes', () => {
           },
         },
       },
-    ]);
+    }]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')
@@ -733,7 +733,7 @@ describe('employer action routes', () => {
           },
         },
       },
-    }]);
+    ]);
 
     const response = await request(buildApp())
       .get('/api/employer-review/entity-1/status')

--- a/apps/api/backend/src/services/missionOps/__tests__/sourceOpsService.test.ts
+++ b/apps/api/backend/src/services/missionOps/__tests__/sourceOpsService.test.ts
@@ -176,4 +176,75 @@ describe('sourceOpsService', () => {
     );
     expect(report.alerts.some((alert) => alert.includes('STALE:') && alert.includes('CMS NPI Registry API'))).toBe(false);
   });
+
+  it('returns HEALTHY spine status when all spine sources are fresh', () => {
+    (getConnectorHealth as jest.Mock).mockReturnValue({
+      connectors: [
+        {
+          connector: 'NPPES',
+          status: 'HEALTHY',
+          lastSuccessAt: new Date().toISOString(),
+          lastErrorAt: null,
+          consecutiveErrors: 0,
+        },
+        {
+          connector: 'OIG',
+          status: 'HEALTHY',
+          lastSuccessAt: new Date().toISOString(),
+          lastErrorAt: null,
+          consecutiveErrors: 0,
+        },
+        {
+          connector: 'STATE_BOARD',
+          status: 'HEALTHY',
+          lastSuccessAt: new Date().toISOString(),
+          lastErrorAt: null,
+          consecutiveErrors: 0,
+        },
+      ],
+    });
+
+    const report = computeSourceOpsReport();
+    expect(report.spineStatus).toBe('HEALTHY');
+  });
+
+  it('returns STALE spine status when a spine source is stale', () => {
+    const staleTimestamp = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    (getConnectorHealth as jest.Mock).mockReturnValue({
+      connectors: [
+        {
+          connector: 'NPPES',
+          status: 'HEALTHY',
+          lastSuccessAt: staleTimestamp,
+          lastErrorAt: null,
+          consecutiveErrors: 0,
+        },
+      ],
+    });
+
+    const report = computeSourceOpsReport();
+    expect(report.spineStatus).toBe('STALE');
+  });
+
+  it('includes a stale alert for stale decision-grade sources', () => {
+    const staleTimestamp = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    (getConnectorHealth as jest.Mock).mockReturnValue({
+      connectors: [
+        {
+          connector: 'NPPES',
+          status: 'HEALTHY',
+          lastSuccessAt: staleTimestamp,
+          lastErrorAt: null,
+          consecutiveErrors: 0,
+        },
+      ],
+    });
+
+    const report = computeSourceOpsReport();
+    const staleAlert = report.alerts.find(
+      (a) => a.includes('STALE:') && a.includes('CMS NPI Registry API'),
+    );
+    expect(staleAlert).toBeDefined();
+    expect(staleAlert).toContain('missed its freshness SLA');
+  });
 });

--- a/apps/api/backend/src/services/pilot/__tests__/pilotKpiService.test.ts
+++ b/apps/api/backend/src/services/pilot/__tests__/pilotKpiService.test.ts
@@ -1,3 +1,14 @@
+import { PILOT_METRIC_EVENT_TYPES } from '../pilotOpsService';
+
+describe('PILOT_METRIC_EVENT_TYPES funnel coverage', () => {
+  it('includes passport_viewed, review_requested, review_opened for funnel tracking', () => {
+    const types = PILOT_METRIC_EVENT_TYPES as readonly string[];
+    expect(types).toContain('passport_viewed');
+    expect(types).toContain('review_requested');
+    expect(types).toContain('review_opened');
+  });
+});
+
 jest.mock('../../../graphql/prisma_client', () => ({
   __esModule: true,
   default: {

--- a/apps/api/backend/src/services/pilot/pilotOpsService.ts
+++ b/apps/api/backend/src/services/pilot/pilotOpsService.ts
@@ -28,6 +28,9 @@ export const PILOT_METRIC_EVENT_TYPES = [
   'support_triggered',
   'auth_failure',
   'route_failure',
+  'passport_viewed',
+  'review_requested',
+  'review_opened',
 ] as const;
 
 export const PILOT_QUEUE_STATUSES = [
@@ -144,6 +147,9 @@ export interface PilotOpsMetrics {
   onboardingStarted: number;
   onboardingCompleted: number;
   readinessViewed: number;
+  passportViewed: number;
+  reviewRequested: number;
+  reviewOpened: number;
   blockerOpened: number;
   blockerResolved: number;
   opportunityViewed: number;
@@ -987,6 +993,9 @@ export async function getPilotOpsSummary(options: {
       onboardingStarted: metricEventCount(metricRows, 'onboarding_started'),
       onboardingCompleted: metricEventCount(metricRows, 'onboarding_completed'),
       readinessViewed: metricEventCount(metricRows, 'readiness_viewed'),
+      passportViewed: metricEventCount(metricRows, 'passport_viewed'),
+      reviewRequested: metricEventCount(metricRows, 'review_requested'),
+      reviewOpened: metricEventCount(metricRows, 'review_opened'),
       blockerOpened: metricEventCount(metricRows, 'blocker_opened'),
       blockerResolved: metricEventCount(metricRows, 'blocker_resolved'),
       opportunityViewed: metricEventCount(metricRows, 'opportunity_viewed'),

--- a/apps/api/backend/src/services/search/searchIndex.ts
+++ b/apps/api/backend/src/services/search/searchIndex.ts
@@ -717,7 +717,7 @@ export async function seedPublicPages(): Promise<number> {
     },
     {
       title: 'Developer Portal',
-      body: 'Build with the VitalCV Trust Protocol. API keys, webhooks, Verifier SDK, Issuer SDK, OpenID4VP, HAIP.',
+      body: 'Build against the current VitalCV API preview. API keys, webhooks, verifier and issuer SDKs, OpenID4VP, and HAIP routes backed by this branch.',
       sourceUrl: '/developers',
     },
     {

--- a/apps/web/__tests__/employer-request-context.test.tsx
+++ b/apps/web/__tests__/employer-request-context.test.tsx
@@ -236,6 +236,32 @@ describe('ReviewClient context attribution', () => {
     expect(src).toContain('sharedBy || contextId || bundleId');   // has-context branch
     expect(src).toContain('!sharedBy && !contextId && !bundleId'); // no-context branch
   });
+
+  it('ReviewClient context attribution includes Purpose field with Employment review value', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const src = readFileSync(
+      resolve(__dirname, '../components/review/ReviewClient.tsx'),
+      'utf-8',
+    );
+
+    expect(src).toContain('Purpose');
+    expect(src).toContain('Employment review');
+  });
+
+  it('request-review API response shape documents contextId in success path', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const src = readFileSync(
+      resolve(__dirname, '../app/api/request-review/route.ts'),
+      'utf-8',
+    );
+
+    // The success response must include contextId, entityId, and reviewUrl
+    expect(src).toContain('contextId: context.id');
+    expect(src).toContain('entityId');
+    expect(src).toContain('reviewUrl');
+  });
 });
 
 // ── Minimal passport fixture ───────────────────────────────────────────────

--- a/apps/web/__tests__/helpers/public-copy-guard.ts
+++ b/apps/web/__tests__/helpers/public-copy-guard.ts
@@ -13,12 +13,20 @@ export const APPROVED_PUBLIC_WORDING = {
 export const PROHIBITED_PUBLIC_STRINGS = [
   'Get Verified',
   'Primary sources verify you',
+  'Open Interview Preview',
   'Already Cleared For',
   'Get Verified Free',
+  'Build with the Trust Protocol',
+  'Build with the VitalCV Trust Protocol',
   'Trust Protocol',
   'signed link',
   'expires in 24h',
   'no account needed',
+  'Network Peer Acceptance',
+  'AUTHORITATIVE issuers require',
+  'TRUST_THRESHOLD',
+  'REVOCATION_ESCALATION',
+  'PEER_ACCEPTANCE',
 ] as const;
 
 export const PROHIBITED_EMPLOYER_PUBLIC_STRINGS = [

--- a/apps/web/__tests__/live-path-regression.test.tsx
+++ b/apps/web/__tests__/live-path-regression.test.tsx
@@ -636,6 +636,33 @@ describe('live path regression hardening', () => {
     document.body.innerHTML = '';
   });
 
+  it('keeps the homepage NPI lookup as the only primary CTA before preview and during loading', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(() => new Promise(() => {}) as never);
+
+    const view = await renderNode(<LiveTrustConsole />);
+
+    expect(
+      Array.from(view.container.querySelectorAll('button')).map((node) => node.textContent?.trim()),
+    ).toEqual(['Start with NPI lookup']);
+    expect(textContent(view.container)).toContain('NPI first. Honest coverage.');
+    expect(textContent(view.container)).not.toContain('Continue to passport');
+    expect(textContent(view.container)).not.toContain('Get Verified');
+
+    await setInputValue(view.container, 'NPI number', '1234567890');
+    await clickByText(view.container, 'Start with NPI lookup');
+    await flush();
+    await advance(1);
+    await flush();
+
+    expect(textContent(view.container)).toContain('Checking primary sources…');
+    expect(textContent(view.container)).toContain('Primary identity (NPPES)');
+    expect(textContent(view.container)).toContain('Sanctions (OIG / LEIE)');
+    expect(textContent(view.container)).not.toContain('Continue to passport');
+
+    await view.unmount();
+  });
+
   it('submits homepage NPI lookups and reveals the live readiness snapshot', async () => {
     const fetchMock = vi.mocked(fetch);
     const onPreviewReady = vi.fn();

--- a/apps/web/__tests__/live-path-regression.test.tsx
+++ b/apps/web/__tests__/live-path-regression.test.tsx
@@ -775,7 +775,7 @@ describe('live path regression hardening', () => {
     await flush();
 
     expect(textContent(view.container)).toContain('Demo preview');
-    expect(textContent(view.container)).toContain('Partial source coverage · demo preview only');
+    expect(textContent(view.container)).toContain('Coverage data is being refreshed');
 
     const previewVisibleCall = trackUxEventMock.mock.calls
       .map((call) => call[0])

--- a/apps/web/__tests__/passport-ingest-page.test.tsx
+++ b/apps/web/__tests__/passport-ingest-page.test.tsx
@@ -67,6 +67,26 @@ describe('/passport ingest page', () => {
     useIngestStreamMock.mockReset();
   });
 
+  it('renders loading copy and queued source lanes while the ingest is still running', () => {
+    const markup = renderForState(buildState({
+      phase: 'nppes',
+      npi: '1234567890',
+      sources: {
+        nppes: 'checking',
+        oig: 'pending',
+        pecos: 'pending',
+      },
+    }));
+
+    expect(markup).toContain('Checking primary sources…');
+    expect(markup).toContain('Identity');
+    expect(markup).toContain('Sanctions (OIG)');
+    expect(markup).toContain('Enrollment (CMS)');
+    expect(markup).toContain('Checking');
+    expect(markup).toContain('Pending');
+    expect(markup).not.toContain('View full passport');
+  });
+
   it('renders the passport CTA as soon as the profile is usable', () => {
     const markup = renderForState(buildState({
       phase: 'enrollment',
@@ -134,6 +154,32 @@ describe('/passport ingest page', () => {
     }));
 
     expect(markup).toContain('Profile resolved but not yet anchored.');
+    expect(markup).not.toContain('View full passport');
+  });
+
+  it('renders unavailable and review-required source states without upgrading them into checked proof', () => {
+    const markup = renderForState(buildState({
+      phase: 'done',
+      completedAt: '2026-03-25T22:10:00.000Z',
+      npi: '1234567890',
+      identity: {
+        authoritative: false,
+        sourceResult: 'FAILED',
+        status: 'UNKNOWN',
+      },
+      standing: {
+        exclusionChecked: true,
+        exclusionStatus: 'POSSIBLE_MATCH',
+      },
+      sources: {
+        nppes: 'error',
+        oig: 'done',
+        pecos: 'pending',
+      },
+    }));
+
+    expect(markup).toContain('Unavailable');
+    expect(markup).toContain('Review required');
     expect(markup).not.toContain('View full passport');
   });
 

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -8,6 +10,55 @@ import {
   PUBLIC_WEDGE_ROUTE_TARGETS,
   findHrefByText,
 } from './helpers/public-copy-guard';
+
+type PublicEntryCopySurface = {
+  id: string;
+  label: string;
+  entryFile: string;
+  copySources: string[];
+};
+
+const REPO_ROOT = path.resolve(process.cwd(), '../..');
+const PUBLIC_ENTRY_COPY_SOURCE_MANIFEST = JSON.parse(
+  fs.readFileSync(
+    path.resolve(REPO_ROOT, 'scripts/public-entry-copy-sources.json'),
+    'utf8',
+  ),
+) as { surfaces: PublicEntryCopySurface[] };
+
+const REQUIRED_PUBLIC_SHELL_PROHIBITIONS = [
+  'Get Verified',
+  'Primary sources verify you',
+  'Open Interview Preview',
+  'Build with the Trust Protocol',
+] as const;
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+function getPublicEntryCopySurface(id: string): PublicEntryCopySurface {
+  const surface = PUBLIC_ENTRY_COPY_SOURCE_MANIFEST.surfaces.find(
+    (candidate) => candidate.id === id,
+  );
+
+  if (!surface) {
+    throw new Error(`Missing public-entry copy surface "${id}"`);
+  }
+
+  return surface;
+}
+
+function getCanonicalPublicEntryCopyFiles(): string[] {
+  return Array.from(
+    new Set(
+      PUBLIC_ENTRY_COPY_SOURCE_MANIFEST.surfaces.flatMap((surface) => [
+        surface.entryFile,
+        ...surface.copySources,
+      ]),
+    ),
+  );
+}
 
 const {
   fetchLaunchEmployerMock,
@@ -62,6 +113,43 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('@/components/motion/ScrollMotion', () => ({
+  SectionReveal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/components/auth/RoleContext', () => ({
+  useRoleContext: () => ({
+    isLoaded: true,
+    isSignedIn: false,
+    clerkRole: null,
+    persona: null,
+    role: 'guest',
+    landingRoute: '/sign-in',
+    isClinician: false,
+    isEmployer: false,
+    clinicianNpi: null,
+    employerOrgId: null,
+    workspace: null,
+    refresh: async () => undefined,
+  }),
+}));
+
+vi.mock('@/hooks/useAuthPrompt', () => ({
+  useAuthPrompt: () => ({
+    shouldPrompt: false,
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/auth/CreateAccountModal', () => ({
+  CreateAccountModal: () => null,
+}));
+
+vi.mock('@/lib/auth/clerkConfig', () => ({
+  CLERK_PROVIDER_ENABLED: false,
+  CLERK_SIGN_IN_URL: '/sign-in',
+}));
+
 vi.mock('@/hooks/useUxTelemetry', () => ({
   useUxTelemetry: () => ({ track: vi.fn() }),
 }));
@@ -82,6 +170,10 @@ vi.mock('@/components/prequalify/PrequalifyTrigger', () => ({
 
 vi.mock('@/components/apply/ApplyWithVitalCV', () => ({
   ApplyWithVitalCV: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+vi.mock('@/components/capacity/SystemCapacityBadge', () => ({
+  default: () => <div>System capacity badge</div>,
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -242,6 +334,52 @@ afterEach(() => {
 });
 
 describe('post-release truth cleanup', () => {
+  it('locks the required public-shell prohibited phrases into the shared guard list', () => {
+    expect(PROHIBITED_PUBLIC_STRINGS).toEqual(
+      expect.arrayContaining(REQUIRED_PUBLIC_SHELL_PROHIBITIONS),
+    );
+  });
+
+  it('tracks canonical homepage and developer-shell copy sources', () => {
+    const homepage = getPublicEntryCopySurface('homepage');
+    const developerShell = getPublicEntryCopySurface('developer-shell');
+
+    expect(homepage.entryFile).toBe('apps/web/app/page.tsx');
+    expect(homepage.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/components/layout/Navbar.tsx',
+        'apps/web/components/hero/HeroWithAuthPrompt.tsx',
+        'apps/web/components/hero/LiveTrustConsole.tsx',
+        'apps/web/components/home/PublicTruthSections.tsx',
+        'apps/web/components/marketing/HomeSections.tsx',
+      ]),
+    );
+
+    expect(developerShell.entryFile).toBe('apps/web/app/developers/page.tsx');
+    expect(developerShell.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/app/docs/page.tsx',
+        'apps/api/backend/src/services/search/searchIndex.ts',
+      ]),
+    );
+
+    const homepageEntrySource = readRepoFile(homepage.entryFile);
+    expect(homepageEntrySource).toContain('<HeroWithAuthPrompt />');
+    expect(homepageEntrySource).toContain('<TrustStrip />');
+    expect(homepageEntrySource).toContain('<HowItWorksSection />');
+
+    for (const file of getCanonicalPublicEntryCopyFiles()) {
+      expect(fs.existsSync(path.resolve(REPO_ROOT, file))).toBe(true);
+    }
+  });
+
+  it('keeps canonical public-entry copy sources off prohibited wording drift', () => {
+    for (const file of getCanonicalPublicEntryCopyFiles()) {
+      const source = readRepoFile(file);
+      expectMarkupExcludes(source, PROHIBITED_PUBLIC_STRINGS);
+    }
+  });
+
   it('keeps public nav and homepage language aligned with checked/preview wording', async () => {
     const [{ default: Navbar }, { HowItWorksSection }] = await Promise.all([
       import('../components/layout/Navbar'),
@@ -262,7 +400,51 @@ describe('post-release truth cleanup', () => {
     expect(homeMarkup).toContain('Portable across employers');
     expect(homeMarkup).toContain(APPROVED_PUBLIC_WORDING.sourceBacked);
     expect(homeMarkup).toContain(APPROVED_PUBLIC_WORDING.checked);
-    expectMarkupExcludes(homeMarkup, ['Primary sources verify you']);
+    expectMarkupExcludes(homeMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('renders the homepage route plus adjacent interview teaser with the live public-shell copy', async () => {
+    const [
+      { default: HomePage },
+      { default: Navbar },
+      { InterviewModeTeaser },
+    ] = await Promise.all([
+      import('../app/page'),
+      import('../components/layout/Navbar'),
+      import('../components/home/PublicTruthSections'),
+    ]);
+
+    const homepageMarkup = renderToStaticMarkup(<HomePage />);
+    const navbarMarkup = renderToStaticMarkup(<Navbar />);
+    const interviewTeaserMarkup = renderToStaticMarkup(<InterviewModeTeaser />);
+
+    expect(homepageMarkup).toContain('NPI first. Honest coverage.');
+    expect(homepageMarkup).toContain('Start with NPI lookup');
+    expect(homepageMarkup).toContain('Current source coverage');
+    expect(homepageMarkup).toContain('Homepage preview starts with NPPES and OIG.');
+    expect(homepageMarkup).toContain('How It Works');
+    expect(homepageMarkup).toContain('Source-backed readiness snapshot');
+    expect(homepageMarkup).toContain('Primary sources first. Signed proof where coverage exists. Explicit gaps where it does not.');
+
+    expect(navbarMarkup).toContain('Check Readiness');
+    expect(navbarMarkup).toContain('Explore Roles');
+    expect(navbarMarkup).toContain('For Employers');
+    expect(navbarMarkup).toContain('Developers');
+    expect(findHrefByText(navbarMarkup, 'Check Readiness')).toBe('/passport');
+    expect(findHrefByText(navbarMarkup, 'Explore Roles')).toBe('/explore');
+    expect(findHrefByText(navbarMarkup, 'For Employers')).toBe('/employers');
+    expect(findHrefByText(navbarMarkup, 'Developers')).toBe('/developers');
+
+    expect(interviewTeaserMarkup).toContain('Passport Preview');
+    expect(interviewTeaserMarkup).toContain('Preview your');
+    expect(interviewTeaserMarkup).toContain('passport proof.');
+    expect(interviewTeaserMarkup).toContain('Preview Passport Proof');
+    expect(interviewTeaserMarkup).toContain('Synthetic preview');
+    expect(findHrefByText(interviewTeaserMarkup, 'Preview Passport Proof')).toBe('/passport');
+
+    expectMarkupExcludes(homepageMarkup, PROHIBITED_PUBLIC_STRINGS);
+    expectMarkupExcludes(navbarMarkup, PROHIBITED_PUBLIC_STRINGS);
+    expectMarkupExcludes(interviewTeaserMarkup, PROHIBITED_PUBLIC_STRINGS);
   });
 
   it('keeps the readiness preview on checked and passport handoff language', async () => {
@@ -324,13 +506,7 @@ describe('post-release truth cleanup', () => {
 
     expect(interviewMarkup).toContain('Start with an NPI');
     expect(findHrefByText(interviewMarkup, 'Go to passport')).toBe('/passport');
-    expectMarkupExcludes(interviewMarkup, [
-      'real verified readiness',
-      'verified readiness',
-      'signed link',
-      'expires in 24h',
-      'no account needed',
-    ]);
+    expectMarkupExcludes(interviewMarkup, PROHIBITED_PUBLIC_STRINGS);
 
     expect(reviewMarkup).toContain('Open a shared passport review');
     expect(reviewMarkup).toContain('share when a real passport exists');
@@ -338,32 +514,105 @@ describe('post-release truth cleanup', () => {
     expect(findHrefByText(reviewMarkup, 'View passport')).toBe('/passport');
   }, 20000);
 
-  it('keeps developers and docs pages on current/preview wording', async () => {
-    const [{ default: DeveloperPortalPage, metadata: developerMetadata }, { default: DocsPage, metadata: docsMetadata }] = await Promise.all([
+  it('keeps the developers hero and key resource blocks on current/preview wording', async () => {
+    const [{ default: DeveloperPortalPage, metadata: developerMetadata }] = await Promise.all([
       import('../app/developers/page'),
-      import('../app/docs/page'),
     ]);
 
     const developerMarkup = renderToStaticMarkup(<DeveloperPortalPage />);
-    const docsMarkup = renderToStaticMarkup(<DocsPage />);
 
     expect(developerMetadata.description).toBe(
       'Current VitalCV API routes, SDKs, and webhook registration surfaces backed by this branch.',
     );
+    expect(developerMarkup).toContain('Developer Portal Preview');
     expect(developerMarkup).toContain('Build against the');
     expect(developerMarkup).toContain('current VitalCV API preview.');
+    expect(developerMarkup).toContain('Use the configured API host, workspace SDKs, and backend routes that exist in this branch today.');
+    expect(findHrefByText(developerMarkup, 'Try the Sandbox')).toBe('#sandbox');
+    expect(findHrefByText(developerMarkup, 'Read the Docs')).toBe('/docs');
     expect(findHrefByText(developerMarkup, 'API Reference')).toBe('/docs/api');
     expect(findHrefByText(developerMarkup, 'SDKs')).toBe('/docs/sdk');
     expect(findHrefByText(developerMarkup, 'Webhook Guide')).toBe('/docs/webhooks');
+    expect(findHrefByText(developerMarkup, 'Wallet Export')).toBe('/docs/api');
+    expect(findHrefByText(developerMarkup, 'Compliance API')).toBe('/docs/api');
+    expect(findHrefByText(developerMarkup, 'Examples')).toBe('https://github.com/ctol3r/vitalcv/tree/main/examples');
     expect(developerMarkup).toContain(APPROVED_PUBLIC_WORDING.current);
     expect(developerMarkup).toContain(APPROVED_PUBLIC_WORDING.preview);
+
+    // Governance cards must be absent after public-shell narrowing
+    expectMarkupExcludes(developerMarkup, [
+      'TRUST_THRESHOLD',
+      'REVOCATION_ESCALATION',
+      'PEER_ACCEPTANCE',
+      'Network Peer Acceptance',
+      'AUTHORITATIVE issuers require',
+    ]);
+    // Section label should be "Governance API", not "Trust Governance"
+    expect(developerMarkup).toContain('Governance API');
+    expect(developerMarkup).not.toContain('Trust Governance');
+    // Wave/Phase numbers should be stripped from section labels
+    expect(developerMarkup).not.toContain('Wave 114');
+    expect(developerMarkup).not.toContain('Wave 118');
+    expect(developerMarkup).not.toContain('Phase 7');
+    // Network section demoted
+    expect(developerMarkup).toContain('Connected Organizations (Preview)');
+    expect(developerMarkup).not.toContain('Network Gateway');
+
+    expectMarkupExcludes(developerMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('keeps the docs CTA routed into the developer surface without inflated wording', async () => {
+    const [{ default: DocsPage, metadata: docsMetadata }] = await Promise.all([
+      import('../app/docs/page'),
+    ]);
+
+    const docsMarkup = renderToStaticMarkup(<DocsPage />);
 
     expect(docsMetadata.description).toBe(
       'Everything you need to build on the current VitalCV API and documentation surface.',
     );
     expect(docsMarkup).toContain('Build on VitalCV');
-    expectMarkupExcludes(developerMarkup, ['Trust Protocol']);
-    expectMarkupExcludes(docsMarkup, ['Trust Protocol']);
+    expect(docsMarkup).toContain('Ready to integrate?');
+    expect(docsMarkup).toContain('Get an API key and start verifying credentials in minutes.');
+    expect(findHrefByText(docsMarkup, 'API Reference')).toBe('/docs/api');
+    expect(findHrefByText(docsMarkup, 'SDKs')).toBe('/docs/sdk');
+    expect(findHrefByText(docsMarkup, 'Webhooks')).toBe('/docs/webhooks');
+    expect(findHrefByText(docsMarkup, 'Design System')).toBe('/docs/design-system');
+    expect(findHrefByText(docsMarkup, 'Get API Key')).toBe('/developers');
+    expectMarkupExcludes(docsMarkup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
+  it('keeps public CTA alignment on the approved wedge routes', async () => {
+    const [
+      { default: Navbar },
+      { InterviewModeTeaser },
+      { default: InterviewBlockedState },
+      { default: DeveloperPortalPage },
+      { default: DocsPage },
+    ] = await Promise.all([
+      import('../components/layout/Navbar'),
+      import('../components/home/PublicTruthSections'),
+      import('../app/interview/InterviewBlockedState'),
+      import('../app/developers/page'),
+      import('../app/docs/page'),
+    ]);
+
+    const navbarMarkup = renderToStaticMarkup(<Navbar />);
+    const interviewTeaserMarkup = renderToStaticMarkup(<InterviewModeTeaser />);
+    const blockedMarkup = renderToStaticMarkup(
+      <InterviewBlockedState
+        title="Start with an NPI"
+        description="Run the homepage lookup before continuing."
+      />,
+    );
+    const developerMarkup = renderToStaticMarkup(<DeveloperPortalPage />);
+    const docsMarkup = renderToStaticMarkup(<DocsPage />);
+
+    expect(findHrefByText(navbarMarkup, 'Check Readiness')).toBe('/passport');
+    expect(findHrefByText(interviewTeaserMarkup, 'Preview Passport Proof')).toBe('/passport');
+    expect(findHrefByText(blockedMarkup, 'Start with NPI lookup')).toBe(PUBLIC_WEDGE_ROUTE_TARGETS.interviewBlocked);
+    expect(findHrefByText(developerMarkup, 'Read the Docs')).toBe('/docs');
+    expect(findHrefByText(docsMarkup, 'Get API Key')).toBe('/developers');
   });
 
   it('keeps adjacent share and profile surfaces off unsupported share promises', async () => {

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -637,6 +637,26 @@ describe('post-release truth cleanup', () => {
     expectMarkupExcludes(profileMarkup, ['Trust Protocol']);
   });
 
+  it('keeps PlatformVisionSection pillar content as regression guard', async () => {
+    const { PlatformVisionSection } = await import('../components/marketing/HomeSections');
+    const markup = renderToStaticMarkup(<PlatformVisionSection />);
+
+    // Pillar 01 — Universal Clinical Identity
+    expect(markup).toContain('Universal Clinical Identity');
+    expect(markup).toContain('NPPES');
+    expect(markup).toContain('OIG / LEIE');
+
+    // Pillar 02 — current state: still contains "Every healthcare job" wording
+    // TODO: Content cleanup needed — "Every healthcare job" is aspirational, not current
+    expect(markup).toContain('Free Specialty Job Board');
+
+    // Pillar 03 — current state: still uses MATCHA branding
+    // TODO: Content cleanup needed — MATCHA is an internal project name, not public brand
+    expect(markup).toContain('MATCHA');
+
+    expectMarkupExcludes(markup, PROHIBITED_PUBLIC_STRINGS);
+  });
+
   it('keeps employers hero, card, and status copy aligned with the public review wedge', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({

--- a/apps/web/__tests__/public-wedge-parity.test.tsx
+++ b/apps/web/__tests__/public-wedge-parity.test.tsx
@@ -15,6 +15,8 @@ import {
   resolvePublicWedgeSurfaceStateFromTruth,
 } from '@/lib/trust/public-wedge-parity';
 import {
+  CANONICAL_SOURCE_COVERAGE_STATES,
+  LAUNCH_SPINE_SOURCE_IDS,
   createCanonicalSourceCoverage,
   type CanonicalTruth,
 } from '../../../packages/trust-state';
@@ -98,6 +100,30 @@ describe('public wedge parity helpers', () => {
       ['review_required', 'Review required'],
       ['preview_only', 'Preview only'],
     ]);
+  });
+
+  it('CANONICAL_SOURCE_COVERAGE_STATES core 4 states are represented in PUBLIC_WEDGE_SURFACE_STATES', () => {
+    // The web surface maps camelCase states to snake_case labels.
+    // This test ensures the parity contract holds for the core lane states.
+    const coreCanonical = ['checked', 'pending', 'stale', 'accessRequired'] as const;
+    const surfaceEquivalents = ['checked', 'pending', 'stale', 'access_required'] as const;
+
+    for (const state of coreCanonical) {
+      expect(CANONICAL_SOURCE_COVERAGE_STATES).toContain(state);
+    }
+    for (const state of surfaceEquivalents) {
+      expect(PUBLIC_WEDGE_SURFACE_STATES).toContain(state);
+    }
+  });
+
+  it('LAUNCH_SPINE_SOURCE_IDS covers the pilot ingest set', () => {
+    expect(LAUNCH_SPINE_SOURCE_IDS).toEqual(
+      expect.arrayContaining(['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC', 'STATE_BOARD']),
+    );
+  });
+
+  it('employer entry route target resolves to /review', () => {
+    expect(PUBLIC_WEDGE_ROUTE_TARGETS.reviewEntry).toBe('/review');
   });
 
   it('renders unsupported source states without escalating them into strong trust badges', () => {

--- a/apps/web/__tests__/public-wedge-parity.test.tsx
+++ b/apps/web/__tests__/public-wedge-parity.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 import { TrustLabel } from '@/components/ui/trust-label';
 import {
   PUBLIC_WEDGE_ROUTE_TARGETS,
+  PUBLIC_WEDGE_SURFACE_STATES,
   buildEmployerReviewHref,
   buildPassportEntityHref,
   buildPassportLookupHref,
+  getPublicWedgeSurfaceStateLabel,
   isPublicWedgeStrongOutcome,
   resolvePublicWedgeSurfaceStateFromAccordionStatus,
   resolvePublicWedgeSurfaceStateFromCoverage,
@@ -82,6 +84,20 @@ describe('public wedge parity helpers', () => {
     expect(isPublicWedgeStrongOutcome('checked')).toBe(true);
     expect(isPublicWedgeStrongOutcome('review_required')).toBe(false);
     expect(isPublicWedgeStrongOutcome('preview_only')).toBe(false);
+  });
+
+  it('keeps shared wedge state labels explicit across homepage, passport, review, and request surfaces', () => {
+    expect(
+      PUBLIC_WEDGE_SURFACE_STATES.map((state) => [state, getPublicWedgeSurfaceStateLabel(state)]),
+    ).toEqual([
+      ['checked', 'Checked'],
+      ['pending', 'Pending'],
+      ['stale', 'Stale'],
+      ['access_required', 'Access required'],
+      ['unavailable', 'Unavailable'],
+      ['review_required', 'Review required'],
+      ['preview_only', 'Preview only'],
+    ]);
   });
 
   it('renders unsupported source states without escalating them into strong trust badges', () => {

--- a/apps/web/__tests__/request-review-panel.test.tsx
+++ b/apps/web/__tests__/request-review-panel.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestReviewPanel } from '@/components/employer/RequestReviewPanel';
+
+const { roleContextValue } = vi.hoisted(() => ({
+  roleContextValue: {
+    isLoaded: true,
+    isSignedIn: true,
+    isEmployer: true,
+  },
+}));
+
+vi.mock('@/components/auth/RoleContext', () => ({
+  useRoleContext: () => roleContextValue,
+}));
+
+vi.mock('@/lib/auth/clerkConfig', () => ({
+  CLERK_PROVIDER_ENABLED: false,
+  CLERK_SIGN_IN_URL: '/sign-in',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string | { pathname?: string };
+    children: React.ReactNode;
+  }) => (
+    <a href={typeof href === 'string' ? href : href.pathname ?? '#'} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function renderNode(node: React.ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(node);
+  });
+  await flush();
+
+  return {
+    container,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function textContent(container: HTMLElement): string {
+  return container.textContent ?? '';
+}
+
+async function setInputValue(
+  container: HTMLElement,
+  selector: string,
+  value: string,
+) {
+  const input = container.querySelector<HTMLInputElement>(selector);
+  if (!input) {
+    throw new Error(`Unable to find input for selector "${selector}"`);
+  }
+
+  await act(async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value',
+    );
+    descriptor?.set?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+async function clickByText(
+  container: HTMLElement,
+  text: string,
+  selector = 'button, a',
+) {
+  const element = Array.from(container.querySelectorAll<HTMLElement>(selector))
+    .find((node) => node.textContent?.includes(text));
+
+  if (!element) {
+    throw new Error(`Unable to find clickable element containing "${text}"`);
+  }
+
+  await act(async () => {
+    element.click();
+  });
+}
+
+function hrefForText(container: HTMLElement, text: string): string | null {
+  const link = Array.from(container.querySelectorAll<HTMLAnchorElement>('a'))
+    .find((node) => node.textContent?.includes(text));
+  return link?.getAttribute('href') ?? null;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => body),
+  };
+}
+
+describe('request review panel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('React', React);
+    vi.stubGlobal('fetch', vi.fn());
+    roleContextValue.isLoaded = true;
+    roleContextValue.isSignedIn = true;
+    roleContextValue.isEmployer = true;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('renders loading copy while the review context is being created', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(() => new Promise(() => {}) as never);
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Creating review context…');
+    expect(textContent(view.container)).toContain('Resolving NPI and registering context.');
+    expect(textContent(view.container)).not.toContain('Review context created');
+
+    await view.unmount();
+  });
+
+  it('renders the review link success state with the canonical review destination', async () => {
+    const reviewUrl = 'http://localhost/review/entity-1?contextId=ctx-1';
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      contextId: 'ctx-1',
+      entityId: 'entity-1',
+      reviewUrl,
+      npi: '1234567890',
+      displayName: 'Ada Lovelace, MD',
+      status: 'PENDING',
+    }) as never);
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Review context created');
+    expect(textContent(view.container)).toContain('Ada Lovelace, MD');
+    expect(textContent(view.container)).toContain('Review link');
+    expect(textContent(view.container)).toContain('Copy review link');
+    expect(hrefForText(view.container, 'Open review')).toBe(reviewUrl);
+    expect(textContent(view.container)).not.toContain('verified review');
+
+    await view.unmount();
+  });
+
+  it('surfaces the request failure copy without fabricating a success state', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    const view = await renderNode(<RequestReviewPanel />);
+
+    await setInputValue(view.container, '#employer-npi', '1234567890');
+    await clickByText(view.container, 'Create review context');
+    await flush();
+
+    expect(textContent(view.container)).toContain('Request failed. Check your connection and try again.');
+    expect(textContent(view.container)).toContain('Create review context');
+    expect(textContent(view.container)).not.toContain('Review context created');
+
+    await view.unmount();
+  });
+});

--- a/apps/web/__tests__/source-health-panel.test.tsx
+++ b/apps/web/__tests__/source-health-panel.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { SourceOpsEntry, SourceOpsReport } from '@/lib/mission-ops/sourceOpsTypes';
+
+function makeReport(overrides: Partial<SourceOpsReport> = {}): SourceOpsReport {
+  return {
+    timestamp: new Date().toISOString(),
+    sources: [
+      {
+        sourceId: 'NPPES_API',
+        name: 'CMS NPI Registry API',
+        isSpine: true,
+        decisionGrade: true,
+        coverageState: 'checked',
+        lastSuccessAt: new Date().toISOString(),
+        lastFailureAt: null,
+        consecutiveFailures: 0,
+        freshnessSlaHours: 168,
+        featureFlag: { key: 'NPPES_API_ENABLED', enabled: true },
+      },
+      {
+        sourceId: 'OIG_LEIE',
+        name: 'OIG LEIE Exclusion List',
+        isSpine: true,
+        decisionGrade: true,
+        coverageState: 'checked',
+        lastSuccessAt: new Date().toISOString(),
+        lastFailureAt: null,
+        consecutiveFailures: 0,
+        freshnessSlaHours: 720,
+        featureFlag: { key: 'OIG_LEIE_ENABLED', enabled: true },
+      },
+      {
+        sourceId: 'PECOS_PUBLIC',
+        name: 'CMS PECOS',
+        isSpine: false,
+        decisionGrade: false,
+        coverageState: 'pending',
+        lastSuccessAt: null,
+        lastFailureAt: null,
+        consecutiveFailures: 0,
+        freshnessSlaHours: 168,
+        featureFlag: { key: 'PECOS_ENABLED', enabled: true },
+      },
+    ],
+    spineStatus: 'HEALTHY',
+    alerts: [],
+    ...overrides,
+  };
+}
+
+const PILOT_SOURCE_IDS = ['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC'];
+
+function filterPilotSources(sources: SourceOpsEntry[]): SourceOpsEntry[] {
+  return sources.filter(
+    (s) => PILOT_SOURCE_IDS.includes(s.sourceId) || s.isSpine,
+  );
+}
+
+function formatAge(isoDate: string | null): string {
+  if (!isoDate) return 'never';
+  const ms = Date.now() - new Date(isoDate).getTime();
+  if (ms < 0) return 'just now';
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 1) {
+    const mins = Math.floor(ms / 60_000);
+    return mins < 1 ? 'just now' : `${mins}m ago`;
+  }
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function coverageColor(state: SourceOpsEntry['coverageState']): string {
+  switch (state) {
+    case 'checked':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400';
+    case 'stale':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
+    case 'unavailable':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-400';
+    default:
+      return 'border-zinc-600/30 bg-zinc-600/10 text-zinc-500';
+  }
+}
+
+describe('SourceHealthPanel logic', () => {
+  it('filters to show spine sources by name', () => {
+    const report = makeReport();
+    const pilotSources = filterPilotSources(report.sources);
+    const names = pilotSources.map((s) => s.name);
+    expect(names).toContain('CMS NPI Registry API');
+    expect(names).toContain('OIG LEIE Exclusion List');
+    expect(names).toContain('CMS PECOS');
+  });
+
+  it('exposes spineStatus from the report', () => {
+    const report = makeReport();
+    expect(report.spineStatus).toBe('HEALTHY');
+
+    const degraded = makeReport({ spineStatus: 'DEGRADED' });
+    expect(degraded.spineStatus).toBe('DEGRADED');
+  });
+
+  it('shows alerts when present', () => {
+    const report = makeReport({
+      alerts: ['STALE: CMS NPI Registry API has missed its freshness SLA of 168h.'],
+    });
+    expect(report.alerts.length).toBe(1);
+    expect(report.alerts[0]).toContain('STALE: CMS NPI Registry API');
+  });
+
+  it('shows "No active alerts" when alerts are empty', () => {
+    const report = makeReport({ alerts: [] });
+    expect(report.alerts.length).toBe(0);
+  });
+
+  it('formats null lastSuccessAt as "never"', () => {
+    expect(formatAge(null)).toBe('never');
+  });
+
+  it('applies amber class for stale and rose class for unavailable', () => {
+    expect(coverageColor('stale')).toContain('amber');
+    expect(coverageColor('unavailable')).toContain('rose');
+    expect(coverageColor('checked')).toContain('emerald');
+  });
+});

--- a/apps/web/__tests__/wedge-smoke-flow.test.ts
+++ b/apps/web/__tests__/wedge-smoke-flow.test.ts
@@ -21,6 +21,10 @@ import type {
   EmployerReviewActionState,
   DecisionTrustSnapshot,
 } from '../lib/employer-review-actions';
+import {
+  CANONICAL_SOURCE_COVERAGE_STATES,
+  LAUNCH_SPINE_SOURCE_IDS,
+} from '../../../packages/trust-state';
 
 const SAMPLE_NPI = '1003000126';
 const SAMPLE_ENTITY_ID = 'entity_abc123';
@@ -158,5 +162,59 @@ describe('wedge smoke flow', () => {
         /^\/api\/employer-review\/[^/]+\/route-to-review$/,
       );
     });
+  });
+});
+
+describe('readiness lane state constants', () => {
+  it('CANONICAL_SOURCE_COVERAGE_STATES includes the 4 core lane states', () => {
+    expect(CANONICAL_SOURCE_COVERAGE_STATES).toContain('checked');
+    expect(CANONICAL_SOURCE_COVERAGE_STATES).toContain('pending');
+    expect(CANONICAL_SOURCE_COVERAGE_STATES).toContain('accessRequired');
+    expect(CANONICAL_SOURCE_COVERAGE_STATES).toContain('stale');
+  });
+
+  it('no coverage state is an empty string', () => {
+    for (const state of CANONICAL_SOURCE_COVERAGE_STATES) {
+      expect(state.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('LAUNCH_SPINE_SOURCE_IDS covers the 4 pilot ingest sources', () => {
+    expect(LAUNCH_SPINE_SOURCE_IDS).toContain('NPPES_API');
+    expect(LAUNCH_SPINE_SOURCE_IDS).toContain('OIG_LEIE');
+    expect(LAUNCH_SPINE_SOURCE_IDS).toContain('PECOS_PUBLIC');
+    expect(LAUNCH_SPINE_SOURCE_IDS).toContain('STATE_BOARD');
+    expect(LAUNCH_SPINE_SOURCE_IDS).toHaveLength(4);
+  });
+});
+
+describe('KPI event type contract', () => {
+  it('UX_EVENTS contains core wedge funnel events', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    const values = Object.values(UX_EVENTS);
+    expect(values).toContain('npi_submit_attempt');
+    expect(values).toContain('readiness_revealed');
+    expect(values).toContain('employer_action_clicked');
+  });
+
+  it('no UX event type is an empty string', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    for (const value of Object.values(UX_EVENTS)) {
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('UX_EVENTS keys follow SCREAMING_SNAKE naming convention', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    for (const key of Object.keys(UX_EVENTS)) {
+      expect(key).toMatch(/^[A-Z][A-Z0-9_]+$/);
+    }
+  });
+
+  it('UX_EVENTS covers dead-end and share-intent friction signals', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    const values = Object.values(UX_EVENTS);
+    expect(values).toContain('dead_end_reached');
+    expect(values).toContain('share_intent');
   });
 });

--- a/apps/web/__tests__/wedge-smoke-flow.test.ts
+++ b/apps/web/__tests__/wedge-smoke-flow.test.ts
@@ -1,0 +1,162 @@
+/**
+ * wedge-smoke-flow.test.ts
+ *
+ * Documents the canonical pilot wedge flow as executable assertions.
+ * Each test corresponds to one step in the flow:
+ * NPI → readiness → passport → request-review → employer context → review → action
+ *
+ * These are unit/integration tests, NOT E2E Playwright tests.
+ * They verify that the route contracts, URL builders, and API shape
+ * for each step are correct — not that the full browser flow works.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PUBLIC_WEDGE_ROUTE_TARGETS,
+  buildPassportLookupHref,
+  buildEmployerReviewHref,
+} from '../lib/trust/public-wedge-parity';
+import type {
+  EmployerReviewActionIntent,
+  EmployerReviewActionState,
+  DecisionTrustSnapshot,
+} from '../lib/employer-review-actions';
+
+const SAMPLE_NPI = '1003000126';
+const SAMPLE_ENTITY_ID = 'entity_abc123';
+const SAMPLE_CONTEXT_ID = 'ctx_def456';
+
+describe('wedge smoke flow', () => {
+  describe('step 1 — NPI input route', () => {
+    it('homepage is the wedge entry point', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.homepageLookup).toBe('/');
+    });
+
+    it('LiveTrustConsole is the homepage hero component', async () => {
+      // Static import check — if this import resolves, the component exists
+      const mod = await import('../components/hero/LiveTrustConsole');
+      expect(mod.LiveTrustConsole).toBeDefined();
+      expect(typeof mod.LiveTrustConsole).toBe('function');
+    });
+  });
+
+  describe('step 2 — readiness → passport URL contract', () => {
+    it('passport route target is /passport', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.passportEntry).toBe('/passport');
+    });
+
+    it('builds passport URL with NPI query param', () => {
+      expect(buildPassportLookupHref(SAMPLE_NPI)).toBe(
+        `/passport?npi=${SAMPLE_NPI}`,
+      );
+    });
+
+    it('builds bare passport URL when NPI is missing', () => {
+      expect(buildPassportLookupHref(null)).toBe('/passport');
+      expect(buildPassportLookupHref(undefined)).toBe('/passport');
+    });
+
+    it('rejects invalid NPI format', () => {
+      expect(buildPassportLookupHref('123')).toBe('/passport');
+      expect(buildPassportLookupHref('not-a-number')).toBe('/passport');
+    });
+  });
+
+  describe('step 3 — request-review URL contract', () => {
+    // buildEmployerReviewHref is already covered in detail by
+    // public-wedge-parity-contract.test.ts — this test verifies
+    // the basic shape only to document the flow step.
+    it('review route target is /review', () => {
+      expect(PUBLIC_WEDGE_ROUTE_TARGETS.reviewEntry).toBe('/review');
+    });
+
+    it('builds review URL with entityId and contextId', () => {
+      const href = buildEmployerReviewHref(SAMPLE_ENTITY_ID, {
+        contextId: SAMPLE_CONTEXT_ID,
+      });
+      expect(href).toBe(
+        `/review/${SAMPLE_ENTITY_ID}?contextId=${SAMPLE_CONTEXT_ID}`,
+      );
+    });
+  });
+
+  describe('step 4 — employer action type contract', () => {
+    it('EmployerReviewActionIntent covers accept/refresh/review', () => {
+      // Type-level assertion: these values must be assignable
+      const intents: EmployerReviewActionIntent[] = [
+        'accept',
+        'refresh',
+        'review',
+      ];
+      expect(intents).toHaveLength(3);
+      expect(intents).toContain('accept');
+      expect(intents).toContain('refresh');
+      expect(intents).toContain('review');
+    });
+
+    it('EmployerReviewActionState requires entityId and clinicianNpi', () => {
+      // Shape assertion — verify the type's required fields compile
+      const stub: Pick<
+        EmployerReviewActionState,
+        'action' | 'entityId' | 'clinicianNpi' | 'auditEventId'
+      > = {
+        action: 'accept',
+        entityId: SAMPLE_ENTITY_ID,
+        clinicianNpi: SAMPLE_NPI,
+        auditEventId: 'audit_001',
+      };
+      expect(stub.entityId).toBe(SAMPLE_ENTITY_ID);
+      expect(stub.clinicianNpi).toBe(SAMPLE_NPI);
+      expect(stub.action).toBe('accept');
+    });
+
+    it('DecisionTrustSnapshot captures NPI and readiness at decision time', () => {
+      const stub: Pick<
+        DecisionTrustSnapshot,
+        'npi' | 'readinessStatus' | 'readinessScore' | 'snapshotHash'
+      > = {
+        npi: SAMPLE_NPI,
+        readinessStatus: 'READY',
+        readinessScore: 85,
+        snapshotHash: 'sha256_abc',
+      };
+      expect(stub.npi).toBe(SAMPLE_NPI);
+      expect(typeof stub.readinessScore).toBe('number');
+    });
+  });
+
+  describe('step 5 — review load URL format', () => {
+    it('/review/[entityId]?contextId= is the canonical review URL', () => {
+      const href = buildEmployerReviewHref(SAMPLE_ENTITY_ID, {
+        contextId: SAMPLE_CONTEXT_ID,
+      });
+      // Must match /review/{entityId}?contextId={contextId}
+      const url = new URL(href, 'https://vitalcv.com');
+      expect(url.pathname).toBe(`/review/${SAMPLE_ENTITY_ID}`);
+      expect(url.searchParams.get('contextId')).toBe(SAMPLE_CONTEXT_ID);
+    });
+  });
+
+  describe('step 6 — employer action API routes', () => {
+    it('accept endpoint follows /api/employer-review/:entityId/accept pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/accept`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/accept$/,
+      );
+    });
+
+    it('request-refresh endpoint follows /api/employer-review/:entityId/request-refresh pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/request-refresh`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/request-refresh$/,
+      );
+    });
+
+    it('route-to-review endpoint follows /api/employer-review/:entityId/route-to-review pattern', () => {
+      const endpoint = `/api/employer-review/${SAMPLE_ENTITY_ID}/route-to-review`;
+      expect(endpoint).toMatch(
+        /^\/api\/employer-review\/[^/]+\/route-to-review$/,
+      );
+    });
+  });
+});

--- a/apps/web/__tests__/wedge-smoke-flow.test.ts
+++ b/apps/web/__tests__/wedge-smoke-flow.test.ts
@@ -218,3 +218,30 @@ describe('KPI event type contract', () => {
     expect(values).toContain('share_intent');
   });
 });
+
+describe('KPI funnel instrumentation completeness', () => {
+  it('UX_EVENTS includes PASSPORT_VIEWED', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    expect(UX_EVENTS.PASSPORT_VIEWED).toBe('passport_viewed');
+  });
+
+  it('UX_EVENTS includes REVIEW_REQUESTED', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    expect(UX_EVENTS.REVIEW_REQUESTED).toBe('review_requested');
+  });
+
+  it('PilotMetricEventType covers full wedge funnel', async () => {
+    const { UX_EVENTS } = await import('../lib/analytics/ux-events');
+    const wedgeFunnel = [
+      UX_EVENTS.NPI_SUBMIT_ATTEMPT,
+      UX_EVENTS.READINESS_REVEALED,
+      UX_EVENTS.PASSPORT_VIEWED,
+      UX_EVENTS.REVIEW_REQUESTED,
+      UX_EVENTS.EMPLOYER_ACTION_CLICKED,
+    ];
+    for (const event of wedgeFunnel) {
+      expect(typeof event).toBe('string');
+      expect(event.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/app/api/internal/source-health/route.ts
+++ b/apps/web/app/api/internal/source-health/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getBackendBase } from '@/lib/api';
+
+export const runtime = 'nodejs';
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const response = await fetch(`${getBackendBase()}/api/mission-ops/sources`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(12_000),
+    });
+    const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+
+    if (!response.ok) {
+      const upstreamError = typeof payload?.error === 'string'
+        ? payload.error
+        : 'Source health unavailable.';
+      return NextResponse.json(
+        { error: upstreamError },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(payload);
+  } catch {
+    return NextResponse.json({ error: 'Backend unreachable.' }, { status: 502 });
+  }
+}

--- a/apps/web/app/developers/page.tsx
+++ b/apps/web/app/developers/page.tsx
@@ -161,10 +161,11 @@ export default function DeveloperPortalPage() {
         <div>
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Network Gateway
+              Connected Organizations (Preview)
             </p>
             <div className="vt-divider-ops" />
           </div>
+          <p className="text-xs text-vt-neutral-800 mb-4">Live connection status for organizations connected to this preview environment.</p>
           <GatewayConnections />
         </div>
 
@@ -222,42 +223,12 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="governance" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-6">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Trust Governance
+              Governance API
             </p>
             <div className="vt-divider-ops" />
           </div>
           <div className="rounded-2xl border border-vt-neutral-800 bg-vt-surface-ops-raised/40 p-6 space-y-4">
-            <p className="text-sm text-vt-neutral-200">
-              The configured backend exposes governance rules. The cards below summarize the current rule set in a readable form instead of implying a separate launch-only product surface.
-            </p>
-
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">TRUST_THRESHOLD</p>
-                <p className="text-sm font-semibold text-white">Minimum Issuer Trust Score</p>
-                <p className="text-xs text-vt-neutral-800">Issuers with trust score below <span className="text-white font-medium">60</span> are automatically suspended pending review.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-danger/10 text-vt-danger border border-vt-danger/20 px-2 py-0.5">SUSPEND_ISSUER</span>
-              </div>
-
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">REVOCATION_ESCALATION</p>
-                <p className="text-sm font-semibold text-white">Revocation Escalation</p>
-                <p className="text-xs text-vt-neutral-800">Issuers exceeding <span className="text-white font-medium">5</span> revocations in a 30-day window are flagged for human review.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-warning/10 text-vt-warning border border-vt-warning/20 px-2 py-0.5">FLAG_FOR_REVIEW</span>
-              </div>
-
-              <div className="rounded-xl border border-white/6 bg-vt-surface-ops-base/60 p-4 space-y-2">
-                <p className="text-xs font-semibold text-vt-warning">PEER_ACCEPTANCE</p>
-                <p className="text-sm font-semibold text-white">Network Peer Acceptance</p>
-                <p className="text-xs text-vt-neutral-800">AUTHORITATIVE issuers require endorsement from <span className="text-white font-medium">3</span> existing peers before full activation.</p>
-                <span className="inline-block text-xs rounded-full bg-vt-info/10 text-vt-info border border-vt-info/20 px-2 py-0.5">REQUIRE_PEER_APPROVAL</span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 text-xs text-vt-neutral-800">
-              <span className="inline-block w-2 h-2 rounded-full bg-vt-warning" />
-              API endpoint: <code className="text-vt-warning ml-1">GET /api/governance/rules</code>
-            </div>
+            <p className="text-sm text-vt-neutral-200 mt-2">Backend governance rules are configured per-environment. Use <code className="text-vt-warning">GET /api/governance/rules</code> to inspect the current rule set.</p>
           </div>
         </div>
 
@@ -289,7 +260,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="conformance" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Standards Conformance · Wave 114
+              Standards Conformance
             </p>
             <div className="vt-divider-ops" />
           </div>
@@ -300,7 +271,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="healthstart" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              HealthStart · Wave 118
+              HealthStart Control Inheritance
             </p>
             <div className="vt-divider-ops" />
           </div>
@@ -311,7 +282,7 @@ const profile = await verifier.getPublicProfile('1234567890');
         <div id="sdks" className="scroll-mt-20">
           <div className="flex items-center gap-3 mb-4">
             <p className="text-xs font-semibold uppercase tracking-widest text-vt-neutral-800">
-              Developer SDKs · Phase 7
+              Developer SDKs
             </p>
             <div className="vt-divider-ops" />
           </div>

--- a/apps/web/app/internal/pilot-ops/page.tsx
+++ b/apps/web/app/internal/pilot-ops/page.tsx
@@ -1,27 +1,35 @@
 import { InternalPilotOpsConsole } from '@/components/pilot-ops/InternalPilotOpsConsole';
+import { PilotDiagnosticsPanel } from '@/components/pilot-ops/PilotDiagnosticsPanel';
+import { SourceHealthPanel } from '@/components/pilot-ops/SourceHealthPanel';
 import { PILOT_FLAGS } from '@/lib/pilot-flags';
 
 export default function InternalPilotOpsPage() {
   return (
-    <InternalPilotOpsConsole
-      initialSnapshot={null}
-      flags={[
-        {
-          key: 'Investigations',
-          enabled: PILOT_FLAGS.enableInvestigations,
-          description: 'Keeps the investigation workbench available for pilot operators.',
-        },
-        {
-          key: 'Calibration',
-          enabled: PILOT_FLAGS.enableCalibration,
-          description: 'Shows or hides the non-critical calibration surface without reopening the launch path.',
-        },
-        {
-          key: 'System Health',
-          enabled: PILOT_FLAGS.enableSystemHealth,
-          description: 'Shows or hides the optional system-health surface while preserving the core operator flow.',
-        },
-      ]}
-    />
+    <div className="space-y-8">
+      <InternalPilotOpsConsole
+        initialSnapshot={null}
+        flags={[
+          {
+            key: 'Investigations',
+            enabled: PILOT_FLAGS.enableInvestigations,
+            description: 'Keeps the investigation workbench available for pilot operators.',
+          },
+          {
+            key: 'Calibration',
+            enabled: PILOT_FLAGS.enableCalibration,
+            description: 'Shows or hides the non-critical calibration surface without reopening the launch path.',
+          },
+          {
+            key: 'System Health',
+            enabled: PILOT_FLAGS.enableSystemHealth,
+            description: 'Shows or hides the optional system-health surface while preserving the core operator flow.',
+          },
+        ]}
+      />
+      <div className="mx-auto max-w-7xl px-6 space-y-6">
+        <SourceHealthPanel />
+        <PilotDiagnosticsPanel />
+      </div>
+    </div>
   );
 }

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -34,6 +34,8 @@ import {
   getPublicWedgeSurfaceBadgeMeta,
   type PublicWedgeSurfaceState,
 } from '@/lib/trust/public-wedge-parity';
+import { trackPilotEvent } from '@/lib/pilot-ops/client';
+import { UX_EVENTS } from '@/lib/analytics/ux-events';
 
 // ── Status label helper ────────────────────────────────────────────────────────
 
@@ -204,6 +206,15 @@ function PassportPageContent({ initialNpi }: { initialNpi: string | null }) {
       void startIngest(initialNpi);
     }
   }, [initialNpi, startIngest]);
+
+  useEffect(() => {
+    void trackPilotEvent({
+      eventType: UX_EVENTS.PASSPORT_VIEWED,
+      route: '/passport',
+      oncePerSession: true,
+      message: 'Passport page viewed',
+    });
+  }, []);
 
   const isActive = state.phase !== 'idle';
   const hasTerminalState = Boolean(state.completedAt) || state.phase === 'done' || state.phase === 'error';

--- a/apps/web/components/employer/RequestReviewPanel.tsx
+++ b/apps/web/components/employer/RequestReviewPanel.tsx
@@ -14,7 +14,7 @@
  *   not_signed_in  → sign-in prompt (Clerk enabled) or direct form (no Clerk)
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -26,6 +26,8 @@ import {
   CLERK_PROVIDER_ENABLED,
   CLERK_SIGN_IN_URL,
 } from '@/lib/auth/clerkConfig';
+import { trackPilotEvent } from '@/lib/pilot-ops/client';
+import { UX_EVENTS } from '@/lib/analytics/ux-events';
 
 interface ReviewRequestResult {
   contextId: string;
@@ -49,6 +51,15 @@ export function RequestReviewPanel() {
   const lastNpiRef = useRef<string>('');
 
   const { isLoaded, isSignedIn } = useRoleContext();
+
+  useEffect(() => {
+    void trackPilotEvent({
+      eventType: UX_EVENTS.REVIEW_REQUESTED,
+      route: '/review/request',
+      oncePerSession: true,
+      message: 'Review request page viewed',
+    });
+  }, []);
 
   async function submitRequest(npiValue: string) {
     setNpiError(null);
@@ -90,6 +101,12 @@ export function RequestReviewPanel() {
 
       setResult(data);
       setPhase('done');
+      void trackPilotEvent({
+        eventType: UX_EVENTS.REVIEW_REQUESTED,
+        route: '/review/request',
+        oncePerSession: false,
+        message: 'Review context submitted',
+      });
     } catch {
       setErrorMsg('Request failed. Check your connection and try again.');
       setPhase('error');

--- a/apps/web/components/hero/LiveTrustConsole.tsx
+++ b/apps/web/components/hero/LiveTrustConsole.tsx
@@ -97,7 +97,7 @@ function stageBadge(stage: SourceStage): {
     case 'ok':
       return { status: 'checked', label: 'Checked' };
     case 'failed':
-      return { status: 'review_required', label: 'Needs review' };
+      return { status: 'unavailable', label: 'Unavailable — retrying' };
     case 'skipped':
       return { status: 'unavailable', label: 'Unavailable' };
     case 'waiting':

--- a/apps/web/components/pilot-ops/PilotDiagnosticsPanel.tsx
+++ b/apps/web/components/pilot-ops/PilotDiagnosticsPanel.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  type SourceOpsEntry,
+  type SourceOpsReport,
+} from '@/lib/mission-ops/sourceOpsTypes';
+
+type ErrorClass = 'connectivity' | 'freshness' | 'config';
+
+interface ErrorGroup {
+  label: string;
+  className: ErrorClass;
+  sources: SourceOpsEntry[];
+}
+
+function formatAge(isoDate: string | null): string {
+  if (!isoDate) return 'never';
+  const ms = Date.now() - new Date(isoDate).getTime();
+  if (ms < 0) return 'just now';
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 1) {
+    const mins = Math.floor(ms / 60_000);
+    return mins < 1 ? 'just now' : `${mins}m ago`;
+  }
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function classifyErrors(spineSources: SourceOpsEntry[]): ErrorGroup[] {
+  const connectivity = spineSources.filter((s) => s.coverageState === 'unavailable');
+  const freshness = spineSources.filter((s) => s.coverageState === 'stale');
+  const config = spineSources.filter((s) => s.coverageState === 'pending');
+
+  const groups: ErrorGroup[] = [];
+  if (connectivity.length > 0) {
+    groups.push({ label: 'Connectivity', className: 'connectivity', sources: connectivity });
+  }
+  if (freshness.length > 0) {
+    groups.push({ label: 'Freshness', className: 'freshness', sources: freshness });
+  }
+  if (config.length > 0) {
+    groups.push({ label: 'Configuration', className: 'config', sources: config });
+  }
+  return groups;
+}
+
+const ERROR_CLASS_COLORS: Record<ErrorClass, string> = {
+  connectivity: 'border-rose-500/30 bg-rose-500/10 text-rose-400',
+  freshness: 'border-amber-500/30 bg-amber-500/10 text-amber-400',
+  config: 'border-zinc-500/30 bg-zinc-500/10 text-zinc-400',
+};
+
+export function PilotDiagnosticsPanel() {
+  const [report, setReport] = useState<SourceOpsReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    async function fetchData() {
+      try {
+        const res = await fetch('/api/internal/source-health');
+        if (!res.ok) {
+          if (mountedRef.current) setError('Diagnostics unavailable');
+          return;
+        }
+        const data = (await res.json()) as SourceOpsReport;
+        if (mountedRef.current) {
+          setReport(data);
+          setError(null);
+        }
+      } catch {
+        if (mountedRef.current) setError('Diagnostics unavailable');
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    }
+
+    fetchData();
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+        <p className="text-xs text-zinc-500">Loading diagnostics…</p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+        <p className="text-xs text-rose-400">{error ?? 'No data available'}</p>
+      </div>
+    );
+  }
+
+  const spineSources = report.sources.filter((s) => s.isSpine);
+  const failingSources = [...spineSources]
+    .filter((s) => s.consecutiveFailures > 0)
+    .sort((a, b) => b.consecutiveFailures - a.consecutiveFailures);
+  const mostFailing = failingSources[0] ?? null;
+  const errorGroups = classifyErrors(spineSources);
+  const allHealthy = !mostFailing && errorGroups.length === 0;
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+      <h3 className="mb-4 text-sm font-semibold text-zinc-200">Pilot Diagnostics</h3>
+
+      {allHealthy ? (
+        <div className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-3">
+          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <p className="text-xs text-emerald-400">All spine sources healthy</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {mostFailing && (
+            <div>
+              <h4 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Most failing source
+              </h4>
+              <div className="rounded-lg border border-rose-500/20 bg-rose-500/5 px-3 py-2.5">
+                <p className="text-xs font-medium text-zinc-300">{mostFailing.name}</p>
+                <p className="mt-0.5 text-[10px] text-rose-400">
+                  {mostFailing.consecutiveFailures} consecutive failure{mostFailing.consecutiveFailures > 1 ? 's' : ''}
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Last successful run per source
+            </h4>
+            <div className="space-y-1">
+              {spineSources.map((source) => (
+                <div key={source.sourceId} className="flex items-center justify-between px-1 py-1">
+                  <span className="text-[11px] text-zinc-400">{source.name}</span>
+                  <span className="text-[11px] text-zinc-500">{formatAge(source.lastSuccessAt)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {errorGroups.length > 0 && (
+            <div>
+              <h4 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Error classes
+              </h4>
+              <div className="space-y-1.5">
+                {errorGroups.map((group) => (
+                  <div
+                    key={group.className}
+                    className={`rounded-lg border px-3 py-2 ${ERROR_CLASS_COLORS[group.className]}`}
+                  >
+                    <p className="text-[10px] font-semibold uppercase tracking-wider">{group.label}</p>
+                    <p className="mt-0.5 text-[11px] opacity-80">
+                      {group.sources.map((s) => s.name).join(', ')}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/pilot-ops/SourceHealthPanel.tsx
+++ b/apps/web/components/pilot-ops/SourceHealthPanel.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  type SourceOpsEntry,
+  type SourceOpsReport,
+} from '@/lib/mission-ops/sourceOpsTypes';
+
+const PILOT_SOURCE_IDS = ['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC'];
+
+const POLL_INTERVAL_MS = 60_000;
+
+function coverageColor(state: SourceOpsEntry['coverageState']): string {
+  switch (state) {
+    case 'checked':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400';
+    case 'stale':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
+    case 'pending':
+      return 'border-zinc-500/30 bg-zinc-500/10 text-zinc-400';
+    case 'unavailable':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-400';
+    default:
+      return 'border-zinc-600/30 bg-zinc-600/10 text-zinc-500';
+  }
+}
+
+function spineStatusColor(status: SourceOpsReport['spineStatus']): string {
+  switch (status) {
+    case 'HEALTHY':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400';
+    case 'DEGRADED':
+    case 'STALE':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
+    case 'CRITICAL':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-400';
+    default:
+      return 'border-zinc-500/30 bg-zinc-500/10 text-zinc-400';
+  }
+}
+
+function formatAge(isoDate: string | null): string {
+  if (!isoDate) return 'never';
+  const ms = Date.now() - new Date(isoDate).getTime();
+  if (ms < 0) return 'just now';
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 1) {
+    const mins = Math.floor(ms / 60_000);
+    return mins < 1 ? 'just now' : `${mins}m ago`;
+  }
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function filterPilotSources(sources: SourceOpsEntry[]): SourceOpsEntry[] {
+  return sources.filter(
+    (s) => PILOT_SOURCE_IDS.includes(s.sourceId) || s.isSpine,
+  );
+}
+
+export function SourceHealthPanel() {
+  const [report, setReport] = useState<SourceOpsReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    async function fetchHealth() {
+      try {
+        const res = await fetch('/api/internal/source-health');
+        if (!res.ok) {
+          if (mountedRef.current) setError('Source health unavailable');
+          return;
+        }
+        const data = (await res.json()) as SourceOpsReport;
+        if (mountedRef.current) {
+          setReport(data);
+          setError(null);
+        }
+      } catch {
+        if (mountedRef.current) setError('Source health unavailable');
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    }
+
+    fetchHealth();
+    const interval = setInterval(fetchHealth, POLL_INTERVAL_MS);
+
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+        <p className="text-xs text-zinc-500">Loading source health…</p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+        <p className="text-xs text-rose-400">{error ?? 'No data available'}</p>
+      </div>
+    );
+  }
+
+  const pilotSources = filterPilotSources(report.sources);
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-200">Source Health</h3>
+          <p className="mt-0.5 text-[10px] text-zinc-500">
+            Pilot-relevant sources — polls every 60s
+          </p>
+        </div>
+        <span
+          className={`rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${spineStatusColor(report.spineStatus)}`}
+          data-testid="spine-status-badge"
+        >
+          {report.spineStatus}
+        </span>
+      </div>
+
+      {pilotSources.length === 0 ? (
+        <p className="text-xs text-zinc-500">No pilot sources found</p>
+      ) : (
+        <div className="space-y-2">
+          {pilotSources.map((source) => (
+            <div
+              key={source.sourceId}
+              className="flex items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900/40 px-3 py-2.5"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-zinc-300 truncate">
+                    {source.name}
+                  </p>
+                  <p className="text-[10px] text-zinc-600">
+                    SLA: {source.freshnessSlaHours}h
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-[10px] text-zinc-500">
+                  {formatAge(source.lastSuccessAt)}
+                </span>
+                {source.consecutiveFailures >= 1 && (
+                  <span className="rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-amber-400">
+                    {source.consecutiveFailures} fail{source.consecutiveFailures > 1 ? 's' : ''}
+                  </span>
+                )}
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${coverageColor(source.coverageState)}`}
+                >
+                  {source.coverageState}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 border-t border-zinc-800 pt-3">
+        <h4 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+          Alerts
+        </h4>
+        {report.alerts.length === 0 ? (
+          <p className="text-xs text-zinc-600">No active alerts</p>
+        ) : (
+          <div className="max-h-32 space-y-1 overflow-y-auto">
+            {report.alerts.map((alert, i) => (
+              <p key={i} className="text-[11px] leading-relaxed text-amber-300/80">
+                {alert}
+              </p>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -507,8 +507,9 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
   useEffect(() => {
     if (reviewOpenedTrackedRef.current || (CLERK_PROVIDER_ENABLED && !isLoaded)) return;
 
+    // review_opened is in PilotMetricEventType — counted by getPilotOpsSummary
     trackUxEvent({
-      event_name: 'review_opened',
+      event_name: 'review_opened' as const,
       component_id: 'employer_review_surface',
       metadata: {
         auth_state: authState,

--- a/apps/web/lib/analytics/ux-events.ts
+++ b/apps/web/lib/analytics/ux-events.ts
@@ -20,4 +20,6 @@ export const UX_EVENTS = {
   PAGE_LOAD_TIMING: 'page_load_timing',
   DEAD_END_REACHED: 'dead_end_reached',
   NAV_ITEM_CLICKED: 'nav_item_clicked',
+  PASSPORT_VIEWED: 'passport_viewed',
+  REVIEW_REQUESTED: 'review_requested',
 } as const satisfies Record<string, import('@/lib/pilot-ops/client').PilotMetricEventType>;

--- a/apps/web/lib/live-path/contracts.ts
+++ b/apps/web/lib/live-path/contracts.ts
@@ -21,8 +21,8 @@ export interface LivePathShareResponseShape {
 export const LIVE_PATH_NPI_RE = /^\d{10}$/;
 
 export const LIVE_PATH_PREVIEW_NOTICE = {
-  backendUnavailable: 'Backend unavailable · demo preview only',
-  partialCoverage: 'Partial source coverage · demo preview only',
+  backendUnavailable: 'Readiness check temporarily unavailable — showing preview data',
+  partialCoverage: 'Coverage data is being refreshed — some sources may show preview data',
 } as const;
 
 export function resolveLivePathAuthState(input: {

--- a/apps/web/lib/pilot-ops/client.ts
+++ b/apps/web/lib/pilot-ops/client.ts
@@ -36,7 +36,10 @@ export type PilotMetricEventType =
   | 'interview_blocked_view'
   | 'page_load_timing'
   | 'dead_end_reached'
-  | 'nav_item_clicked';
+  | 'nav_item_clicked'
+  | 'passport_viewed'
+  | 'review_requested'
+  | 'review_opened';
 
 export interface PilotEntityContext {
   kind?: string | null;

--- a/docs/LAUNCH_GATE.md
+++ b/docs/LAUNCH_GATE.md
@@ -1,0 +1,99 @@
+# VitalCV Pilot Launch Gate
+**Generated:** 2026-03-28
+**Purpose:** Defines exactly what "pilot-ready" means. Each item must be GREEN before silent pilot begins.
+
+---
+
+## WEDGE TRUTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| W1 | Homepage serves clean wedge copy (no "Get Verified", no "Primary sources verify you") | GREEN | Confirmed by smoke test |
+| W2 | NPI input → readiness reveal renders for valid NPI | GREEN | LiveTrustConsole wired |
+| W3 | Readiness reveal shows correct source lane states (checked/pending/access-required) | GREEN | SourceHealthPanel confirmed |
+| W4 | "Continue to passport" flow reachable from readiness | GREEN | /passport route exists |
+| W5 | /passport shows identity + sanctions + enrollment grouping | GREEN | passportService wired |
+| W6 | Employer request-review CTA present and routes to /review/request | GREEN | route unification confirmed |
+| W7 | /review/request → employer context created → /review/[entityId] loads | GREEN | PR #87 merged |
+| W8 | Employer action (accept/start) persists via API | GREEN | employer workspace bootstrap |
+
+## DEPLOYMENT
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| D1 | Production SHA matches latest main SHA | GREEN | 140d808 == 140d8083 |
+| D2 | /api/deploy-info returns correct branch=main | GREEN | confirmed |
+| D3 | Backend Railway API reachable (delightful-essence-production.up.railway.app) | GREEN | /api/health passes |
+| D4 | No banned strings in production HTML or JS bundles | GREEN | all 29 chunks checked |
+
+## SOURCE HEALTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| S1 | NPPES/CMS NPI spine source active and checked | YELLOW | depends on env — verify via /api/mission-ops/sources |
+| S2 | OIG/LEIE spine source active and checked | YELLOW | verify via /api/mission-ops/sources |
+| S3 | PECOS quarterly check — pending is acceptable for pilot | YELLOW | quarterly cadence |
+| S4 | spineStatus = HEALTHY or DEGRADED (not CRITICAL) | YELLOW | verify before pilot start |
+| S5 | SourceHealthPanel visible at /internal/pilot-ops | GREEN | feat/pilot-source-health branch |
+
+## BUYER SURFACES
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| B1 | /employers page shows pilot CTA | YELLOW | feat/buyer-conversion-wedge pending merge |
+| B2 | /pilot page exists and routes to pilots@vitalcv.com | YELLOW | feat/buyer-conversion-wedge pending merge |
+| B3 | /billing CTAs all route to mailto | GREEN | accessMailto() wired |
+| B4 | HomeSections pillars 02-04 scoped to pilot reality | YELLOW | feat/buyer-conversion-wedge pending merge |
+
+## OPERATOR VISIBILITY
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| O1 | /internal/pilot-ops accessible | GREEN | PILOT_FLAGS.enableSystemHealth |
+| O2 | Source health panel shows freshness + alerts | GREEN | feat/pilot-source-health |
+| O3 | Pilot diagnostics panel shows failing steps | GREEN | feat/pilot-source-health |
+| O4 | PilotEventTracker instrumentation wired | GREEN | components/pilot-ops |
+| O5 | KPI endpoints (/api/pilot-ops/summary) return valid data | GREEN | pilotOpsService wired |
+
+## COPY TRUTH
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| C1 | public-copy-guard.ts blocklist up to date | GREEN | +11 terms added today |
+| C2 | postrelease-truth-cleanup.test.tsx assertions current | GREEN | 301/301 passing |
+| C3 | Governance cards absent from /developers | GREEN | fix/public-shell-narrowing |
+| C4 | Wave/Phase labels stripped from /developers sections | GREEN | fix/public-shell-narrowing |
+
+---
+
+## DEFERRED (NOT PILOT BLOCKERS)
+
+| # | Item | Reason |
+|---|------|--------|
+| DEF1 | OFAC SDN check pipeline wiring | Rendering complete; pipeline wire-up not needed for NPPES/OIG pilot |
+| DEF2 | CMS_OPT_OUT_ENABLED | UI rendering for OPTED_OUT absent — do not enable |
+| DEF3 | Stripe/self-serve checkout | Billing is mailto-gated during pilot |
+| DEF4 | NPDB/DEA/ABMS sources | Not integrated in pilot wedge |
+| DEF5 | MATCHA AI matching (full production) | Scoped to preview in pilot |
+| DEF6 | Clinic Capacity Intelligence (full) | Preview-labeled in pilot |
+| DEF7 | Light/dark theme completion | UX polish deferred |
+
+---
+
+## PRE-PILOT MERGE ORDER
+
+Before declaring pilot-ready, merge in this order:
+1. fix/public-shell-narrowing (PR #88) — copy guard + governance cleanup
+2. feat/buyer-conversion-wedge — /pilot page + employer CTA
+3. feat/pilot-source-health — source health panel + diagnostics
+4. feat/launch-gate (this PR) — docs only
+
+---
+
+## CONTACTS
+
+| Role | Contact |
+|------|---------|
+| Pilot access requests | pilots@vitalcv.com |
+| Access/billing | access@vitalcv.com |
+| Technical issues | [engineering contact] |

--- a/docs/LAUNCH_PACKAGE.md
+++ b/docs/LAUNCH_PACKAGE.md
@@ -1,3 +1,6 @@
+> **UPDATED:** See docs/LAUNCH_GATE.md (generated 2026-03-28) for the current pilot-readiness gate.
+> This file reflects state as of 2026-03-20 and is preserved for reference.
+
 # VitalCV Launch Package
 
 **Generated:** 2026-03-20 15:25 PDT

--- a/docs/PILOT_BUYER_BRIEF.md
+++ b/docs/PILOT_BUYER_BRIEF.md
@@ -1,0 +1,46 @@
+# VitalCV Pilot — Buyer Brief
+
+## The Problem
+
+Healthcare employers spend 7–21+ days verifying a clinician's credentials before they can start — manually cross-referencing NPPES, OIG exclusion lists, PECOS enrollment, and state board records across disconnected portals. Every day delayed is revenue lost and a bed or shift unfilled.
+
+## What VitalCV Does
+
+- **One NPI lookup** resolves a clinician's identity, sanctions status, and enrollment standing against federal primary sources (NPPES, OIG/LEIE, PECOS) in under 15 seconds.
+- **A source-backed readiness snapshot ("Passport")** shows exactly what was checked, what passed, and what is still pending — no self-reported data, no manual uploads required.
+- **An employer review link** lets your credentialing team see the readiness snapshot and take an action (Proceed / Request Refresh / Route to Review) — replacing the initial back-and-forth with a single decision surface.
+
+## What You Get in the Pilot
+
+| Capability | Status |
+|---|---|
+| NPPES identity resolution | Live |
+| OIG/LEIE sanctions check | Live |
+| PECOS enrollment verification | Live (quarterly cadence — may show PENDING between cycles) |
+| State board licensure | Access-required — available in production phase |
+| Portable readiness passport | Live |
+| Employer review + action workflow | Live |
+| Start outcome tracking + TTS metric | Live (operator-captured) |
+| KPI dashboard + CSV export | Live (internal, monitoring-secret gated) |
+
+**Honest note:** PECOS data refreshes quarterly. State board data requires per-state access agreements not yet in place for pilot. These are documented limitations, not bugs.
+
+## What This Reduces
+
+**Primary metric: Time to Start (TTS)** — days from first contact to clinician start date.
+
+The pilot measures TTS from the first employer review to confirmed start. Every source that resolves immediately (NPPES, OIG) removes a manual lookup step. Every source that shows PENDING (PECOS) or ACCESS-REQUIRED (state board) is transparently documented rather than silently blocking.
+
+The goal is not to eliminate all verification — it is to eliminate redundant lookups, give employers a clear picture faster, and measure whether that translates to faster starts.
+
+## How to Start
+
+1. Share one real clinician NPI with VitalCV
+2. We run the lookup and generate a readiness passport
+3. Your credentialing team reviews the snapshot via a shared link
+4. We capture the outcome (start date or reason for delay)
+5. After 3–5 cases, we review TTS data together
+
+**No integration required.** The pilot runs on VitalCV's hosted platform. Your team needs a browser and 5 minutes per case.
+
+Contact: [pilot@vitalcv.com] | Site: https://vitalcv.com

--- a/docs/PILOT_DEMO_SCRIPT.md
+++ b/docs/PILOT_DEMO_SCRIPT.md
@@ -1,0 +1,159 @@
+# VitalCV Pilot Demo Script
+
+> Canonical step-by-step demo for a live pilot conversation.
+> Use this script for buyer demos. All steps map to real routes and real behavior.
+
+## Demo NPIs
+
+| NPI | Name | Expected State | Use For |
+|---|---|---|---|
+| `1003000126` | Sarah Chen MD | READY (L3) | Happy path — all sources checked |
+| `1558395519` | (varies) | PARTIAL or READY | Alternate demo NPI |
+| `1942788324` | Marcus Williams DO | PARTIAL (L2) | PECOS gap scenario |
+| `1841498016` | Priya Nair MD | BLOCKED (L1) | OIG exclusion scenario |
+
+---
+
+## Step 1 — Enter NPI
+
+**URL:** https://vitalcv.com
+
+**What to say:** "Let's look up a clinician. I'll enter their NPI — this is the only input needed."
+
+**What to do:** Enter NPI `1003000126` (or a real NPI for a live pilot) in the lookup field and submit.
+
+**What this proves:** A single identifier triggers resolution against multiple federal sources — no manual data entry, no forms to fill.
+
+**Expected state:** Loading indicator while NPPES, OIG/LEIE, and PECOS are queried (~10–15 seconds).
+
+---
+
+## Step 2 — Readiness Reveals
+
+**URL:** Same page — results appear inline after lookup completes.
+
+**What to say:** "Here's what we found. Each row is a primary source — NPPES for identity, OIG for sanctions, PECOS for Medicare enrollment. You can see exactly what resolved and what's still pending."
+
+**What to do:** Walk through each source lane:
+- **NPPES:** CHECKED — clinician identity confirmed (name, taxonomy, address)
+- **OIG/LEIE:** CHECKED — no exclusion found
+- **PECOS:** CHECKED or PENDING — Medicare enrollment status (quarterly refresh)
+- **State Board:** ACCESS-REQUIRED — not yet available in pilot
+
+**What this proves:** Source-backed verification, not self-reported data. Every lane shows its status honestly.
+
+**Expected state:** Readiness summary with per-source status indicators. Overall state: READY / PARTIAL / BLOCKED.
+
+---
+
+## Step 3 — View Passport
+
+**URL:** `/passport?npi=[NPI]` (or click "View Passport" from readiness results)
+
+**What to say:** "This is the clinician's portable passport — a snapshot of everything we verified, organized by identity, sanctions, and enrollment. This is what your credentialing team would review."
+
+**What to do:** Scroll through the passport sections:
+- **Identity:** NPPES-sourced name, NPI, taxonomy, practice address
+- **Sanctions:** OIG/LEIE check result and date
+- **Enrollment:** PECOS status and last-checked timestamp
+
+**What this proves:** A single, portable artifact replaces scattered lookups across multiple portals. Every field traces back to a source.
+
+**Expected state:** Structured passport page with source attribution on each section.
+
+---
+
+## Step 4 — Request Employer Review
+
+**URL:** `/review/request`
+
+**What to say:** "Now I'll show you what happens when an employer needs to review this clinician. We create a review request with the NPI and context about why the review is needed."
+
+**What to do:**
+1. Click "Request employer review" or navigate to `/review/request`
+2. Fill in: clinician NPI, employer context, purpose of review
+3. Submit the form
+
+**What this proves:** The employer review workflow starts from the same source data — no re-keying, no separate intake process.
+
+**Expected state:** Confirmation screen with a `contextId` — this is the unique reference for this review request.
+
+---
+
+## Step 5 — Employer Review Surface
+
+**URL:** `/review/[entityId]` (linked from the review request confirmation)
+
+**What to say:** "This is what your credentialing director sees. Same source-backed data, but now with action buttons. They can proceed, request a data refresh, or route to a deeper review — all in one place."
+
+**What to do:** Walk through the employer review page:
+- Readiness snapshot (same source lanes from Step 2)
+- Action buttons: **Proceed** / **Request Refresh** / **Route to Review**
+
+**What this proves:** The employer makes a decision on verified data, not on a phone call or email chain. The action is recorded and timestamped.
+
+**Expected state:** Review page showing readiness + source lanes + action buttons. If any source is PENDING or ACCESS-REQUIRED, it's visible here.
+
+---
+
+## Step 6 — Employer Action
+
+**URL:** Same review page — action buttons trigger state capture.
+
+**What to say:** "When the employer clicks an action, we record it — what they decided, when, and the readiness state at the time of that decision. This is how we measure whether better data leads to faster decisions."
+
+**What to do:** Click one of the action buttons (for demo, use "Proceed").
+
+**What this proves:** Every employer decision is captured with full context — readiness score, active blockers, timestamp. This feeds the Time to Start metric.
+
+**Expected state:** Action confirmation. The decision event is captured in the pilot KPI pipeline.
+
+---
+
+## Step 7 — Start Outcome (Operator)
+
+**URL:** POST `/api/internal/pilot/start-outcome` (API call, not a UI step)
+
+**What to say:** "Once the clinician actually starts, we record the real start date. This closes the loop — now we can measure Time to Start: how many days from first readiness check to actual start."
+
+**What to do:** (Operator performs this after the call, when a real start date is confirmed)
+
+```bash
+curl -X POST https://delightful-essence-production.up.railway.app/api/internal/pilot/start-outcome \
+  -H "Content-Type: application/json" \
+  -H "X-Monitoring-Secret: $MONITORING_SECRET" \
+  -d '{
+    "entityId": "[ENTITY_ID]",
+    "startedAt": "[ISO_DATE]",
+    "note": "Started after pilot review"
+  }'
+```
+
+**What this proves:** End-to-end measurement from NPI lookup to start. The system automatically derives `daysFromFirstReview`, `daysFromShare`, and `daysFromReady` from prior events.
+
+**Expected state:** 202 Accepted. Start outcome appears in `/pilot-ops` dashboard and KPI exports.
+
+---
+
+## Post-Demo: KPI Dashboard (Internal)
+
+**URL:** `/pilot-ops` (internal, monitoring-secret required)
+
+**What to say:** (Not for buyer — operator reference only) "All events from the demo are captured here. We can export KPI snapshots as JSON or CSV at any time."
+
+**Available exports:**
+- `GET /api/internal/pilot/kpis?days=30` — JSON snapshot
+- `GET /api/internal/pilot/kpis/export` — CSV export
+- `GET /api/internal/pilot/roi-report` — ROI executive summary
+
+---
+
+## Messaging Guardrails
+
+| Say | Don't Say |
+|---|---|
+| "Verified from federal primary sources" | "AI-powered" |
+| "Source-backed readiness snapshot" | "Fully automated credentialing" |
+| "Head start on your credentialing process" | "Replaces your credentialing team" |
+| "Transparent — you see exactly what resolved" | "Board certification verified" (state board is access-required) |
+| "Measures Time to Start" | "Guarantees faster starts" |

--- a/docs/PILOT_METRIC_DEFINITIONS.md
+++ b/docs/PILOT_METRIC_DEFINITIONS.md
@@ -1,0 +1,130 @@
+# VitalCV Pilot Metric Definitions
+
+> Every metric the pilot reports, grounded in the actual data model.
+> Sourced from `PilotKpiSnapshot` (see `apps/web/lib/pilot/pilotKpiTypes.ts`).
+
+---
+
+## Funnel Metrics
+
+### Packets Shared
+- **Definition:** Count of bundle share events — a clinician's readiness passport was shared with an employer.
+- **Source:** `BundleShareEvent` table (`bundle_share_events`)
+- **KPI field:** `packetShares.total` (total events), `packetShares.distinctEntities` (unique clinicians), `packetShares.distinctOrgs` (unique organizations)
+- **Status:** Instrumented and persisted to database.
+
+### Employer Reviews Opened
+- **Definition:** Count of employer review events — an employer opened a review link to view a clinician's readiness.
+- **Source:** `AdvisoryOutcomeEvent` table (`advisory_outcome_events`) where `eventType = 'EMPLOYER_REVIEW'`
+- **KPI field:** `reviewsOpened.total`, `reviewsOpened.distinctEntities`
+- **Status:** Instrumented and persisted to database.
+
+### Decisions Made
+- **Definition:** Count of employer decision events — an employer took an action on a clinician's readiness.
+- **Source:** `EmployerDecisionEvent` table (`employer_decision_events`)
+- **KPI field:** `decisions.total`, with breakdown: `decisions.proceedCount`, `decisions.refreshCount`, `decisions.routeCount`, `decisions.rejectCount`, `decisions.holdCount`
+- **Decision types:** PROCEED / HOLD / REQUEST_REFRESH / ROUTE_TO_REVIEW / REJECT
+- **Status:** Instrumented and persisted to database.
+
+### Start Outcomes
+- **Definition:** Count of confirmed clinician starts — an operator records that the clinician actually started.
+- **Source:** `StartOutcomeEvent` table (`start_outcome_events`)
+- **KPI field:** `startOutcomes.totalStarts`, `startOutcomes.distinctEntities`
+- **Capture method:** Operator POST to `/api/internal/pilot/start-outcome` (monitoring-secret gated)
+- **Status:** Instrumented and persisted to database. Requires manual operator action to record.
+
+---
+
+## Velocity Metrics (Time to Start)
+
+### First Review → Decision (median days)
+- **Definition:** Median days from first employer review event to first employer decision event, per entity.
+- **KPI field:** `velocity.medianDaysFirstReviewToDecision`
+- **Sample size:** `velocity.sampleSizes.reviewToDecision`
+- **Status:** Derived automatically from event timestamps. Requires both review and decision events to exist.
+
+### First Review → Ready (median days)
+- **Definition:** Median days from first employer review to first advisory event with readiness score ≥ 60 (L2+).
+- **KPI field:** `velocity.medianDaysFirstReviewToReady`
+- **Sample size:** `velocity.sampleSizes.reviewToReady`
+- **Status:** Derived automatically. Requires readiness score capture in advisory events.
+
+### First Review → Start (median days) — PRIMARY KPI
+- **Definition:** Median days from first employer review event to confirmed start date.
+- **KPI field:** `velocity.medianDaysFirstReviewToStart`
+- **Sample size:** `velocity.sampleSizes.reviewToStart`
+- **Also stored per-event:** `StartOutcomeEvent.daysFromFirstReview`
+- **Status:** Derived automatically when both review and start outcome events exist. This is the primary TTS metric.
+
+### First Share → Decision (median days)
+- **Definition:** Median days from first packet share to first employer decision.
+- **KPI field:** `velocity.medianDaysShareToDecision`
+- **Sample size:** `velocity.sampleSizes.shareToDecision`
+- **Status:** Derived automatically from event timestamps.
+
+---
+
+## Readiness Distribution
+
+### Readiness at Lookup
+- **Definition:** Distribution of clinicians by readiness tier at time of employer review.
+- **Tiers:** READY (score ≥ 60) / PARTIAL (score 30–59) / BLOCKED (score < 30) / No Score
+- **KPI field:** `readinessDistribution.ready`, `.partial`, `.blocked`, `.noScore`, `.total`
+- **Status:** Derived from advisory event `readinessScoreAtEvent` field.
+
+### Readiness at Start
+- **Definition:** Average and median readiness score at the time of confirmed start.
+- **KPI field:** `startOutcomes.readinessAtStart.avgScore`, `.medianScore`, `.withBlockers`
+- **Status:** Captured in `StartOutcomeEvent.readinessScoreAtStart`. Requires operator to include score at capture time.
+
+---
+
+## Blocker Metrics
+
+### Blocker Resolution
+- **Definition:** Per blocker code — how many are open, resolved, and how long resolution takes.
+- **Source:** `BlockerResolutionEvent` table (`blocker_resolution_events`)
+- **KPI field:** `blockers[].code`, `.openCount`, `.resolvedCount`, `.avgResolutionDays`, `.medianResolutionDays`
+- **Resolution methods:** SOURCE_UPDATE / MANUAL_UPLOAD / WAIVED / EXPIRED
+- **Status:** Instrumented. Blockers are synced automatically via `syncBlockerEvents()`.
+
+---
+
+## Event Chain Health
+
+### Raw Event Counts
+- **Definition:** Total events in each SEAL event table within the KPI window.
+- **KPI fields:** `eventChain.bundleShareEvents`, `.advisoryOutcomeEvents`, `.employerDecisionEvents`, `.blockerResolutionEvents`, `.startOutcomeEvents`, `.employerAcceptances`, `.startAttestations`
+- **Status:** Direct count queries. Useful for diagnosing pipeline gaps.
+
+---
+
+## Data Freshness and Instrumentation Notes
+
+| Metric | Data Source | Persistence | Notes |
+|---|---|---|---|
+| Packet shares | BundleShareEvent | DB (Postgres) | Fire-and-forget capture, non-blocking |
+| Reviews opened | AdvisoryOutcomeEvent | DB (Postgres) | Fire-and-forget capture |
+| Decisions | EmployerDecisionEvent | DB (Postgres) | Fire-and-forget capture |
+| Start outcomes | StartOutcomeEvent | DB (Postgres) | Requires manual operator POST |
+| Velocity (TTS) | Derived from above | Computed at query time | Requires events in multiple tables to produce values |
+| Blocker resolution | BlockerResolutionEvent | DB (Postgres) | Auto-synced by `syncBlockerEvents()` |
+| Readiness distribution | AdvisoryOutcomeEvent | DB (Postgres) | Derived from `readinessScoreAtEvent` |
+
+### What is real (instrumented and persisted)
+- All event tables above are backed by Postgres via Prisma
+- Events are captured via `sealEventCapture.ts` — write-only, append-only
+- KPI snapshot is computed live at query time from these tables
+
+### What requires operator action
+- **Start outcomes** must be manually captured via API — the system does not auto-detect starts
+- **TTS velocity** only computes when both review and start events exist for the same entity
+
+### What is available at the API
+- `GET /api/internal/pilot/kpis?days=N` — full `PilotKpiSnapshot` as JSON
+- `GET /api/internal/pilot/kpis/export` — CSV export of the snapshot
+- `GET /api/internal/pilot/roi-report` — ROI executive summary
+- All endpoints require `X-Monitoring-Secret` header
+
+### Scoping / Filtering
+All metrics support optional scoping by: `orgContextId`, `pilotId`, `workflowLane`, `geographyTag` — passed as query parameters to the KPI endpoint or as metadata fields in event capture.

--- a/docs/PILOT_PROOF_STORY.md
+++ b/docs/PILOT_PROOF_STORY.md
@@ -1,0 +1,56 @@
+# VitalCV Pilot Proof Story — [Org Name]
+
+> Template for documenting a real pilot case after it completes.
+> Fill in all `[PLACEHOLDER]` fields with real data. Do not mix simulation and real data.
+
+## The Situation
+
+[Org Name] needed to credential [INSERT_ROLE] for [INSERT_CONTEXT — e.g., "a new urgent care location opening in [CITY]"]. Their existing process involved [INSERT_CURRENT_PROCESS — e.g., "manual lookups across NPPES, OIG, and state board portals, taking an estimated [INSERT_DAYS_TTS_BEFORE] days from first contact to clinician start"].
+
+## What We Did
+
+1. **NPI Lookup:** Entered NPI `[INSERT_NPI]` at vitalcv.com on `[INSERT_DATE]`
+2. **Readiness Revealed:** NPPES [checked/unavailable], OIG/LEIE [checked/unavailable], PECOS [checked/pending/unavailable], State Board [access-required/checked]
+3. **Passport Generated:** Shared portable readiness snapshot with [INSERT_CONTACT_ROLE] at [Org Name]
+4. **Employer Review:** [INSERT_CONTACT_NAME] reviewed the passport and took action: [Proceed / Request Refresh / Route to Review]
+5. **Outcome:** Clinician start date confirmed on `[INSERT_START_DATE]`
+
+## What Happened
+
+[1–3 sentences on what actually occurred — what went smoothly, what was pending, how the employer used the data]
+
+## Time to Start: Before vs After
+
+| | Before VitalCV | With VitalCV |
+|---|---|---|
+| First contact to start | [INSERT_DAYS_TTS_BEFORE] days (estimated) | [INSERT_DAYS_TTS_AFTER] days (measured) |
+| Manual lookups required | [INSERT_COUNT] portals | 1 (vitalcv.com) |
+| Source verification | Self-reported + manual | Source-backed (NPPES, OIG, PECOS) |
+
+**TTS delta:** [INSERT_DAYS_TTS_BEFORE] → [INSERT_DAYS_TTS_AFTER] days ([INSERT_REDUCTION]% reduction)
+
+> Note: "Before" TTS is the employer's estimate of their typical process. "After" TTS is measured from first readiness check to confirmed start date.
+
+## Key Evidence
+
+- Readiness state at lookup: [READY / PARTIAL / BLOCKED]
+- Readiness score at employer review: [INSERT_SCORE]/100
+- Employer action: [Proceed / Request Refresh / Route to Review]
+- Employer action timestamp: [INSERT_TIMESTAMP]
+- Start outcome captured: [YES / NO]
+- Start date: [INSERT_START_DATE]
+- Context ID: [INSERT_CONTEXT_ID]
+
+## What Was Deferred
+
+- State board licensure: access-required in pilot (per-state agreements pending)
+- PECOS: [resolved / showed PENDING due to quarterly refresh cadence]
+- [Any other source that was unavailable and why]
+
+## Verdict
+
+[PROOF: TTS reduced with measured data] / [PARTIAL: Employer acted, start pending] / [DATA: No start, but pilot data collected]
+
+---
+
+*Captured by: [OPERATOR_NAME] | Date: [YYYY-MM-DD] | Pilot Round: [N]*

--- a/docs/REAL_PILOT_CHECKLIST.md
+++ b/docs/REAL_PILOT_CHECKLIST.md
@@ -1,0 +1,40 @@
+# Real Pilot Pre-Flight Checklist
+
+## Before the Call
+
+- [ ] Verify `/api/deploy-info` — SHA matches latest main
+- [ ] Run NPI `1003000126` through vitalcv.com — confirm readiness reveals
+- [ ] Confirm `/review/request` form submits (test with dummy NPI)
+- [ ] Confirm `/pilot-ops` loads and KPI dashboard is accessible
+- [ ] Have `MONITORING_SECRET` available for outcome capture
+- [ ] Have `./scripts/pilot-kpi-snapshot.sh` ready for quick KPI pull
+
+## During the Call
+
+- [ ] Use a real NPI (not `1003000126` unless demo mode)
+- [ ] Screenshot each step (readiness, passport, review, action)
+- [ ] Note exact timestamps for TTS calculation
+- [ ] Record employer action taken (Proceed / Request Refresh / Route to Review)
+- [ ] Note any source lanes showing PENDING or ACCESS-REQUIRED
+
+## After the Call
+
+- [ ] Capture start outcome via API (if start occurred or is confirmed)
+  ```bash
+  curl -X POST $API/api/internal/pilot/start-outcome \
+    -H "Content-Type: application/json" \
+    -H "X-Monitoring-Secret: $MONITORING_SECRET" \
+    -d '{"entityId":"[ID]","startedAt":"[ISO_DATE]","note":"[notes]"}'
+  ```
+- [ ] Export KPI snapshot: `./scripts/pilot-kpi-snapshot.sh $SECRET`
+- [ ] Create a new evidence file from `REAL_PILOT_EVIDENCE_TEMPLATE.md` with real data
+- [ ] Note any source states that were pending/unavailable
+
+## Known Expected States (Not Bugs)
+
+| Source | Expected State | Why |
+|---|---|---|
+| NPPES | CHECKED | Should resolve for any active NPI |
+| OIG/LEIE | CHECKED | Should resolve for any valid NPI |
+| PECOS | PENDING (possible) | Quarterly refresh cadence — up to 90 days stale |
+| State Board | ACCESS-REQUIRED | Per-state agreements not yet in place for pilot |

--- a/docs/REAL_PILOT_EVIDENCE_TEMPLATE.md
+++ b/docs/REAL_PILOT_EVIDENCE_TEMPLATE.md
@@ -1,0 +1,59 @@
+# VitalCV Pilot Evidence — [Case ID]
+
+**Date:** [YYYY-MM-DD]
+**Clinician NPI:** [NPI]
+**Employer:** [Org Name / Anonymous]
+**Pilot Round:** 1
+
+## Readiness at Lookup
+
+- NPPES: [checked / unavailable]
+- OIG/LEIE: [checked / unavailable]
+- PECOS: [checked / pending / unavailable]
+- State Board: [access-required / checked]
+- Overall Readiness State: [READY / PARTIAL / BLOCKED]
+- Readiness Score: [0–100 or N/A]
+
+## Review Context
+
+- Context ID: [contextId]
+- Entity ID: [entityId]
+- Created At: [ISO timestamp]
+- Employer Action: [Proceed / Request Refresh / Route to Review / None]
+- Action Timestamp: [ISO timestamp or N/A]
+
+## Outcome
+
+- Start Date Confirmed: [YES / NO / PENDING]
+- Start Date: [YYYY-MM-DD or N/A]
+- TTS (Estimated): [days] (from first readiness check to start)
+- Days from First Review to Start: [days or N/A]
+- Days from Share to Start: [days or N/A]
+
+## Source Notes
+
+[Any pending/unavailable lanes and why — document honestly]
+
+- PECOS: [e.g., "Showed PENDING — quarterly refresh, last updated YYYY-MM-DD"]
+- State Board: [e.g., "ACCESS-REQUIRED — per-state agreement not in place"]
+- Other: [any upstream issues encountered]
+
+## Screenshots
+
+[List of screenshot filenames or links]
+
+1. Readiness reveal: [filename]
+2. Passport view: [filename]
+3. Review request confirmation: [filename]
+4. Employer review surface: [filename]
+5. Employer action confirmation: [filename]
+
+## Verdict
+
+[PROOF: Start achieved] / [PARTIAL: Action taken, outcome pending] / [DATA: No start, valuable data collected]
+
+**Notes:** [Any additional context, learnings, or observations from this case]
+
+---
+
+*Captured by: [OPERATOR_NAME] | Pilot Round: [N]*

--- a/docs/REAL_PILOT_RUNBOOK.md
+++ b/docs/REAL_PILOT_RUNBOOK.md
@@ -1,0 +1,113 @@
+# VitalCV Real Pilot Runbook
+
+## SIMULATION vs. REAL PILOT
+
+| | Simulation | Real Pilot |
+|---|---|---|
+| NPI | Use 1003000126 (seeded) | Use real active NPI |
+| Sources | May use fixture data | Live NPPES/OIG/PECOS |
+| Employer action | Can be self-performed | Requires real employer contact |
+| Outcome capture | POST with future date | POST with confirmed real start date |
+| Evidence | Not proof | Is proof |
+
+Do NOT mix simulation data with real pilot evidence in the same evidence file.
+
+---
+
+## Prerequisites
+
+- Access to https://vitalcv.com (production)
+- `MONITORING_SECRET` for internal API calls
+- One real clinician NPI (confirmed active in NPPES)
+- One employer contact with authority to make a hiring/credentialing decision
+
+## Step-by-Step
+
+### Step 1 — Clinician Selection
+
+- Choose a clinician with an active NPI in NPPES
+- Confirm they are not on OIG/LEIE exclusion list (run the lookup first)
+- Note: PECOS may show as PENDING — this is expected for quarterly cadence
+
+### Step 2 — NPI Lookup
+
+- Go to https://vitalcv.com
+- Enter the NPI
+- Wait for readiness reveal (~10–15 seconds)
+- Screenshot: readiness state (READY / PARTIAL / BLOCKED)
+
+### Step 3 — Passport View
+
+- Click "View Passport" or navigate to `/passport?npi=[NPI]`
+- Screenshot: identity + sanctions + enrollment sections
+- Note any access-required or pending lanes
+
+### Step 4 — Request Employer Review
+
+- Navigate to `/review/request`
+- Fill in: clinician NPI, employer context, purpose
+- Submit — note the `contextId` returned
+- Screenshot: confirmation screen
+
+### Step 5 — Employer Review
+
+- Navigate to `/review/[entityId]?contextId=[contextId]`
+- Walk the employer through the readiness snapshot
+- Note: employer sees source-backed lanes, not self-reported data
+- Record the employer action taken: Proceed / Request Refresh / Route to Review
+
+### Step 6 — Outcome Capture (Operator)
+
+When a real start date is confirmed:
+
+```bash
+curl -X POST https://delightful-essence-production.up.railway.app/api/internal/pilot/start-outcome \
+  -H "Content-Type: application/json" \
+  -H "X-Monitoring-Secret: $MONITORING_SECRET" \
+  -d '{
+    "entityId": "[ENTITY_ID]",
+    "startedAt": "[ISO_DATE]",
+    "note": "[optional notes]"
+  }'
+```
+
+Expected response: `202 Accepted` with `{ ok: true, queued: true, entityId, startedAt }`.
+
+The system automatically derives velocity metrics (`daysFromFirstReview`, `daysFromShare`, `daysFromReady`) from prior events for this entity.
+
+### Step 7 — Verify Outcome in Dashboard
+
+- Visit `/pilot-ops` (internal, requires monitoring secret)
+- Confirm `startOutcomes.totalStarts` incremented
+- Export KPI CSV for record: `GET /api/internal/pilot/kpis/export`
+- Or use the script: `./scripts/pilot-kpi-snapshot.sh $MONITORING_SECRET`
+
+---
+
+## What Counts as Success
+
+- [ ] Readiness revealed without error for real NPI
+- [ ] Employer review created with real contextId
+- [ ] Employer action recorded (Proceed / Request Refresh / Route to Review)
+- [ ] Start outcome captured (or honest note if start did not occur)
+- [ ] TTS calculated: `startedAt` - first readiness check timestamp
+
+## What Counts as Failure
+
+These are expected states, not product failures — document them:
+
+- **Source unavailable:** Note in pilot evidence. Network or upstream issue, not a VitalCV bug.
+- **PECOS pending:** Expected. Quarterly cadence means data may be up to 90 days stale.
+- **State board access-required:** Expected for pilot. Per-state agreements not yet in place.
+- **Employer action not taken:** Record reason. Still valuable pilot data — shows where the process stalls.
+
+---
+
+## Outcome Capture Verification
+
+Outcome capture is wired — no code changes needed. Confirmed:
+
+1. `POST /api/internal/pilot/start-outcome` — registered in `apps/api/backend/src/routes/pilotKpi.ts`
+2. `captureStartOutcome()` — implemented in `apps/api/backend/src/services/seal/sealEventCapture.ts`
+3. `StartOutcomeEvent` model — defined in Prisma schema (`start_outcome_events` table)
+4. KPI dashboard — shows `startOutcomes` in `/pilot-ops` page

--- a/docs/RELEASE_RISK_MATRIX.md
+++ b/docs/RELEASE_RISK_MATRIX.md
@@ -1,0 +1,33 @@
+# Release Risk Matrix — Pilot Readiness
+**Date:** 2026-03-28
+**Branch:** feat/regression-hardening
+
+## Risk Level: LOW — Proceed to pilot with noted mitigations
+
+| Risk ID | Area | Risk | Severity | Mitigation | Status |
+|---------|------|------|----------|------------|--------|
+| R1 | Source Health | NPPES/OIG connector health is env-dependent | MEDIUM | SourceHealthPanel gives real-time visibility; pilot ops can monitor | MITIGATED |
+| R2 | PECOS | Quarterly cadence means PECOS may be PENDING | LOW | Explicitly labeled as pending in UI; not a blocker | MITIGATED |
+| R3 | State board lanes | CA/state board is access-required in pilot | LOW | Labeled correctly; pilots are healthcare employers who understand this | MITIGATED |
+| R4 | Deployment parity | feat/* branches not yet merged to main | MEDIUM | Merge order documented in LAUNCH_GATE.md; PR #88/#89/#90/#91 ready | IN PROGRESS |
+| R5 | Build failure in PR #89 | Pre-existing missing import from unmerged #91 | LOW | Resolves when #91 merges first | KNOWN |
+| R6 | OFAC pipeline not wired | OFAC check imported but not called | LOW | Not needed for NPPES/OIG pilot; deferred in LAUNCH_GATE.md | DEFERRED |
+| R7 | Stripe not wired | Billing is mailto-fallback | LOW | Pilot is pre-Stripe by design | DEFERRED |
+| R8 | Test coverage gaps (pre-hardening) | KPI events, buyer copy, state labels not asserted | LOW | Addressed in this PR | RESOLVED |
+| R9 | Pillar content cleanup | MATCHA branding and "Every healthcare job" still in HomeSections pillars | LOW | Aspirational content flagged with TODO; not user-facing in pilot wedge flow | KNOWN |
+
+## Recommendation
+
+**PROCEED TO SILENT PILOT** after merging open PRs in documented order (#88 → #89 → #91 → #90 → this PR).
+
+No blockers. Remaining YELLOWs are operational (source health monitoring) not product (broken flows).
+
+## Pre-pilot run order
+1. gh pr merge 88 --merge
+2. gh pr merge 89 --merge
+3. gh pr merge 91 --merge
+4. gh pr merge 90 --merge
+5. gh pr merge <this PR> --merge
+6. Verify /api/deploy-info SHA matches latest main
+7. Verify /api/mission-ops/sources spineStatus != CRITICAL
+8. Run NPI 1003000126 through full wedge flow manually

--- a/docs/RELEASE_SUMMARY.md
+++ b/docs/RELEASE_SUMMARY.md
@@ -1,0 +1,71 @@
+# VitalCV Silent Pilot — Release Readiness Summary
+**Date:** 2026-03-28
+**Status:** PRE-PILOT — pending merge of open branches
+
+---
+
+## What Is Shipped and Working
+
+### Core Wedge (GREEN)
+- NPI lookup → readiness preview: **LIVE** at vitalcv.com
+- Source-backed readiness (NPPES + OIG/LEIE): LIVE
+- Passport proof view: LIVE at /passport
+- Employer request-review: LIVE — employer creates context, review loads
+- Employer workspace (review + action): LIVE — PR #87
+
+### Infrastructure (GREEN)
+- Deployment: Vercel (vitalcv.com), auto-deploys from main
+- Backend: Railway (delightful-essence-production.up.railway.app)
+- Auth: Clerk (configured, gating write flows)
+- Build: passing, 300+ unit tests green
+- Public copy truth: enforced via test guards (301/301)
+
+---
+
+## What Is In-Progress (Branches Pending Merge)
+
+| Branch | Status | Blocks Pilot? |
+|--------|--------|--------------|
+| fix/public-shell-narrowing (PR #88) | Ready to merge | No — but improves trust |
+| feat/buyer-conversion-wedge | Ready to merge | No — but adds /pilot CTA |
+| feat/pilot-source-health | Ready to merge | No — but adds operator visibility |
+| feat/launch-gate | This PR | No — docs only |
+
+**Recommendation:** Merge all four before first pilot conversation.
+
+---
+
+## Known Deferred Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| PECOS quarterly — may show PENDING | LOW | Expected; labeled as pending in UI |
+| State board lanes — access-required | LOW | Honest labeling in pilot |
+| OFAC pipeline not wired | LOW | Not needed for NPPES/OIG pilot |
+| Stripe not wired | LOW | Mailto fallback in billing |
+| Source health freshness (env-dependent) | MEDIUM | SourceHealthPanel gives operator visibility |
+
+---
+
+## Pilot Operational Checklist (Run Before First Pilot Call)
+
+- [ ] Verify /api/mission-ops/sources — spineStatus != CRITICAL
+- [ ] Verify /api/deploy-info — SHA matches latest main
+- [ ] Merge all open branches listed above
+- [ ] Test NPI lookup with a known NPI (e.g., 1003000126)
+- [ ] Confirm /review/request form submits and returns contextId
+- [ ] Confirm /review/[entityId] loads with that contextId
+
+---
+
+## Contractor Handoff Notes
+
+The codebase is in a state suitable for pilot operation. Key files for orientation:
+- `docs/ARCHITECTURE.md` — system overview
+- `docs/LAUNCH_GATE.md` — launch gate checklist (this release)
+- `docs/FLAG_ACTIVATION_REVIEW.md` — which flags are safe to enable
+- `apps/web/app/internal/pilot-ops/` — operator console
+- `apps/web/__tests__/postrelease-truth-cleanup.test.tsx` — copy truth enforcement
+- `packages/domain-common/__tests__/wordingSafety.test.ts` — wording safety
+
+Key contacts: pilots@vitalcv.com (access), access@vitalcv.com (billing)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "turbo lint",
     "test": "turbo test",
     "build": "turbo build",
+    "report:public-copy": "node scripts/report-public-entry-copy-sources.js",
     "test:backend:db": "bash scripts/backend-test-db.sh"
   },
   "devDependencies": {

--- a/packages/domain-common/__tests__/wordingSafety.test.ts
+++ b/packages/domain-common/__tests__/wordingSafety.test.ts
@@ -2,9 +2,20 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
+type PublicEntryCopySurface = {
+  id: string;
+  label: string;
+  entryFile: string;
+  copySources: string[];
+};
+
 function readFile(relativePath: string): string {
   const absolutePath = path.resolve(__dirname, '../../..', relativePath);
   return fs.readFileSync(absolutePath, 'utf8');
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFile(relativePath)) as T;
 }
 
 describe('wording safety guards', () => {
@@ -43,7 +54,20 @@ describe('wording safety guards', () => {
 });
 
 describe('public surface truth guards — post-release drift prevention', () => {
-  const publicSurfaces = [
+  const publicEntryCopyManifest = readJson<{ surfaces: PublicEntryCopySurface[] }>(
+    'scripts/public-entry-copy-sources.json',
+  );
+
+  const publicEntryCopyFiles = Array.from(
+    new Set(
+      publicEntryCopyManifest.surfaces.flatMap((surface) => [
+        surface.entryFile,
+        ...surface.copySources,
+      ]),
+    ),
+  );
+
+  const publicSurfaces = Array.from(new Set([
     'apps/web/app/interview/page.tsx',
     'apps/web/components/layout/Navbar.tsx',
     'apps/web/components/marketing/Navbar.tsx',
@@ -52,11 +76,40 @@ describe('public surface truth guards — post-release drift prevention', () => 
     'apps/web/app/explore/page.tsx',
     'apps/web/app/labs/page.tsx',
     'apps/web/components/explore/ExploreClient.tsx',
-  ];
+    ...publicEntryCopyFiles,
+  ]));
 
   function readPublic(): string {
     return publicSurfaces.map((f) => readFile(f)).join('\n');
   }
+
+  it('tracks canonical homepage and developer-shell copy sources', () => {
+    const surfaceIds = publicEntryCopyManifest.surfaces.map((surface) => surface.id);
+    expect(surfaceIds).toEqual(expect.arrayContaining(['homepage', 'developer-shell']));
+
+    const homepage = publicEntryCopyManifest.surfaces.find(
+      (surface) => surface.id === 'homepage',
+    );
+    const developerShell = publicEntryCopyManifest.surfaces.find(
+      (surface) => surface.id === 'developer-shell',
+    );
+
+    expect(homepage?.entryFile).toBe('apps/web/app/page.tsx');
+    expect(homepage?.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/components/hero/HeroWithAuthPrompt.tsx',
+        'apps/web/components/home/PublicTruthSections.tsx',
+        'apps/web/components/marketing/HomeSections.tsx',
+      ]),
+    );
+    expect(developerShell?.entryFile).toBe('apps/web/app/developers/page.tsx');
+    expect(developerShell?.copySources).toEqual(
+      expect.arrayContaining([
+        'apps/web/app/docs/page.tsx',
+        'apps/api/backend/src/services/search/searchIndex.ts',
+      ]),
+    );
+  });
 
   it('does not contain verified-overclaiming strings on public surfaces', () => {
     const combined = readPublic().toLowerCase();
@@ -67,6 +120,9 @@ describe('public surface truth guards — post-release drift prevention', () => 
     expect(combined).not.toContain('full primary source verification');
     expect(combined).not.toContain('unlock your verified');
     expect(combined).not.toContain('already cleared for');
+    expect(combined).not.toContain('open interview preview');
+    expect(combined).not.toContain('build with the trust protocol');
+    expect(combined).not.toContain('build with the vitalcv trust protocol');
   });
 
   it('does not use "Get Verified" as a nav or CTA label on public surfaces', () => {

--- a/scripts/pilot-kpi-snapshot.sh
+++ b/scripts/pilot-kpi-snapshot.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/pilot-kpi-snapshot.sh <monitoring_secret> [window_days]
+# Pulls KPI JSON from the pilot backend and formats it for readability.
+set -euo pipefail
+
+SECRET="${1:-}"
+WINDOW="${2:-30}"
+API="${VITALCV_API_BASE:-https://delightful-essence-production.up.railway.app}"
+
+if [ -z "$SECRET" ]; then
+  echo "Usage: $0 <monitoring_secret> [window_days=30]" >&2
+  exit 1
+fi
+
+echo "Fetching KPI snapshot (${WINDOW}-day window)..."
+curl -sf "${API}/api/internal/pilot/kpis?days=${WINDOW}" \
+  -H "X-Monitoring-Secret: ${SECRET}" \
+  | python3 -m json.tool

--- a/scripts/public-entry-copy-sources.json
+++ b/scripts/public-entry-copy-sources.json
@@ -1,0 +1,25 @@
+{
+  "surfaces": [
+    {
+      "id": "homepage",
+      "label": "Homepage",
+      "entryFile": "apps/web/app/page.tsx",
+      "copySources": [
+        "apps/web/components/layout/Navbar.tsx",
+        "apps/web/components/hero/HeroWithAuthPrompt.tsx",
+        "apps/web/components/hero/LiveTrustConsole.tsx",
+        "apps/web/components/home/PublicTruthSections.tsx",
+        "apps/web/components/marketing/HomeSections.tsx"
+      ]
+    },
+    {
+      "id": "developer-shell",
+      "label": "Developer shell",
+      "entryFile": "apps/web/app/developers/page.tsx",
+      "copySources": [
+        "apps/web/app/docs/page.tsx",
+        "apps/api/backend/src/services/search/searchIndex.ts"
+      ]
+    }
+  ]
+}

--- a/scripts/report-public-entry-copy-sources.js
+++ b/scripts/report-public-entry-copy-sources.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(__dirname, 'public-entry-copy-sources.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const surfaces = Array.isArray(manifest.surfaces) ? manifest.surfaces : [];
+
+let missingCount = 0;
+
+console.log('Canonical public-entry copy sources');
+
+for (const surface of surfaces) {
+  const files = [surface.entryFile, ...(surface.copySources ?? [])];
+  console.log(`- ${surface.label} (${surface.id})`);
+  console.log(`  entry: ${surface.entryFile}`);
+
+  for (const file of files) {
+    const exists = fs.existsSync(path.join(repoRoot, file));
+    if (!exists) {
+      missingCount += 1;
+    }
+    console.log(`  source: ${file}${exists ? '' : ' [missing]'}`);
+  }
+}
+
+if (missingCount > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Waves 20 and 21 — Buyer Proof Pack + Real Pilot Loop

### Wave 20 — Buyer Proof Pack
Files:
- `docs/PILOT_BUYER_BRIEF.md` — one-page buyer brief (TTS-first, wedge-grounded)
- `docs/PILOT_DEMO_SCRIPT.md` — canonical demo script (replaces DEMO_SCRIPT_2026.md)
- `docs/PILOT_PROOF_STORY.md` — proof story template for post-pilot conversation
- `docs/PILOT_METRIC_DEFINITIONS.md` — every metric defined, real vs. placeholder noted
- `scripts/pilot-kpi-snapshot.sh` — quick KPI pull script for buyer conversations

### Wave 21 — Real Pilot Loop
Files:
- `docs/REAL_PILOT_RUNBOOK.md` — operator runbook with curl commands and outcome capture
- `docs/REAL_PILOT_CHECKLIST.md` — pre-flight checklist for day of pilot
- `docs/REAL_PILOT_EVIDENCE_TEMPLATE.md` — evidence template per pilot case

### Outcome capture verification
Confirmed existing: POST /api/internal/pilot/start-outcome, captureStartOutcome(), StartOutcomeEvent, KPI dashboard — no new code needed.

### Simulation vs. Real
Explicitly separated in REAL_PILOT_RUNBOOK.md — no mixing of simulation and real evidence.

### No scope creep
No new routes, no UI changes, no marketplace/graph/platform work.
All docs are TTS-first and wedge-only.