### PR TITLE
feat(hybrid-loader): instant-render provider identity via cache + SSR seed

### DIFF
--- a/apps/web/__tests__/identity-cache.test.ts
+++ b/apps/web/__tests__/identity-cache.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearIdentity,
+  readIdentity,
+  writeIdentity,
+  type CachedIdentity,
+} from '../lib/hybrid-loader/identityCache';
+import type { StreamIdentity } from '../hooks/ingestStreamState';
+
+const TEST_KEY = '1234567890';
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+function buildIdentity(overrides: Partial<StreamIdentity> = {}): StreamIdentity {
+  return {
+    entityId: 'entity-1',
+    displayName: 'Jane Doe',
+    specialty: 'Internal Medicine',
+    entityType: 'PERSON',
+    status: 'VERIFIED',
+    authoritative: true,
+    ...overrides,
+  };
+}
+
+describe('identityCache', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  describe('readIdentity', () => {
+    it('returns null when no entry exists', () => {
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+
+    it('returns null when the entry is malformed JSON', () => {
+      window.localStorage.setItem('vcv:identity:v1:' + TEST_KEY, '{not json');
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+
+    it('returns null when the schema version does not match', () => {
+      const entry = {
+        v: 99,
+        savedAt: Date.now(),
+        key: TEST_KEY,
+        identity: buildIdentity(),
+      };
+      window.localStorage.setItem('vcv:identity:v1:' + TEST_KEY, JSON.stringify(entry));
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+
+    it('returns null when the entry has expired the 24h TTL', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+      writeIdentity(TEST_KEY, { identity: buildIdentity() });
+
+      // Advance past the 24h TTL
+      vi.setSystemTime(new Date('2026-04-10T12:00:00Z').getTime() + TTL_MS + 1);
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+
+    it('returns the cached entry when savedAt is fresh', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-10T12:00:00Z'));
+
+      writeIdentity(TEST_KEY, { identity: buildIdentity() });
+
+      // Just under the TTL
+      vi.setSystemTime(new Date('2026-04-10T12:00:00Z').getTime() + TTL_MS - 1);
+
+      const result = readIdentity(TEST_KEY);
+      expect(result).not.toBeNull();
+      expect(result?.identity.displayName).toBe('Jane Doe');
+      expect(result?.v).toBe(1);
+    });
+
+    it('returns null when savedAt is not a number', () => {
+      const entry = {
+        v: 1,
+        savedAt: 'nope',
+        key: TEST_KEY,
+        identity: buildIdentity(),
+      } as unknown as CachedIdentity;
+      window.localStorage.setItem('vcv:identity:v1:' + TEST_KEY, JSON.stringify(entry));
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+  });
+
+  describe('writeIdentity', () => {
+    it('round-trips identity + standing + readiness', () => {
+      writeIdentity(TEST_KEY, {
+        identity: buildIdentity(),
+        standing: {
+          exclusionChecked: true,
+          exclusionClear: true,
+          exclusionStatus: 'CLEAR',
+          enrollmentChecked: true,
+          enrollmentStatus: 'ENROLLED',
+        },
+        readiness: {
+          score: 87,
+          level: 'L3',
+          status: 'READY',
+        },
+      });
+
+      const result = readIdentity(TEST_KEY);
+      expect(result?.identity.displayName).toBe('Jane Doe');
+      expect(result?.standing?.exclusionStatus).toBe('CLEAR');
+      expect(result?.readiness?.score).toBe(87);
+      expect(result?.readiness?.level).toBe('L3');
+    });
+
+    it('preserves previously-cached standing when the next write is identity-only', () => {
+      writeIdentity(TEST_KEY, {
+        identity: buildIdentity(),
+        standing: {
+          exclusionChecked: true,
+          exclusionClear: true,
+          exclusionStatus: 'CLEAR',
+          enrollmentChecked: false,
+        },
+      });
+
+      // Identity-only update (e.g. a freshness re-fetch that only touched
+      // NPPES). Standing should carry forward from the earlier write.
+      writeIdentity(TEST_KEY, {
+        identity: buildIdentity({ displayName: 'Jane Updated' }),
+      });
+
+      const result = readIdentity(TEST_KEY);
+      expect(result?.identity.displayName).toBe('Jane Updated');
+      expect(result?.standing?.exclusionStatus).toBe('CLEAR');
+      expect(result?.standing?.exclusionClear).toBe(true);
+    });
+
+    it('refreshes savedAt on every write so the TTL rolls forward', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-10T00:00:00Z'));
+      writeIdentity(TEST_KEY, { identity: buildIdentity() });
+      const first = readIdentity(TEST_KEY)?.savedAt;
+
+      vi.setSystemTime(new Date('2026-04-10T06:00:00Z'));
+      writeIdentity(TEST_KEY, { identity: buildIdentity({ displayName: 'Jane Two' }) });
+      const second = readIdentity(TEST_KEY)?.savedAt;
+
+      expect(second).toBeDefined();
+      expect(second).toBeGreaterThan(first ?? 0);
+    });
+
+    it('is a no-op when localStorage.setItem throws', () => {
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new Error('QuotaExceededError');
+      };
+
+      try {
+        expect(() => writeIdentity(TEST_KEY, { identity: buildIdentity() })).not.toThrow();
+      } finally {
+        Storage.prototype.setItem = original;
+      }
+    });
+  });
+
+  describe('clearIdentity', () => {
+    it('removes a previously-written entry', () => {
+      writeIdentity(TEST_KEY, { identity: buildIdentity() });
+      expect(readIdentity(TEST_KEY)).not.toBeNull();
+
+      clearIdentity(TEST_KEY);
+      expect(readIdentity(TEST_KEY)).toBeNull();
+    });
+
+    it('is a no-op when the entry does not exist', () => {
+      expect(() => clearIdentity('nonexistent-key')).not.toThrow();
+    });
+  });
+});

--- a/apps/web/__tests__/passport-to-stream-seed.test.ts
+++ b/apps/web/__tests__/passport-to-stream-seed.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PassportData } from '../lib/trust/passport-contract';
+import { passportToStreamSeed } from '../lib/hybrid-loader/passportToStreamSeed';
+
+/**
+ * `passportToStreamSeed` is a pure mapping function: `PassportData → IngestStreamState`.
+ * It reads a focused subset of passport fields (identity, standing, readiness) and
+ * never calls the full passport type guard. That means fixtures only need to carry
+ * the fields the mapper actually reads — the `as PassportData` cast is safe because
+ * no other fields are consulted.
+ *
+ * Builder structure mirrors the fields the mapper reads:
+ *   - identity.{displayName,status,specialty,entityType,npi?}
+ *   - entityId, npi?
+ *   - standing.{exclusionStatus,exclusionClear,pecosEnrollmentStatus}
+ *   - readiness.{status,score,level}
+ */
+interface MinimalPassport {
+  entityId: string;
+  npi?: string;
+  identity: {
+    displayName: string;
+    specialty?: string;
+    entityType: string;
+    status: string;
+    npi?: string;
+  };
+  standing: {
+    exclusionClear: boolean;
+    exclusionStatus: PassportData['standing']['exclusionStatus'];
+    pecosEnrollmentStatus: PassportData['standing']['pecosEnrollmentStatus'];
+  };
+  readiness: {
+    status: PassportData['readiness']['status'];
+    score: number;
+    level: string;
+  };
+}
+
+function buildPassport(overrides: Partial<MinimalPassport> = {}): PassportData {
+  const base: MinimalPassport = {
+    entityId: 'entity-42',
+    npi: '1234567890',
+    identity: {
+      displayName: 'Ada Lovelace',
+      specialty: 'Cardiology',
+      entityType: 'PERSON',
+      status: 'ACTIVE',
+      npi: '1234567890',
+    },
+    standing: {
+      exclusionClear: true,
+      exclusionStatus: 'CLEAR',
+      pecosEnrollmentStatus: 'ENROLLED',
+    },
+    readiness: {
+      status: 'READY',
+      score: 92,
+      level: 'L2',
+    },
+  };
+
+  const merged: MinimalPassport = {
+    ...base,
+    ...overrides,
+    identity: { ...base.identity, ...(overrides.identity ?? {}) },
+    standing: { ...base.standing, ...(overrides.standing ?? {}) },
+    readiness: { ...base.readiness, ...(overrides.readiness ?? {}) },
+  };
+
+  // Cast — the mapper only reads the fields above. Other required fields on
+  // PassportData (authority, training, sourceCoverage, trustPosture, …) are
+  // never accessed by `passportToStreamSeed`.
+  return merged as unknown as PassportData;
+}
+
+describe('passportToStreamSeed', () => {
+  it('maps a fully authoritative passport to a done, usable stream state', () => {
+    const seed = passportToStreamSeed(buildPassport());
+
+    expect(seed.phase).toBe('done');
+    expect(seed.isUsable).toBe(true);
+    expect(seed.npi).toBe('1234567890');
+    expect(seed.anchorEntityId).toBe('entity-42');
+    expect(seed.readyAt).toBeDefined();
+
+    expect(seed.identity.entityId).toBe('entity-42');
+    expect(seed.identity.displayName).toBe('Ada Lovelace');
+    expect(seed.identity.specialty).toBe('Cardiology');
+    expect(seed.identity.entityType).toBe('PERSON');
+    expect(seed.identity.status).toBe('ACTIVE');
+    expect(seed.identity.authoritative).toBe(true);
+  });
+
+  it('forwards standing from the passport (exclusion + enrollment)', () => {
+    const seed = passportToStreamSeed(buildPassport());
+
+    expect(seed.standing.exclusionChecked).toBe(true);
+    expect(seed.standing.exclusionClear).toBe(true);
+    expect(seed.standing.exclusionStatus).toBe('CLEAR');
+    expect(seed.standing.enrollmentChecked).toBe(true);
+    expect(seed.standing.enrollmentStatus).toBe('ENROLLED');
+  });
+
+  it('forwards readiness score, level, and status', () => {
+    const seed = passportToStreamSeed(buildPassport());
+
+    expect(seed.readiness.score).toBe(92);
+    expect(seed.readiness.level).toBe('L2');
+    expect(seed.readiness.status).toBe('READY');
+  });
+
+  it('marks identity non-authoritative when status is UNKNOWN', () => {
+    const seed = passportToStreamSeed(
+      buildPassport({ identity: { displayName: 'Ada Lovelace', entityType: 'PERSON', status: 'UNKNOWN' } }),
+    );
+
+    expect(seed.identity.authoritative).toBe(false);
+    expect(seed.isUsable).toBe(false);
+    expect(seed.anchorEntityId).toBeUndefined();
+    expect(seed.readyAt).toBeUndefined();
+  });
+
+  it('marks identity non-authoritative when status is MISSING or PREVIEW', () => {
+    const missing = passportToStreamSeed(
+      buildPassport({ identity: { displayName: 'Ada Lovelace', entityType: 'PERSON', status: 'MISSING' } }),
+    );
+    const preview = passportToStreamSeed(
+      buildPassport({ identity: { displayName: 'Ada Lovelace', entityType: 'PERSON', status: 'PREVIEW' } }),
+    );
+
+    expect(missing.identity.authoritative).toBe(false);
+    expect(missing.isUsable).toBe(false);
+    expect(preview.identity.authoritative).toBe(false);
+    expect(preview.isUsable).toBe(false);
+  });
+
+  it('marks identity non-authoritative when displayName is empty', () => {
+    const seed = passportToStreamSeed(
+      buildPassport({ identity: { displayName: '', entityType: 'PERSON', status: 'ACTIVE' } }),
+    );
+
+    expect(seed.identity.authoritative).toBe(false);
+    expect(seed.isUsable).toBe(false);
+    expect(seed.sources.nppes).toBe('pending');
+  });
+
+  it('maps standing.exclusionStatus UNCHECKED to sources.oig = pending', () => {
+    const seed = passportToStreamSeed(
+      buildPassport({
+        standing: {
+          exclusionClear: false,
+          exclusionStatus: 'UNCHECKED',
+          pecosEnrollmentStatus: 'ENROLLED',
+        },
+      }),
+    );
+
+    expect(seed.standing.exclusionChecked).toBe(false);
+    expect(seed.sources.oig).toBe('pending');
+    // Identity is still authoritative, so the seed remains usable.
+    expect(seed.isUsable).toBe(true);
+  });
+
+  it('maps pecosEnrollmentStatus UNCHECKED / UNKNOWN to enrollmentChecked: false and sources.pecos = pending', () => {
+    const unchecked = passportToStreamSeed(
+      buildPassport({
+        standing: {
+          exclusionClear: true,
+          exclusionStatus: 'CLEAR',
+          pecosEnrollmentStatus: 'UNCHECKED',
+        },
+      }),
+    );
+    const unknown = passportToStreamSeed(
+      buildPassport({
+        standing: {
+          exclusionClear: true,
+          exclusionStatus: 'CLEAR',
+          pecosEnrollmentStatus: 'UNKNOWN',
+        },
+      }),
+    );
+
+    expect(unchecked.standing.enrollmentChecked).toBe(false);
+    expect(unchecked.standing.enrollmentStatus).toBeUndefined();
+    expect(unchecked.sources.pecos).toBe('pending');
+
+    expect(unknown.standing.enrollmentChecked).toBe(false);
+    expect(unknown.standing.enrollmentStatus).toBeUndefined();
+    expect(unknown.sources.pecos).toBe('pending');
+  });
+
+  it('falls back to identity.npi when the top-level npi is absent', () => {
+    const seed = passportToStreamSeed(
+      buildPassport({
+        npi: undefined,
+        identity: {
+          displayName: 'Ada Lovelace',
+          entityType: 'PERSON',
+          status: 'ACTIVE',
+          npi: '9876543210',
+        },
+      }),
+    );
+
+    expect(seed.npi).toBe('9876543210');
+    // Identity is still authoritative even when only identity.npi is set.
+    expect(seed.isUsable).toBe(true);
+    expect(seed.anchorEntityId).toBe('entity-42');
+  });
+
+  it('returns seed.npi undefined when neither npi is provided — still usable via entityId', () => {
+    const seed = passportToStreamSeed(
+      buildPassport({
+        npi: undefined,
+        // Explicitly clear identity.npi too — the builder's base identity
+        // carries an NPI, so the override must blank both.
+        identity: {
+          displayName: 'Ada Lovelace',
+          entityType: 'PERSON',
+          status: 'ACTIVE',
+          npi: undefined,
+        },
+      }),
+    );
+
+    expect(seed.npi).toBeUndefined();
+    expect(seed.isUsable).toBe(true);
+    expect(seed.anchorEntityId).toBe('entity-42');
+  });
+
+  it('is pure — same input produces the same mapped fields (readyAt aside)', () => {
+    const passport = buildPassport();
+    const a = passportToStreamSeed(passport);
+    const b = passportToStreamSeed(passport);
+
+    // Every mapped field except readyAt (which is Date.now()-based) must be
+    // identical across invocations. Compare by JSON to avoid strict identity
+    // failures on nested object references.
+    const strip = (seed: ReturnType<typeof passportToStreamSeed>) => {
+      const { readyAt: _readyAt, ...rest } = seed;
+      return JSON.stringify(rest);
+    };
+
+    expect(strip(a)).toBe(strip(b));
+  });
+});

--- a/apps/web/__tests__/use-hybrid-provider-data.test.tsx
+++ b/apps/web/__tests__/use-hybrid-provider-data.test.tsx
@@ -1,0 +1,365 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useHybridProviderData } from '../hooks/useHybridProviderData';
+import {
+  clearIdentity,
+  readIdentity,
+  writeIdentity,
+} from '../lib/hybrid-loader/identityCache';
+import {
+  createInitialIngestStreamState,
+  type IngestStreamState,
+} from '../hooks/ingestStreamState';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NPI = '1234567890';
+
+// ── Mock EventSource ─────────────────────────────────────────────────────────
+// Same shape as use-ingest-stream.test.tsx — progressive hydration is owned by
+// useIngestStream under the hood, and this wrapper delegates to it.
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  readonly listeners = new Map<string, Set<(event: MessageEvent<string>) => void>>();
+  closed = false;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event?: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    const handlers = this.listeners.get(type) ?? new Set<(event: MessageEvent<string>) => void>();
+    handlers.add(listener as unknown as (event: MessageEvent<string>) => void);
+    this.listeners.set(type, handlers);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(type: string, payload: unknown): void {
+    const event = { data: JSON.stringify(payload) } as MessageEvent<string>;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+interface HarnessProps {
+  dataKey: string | null | undefined;
+  ssrSeed?: IngestStreamState | null;
+  autoStart?: boolean;
+}
+
+function Harness(props: HarnessProps) {
+  const { state } = useHybridProviderData({
+    key: props.dataKey,
+    ssrSeed: props.ssrSeed,
+    autoStart: props.autoStart,
+  });
+
+  return (
+    <pre data-testid="state">
+      {JSON.stringify({
+        phase: state.phase,
+        isUsable: state.isUsable,
+        displayName: state.identity.displayName ?? null,
+        anchorEntityId: state.anchorEntityId ?? null,
+      })}
+    </pre>
+  );
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function renderHarness(props: HarnessProps) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<Harness {...props} />);
+  });
+  await flush();
+
+  return {
+    container,
+    async rerender(next: HarnessProps) {
+      await act(async () => {
+        root.render(<Harness {...next} />);
+      });
+      await flush();
+    },
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function readState(container: HTMLElement): Record<string, unknown> {
+  const node = container.querySelector<HTMLElement>('[data-testid="state"]');
+  if (!node?.textContent) {
+    throw new Error('Missing state node');
+  }
+  return JSON.parse(node.textContent) as Record<string, unknown>;
+}
+
+function buildSeed(overrides: Partial<IngestStreamState> = {}): IngestStreamState {
+  const base = createInitialIngestStreamState();
+  return {
+    ...base,
+    phase: 'done',
+    isUsable: true,
+    anchorEntityId: 'entity-seed',
+    readyAt: '2026-04-10T12:00:00.000Z',
+    identity: {
+      entityId: 'entity-seed',
+      displayName: 'SSR Seed Name',
+      specialty: 'Cardiology',
+      entityType: 'PERSON',
+      status: 'ACTIVE',
+      authoritative: true,
+    },
+    ...overrides,
+  };
+}
+
+describe('useHybridProviderData', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+    // Default: no-op fetch so auto-start effects don't explode on accidental runs.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ runId: 'run-test' }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+    vi.stubGlobal('EventSource', MockEventSource);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  describe('initial state precedence (SSR > cache > empty)', () => {
+    it('uses the SSR seed on first paint even when cache is also populated', async () => {
+      // Cache says "Old Cached Name" — SSR says "SSR Seed Name".
+      writeIdentity(NPI, {
+        identity: {
+          entityId: 'entity-cached',
+          displayName: 'Old Cached Name',
+          entityType: 'PERSON',
+          status: 'ACTIVE',
+          authoritative: true,
+        },
+      });
+
+      const view = await renderHarness({
+        dataKey: NPI,
+        ssrSeed: buildSeed(),
+        autoStart: false,
+      });
+
+      try {
+        expect(readState(view.container)).toMatchObject({
+          displayName: 'SSR Seed Name',
+          isUsable: true,
+        });
+      } finally {
+        await view.unmount();
+      }
+    });
+
+    it('uses the cache on first paint when no SSR seed is provided', async () => {
+      writeIdentity(NPI, {
+        identity: {
+          entityId: 'entity-cached',
+          displayName: 'Cached Name',
+          entityType: 'PERSON',
+          status: 'ACTIVE',
+          authoritative: true,
+        },
+      });
+
+      const view = await renderHarness({ dataKey: NPI, autoStart: false });
+
+      try {
+        expect(readState(view.container)).toMatchObject({
+          displayName: 'Cached Name',
+          isUsable: true,
+          anchorEntityId: 'entity-cached',
+        });
+      } finally {
+        await view.unmount();
+      }
+    });
+
+    it('falls through to the default empty state when no SSR seed and no cache', async () => {
+      const view = await renderHarness({ dataKey: NPI, autoStart: false });
+
+      try {
+        expect(readState(view.container)).toMatchObject({
+          isUsable: false,
+          displayName: null,
+        });
+      } finally {
+        await view.unmount();
+      }
+    });
+
+    it('renders the empty default when the key is null (no cache lookup)', async () => {
+      const view = await renderHarness({ dataKey: null, autoStart: false });
+
+      try {
+        expect(readState(view.container)).toMatchObject({
+          isUsable: false,
+          displayName: null,
+        });
+      } finally {
+        await view.unmount();
+      }
+    });
+  });
+
+  describe('auto-start behaviour', () => {
+    it('auto-starts an ingest run for a 10-digit NPI key', async () => {
+      const view = await renderHarness({ dataKey: NPI });
+      try {
+        // The ingest kicks off fetch + EventSource. One EventSource instance
+        // is proof that startIngest ran.
+        expect(MockEventSource.instances).toHaveLength(1);
+      } finally {
+        await view.unmount();
+      }
+    });
+
+    it('does not auto-start when the key is not NPI-shaped', async () => {
+      const view = await renderHarness({ dataKey: 'entity-abc', autoStart: true });
+      try {
+        expect(MockEventSource.instances).toHaveLength(0);
+      } finally {
+        await view.unmount();
+      }
+    });
+
+    it('does not auto-start when autoStart is false', async () => {
+      const view = await renderHarness({ dataKey: NPI, autoStart: false });
+      try {
+        expect(MockEventSource.instances).toHaveLength(0);
+      } finally {
+        await view.unmount();
+      }
+    });
+  });
+
+  describe('write-through cache', () => {
+    it('persists authoritative state to cache when SSE becomes usable', async () => {
+      // Start with no cache, NPI key, autoStart true so SSE fires.
+      expect(readIdentity(NPI)).toBeNull();
+
+      const view = await renderHarness({ dataKey: NPI });
+
+      try {
+        const stream = MockEventSource.instances[0];
+        expect(stream).toBeDefined();
+
+        // Drive the stream all the way to passport_ready so state.isUsable flips.
+        await act(async () => {
+          stream!.emit('source_start', {
+            type: 'source_start',
+            sourceId: 'nppes',
+            timestamp: '2026-04-10T12:00:00.000Z',
+            payload: { sourceId: 'nppes' },
+          });
+        });
+        await act(async () => {
+          stream!.emit('source_complete', {
+            type: 'source_complete',
+            sourceId: 'nppes',
+            timestamp: '2026-04-10T12:00:01.000Z',
+            payload: {
+              sourceId: 'nppes',
+              resultStatus: 'SUCCESS',
+              entityId: 'entity-live',
+              displayName: 'Live Ada Lovelace',
+              identityStatus: 'ACTIVE',
+            },
+          });
+        });
+        await act(async () => {
+          stream!.emit('passport_ready', {
+            type: 'passport_ready',
+            timestamp: '2026-04-10T12:00:02.000Z',
+            payload: {
+              entityId: 'entity-live',
+              displayName: 'Live Ada Lovelace',
+              identityStatus: 'ACTIVE',
+              readinessScore: 91,
+              readinessLevel: 'L3',
+              readinessStatus: 'READY',
+              exclusionChecked: true,
+              exclusionClear: true,
+              exclusionStatus: 'CLEAR',
+              enrollmentChecked: true,
+              enrollmentStatus: 'ENROLLED',
+            },
+          });
+        });
+        await flush();
+
+        // UI reflects the live payload.
+        expect(readState(view.container)).toMatchObject({
+          isUsable: true,
+          displayName: 'Live Ada Lovelace',
+          anchorEntityId: 'entity-live',
+        });
+
+        // Cache has been written through with the same identity.
+        const cached = readIdentity(NPI);
+        expect(cached).not.toBeNull();
+        expect(cached?.identity.displayName).toBe('Live Ada Lovelace');
+        expect(cached?.identity.authoritative).toBe(true);
+        expect(cached?.standing?.exclusionStatus).toBe('CLEAR');
+        expect(cached?.readiness?.level).toBe('L3');
+      } finally {
+        clearIdentity(NPI);
+        await view.unmount();
+      }
+    });
+
+    it('does not write to cache when state is not yet usable', async () => {
+      // No seed, no cache, and autoStart disabled — state stays at default,
+      // isUsable stays false, so no write-through fires.
+      const view = await renderHarness({ dataKey: NPI, autoStart: false });
+
+      try {
+        expect(readIdentity(NPI)).toBeNull();
+      } finally {
+        await view.unmount();
+      }
+    });
+  });
+});

--- a/apps/web/app/review/[entityId]/ReviewPageClient.tsx
+++ b/apps/web/app/review/[entityId]/ReviewPageClient.tsx
@@ -7,6 +7,7 @@ import { getBackendBase } from '@/lib/api';
 import type {
   EmployerAcceptanceHistoryResponse,
 } from '@/lib/employer-review-actions';
+import { passportToStreamSeed } from '@/lib/hybrid-loader/passportToStreamSeed';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { PUBLIC_WEDGE_ROUTE_TARGETS } from '@/lib/trust/public-wedge-parity';
 
@@ -172,6 +173,12 @@ export default async function ReviewPageClient({
     }),
   }).catch(() => null);
 
+  // Hybrid-loader SSR→client bridge: compute the initial IngestStreamState on
+  // the server from the authoritative PassportData. The client wrapper
+  // (useHybridProviderData) uses this as its first-paint state and writes it
+  // through to localStorage so subsequent visits render instantly.
+  const hybridSeed = passportToStreamSeed(passport);
+
   return (
     <ReviewClient
       passport={passport}
@@ -179,6 +186,7 @@ export default async function ReviewPageClient({
       bundleId={bundleId}
       sharedBy={from}
       acceptanceHistory={acceptanceHistory}
+      hybridSeed={hybridSeed}
     />
   );
 }

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -39,6 +39,8 @@ import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { TrustLabel, type TrustStatus } from '@/components/ui/trust-label';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { readinessLevelLabel } from '@/lib/trust/status-language';
+import { useHybridProviderData } from '@/hooks/useHybridProviderData';
+import type { IngestStreamState } from '@/hooks/ingestStreamState';
 import { EmployerAdvisoryPanel } from '@/components/advisory/AdvisoryPanel';
 import { UX_EVENTS } from '@/lib/analytics/ux-events';
 import {
@@ -540,6 +542,12 @@ interface ReviewClientLoadedProps {
   bundleId?:  string;
   sharedBy?:  string;
   acceptanceHistory?: EmployerAcceptanceHistoryResponse;
+  /**
+   * Hybrid-loader seed produced by ReviewPageClient via `passportToStreamSeed`.
+   * When provided, the client hook uses it as the initial streaming state on
+   * first paint and writes it through to localStorage.
+   */
+  hybridSeed?: IngestStreamState | null;
 }
 
 interface ReviewClientLoadingProps {
@@ -884,7 +892,20 @@ function ReviewClientLoaded({
   bundleId,
   sharedBy,
   acceptanceHistory,
+  hybridSeed,
 }: ReviewClientLoadedProps) {
+  // Hybrid loader wiring — populates the synchronous identity cache with the
+  // SSR-computed seed so subsequent visits render instantly. /review is not a
+  // streaming surface (no public ingest run for employer entity keys), so
+  // autoStart is false — this hook call exists solely for the write-through
+  // side effect. Render continues to flow from the authoritative `passport`
+  // prop below; we intentionally do not read streaming state here.
+  useHybridProviderData({
+    key: passport.npi ?? passport.identity.npi ?? passport.entityId,
+    ssrSeed: hybridSeed ?? null,
+    autoStart: false,
+  });
+
   const [actionState, setActionState] = useState<ActionState>({ phase: 'idle' });
   const [persistedActionState, setPersistedActionState] = useState<EmployerReviewActionState | null>(null);
   const [confirmStartState, setConfirmStartState] = useState<

--- a/apps/web/hooks/useHybridProviderData.ts
+++ b/apps/web/hooks/useHybridProviderData.ts
@@ -1,0 +1,164 @@
+'use client';
+
+/**
+ * useHybridProviderData — Instant-render provider identity with progressive SSE upgrade.
+ *
+ * Composes three primitives into a single consumer-facing hook:
+ *
+ *   1. An SSR seed (from PassportData passed by a server component), if available
+ *   2. A synchronous localStorage cache (identityCache.ts), read at lazy-init time
+ *   3. The canonical streaming hook (useIngestStream), which owns the SSE loop
+ *
+ * Precedence on first paint:
+ *   SSR seed  >  cache  >  empty initial state
+ *
+ * Once the hook mounts, useIngestStream owns the state transitions via its
+ * reducer (applyIngestEvent). We subscribe as a side-effect and write through
+ * to cache whenever `state.isUsable === true`.
+ *
+ * The underlying useIngestStream is NEVER modified — /passport can continue
+ * to call it directly without adopting this wrapper.
+ *
+ * See: docs/superpowers/specs/2026-04-10-hybrid-loader-design.md
+ */
+
+import { useEffect, useRef } from 'react';
+
+import {
+  readIdentity,
+  writeIdentity,
+  type CachedIdentity,
+} from '@/lib/hybrid-loader/identityCache';
+import { useIngestStream } from '@/hooks/useIngestStream';
+import {
+  createInitialIngestStreamState,
+  type IngestStreamState,
+} from '@/hooks/ingestStreamState';
+
+const NPI_PATTERN = /^\d{10}$/;
+
+export interface HybridProviderDataInput {
+  /** Canonical cache key. NPI for public surfaces, entityId for authenticated ones. */
+  key: string | null | undefined;
+  /** Server-rendered seed (e.g. from ReviewPageClient). Wins over cache on first paint. */
+  ssrSeed?: IngestStreamState | null;
+  /**
+   * Whether to automatically start an SSE ingest on mount.
+   * Only fires when `key` matches the 10-digit NPI shape. Defaults to `true`.
+   */
+  autoStart?: boolean;
+}
+
+/**
+ * Reconstitute an IngestStreamState from a cached identity entry. Marks the
+ * state as usable (`isUsable: true`) iff the cached identity is authoritative,
+ * matching the invariant that the cache only persists authoritative data.
+ */
+function hydrateFromCache(cached: CachedIdentity): IngestStreamState {
+  const base = createInitialIngestStreamState();
+
+  return {
+    ...base,
+    phase: 'done',
+    npi: cached.key.length === 10 && NPI_PATTERN.test(cached.key) ? cached.key : undefined,
+    identity: cached.identity,
+    standing: cached.standing ?? base.standing,
+    readiness: cached.readiness ?? base.readiness,
+    anchorEntityId: cached.identity.authoritative ? cached.identity.entityId : undefined,
+    isUsable: cached.identity.authoritative,
+    readyAt: cached.identity.authoritative
+      ? new Date(cached.savedAt).toISOString()
+      : undefined,
+    sources: {
+      nppes: cached.identity.authoritative ? 'done' : 'pending',
+      oig: cached.standing?.exclusionChecked ? 'done' : 'pending',
+      pecos: cached.standing?.enrollmentChecked ? 'done' : 'pending',
+    },
+  };
+}
+
+/**
+ * Compute the initial state once, synchronously.
+ *
+ * Called from a `useRef` lazy init so it runs exactly once per mount.
+ * Returning `undefined` means "let useIngestStream use its own default".
+ */
+function computeInitialState(
+  key: string | null | undefined,
+  ssrSeed: IngestStreamState | null | undefined,
+): IngestStreamState | undefined {
+  if (ssrSeed) {
+    return ssrSeed;
+  }
+
+  if (!key) {
+    return undefined;
+  }
+
+  const cached = readIdentity(key);
+  if (!cached) {
+    return undefined;
+  }
+
+  return hydrateFromCache(cached);
+}
+
+/**
+ * Public API — a thin wrapper around `useIngestStream` that adds a cache
+ * layer and an SSR seed bridge. Returns the same shape as `useIngestStream`
+ * (state + imperative functions), so consumers can swap between them freely.
+ */
+export function useHybridProviderData({
+  key,
+  ssrSeed,
+  autoStart = true,
+}: HybridProviderDataInput) {
+  // Lazy-compute the initial state exactly once. A ref (not useState) because
+  // useIngestStream owns the authoritative state; we only feed it a seed.
+  const seedRef = useRef<IngestStreamState | undefined | null>(null);
+  if (seedRef.current === null) {
+    seedRef.current = computeInitialState(key, ssrSeed);
+  }
+
+  const hook = useIngestStream(seedRef.current);
+
+  // Write-through cache — persist only authoritative state. The dependency
+  // intentionally targets the fields we actually cache, so unrelated state
+  // churn (events log, disconnected flag) doesn't re-trigger the effect.
+  const { state } = hook;
+  useEffect(() => {
+    if (!key) {
+      return;
+    }
+    if (!state.isUsable) {
+      return;
+    }
+    writeIdentity(key, {
+      identity: state.identity,
+      standing: state.standing,
+      readiness: state.readiness,
+    });
+  }, [
+    key,
+    state.isUsable,
+    state.identity,
+    state.standing,
+    state.readiness,
+  ]);
+
+  // Auto-start the SSE ingest run when we have an NPI-shaped key. EntityId-
+  // keyed surfaces don't trigger the public ingest run; they rely on the seed
+  // or cache and a server-initiated refresh.
+  const startIngest = hook.startIngest;
+  useEffect(() => {
+    if (!autoStart) {
+      return;
+    }
+    if (!key || !NPI_PATTERN.test(key)) {
+      return;
+    }
+    void startIngest(key);
+  }, [autoStart, key, startIngest]);
+
+  return hook;
+}

--- a/apps/web/lib/hybrid-loader/identityCache.ts
+++ b/apps/web/lib/hybrid-loader/identityCache.ts
@@ -1,0 +1,143 @@
+/**
+ * identityCache.ts — Synchronous localStorage cache for provider identity.
+ *
+ * Part of the Hybrid Loader (see docs/superpowers/specs/2026-04-10-hybrid-loader-design.md).
+ * This module provides a zero-dependency, sync-read cache so that surfaces
+ * consuming provider identity can render instantly on first paint — even
+ * on a hard reload — and then progressively upgrade via SSE.
+ *
+ * Design rules:
+ *   - Sync read (no Promise) so `useState` lazy init can consume it without
+ *     an intermediate render.
+ *   - 24h TTL. Expired entries read as a cache miss (null), not as "stale".
+ *     Trust state "stale" has its own meaning (decision-grade but aging).
+ *   - Version field `v: 1`. Any breaking change bumps this and silently
+ *     invalidates old entries.
+ *   - SSR-safe: all methods return undefined/null when `window` is missing.
+ *   - Best-effort writes: localStorage can throw (private mode, quota).
+ *     We swallow those errors — the cache is a hint, not an invariant.
+ *
+ * Scope: only caches identity + standing + readiness (the "instant-render"
+ * triple). Credentials, proof panels, and full PassportData blobs are
+ * server-owned and intentionally not cached here.
+ */
+
+import type {
+  StreamIdentity,
+  StreamReadiness,
+  StreamStanding,
+} from '@/hooks/ingestStreamState';
+
+const KEY_PREFIX = 'vcv:identity:v1:';
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface CachedIdentity {
+  /** Schema version. Breaking changes bump this and silently invalidate old entries. */
+  v: 1;
+  /** Epoch ms when the entry was last written. Used for TTL. */
+  savedAt: number;
+  /** Canonical cache key (NPI for public surfaces, entityId for authenticated ones). */
+  key: string;
+  /** Authoritative identity snapshot. */
+  identity: StreamIdentity;
+  /** Standing snapshot (exclusion + enrollment). Optional — may not be known yet. */
+  standing?: StreamStanding;
+  /** Readiness snapshot. Optional — may not be known yet. */
+  readiness?: StreamReadiness;
+}
+
+function storageKey(key: string): string {
+  return `${KEY_PREFIX}${key}`;
+}
+
+/**
+ * Read a cached identity entry synchronously.
+ *
+ * Returns `null` on any of:
+ *   - SSR (no window)
+ *   - Missing entry
+ *   - Malformed JSON
+ *   - Version mismatch
+ *   - TTL expired
+ *
+ * The caller cannot distinguish between these cases — all of them mean
+ * "no usable cache, render empty or wait for SSE".
+ */
+export function readIdentity(key: string): CachedIdentity | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey(key));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as CachedIdentity;
+    if (!parsed || parsed.v !== 1) {
+      return null;
+    }
+
+    if (typeof parsed.savedAt !== 'number' || Date.now() - parsed.savedAt > TTL_MS) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export interface WriteIdentityInput {
+  identity: StreamIdentity;
+  standing?: StreamStanding;
+  readiness?: StreamReadiness;
+}
+
+/**
+ * Write an identity entry to cache. Merges with any existing entry so that
+ * partial updates (e.g. identity-only) don't clobber previously-cached
+ * standing or readiness.
+ *
+ * This is a best-effort write. localStorage.setItem can throw in private
+ * browsing mode or when the quota is exceeded; we swallow those errors
+ * silently since the cache is a hint, not an invariant.
+ */
+export function writeIdentity(key: string, input: WriteIdentityInput): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const prev = readIdentity(key);
+    const next: CachedIdentity = {
+      v: 1,
+      savedAt: Date.now(),
+      key,
+      identity: input.identity ?? prev?.identity ?? { authoritative: false },
+      standing: input.standing ?? prev?.standing,
+      readiness: input.readiness ?? prev?.readiness,
+    };
+
+    window.localStorage.setItem(storageKey(key), JSON.stringify(next));
+  } catch {
+    // quota exceeded, private mode, blocked by extension — best-effort
+  }
+}
+
+/**
+ * Remove a cache entry. Used by explicit invalidation flows (e.g. admin
+ * re-runs ingest, or a surface wants to force-refresh).
+ */
+export function clearIdentity(key: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(storageKey(key));
+  } catch {
+    // best-effort
+  }
+}

--- a/apps/web/lib/hybrid-loader/passportToStreamSeed.ts
+++ b/apps/web/lib/hybrid-loader/passportToStreamSeed.ts
@@ -1,0 +1,102 @@
+/**
+ * passportToStreamSeed.ts — SSR → client hydration bridge.
+ *
+ * Part of the Hybrid Loader (see docs/superpowers/specs/2026-04-10-hybrid-loader-design.md).
+ *
+ * Pure function that maps a server-fetched PassportData into an
+ * IngestStreamState so the client hook (useIngestStream, via
+ * useHybridProviderData) can use it as its initial state.
+ *
+ * Call sites:
+ *   - apps/web/app/review/[entityId]/ReviewPageClient.tsx (server component):
+ *       passes `passportToStreamSeed(passport)` to <ReviewClient hybridSeed=.../>.
+ *
+ * Why pure: it's called on the server, serialized across the RSC boundary,
+ * and re-read on the client. Any React or storage access would break that.
+ */
+
+import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  createInitialIngestStreamState,
+  type IngestStreamState,
+} from '@/hooks/ingestStreamState';
+
+const UNKNOWN_IDENTITY_STATUSES = new Set(['UNKNOWN', 'MISSING', 'PREVIEW']);
+
+/**
+ * Convert a PassportData snapshot into an IngestStreamState seed.
+ *
+ * Preconditions:
+ *   - `passport` is a full, server-validated payload.
+ *
+ * Postconditions:
+ *   - Returns an IngestStreamState with `phase: 'done'` and `isUsable: true`
+ *     (iff identity is authoritative).
+ *   - Never throws. Falls back to an empty initial state if the passport
+ *     lacks the minimum identity surface.
+ */
+export function passportToStreamSeed(passport: PassportData): IngestStreamState {
+  const base = createInitialIngestStreamState();
+
+  // Defensive reads: ReviewPageClient runs this immediately after an external
+  // backend fetch, and contract tests (plus the real NPPES proxy path) can
+  // return passport shells that lack identity/standing/readiness entirely. The
+  // function's documented contract is "never throw; fall back to an empty seed"
+  // so we treat any missing field as its most conservative default.
+  const identity = (passport?.identity ?? {}) as Partial<PassportData['identity']>;
+  const standing = (passport?.standing ?? {}) as Partial<PassportData['standing']>;
+  const readiness = (passport?.readiness ?? {}) as Partial<PassportData['readiness']>;
+
+  const displayName = typeof identity.displayName === 'string' ? identity.displayName : '';
+  const statusString = typeof identity.status === 'string' ? identity.status : '';
+
+  const identityAuthoritative =
+    Boolean(displayName)
+    && !UNKNOWN_IDENTITY_STATUSES.has(statusString.toUpperCase());
+
+  const exclusionStatus = standing.exclusionStatus;
+  const exclusionChecked =
+    typeof exclusionStatus === 'string' && exclusionStatus !== 'UNCHECKED';
+
+  const pecosEnrollmentStatus = standing.pecosEnrollmentStatus;
+  const enrollmentChecked =
+    typeof pecosEnrollmentStatus === 'string'
+    && pecosEnrollmentStatus !== 'UNCHECKED'
+    && pecosEnrollmentStatus !== 'UNKNOWN';
+
+  const readyAt = new Date().toISOString();
+
+  return {
+    ...base,
+    phase: 'done',
+    npi: passport?.npi ?? identity.npi,
+    anchorEntityId: identityAuthoritative ? passport?.entityId : undefined,
+    isUsable: identityAuthoritative,
+    readyAt: identityAuthoritative ? readyAt : undefined,
+    identity: {
+      entityId: passport?.entityId,
+      displayName: identity.displayName,
+      specialty: identity.specialty,
+      entityType: identity.entityType,
+      status: identity.status,
+      authoritative: identityAuthoritative,
+    },
+    standing: {
+      exclusionChecked,
+      exclusionClear: standing.exclusionClear,
+      exclusionStatus: standing.exclusionStatus,
+      enrollmentChecked,
+      enrollmentStatus: enrollmentChecked ? pecosEnrollmentStatus : undefined,
+    },
+    readiness: {
+      score: readiness.score,
+      level: readiness.level,
+      status: readiness.status,
+    },
+    sources: {
+      nppes: displayName ? 'done' : 'pending',
+      oig: exclusionChecked ? 'done' : 'pending',
+      pecos: enrollmentChecked ? 'done' : 'pending',
+    },
+  };
+}

--- a/apps/web/lib/trust/status-language.ts
+++ b/apps/web/lib/trust/status-language.ts
@@ -82,10 +82,16 @@ const TRUST_STATUS_META: Record<TrustUiStatus, { label: string; badgeClassName: 
 };
 
 const SAFE_DISPLAY_LABELS: Record<TrustUiStatus, readonly string[]> = {
-  verified: ['Source-backed'],
+  // Hybrid loader copy: `Updated just now` is the freshness-within-10s copy
+  // emitted by surfaces that just received an authoritative SSE event.
+  // `Source-backed` remains the steady-state label once that window closes.
+  verified: ['Source-backed', 'Updated just now'],
   clear: ['Checked', 'No sanctions found'],
   checked: ['Checked', 'Source-backed'],
-  pending: ['Pending'],
+  // `Checking…` is the in-flight copy used while an ingest source is running
+  // (source_start received, source_complete not yet). `Pending` remains the
+  // steady-state "no run in flight" copy.
+  pending: ['Pending', 'Checking…'],
   stale: ['Stale'],
   unavailable: ['Unavailable'],
   access_required: ['Access required'],

--- a/docs/superpowers/specs/2026-04-10-hybrid-loader-design.md
+++ b/docs/superpowers/specs/2026-04-10-hybrid-loader-design.md
@@ -1,0 +1,501 @@
+# Hybrid Loader Design — Instant Provider Identity, Then Streaming Upgrade
+
+**Status:** Design approved, ready for implementation
+**Branch:** `feat/hybrid-loader`
+**Owner:** Chris Toler
+**Date:** 2026-04-10
+
+---
+
+## Problem
+
+Today, provider identity only renders instantly on `/passport` (via `useIngestStream`
++ `hydrateFromHomepagePreview`), and only when the user arrives from the homepage
+in the same React tree. A fresh visit, a browser reload, or navigating to
+`/review/[entityId]` shows a cold load — blank placeholders until the SSR fetch
+or SSE stream produces data.
+
+The goal: **any surface that shows provider identity renders instantly on
+first paint, every time, then progressively upgrades via SSE.** No blanks. No
+flicker. Works on reload. Degrades gracefully when offline.
+
+---
+
+## Non-Goals
+
+- **Do not migrate `/passport` off `useIngestStream`.** `useIngestStream` is the
+  canonical streaming hook and remains the source of truth.
+- **Do not introduce a new SSE protocol.** Reuse `apps/web/app/api/ingest/stream/[runId]/route.ts`.
+- **Do not cache anything beyond provider identity + standing + readiness snapshot.**
+  No credential lists, no full `PassportData` blobs — those are server-owned.
+- **No new trust status labels.** Reuse `pending` / `verified` / `stale` from
+  `apps/web/lib/trust/status-language.ts`.
+
+---
+
+## Constraints (user-locked)
+
+1. **Storage:** `localStorage` + 24h TTL. Synchronous read so first paint has no
+   async race.
+2. **Source of truth:** `useIngestStream` stays untouched. Its file
+   (`apps/web/hooks/useIngestStream.ts`) is not modified.
+3. **Reusable wrapper:** A new `useHybridProviderData` hook composes cache +
+   `useIngestStream` + SSR seed. `/passport` may opt in to the cache via its
+   existing `initialState` parameter without adopting the wrapper.
+4. **Must work for `/review` (a server component)** — the SSR payload becomes
+   the client hook's initial state via a mapping function.
+5. **Never block UI** — partial data is always rendered. Offline uses cache only.
+
+---
+
+## Architecture (Option A — side-effect subscriber)
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│ useHybridProviderData({ key, ssrSeed? })                              │
+│                                                                       │
+│   1. initialState = ssrSeed ?? readIdentity(key) ?? createInitial()  │
+│   2. const { state, startIngest } = useIngestStream(initialState)     │
+│   3. useEffect(() => { if (state.isUsable) writeIdentity(key, state) }│
+│                                                          , [state])   │
+│   4. return { state, startIngest, reset }                             │
+└───────────────────────────────────────────────────────────────────────┘
+         ▲                               ▲                      ▲
+         │ ssrSeed (server)              │ readIdentity (sync)  │ state updates
+         │                               │                      │
+┌────────┴────────────┐       ┌──────────┴──────────┐   ┌───────┴──────────┐
+│ passportToStreamSeed│       │ identityCache.ts    │   │ useIngestStream  │
+│ (pure mapper,       │       │ (localStorage, 24h  │   │ (unchanged)      │
+│  PassportData →     │       │  TTL, sync read)    │   │                  │
+│  Partial<IngestStr.>│       └─────────────────────┘   └──────────────────┘
+└─────────────────────┘
+```
+
+### Four new files
+
+| File | LOC | Purpose |
+|---|---|---|
+| `apps/web/lib/hybrid-loader/identityCache.ts` | ~80 | Sync localStorage get/set/prune with 24h TTL |
+| `apps/web/lib/hybrid-loader/passportToStreamSeed.ts` | ~60 | Pure `PassportData → Partial<IngestStreamState>` mapper for SSR bridge |
+| `apps/web/hooks/useHybridProviderData.ts` | ~60 | Thin wrapper composing cache + SSE + seed |
+| `apps/web/__tests__/hybrid-loader.test.*` | ~300 total | Unit tests for all three (+ integration) |
+
+### Three modified files
+
+1. `apps/web/components/review/ReviewClient.tsx` — the review client currently
+   receives `passport: PassportData` as a prop from the server component. Change
+   the component to additionally call `useHybridProviderData({ key, ssrSeed })`
+   where the seed is derived from `passport`. The existing `passport` prop stays
+   as the authoritative display source for **static** review data (authority
+   credentials, proof sections — all server-owned). The hook adds a **live
+   overlay** for identity freshness: "Checking…" → "Updated just now" badges.
+2. `apps/web/app/review/[entityId]/ReviewPageClient.tsx` — the server component.
+   Compute `passportToStreamSeed(passport)` and pass it as a new `hybridSeed`
+   prop to `<ReviewClient>`.
+3. `apps/web/lib/trust/status-language.ts` — add `"Checking…"` under `pending`
+   and `"Updated just now"` under `verified` in `SAFE_DISPLAY_LABELS`. Two
+   additions, no other changes.
+
+**Zero changes** to `useIngestStream.ts` or `ingestStreamState.ts`.
+
+---
+
+## The three primitives
+
+### 1. `identityCache.ts`
+
+```ts
+// apps/web/lib/hybrid-loader/identityCache.ts
+
+const KEY_PREFIX = 'vcv:identity:v1:';
+const TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+export interface CachedIdentity {
+  v: 1;
+  savedAt: number;           // epoch ms
+  key: string;               // npi or entityId
+  identity: StreamIdentity;  // from ingestStreamState
+  standing?: StreamStanding;
+  readiness?: StreamReadiness;
+}
+
+export function readIdentity(key: string): CachedIdentity | null {
+  if (typeof window === 'undefined') return null;      // SSR safety
+  try {
+    const raw = window.localStorage.getItem(KEY_PREFIX + key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedIdentity;
+    if (parsed.v !== 1) return null;
+    if (Date.now() - parsed.savedAt > TTL_MS) return null;  // treat as cache miss, not "stale"
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeIdentity(key: string, partial: Partial<CachedIdentity>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const prev = readIdentity(key);
+    const next: CachedIdentity = {
+      v: 1,
+      savedAt: Date.now(),
+      key,
+      identity: partial.identity ?? prev?.identity ?? { authoritative: false },
+      standing: partial.standing ?? prev?.standing,
+      readiness: partial.readiness ?? prev?.readiness,
+    };
+    window.localStorage.setItem(KEY_PREFIX + key, JSON.stringify(next));
+  } catch {
+    // quota exceeded, private mode, etc. — cache is best-effort
+  }
+}
+
+export function clearIdentity(key: string): void {
+  if (typeof window === 'undefined') return;
+  try { window.localStorage.removeItem(KEY_PREFIX + key); } catch {}
+}
+```
+
+**Design notes:**
+- **Sync read.** No `await`, no Promise. Called during `useState` lazy init, so
+  first paint has the cached value without an intermediate render.
+- **TTL is "cache miss", not "stale."** When the cache entry is too old we
+  return `null` and let SSE populate fresh state. This avoids mis-mapping to
+  the `stale` trust label, which has its own meaning (decision-grade but aging
+  evidence).
+- **Key is the NPI or entityId.** Same key space as `useIngestStream.startIngest(npi)`.
+- **SSR safety.** `typeof window === 'undefined'` check so the module is
+  import-safe from Next.js server components.
+- **Version field `v: 1`.** Any future breaking change to the stored shape
+  bumps this and silently invalidates old entries.
+
+### 2. `passportToStreamSeed.ts` — the SSR bridge
+
+```ts
+// apps/web/lib/hybrid-loader/passportToStreamSeed.ts
+// Pure function. Unit-tested. No React. No storage.
+
+import type { PassportData } from '@/lib/trust/passport-contract';
+import type { IngestStreamState } from '@/hooks/ingestStreamState';
+import { createInitialIngestStreamState } from '@/hooks/ingestStreamState';
+
+/**
+ * Map a server-fetched PassportData into an IngestStreamState that the
+ * client hook can use as its initial state. This is the SSR → client bridge.
+ *
+ * We only populate the fields that PassportData actually knows about at
+ * the moment of the fetch. Fields that PassportData cannot provide
+ * (e.g. raw NPPES taxonomies) stay undefined; SSE will fill them later.
+ */
+export function passportToStreamSeed(passport: PassportData): IngestStreamState {
+  const base = createInitialIngestStreamState();
+
+  return {
+    ...base,
+    phase: 'done',
+    npi: passport.npi,
+    anchorEntityId: passport.entityId,
+    isUsable: true,
+    identity: {
+      entityId: passport.entityId,
+      displayName: passport.identity.displayName,
+      specialty: passport.identity.specialty,
+      entityType: passport.identity.entityType,
+      status: passport.identity.status,
+      authoritative: passport.identity.status?.toUpperCase() !== 'UNKNOWN',
+    },
+    standing: {
+      exclusionChecked: passport.standing.exclusionStatus !== 'UNCHECKED',
+      exclusionClear: passport.standing.exclusionClear,
+      exclusionStatus: passport.standing.exclusionStatus,
+      enrollmentChecked: passport.standing.pecosEnrollmentStatus !== 'UNCHECKED',
+      enrollmentStatus: passport.standing.pecosEnrollmentStatus,
+    },
+    // readiness is filled from passport.readiness if present
+    readiness: {
+      score: passport.readiness?.score,
+      level: passport.readiness?.level,
+      status: passport.readiness?.status,
+    },
+    // sources: mark everything done if the SSR payload has values for them
+    sources: {
+      nppes: passport.identity.displayName ? 'done' : 'pending',
+      oig: passport.standing.exclusionStatus !== 'UNCHECKED' ? 'done' : 'pending',
+      pecos: passport.standing.pecosEnrollmentStatus !== 'UNCHECKED' ? 'done' : 'pending',
+    },
+  };
+}
+```
+
+**Design notes:**
+- **Pure function.** Easy to unit-test with fixture `PassportData`.
+- **Seeds `phase: 'done'`.** Because the server returned a complete snapshot,
+  the initial phase reflects "done from cache/server" — SSE will override it
+  if a new run starts.
+- **Conservative `authoritative` flag.** Uses the same `!== 'UNKNOWN'` rule
+  that `isAuthoritativeIdentity` uses at `ingestStreamState.ts:165-179`.
+- **No readiness normalization** — we pass through whatever `PassportData`
+  has. If the review page didn't fetch readiness, the hook still renders
+  identity, and the UI badge for readiness is `pending`.
+
+### 3. `useHybridProviderData.ts`
+
+```ts
+// apps/web/hooks/useHybridProviderData.ts
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useIngestStream } from '@/hooks/useIngestStream';
+import type { IngestStreamState } from '@/hooks/ingestStreamState';
+import { readIdentity, writeIdentity } from '@/lib/hybrid-loader/identityCache';
+
+export interface HybridProviderDataInput {
+  /** Canonical key — NPI for public surfaces, entityId for authenticated surfaces */
+  key: string;
+  /** Server-rendered seed, if available (e.g. /review). Wins over cache on first paint. */
+  ssrSeed?: IngestStreamState | null;
+  /** Whether to automatically start an SSE ingest on mount. Default: true. */
+  autoStart?: boolean;
+}
+
+export function useHybridProviderData({
+  key,
+  ssrSeed,
+  autoStart = true,
+}: HybridProviderDataInput) {
+  // Lazy init — runs once, synchronously. Precedence: SSR > cache > empty.
+  const initialState = useRef<IngestStreamState | undefined>(undefined);
+  if (initialState.current === undefined) {
+    if (ssrSeed) {
+      initialState.current = ssrSeed;
+    } else {
+      const cached = readIdentity(key);
+      initialState.current = cached
+        ? hydrateFromCachedIdentity(cached)
+        : undefined;
+    }
+  }
+
+  const hook = useIngestStream(initialState.current);
+
+  // Write-through cache: persist only authoritative state.
+  useEffect(() => {
+    if (!hook.state.isUsable) return;
+    writeIdentity(key, {
+      identity: hook.state.identity,
+      standing: hook.state.standing,
+      readiness: hook.state.readiness,
+    });
+  }, [key, hook.state]);
+
+  // Auto-start SSE if we have a key and no authoritative data yet, OR if the
+  // seed/cache is present but we want to refresh in the background.
+  useEffect(() => {
+    if (!autoStart) return;
+    if (!key) return;
+    // Only auto-start if we have an NPI shape (public ingest only runs on NPI)
+    if (!/^\d{10}$/.test(key)) return;
+    // Fire and forget — the hook mutex'es duplicate calls.
+    void hook.startIngest(key);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, autoStart]);
+
+  return hook;
+}
+```
+
+**Design notes:**
+- **Lazy-init via ref, not `useState` initializer.** `useIngestStream` already
+  does `useState(() => initialState ?? createInitialIngestStreamState())` at
+  `useIngestStream.ts:51-53`, so we pass our computed seed in and let the
+  existing lazy init handle it.
+- **`autoStart: true` by default.** `/review` passes `autoStart: true` so the
+  server payload gets immediately refreshed via SSE. `/passport` can continue
+  to call `startIngest` manually by passing `autoStart: false`.
+- **Only auto-starts on NPI-shaped keys.** EntityId-keyed callers don't trigger
+  the public SSE run automatically.
+- **Write-through on every state update where `isUsable=true`.** Cheap enough
+  — localStorage writes take microseconds — and guarantees the cache is never
+  stale within a session.
+
+---
+
+## SSR → client wiring in `/review`
+
+Current flow (`app/review/[entityId]/ReviewPageClient.tsx`):
+
+```
+[server] fetchBackendJson<PassportData>('/api/passport/...')
+   │
+   ▼
+[server] <ReviewClient passport={passport} ... />
+   │
+   ▼
+[client] ReviewClient renders passport statically
+```
+
+New flow:
+
+```
+[server] fetchBackendJson<PassportData>('/api/passport/...')
+   │
+   ▼
+[server] <ReviewClient passport={passport} hybridSeed={passportToStreamSeed(passport)} ... />
+   │
+   ▼
+[client] ReviewClient:
+           const { state } = useHybridProviderData({
+             key: passport.npi ?? passport.entityId,
+             ssrSeed: hybridSeed,
+             autoStart: Boolean(passport.npi),
+           });
+           // Static render still uses `passport` prop (credentials, proof).
+           // Live overlay uses `state.identity` + `state.sources` for the
+           // "Checking…" / "Updated just now" header badge.
+```
+
+**Why keep `passport` prop AND the hook state?** Because `PassportData` contains
+authoritative server-owned data (credentials, proof panels, acceptance history)
+that we do NOT want to cache in localStorage. The hook state is a narrow
+"identity + freshness" overlay. They coexist.
+
+**`passportToStreamSeed` runs on the server.** It's a pure function that takes
+`PassportData` and returns a plain object — no React, no storage, safe to run
+at the `ReviewPageClient.tsx` server component boundary. Serializing the
+result into the client prop graph is free (it's just JSON).
+
+---
+
+## UI state copy
+
+No new labels. Using existing ones from `apps/web/lib/trust/status-language.ts`:
+
+| Condition | Badge | Source |
+|---|---|---|
+| First paint from SSR or cache, SSE hasn't reported anything yet | `pending` → "Loading" | status-language.ts:60 |
+| SSE `source_start` is in-flight | `pending` → "Checking…" *(new SAFE_DISPLAY_LABEL)* | status-language.ts:96 |
+| `state.isUsable && Date.now() - readyAt < 10_000` | `verified` → "Updated just now" *(new SAFE_DISPLAY_LABEL)* | status-language.ts:91 |
+| `state.isUsable && Date.now() - readyAt ≥ 10_000` | `verified` → "Source-backed" | status-language.ts:92 |
+| SSE errored AND cache hit | `verified` with a muted "offline" affordance; cached data still wins | — |
+| SSE errored AND cold (no cache, no seed) | `unavailable` → "Unavailable" | status-language.ts:102 |
+
+**Two new SAFE_DISPLAY_LABELS** added in `status-language.ts`: `"Checking…"`
+(under `pending`) and `"Updated just now"` (under `verified`). These are the
+only copy additions. Everything else stays identical.
+
+---
+
+## Merge precedence (when SSR, cache, and SSE disagree)
+
+The hook has a single reducer (`applyIngestEvent`), so merging is handled for us
+as long as we seed the initial state correctly. The precedence is:
+
+1. **SSE, once `isUsable=true`** — wins on all fields it provides. Server-truth.
+2. **SSR seed (ssrSeed)** — beats cache on first paint. It's also server-truth,
+   just frozen at fetch time.
+3. **Cache (localStorage)** — only used when no SSR seed.
+4. **Nothing** — if cold, first paint is `createInitialIngestStreamState()`.
+
+Field-level: the existing `mergeIdentity`/`mergeStanding`/`mergeReadiness`
+helpers at `ingestStreamState.ts:181-256` already do `readString(payload, key)
+?? prev.field` — i.e. SSE wins when it has a value, prev (seed/cache) wins
+otherwise. No new merge code is needed.
+
+---
+
+## Offline behavior
+
+- `readIdentity` is pure localStorage read — works offline.
+- `useIngestStream.startIngest` will fail on `fetch` (no network). That triggers
+  its existing error path at `useIngestStream.ts:124-135`, which sets `phase:
+  'error'` but **does not clear the cached identity**, because `applyIngestEvent`'s
+  error branch at `ingestStreamState.ts:525-542` explicitly preserves `isUsable=true`
+  state.
+- The user sees cached identity with an "offline" muted affordance. No blank
+  screen, no error toast.
+
+This is a free win from the existing `ingestStreamState` reducer — we don't
+have to write special offline logic.
+
+---
+
+## Testing strategy
+
+### `identity-cache.test.ts` (~100 LOC)
+- `readIdentity` returns `null` on cache miss
+- `readIdentity` returns `null` on TTL expiry (mock `Date.now`)
+- `readIdentity` returns `null` on version mismatch (`v !== 1`)
+- `readIdentity` returns `null` on malformed JSON
+- `writeIdentity` round-trips identity/standing/readiness
+- `writeIdentity` is a no-op when localStorage throws (private mode)
+- `clearIdentity` removes the key
+- All methods are no-ops under SSR (`typeof window === 'undefined'`)
+
+### `passport-to-stream-seed.test.ts` (~80 LOC)
+- Fixture `PassportData` with full identity → seed with `phase: 'done'`, `isUsable: true`
+- Fixture with `identity.status === 'UNKNOWN'` → `authoritative: false`
+- Fixture with `standing.exclusionStatus === 'UNCHECKED'` → `sources.oig: 'pending'`
+- Fixture without NPI → seed `npi: undefined`, still usable via `entityId`
+- Pure function: same input produces same output (no clocks, no I/O)
+
+### `use-hybrid-provider-data.test.tsx` (~120 LOC)
+- First render with `ssrSeed` renders identity immediately (no waiting)
+- First render with cache hit (no SSR seed) renders identity immediately
+- First render with neither renders empty state
+- `state.isUsable=true` triggers `writeIdentity`
+- Every subsequent authoritative state update writes through to cache (cheap — sub-ms localStorage.setItem)
+- `autoStart: true` calls `startIngest` when key is NPI-shaped
+- `autoStart: true` does NOT call `startIngest` when key is entityId-shaped
+- Offline (fetch throws) preserves cached identity in state
+
+### Integration test extension for `/review`
+- Update `__tests__/review-page-contract.test.tsx` to assert that a render of
+  `ReviewClient` with a mock `PassportData` + seed produces the "Updated just
+  now" badge and the displayName on first paint (no `waitFor`).
+
+**All tests use vitest**, matching the rest of the `apps/web/__tests__/` folder.
+
+---
+
+## Risk table
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| localStorage quota exceeded | Low | try/catch wraps writes; cache is best-effort |
+| Cached identity is stale (provider changed name) | Low | 24h TTL; SSE overwrites on first successful run |
+| PII in localStorage is visible to shared-device users | Medium | Documented trade-off — user explicitly chose localStorage for sync semantics. NPI + name are already public data (PECOS, NPPES). Nothing PHI. |
+| SSR seed shape drifts from `IngestStreamState` | Medium | `passportToStreamSeed` is a pure function with its own unit tests; a schema change in `PassportData` will break those tests immediately |
+| `/passport`'s existing `initialState` semantics change | Low | We're not modifying `useIngestStream`; we just pass the existing parameter |
+| Cache key collision across tenants/users | Low | Key is NPI/entityId only. Public-surface data only — no tenant scoping needed. If this gets reused for authenticated views, add tenant prefix later. |
+
+---
+
+## Out-of-scope (deferred)
+
+- **Cache invalidation on authoritative mutations** (e.g. admin re-runs ingest).
+  Deferred to a follow-up; 24h TTL is sufficient for the launch use case.
+- **IndexedDB migration.** Only if we ever need to cache >5MB of provider lists.
+- **Service Worker offline mode.** Out of scope; localStorage covers the "reload
+  renders instantly" requirement.
+- **Applying to provider profile surfaces.** Those don't exist yet. When they
+  land, they adopt `useHybridProviderData` as-is.
+- **`/passport` cache opt-in.** Not in this PR. `/passport` continues to call
+  `useIngestStream` directly; the wrapper becomes available for future opt-in.
+  This keeps the PR focused on `/review` and the new primitives.
+
+---
+
+## Definition of done
+
+- [x] Spec approved
+- [ ] 3 new files created under `apps/web/lib/hybrid-loader/` and `apps/web/hooks/`
+- [ ] 3 new test files under `apps/web/__tests__/`
+- [ ] `apps/web/components/review/ReviewClient.tsx` wired to `useHybridProviderData`
+- [ ] `status-language.ts` adds `"Checking…"` and `"Updated just now"` to `SAFE_DISPLAY_LABELS`
+- [ ] `pnpm --filter web test` passes with new test files
+- [ ] `pnpm --filter web build` passes (no TS/ESLint errors — `next.config.mjs` enforces this)
+- [ ] Manual verification: visit `/review/1234567890`, reload, confirm identity is visible on first paint (no flicker)
+- [ ] Manual verification: DevTools → Network → offline, reload, confirm identity still renders
+- [ ] `useIngestStream.ts` unchanged (`git diff main -- apps/web/hooks/useIngestStream.ts` is empty)
+- [ ] PR opened against `main`


### PR DESCRIPTION
## Summary

Implements the **hybrid loader** from `docs/superpowers/specs/2026-04-10-hybrid-loader-design.md` (Option A: cache-as-side-effect-subscriber).

- **Goal:** Make provider identity render on first paint for every surface (SSR, reload, client nav) without waiting on SSE, then upgrade progressively.
- **Approach:** `useIngestStream` stays untouched. A thin `useHybridProviderData` wrapper composes it with a synchronous `localStorage` cache (v:1, 24h TTL) and an SSR seed bridge (`passportToStreamSeed`).
- **This PR wires `/review`** as the first consumer. `/passport` continues to use `useIngestStream` directly — no migration.

## What's in here

**New modules (`apps/web/lib/hybrid-loader/`)**
- `identityCache.ts` — versioned, TTL'd, sync-readable localStorage cache. Gracefully handles missing `window`, quota errors, and schema-version eviction.
- `passportToStreamSeed.ts` — pure `PassportData -> IngestStreamState` mapper. Honors its documented "never throws" contract via `Partial` guards so minimal passport shells (contract tests, NPPES proxy) fall through to the empty seed.

**New hook (`apps/web/hooks/useHybridProviderData.ts`)**
- Lazy-init precedence: **SSR seed > cache > empty default**.
- Write-through effect persists only authoritative state (`isUsable === true`).
- Auto-starts an ingest run for NPI-shaped keys; inert for entity keys.

**Wiring**
- `app/review/[entityId]/ReviewPageClient.tsx` computes the SSR seed server-side and passes it to `ReviewClient`.
- `components/review/ReviewClient.tsx` calls `useHybridProviderData` with `autoStart: false` purely for the write-through side effect. Render still flows from the authoritative `passport` prop.
- `lib/trust/status-language.ts` adds `Checking...` (in-flight) and `Updated just now` (freshness window) to `SAFE_DISPLAY_LABELS`.

**Tests (32 new, 430 total passing in apps/web)**
- `identity-cache.test.ts` (12) — round-trip, TTL expiry, schema-version eviction, quota handling, missing storage.
- `passport-to-stream-seed.test.ts` (11) — authoritative mapping, `UNKNOWN`/`MISSING`/`PREVIEW` downgrades, `UNCHECKED` source statuses, NPI fallback, purity.
- `use-hybrid-provider-data.test.tsx` (9) — precedence rules, NPI-keyed auto-start, SSE-driven write-through.

## Test plan

- [x] `pnpm --filter web test` — **89 files, 430 tests pass** (adds 32, zero regressions)
- [x] `tsc --noEmit` in `apps/web` — clean on all hybrid-loader files; remaining errors are pre-existing on baseline (`backend/src/services/psv/oigLeieChecker.ts`, `app/billing/page.tsx`, `components/employer/RequestReviewPanel.tsx`)
- [ ] Manual: load `/review/<entityId>`, confirm identity renders on first paint; reload to confirm it's still instant; `localStorage.clear()` and reload to confirm SSR seed still fills
- [ ] Manual: load `/passport/<npi>`, confirm it still uses the existing streaming path with no behavior change

## Out of scope (follow-ups)

- Migrating other surfaces (public wedge, provider profile) to the wrapper — separate PRs.
- Telemetry on cache hit/miss rate.
- Changing `/passport` to read through the wrapper (the spec explicitly keeps it on direct `useIngestStream`).

Design spec: `docs/superpowers/specs/2026-04-10-hybrid-loader-design.md`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)