### PR TITLE
fix(api): skip launch opportunity seed on schema gaps

### DIFF
--- a/apps/api/backend/__tests__/e2e.providerFabric.test.ts
+++ b/apps/api/backend/__tests__/e2e.providerFabric.test.ts
@@ -152,6 +152,9 @@ describe('FHIR R4 Export', () => {
       credential: 'MD',
       gender: 'M',
       trustBand: 'L3',
+      licenses: [],
+      boardCerts: [],
+      educations: [],
       taxonomies: [{ code: '207R00000X', description: 'Internal Medicine', primary: true }],
       credentials: [{
         credentialId: 'cred-001',
@@ -181,6 +184,9 @@ describe('FHIR R4 Export', () => {
       npi: '1003000126',
       firstName: 'Jane',
       lastName: 'Doe',
+      licenses: [],
+      boardCerts: [],
+      educations: [],
       credentials: [{
         credentialId: 'cred-002',
         type: 'BoardCertification',
@@ -199,6 +205,9 @@ describe('FHIR R4 Export', () => {
       npi: '1003000126',
       firstName: 'John',
       lastName: 'Smith',
+      licenses: [],
+      boardCerts: [],
+      educations: [],
       taxonomies: [{ code: '207R00000X', description: 'Internal Medicine', primary: true, state: 'CA' }],
     });
 
@@ -214,6 +223,9 @@ describe('FHIR R4 Export', () => {
       firstName: 'Test',
       lastName: 'Provider',
       trustBand: 'L2',
+      licenses: [],
+      boardCerts: [],
+      educations: [],
     });
 
     const practitioner = bundle.entry[0].resource as any;

--- a/apps/api/backend/src/server.ts
+++ b/apps/api/backend/src/server.ts
@@ -177,7 +177,7 @@ async function bootstrapApp() {
   const { log } = await import('./obs/logger');
   const { loadEnv } = await import('./config/env');
   const { ensureInvestigationSeedDataBootstrapped } = await import('./services/investigators/seedInvestigationData');
-  const { ensureLaunchOpportunitiesBootstrapped } = await import('./services/opportunities/launchOpportunitySeed');
+  const { ensureLaunchOpportunitiesBootstrappedForStartup } = await import('./services/opportunities/launchOpportunitySeed');
   const { requestIntelligenceAutoWarm } = await import('./services/intelligence/intelligenceAutoWarmService');
   const { initializeTelemetry, shutdownTelemetry } = await import('./telemetry');
   const { runMonitoringCycle } = await import('../jobs/monitoringJob');
@@ -189,7 +189,7 @@ async function bootstrapApp() {
   const config = loadEnv();
   await ensureInvestigationSeedDataBootstrapped({ logger: log });
   if (config.NODE_ENV === 'production') {
-    await ensureLaunchOpportunitiesBootstrapped({ logger: log });
+    await ensureLaunchOpportunitiesBootstrappedForStartup({ logger: log });
   }
 
   const productionDeployment = config.NODE_ENV === 'production';

--- a/apps/api/backend/src/services/opportunities/__tests__/launchOpportunitySeed.test.ts
+++ b/apps/api/backend/src/services/opportunities/__tests__/launchOpportunitySeed.test.ts
@@ -1,0 +1,80 @@
+jest.mock('../../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { Prisma } from '@prisma/client';
+import { ensureLaunchOpportunitiesBootstrappedForStartup } from '../launchOpportunitySeed';
+
+const logger = jest.fn<
+  void,
+  ['info' | 'warn' | 'error', string, Record<string, unknown>?]
+>();
+
+describe('ensureLaunchOpportunitiesBootstrappedForStartup', () => {
+  beforeEach(() => {
+    logger.mockReset();
+  });
+
+  it('logs and skips when bootstrap hits an opportunity schema gap', async () => {
+    const bootstrap = jest.fn().mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('missing Opportunity table', {
+        code: 'P2021',
+        clientVersion: '6.19.2',
+      }),
+    );
+
+    await expect(ensureLaunchOpportunitiesBootstrappedForStartup({
+      logger,
+      bootstrap,
+    })).resolves.toBeNull();
+
+    expect(bootstrap).toHaveBeenCalledWith({
+      logger,
+      prismaClient: undefined,
+    });
+    expect(logger).toHaveBeenCalledWith(
+      'warn',
+      'launch_opportunity_seed.startup_skipped_schema_gap',
+      expect.objectContaining({
+        event: 'launch_opportunity_seed.startup_skipped_schema_gap',
+        prisma_code: 'P2021',
+        reason: 'schema_compatibility',
+        error: 'missing Opportunity table',
+      }),
+    );
+  });
+
+  it('rethrows non-schema Prisma initialization failures', async () => {
+    const error = new Prisma.PrismaClientInitializationError('db auth failed', '6.19.2');
+    const bootstrap = jest.fn().mockRejectedValue(error);
+
+    await expect(ensureLaunchOpportunitiesBootstrappedForStartup({
+      logger,
+      bootstrap,
+    })).rejects.toBe(error);
+
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('returns the underlying bootstrap summary when bootstrap succeeds', async () => {
+    const summary = {
+      activeOpportunityCount: 5,
+      seededOpportunityCount: 0,
+      createdOrganizationCount: 0,
+      skipped: false,
+    };
+    const bootstrap = jest.fn().mockResolvedValue(summary);
+
+    await expect(ensureLaunchOpportunitiesBootstrappedForStartup({
+      logger,
+      bootstrap,
+    })).resolves.toEqual(summary);
+
+    expect(bootstrap).toHaveBeenCalledWith({
+      logger,
+      prismaClient: undefined,
+    });
+    expect(logger).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/backend/src/services/opportunities/launchOpportunitySeed.ts
+++ b/apps/api/backend/src/services/opportunities/launchOpportunitySeed.ts
@@ -1,4 +1,4 @@
-import { EmployerHiringStatus, type Prisma, type PrismaClient } from '@prisma/client';
+import { EmployerHiringStatus, Prisma, type PrismaClient } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 
 type SeedLogger = (
@@ -250,6 +250,11 @@ export interface LaunchOpportunitySeedSummary {
   skipped: boolean;
 }
 
+type LaunchOpportunityBootstrapper = (options: {
+  prismaClient?: PrismaClient;
+  logger?: SeedLogger;
+}) => Promise<LaunchOpportunitySeedSummary | null>;
+
 function requirementsAsJson(
   requirements: SeedOrganization['requirements'],
 ): Prisma.InputJsonValue {
@@ -474,4 +479,40 @@ export async function ensureLaunchOpportunitiesBootstrapped(options: {
   });
 
   return seedLaunchOpportunities(prismaClient, logger);
+}
+
+function isLaunchOpportunitySchemaCompatibilityError(
+  error: unknown,
+): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError
+    && (error.code === 'P2021' || error.code === 'P2022');
+}
+
+export async function ensureLaunchOpportunitiesBootstrappedForStartup(options: {
+  prismaClient?: PrismaClient;
+  logger?: SeedLogger;
+  bootstrap?: LaunchOpportunityBootstrapper;
+} = {}): Promise<LaunchOpportunitySeedSummary | null> {
+  const bootstrap = options.bootstrap ?? ensureLaunchOpportunitiesBootstrapped;
+
+  try {
+    return await bootstrap({
+      prismaClient: options.prismaClient,
+      logger: options.logger,
+    });
+  } catch (error) {
+    if (!isLaunchOpportunitySchemaCompatibilityError(error)) {
+      throw error;
+    }
+
+    const schemaError = error as Prisma.PrismaClientKnownRequestError;
+
+    options.logger?.('warn', 'launch_opportunity_seed.startup_skipped_schema_gap', {
+      event: 'launch_opportunity_seed.startup_skipped_schema_gap',
+      prisma_code: schemaError.code,
+      reason: 'schema_compatibility',
+      error: schemaError.message,
+    });
+    return null;
+  }
 }

--- a/tests/e2e/fhirExport.spec.ts
+++ b/tests/e2e/fhirExport.spec.ts
@@ -10,6 +10,9 @@ describe('FHIR export', () => {
       lastName: clinician.lastName,
       credential: 'MD',
       organization: 'Wave 124 Health System',
+      licenses: [],
+      boardCerts: [],
+      educations: [],
       taxonomies: [{
         code: clinician.taxonomyCode,
         description: clinician.taxonomyDescription,


### PR DESCRIPTION
## Changes

- Add graceful error handling for launch opportunity seed during startup when schema compatibility issues occur (Prisma errors P2021/P2022)
- Introduce `ensureLaunchOpportunitiesBootstrappedForStartup()` that catches schema-related errors and logs them as warnings instead of failing startup
- Rename server.ts to use the new startup-safe function
- Add comprehensive test suite for schema gap handling
- Update test fixtures to include empty arrays for `licenses`, `boardCerts`, and `educations` fields

## Rationale

Prevents application startup failures due to schema compatibility gaps in the opportunities feature, allowing the application to continue functioning while logging the issue for investigation.