### PR TITLE
fix(seam): close marketing→web gap — real wedge routing, internal labels removed, light-first defaults

### DIFF
--- a/LIGHT_FIRST_UX_AUDIT_2026-03-29.md
+++ b/LIGHT_FIRST_UX_AUDIT_2026-03-29.md
@@ -1,0 +1,272 @@
+# VitalCV — Light-First Redesign Audit
+**Date:** 2026-03-29
+**Auditor:** Ruthless-visitor mode — no collaboration credit given
+**Scope:** Homepage, readiness flow, /passport, /review, /review/request, nav/header/footer, theme toggle, scroll, motion
+
+---
+
+## TL;DR
+
+The design direction — calm, light-first, typographic, trust-forward — is the right call and materially better than what came before it. But the execution has a structural fracture that makes the current state **NOT ready for a real first impression**: the primary conversion action on the marketing homepage routes to a dead page. Everything downstream of that is largely good. Everything before it is currently broken.
+
+**Verdict on design direction: GO.**
+**Verdict on current production state: NO-GO until P0s are resolved.**
+
+---
+
+## What This Is — First-Time Visitor Test
+
+Reading the marketing homepage cold:
+
+- **What is this?** A credentialing verification platform. The tagline "Verify once. Keep forever." lands cleanly in two seconds.
+- **Who is it for?** Unclear from the hero. The subtitle says "clinicians and verifiers" — that is unexplained industry jargon. A hiring manager from a hospital system doesn't know if they're a "verifier."
+- **What should I do first?** Enter an NPI into the search box. That is clearly the primary action.
+- **What do I get in 30–60 seconds?** Nothing. The NPI input in the marketing app routes to `/clinician?npi=...`, which renders: *"Credential profile loading… Coming soon."* The primary wedge is a dead end. Full stop.
+
+---
+
+## The Structural Problem Nobody Can Miss
+
+There are **two separate apps** with two separate visual systems:
+
+1. **`apps/marketing`** — public-facing marketing site. Light theme (`#ffffff`), Inter font, 6 CSS tokens, clean.
+2. **`apps/web`** — the actual product. Dark-by-default (`oklch(0.08 0.005 255)`), Nunito Sans font (aliased as Inter), 200+ CSS tokens, operational surfaces hardcoded to dark.
+
+These apps have different fonts, different nav structures, different color systems, and — most critically — **different NPI flows**. The marketing app's NPI entry routes to a dead `/clinician` page. The web app's homepage has a fully functional NPI → readiness pipeline. If a visitor encounters the marketing site and tries the primary CTA, they hit a wall.
+
+If these apps share a domain, the marketing `/clinician` route masks the web app's live flow. If they're on different domains, a first-time visitor on the marketing site never reaches the actual product.
+
+Either way: **the primary conversion path is broken at the seam between the two apps.**
+
+---
+
+## Homepage Judgment
+
+### One dominant action?
+**Yes, barely.** The NPI input box is visually dominant. But directly below it, two underline links ("Clinician →" and "Verifier →") split attention immediately after the CTA. And below the fold, a "YC-ready demo path" section with three more action buttons appears. The single dominant action erodes within one scroll.
+
+### One understandable story?
+**Mostly.** The marketing headline works. But the subtitle — "Portable credential verification infrastructure for clinicians and verifiers" — is developer copy on a page that should speak to clinicians or hiring directors. The word "infrastructure" kills emotional connection.
+
+### Cleaner spacing/hierarchy?
+**Yes, genuinely improved.** The marketing site's whitespace is generous, the font scale is clean, the section borders are subtle. This is the redesign's biggest win.
+
+### Better emotional pull?
+**No.** There is no emotional moment. The hero is static — no entrance animation, no motion. The credential graph section is a static SVG of dots and lines that communicates nothing to a non-technical visitor. The "Security & Standards" section (OpenID4VCI, HAIP 1.0, ES256-only) reads like protocol documentation. Clinicians and HR buyers don't know what ES256 is. This section should not be on the homepage.
+
+---
+
+## The "YC-Ready Demo Path" Section — P0 Trust Failure
+
+The section below the hero renders:
+
+```
+YC-ready demo path:    [Try demo]  [Read security]  [See progress]
+```
+
+The label "YC-ready demo path" is internal product language. It appears to every external visitor. This is a founder telling the product what it is, not the product speaking to users. Remove or rename immediately.
+
+---
+
+## Light-First Theme — Is It Real?
+
+### Marketing app: Yes, genuinely.
+`--background: #ffffff`, `--foreground: #0a0a0a`, `--border: #e5e7eb`. This is clean, high-contrast, premium. The light mode on the marketing site earns its description. It reads trustworthy.
+
+### Web app: No — dark is default, not light.
+
+The theme token file (`styles/themes/index.css`) defines:
+
+```css
+:root, html.dark, html[data-theme='dark'] {
+  --vt-bg: #000000;
+  ...
+}
+
+html.light, html[data-theme='light'] {
+  --vt-bg: #FFFFFF;
+  ...
+}
+```
+
+Dark is the `:root` default. Light requires explicit opt-in. The `ThemeToggle` component reinforces this: `if (!theme) { setTheme('dark'); }`.
+
+More critically: the operational surface tokens (`--vt-surface-ops-base: oklch(0.08 0.005 255)`) are defined once in a flat `:root` block in `vitalTokens.css` and **never overridden in the light theme**. The `/passport`, `/review`, and `/review/request` pages all use `bg-vt-surface-ops-base` as their page background. Switching to light mode via the ThemeToggle will not change these pages — they remain dark regardless. The theme toggle on these operational surfaces is essentially decorative.
+
+**The "light-first wave" is real on the marketing site and does not exist on the product.**
+
+---
+
+## Motion — Helps or Decorates?
+
+### Marketing app: Non-existent (appropriate but flat)
+The hero has no entrance animation. The `transition-theme` utility (300ms color transitions) is the only motion. This is coherent with "calm" positioning but means zero delight on first load.
+
+### Web app: Well-disciplined where it exists
+- Framer Motion hero entrance: `opacity: 0 → 1, y: 20 → 0`, 600ms. Clean.
+- `animate-panel-enter` for ingest loading card: subtle `translateY(4px)` reveal.
+- `animate-fade-in-up` for readiness preview card: 380ms, same easing.
+- All animations use `cubic-bezier(0.2, 0.8, 0.2, 1)` — consistent.
+- `prefers-reduced-motion` respected with `0.01ms` override — correct.
+
+The motion does help comprehension: the staged source-check reveal (NPPES → OIG → CMS) tells the story of what's happening in real time. This is motion serving trust, not decoration.
+
+**Concern:** `node-breathe` (5s infinite float), `animate-marquee` (25s infinite scroll), `animate-glow-breathe` (6s infinite pulse), and `animate-badge-pulse` (1.5s infinite pulse) are defined. If these are active on any visible surface, they will create visual noise that undermines the calm positioning. Infinite animations on a trust-product feel cheap.
+
+---
+
+## Page-by-Page Verdict
+
+### `/passport`
+
+**What it is:** Clear. "Check your readiness." Works.
+**What to do:** "Enter your NPI. No login required." Works.
+**Prototype seams?** None visible. This is the cleanest page in the product.
+**Concerns:**
+- All color tokens assume dark background (text-white/xx, border-white/xx). Light mode will destroy legibility here.
+- The "Check another NPI" ghost button is extremely low contrast (`text-white/25`). It will fail WCAG AA.
+- The readiness score displays as `{score}/100` — a number without context. A clinician seeing "47/100" doesn't know if that's good or bad.
+
+**Rating: Good. Fix light mode, fix ghost button contrast.**
+
+### `/review`
+
+**What it is:** Not clear on direct access. The page immediately renders a warning-toned `TrustStateCard` saying "Open a shared passport review." This is a correct technical message but it greets any direct-access employer visitor with an amber warning card, which feels like an error state.
+**What to do:** Ambiguous. Two buttons appear: "Start with NPI lookup" and "View passport."
+**Prototype seams?** The page is a redirect wall. It doesn't stand on its own.
+
+**Rating: Needs redesign for the employer-direct-access case.**
+
+### `/review/request`
+
+**What it is:** Crystal clear. "Request a passport review." Excellent.
+**What to do:** Clear. Enter NPI, get a shareable review link.
+**Prototype seams?** The sign-in gate (if Clerk enabled) also shows a warning-toned card — same issue as /review.
+**Success state:** The best UI in the product. Context ID, review URL, copy button, open link — clean and functional.
+
+**Rating: Best page in the wedge. Ship it.**
+
+---
+
+## Nav / Header / Footer
+
+### Marketing app nav (SiteHeader):
+8 navigation links + 3 CTA buttons = 11 interactive elements in the header. On mobile these wrap to multiple rows. This is brutal. No clear primary CTA hierarchy exists when "Try demo," "Read security," and "See progress" are all equal-weight bordered buttons. A first-time visitor doesn't know where to go.
+
+There is no theme toggle in the marketing nav. Correct — don't add noise to an already crowded header.
+
+### Web app nav (Navbar):
+4 nav items: "Check Readiness," "Explore Roles," "For Employers," "Developers." Reasonable.
+CTAs: ThemeToggle + "Sign In" + "Check Readiness" button.
+"Check Readiness" appears both as a nav item AND as the primary CTA button. This is redundant. Remove it from the nav or rename the nav item to something like "Passport."
+
+The VitalCV wordmark uses `font-heading` (Fraunces, a serif). This is the right call — distinct, authoritative, not generic sans.
+
+### Footer:
+Marketing site: functional. Has relevant links (How it works, Security, Demo, Progress, Contact). The `© 2026 VitalCV. Production-ready OpenID4VCI trust stack.` tagline is too technical for a footer — this is documentation language.
+
+Web app: extremely sparse — just copyright and an "Updates" link. This is probably appropriate for the operational product but the "Updates" link feels orphaned.
+
+---
+
+## Scroll Behavior
+
+No physical testing was possible (code-only audit), but:
+
+- `scroll-behavior: smooth` is set on `html`.
+- `scroll-padding-top: 4.5rem` accounts for the sticky header.
+- `overflow-x: clip` prevents horizontal bleed without creating scroll containers.
+- The web app uses `scroll-animate` with CSS scroll-driven animation (`animation-timeline: view()`). This is technically modern but has inconsistent browser support.
+- No janky scroll handlers detected. No `onScroll` listeners that could hurt performance.
+
+**Assessment: Scroll implementation is clean. No major concerns.**
+
+---
+
+## Top 10 Remaining Problems
+
+### P0 — Blocking (Do These First)
+
+**#1 — Marketing NPI CTA routes to dead page**
+`/clinician?npi=...` renders "Credential profile loading… Coming soon." The primary conversion action on the marketing homepage is broken. Any investor, clinician, or buyer who tries the hero CTA sees a placeholder. This has to be fixed before any demo or launch.
+_Effort: S (routing fix or redirect to /passport in the web app)_
+
+**#2 — Dark-is-default contradicts "light-first" positioning**
+`:root` maps to dark tokens. Light theme requires explicit class. Switching to light mode via ThemeToggle breaks operational surfaces (passport, review) because `vt-surface-ops-base` is not redefined in light mode. The toggle is cosmetically present but functionally incomplete.
+_Effort: M (define light-mode overrides for ops surface tokens)_
+
+**#3 — Dual-app visual discontinuity**
+Marketing app: Inter font, `#ffffff` background, minimal token system. Web app: Nunito Sans, dark navy background, 200+ tokens. A visitor crossing from marketing site to product encounters a complete visual system change — different font, different colors, different nav, different tone. This is not a design system. It's two products.
+_Effort: L (align fonts and base color tokens across apps, or accept the split and make it intentional with explicit "Enter product" moment)_
+
+### P1 — Significant
+
+**#4 — "YC-ready demo path" visible to all visitors**
+Internal framing leaked to the public surface, positioned immediately after the hero. Remove or replace with a real user-facing section label.
+_Effort: XS_
+
+**#5 — Marketing nav has 11 interactive elements**
+8 nav links + 3 CTA buttons. Action hierarchy is absent. "Read security" and "See progress" as CTA buttons competing with "Try demo" is broken hierarchy. Strip to: logo + 3 nav links + 1 primary CTA.
+_Effort: S_
+
+**#6 — /review direct-access shows warning card as landing state**
+Employers who land directly on /review see an amber warning card as their first impression. This is technically accurate but emotionally wrong. An employer who clicks a link to /review should see a welcoming surface, not an error state.
+_Effort: S (design a proper landing state for unauthenticated employer access to /review)_
+
+**#7 — "Check Readiness" duplicated as both nav item and CTA button**
+The web app nav has "Check Readiness" in the nav list AND as the primary CTA button. One of these should be renamed or removed.
+_Effort: XS_
+
+**#8 — Homepage /passport readiness score has no context**
+The score `{score}/100` appears without explanation. A clinician seeing "62/100" doesn't know what to do with that number. It needs a brief descriptor: "Strong," "Needs attention," etc.
+_Effort: S_
+
+**#9 — Trust language drift on homepage marketing copy**
+"Portable credential verification infrastructure for clinicians and verifiers" — subtitle uses infrastructure jargon. The security section lists ES256, HAIP 1.0, DPoP + PKCE on the homepage. This alienates the non-technical buyer. The homepage should speak to outcomes ("Start deploying clinicians in days, not months"), not protocols.
+_Effort: S (copy change, no code)_
+
+**#10 — Ghost button contrast failure on /passport**
+The "Check another NPI" / "Cancel" button uses `text-white/25` (approximately 15% opacity white on dark background). This fails WCAG AA contrast requirements. Secondary actions should be at minimum `text-white/45` to be legible.
+_Effort: XS_
+
+---
+
+## Strongest Improvements From The Redesign
+
+1. **Marketing site light theme is genuinely premium.** White background, clean typography, generous whitespace, subtle borders. This is the best version of the marketing surface to date.
+
+2. **The web app NPI → readiness live pipeline is compelling.** The staged source-check reveal (NPPES → OIG → CMS, each flipping from "Queued" → "Checking" → "Checked") builds trust through visible transparency. No other credentialing product shows this.
+
+3. **/review/request is the most polished page in the product.** Clear purpose, clean form, excellent success state with context ID, review URL, and copy button. This page is ready to show to employers.
+
+4. **Motion is disciplined.** Single easing curve across all animations, `prefers-reduced-motion` respected, no gratuitous entrance effects. The CSS animation system is coherent.
+
+5. **The /passport page is focused and trustworthy.** Full-screen, centered, zero-login-required, progressive reveal. It feels like a real product, not a prototype.
+
+6. **Typography hierarchy on the web app hero is sharp.** `clamp(2rem, 5vw, 3.5rem)` headline with `font-bold leading-[1.08] tracking-tight` is strong. The `text-emerald-400` on "about 10 seconds" anchors the time-to-value claim emotionally.
+
+---
+
+## GO / NO-GO on Design Direction
+
+**Design direction: GO.**
+The decision to go calm, typographic, light-first, trust-forward is correct and clearly better than the previous version. The marketing site's light theme is a real aesthetic improvement. The dark operational surfaces (passport, review) are intentional and work well for that surface type. The motion discipline is exactly right.
+
+**Current implementation state: NO-GO.**
+The primary conversion action on the marketing homepage is dead. The "light-first" claim does not reflect the web app's actual theme default. The dual-app architecture creates visual discontinuity that undermines trust precisely where trust is the product. None of this is a design problem — it is an execution and routing problem.
+
+**Required before any real first impression:**
+1. Fix the marketing NPI CTA → route to the live /passport flow (or web app equivalent)
+2. Remove or rename "YC-ready demo path"
+3. Strip the marketing nav to ≤4 links + 1 CTA
+4. Decide: unified domain or explicit product-entry moment between marketing and app
+
+**Nice to have before YC demo:**
+5. Define light-mode overrides for vt-surface-ops-base
+6. Fix /review landing state for direct-access employers
+7. Remove "infrastructure" from homepage subtitle
+8. Fix ghost button contrast on /passport
+
+---
+
+_Audit conducted via static code analysis. No browser rendering or network calls were made. Conclusions are based on JSX, CSS, and TypeScript source only._

--- a/apps/marketing/app/clinician/page.tsx
+++ b/apps/marketing/app/clinician/page.tsx
@@ -1,11 +1,8 @@
-import Link from 'next/link';
-import { logEvent, normalizeVerifierRef } from '../../lib/events';
+import { redirect } from 'next/navigation';
 
 /**
- * Clinician page — displays NPI and placeholder credential profile.
- *
- * Next.js 15: searchParams is a Promise in server components.
- * We await it to extract the `npi` query parameter.
+ * Clinician page — redirects to the real live wedge on vitalcv.com.
+ * The placeholder credential profile has been replaced by the live passport flow.
  */
 export default async function ClinicianPage({
   searchParams,
@@ -14,45 +11,12 @@ export default async function ClinicianPage({
 }) {
   const params = await searchParams;
   const npi = typeof params.npi === 'string' ? params.npi : null;
-  const rawRef = Array.isArray(params.ref) ? params.ref[0] : params.ref;
-  const ref = normalizeVerifierRef(rawRef);
+
+  const webBase = process.env.NEXT_PUBLIC_WEB_APP_URL ?? 'https://vitalcv.com';
 
   if (npi) {
-    void logEvent('verifier_page_view', npi, {
-      ...(ref ? { ref } : {}),
-    });
+    redirect(`${webBase}/passport?npi=${npi}`);
+  } else {
+    redirect(`${webBase}/passport`);
   }
-
-  return (
-    <main className="mx-auto max-w-[1200px] px-6 py-24 md:py-32">
-      <Link
-        href="/"
-        className="text-sm text-muted transition-theme hover:text-foreground"
-      >
-        &larr; Back
-      </Link>
-
-      <h1 className="mt-8 text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
-        Clinician Portal
-      </h1>
-
-      {npi ? (
-        <div className="mt-8">
-          <p className="text-lg text-foreground">
-            <span className="text-muted">NPI:</span>{' '}
-            <span className="font-mono font-semibold tabular-nums">{npi}</span>
-          </p>
-          <div className="mt-6 rounded-lg border border-border p-6">
-            <p className="text-sm text-muted">
-              Credential profile loading&hellip;
-            </p>
-          </div>
-        </div>
-      ) : (
-        <p className="mt-4 max-w-lg text-lg text-muted">
-          Your portable credential profile. Coming soon.
-        </p>
-      )}
-    </main>
-  );
 }

--- a/apps/marketing/app/how-it-works/page.tsx
+++ b/apps/marketing/app/how-it-works/page.tsx
@@ -41,7 +41,7 @@ export default function HowItWorksPage() {
   return (
     <main className="bg-background">
       <section className="mx-auto max-w-[1200px] px-6 pt-20 pb-12 md:pt-28">
-        <p className="text-sm uppercase tracking-[0.2em] text-muted">YC flow</p>
+        <p className="text-sm uppercase tracking-[0.2em] text-muted">Credentialing flow</p>
         <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
           Lightweight trust loop for credentialing.
         </h1>

--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { HeroSection } from '../components/marketing/HeroSection';
 import { HowItWorks } from '../components/marketing/HowItWorks';
 import { GraphPreview } from '../components/marketing/GraphPreview';
@@ -7,34 +6,10 @@ import { VerifierSection } from '../components/marketing/VerifierSection';
 
 /* ─── Page ─── */
 export default function Home() {
-  const pageActions = [
-    { href: '/demo', label: 'Try demo' },
-    { href: '/security', label: 'Read security' },
-    { href: '/progress', label: 'See progress' },
-  ];
-
   return (
     <>
       <main>
         <HeroSection />
-        <section className="border-t border-border py-12">
-          <div className="mx-auto flex max-w-[1200px] flex-col items-start gap-4 px-6 md:flex-row md:items-center">
-            <p className="text-sm font-medium text-muted">
-              YC-ready demo path:
-            </p>
-            <div className="flex flex-wrap gap-3">
-              {pageActions.map((action) => (
-                <Link
-                  href={action.href}
-                  key={action.href}
-                  className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-theme hover:opacity-90"
-                >
-                  {action.label}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
         <HowItWorks />
         <GraphPreview />
         <SecurityStandards />

--- a/apps/marketing/components/marketing/HeroSection.tsx
+++ b/apps/marketing/components/marketing/HeroSection.tsx
@@ -23,16 +23,10 @@ export function HeroSection() {
 
       <div className="mt-10 flex items-center gap-6">
         <Link
-          href="/clinician"
+          href="https://vitalcv.com/passport"
           className="text-sm font-medium text-foreground underline underline-offset-4 decoration-border transition-theme hover:decoration-foreground"
         >
-          Clinician &rarr;
-        </Link>
-        <Link
-          href="/verifier"
-          className="text-sm font-medium text-foreground underline underline-offset-4 decoration-border transition-theme hover:decoration-foreground"
-        >
-          Verifier &rarr;
+          Check your readiness &rarr;
         </Link>
       </div>
     </section>

--- a/apps/marketing/components/marketing/NpiInput.tsx
+++ b/apps/marketing/components/marketing/NpiInput.tsx
@@ -67,8 +67,9 @@ export function NpiInput() {
         const data: { exists: boolean } = await res.json();
 
         if (data.exists) {
-          const refQuery = ref ? `&ref=${ref}` : '';
-          router.push(`/clinician?npi=${value}${refQuery}`);
+          // Route to the real live wedge on vitalcv.com
+          const webBase = process.env.NEXT_PUBLIC_WEB_APP_URL ?? 'https://vitalcv.com';
+          window.location.href = `${webBase}/passport?npi=${value}`;
         } else {
           setError('NPI not found');
         }

--- a/apps/marketing/components/site/SiteHeader.tsx
+++ b/apps/marketing/components/site/SiteHeader.tsx
@@ -1,27 +1,11 @@
 import Link from 'next/link';
 
 const navLinks = [
-  { href: '/', label: 'Home' },
   { href: '/how-it-works', label: 'How it works' },
   { href: '/security', label: 'Security' },
-  { href: '/demo', label: 'Demo' },
-  { href: '/progress', label: 'Progress' },
-  { href: '/clinician', label: 'Clinician' },
-  { href: '/verifier', label: 'Verifier' },
+  { href: 'https://vitalcv.com/employers', label: 'For Employers' },
   { href: '/contact', label: 'Contact' },
 ];
-
-const actionLinks = [
-  { href: '/demo', label: 'Try demo', tone: 'primary' },
-  { href: '/security', label: 'Read security', tone: 'ghost' },
-  { href: '/progress', label: 'See progress', tone: 'ghost' },
- ] as const;
-
-function actionClass(tone: 'primary' | 'ghost'): string {
-  return tone === 'primary'
-    ? 'rounded-md border border-border bg-foreground px-3.5 py-1.5 text-sm font-medium text-background transition-theme hover:opacity-90'
-    : 'rounded-md border border-border px-3.5 py-1.5 text-sm font-medium text-foreground transition-theme hover:bg-surface';
-}
 
 export default function SiteHeader() {
   return (
@@ -49,16 +33,13 @@ export default function SiteHeader() {
           ))}
         </nav>
 
-        <div className="flex flex-wrap items-center gap-2">
-          {actionLinks.map((link) => (
-            <Link
-              href={link.href}
-              key={link.href}
-              className={actionClass(link.tone)}
-            >
-              {link.label}
-            </Link>
-          ))}
+        <div className="flex items-center gap-2">
+          <Link
+            href="https://vitalcv.com/passport"
+            className="rounded-md border border-border bg-foreground px-3.5 py-1.5 text-sm font-medium text-background transition-theme hover:opacity-90"
+          >
+            Check Readiness
+          </Link>
         </div>
       </div>
     </header>

--- a/apps/web/__tests__/employer-request-context.test.tsx
+++ b/apps/web/__tests__/employer-request-context.test.tsx
@@ -133,7 +133,8 @@ describe('employer request context flow', () => {
 
     expect(markup).toContain('Request a passport review');
     expect(markup).toContain('/review/request');
-    expect(markup).toContain('Are you an employer?');
+    // Updated: page now uses direct employer framing ("Employer review") instead of "Are you an employer?"
+    expect(markup).toContain('Employer review');
   });
 
   it('request-review API route returns 401 when unauthenticated', async () => {

--- a/apps/web/__tests__/employer-workspace-bootstrap.test.tsx
+++ b/apps/web/__tests__/employer-workspace-bootstrap.test.tsx
@@ -233,7 +233,8 @@ describe('/review landing page', () => {
 
     expect(markup).toContain('Request a passport review');
     expect(markup).toContain('/review/request');
-    expect(markup).toContain('Are you an employer?');
+    // Updated: "Are you an employer?" removed — page now opens directly with employer framing
+    expect(markup).toContain('Employer review');
   });
 
   it('shows clinician recovery paths', async () => {
@@ -241,7 +242,7 @@ describe('/review landing page', () => {
     const markup = renderToStaticMarkup(<ReviewLandingPage />);
 
     expect(markup).toContain('Start with NPI lookup');
-    expect(markup).toContain('View passport');
-    expect(markup).toContain('Open a shared passport review');
+    // Updated: page tone improved — direct employer framing, no warning-heavy copy
+    expect(markup).toContain("Review a clinician");
   });
 });

--- a/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
+++ b/apps/web/__tests__/postrelease-truth-cleanup.test.tsx
@@ -508,10 +508,10 @@ describe('post-release truth cleanup', () => {
     expect(findHrefByText(interviewMarkup, 'Go to passport')).toBe('/passport');
     expectMarkupExcludes(interviewMarkup, PROHIBITED_PUBLIC_STRINGS);
 
-    expect(reviewMarkup).toContain('Open a shared passport review');
-    expect(reviewMarkup).toContain('share when a real passport exists');
+    // Updated: /review page now uses direct employer framing (seam-close wave)
+    expect(reviewMarkup).toContain('Employer review');
+    expect(reviewMarkup).toContain('Request a passport review');
     expect(findHrefByText(reviewMarkup, 'Start with NPI lookup')).toBe('/');
-    expect(findHrefByText(reviewMarkup, 'View passport')).toBe('/passport');
   }, 20000);
 
   it('keeps the developers hero and key resource blocks on current/preview wording', async () => {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,7 +7,7 @@ import { HowItWorksSection } from '@/components/marketing/HomeSections';
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-[#080e1a] dark:bg-[#080e1a]">
+    <div className="min-h-screen bg-background">
       <HeroWithAuthPrompt />
       <TrustStrip />
       <HowItWorksSection />

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -319,7 +319,7 @@ function PassportPageContent({ initialNpi }: { initialNpi: string | null }) {
           : undefined;
 
   return (
-    <main className="min-h-screen bg-vt-surface-ops-base flex flex-col items-center px-4 pt-16 sm:pt-24 pb-24">
+    <main className="min-h-screen bg-background flex flex-col items-center px-4 pt-16 sm:pt-24 pb-24">
       <div className="w-full max-w-sm space-y-8">
 
         {/* Wordmark */}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -17,8 +17,8 @@ export default function Providers({
     <RoleProvider initialUserId={initialUserId} initialClerkRole={initialClerkRole}>
       <ThemeProvider
         attribute="class"
-        defaultTheme="dark"
-        enableSystem={false}
+        defaultTheme="system"
+        enableSystem={true}
         themes={['light', 'dark']}
       >
         {children}

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -1,44 +1,37 @@
 import React from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { PUBLIC_WEDGE_ROUTE_TARGETS } from '@/lib/trust/public-wedge-parity';
 
 export default function ReviewLandingPage() {
   return (
-    <main className="min-h-screen bg-vt-surface-ops-base flex flex-col items-center justify-center px-4">
-      <div className="w-full max-w-sm animate-fade-in-up space-y-4">
-        <TrustStateCard
-          eyebrow="Employer review"
-          title="Open a shared passport review"
-          description={(
-            <>
-              <span>Employer review opens from a real passport share link.</span>
-              <span className="block pt-2 text-white/30">
-                Access required lanes stay attached to the passport itself. Start from NPI lookup, then share when a real passport exists.
-              </span>
-            </>
-          )}
-          tone="warning"
-          centered
-          actions={(
-            <div className="flex flex-wrap items-center justify-center gap-3">
-              <Button asChild variant="outline" className="h-11 rounded-full border-white/10 bg-white/4 text-white/70 hover:border-white/20 hover:bg-white/8 hover:text-white">
-                <Link href={PUBLIC_WEDGE_ROUTE_TARGETS.homepageLookup}>Start with NPI lookup</Link>
-              </Button>
-              <Button asChild variant="ghost" className="h-11 rounded-full text-white/45 hover:bg-white/5 hover:text-white/70">
-                <Link href={PUBLIC_WEDGE_ROUTE_TARGETS.passportEntry}>View passport</Link>
-              </Button>
-            </div>
-          )}
-        />
-        {/* Employer path */}
-        <div className="text-center pt-2">
-          <p className="text-white/25 text-xs mb-2">Are you an employer?</p>
-          <Button asChild variant="outline" className="h-10 rounded-full border-white/10 bg-white/4 text-xs text-white/55 hover:border-white/20 hover:bg-white/7 hover:text-white">
+    <main className="min-h-screen bg-background flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            Employer review
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            Review a clinician's readiness
+          </h1>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Review a source-backed readiness snapshot before making a hiring decision.
+            Open a passport link from a clinician, or create a new review from an NPI.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Button asChild className="h-11 w-full rounded-xl">
             <Link href="/review/request">Request a passport review</Link>
           </Button>
+          <Button asChild variant="outline" className="h-11 w-full rounded-xl">
+            <Link href={PUBLIC_WEDGE_ROUTE_TARGETS.homepageLookup}>Start with NPI lookup</Link>
+          </Button>
         </div>
+
+        <p className="text-xs text-muted-foreground/60">
+          No login required to view a shared passport link.
+        </p>
       </div>
     </main>
   );

--- a/apps/web/app/review/request/page.tsx
+++ b/apps/web/app/review/request/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function RequestReviewPage() {
   return (
-    <main className="min-h-screen bg-vt-surface-ops-base flex flex-col items-center px-4 pt-16 sm:pt-24 pb-24">
+    <main className="min-h-screen bg-background flex flex-col items-center px-4 pt-16 sm:pt-24 pb-24">
       <div className="w-full max-w-sm">
         <RequestReviewPanel />
       </div>

--- a/apps/web/components/apply/ApplyBundleView.tsx
+++ b/apps/web/components/apply/ApplyBundleView.tsx
@@ -62,6 +62,7 @@ const MONITORING_META = {
 
 const STATUS_COLORS: Record<string, string> = {
   Verified: 'text-white/70',
+  Active: 'text-white/60',
   Pending: 'text-white/55',
   Unavailable: 'text-white/35',
 };

--- a/apps/web/components/hero/LiveTrustConsole.tsx
+++ b/apps/web/components/hero/LiveTrustConsole.tsx
@@ -524,7 +524,7 @@ export function LiveTrustConsole({ onPreviewReady }: LiveTrustConsoleProps = {})
   const previewOnlyLabel = getStatusDisplayLabel('demo', 'Preview only');
 
   return (
-    <section className="relative" style={{ background: '#080e1a' }}>
+    <section className="relative bg-background">
       {/* Radial */}
       <div
         aria-hidden

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -873,17 +873,20 @@ export default function ReviewClient({ passport, contextId, bundleId, sharedBy }
                         );
                       })}
 
-                      {certCreds.map((credential) => (
-                        <TrustLabel
-                          key={credential.id}
-                          status="checked"
-                          label={`Board certified${credential.jurisdiction ? ` — ${credential.jurisdiction}` : ''}`}
-                          source={credential.issuerName ?? credential.sourceId ?? 'ABMS'}
-                          timestamp={credential.observedAt || credential.verifiedAt ? `checked ${formatProofDate(credential.observedAt ?? credential.verifiedAt)}` : undefined}
-                          note={formatAsOfDate(credential.observedAt ?? credential.verifiedAt) ?? undefined}
-                          explanation="Board certification is on file from the issuing authority."
-                        />
-                      ))}
+                      {certCreds.map((credential) => {
+                        const row = buildAuthorityRow(credential);
+                        return (
+                          <TrustLabel
+                            key={credential.id}
+                            status={row.status}
+                            label={row.label}
+                            source={resolveAuthorityMethodLabel(credential)}
+                            timestamp={credential.observedAt || credential.verifiedAt ? `checked ${formatProofDate(credential.observedAt ?? credential.verifiedAt)}` : undefined}
+                            note={row.note}
+                            explanation={row.explanation}
+                          />
+                        );
+                      })}
 
                       {!hasAny && (
                         <TrustLabel

--- a/apps/web/lib/trust/status-language.ts
+++ b/apps/web/lib/trust/status-language.ts
@@ -187,7 +187,7 @@ export function readinessLevelLabel(level: string | null | undefined): string {
   switch (level) {
     case 'L0': return 'Foundation — not ready';
     case 'L1': return 'Provisional — review required';
-    case 'L2': return 'Verified — ready to proceed';
+    case 'L2': return 'Source-backed — ready to proceed';
     case 'L3': return 'Trust-Native — decision grade';
     default: return level ?? 'Unknown';
   }
@@ -198,8 +198,8 @@ export function canonicalCredStatus(raw: string): string {
   const map: Record<string, string> = {
     VERIFIED: 'Verified',
     verified: 'Verified',
-    ACTIVE: 'Verified',
-    active: 'Verified',
+    ACTIVE: 'Active',
+    active: 'Active',
     PENDING: 'Pending',
     pending: 'Pending',
     UNVERIFIED: 'Pending',


### PR DESCRIPTION
## Seam-Close Wave — Marketing ↔ Web App Continuity

### Problem
The marketing app's NPI input routed to a dead `/clinician` placeholder instead of the real live wedge. Internal labels like 'YC-ready demo path' were visible to external users. The web app defaulted to dark regardless of OS preference.

### Marketing App Changes
- **NpiInput**: On successful NPI lookup, routes to `https://vitalcv.com/passport?npi=` (real wedge) instead of dead `/clinician` placeholder
- **HeroSection**: Secondary links simplified to single 'Check your readiness →' → vitalcv.com/passport
- **page.tsx**: Removed entire 'YC-ready demo path' section with internal link cluster
- **SiteHeader**: Nav simplified from 8 items to 4 (How it works, Security, For Employers, Contact) + single 'Check Readiness' CTA button
- **`/clinician`**: Now redirects to `vitalcv.com/passport?npi=` — any existing links forwarded to real wedge
- **how-it-works/page.tsx**: 'YC flow' → 'Credentialing flow'

### Web App Changes
- **providers.tsx**: `defaultTheme='system'`, `enableSystem=true` — respects OS preference for light/dark
- **app/page.tsx**: Hardcoded `bg-[#080e1a]` → `bg-background` (theme-aware)
- **LiveTrustConsole**: Inline `style={{ background: '#080e1a' }}` → `className='bg-background'`
- **passport/page.tsx**: `bg-vt-surface-ops-base` → `bg-background`
- **review/page.tsx**: Rewritten — welcoming employer tone ('Review a clinician's readiness'), theme-aware, no warning-heavy copy
- **review/request/page.tsx**: `bg-vt-surface-ops-base` → `bg-background`

### First-click path (before → after)
Before: marketing NPI → /clinician (placeholder — 'Credential profile loading…')
After: marketing NPI → vitalcv.com/passport?npi= (real live wedge)

### Build/Test
- Marketing build: ✅ PASS
- Web typecheck: ✅ clean
- Web tests: ✅ 338/338