### PR TITLE
fix(deploy): truth-enforcement rootDir for cross-package source imports

### DIFF
--- a/packages/source-adapters/src/apply-session.ts
+++ b/packages/source-adapters/src/apply-session.ts
@@ -2,7 +2,7 @@
 // Turns a static Proof Pack Manifest into an employer action loop.
 // The employer reviews the immutable snapshot and takes a compliance action.
 
-import { ProofAvailability, ReadinessPosture } from '../../trust-contract/dist/index';
+import { ProofAvailability, ReadinessPosture } from '../../trust-contract/src/index';
 import { AuditEventType, createAuditEvent, type AuditEvent } from './audit-events';
 import type { ProofManifest } from './manifest-engine';
 

--- a/packages/source-adapters/src/apply-test.ts
+++ b/packages/source-adapters/src/apply-test.ts
@@ -1,6 +1,6 @@
 // ── Apply-with-VCV Flow Tests ────────────────────────────────────
 
-import { ProofAvailability, ReadinessPosture } from '../../trust-contract/dist/index';
+import { ProofAvailability, ReadinessPosture } from '../../trust-contract/src/index';
 import { ApplySessionStatus, ApplyActionType, createApplySession, openApplySession, executeApplyAction } from './apply-session';
 import { AuditEventType } from './audit-events';
 import type { ProofManifest } from './manifest-engine';

--- a/packages/source-adapters/src/claim-test.ts
+++ b/packages/source-adapters/src/claim-test.ts
@@ -1,7 +1,7 @@
 // ── Claim Engine Tests ───────────────────────────────────────────
 
 import type { SourceCheckResult } from './types';
-import { SourceStatus } from '../../trust-contract/dist/index';
+import { SourceStatus } from '../../trust-contract/src/index';
 import { extractClaims, hashClaims, type Claim, type ClaimBatch } from './claim-engine';
 
 let passed = 0;

--- a/packages/source-adapters/src/drift-engine.ts
+++ b/packages/source-adapters/src/drift-engine.ts
@@ -3,7 +3,7 @@
 // Compares the last known state (e.g. from the most recent Manifest)
 // against a fresh SourceCheckResult.
 
-import { SourceStatus } from '../../trust-contract/dist/index';
+import { SourceStatus } from '../../trust-contract/src/index';
 import type { SourceCheckResult } from './types';
 import type { CoverageLane } from './manifest-engine';
 import { AuditEventType, createAuditEvent, type AuditEvent } from './audit-events';

--- a/packages/source-adapters/src/drift-test.ts
+++ b/packages/source-adapters/src/drift-test.ts
@@ -1,6 +1,6 @@
 // ── Drift Engine Tests ───────────────────────────────────────────
 
-import { SourceStatus } from '../../trust-contract/dist/index';
+import { SourceStatus } from '../../trust-contract/src/index';
 import type { SourceCheckResult } from './types';
 import type { CoverageLane } from './manifest-engine';
 import type { Claim } from './claim-engine';

--- a/packages/source-adapters/src/manifest-engine.ts
+++ b/packages/source-adapters/src/manifest-engine.ts
@@ -2,7 +2,7 @@
 // The canonical trust object. Combines claims, receipts, coverage,
 // and limitations into ONE deterministic, exportable object.
 
-import { SourceStatus, ReadinessPosture, ProofAvailability, derivePosture } from '../../trust-contract/dist/index';
+import { SourceStatus, ReadinessPosture, ProofAvailability, derivePosture } from '../../trust-contract/src/index';
 import type { Claim, ClaimLimitation } from './claim-engine';
 import { getRegistryEntry, getDecisionGradeSources } from './types';
 

--- a/packages/source-adapters/src/manifest-test.ts
+++ b/packages/source-adapters/src/manifest-test.ts
@@ -1,7 +1,7 @@
 // ── Manifest Engine Tests ────────────────────────────────────────
 
 import { buildManifest } from './manifest-engine';
-import { SourceStatus, ReadinessPosture, ProofAvailability } from '../../trust-contract/dist/index';
+import { SourceStatus, ReadinessPosture, ProofAvailability } from '../../trust-contract/src/index';
 import type { CoverageLane, SourceReceipt } from './manifest-engine';
 
 let passed = 0;

--- a/packages/source-adapters/src/simulation.ts
+++ b/packages/source-adapters/src/simulation.ts
@@ -1,7 +1,7 @@
 // ── Pilot Simulation Engine ────────────────────────────────────────
 
 import { AuditEventType, createAuditEvent, type AuditEvent } from './audit-events';
-import { ReadinessPosture } from '../../trust-contract/dist/index';
+import { ReadinessPosture } from '../../trust-contract/src/index';
 
 // ── Baseline Config ──────────────────────────────────────────────
 

--- a/packages/source-adapters/src/types.ts
+++ b/packages/source-adapters/src/types.ts
@@ -3,8 +3,8 @@
 // Local adapter implementations are FORBIDDEN — import from here.
 
 // Re-export from trust-contract for convenience
-export { SourceStatus } from '../../trust-contract/dist/index';
-import { SourceStatus } from '../../trust-contract/dist/index';
+export { SourceStatus } from '../../trust-contract/src/index';
+import { SourceStatus } from '../../trust-contract/src/index';
 
 // ── Core Types ───────────────────────────────────────────────────
 

--- a/packages/trust-contract/package.json
+++ b/packages/trust-contract/package.json
@@ -3,5 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "main": "src/index.ts",
-  "types": "src/index.ts"
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "echo 'trust-contract: source-only package, no build needed'",
+    "typecheck": "echo 'trust-contract: checked transitively via consumer packages'"
+  }
 }

--- a/packages/truth-enforcement/src/attack-test.ts
+++ b/packages/truth-enforcement/src/attack-test.ts
@@ -1,10 +1,10 @@
 // ── Live Failure Attack Scenarios ─────────────────────────────────
 // Simulates real-world attacks against the enforcement layer.
 
-import { SourceStatus, ReadinessPosture } from '../../trust-contract/dist/index';
-import { IssuerType, type NetworkIssuer } from '../../trust-contract/dist/multi-issuer';
-import { verifyNetworkClaim, type SignedClaimPayload } from '../../trust-contract/dist/multi-issuer';
-import { arbitrateConflict, type ClaimConflict, type ConflictingClaim } from '../../trust-contract/dist/arbitration-engine';
+import { SourceStatus, ReadinessPosture } from '../../trust-contract/src/index';
+import { IssuerType, type NetworkIssuer } from '../../trust-contract/src/multi-issuer';
+import { verifyNetworkClaim, type SignedClaimPayload } from '../../trust-contract/src/multi-issuer';
+import { arbitrateConflict, type ClaimConflict, type ConflictingClaim } from '../../trust-contract/src/arbitration-engine';
 import {
   guardAdapterResult,
   guardReadinessTransition,

--- a/packages/truth-enforcement/src/index.ts
+++ b/packages/truth-enforcement/src/index.ts
@@ -2,7 +2,7 @@
 // Converts the failure matrix into enforced system guarantees.
 // Every seam has a guard. Every violation fails CLOSED.
 
-import { SourceStatus, ReadinessPosture } from '../../trust-contract/dist/index';
+import { SourceStatus, ReadinessPosture } from '../../trust-contract/src/index';
 
 // ── Enforcement Error ────────────────────────────────────────────
 

--- a/packages/truth-enforcement/src/test.ts
+++ b/packages/truth-enforcement/src/test.ts
@@ -1,7 +1,7 @@
 // ── Truth Enforcement Tests ───────────────────────────────────────
 // Critical gap coverage: Revocation cascade, Divergence detection, Acceptance HTTP semantics
 
-import { SourceStatus, ReadinessPosture } from '../../trust-contract/dist/index';
+import { SourceStatus, ReadinessPosture } from '../../trust-contract/src/index';
 import {
   guardAdapterResult,
   guardReadinessTransition,

--- a/packages/truth-enforcement/tsconfig.json
+++ b/packages/truth-enforcement/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022", "dom"],
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "../..",
     "strict": true,
     "types": ["node"],
     "declaration": true,


### PR DESCRIPTION
Companion to #150. rootDir src→../.. so truth-enforcement can import trust-contract/src.