### PR TITLE
feat(buyer-shell): Wave 29 — buyer conversion + commercial surface (rebased + test fix)

### DIFF
--- a/apps/web/__tests__/helpers/public-copy-guard.ts
+++ b/apps/web/__tests__/helpers/public-copy-guard.ts
@@ -27,6 +27,9 @@ export const PROHIBITED_PUBLIC_STRINGS = [
   'TRUST_THRESHOLD',
   'REVOCATION_ESCALATION',
   'PEER_ACCEPTANCE',
+  'Every healthcare job, every specialty',
+  'MATCHA — AI Career Matching',
+  'connect to the trust network',
 ] as const;
 
 export const PROHIBITED_EMPLOYER_PUBLIC_STRINGS = [

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -697,4 +697,34 @@ describe('post-release truth cleanup', () => {
     expect(findHrefByText(employerProfileMarkup, 'Current roles')).toBe('/explore?organizationSlug=sample-health');
     expectMarkupExcludes(employerProfileMarkup, PROHIBITED_EMPLOYER_PUBLIC_STRINGS);
   }, 20000);
+
+  it('keeps HomeSections pillars scoped to the current wedge', async () => {
+    const { PlatformVisionSection } = await import(
+      '../components/marketing/HomeSections'
+    );
+    const markup = renderToStaticMarkup(<PlatformVisionSection />);
+
+    // Pillar 02: job board must not overstate scope
+    expect(markup).not.toContain(
+      'Every healthcare job, every specialty, free to post',
+    );
+    // Pillar 03: MATCHA branding removed
+    expect(markup).not.toContain('MATCHA — AI Career Matching');
+    expect(markup).not.toContain(
+      'credential-aware AI that knows your exact qualifications',
+    );
+    // Pillar 03 replacement
+    expect(markup).toContain('Career Signal');
+    // Pillar 04: capacity model scoped
+    expect(markup).not.toContain('New Metric');
+    expect(markup).toContain('Pilot Only');
+  });
+
+  it('keeps billing issuers card off trust-network overstatement', async () => {
+    const { default: BillingPage } = await import('../app/billing/page');
+    const markup = renderToStaticMarkup(<BillingPage />);
+
+    expect(markup).not.toContain('connect to the trust network');
+    expect(markup).toContain('current preview environment');
+  });
 });

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -650,9 +650,9 @@ describe('post-release truth cleanup', () => {
     // TODO: Content cleanup needed — "Every healthcare job" is aspirational, not current
     expect(markup).toContain('Free Specialty Job Board');
 
-    // Pillar 03 — current state: still uses MATCHA branding
-    // TODO: Content cleanup needed — MATCHA is an internal project name, not public brand
-    expect(markup).toContain('MATCHA');
+    // Pillar 03 — renamed from MATCHA to "Career Signal" (Wave 17)
+    expect(markup).toContain('Career Signal');
+    expect(markup).not.toContain('MATCHA — AI Career Matching');
 
     expectMarkupExcludes(markup, PROHIBITED_PUBLIC_STRINGS);
   });

--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -90,7 +90,7 @@ export default function BillingPage() {
         >
           {[
             { label: 'Clinicians', note: 'Free forever', desc: 'Build, share, and own your readiness profile at no cost.' },
-            { label: 'Issuers', note: 'Free forever', desc: 'Issue credentials and connect to the trust network at no cost.' },
+            { label: 'Issuers', note: 'Free forever', desc: 'Issue credentials in the current preview environment at no cost.' },
             { label: 'Organizations', note: 'Pay for workflow', desc: 'Verified pulls, monitoring refreshes, exports, and API access.' },
           ].map(({ label, note, desc }) => (
             <div key={label} className="rounded-xl border border-border bg-card px-4 py-3">

--- a/apps/web/app/employers/page.tsx
+++ b/apps/web/app/employers/page.tsx
@@ -301,6 +301,31 @@ export default async function EmployersPage() {
             </div>
           )}
 
+          {/* Pilot CTA */}
+          <div className="mt-10 rounded-3xl border border-emerald-400/20 bg-emerald-400/[0.04] p-8 text-center">
+            <h3 className="text-xl font-semibold text-white">
+              Using VitalCV for clinician review?
+            </h3>
+            <p className="mt-3 max-w-xl mx-auto text-sm leading-7 text-white/65">
+              Request pilot access to connect employer review to source-backed readiness.
+              One workflow, one NPI, one audit trail.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/pilot"
+                className="inline-flex items-center gap-2 rounded-2xl bg-emerald-500 hover:bg-emerald-400 px-6 py-3 text-sm font-bold text-black transition-all shadow-lg shadow-emerald-500/20"
+              >
+                Request pilot access
+              </Link>
+              <Link
+                href="/review"
+                className="inline-flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/70 hover:text-white transition"
+              >
+                See how review works
+              </Link>
+            </div>
+          </div>
+
           <div className="mt-10 rounded-3xl border border-white/10 bg-white/[0.03] p-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div className="max-w-2xl">

--- a/apps/web/app/pilot/page.tsx
+++ b/apps/web/app/pilot/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Request Pilot — VitalCV",
+  description: "Request pilot access to the VitalCV employer review workflow.",
+};
+
+export default function PilotPage() {
+  return (
+    <div className="min-h-screen bg-ops-gradient text-white flex items-center justify-center px-6 py-20">
+      <div className="max-w-lg w-full">
+        <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-300 mb-6">
+          Silent Pilot
+        </span>
+        <h1 className="text-3xl font-semibold text-white">
+          Request pilot access.
+        </h1>
+        <p className="mt-4 text-base text-white/65 leading-7">
+          VitalCV connects clinician source-backed readiness to your employer review workflow.
+          One NPI. NPPES identity, OIG/LEIE screening, and PECOS enrollment — before the conversation starts.
+        </p>
+        <div className="mt-8 space-y-3">
+          <a
+            href="mailto:pilots@vitalcv.com?subject=Pilot+access+request"
+            className="block w-full rounded-2xl bg-emerald-500 hover:bg-emerald-400 px-6 py-4 text-center text-sm font-bold text-black transition-all shadow-lg shadow-emerald-500/20"
+          >
+            Email pilots@vitalcv.com
+          </a>
+          <Link
+            href="/review"
+            className="block w-full rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-4 text-center text-sm font-medium text-white/70 hover:text-white transition"
+          >
+            See how review works →
+          </Link>
+        </div>
+        <p className="mt-6 text-xs text-white/35 text-center">
+          No account required to preview. Pilot access is granted directly — no plan selection.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/marketing/HomeSections.tsx
+++ b/apps/web/components/marketing/HomeSections.tsx
@@ -679,22 +679,22 @@ const PILLARS = [
   {
     number: '02',
     title: 'Free Specialty Job Board',
-    body: 'Every healthcare job, every specialty, free to post. Physicians, NPs, CRNAs, therapists — one platform for all of medicine. Employers stop paying $5,000 for a single oncology posting.',
-    tags: ['All Specialties', 'All Provider Types', 'Free to Post', 'Auto-Aggregated'],
+    body: 'Role listings attached to the current employer cohort. Clinicians can browse open roles connected to employers in this environment.',
+    tags: ['Current Cohort', 'All Provider Types', 'Preview', 'Employer-Attached'],
     color: 'emerald',
   },
   {
     number: '03',
-    title: 'MATCHA — AI Career Matching',
-    body: 'Not keyword matching. Credential-aware AI that knows your exact qualifications, your gaps, your trajectory. Surfaces opportunities you\'re actually eligible for — before you go looking.',
-    tags: ['Gap Analysis', 'Career Paths', 'Readiness Score', 'Match Intelligence'],
+    title: 'Career Signal',
+    body: 'Readiness-aware role matching in preview. Surfaces roles you are eligible for based on source-checked credentials — not keyword matching.',
+    tags: ['Preview', 'Credential-Aware', 'Readiness-Based', 'Not Production'],
     color: 'violet',
   },
   {
     number: '04',
     title: 'Clinic Capacity Intelligence',
-    body: 'For the first time, health systems can measure hiring capacity — not just headcount. How many physicians can actually start this quarter? VitalCV tells you, and tells you how to increase it.',
-    tags: ['Staffing Projections', 'Credentialing Velocity', 'Capacity Model', 'New Metric'],
+    body: 'Credentialing velocity signals for health systems. Understand which positions have clear source coverage and which are blocked pending source access.',
+    tags: ['Preview', 'Credentialing Velocity', 'Source Coverage', 'Pilot Only'],
     color: 'amber',
   },
   {
@@ -722,8 +722,8 @@ const NOVEL_CLAIMS = [
     detail: 'NPI → credentials → publications → career history — one traversable, source-backed, cryptographically-signed graph. No one has built this for healthcare.',
   },
   {
-    claim: 'Credential-aware job matching',
-    detail: 'MATCHA knows what you\'re qualified for today, what you\'re 6 months from qualifying for, and what your peers pivoted to. That\'s not a job board — it\'s a career engine.',
+    claim: 'Credential-aware job matching (preview)',
+    detail: 'Career Signal surfaces roles you are eligible for based on source-checked credentials — not keyword matching. Gap-aware matching is in preview, not production.',
   },
   {
     // M1: "trusted forever" removed — credentials expire and sources have freshness windows


### PR DESCRIPTION
## Wave 29 — Buyer Conversion + Commercial Surface

Rebased PR #89 (feat/buyer-conversion-wedge) onto current main + fixes a stale test regression.

### What this contains (from PR #89, now rebased)
- `apps/web/app/pilot/page.tsx` — new: clean `/pilot` conversion page → `pilots@vitalcv.com`
- `apps/web/app/employers/page.tsx` — pilot CTA block: "Using VitalCV for clinician review?" → `/pilot` (primary), `/review` (secondary)
- `apps/web/app/billing/page.tsx` — issuers copy: "connect to trust network" → "current preview environment"
- `apps/web/components/marketing/HomeSections.tsx` — pillars 02–04 scoped to pilot reality (job board → cohort-scoped, MATCHA → "Career Signal", capacity → velocity signals)
- `apps/web/__tests__/helpers/public-copy-guard.ts` — +3 blocklist entries
- `apps/web/__tests__/postrelease-truth-cleanup.test.tsx` — +2 assertions + fixed stale MATCHA guard

### Test fix (new commit)
- `postrelease-truth-cleanup.test.tsx`: Updated pillar 03 regression guard — MATCHA branding was removed (renamed to "Career Signal" in HomeSections), test was asserting old name still present

### Build
- Typecheck: ✅ clean
- Tests: ✅ 340/340

### Buyer surface now
- One buyer: healthcare employer / credentialing director
- One workflow: NPI → readiness → passport → review → start
- One CTA path: /pilot → pilots@vitalcv.com
- Pricing: clinicians free, issuers free, orgs pay for workflow (unchanged)

### Supersedes PR #89
Close #89 after merging this.