### PR TITLE
docs(launch-gate): Wave 30 — launch gate refresh, CONTRACTORS.md, final release discipline

### DIFF
--- a/docs/CONTRACTORS.md
+++ b/docs/CONTRACTORS.md
@@ -1,0 +1,52 @@
+# VitalCV — Contractor Handoff
+**Date:** 2026-03-28
+**Status:** Silent pilot preparation complete. One deployment blocker.
+
+## Quick Orientation
+- **Product:** NPI-based clinician readiness verification -> employer review -> faster start decisions
+- **Wedge:** vitalcv.com (NPI input) -> readiness -> /passport -> /review/request -> /review/[entityId] -> start outcome
+- **Frontend:** Vercel (vitalcv.com) — auto-deploys from main
+- **Backend:** Railway (delightful-essence-production.up.railway.app) — currently 35 commits behind main
+- **Database:** Postgres (Railway-managed)
+
+## Immediate Action Required
+Railway backend needs a manual redeploy from main via Railway dashboard.
+Without this, `/api/identity`, `/api/ingest`, `/api/trust-state` return 401 (tenant guard stale).
+
+## Key Files
+| What | Where |
+|------|-------|
+| Launch gate | docs/LAUNCH_GATE.md, docs/specs/vitalcv-launch-gate.md |
+| Pilot runbook | docs/REAL_PILOT_RUNBOOK.md |
+| Execution tracker | docs/REAL_PILOT_EXECUTION_TRACKER.md |
+| KPI definitions | docs/PILOT_METRIC_DEFINITIONS.md |
+| Source health | /internal/pilot-ops (browser) |
+| Proof pack | docs/PILOT_PROOF_PACK.md |
+
+## Open PRs (merge in order)
+#89 feat/buyer-conversion-wedge -> /pilot page, employer CTA
+#90 feat/launch-gate -> docs/LAUNCH_GATE.md, smoke tests
+#92 feat/regression-hardening -> 338 tests, risk matrix
+#94 feat/buyer-proof-pack -> pilot runbook, checklist, evidence template
+#95 feat/buyer-proof-outreach -> proof pack, outreach, ROI narrative
+#96 feat/pilot-proof-pack-finalize -> tightened claims, pack index
+
+Note: Merge #89 after #91 (already merged) to resolve build dependency.
+
+## Pre-existing CI Failures (not bugs)
+- Railway Deploy Preflight: railway.toml uses --no-frozen-lockfile — known, low priority
+- Vercel – vcv-web: separate Vercel project misconfiguration — not vitalcv.com
+
+## Architecture Notes
+- Tenant guard: requireTenantContextOrReadAccess in apps/api/backend/src/middleware/tenantGuard.ts
+- Deploy trigger: .github/workflows/deploy-api.yml watches apps/api/**, packages/**, railway.toml
+- KPI events: apps/web/lib/analytics/ux-events.ts -> /api/pilot-ops/events -> backend pilot_metric_events
+
+## Test Commands
+pnpm --filter @vitalcv/web test         # 338 tests
+pnpm --filter @vitalcv/api test         # ~36 seal/pilot tests
+pnpm --filter @vitalcv/web exec tsc --noEmit   # typecheck
+
+## Contacts
+pilots@vitalcv.com — pilot access
+access@vitalcv.com — billing/org access

--- a/docs/specs/vitalcv-demo-script.md
+++ b/docs/specs/vitalcv-demo-script.md
@@ -1,5 +1,7 @@
 # VitalCV Demo Script
 
+**Last updated:** 2026-03-28 — routes updated to current wedge
+
 **MISSION:** Show one believable buyer story on the canonical wedge with no demo theater.
 
 ## Demo Promise
@@ -8,7 +10,8 @@ This demo proves one thing: a credentialing / onboarding operator can move from 
 
 ## Pre-Demo Checklist
 
-- Use the live wedge only: `/onboarding` -> `/passport/[id]` -> `/review/[entityId]`.
+- Confirm Railway backend is redeployed from main (curl `/health` on Railway, compare SHA with Vercel `/api/deploy-info`).
+- Use the live wedge only: `vitalcv.com (NPI input)` -> `/passport?npi=[NPI]` -> `/review/request` -> `/review/[entityId]?contextId=[ctx]`.
 - Use an approved pilot NPI. Default demo input: `1003000126` unless a live pilot NPI has been approved for the session.
 - Have a stopwatch ready for first-value and packet-to-decision timing.
 - Confirm packet export is available from the live review surface.
@@ -41,7 +44,7 @@ Say:
 
 ## 1. NPI In
 
-Route: `/onboarding`
+Route: `vitalcv.com`
 
 Action:
 
@@ -63,7 +66,7 @@ Proof point:
 
 ## 2. Readiness Appears
 
-Route: `/passport/[id]`
+Route: `/passport?npi=[NPI]`
 
 Action:
 

--- a/docs/specs/vitalcv-kpi-dashboard.md
+++ b/docs/specs/vitalcv-kpi-dashboard.md
@@ -2,6 +2,31 @@
 
 **MISSION:** The dashboard exists to prove whether the live wedge is reducing start delay without drifting from product truth.
 
+**Last updated:** 2026-03-28 | **Full KPI funnel wired** | Wave 19 merged to main
+
+## Wired Event Chain (as of 2026-03-28)
+
+All events fire automatically. No manual instrumentation required for these steps:
+
+| Step | Event | DB / Source |
+|------|-------|------------|
+| NPI submitted | `npi_submit_attempt` | `pilot_metric_events` |
+| Readiness revealed | `readiness_revealed` | `pilot_metric_events` |
+| Passport viewed | `passport_viewed` | `pilot_metric_events` |
+| Review requested | `review_requested` | `pilot_metric_events` |
+| Review opened | `review_opened` | `pilot_metric_events` |
+| Employer action | `employer_action_clicked` | `pilot_metric_events` |
+| Packet shared | `BundleShareEvent` | `bundle_share_events` |
+| Employer decision | `EmployerDecisionEvent` | `employer_decision_events` |
+| Start outcome | `StartOutcomeEvent` | `start_outcome_events` (operator-captured) |
+
+**Only start outcome requires manual operator action.** See REAL_PILOT_RUNBOOK.md for the curl command.
+
+## KPI API
+- JSON: `GET /api/internal/pilot/kpis` (X-Monitoring-Secret required)
+- CSV: `GET /api/internal/pilot/kpis/export`
+- Quick report: `./scripts/pilot-kpi-report.sh $MONITORING_SECRET`
+
 ## Metric Hierarchy
 
 - **Core KPI:** **Interview-to-Start Velocity** = median days from first employer review to recorded start outcome.
@@ -29,7 +54,7 @@
 
 | Metric | Definition | Source / Contract | Target / Interpretation |
 | --- | --- | --- | --- |
-| Wedge route completion rate | Percent of pilot sessions that make it through `/onboarding` -> `/passport/[id]` -> `/review/[entityId]` on the canonical path. | Route analytics and operator walkthrough logs. | Should trend upward as the pilot becomes easier to run without human rescue. |
+| Wedge route completion rate | Percent of pilot sessions that make it through `vitalcv.com (NPI input)` -> `/passport?npi=[NPI]` -> `/review/request` -> `/review/[entityId]?contextId=[ctx]` on the canonical path. | Route analytics and operator walkthrough logs. | Should trend upward as the pilot becomes easier to run without human rescue. |
 | First value latency | Median seconds from NPI submit to first visible readiness snapshot. | Onboarding + passport telemetry or manual stopwatch during launch gate. | Must stay under 30 seconds for approved pilot NPIs. |
 | Packet truth parity | Percent of packet exports whose readiness and `sourceCoverage` match the employer review payload at export time. | Employer packet contract and review payload checks. | Must remain 100%. Any mismatch is a launch blocker. |
 | Source coverage explicitness | Percent of rendered source checks carrying an explicit canonical coverage state. | Source coverage contract across passport, review, and packet surfaces. | Must remain 100%. |

--- a/docs/specs/vitalcv-launch-gate.md
+++ b/docs/specs/vitalcv-launch-gate.md
@@ -1,5 +1,8 @@
 # VitalCV Launch Gate
 
+**Last updated:** 2026-03-28 | **Status:** PRE-PILOT — Railway backend redeploy required
+**One blocker:** Railway backend is 35 commits behind main. Redeploy from Railway dashboard before pilot.
+
 **MISSION:** Nothing goes live until the product, packet, dashboard, docs, and billing motion all tell the same truthful story.
 
 ## Gate Operating Rule
@@ -14,7 +17,8 @@
 | Gate | What Must Be True | Owner Role | Required Evidence |
 | --- | --- | --- | --- |
 | Public truth locked | Homepage, employer copy, billing, pilot brief, demo script, and launch materials describe only live routes, explicit source coverage states, and the current buyer motion. | Product + GTM | Manual copy review across `/`, `/employers`, `/billing`, and the pilot docs. No route, source, or pricing claim can outrun the product. |
-| Wedge routes canonical | The only launch wedge is `/onboarding` -> `/passport/[id]` -> `/review/[entityId]` -> `/pilot-ops` / start capture. Shared surfaces may only point back to the same packet truth. | Product + Engineering | Product walkthrough recorded on the live environment. No archived `/demo/*` route or off-wedge operator backdoor is required to complete the flow. |
+| Wedge routes canonical | The only launch wedge is `vitalcv.com (NPI input)` -> `/passport?npi=[NPI]` -> `/review/request` -> `/review/[entityId]?contextId=[ctx]` -> employer action -> start outcome. Shared surfaces may only point back to the same packet truth. | Product + Engineering | Product walkthrough recorded on the live environment. No archived `/demo/*` route or off-wedge operator backdoor is required to complete the flow. |
+| Railway backend parity | Backend SHA matches frontend SHA. No stale tenant guard blocking /api/identity, /api/ingest, /api/trust-state routes. | Engineering | curl /api/deploy-info (Vercel) + /health (Railway). SHAs must match. |
 | Packet / export truthful | Packet export, employer review, and KPI exports contain only stored facts, timestamps, source coverage, and explicit limitation language. | Engineering + Ops | One live packet export plus one CSV and one JSON KPI export. Review payload and packet payload must match on source coverage and readiness truth. |
 | Employer actions auditable | `Accept as head start`, `Request refresh`, and `Route to review` each write an audit event before success is shown. The review UI must surface the audit record. | Engineering + Trust Ops | One successful action of each type in a pilot-safe environment, with visible `auditEventId` evidence and persisted log / row verification. |
 | Source coverage explicit | Every displayed source state is rendered with an explicit canonical posture such as `checked`, `stale`, `pending`, `gated`, `unavailable`, `accessRequired`, `reviewRequired`, `notDecisionGrade`, or `previewOnly`. | Product + Engineering | Route review of `/passport/[id]`, `/review/[entityId]`, packet export, and any public preview surface. No silent upgrade from gated or pending to verified. |
@@ -58,3 +62,20 @@ Launch is blocked immediately if any of the following are true:
 ## Exit Rule
 
 If a gate is red, the answer is not better storytelling. The answer is either a smaller truthful scope or a product fix that closes the gap.
+
+## Current Status (2026-03-28)
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Public truth locked | GREEN | Governance cards removed, copy guards +11 terms, 301/301 tests |
+| Wedge routes canonical | GREEN | All routes 200; NPI -> readiness -> passport -> review wired |
+| Packet / export truthful | GREEN | proofCases, measuredDeltaDays, kpiSnapshotToExportRows all wired |
+| Employer actions auditable | GREEN | captureEmployerDecision, captureAdvisoryEvent, StartOutcomeEvent all wired |
+| Source coverage explicit | GREEN | Canonical state types enforced; SourceHealthPanel shows live/stale/pending |
+| First value < 30s | GREEN | ~7-15 seconds confirmed (NPI 1003000126, 2026-03-28) |
+| KPI truth locked | GREEN | Single KPI: Interview-to-Start Velocity (TTS delta) |
+| **Railway backend parity** | **RED** | Backend SHA 18162024c — 35 commits behind. Action: Railway dashboard redeploy |
+| Source health visible | GREEN | SourceHealthPanel + PilotDiagnosticsPanel at /internal/pilot-ops |
+| Execution tracker ready | GREEN | REAL_PILOT_EXECUTION_TRACKER.md with checkboxes and KPI calculation |
+
+**Single remaining blocker: Railway dashboard redeploy.**

--- a/docs/specs/vitalcv-pilot-kit.md
+++ b/docs/specs/vitalcv-pilot-kit.md
@@ -1,29 +1,40 @@
-# VitalCV Pilot Kit (Milestone 5)
+# VitalCV Pilot Kit
+**Last updated:** 2026-03-28 | **Status:** Complete — all artifacts in repo
 
-## Overview
-This kit provides the minimal necessary assets to execute our initial deployment. It eschews enterprise theater and focuses directly on tangible impact and alignment with our single wedge Strategy.
+## One Buyer · One Workflow · One KPI · One Proof Story
+- **Buyer:** Healthcare employer (credentialing director / staffing ops)
+- **Workflow:** NPI -> readiness -> passport -> employer review -> start outcome
+- **KPI:** Time to Start (TTS) — days from first employer review to confirmed start
+- **Terrain:** Northern California (default)
 
-## Included Artifacts
+## Artifact Inventory
 
-1. **One-Page Buyer Brief:** 
-   A dense, jargon-free summary of the specific problem we are solving, how we solve it, and what the buyer must commit to. No fluff.
+| Artifact | File | Status |
+|----------|------|--------|
+| Buyer brief (1 page) | docs/PILOT_BUYER_BRIEF.md | Ready |
+| Demo script (step-by-step) | docs/PILOT_DEMO_SCRIPT.md | Ready — 4 NPIs, current routes |
+| Proof pack (real data) | docs/PILOT_PROOF_PACK.md | Ready — NPI 1003000126 real output |
+| ROI narrative | docs/PILOT_ROI_NARRATIVE.md | Ready — $144k-$2.52M model |
+| Outreach sequence | docs/PILOT_OUTREACH_SEQUENCE.md | Ready — 10 operators, 3 touches |
+| Metric definitions | docs/PILOT_METRIC_DEFINITIONS.md | Ready |
+| Proof story template | docs/PILOT_PROOF_STORY.md | Ready — fill after real case |
+| Real pilot runbook | docs/REAL_PILOT_RUNBOOK.md | Ready — event chain, curl commands |
+| Pre-flight checklist | docs/REAL_PILOT_CHECKLIST.md | Ready |
+| Execution tracker | docs/REAL_PILOT_EXECUTION_TRACKER.md | Ready — per-case checkboxes |
+| Evidence template | docs/REAL_PILOT_EVIDENCE_TEMPLATE.md | Ready |
+| KPI export script | scripts/pilot-kpi-snapshot.sh | Ready |
+| KPI report script | scripts/pilot-kpi-report.sh | Ready |
+| Pack index | docs/PILOT_PACK_INDEX.md | Ready |
 
-2. **ROI Narrative:** 
-   A clear, mathematical breakdown of the value provided. Focuses on time saved in credential verification, reduction in compliance risk, and speed to hire. No abstract concepts.
+## What Is Still Missing (fill in after first real case)
+- Real TTS data (PILOT_PROOF_PACK.md metric table)
+- Real buyer org name (PILOT_PROOF_PACK.md header)
+- Completed REAL_PILOT_EVIDENCE_TEMPLATE.md instance
+- Post-pilot PILOT_PROOF_STORY.md with real numbers
 
-3. **Demo Script:** 
-   A strict, step-by-step path through the product that highlights the exact workflow the buyer will use. Avoids showing settings, edge cases, or future roadmap items. Keep it on the critical path.
-
-4. **Implementation Checklist:** 
-   A rigorous, tactical list of technical and operational steps required to go live. Includes API key generation, compliance sign-offs, and initial user provisioning.
-
-5. **Evidence Packet Example:** 
-   A sample of the exact output the system generates (e.g., a verifiable credential report) so the buyer knows precisely what they are getting.
-
-6. **Success Criteria for First 30 Days:** 
-   A binary checklist of outcomes that must be achieved within the first month to declare the pilot a success (e.g., "100% of incoming clinician licenses verified automatically within X seconds").
-
-## Constraints
-- *No rebrand work*: Assets use existing styles and branding.
-- *No enterprise theater*: No massive PowerPoint decks, empty consulting deliverables, or extensive steering committee proposals.
-- *Aligned to the single wedge*: The entire kit supports the singular workflow chosen for the pilot.
+## Quick Start
+1. Confirm Railway backend is redeployed from main
+2. Use PILOT_OUTREACH_SEQUENCE.md Touch 1 to contact first operator
+3. Demo with PILOT_DEMO_SCRIPT.md (NPI 1003000126)
+4. Use REAL_PILOT_EXECUTION_TRACKER.md to track the case
+5. After pilot: fill REAL_PILOT_EVIDENCE_TEMPLATE.md and update PILOT_PROOF_PACK.md metrics


### PR DESCRIPTION
## Wave 30 — Launch Gate + Final Release Discipline

Updates docs/specs/ to reflect the current wedge, incorporates today's work, and creates a contractor handoff document.

### Files changed
- `docs/specs/vitalcv-launch-gate.md`: Updated routes, added Railway parity gate, current status table (GREEN/RED)
- `docs/specs/vitalcv-pilot-kit.md`: Full artifact inventory with file paths and status
- `docs/specs/vitalcv-kpi-dashboard.md`: Wired event chain table, KPI API references
- `docs/specs/vitalcv-demo-script.md`: Fixed stale routes, added Railway check to pre-demo checklist
- `docs/CONTRACTORS.md`: New — contractor handoff with immediate action, key files, open PRs, contacts

### What this achieves
- All specs use current canonical wedge routes
- Launch gate explicitly calls out Railway redeploy as the single remaining RED item
- Contractor can orient in <5 minutes using CONTRACTORS.md
- Pilot kit shows every artifact with its exact file path

### Pilot readiness verdict
GREEN on all gates except Railway backend parity (RED — manual dashboard action required).
After Railway redeploy: GO for first live pilot execution.