### PR TITLE
feat(trust): Wave 13 employer explainability, next steps, and decision posture

### DIFF
--- a/apps/web/components/passport/PassportWallet.tsx
+++ b/apps/web/components/passport/PassportWallet.tsx
@@ -43,6 +43,7 @@ import { PassportSourceCoveragePanel } from '@/components/trust/PassportSourceCo
 import { SharePacketModal } from '@/components/passport/SharePacketModal';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { DivergenceSummaryCard } from '@/components/trust/DivergenceSummaryCard';
+import { ActionableNextSteps } from '@/components/trust/ActionableNextSteps';
 import { TrustSummarySection } from '@/components/passport/TrustSummarySection';
 import { ResearchPublicationsSection } from '@/components/passport/ResearchPublicationsSection';
 import type { PassportResearchData } from '@/lib/trust/research-passport-types';
@@ -794,23 +795,15 @@ function PassportWalletLoaded({ passport }: PassportWalletLoadedProps) {
           </EvidenceDisclosureCard>
         </SectionReveal>
 
-        {/* ── Next actions (from readiness engine) ──────────────────────────── */}
-        {readiness.nextActions.length > 0 && (
-          <SectionReveal delay={0.25}>
-            <Card className="gap-3 rounded-2xl border-white/8 bg-white/[0.03] px-5 py-4 shadow-none">
-              <p className="text-foreground/70 text-sm font-medium">What should happen next</p>
-              {readiness.nextActions.slice(0, 4).map((action) => (
-                <div key={action.id} className="flex items-start gap-3">
-                  <span className="text-muted-foreground/50 mt-1 select-none text-xs">—</span>
-                  <div>
-                    <p className="text-foreground/70 text-sm">{action.title}</p>
-                    <p className="text-muted-foreground text-xs mt-0.5">{action.detail}</p>
-                  </div>
-                </div>
-              ))}
-            </Card>
-          </SectionReveal>
-        )}
+        {/* ── Wave 13: Actionable Next Steps (clinician mode) ──────────── */}
+        <SectionReveal delay={0.25}>
+          <ActionableNextSteps
+            readiness={readiness}
+            trustPosture={trustPosture}
+            divergence={passport.divergence}
+            mode="clinician"
+          />
+        </SectionReveal>
 
         {/* ── Explicit missing items ─────────────────────────────────────── */}
         {(trustPosture.missingItems.length > 0 || trustPosture.gatedItems.length > 0) && (

--- a/apps/web/components/review/EmployerDecisionPosture.tsx
+++ b/apps/web/components/review/EmployerDecisionPosture.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { TrustStatusBadge } from '@/components/ui/trust-status-badge';
+import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  resolveRecommendation,
+  RECOMMENDATION_CONFIG,
+} from '@/lib/trust/employer-decision-posture';
+import { formatProofDate } from '@/lib/trust/proof-language';
+
+void React;
+
+export function EmployerDecisionPosture({ passport }: { passport: PassportData }) {
+  const recommendation = resolveRecommendation(passport);
+  const config = RECOMMENDATION_CONFIG[recommendation];
+
+  const proven = passport.decisionPosture?.proven ?? [];
+  const missingFromPosture = passport.decisionPosture?.missing ?? [];
+
+  const gaps = [
+    ...missingFromPosture.map((m) => ({
+      id: `missing-${m.sourceId}`,
+      label: `${m.dimension} — ${m.sourceId}`,
+      detail: m.reason,
+    })),
+    ...passport.trustPosture.missingItems
+      .filter((item) => !missingFromPosture.some((m) => m.sourceId === item))
+      .map((item) => ({
+        id: `posture-missing-${item}`,
+        label: item,
+        detail: 'Missing or unresolved',
+      })),
+    ...passport.trustPosture.gatedItems
+      .filter((item) => !missingFromPosture.some((m) => m.sourceId === item))
+      .map((item) => ({
+        id: `posture-gated-${item}`,
+        label: item,
+        detail: 'Requires institutional access',
+      })),
+  ];
+
+  return (
+    <Card className="gap-0 rounded-2xl py-0 shadow-none overflow-hidden">
+      {/* Recommendation hero */}
+      <div className={`px-5 py-5 ${config.cardClass}`}>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/50">
+          Decision posture
+        </p>
+        <p className="mt-2 text-lg font-semibold text-foreground/90">
+          {config.label}
+        </p>
+        <p className="mt-1 text-sm leading-relaxed text-foreground/60">
+          {config.description}
+        </p>
+      </div>
+
+      {/* Verified signals */}
+      {proven.length > 0 && (
+        <div className="border-t border-white/6 px-5 py-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/30">
+            Verified signals
+          </p>
+          <div className="mt-3 space-y-2">
+            {proven.map((source) => (
+              <div
+                key={source.sourceId}
+                className="flex items-start justify-between gap-3 rounded-lg border border-white/6 bg-white/[0.02] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm text-foreground/70">
+                    {source.dimension} — {source.sourceId}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">{source.reason}</p>
+                  {source.checkedAt && (
+                    <p className="mt-0.5 text-[10px] text-muted-foreground/40">
+                      Checked {formatProofDate(source.checkedAt)}
+                    </p>
+                  )}
+                </div>
+                <TrustStatusBadge status="checked" size="sm" className="shrink-0" />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Unresolved gaps */}
+      {gaps.length > 0 && (
+        <div className="border-t border-white/6 px-5 py-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/30">
+            Unresolved gaps
+          </p>
+          <div className="mt-3 space-y-2">
+            {gaps.map((gap) => (
+              <div
+                key={gap.id}
+                className="flex items-start justify-between gap-3 rounded-lg border border-white/6 bg-white/[0.02] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm text-foreground/70">{gap.label}</p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">{gap.detail}</p>
+                </div>
+                <TrustStatusBadge status="access_required" size="sm" className="shrink-0" />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Audit footer */}
+      <div className="border-t border-white/6 px-5 py-3">
+        <p className="text-[10px] text-muted-foreground/40">
+          This recommendation reflects source-backed evidence as of {formatProofDate(passport.lastCheckedAt) ?? 'unknown'}.
+          It does not replace institutional credentialing or privileging processes.
+        </p>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -38,6 +38,9 @@ import { PassportSourceCoveragePanel } from '@/components/trust/PassportSourceCo
 import { TimeToStartEstimateSummary } from '@/components/trust/TimeToStartEstimateSummary';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { DivergenceSummaryCard } from '@/components/trust/DivergenceSummaryCard';
+import { ActionableNextSteps } from '@/components/trust/ActionableNextSteps';
+import { ScoreExplainabilityBlock } from '@/components/employer/ScoreExplainabilityBlock';
+import { EmployerDecisionPosture } from '@/components/review/EmployerDecisionPosture';
 import { TrustLabel, type TrustStatus } from '@/components/ui/trust-label';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { readinessLevelLabel } from '@/lib/trust/status-language';
@@ -1506,6 +1509,12 @@ function ReviewClientLoaded({
             </div>
           </div>
 
+          {/* ── Wave 13: Employer Decision Posture ─────────────────────── */}
+          <EmployerDecisionPosture passport={passport} />
+
+          {/* ── Wave 13: Score Explainability ──────────────────────────── */}
+          <ScoreExplainabilityBlock passport={passport} />
+
           {/* MS16-F: Employer 6-question flow — strict order */}
           <div className="pt-2 mt-4 space-y-6">
             {/* Q1: Who is this? */}
@@ -1697,6 +1706,14 @@ function ReviewClientLoaded({
         {passport.divergence?.activeCount ? (
           <DivergenceSummaryCard divergence={passport.divergence} mode="review" />
         ) : null}
+
+        {/* ── Wave 13: Actionable Next Steps (employer mode) ──────────── */}
+        <ActionableNextSteps
+          readiness={readiness}
+          trustPosture={passport.trustPosture}
+          divergence={passport.divergence}
+          mode="employer"
+        />
 
         {/* ── Proof panel — collapsible ────────────────────────────────────── */}
         {proofItems.length > 0 && (

--- a/apps/web/components/trust/ActionableNextSteps.tsx
+++ b/apps/web/components/trust/ActionableNextSteps.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { TrustStatusBadge } from '@/components/ui/trust-status-badge';
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+void React;
+
+const PRIORITY_CLASS: Record<string, string> = {
+  HIGH: 'border-rose-500/30 bg-rose-500/10 text-rose-200',
+  MEDIUM: 'border-amber-500/30 bg-amber-500/10 text-amber-100',
+  LOW: 'border-sky-500/30 bg-sky-500/10 text-sky-100',
+};
+
+type NextAction = PassportData['readiness']['nextActions'][number];
+
+function groupByPriority(actions: NextAction[]): Record<string, NextAction[]> {
+  const groups: Record<string, NextAction[]> = { HIGH: [], MEDIUM: [], LOW: [] };
+  for (const action of actions) {
+    const bucket = groups[action.priority];
+    if (bucket) {
+      bucket.push(action);
+    } else {
+      groups.LOW!.push(action);
+    }
+  }
+  return groups;
+}
+
+export function ActionableNextSteps({
+  readiness,
+  trustPosture,
+  divergence,
+  mode,
+}: {
+  readiness: PassportData['readiness'];
+  trustPosture: PassportData['trustPosture'];
+  divergence?: PassportData['divergence'];
+  mode: 'clinician' | 'employer';
+}) {
+  const allActions = [...readiness.nextActions];
+
+  if (divergence && divergence.activeCount > 0) {
+    allActions.push({
+      id: 'resolve-divergence',
+      title: 'Resolve cross-source conflicts',
+      detail: `${divergence.activeCount} active divergence${divergence.activeCount === 1 ? '' : 's'} applying -${divergence.totalPenalty} CRS penalty. Resolution restores the penalty.`,
+      priority: divergence.highCount > 0 ? 'HIGH' : 'MEDIUM',
+    });
+  }
+
+  if (allActions.length === 0 && readiness.blockers.length === 0) {
+    return null;
+  }
+
+  const grouped = groupByPriority(allActions);
+  const priorityOrder: Array<{ key: string; label: string }> = [
+    { key: 'HIGH', label: 'Urgent' },
+    { key: 'MEDIUM', label: 'Recommended' },
+    { key: 'LOW', label: 'Optional' },
+  ];
+
+  return (
+    <Card className="gap-0 rounded-2xl border-white/8 bg-white/[0.03] py-0 shadow-none">
+      <div className="px-5 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/40">
+              {mode === 'clinician' ? 'What should happen next' : 'Recommended actions'}
+            </p>
+            <p className="text-sm text-foreground/70">
+              {readiness.level} · {readiness.score}% ready
+            </p>
+          </div>
+          <TrustStatusBadge
+            status={
+              readiness.status === 'BLOCKED' ? 'blocked'
+              : readiness.status === 'PARTIAL' ? 'stale'
+              : 'checked'
+            }
+            size="sm"
+          />
+        </div>
+      </div>
+
+      {/* Blockers — always shown first */}
+      {readiness.blockers.length > 0 && (
+        <div className="border-t border-rose-500/15 bg-rose-500/[0.04] px-5 py-3">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-rose-300/60">
+            {readiness.blockers.length} blocker{readiness.blockers.length === 1 ? '' : 's'}
+          </p>
+          <div className="mt-2 space-y-1.5">
+            {readiness.blockers.map((blocker) => (
+              <div key={blocker} className="flex items-start gap-2">
+                <span className="mt-0.5 text-xs text-rose-300/40">—</span>
+                <p className="text-sm text-rose-100/80">{blocker}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Priority-grouped actions */}
+      <div className="divide-y divide-white/6">
+        {priorityOrder.map(({ key, label }) => {
+          const actions = grouped[key];
+          if (!actions || actions.length === 0) return null;
+
+          return (
+            <div key={key} className="px-5 py-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/30">
+                {label}
+              </p>
+              <div className="mt-2 space-y-2">
+                {actions.map((action) => (
+                  <div key={action.id} className="flex items-start gap-3">
+                    <Badge
+                      variant="outline"
+                      className={[
+                        'mt-0.5 shrink-0 rounded-full px-1.5 py-0.5 text-[9px]',
+                        PRIORITY_CLASS[action.priority] ?? PRIORITY_CLASS.LOW,
+                      ].join(' ')}
+                    >
+                      {action.priority}
+                    </Badge>
+                    <div className="min-w-0">
+                      <p className="text-sm text-foreground/70">
+                        {mode === 'employer' ? `Employer action: ${action.title}` : action.title}
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{action.detail}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/lib/trust/employer-decision-posture.ts
+++ b/apps/web/lib/trust/employer-decision-posture.ts
@@ -1,0 +1,66 @@
+/**
+ * Wave 13: Employer Decision Posture — recommendation resolver.
+ *
+ * Deterministically maps PassportData to a four-level recommendation
+ * that tells an employer whether to proceed, review, take action, or stop.
+ */
+
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+export type ReviewRecommendation = 'proceed' | 'review' | 'action_required' | 'do_not_proceed';
+
+export interface RecommendationConfig {
+  label: string;
+  description: string;
+  tone: 'emerald' | 'amber' | 'rose';
+  cardClass: string;
+}
+
+export const RECOMMENDATION_CONFIG: Record<ReviewRecommendation, RecommendationConfig> = {
+  proceed: {
+    label: 'Safe to proceed',
+    description: 'Safe to proceed based on attached source-backed evidence.',
+    tone: 'emerald',
+    cardClass: 'border-emerald-500/20 bg-emerald-500/6',
+  },
+  review: {
+    label: 'Manual review recommended',
+    description: 'Manual review recommended before proceeding.',
+    tone: 'amber',
+    cardClass: 'border-amber-500/20 bg-amber-500/6',
+  },
+  action_required: {
+    label: 'Action required',
+    description: 'Action required before this review is complete.',
+    tone: 'amber',
+    cardClass: 'border-amber-500/25 bg-amber-500/8',
+  },
+  do_not_proceed: {
+    label: 'Do not proceed',
+    description: 'Do not proceed — critical issues attached.',
+    tone: 'rose',
+    cardClass: 'border-rose-500/20 bg-rose-500/6',
+  },
+};
+
+export function resolveRecommendation(passport: PassportData): ReviewRecommendation {
+  const { readiness, standing, divergence, trustPosture } = passport;
+
+  // ── Do not proceed ─────────────────────────────────────────────────────
+  if (readiness.status === 'BLOCKED') return 'do_not_proceed';
+  if (standing.exclusionStatus === 'EXCLUDED') return 'do_not_proceed';
+  if (standing.exclusionStatus === 'POSSIBLE_MATCH') return 'do_not_proceed';
+  if (divergence && divergence.highCount > 0) return 'do_not_proceed';
+
+  // ── Action required ────────────────────────────────────────────────────
+  if (trustPosture.gatedItems.length > 0) return 'action_required';
+  if (trustPosture.missingItems.length > 2) return 'action_required';
+
+  // ── Review ─────────────────────────────────────────────────────────────
+  if (readiness.status === 'PARTIAL') return 'review';
+  if (divergence && divergence.mediumCount > 0) return 'review';
+  if (trustPosture.staleItems.length > 0) return 'review';
+
+  // ── Proceed ────────────────────────────────────────────────────────────
+  return 'proceed';
+}


### PR DESCRIPTION
## Summary
- **Employer Decision Posture**: New `EmployerDecisionPosture` component with deterministic 4-level recommendation (proceed / review / action_required / do_not_proceed) based on readiness, exclusion, divergence, and trust posture state
- **Score Explainability**: "Why this score?" block with three-column layout (Helping / Hurting / Ceiling effects) showing CRS contributors, penalties, and trust caps
- **Actionable Next Steps**: Priority-grouped (HIGH/MEDIUM/LOW) next steps component with clinician/employer modes, blocker callouts, and divergence resolution CTAs
- **Passport integration**: TrustSummarySection, ResearchPublicationsSection, and ActionableNextSteps wired into PassportWallet; employer components wired into ReviewClient

## Files changed
- `apps/web/components/review/EmployerDecisionPosture.tsx` — new
- `apps/web/lib/trust/employer-decision-posture.ts` — new
- `apps/web/components/trust/ActionableNextSteps.tsx` — new
- `apps/web/components/passport/PassportWallet.tsx` — integration
- `apps/web/components/review/ReviewClient.tsx` — integration

## Test plan
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Dev server renders `/passport` without errors
- [ ] Decision posture shows correct recommendation for each readiness state
- [ ] Score explainability columns populate from passport data
- [ ] Next steps group by priority with mode-appropriate language
- [ ] Divergence CTA appears when active conflicts exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)