### PR TITLE
fix: Wave 17 copy truth — remove false claims from marketing surfaces

### DIFF
--- a/apps/web/components/marketing/Hero.tsx
+++ b/apps/web/components/marketing/Hero.tsx
@@ -18,7 +18,7 @@ const TERMINAL_LINES = [
   { text: '> Querying OIG/LEIE exclusion registry…', delay: 2600 },
   { text: '  ✓ Not excluded', delay: 3200 },
   { text: '> Querying Nursys (state board network)…', delay: 3800 },
-  { text: '  ✓ License standing confirmed', delay: 4500 },
+  { text: '  ⚠ Nursys: institutional access required', delay: 4500 },
   { text: '> Signing credential bundle (ES256)…', delay: 5000 },
   { text: '  ✓ Bundle signed — ready to share', delay: 5700 },
   { text: '> Running ReadinessEvaluator…', delay: 6200 },
@@ -119,7 +119,7 @@ export function Hero() {
             <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/[0.06] px-4 py-1.5">
               <Shield className="h-3.5 w-3.5 text-emerald-400" />
               <span className="text-[11px] font-bold uppercase tracking-[0.25em] text-emerald-400">
-                Zero-Trust Credentialing Infrastructure
+                Source-Backed Credentialing
               </span>
             </div>
 
@@ -131,18 +131,19 @@ export function Hero() {
             </h1>
 
             <p className="max-w-xl text-lg leading-relaxed text-white/55">
-              VitalCV is the cryptographic trust infrastructure for healthcare.
-              We automate primary source verification, anchor it to a zero-trust
-              ledger, and continuously monitor compliance — so you can hire instantly.
+              VitalCV is the source-backed credentialing infrastructure for healthcare.
+              We automate primary source verification, generate audit-ready credential
+              packets, and continuously monitor compliance — so you can start clinicians
+              in days, not months.
             </p>
 
             {/* CTAs */}
             <div className="flex flex-wrap items-center gap-4 pt-2">
               <Link
-                href="/verifier"
+                href="/demo"
                 className="group inline-flex items-center gap-2 rounded-full bg-emerald-500 px-7 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-zinc-950"
               >
-                Request a Demo
+                See it live
                 <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
               </Link>
               <Link
@@ -156,7 +157,7 @@ export function Hero() {
 
             {/* Trust badges */}
             <div className="flex flex-wrap items-center gap-5 pt-4">
-              {['SOC 2', 'HIPAA', 'NCQA', 'ES256'].map((badge) => (
+              {['HIPAA-aligned', 'W3C VC', 'ES256'].map((badge) => (
                 <span
                   key={badge}
                   className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/25"

--- a/apps/web/components/marketing/HomeSections.tsx
+++ b/apps/web/components/marketing/HomeSections.tsx
@@ -304,9 +304,9 @@ const TRACTION_STATS = [
 const BUILD_SIGNALS = [
   { icon: CheckCircle2, text: 'Live NPI verification via NPPES (7M+ provider registry)' },
   { icon: CheckCircle2, text: 'Cryptographic SD-JWT credentials — W3C VC + OID4VCI compliant' },
-  { icon: CheckCircle2, text: 'Clinician identity graph: NPI → readiness → portable trust packet' },
+  { icon: CheckCircle2, text: 'Clinician identity chain: NPI → readiness → portable trust packet' },
   { icon: CheckCircle2, text: 'Employer acceptance flow — review and accept verified packets' },
-  { icon: CheckCircle2, text: 'HIPAA-compliant audit ledger with continuous license monitoring' },
+  { icon: CheckCircle2, text: 'HIPAA-aligned audit trail with continuous license monitoring' },
 ] as const;
 
 const COMPLIANCE_BADGES = [


### PR DESCRIPTION
P0/P1/P2 messaging violations fixed:
- W17-2 (P0): eyebrow → 'Source-Backed Credentialing'
- W17-1 (P0): body copy → removes 'zero-trust ledger' + 'hire instantly'
- W17-5 (P1): Nursys terminal → '⚠ institutional access required'
- W17-3 (P1): 'identity graph' → 'identity chain'
- W17-4 (P1): 'HIPAA-compliant audit ledger' → 'HIPAA-aligned audit trail'
- W17-6 (P2): trust badges → HIPAA-aligned, W3C VC, ES256 only
- W17-7 (P2): 'Request a Demo' CTA → /demo