### PR TITLE
fix(credibility): remove 'Verified since [date]' employer label — unsupported certainty claim

### DIFF
--- a/apps/api/backend/src/services/employers/employerService.ts
+++ b/apps/api/backend/src/services/employers/employerService.ts
@@ -138,7 +138,9 @@ function buildTrustIndicators(detail: {
   const indicators: string[] = [];
 
   if (detail.verified) {
-    indicators.push(detail.verifiedSince ? `Verified since ${detail.verifiedSince.slice(0, 10)}` : 'Verified employer');
+    // Do not claim "Verified since [date]" — that implies continuous verification we cannot assert.
+    // "Directory listed" is the honest label for employers in this environment.
+    indicators.push('Directory listed');
   }
 
   if (detail.trustScore > 0) {


### PR DESCRIPTION
## Secondary Surface Credibility Fix

From release-blocker sweep audit: `/employers` page was showing `Verified since 2021-03-01` on employer cards. This implies continuous source-backed verification since that date, which we cannot assert.

### Change
- `employerService.ts`: `buildTrustIndicators()` now emits `'Directory listed'` instead of `'Verified since [date]'` when an employer has `verified: true`

### Why
- "Verified since" is a certainty claim that outruns what the pilot can support
- "Directory listed" is accurate — the employer is listed in the current directory feed
- Preserves the trust badge without overclaiming

### Tests
- Employer service tests: 33/33 ✅