### PR TITLE
feat(pilot): add pilot intake and operator handoff workflow

### DIFF
--- a/apps/web/__tests__/action-owner.test.ts
+++ b/apps/web/__tests__/action-owner.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACTION_OWNER,
+  resolveBlockerOwnership,
+  resolveOmegaRecomputeFailureOwnership,
+  resolveStateBoardOwnership,
+} from '@/lib/trust/action-owner';
+
+// Doctrine-level tests. These guard the four invariants the wedge
+// depends on:
+//   1. System failure is never assigned to USER.
+//   2. Access-required is never a clinician defect.
+//   3. Stale source is not equivalent to user missing data.
+//   4. No ownerless blockers on live wedge surfaces.
+describe('resolveBlockerOwnership', () => {
+  const KNOWN_BLOCKERS = [
+    'On OIG exclusion list',
+    'Exclusion check failed',
+    'Medicare enrollment unresolved',
+    'Not enrolled in Medicare',
+  ] as const;
+
+  it('never returns ActionOwner.UNKNOWN for a known blocker string', () => {
+    for (const blocker of KNOWN_BLOCKERS) {
+      const ownership = resolveBlockerOwnership(blocker);
+      expect(ownership.owner).not.toBe(ACTION_OWNER.UNKNOWN);
+    }
+  });
+
+  it('never returns the generic "Take Action" CTA — every label is a concrete verb', () => {
+    for (const blocker of KNOWN_BLOCKERS) {
+      const ownership = resolveBlockerOwnership(blocker);
+      expect(ownership.actionLabel.toLowerCase()).not.toBe('take action');
+      expect(ownership.actionLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('supplies a non-empty owner-prefixed line for every known blocker', () => {
+    for (const blocker of KNOWN_BLOCKERS) {
+      const ownership = resolveBlockerOwnership(blocker);
+      expect(ownership.ownerPrefix.length).toBeGreaterThan(0);
+      expect(ownership.plainLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never assigns a source-unavailable (VitalCV retry) scenario to USER', () => {
+    const retryOwnership = resolveBlockerOwnership('Exclusion check failed');
+    expect(retryOwnership.owner).toBe(ACTION_OWNER.VITALCV);
+    expect(retryOwnership.canProceed).toBe(true);
+  });
+
+  it('marks an active OIG exclusion as USER-owned and non-continuable', () => {
+    const exclusion = resolveBlockerOwnership('On OIG exclusion list');
+    expect(exclusion.owner).toBe(ACTION_OWNER.USER);
+    expect(exclusion.canProceed).toBe(false);
+  });
+
+  it('marks PECOS unresolved (quarterly refresh lag) as SOURCE-owned, not USER-owned', () => {
+    const unresolved = resolveBlockerOwnership('Medicare enrollment unresolved');
+    expect(unresolved.owner).toBe(ACTION_OWNER.SOURCE);
+    expect(unresolved.canProceed).toBe(true);
+  });
+
+  it('marks a definitive not-enrolled status as USER-owned (clinician submits PECOS enrollment)', () => {
+    const notEnrolled = resolveBlockerOwnership('Not enrolled in Medicare');
+    expect(notEnrolled.owner).toBe(ACTION_OWNER.USER);
+  });
+
+  it('falls back to UNKNOWN with plainLabel carrying the raw blocker for unclassified strings', () => {
+    const unclassified = resolveBlockerOwnership('Some future blocker we have not classified');
+    expect(unclassified.owner).toBe(ACTION_OWNER.UNKNOWN);
+    expect(unclassified.plainLabel).toBe('Some future blocker we have not classified');
+  });
+
+  it('treats "N unresolved readiness items" as UNKNOWN but provides a passport-detail next step', () => {
+    const aggregated = resolveBlockerOwnership('3 unresolved readiness items');
+    expect(aggregated.owner).toBe(ACTION_OWNER.UNKNOWN);
+    expect(aggregated.actionLabel.toLowerCase()).not.toBe('take action');
+    expect(aggregated.plainLabel).toContain('unresolved readiness items');
+  });
+});
+
+describe('resolveStateBoardOwnership', () => {
+  it('assigns state-board access to INSTITUTION, never to USER', () => {
+    const ownership = resolveStateBoardOwnership();
+    expect(ownership.owner).toBe(ACTION_OWNER.INSTITUTION);
+    expect(ownership.owner).not.toBe(ACTION_OWNER.USER);
+  });
+
+  it('allows provisional continuation (canProceed) — state-board gap is not a clinician defect', () => {
+    const ownership = resolveStateBoardOwnership();
+    expect(ownership.canProceed).toBe(true);
+  });
+
+  it('names the institution in the owner prefix, not the clinician', () => {
+    const ownership = resolveStateBoardOwnership();
+    expect(ownership.ownerPrefix.toLowerCase()).toMatch(/employer|institution/);
+    expect(ownership.ownerPrefix.toLowerCase()).not.toMatch(/^you /);
+  });
+});
+
+describe('resolveOmegaRecomputeFailureOwnership', () => {
+  it('assigns recompute failure to VITALCV, never to USER', () => {
+    const ownership = resolveOmegaRecomputeFailureOwnership();
+    expect(ownership.owner).toBe(ACTION_OWNER.VITALCV);
+    expect(ownership.owner).not.toBe(ACTION_OWNER.USER);
+  });
+
+  it('carries an ETA so the user sees when the retry will land', () => {
+    const ownership = resolveOmegaRecomputeFailureOwnership();
+    expect(ownership.etaOrDependency).not.toBeNull();
+    expect((ownership.etaOrDependency ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('permits continuation — the local action was recorded; only the upstream recompute lagged', () => {
+    const ownership = resolveOmegaRecomputeFailureOwnership();
+    expect(ownership.canProceed).toBe(true);
+  });
+});

--- a/apps/web/__tests__/application-progress.test.ts
+++ b/apps/web/__tests__/application-progress.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveApplicationProgress,
+  resolveEmployerApplicationContext,
+} from '@/lib/apply/application-progress';
+import { ACTION_OWNER } from '@/lib/trust/action-owner';
+import type { ApplicationStatus } from '@/lib/apply/application-snapshot';
+
+const ALL_STATUSES: ApplicationStatus[] = [
+  'draft',
+  'submitted',
+  'viewed',
+  'in_review',
+  'waiting_on_refresh',
+  'waiting_on_manual_review',
+  'advanced',
+  'credentialing',
+  'approved',
+  'start_ready',
+  'started',
+];
+
+describe('resolveApplicationProgress', () => {
+  it('produces a non-empty copy block for every status', () => {
+    for (const status of ALL_STATUSES) {
+      const copy = resolveApplicationProgress(status);
+      expect(copy.label.trim().length).toBeGreaterThan(0);
+      expect(copy.description.trim().length).toBeGreaterThan(0);
+      expect(copy.clinicianNextStep.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('assigns VitalCV ownership to refresh-waiting state (never the clinician)', () => {
+    const waiting = resolveApplicationProgress('waiting_on_refresh');
+    expect(waiting.nextOwner).toBe(ACTION_OWNER.VITALCV);
+    expect(waiting.clinicianCanAct).toBe(false);
+  });
+
+  it('assigns Reviewer ownership to manual-review wait (never the clinician)', () => {
+    const waiting = resolveApplicationProgress('waiting_on_manual_review');
+    expect(waiting.nextOwner).toBe(ACTION_OWNER.REVIEWER);
+    expect(waiting.clinicianCanAct).toBe(false);
+  });
+
+  it('assigns Employer ownership to submitted / viewed / in_review', () => {
+    for (const status of ['submitted', 'viewed', 'in_review'] as ApplicationStatus[]) {
+      expect(resolveApplicationProgress(status).nextOwner).toBe(ACTION_OWNER.EMPLOYER);
+    }
+  });
+
+  it('allows clinician action only on draft and start_ready', () => {
+    for (const status of ALL_STATUSES) {
+      const copy = resolveApplicationProgress(status);
+      if (status === 'draft' || status === 'start_ready') {
+        expect(copy.clinicianCanAct).toBe(true);
+      } else {
+        expect(copy.clinicianCanAct).toBe(false);
+      }
+    }
+  });
+
+  it('marks only `started` as terminal', () => {
+    for (const status of ALL_STATUSES) {
+      const copy = resolveApplicationProgress(status);
+      expect(copy.terminal).toBe(status === 'started');
+    }
+  });
+
+  it('never frames waiting states as clinician defect in the copy', () => {
+    const waitingRefresh = resolveApplicationProgress('waiting_on_refresh');
+    const waitingReview = resolveApplicationProgress('waiting_on_manual_review');
+    // Clinician next step must name VitalCV / reviewer as the actor, not the clinician.
+    expect(waitingRefresh.clinicianNextStep.toLowerCase()).toContain('vitalcv');
+    expect(waitingReview.clinicianNextStep.toLowerCase()).toContain('reviewer');
+    // Must not say "your action" or "you need to" as a defect framing.
+    expect(waitingRefresh.clinicianNextStep.toLowerCase()).not.toMatch(/you need to/);
+    expect(waitingReview.clinicianNextStep.toLowerCase()).not.toMatch(/you need to/);
+  });
+
+  it('never promises a partial application will become decision-grade automatically', () => {
+    for (const status of ALL_STATUSES) {
+      const copy = resolveApplicationProgress(status);
+      const combined = `${copy.description} ${copy.clinicianNextStep}`.toLowerCase();
+      expect(combined).not.toMatch(/automatically upgrad/);
+      expect(combined).not.toMatch(/will become decision-grade/);
+    }
+  });
+});
+
+describe('resolveEmployerApplicationContext', () => {
+  it('produces a context headline and next step for every status', () => {
+    for (const status of ALL_STATUSES) {
+      const context = resolveEmployerApplicationContext(status);
+      expect(context.contextHeadline.trim().length).toBeGreaterThan(0);
+      expect(context.employerNextStep.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('submitted context explicitly tells the employer the snapshot is frozen at submit time', () => {
+    const context = resolveEmployerApplicationContext('submitted');
+    expect(context.contextHeadline.toLowerCase()).toMatch(/frozen|submit time/);
+  });
+
+  it('waiting_on_refresh context warns that a new snapshot is pending', () => {
+    const context = resolveEmployerApplicationContext('waiting_on_refresh');
+    expect(context.contextHeadline.toLowerCase()).toMatch(/refresh|new snapshot/);
+  });
+
+  it('draft context disables employer action (no application exists yet)', () => {
+    const context = resolveEmployerApplicationContext('draft');
+    expect(context.employerNextStep.toLowerCase()).toMatch(/no action|not been submitted/);
+  });
+});

--- a/apps/web/__tests__/application-snapshot.test.ts
+++ b/apps/web/__tests__/application-snapshot.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeApplicationSnapshotHash,
+  createApplicationSnapshot,
+  isTransitionAllowed,
+  refreshApplicationSnapshot,
+  requestApplicationAction,
+  submitApplicationSnapshot,
+  transitionApplicationStatus,
+  verifySnapshotIntegrity,
+  type ApplicationStatus,
+} from '@/lib/apply/application-snapshot';
+
+// Base fixture — a minimal partial-tier snapshot the tests reuse.
+function baseDraft() {
+  return createApplicationSnapshot({
+    applicationId: 'app_1',
+    subjectId: 'subject_1',
+    employerId: 'employer_1',
+    roleId: 'role_1',
+    includedLanes: ['nppes', 'oig', 'pecos'],
+    includedClaims: [
+      { claimId: 'c_nppes_identity', sourceId: 'NPPES', kind: 'identity', verifiedAt: '2026-04-01T00:00:00Z' },
+      { claimId: 'c_oig_exclusion', sourceId: 'OIG_LEIE', kind: 'safety', verifiedAt: '2026-04-01T00:00:00Z' },
+    ],
+    proofTier: 'partial_proof_pack',
+    completeness: 72,
+    createdAt: '2026-04-10T12:00:00Z',
+  });
+}
+
+describe('computeApplicationSnapshotHash', () => {
+  it('is deterministic for identical evidence', () => {
+    const input = {
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['nppes', 'oig'] as const,
+      includedClaims: [
+        { claimId: 'c1', sourceId: 'NPPES', kind: 'identity', verifiedAt: null },
+      ],
+      proofTier: 'partial_proof_pack' as const,
+      createdAt: '2026-04-10T00:00:00Z',
+    };
+    expect(computeApplicationSnapshotHash(input)).toBe(
+      computeApplicationSnapshotHash(input),
+    );
+  });
+
+  it('changes when proof tier changes', () => {
+    const partial = computeApplicationSnapshotHash({
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['nppes'],
+      includedClaims: [],
+      proofTier: 'partial_proof_pack',
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    const decisionGrade = computeApplicationSnapshotHash({
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['nppes'],
+      includedClaims: [],
+      proofTier: 'decision_grade_proof_pack',
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    expect(partial).not.toBe(decisionGrade);
+  });
+
+  it('is stable under lane reordering (sorted internally)', () => {
+    const ordered = computeApplicationSnapshotHash({
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['nppes', 'oig', 'pecos'],
+      includedClaims: [],
+      proofTier: 'partial_proof_pack',
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    const reordered = computeApplicationSnapshotHash({
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['pecos', 'nppes', 'oig'],
+      includedClaims: [],
+      proofTier: 'partial_proof_pack',
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    expect(ordered).toBe(reordered);
+  });
+});
+
+describe('createApplicationSnapshot', () => {
+  it('initializes in draft status with an empty audit log', () => {
+    const snap = baseDraft();
+    expect(snap.status).toBe('draft');
+    expect(snap.auditLog).toEqual([]);
+  });
+
+  it('sorts lanes and claims deterministically before hashing', () => {
+    const snap = createApplicationSnapshot({
+      applicationId: 'app_1',
+      subjectId: 's1',
+      employerId: 'e1',
+      roleId: 'r1',
+      includedLanes: ['pecos', 'nppes', 'oig'],
+      includedClaims: [
+        { claimId: 'c_b', sourceId: 'OIG', kind: 'safety', verifiedAt: null },
+        { claimId: 'c_a', sourceId: 'NPPES', kind: 'identity', verifiedAt: null },
+      ],
+      proofTier: 'partial_proof_pack',
+      completeness: 50,
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    expect(snap.includedLanes).toEqual(['nppes', 'oig', 'pecos']);
+    expect(snap.includedClaims.map((c) => c.claimId)).toEqual(['c_a', 'c_b']);
+  });
+
+  it('clamps completeness into the 0-100 range', () => {
+    const over = createApplicationSnapshot({
+      applicationId: 'app_1',
+      subjectId: 's',
+      employerId: 'e',
+      roleId: 'r',
+      includedLanes: [],
+      includedClaims: [],
+      proofTier: 'partial_proof_pack',
+      completeness: 150,
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    expect(over.completeness).toBe(100);
+    const under = createApplicationSnapshot({
+      applicationId: 'app_1',
+      subjectId: 's',
+      employerId: 'e',
+      roleId: 'r',
+      includedLanes: [],
+      includedClaims: [],
+      proofTier: 'partial_proof_pack',
+      completeness: -5,
+      createdAt: '2026-04-10T00:00:00Z',
+    });
+    expect(under.completeness).toBe(0);
+  });
+
+  it('produces a hash that verifies via verifySnapshotIntegrity', () => {
+    const snap = baseDraft();
+    expect(verifySnapshotIntegrity(snap)).toBe(true);
+  });
+});
+
+describe('submitApplicationSnapshot', () => {
+  it('transitions draft -> submitted and appends an audit entry', () => {
+    const snap = baseDraft();
+    const submitted = submitApplicationSnapshot(snap, '2026-04-11T00:00:00Z');
+    expect(submitted.status).toBe('submitted');
+    expect(submitted.auditLog).toHaveLength(1);
+    expect(submitted.auditLog[0].action).toBe('submitted');
+    expect(submitted.auditLog[0].actor).toBe('clinician');
+    expect(submitted.auditLog[0].from).toBe('draft');
+    expect(submitted.auditLog[0].to).toBe('submitted');
+  });
+
+  it('preserves proof tier and snapshotHash exactly on submit', () => {
+    const snap = baseDraft();
+    const submitted = submitApplicationSnapshot(snap);
+    expect(submitted.proofTier).toBe(snap.proofTier);
+    expect(submitted.snapshotHash).toBe(snap.snapshotHash);
+    expect(submitted.includedLanes).toEqual(snap.includedLanes);
+    expect(submitted.includedClaims).toEqual(snap.includedClaims);
+  });
+
+  it('refuses to submit a non-draft snapshot', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    expect(() => submitApplicationSnapshot(submitted)).toThrow();
+  });
+});
+
+describe('transitionApplicationStatus', () => {
+  it('allows every legal transition in the continuity chain', () => {
+    const legal: Array<[ApplicationStatus, ApplicationStatus]> = [
+      ['draft', 'submitted'],
+      ['submitted', 'viewed'],
+      ['submitted', 'waiting_on_refresh'],
+      ['submitted', 'waiting_on_manual_review'],
+      ['viewed', 'in_review'],
+      ['in_review', 'advanced'],
+      ['advanced', 'credentialing'],
+      ['credentialing', 'approved'],
+      ['approved', 'start_ready'],
+      ['start_ready', 'started'],
+    ];
+    for (const [from, to] of legal) {
+      expect(isTransitionAllowed(from, to)).toBe(true);
+    }
+  });
+
+  it('rejects submitted -> approved (cannot skip review + credentialing)', () => {
+    expect(isTransitionAllowed('submitted', 'approved')).toBe(false);
+  });
+
+  it('rejects draft -> viewed (must go through submitted)', () => {
+    expect(isTransitionAllowed('draft', 'viewed')).toBe(false);
+  });
+
+  it('started is terminal — no outgoing transitions', () => {
+    const statuses: ApplicationStatus[] = [
+      'draft', 'submitted', 'viewed', 'in_review',
+      'waiting_on_refresh', 'waiting_on_manual_review',
+      'advanced', 'credentialing', 'approved', 'start_ready', 'started',
+    ];
+    for (const status of statuses) {
+      expect(isTransitionAllowed('started', status)).toBe(false);
+    }
+  });
+
+  it('throws on a disallowed transition at runtime', () => {
+    const snap = submitApplicationSnapshot(baseDraft());
+    expect(() =>
+      transitionApplicationStatus(snap, 'approved', { actor: 'employer' }),
+    ).toThrow();
+  });
+
+  it('appends audit entry with actor + note on allowed transition', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const viewed = transitionApplicationStatus(submitted, 'viewed', {
+      actor: 'employer',
+      at: '2026-04-12T00:00:00Z',
+      note: 'Employer opened the review surface',
+    });
+    expect(viewed.status).toBe('viewed');
+    expect(viewed.auditLog).toHaveLength(2);
+    expect(viewed.auditLog[1].actor).toBe('employer');
+    expect(viewed.auditLog[1].note).toContain('Employer');
+  });
+});
+
+describe('requestApplicationAction', () => {
+  it('request_refresh moves the application into waiting_on_refresh', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const waiting = requestApplicationAction(submitted, 'request_refresh', {
+      actor: 'employer',
+      note: 'Need fresh PECOS',
+    });
+    expect(waiting.status).toBe('waiting_on_refresh');
+  });
+
+  it('route_to_review moves the application into waiting_on_manual_review', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const routed = requestApplicationAction(submitted, 'route_to_review', {
+      actor: 'employer',
+    });
+    expect(routed.status).toBe('waiting_on_manual_review');
+  });
+
+  it('audit entry names the requesting employer and the action kind', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const waiting = requestApplicationAction(submitted, 'request_refresh', {
+      actor: 'employer',
+      note: 'stale PECOS',
+    });
+    const last = waiting.auditLog[waiting.auditLog.length - 1];
+    expect(last.actor).toBe('employer');
+    expect(last.action).toBe('request_refresh');
+    expect(last.note).toBe('stale PECOS');
+  });
+});
+
+describe('refreshApplicationSnapshot', () => {
+  it('produces a NEW snapshotHash when evidence changes', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const waiting = requestApplicationAction(submitted, 'request_refresh', { actor: 'employer' });
+    const refreshed = refreshApplicationSnapshot(
+      waiting,
+      {
+        proofTier: 'decision_grade_proof_pack',
+        completeness: 100,
+      },
+      { at: '2026-04-15T00:00:00Z' },
+    );
+    expect(refreshed.snapshotHash).not.toBe(waiting.snapshotHash);
+  });
+
+  it('carries forward the full audit log plus a refresh_landed entry', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const waiting = requestApplicationAction(submitted, 'request_refresh', { actor: 'employer' });
+    const refreshed = refreshApplicationSnapshot(waiting, {
+      proofTier: 'decision_grade_proof_pack',
+    });
+    expect(refreshed.auditLog).toHaveLength(waiting.auditLog.length + 1);
+    const last = refreshed.auditLog[refreshed.auditLog.length - 1];
+    expect(last.action).toBe('refresh_landed');
+    expect(last.actor).toBe('vitalcv');
+  });
+
+  it('moves into in_review after a refresh lands', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const waiting = requestApplicationAction(submitted, 'request_refresh', { actor: 'employer' });
+    const refreshed = refreshApplicationSnapshot(waiting, {});
+    expect(refreshed.status).toBe('in_review');
+  });
+
+  it('refuses to refresh an application not in waiting_on_refresh', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    expect(() => refreshApplicationSnapshot(submitted, {})).toThrow();
+  });
+
+  it('PARTIAL STAYS PARTIAL: a submitted snapshot never silently upgrades to decision_grade without a refresh', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    // Try to transition the submitted snapshot forward without writing
+    // a new hash. The proof tier never changes on the original hash.
+    const viewed = transitionApplicationStatus(submitted, 'viewed', { actor: 'employer' });
+    expect(viewed.proofTier).toBe('partial_proof_pack');
+    expect(viewed.snapshotHash).toBe(submitted.snapshotHash);
+  });
+});
+
+describe('verifySnapshotIntegrity', () => {
+  it('returns true for a freshly created snapshot', () => {
+    expect(verifySnapshotIntegrity(baseDraft())).toBe(true);
+  });
+
+  it('returns true after a legal status transition (hash is over evidence, not status)', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    expect(verifySnapshotIntegrity(submitted)).toBe(true);
+  });
+
+  it('returns false if proof tier is mutated post-hoc (detects silent upgrade)', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const tampered = { ...submitted, proofTier: 'decision_grade_proof_pack' as const };
+    expect(verifySnapshotIntegrity(tampered)).toBe(false);
+  });
+
+  it('returns false if an included lane is added without rehashing', () => {
+    const submitted = submitApplicationSnapshot(baseDraft());
+    const tampered = {
+      ...submitted,
+      includedLanes: [...submitted.includedLanes, 'dea' as const],
+    };
+    expect(verifySnapshotIntegrity(tampered)).toBe(false);
+  });
+});

--- a/apps/web/__tests__/buyer-pilot-copy.test.ts
+++ b/apps/web/__tests__/buyer-pilot-copy.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALLOWED_CTA_VERBS,
+  BANNED_BUYER_PHRASES,
+  BUYER_PILOT_CTA,
+  BUYER_PILOT_KPI_COPY,
+  BUYER_PILOT_LIMITATIONS,
+  containsBannedBuyerPhrase,
+  isAllowedCtaVerb,
+} from '@/lib/pilot/buyer-pilot-copy';
+
+function collectAllBuyerCopy(): string {
+  const cta = BUYER_PILOT_CTA;
+  const chunks: string[] = [
+    cta.headline,
+    cta.description,
+    cta.primaryActionLabel,
+    ...Object.values(cta.answers),
+    BUYER_PILOT_KPI_COPY.sectionHeadline,
+    BUYER_PILOT_KPI_COPY.sectionDescription,
+    BUYER_PILOT_KPI_COPY.emptyStateNote,
+    BUYER_PILOT_KPI_COPY.partialStateNote,
+    ...Object.values(BUYER_PILOT_KPI_COPY.tileMeta).flatMap((t) => [t.label, t.readsFrom]),
+    ...BUYER_PILOT_LIMITATIONS,
+  ];
+  return chunks.join(' \n ');
+}
+
+describe('BUYER_PILOT_CTA — answers every required buyer question', () => {
+  it('answers all five Lane D questions with non-empty strings', () => {
+    const { answers } = BUYER_PILOT_CTA;
+    expect(answers.whatHappensOnRequest.trim().length).toBeGreaterThan(0);
+    expect(answers.whatWeMeasure.trim().length).toBeGreaterThan(0);
+    expect(answers.whatYouProvide.trim().length).toBeGreaterThan(0);
+    expect(answers.successCriteria.trim().length).toBeGreaterThan(0);
+    expect(answers.outsideCurrentCoverage.trim().length).toBeGreaterThan(0);
+  });
+
+  it('whatHappensOnRequest is concrete — contains a timeframe or a commitment', () => {
+    const text = BUYER_PILOT_CTA.answers.whatHappensOnRequest.toLowerCase();
+    // Must name either a day window, a business-day commitment, a scope doc,
+    // or another concrete boundary. Rules out "we'll be in touch" vagueness.
+    const concreteMarkers = /(day|week|business|scope|signed|within|reply)/;
+    expect(text).toMatch(concreteMarkers);
+  });
+
+  it('outsideCurrentCoverage names specific sources that are NOT integrated', () => {
+    const text = BUYER_PILOT_CTA.answers.outsideCurrentCoverage.toUpperCase();
+    // At least two of these well-known sources must be named.
+    const sourceMentions = ['NPDB', 'DEA', 'ABMS', 'CAQH', 'SAM.GOV', 'PECOS'];
+    const mentioned = sourceMentions.filter((s) => text.includes(s));
+    expect(mentioned.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('whatWeMeasure names the startability chain explicitly', () => {
+    const text = BUYER_PILOT_CTA.answers.whatWeMeasure.toLowerCase();
+    expect(text).toContain('submit');
+    expect(text).toContain('first view');
+    expect(text).toContain('start-ready');
+  });
+
+  it('primary CTA verb is in the approved allowlist', () => {
+    expect(isAllowedCtaVerb(BUYER_PILOT_CTA.primaryActionLabel)).toBe(true);
+  });
+
+  it('primary CTA routes to the in-page request form, not a vague marketing page', () => {
+    expect(BUYER_PILOT_CTA.primaryActionHref).toMatch(/request-form|pilot|contact/);
+  });
+});
+
+describe('Buyer-facing language — no fake / over-promising copy', () => {
+  it('no buyer copy contains any banned phrase from BANNED_BUYER_PHRASES', () => {
+    const text = collectAllBuyerCopy();
+    const hit = containsBannedBuyerPhrase(text);
+    expect(hit).toBeNull();
+  });
+
+  it('containsBannedBuyerPhrase detects banned phrases case-insensitively', () => {
+    expect(containsBannedBuyerPhrase('We are TRUSTED BY the top hospitals')).toBe('trusted by');
+    expect(containsBannedBuyerPhrase('Everything is Fully Verified')).toBe('fully verified');
+    expect(containsBannedBuyerPhrase('A truthful pilot description')).toBeNull();
+  });
+
+  it('no buyer copy contains "100% verified" or "all checks passed"', () => {
+    const text = collectAllBuyerCopy().toLowerCase();
+    expect(text).not.toContain('100% verified');
+    expect(text).not.toContain('all checks passed');
+  });
+
+  it('no buyer copy fabricates customer names or traction claims', () => {
+    const text = collectAllBuyerCopy().toLowerCase();
+    // Generic marketing cliches that imply traction we have not earned.
+    expect(text).not.toContain('trusted by');
+    expect(text).not.toContain('used by leading');
+    expect(text).not.toContain('fortune 500');
+  });
+
+  it('BANNED_BUYER_PHRASES list is non-empty (the guard is active)', () => {
+    expect(BANNED_BUYER_PHRASES.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Buyer limitations — canonical list stays operational', () => {
+  it('BUYER_PILOT_LIMITATIONS names at least one integration scope', () => {
+    const joined = BUYER_PILOT_LIMITATIONS.join(' ').toUpperCase();
+    expect(joined).toMatch(/NPDB|DEA|ABMS|CAQH|STATE BOARD|PECOS/);
+  });
+
+  it('limitation lines never claim completeness', () => {
+    for (const line of BUYER_PILOT_LIMITATIONS) {
+      const hit = containsBannedBuyerPhrase(line);
+      expect(hit).toBeNull();
+      expect(line.toLowerCase()).not.toMatch(/fully verified|complete credentialing/);
+    }
+  });
+
+  it('limitation lines are sentence-length (not single-word platitudes)', () => {
+    for (const line of BUYER_PILOT_LIMITATIONS) {
+      expect(line.split(/\s+/).length).toBeGreaterThanOrEqual(6);
+    }
+  });
+});
+
+describe('KPI summary copy — honest partial framing', () => {
+  it('emptyStateNote does not promise delivered metrics', () => {
+    const text = BUYER_PILOT_KPI_COPY.emptyStateNote.toLowerCase();
+    expect(text).not.toMatch(/verified|complete|ready to present/);
+    expect(text).toMatch(/(not|no|yet)/);
+  });
+
+  it('partialStateNote flags missing metrics as honest-partial, not an error', () => {
+    const text = BUYER_PILOT_KPI_COPY.partialStateNote.toLowerCase();
+    expect(text).toContain('partial');
+    // Accepts copy that explicitly negates the "error" framing
+    // ("this is not an error"); rejects copy that labels the state
+    // itself as an error ("an error occurred", "error state", etc.).
+    expect(text).not.toMatch(/(is an error|error state|error occurred|encountered an error)/);
+  });
+
+  it('sectionDescription explicitly states metrics degrade rather than impute', () => {
+    const text = BUYER_PILOT_KPI_COPY.sectionDescription.toLowerCase();
+    expect(text).toMatch(/(degrade|missing|not impute|"—")/);
+  });
+
+  it('every tile has a non-empty readsFrom attribution', () => {
+    for (const meta of Object.values(BUYER_PILOT_KPI_COPY.tileMeta)) {
+      expect(meta.readsFrom.trim().length).toBeGreaterThan(0);
+      expect(meta.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('ALLOWED_CTA_VERBS — commercial clarity', () => {
+  it('rejects vague marketing verbs as CTA labels', () => {
+    expect(isAllowedCtaVerb('Get started')).toBe(false);
+    expect(isAllowedCtaVerb('Try it now')).toBe(false);
+    expect(isAllowedCtaVerb('Learn more')).toBe(false);
+  });
+
+  it('accepts pilot-specific verbs', () => {
+    expect(ALLOWED_CTA_VERBS.every((v) => v.toLowerCase().includes('pilot'))).toBe(true);
+  });
+});

--- a/apps/web/__tests__/employer-action-consequence.test.ts
+++ b/apps/web/__tests__/employer-action-consequence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  proofTierToShortKey,
   resolveEmployerActionConsequence,
   resolveProofTier,
   type EmployerActionCopyKey,
@@ -134,3 +135,25 @@ describe('resolveProofTier', () => {
     expect(tiers.length).toBe(3);
   });
 });
+
+// Canonicalization guard. The long-form (narrative) ProofTier and the
+// short-form (action-label selector) vocabulary must stay aligned via
+// `proofTierToShortKey`. Without the mapper, callers re-invent the
+// conversion inline — which is exactly the duplication this helper
+// retires.
+describe('proofTierToShortKey', () => {
+  it('maps each long-form proof tier to the canonical short key', () => {
+    expect(proofTierToShortKey('draft_snapshot')).toBe('draft');
+    expect(proofTierToShortKey('partial_proof_pack')).toBe('partial');
+    expect(proofTierToShortKey('decision_grade_proof_pack')).toBe('decision_grade');
+  });
+});
+
+// Note: the original polish commit (cceada8b on the feature branch) also
+// landed tests for `getEmployerActionLabel` tier-awareness and
+// `getOwnerAttributedPublicNextStep`. Both helpers lived in
+// `lib/trust/decision-copy.ts`, which main deleted as part of the
+// post-Liquid-Glass refactor. Those tests are intentionally not ported
+// here — the doctrine they enforce will re-enter the tree through the
+// manual surface-port commit once it targets main's current copy
+// modules rather than the retired ones.

--- a/apps/web/__tests__/employer-action-consequence.test.ts
+++ b/apps/web/__tests__/employer-action-consequence.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveEmployerActionConsequence,
+  resolveProofTier,
+  type EmployerActionCopyKey,
+  type ProofTier,
+} from '@/lib/trust/employer-action-consequence';
+import { ACTION_OWNER } from '@/lib/trust/action-owner';
+
+const EMPLOYER_ACTIONS: EmployerActionCopyKey[] = [
+  'accept',
+  'refresh',
+  'review',
+  'pause',
+  'reject',
+];
+
+describe('resolveEmployerActionConsequence', () => {
+  it('returns non-empty does/assumes/auditEvent for every action', () => {
+    for (const action of EMPLOYER_ACTIONS) {
+      const c = resolveEmployerActionConsequence(action);
+      expect(c.does.trim().length).toBeGreaterThan(0);
+      expect(c.assumes.trim().length).toBeGreaterThan(0);
+      expect(c.auditEvent.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('assigns ownership to the correct post-action owner', () => {
+    expect(resolveEmployerActionConsequence('accept').ownerAfter).toBe(ACTION_OWNER.EMPLOYER);
+    expect(resolveEmployerActionConsequence('refresh').ownerAfter).toBe(ACTION_OWNER.VITALCV);
+    expect(resolveEmployerActionConsequence('review').ownerAfter).toBe(ACTION_OWNER.REVIEWER);
+  });
+
+  it('audit event for accept writes EmployerDecisionEvent + AuditEvent', () => {
+    const c = resolveEmployerActionConsequence('accept');
+    expect(c.auditEvent).toContain('EmployerDecisionEvent');
+    expect(c.auditEvent).toContain('AuditEvent');
+  });
+
+  it('accept action carries the "NOT included" line so partial acceptance is never implied', () => {
+    const c = resolveEmployerActionConsequence('accept');
+    expect(c.acceptNotIncluded).not.toBeNull();
+    expect((c.acceptNotIncluded ?? '').toLowerCase()).toMatch(/not include|remain|employer/i);
+  });
+
+  it('non-accept actions carry no acceptNotIncluded line', () => {
+    for (const action of ['refresh', 'review', 'pause', 'reject'] as const) {
+      const c = resolveEmployerActionConsequence(action);
+      expect(c.acceptNotIncluded).toBeNull();
+    }
+  });
+
+  it('refresh action explicitly does NOT assume decision-grade state (safe at any tier)', () => {
+    const c = resolveEmployerActionConsequence('refresh');
+    expect(c.assumes.toLowerCase()).toContain('nothing');
+  });
+
+  it('every accept-like action names its risk remaining after the click', () => {
+    const c = resolveEmployerActionConsequence('accept');
+    expect(c.remainsAfter).not.toBeNull();
+    expect((c.remainsAfter ?? '').toLowerCase()).toMatch(/credentialing|employer|privileging/);
+  });
+});
+
+describe('resolveProofTier', () => {
+  const cleanInput = {
+    hasAnchor: true,
+    allRequiredLanesResolved: true,
+    hasUnresolvedBlockers: false,
+    anyLanePending: false,
+    anyLaneReviewRequired: false,
+    anyLaneAccessRequired: false,
+    anyLaneUnavailable: false,
+    anyLaneStale: false,
+    anyLaneNoRecord: false,
+    hasOpenDriftAlerts: false,
+  };
+
+  it('returns decision_grade_proof_pack only when every flag is clean', () => {
+    const tier = resolveProofTier(cleanInput);
+    expect(tier.tier).toBe('decision_grade_proof_pack');
+    expect(tier.acceptAllowed).toBe(true);
+    expect(tier.acceptBlockedReason).toBeNull();
+  });
+
+  it('never returns decision_grade when a lane is unavailable', () => {
+    const tier = resolveProofTier({ ...cleanInput, anyLaneUnavailable: true });
+    expect(tier.tier).not.toBe('decision_grade_proof_pack');
+    expect(tier.acceptAllowed).toBe(false);
+    expect(tier.acceptBlockedReason).not.toBeNull();
+  });
+
+  it('never returns decision_grade when access_required lane exists', () => {
+    const tier = resolveProofTier({ ...cleanInput, anyLaneAccessRequired: true });
+    expect(tier.tier).toBe('partial_proof_pack');
+    expect(tier.acceptAllowed).toBe(false);
+  });
+
+  it('never returns decision_grade when drift alerts are open', () => {
+    const tier = resolveProofTier({ ...cleanInput, hasOpenDriftAlerts: true });
+    expect(tier.acceptAllowed).toBe(false);
+  });
+
+  it('collapses to draft_snapshot when no passport anchor exists', () => {
+    const tier = resolveProofTier({ ...cleanInput, hasAnchor: false });
+    expect(tier.tier).toBe('draft_snapshot');
+    expect(tier.acceptAllowed).toBe(false);
+  });
+
+  it('partial_proof_pack tier never labels itself as ready', () => {
+    const tier = resolveProofTier({ ...cleanInput, anyLaneStale: true });
+    expect(tier.tier).toBe('partial_proof_pack');
+    expect(tier.label.toLowerCase()).not.toContain('ready');
+    expect(tier.description.toLowerCase()).not.toContain('ready');
+  });
+
+  it('acceptBlockedReason is specific to the dominant gap (not a generic message)', () => {
+    const unavailable = resolveProofTier({ ...cleanInput, anyLaneUnavailable: true });
+    expect((unavailable.acceptBlockedReason ?? '').toLowerCase()).toMatch(/reach|source/);
+
+    const stale = resolveProofTier({ ...cleanInput, anyLaneStale: true });
+    expect((stale.acceptBlockedReason ?? '').toLowerCase()).toContain('stale');
+
+    const reviewRequired = resolveProofTier({ ...cleanInput, anyLaneReviewRequired: true });
+    expect((reviewRequired.acceptBlockedReason ?? '').toLowerCase()).toMatch(/review/);
+  });
+
+  it('the three proof tiers cover the full decision space', () => {
+    const tiers: ProofTier[] = [
+      'draft_snapshot',
+      'partial_proof_pack',
+      'decision_grade_proof_pack',
+    ];
+    expect(tiers.length).toBe(3);
+  });
+});

--- a/apps/web/__tests__/employer-cockpit-wiring.test.ts
+++ b/apps/web/__tests__/employer-cockpit-wiring.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveEmployerActionConsequence,
+  resolveProofTier,
+} from '@/lib/trust/employer-action-consequence';
+import { resolveBlockerOwnership } from '@/lib/trust/action-owner';
+
+/**
+ * Composition-layer tests for the EmployerCockpit wiring on main.
+ * These tests do NOT render React — they construct realistic posture
+ * shapes that the cockpit passes into the contract resolvers and
+ * assert the contract answers the expected tier / ownership.
+ *
+ * If a future edit to EmployerCockpit breaks the input shape (e.g.,
+ * feeding wrong lane-state strings into resolveProofTier), these
+ * assertions surface the drift.
+ */
+
+// Minimal posture shapes mirroring the `posture.proven` / `posture.missing`
+// entries from DecisionPosture. The cockpit maps `state` values into the
+// proofTier input flags — these tests lock that mapping.
+type MissingItem = { state: string };
+
+function inputFromMissing(missing: MissingItem[], hasBlockers: boolean) {
+  return {
+    hasAnchor: true,
+    allRequiredLanesResolved: missing.length === 0 && !hasBlockers,
+    hasUnresolvedBlockers: hasBlockers,
+    anyLanePending: missing.some((s) => s.state === 'pending'),
+    anyLaneReviewRequired: missing.some((s) => s.state === 'reviewRequired'),
+    anyLaneAccessRequired: missing.some(
+      (s) => s.state === 'accessRequired' || s.state === 'gated',
+    ),
+    anyLaneUnavailable: missing.some((s) => s.state === 'unavailable'),
+    anyLaneStale: missing.some((s) => s.state === 'stale'),
+    anyLaneNoRecord: missing.some(
+      (s) => s.state === 'notDecisionGrade' || s.state === 'previewOnly',
+    ),
+    hasOpenDriftAlerts: false,
+  };
+}
+
+describe('EmployerCockpit wiring — proof tier composition', () => {
+  it('renders decision_grade when nothing is missing and no blockers exist', () => {
+    const tier = resolveProofTier(inputFromMissing([], false));
+    expect(tier.tier).toBe('decision_grade_proof_pack');
+    expect(tier.acceptAllowed).toBe(true);
+  });
+
+  it('renders partial_proof_pack when an access-required lane exists, even with no active blockers', () => {
+    const tier = resolveProofTier(
+      inputFromMissing([{ state: 'accessRequired' }], false),
+    );
+    expect(tier.tier).toBe('partial_proof_pack');
+    expect(tier.acceptAllowed).toBe(false);
+    expect(tier.acceptBlockedReason).not.toBeNull();
+  });
+
+  it('maps the cockpit`s "gated" state to access-required tier semantics', () => {
+    const gated = resolveProofTier(inputFromMissing([{ state: 'gated' }], false));
+    expect(gated.tier).toBe('partial_proof_pack');
+    expect(gated.acceptAllowed).toBe(false);
+  });
+
+  it('maps "notDecisionGrade" and "previewOnly" states into no-record classification', () => {
+    const notDg = resolveProofTier(
+      inputFromMissing([{ state: 'notDecisionGrade' }], false),
+    );
+    expect(notDg.tier).toBe('partial_proof_pack');
+
+    const preview = resolveProofTier(
+      inputFromMissing([{ state: 'previewOnly' }], false),
+    );
+    expect(preview.tier).toBe('partial_proof_pack');
+  });
+
+  it('blocks acceptance when a lane is unavailable, regardless of other state', () => {
+    const tier = resolveProofTier(
+      inputFromMissing([{ state: 'unavailable' }], false),
+    );
+    expect(tier.acceptAllowed).toBe(false);
+    expect((tier.acceptBlockedReason ?? '').toLowerCase()).toMatch(/source|reach/);
+  });
+
+  it('blocks acceptance whenever blockers are present, even with clean source states', () => {
+    const tier = resolveProofTier(inputFromMissing([], true));
+    expect(tier.acceptAllowed).toBe(false);
+    expect(tier.tier).toBe('partial_proof_pack');
+  });
+});
+
+describe('EmployerCockpit wiring — blocker ownership rendering', () => {
+  it('every rendered blocker resolves to an owner-prefixed line (or falls back to UNKNOWN for unclassified)', () => {
+    const blockers = [
+      'On OIG exclusion list',
+      'Not enrolled in Medicare',
+      'Some future blocker not yet classified',
+    ];
+    for (const b of blockers) {
+      const ownership = resolveBlockerOwnership(b);
+      expect(ownership.plainLabel.trim().length).toBeGreaterThan(0);
+      expect(ownership.ownerPrefix.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('EmployerCockpit wiring — consequence strip', () => {
+  it('each action button on the cockpit surface is backed by a consequence object', () => {
+    const actions = ['accept', 'refresh', 'review'] as const;
+    for (const action of actions) {
+      const consequence = resolveEmployerActionConsequence(action);
+      expect(consequence.does.trim().length).toBeGreaterThan(0);
+      expect(consequence.auditEvent).toContain('EmployerDecisionEvent');
+    }
+  });
+
+  it('accept carries the explicit NOT-included line that the cockpit surfaces', () => {
+    const accept = resolveEmployerActionConsequence('accept');
+    expect(accept.acceptNotIncluded).not.toBeNull();
+  });
+});

--- a/apps/web/__tests__/pilot-intake.test.ts
+++ b/apps/web/__tests__/pilot-intake.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDefaultBaselineSkeleton,
+  computePilotSubmissionHash,
+  createPilotRequestRecord,
+  DEFAULT_PILOT_SUCCESS_CRITERIA,
+  isPilotBaselinePartial,
+  isPilotStatusTransitionAllowed,
+  resolveNextStepForStatus,
+  resolveOwnerForStatus,
+  transitionPilotStatus,
+  updatePilotBaseline,
+  validatePilotIntakeInput,
+  type PilotRequestRecord,
+  type PilotStatus,
+} from '@/lib/pilot/pilot-intake';
+
+const ALL_STATUSES: PilotStatus[] = [
+  'requested',
+  'qualified',
+  'scoping',
+  'baseline_captured',
+  'ready_to_launch',
+  'active',
+  'completed',
+  'archived',
+];
+
+function base(): ReturnType<typeof createPilotRequestRecord> {
+  return createPilotRequestRecord({
+    orgName: 'Acme Health',
+    contactName: 'Jane Smith',
+    contactEmail: 'jane@acme.health',
+    sourceContext: '/pilot',
+    requestedAt: '2026-04-18T00:00:00Z',
+  });
+}
+
+describe('validatePilotIntakeInput', () => {
+  it('rejects missing org name / contact / email', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: '',
+      contactName: '',
+      contactEmail: '',
+    });
+    expect(errs.map((e) => e.field).sort()).toEqual([
+      'contactEmail',
+      'contactName',
+      'orgName',
+    ]);
+  });
+
+  it('rejects malformed email with a specific reason', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: 'x',
+      contactName: 'y',
+      contactEmail: 'not-an-email',
+    });
+    expect(errs.length).toBe(1);
+    expect(errs[0].field).toBe('contactEmail');
+    expect(errs[0].reason.toLowerCase()).toContain('valid');
+  });
+
+  it('accepts a valid input with zero errors', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+    });
+    expect(errs).toEqual([]);
+  });
+});
+
+describe('createPilotRequestRecord', () => {
+  it('throws on invalid input rather than returning a blank record', () => {
+    expect(() =>
+      createPilotRequestRecord({
+        orgName: '',
+        contactName: '',
+        contactEmail: '',
+      }),
+    ).toThrow();
+  });
+
+  it('assigns the canonical pilot_ops owner at creation time (no ownerless records)', () => {
+    const record = base();
+    expect(record.owner).toBe('pilot_ops');
+  });
+
+  it('status starts at "requested" and nextStep is never blank', () => {
+    const record = base();
+    expect(record.status).toBe('requested');
+    expect(record.nextStep.trim().length).toBeGreaterThan(0);
+  });
+
+  it('writes an initial audit entry attributing the buyer as the requester', () => {
+    const record = base();
+    expect(record.auditLog).toHaveLength(1);
+    expect(record.auditLog[0].actor).toBe('buyer');
+    expect(record.auditLog[0].action).toBe('requested');
+    expect(record.auditLog[0].to).toBe('requested');
+  });
+
+  it('uses the canonical success-criteria default when none supplied', () => {
+    const record = base();
+    expect(record.successCriteria.length).toBe(DEFAULT_PILOT_SUCCESS_CRITERIA.length);
+    expect(record.successCriteria[0].kind).toBe('comparable_delta');
+  });
+
+  it('uses the baseline skeleton when none supplied — every metric starts null + source="unknown"', () => {
+    const record = base();
+    expect(record.baselineMetrics.every((m) => m.value === null)).toBe(true);
+    expect(record.baselineMetrics.every((m) => m.source === 'unknown')).toBe(true);
+  });
+
+  it('defaults roleOrWorkflowTarget to "Credentialing review" when absent', () => {
+    const record = base();
+    expect(record.roleOrWorkflowTarget).toBe('Credentialing review');
+  });
+
+  it('produces a deterministic submissionHash for identical input within the same second', () => {
+    const record1 = createPilotRequestRecord({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    const record2 = createPilotRequestRecord({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    expect(record1.submissionHash).toBe(record2.submissionHash);
+    // Different pilotIds though — each record is its own artifact.
+    expect(record1.pilotId).not.toBe(record2.pilotId);
+  });
+
+  it('submissionHash changes when org / email / workflow differ', () => {
+    const a = computePilotSubmissionHash({
+      orgName: 'Acme',
+      contactEmail: 'jane@acme.health',
+      roleOrWorkflowTarget: 'Credentialing review',
+      sourceContext: '/pilot',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    const b = computePilotSubmissionHash({
+      orgName: 'Acme',
+      contactEmail: 'jane@acme.health',
+      roleOrWorkflowTarget: 'Locum placement',
+      sourceContext: '/pilot',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('Status transitions', () => {
+  it('every status has a canonical next step (no blank nextStep)', () => {
+    for (const status of ALL_STATUSES) {
+      expect(resolveNextStepForStatus(status).trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every status has a canonical owner (no ownerless status)', () => {
+    for (const status of ALL_STATUSES) {
+      const owner = resolveOwnerForStatus(status);
+      expect(owner).toBeDefined();
+    }
+  });
+
+  it('requested -> qualified is allowed; requested -> active is NOT', () => {
+    expect(isPilotStatusTransitionAllowed('requested', 'qualified')).toBe(true);
+    expect(isPilotStatusTransitionAllowed('requested', 'active')).toBe(false);
+  });
+
+  it('archived is terminal — no outgoing transitions', () => {
+    for (const to of ALL_STATUSES) {
+      expect(isPilotStatusTransitionAllowed('archived', to)).toBe(false);
+    }
+  });
+
+  it('transitionPilotStatus reassigns owner + nextStep per the new status', () => {
+    const record = base();
+    const qualified = transitionPilotStatus(record, 'qualified', { actor: 'operator' });
+    expect(qualified.owner).toBe(resolveOwnerForStatus('qualified'));
+    expect(qualified.nextStep).toBe(resolveNextStepForStatus('qualified'));
+
+    const scoped = transitionPilotStatus(qualified, 'scoping', { actor: 'operator' });
+    // Scoping is owned by solutions_engineer, not pilot_ops.
+    expect(scoped.owner).toBe('solutions_engineer');
+  });
+
+  it('transitionPilotStatus appends an audit entry with actor + from/to', () => {
+    const record = base();
+    const qualified = transitionPilotStatus(record, 'qualified', {
+      actor: 'operator',
+      at: '2026-04-19T00:00:00Z',
+      note: 'scope call booked',
+    });
+    expect(qualified.auditLog).toHaveLength(2);
+    expect(qualified.auditLog[1]).toMatchObject({
+      actor: 'operator',
+      action: 'status_change',
+      from: 'requested',
+      to: 'qualified',
+      note: 'scope call booked',
+    });
+  });
+
+  it('throws on a disallowed transition', () => {
+    const record = base();
+    expect(() =>
+      transitionPilotStatus(record, 'active', { actor: 'operator' }),
+    ).toThrow();
+  });
+});
+
+describe('Baseline updates', () => {
+  it('isPilotBaselinePartial true for a fresh record (skeleton values are null)', () => {
+    const record = base();
+    expect(isPilotBaselinePartial(record)).toBe(true);
+  });
+
+  it('updatePilotBaseline only works during "scoping" status', () => {
+    const record = base(); // requested
+    expect(() =>
+      updatePilotBaseline(record, buildDefaultBaselineSkeleton(), { actor: 'operator' }),
+    ).toThrow();
+  });
+
+  it('captures real baseline values when operator supplies them during scoping', () => {
+    let r: PilotRequestRecord = base();
+    r = transitionPilotStatus(r, 'qualified', { actor: 'operator' });
+    r = transitionPilotStatus(r, 'scoping', { actor: 'operator' });
+    r = updatePilotBaseline(
+      r,
+      [
+        {
+          key: 'current_time_to_start_days',
+          label: 'Current median days from hire to start',
+          value: 63,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'current_time_to_first_review_days',
+          label: 'Current median days from application to first review',
+          value: 11,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'applications_per_month',
+          label: 'Typical applications per month',
+          value: 40,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'reviews_per_month',
+          label: 'Typical reviews per month',
+          value: 40,
+          source: 'buyer_reported',
+        },
+      ],
+      { actor: 'operator' },
+    );
+    expect(isPilotBaselinePartial(r)).toBe(false);
+    expect(r.baselineMetrics.every((m) => m.value !== null)).toBe(true);
+    expect(r.auditLog[r.auditLog.length - 1].action).toBe('baseline_updated');
+  });
+
+  it('baseline with any buyer-unknown value keeps isPilotBaselinePartial true', () => {
+    let r: PilotRequestRecord = base();
+    r = transitionPilotStatus(r, 'qualified', { actor: 'operator' });
+    r = transitionPilotStatus(r, 'scoping', { actor: 'operator' });
+    r = updatePilotBaseline(
+      r,
+      [
+        {
+          key: 'current_time_to_start_days',
+          label: 'Current median days from hire to start',
+          value: 63,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'applications_per_month',
+          label: 'Typical applications per month',
+          value: null,
+          source: 'unknown',
+          note: 'buyer does not track this yet',
+        },
+      ],
+      { actor: 'operator' },
+    );
+    expect(isPilotBaselinePartial(r)).toBe(true);
+  });
+});
+
+describe('Success criteria defaults — no fake absolute targets', () => {
+  it('every default criterion uses comparable_delta or qualitative_signal (never absolute_target)', () => {
+    for (const c of DEFAULT_PILOT_SUCCESS_CRITERIA) {
+      expect(c.kind).not.toBe('absolute_target');
+    }
+  });
+
+  it('default criteria that require baseline are flagged correctly', () => {
+    const requiresBaseline = DEFAULT_PILOT_SUCCESS_CRITERIA.filter((c) => c.requiresBaseline);
+    expect(requiresBaseline.length).toBeGreaterThan(0);
+    for (const c of requiresBaseline) {
+      // Summary must reference the baseline / before-after relationship.
+      expect(c.summary.toLowerCase()).toMatch(/baseline|before|after|compar/);
+    }
+  });
+
+  it('qualitative-signal defaults never claim a numeric target', () => {
+    const qualitative = DEFAULT_PILOT_SUCCESS_CRITERIA.filter((c) => c.kind === 'qualitative_signal');
+    for (const c of qualitative) {
+      expect(c.summary).not.toMatch(/\d+%/);
+      expect(c.summary).not.toMatch(/\bby \d+\b/);
+    }
+  });
+});
+
+describe('Contract invariants — no ownerless / no blank-nextStep records', () => {
+  it('every status resolves to a defined owner role', () => {
+    const owners = new Set(ALL_STATUSES.map(resolveOwnerForStatus));
+    // At least two distinct owners should exist across the lifecycle
+    // (pilot_ops handles request + archived; solutions_engineer handles
+    // scoping; customer_success handles active). Sanity check.
+    expect(owners.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('post-transition records always carry a fresh nextStep matching the new status', () => {
+    let r = base();
+    const legalChain: PilotStatus[] = [
+      'qualified',
+      'scoping',
+      'baseline_captured',
+      'ready_to_launch',
+      'active',
+      'completed',
+    ];
+    for (const next of legalChain) {
+      r = transitionPilotStatus(r, next, { actor: 'operator' });
+      expect(r.nextStep).toBe(resolveNextStepForStatus(next));
+      expect(r.nextStep.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/__tests__/pilot-proof-pack.test.ts
+++ b/apps/web/__tests__/pilot-proof-pack.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createApplicationSnapshot,
+  refreshApplicationSnapshot,
+  requestApplicationAction,
+  submitApplicationSnapshot,
+  transitionApplicationStatus,
+  type ApplicationSnapshot,
+} from '@/lib/apply/application-snapshot';
+import {
+  buildPilotProofPack,
+  serializePilotProofPack,
+} from '@/lib/proof/pilot-proof-pack';
+
+function mkSnap(
+  id: string,
+  overrides: {
+    tier?: 'partial_proof_pack' | 'decision_grade_proof_pack' | 'draft_snapshot';
+    createdAt?: string;
+  } = {},
+): ApplicationSnapshot {
+  return createApplicationSnapshot({
+    applicationId: id,
+    subjectId: `subj_${id}`,
+    employerId: 'emp_1',
+    roleId: 'role_1',
+    includedLanes: ['nppes', 'oig', 'pecos'],
+    includedClaims: [],
+    proofTier: overrides.tier ?? 'partial_proof_pack',
+    completeness: 70,
+    createdAt: overrides.createdAt ?? '2026-04-01T00:00:00Z',
+  });
+}
+
+describe('buildPilotProofPack — empty input', () => {
+  it('returns zeroed counts and explicit limitation when no applications exist', () => {
+    const { pack } = buildPilotProofPack({ applications: [] });
+    expect(pack.applicationCount).toBe(0);
+    expect(pack.counts.applicationsSubmitted).toBe(0);
+    expect(pack.counts.startedCount).toBe(0);
+    expect(pack.partialDataNotice).not.toBeNull();
+    expect(pack.limitations.some((l) => l.toLowerCase().includes('no applications')))
+      .toBe(true);
+  });
+
+  it('all medians are null when no applications are in the set', () => {
+    const { pack } = buildPilotProofPack({ applications: [] });
+    expect(pack.medians.medianMinutesToFirstView).toBeNull();
+    expect(pack.medians.medianDaysToStarted).toBeNull();
+  });
+});
+
+describe('buildPilotProofPack — partial data honesty', () => {
+  it('surfaces partialDataNotice whenever any application is missing any timeline', () => {
+    const snap = submitApplicationSnapshot(mkSnap('a1'));
+    const { pack } = buildPilotProofPack({ applications: [snap] });
+    expect(pack.partialDataNotice).not.toBeNull();
+  });
+
+  it('never fabricates medians — only uses applications with both endpoints present', () => {
+    let snap1 = submitApplicationSnapshot(mkSnap('a1'), '2026-04-01T12:00:00Z');
+    snap1 = transitionApplicationStatus(snap1, 'viewed', {
+      actor: 'employer',
+      at: '2026-04-01T14:00:00Z',
+    });
+    const snap2 = submitApplicationSnapshot(mkSnap('a2'), '2026-04-02T00:00:00Z');
+    // snap2 has no viewed event — should not participate in first-view median.
+    const { pack } = buildPilotProofPack({ applications: [snap1, snap2] });
+    // Median comes from snap1 only: 120 minutes.
+    expect(pack.medians.medianMinutesToFirstView).toBe(120);
+    expect(pack.counts.applicationsSubmitted).toBe(2);
+    expect(pack.counts.reviewsOpened).toBe(1);
+    expect(pack.limitations.some((l) => l.toLowerCase().includes('not been opened')))
+      .toBe(true);
+  });
+
+  it('counts decision-grade vs partial vs draft tiers separately in tierContext', () => {
+    const partial = submitApplicationSnapshot(mkSnap('p1'));
+    const decisionGrade = submitApplicationSnapshot(
+      mkSnap('dg1', { tier: 'decision_grade_proof_pack' }),
+    );
+    const { pack } = buildPilotProofPack({
+      applications: [partial, decisionGrade],
+    });
+    expect(pack.tierContext.decisionGradeAtSubmit).toBe(1);
+    expect(pack.tierContext.partialAtSubmit).toBe(1);
+    expect(pack.tierContext.draftAtSubmit).toBe(0);
+  });
+
+  it('surfaces limitation line when ANY application submitted at partial tier', () => {
+    const partial = submitApplicationSnapshot(mkSnap('p1'));
+    const { pack } = buildPilotProofPack({ applications: [partial] });
+    expect(pack.limitations.some((l) => l.toLowerCase().includes('partial'))).toBe(true);
+  });
+});
+
+describe('buildPilotProofPack — open wait honesty', () => {
+  it('flags applications currently in open waiting states', () => {
+    let snap = submitApplicationSnapshot(mkSnap('a1'));
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    const { pack } = buildPilotProofPack({ applications: [snap] });
+    expect(pack.blockers.applicationsWithOpenWait).toBe(1);
+    expect(pack.limitations.some((l) => l.toLowerCase().includes('open waiting'))).toBe(true);
+  });
+
+  it('medianMinutesInRefreshWait is null when no wait has closed yet', () => {
+    let snap = submitApplicationSnapshot(mkSnap('a1'));
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    const { pack } = buildPilotProofPack({ applications: [snap] });
+    expect(pack.blockers.medianMinutesInRefreshWait).toBeNull();
+  });
+
+  it('computes medianMinutesInRefreshWait from closed waits only', () => {
+    let snap1 = submitApplicationSnapshot(mkSnap('a1'));
+    snap1 = requestApplicationAction(snap1, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    snap1 = refreshApplicationSnapshot(snap1, {}, { at: '2026-04-02T02:00:00Z' });
+    // Closed wait: 120 minutes.
+
+    let snap2 = submitApplicationSnapshot(mkSnap('a2'));
+    snap2 = requestApplicationAction(snap2, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-03T00:00:00Z',
+    });
+    snap2 = refreshApplicationSnapshot(snap2, {}, { at: '2026-04-03T04:00:00Z' });
+    // Closed wait: 240 minutes.
+
+    const { pack } = buildPilotProofPack({ applications: [snap1, snap2] });
+    expect(pack.blockers.medianMinutesInRefreshWait).toBe(180);
+  });
+});
+
+describe('buildPilotProofPack — full-chain counts', () => {
+  it('counts advanced / start_ready / started ONLY from real status events', () => {
+    let snap = submitApplicationSnapshot(mkSnap('a1'), '2026-04-01T12:00:00Z');
+    snap = transitionApplicationStatus(snap, 'viewed', { actor: 'employer', at: '2026-04-01T13:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'in_review', { actor: 'employer', at: '2026-04-01T14:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'advanced', { actor: 'employer', at: '2026-04-02T10:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'credentialing', { actor: 'employer', at: '2026-04-03T10:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'approved', { actor: 'employer', at: '2026-04-10T10:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'start_ready', { actor: 'employer', at: '2026-04-14T10:00:00Z' });
+    snap = transitionApplicationStatus(snap, 'started', { actor: 'employer', at: '2026-04-15T08:00:00Z' });
+
+    const { pack } = buildPilotProofPack({ applications: [snap] });
+    expect(pack.counts.advancedCount).toBe(1);
+    expect(pack.counts.startReadyCount).toBe(1);
+    expect(pack.counts.startedCount).toBe(1);
+    expect(pack.medians.medianDaysToStarted).not.toBeNull();
+  });
+
+  it('does not count a draft-only application as submitted', () => {
+    const draftOnly = mkSnap('a1'); // draft, never submitted
+    const { pack } = buildPilotProofPack({ applications: [draftOnly] });
+    expect(pack.counts.applicationsSubmitted).toBe(0);
+  });
+
+  it('startedCount never exceeds applicationsSubmitted', () => {
+    // Property: the proof pack cannot claim more started events than
+    // submitted applications.
+    const snap1 = submitApplicationSnapshot(mkSnap('a1'));
+    const snap2 = mkSnap('a2'); // draft only
+    const { pack } = buildPilotProofPack({ applications: [snap1, snap2] });
+    expect(pack.counts.startedCount).toBeLessThanOrEqual(pack.counts.applicationsSubmitted);
+  });
+});
+
+describe('serializePilotProofPack', () => {
+  it('produces deterministic JSON for the same input', () => {
+    const snap = submitApplicationSnapshot(mkSnap('a1'));
+    const { pack } = buildPilotProofPack({
+      applications: [snap],
+      generatedAt: '2026-04-15T00:00:00Z',
+    });
+    const first = serializePilotProofPack(pack);
+    const second = serializePilotProofPack(pack);
+    expect(first).toBe(second);
+  });
+
+  it('serialized pack is valid JSON and includes limitation lines', () => {
+    const snap = submitApplicationSnapshot(mkSnap('a1'));
+    const { pack } = buildPilotProofPack({ applications: [snap] });
+    const json = serializePilotProofPack(pack);
+    const parsed = JSON.parse(json);
+    expect(parsed.limitations).toBeInstanceOf(Array);
+    expect(parsed.partialDataNotice).not.toBeNull();
+  });
+});

--- a/apps/web/__tests__/pilot-request-route.test.ts
+++ b/apps/web/__tests__/pilot-request-route.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { POST } from '@/app/api/pilot-request/route';
+
+function jsonRequest(body: unknown): Request {
+  return new Request('http://localhost/api/pilot-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function formRequest(fields: Record<string, string>): Request {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(fields)) params.append(k, v);
+  return new Request('http://localhost/api/pilot-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+}
+
+describe('/api/pilot-request POST — structured intake', () => {
+  it('returns a structured record + confirmation for a valid JSON submission', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'Acme Health',
+        name: 'Jane Smith',
+        email: 'jane@acme.health',
+        usecase: 'Locum placement for ER coverage',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      record: {
+        pilotId: string;
+        owner: string;
+        status: string;
+        nextStep: string;
+        orgName: string;
+        roleOrWorkflowTarget: string;
+        successCriteria: Array<{ kind: string }>;
+        baselineMetrics: Array<{ value: number | null }>;
+      };
+      confirmation: { acknowledgement: string; bullets: { whatHappensNext: string[] } };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.record.owner).toBe('pilot_ops');
+    expect(body.record.status).toBe('requested');
+    expect(body.record.orgName).toBe('Acme Health');
+    expect(body.record.roleOrWorkflowTarget).toBe('Locum placement for ER coverage');
+    expect(body.record.nextStep.trim().length).toBeGreaterThan(0);
+    expect(body.record.successCriteria.length).toBeGreaterThan(0);
+    expect(body.record.baselineMetrics.every((m) => m.value === null)).toBe(true);
+    expect(body.confirmation.bullets.whatHappensNext.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the HTML form encoding used by /pilot page fallback', async () => {
+    const res = await POST(
+      formRequest({
+        organization: 'Form Corp',
+        name: 'Sam Buyer',
+        email: 'sam@formcorp.health',
+        usecase: 'Credentialing committee pre-screen',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; record: { orgName: string } };
+    expect(body.ok).toBe(true);
+    expect(body.record.orgName).toBe('Form Corp');
+  });
+
+  it('returns 400 with structured errors on missing fields', async () => {
+    const res = await POST(jsonRequest({ organization: '', name: '', email: '' }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      ok: boolean;
+      errors: Array<{ field: string; reason: string }>;
+    };
+    expect(body.ok).toBe(false);
+    expect(body.errors.length).toBe(3);
+    expect(body.errors.map((e) => e.field).sort()).toEqual([
+      'contactEmail',
+      'contactName',
+      'orgName',
+    ]);
+  });
+
+  it('returns 400 with a specific email error on malformed address', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'x',
+        name: 'y',
+        email: 'not-an-email',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      errors: Array<{ field: string; reason: string }>;
+    };
+    expect(body.errors[0].field).toBe('contactEmail');
+  });
+
+  it('confirmation acknowledgement names the org and the owner inbox line', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'Named Health System',
+        name: 'Jane',
+        email: 'jane@named.health',
+      }),
+    );
+    const body = (await res.json()) as {
+      confirmation: { acknowledgement: string };
+    };
+    expect(body.confirmation.acknowledgement).toContain('Named Health System');
+    // Owner-inbox line for pilot_ops must mention "two business days".
+    expect(body.confirmation.acknowledgement.toLowerCase()).toContain('two business days');
+  });
+
+  it('structured record carries an audit entry attributing the buyer', async () => {
+    const res = await POST(
+      jsonRequest({ organization: 'x', name: 'y', email: 'z@z.com' }),
+    );
+    const body = (await res.json()) as {
+      record: {
+        auditLog: Array<{ actor: string; action: string; to: string | undefined }>;
+      };
+    };
+    expect(body.record.auditLog).toHaveLength(1);
+    expect(body.record.auditLog[0].actor).toBe('buyer');
+    expect(body.record.auditLog[0].action).toBe('requested');
+    expect(body.record.auditLog[0].to).toBe('requested');
+  });
+
+  it('invalid JSON body + missing fields still returns 400 (does not throw)', async () => {
+    const brokenJson = new Request('http://localhost/api/pilot-request', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not{json[',
+    });
+    const res = await POST(brokenJson);
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/__tests__/proof-pack-route.test.ts
+++ b/apps/web/__tests__/proof-pack-route.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { GET, POST } from '@/app/api/pilot/proof-pack/route';
+import {
+  createApplicationSnapshot,
+  submitApplicationSnapshot,
+  type ApplicationSnapshot,
+} from '@/lib/apply/application-snapshot';
+
+function mkSnap(id: string, overrides: { submitted?: boolean } = {}): ApplicationSnapshot {
+  const draft = createApplicationSnapshot({
+    applicationId: id,
+    subjectId: `subj_${id}`,
+    employerId: 'emp_1',
+    roleId: 'role_1',
+    includedLanes: ['nppes', 'oig', 'pecos'],
+    includedClaims: [],
+    proofTier: 'partial_proof_pack',
+    completeness: 70,
+    createdAt: '2026-04-01T00:00:00Z',
+  });
+  return overrides.submitted ? submitApplicationSnapshot(draft) : draft;
+}
+
+function makeRequest(url: string, options: RequestInit = {}): Request {
+  return new Request(url, options);
+}
+
+describe('/api/pilot/proof-pack — GET', () => {
+  it('returns a zero-application pack with honest limitations', async () => {
+    const res = await GET(
+      makeRequest('http://localhost/api/pilot/proof-pack'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      pack: { applicationCount: number; partialDataNotice: string | null; limitations: string[] };
+      serialized: string;
+    };
+    expect(body.pack.applicationCount).toBe(0);
+    expect(body.pack.partialDataNotice).not.toBeNull();
+    expect(body.pack.limitations.length).toBeGreaterThan(0);
+    expect(body.serialized.length).toBeGreaterThan(0);
+  });
+
+  it('returns downloadable JSON with Content-Disposition when download=json', async () => {
+    const res = await GET(
+      makeRequest(
+        'http://localhost/api/pilot/proof-pack?download=json',
+      ));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    const disposition = res.headers.get('Content-Disposition') ?? '';
+    expect(disposition).toContain('attachment');
+    expect(disposition).toContain('vitalcv-pilot-proof-pack-');
+    const text = await res.text();
+    const parsed = JSON.parse(text) as { limitations: string[] };
+    expect(parsed.limitations).toBeInstanceOf(Array);
+  });
+});
+
+describe('/api/pilot/proof-pack — POST', () => {
+  it('builds a pack from the supplied snapshots', async () => {
+    const snap = mkSnap('app_1', { submitted: true });
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: JSON.stringify({
+          applications: [snap],
+          generatedAt: '2026-04-15T00:00:00Z',
+        }),
+      }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      pack: {
+        applicationCount: number;
+        counts: { applicationsSubmitted: number };
+        tierContext: { partialAtSubmit: number };
+        generatedAt: string;
+      };
+    };
+    expect(body.pack.applicationCount).toBe(1);
+    expect(body.pack.counts.applicationsSubmitted).toBe(1);
+    expect(body.pack.tierContext.partialAtSubmit).toBe(1);
+    expect(body.pack.generatedAt).toBe('2026-04-15T00:00:00Z');
+  });
+
+  it('rejects body without applications array with a clear error', async () => {
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: '{"not":"valid"}',
+      }));
+    // Empty applications array is valid; missing array is coerced to [].
+    // This test should succeed with applicationCount=0, not 400.
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects invalid JSON body with 400', async () => {
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: 'not json{{{',
+      }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects malformed snapshot with index-specific error message', async () => {
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: JSON.stringify({
+          applications: [{ applicationId: 'x' }], // missing required fields
+        }),
+      }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('applications[0]');
+  });
+
+  it('returns deterministic serialized JSON for identical input', async () => {
+    const snap = mkSnap('app_1', { submitted: true });
+    const body = {
+      applications: [snap],
+      generatedAt: '2026-04-15T00:00:00Z',
+    };
+    const first = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }));
+    const second = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }));
+    const a = (await first.json()) as { serialized: string };
+    const b = (await second.json()) as { serialized: string };
+    expect(a.serialized).toBe(b.serialized);
+  });
+
+  it('serves a downloadable body (not the json envelope) when download=json', async () => {
+    const snap = mkSnap('app_1', { submitted: true });
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack?download=json', {
+        method: 'POST',
+        body: JSON.stringify({ applications: [snap] }),
+      }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Disposition')).toContain('attachment');
+    const text = await res.text();
+    const parsed = JSON.parse(text) as { applicationCount: number; limitations: string[] };
+    // download response is the pack directly, not { pack, serialized }.
+    expect(parsed.applicationCount).toBe(1);
+    expect(parsed.limitations).toBeInstanceOf(Array);
+  });
+
+  it('preserves partial-data notice when any application is partial', async () => {
+    const snap = mkSnap('app_1', { submitted: true });
+    const res = await POST(
+      makeRequest('http://localhost/api/pilot/proof-pack', {
+        method: 'POST',
+        body: JSON.stringify({ applications: [snap] }),
+      }));
+    const body = (await res.json()) as {
+      pack: { partialDataNotice: string | null; limitations: string[] };
+    };
+    expect(body.pack.partialDataNotice).not.toBeNull();
+    expect(body.pack.limitations.some((l) => l.toLowerCase().includes('partial'))).toBe(true);
+  });
+});

--- a/apps/web/__tests__/recovery-path.test.ts
+++ b/apps/web/__tests__/recovery-path.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { ACTION_OWNER } from '@/lib/trust/action-owner';
+import {
+  getLaneLabel,
+  resolvePassportContinuation,
+  resolveRecoveryPath,
+  type SourceLane,
+  type SourceLaneState,
+} from '@/lib/trust/recovery-path';
+
+const LANES: SourceLane[] = ['nppes', 'oig', 'pecos', 'state_board'];
+const STATES: SourceLaneState[] = [
+  'pending',
+  'checked',
+  'review_required',
+  'unavailable',
+  'access_required',
+  'stale',
+  'no_record',
+];
+
+describe('resolveRecoveryPath', () => {
+  it('returns a non-empty laneLabel and statusLabel for every (lane, state) pair', () => {
+    for (const lane of LANES) {
+      for (const state of STATES) {
+        const path = resolveRecoveryPath(lane, state);
+        expect(path.laneLabel.length).toBeGreaterThan(0);
+        expect(path.statusLabel.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('never relabels an unavailable lane as "Checking…" or any progress phrase', () => {
+    for (const lane of LANES) {
+      const path = resolveRecoveryPath(lane, 'unavailable');
+      expect(path.statusLabel.toLowerCase()).not.toContain('checking');
+      expect(path.statusLabel.toLowerCase()).not.toContain('loading');
+      expect(path.statusLabel.toLowerCase()).not.toContain('verifying');
+      // The honest posture is "unavailable" or "source unavailable"
+      expect(path.statusLabel.toLowerCase()).toContain('unavailable');
+    }
+  });
+
+  it('never assigns an unavailable lane to USER — recovery is VitalCV-owned', () => {
+    for (const lane of LANES) {
+      const path = resolveRecoveryPath(lane, 'unavailable');
+      expect(path.owner).not.toBe(ACTION_OWNER.USER);
+      expect(path.owner).toBe(ACTION_OWNER.VITALCV);
+    }
+  });
+
+  it('never assigns access_required to USER — institutional gates are not clinician defects', () => {
+    for (const lane of LANES) {
+      const path = resolveRecoveryPath(lane, 'access_required');
+      expect(path.owner).not.toBe(ACTION_OWNER.USER);
+    }
+  });
+
+  it('state_board access_required is routed through the institution-owned contract', () => {
+    const path = resolveRecoveryPath('state_board', 'access_required');
+    expect(path.owner).toBe(ACTION_OWNER.INSTITUTION);
+    expect(path.canContinuePartial).toBe(true);
+  });
+
+  it('pending never renders a retry CTA (nothing has failed yet)', () => {
+    for (const lane of LANES) {
+      const path = resolveRecoveryPath(lane, 'pending');
+      expect(path.actionType).toBe('none');
+      expect(path.ctaLabel).toBeNull();
+    }
+  });
+
+  it('review_required never permits partial continuation — a reviewer must see it', () => {
+    for (const lane of LANES) {
+      const path = resolveRecoveryPath(lane, 'review_required');
+      expect(path.canContinuePartial).toBe(false);
+    }
+  });
+
+  it('no_record on NPPES blocks partial continuation; on other lanes permits upload', () => {
+    const nppes = resolveRecoveryPath('nppes', 'no_record');
+    expect(nppes.canContinuePartial).toBe(false);
+    expect(nppes.ctaLabel).toMatch(/NPI/i);
+
+    const pecos = resolveRecoveryPath('pecos', 'no_record');
+    expect(pecos.canContinuePartial).toBe(true);
+  });
+});
+
+describe('getLaneLabel', () => {
+  it('returns a plain-language label for every lane (no internal jargon)', () => {
+    for (const lane of LANES) {
+      const label = getLaneLabel(lane);
+      expect(label.length).toBeGreaterThan(0);
+      expect(label.toLowerCase()).not.toContain('lane');
+      expect(label.toLowerCase()).not.toContain('configured');
+    }
+  });
+});
+
+describe('resolvePassportContinuation', () => {
+  // Default "all clean" input — a fully resolved passport with no
+  // outstanding lane state. Individual tests flip one flag at a time.
+  const cleanInput = {
+    hasAnchor: true,
+    allRequiredLanesResolved: true,
+    hasUnresolvedBlockers: false,
+    anyLanePending: false,
+    anyLaneReviewRequired: false,
+    anyLaneAccessRequired: false,
+    anyLaneUnavailable: false,
+    anyLaneStale: false,
+    anyLaneNoRecord: false,
+  };
+
+  it('returns decision_grade only when every lane is fully resolved with no open gates', () => {
+    const continuation = resolvePassportContinuation(cleanInput);
+    expect(continuation.state).toBe('decision_grade');
+    expect(continuation.provisionalNotice).toBeNull();
+  });
+
+  it('never returns decision_grade when a lane is unavailable', () => {
+    const continuation = resolvePassportContinuation({
+      ...cleanInput,
+      anyLaneUnavailable: true,
+    });
+    expect(continuation.state).not.toBe('decision_grade');
+    expect(continuation.provisionalNotice).not.toBeNull();
+  });
+
+  it('never returns decision_grade when any lane is access_required', () => {
+    const continuation = resolvePassportContinuation({
+      ...cleanInput,
+      anyLaneAccessRequired: true,
+    });
+    expect(continuation.state).not.toBe('decision_grade');
+  });
+
+  it('never returns decision_grade when any lane is stale or missing a record', () => {
+    const staleContinuation = resolvePassportContinuation({
+      ...cleanInput,
+      anyLaneStale: true,
+    });
+    expect(staleContinuation.state).not.toBe('decision_grade');
+
+    const noRecordContinuation = resolvePassportContinuation({
+      ...cleanInput,
+      anyLaneNoRecord: true,
+    });
+    expect(noRecordContinuation.state).not.toBe('decision_grade');
+  });
+
+  it('partial passport never labels the CTA or headline as "ready"', () => {
+    const continuation = resolvePassportContinuation({
+      ...cleanInput,
+      allRequiredLanesResolved: false,
+      hasUnresolvedBlockers: true,
+    });
+    expect(continuation.state).toBe('partial_passport');
+    expect(continuation.ctaLabel.toLowerCase()).not.toContain('ready');
+    expect(continuation.headline.toLowerCase()).not.toContain('ready');
+  });
+
+  it('no anchor collapses to draft_snapshot (nothing decision-grade exists)', () => {
+    const continuation = resolvePassportContinuation({
+      ...cleanInput,
+      hasAnchor: false,
+    });
+    expect(continuation.state).toBe('draft_snapshot');
+    expect(continuation.provisionalNotice).not.toBeNull();
+  });
+
+  it('decision_grade continuation has the "view full passport" framing', () => {
+    const continuation = resolvePassportContinuation(cleanInput);
+    expect(continuation.ctaLabel.toLowerCase()).toContain('view');
+  });
+});

--- a/apps/web/__tests__/startability-timeline.test.ts
+++ b/apps/web/__tests__/startability-timeline.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createApplicationSnapshot,
+  refreshApplicationSnapshot,
+  requestApplicationAction,
+  submitApplicationSnapshot,
+  transitionApplicationStatus,
+} from '@/lib/apply/application-snapshot';
+import {
+  deriveBlockerDurationTotals,
+  deriveStartabilityMetrics,
+  deriveStartabilityTimeline,
+} from '@/lib/proof/startability-timeline';
+
+function freshDraft(overrides: { createdAt?: string } = {}) {
+  return createApplicationSnapshot({
+    applicationId: 'app_1',
+    subjectId: 's1',
+    employerId: 'e1',
+    roleId: 'r1',
+    includedLanes: ['nppes', 'oig', 'pecos'],
+    includedClaims: [],
+    proofTier: 'partial_proof_pack',
+    completeness: 70,
+    createdAt: overrides.createdAt ?? '2026-04-01T00:00:00Z',
+  });
+}
+
+// Build a snapshot that's traversed submitted -> viewed -> in_review ->
+// advanced -> credentialing -> approved -> start_ready -> started, with
+// fixed timestamps on each transition so we can verify deltas exactly.
+function fullyProgressedSnapshot() {
+  let snap = freshDraft();
+  snap = submitApplicationSnapshot(snap, '2026-04-01T12:00:00Z');
+  snap = transitionApplicationStatus(snap, 'viewed', {
+    actor: 'employer',
+    at: '2026-04-01T13:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'in_review', {
+    actor: 'employer',
+    at: '2026-04-01T14:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'advanced', {
+    actor: 'employer',
+    at: '2026-04-02T10:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'credentialing', {
+    actor: 'employer',
+    at: '2026-04-03T10:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'approved', {
+    actor: 'employer',
+    at: '2026-04-10T10:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'start_ready', {
+    actor: 'employer',
+    at: '2026-04-14T10:00:00Z',
+  });
+  snap = transitionApplicationStatus(snap, 'started', {
+    actor: 'employer',
+    at: '2026-04-15T08:00:00Z',
+  });
+  return snap;
+}
+
+describe('deriveStartabilityTimeline', () => {
+  it('returns all-null timeline for a freshly created draft', () => {
+    const snap = freshDraft();
+    const t = deriveStartabilityTimeline(snap);
+    expect(t.applicationSubmittedAt).toBeNull();
+    expect(t.firstViewedAt).toBeNull();
+    expect(t.firstActionAt).toBeNull();
+    expect(t.reviewAdvancedAt).toBeNull();
+    expect(t.startReadyAt).toBeNull();
+    expect(t.startedAt).toBeNull();
+  });
+
+  it('captures the submission timestamp from the audit log', () => {
+    const snap = submitApplicationSnapshot(freshDraft(), '2026-04-05T09:30:00Z');
+    const t = deriveStartabilityTimeline(snap);
+    expect(t.applicationSubmittedAt).toBe('2026-04-05T09:30:00Z');
+  });
+
+  it('respects caller-provided readinessAt', () => {
+    const snap = submitApplicationSnapshot(freshDraft());
+    const t = deriveStartabilityTimeline(snap, {
+      readinessAt: '2026-03-30T00:00:00Z',
+    });
+    expect(t.readinessAt).toBe('2026-03-30T00:00:00Z');
+  });
+
+  it('captures the FIRST view and FIRST action (not a later one)', () => {
+    let snap = submitApplicationSnapshot(freshDraft(), '2026-04-01T00:00:00Z');
+    snap = transitionApplicationStatus(snap, 'viewed', {
+      actor: 'employer',
+      at: '2026-04-01T03:00:00Z',
+    });
+    snap = transitionApplicationStatus(snap, 'in_review', {
+      actor: 'employer',
+      at: '2026-04-01T04:00:00Z',
+    });
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-01T05:00:00Z',
+    });
+    const t = deriveStartabilityTimeline(snap);
+    expect(t.firstViewedAt).toBe('2026-04-01T03:00:00Z');
+    // firstActionAt is the earliest employer-mutation entry.
+    expect(t.firstActionAt).toBe('2026-04-01T03:00:00Z');
+  });
+
+  it('captures reviewAdvancedAt, startReadyAt, and startedAt on a full chain', () => {
+    const snap = fullyProgressedSnapshot();
+    const t = deriveStartabilityTimeline(snap, {
+      readinessAt: '2026-03-31T00:00:00Z',
+    });
+    expect(t.reviewAdvancedAt).toBe('2026-04-02T10:00:00Z');
+    expect(t.startReadyAt).toBe('2026-04-14T10:00:00Z');
+    expect(t.startedAt).toBe('2026-04-15T08:00:00Z');
+  });
+
+  it('NEVER fabricates timestamps — missing readinessAt stays null', () => {
+    const snap = submitApplicationSnapshot(freshDraft());
+    const t = deriveStartabilityTimeline(snap);
+    expect(t.readinessAt).toBeNull();
+  });
+});
+
+describe('deriveStartabilityMetrics', () => {
+  it('returns all-null metrics and chainComplete=false for an empty timeline', () => {
+    const t = deriveStartabilityTimeline(freshDraft());
+    const m = deriveStartabilityMetrics(t);
+    expect(m.minutesToSubmit).toBeNull();
+    expect(m.minutesToFirstView).toBeNull();
+    expect(m.minutesToFirstAction).toBeNull();
+    expect(m.minutesToReviewAdvanced).toBeNull();
+    expect(m.daysToStartReady).toBeNull();
+    expect(m.daysToStarted).toBeNull();
+    expect(m.chainComplete).toBe(false);
+    expect(m.missingTimestamps.length).toBeGreaterThan(0);
+  });
+
+  it('computes minutesToFirstView exactly for a submitted-then-viewed chain', () => {
+    let snap = submitApplicationSnapshot(freshDraft(), '2026-04-01T12:00:00Z');
+    snap = transitionApplicationStatus(snap, 'viewed', {
+      actor: 'employer',
+      at: '2026-04-01T14:30:00Z',
+    });
+    const metrics = deriveStartabilityMetrics(deriveStartabilityTimeline(snap));
+    expect(metrics.minutesToFirstView).toBe(150);
+  });
+
+  it('computes daysToStarted with one-decimal precision', () => {
+    const snap = fullyProgressedSnapshot();
+    const metrics = deriveStartabilityMetrics(deriveStartabilityTimeline(snap));
+    // submit 2026-04-01T12:00:00Z -> started 2026-04-15T08:00:00Z = 13.83 days
+    expect(metrics.daysToStarted).toBeCloseTo(13.8, 1);
+  });
+
+  it('chainComplete becomes true only when every timestamp is populated', () => {
+    const snap = fullyProgressedSnapshot();
+    const t = deriveStartabilityTimeline(snap, { readinessAt: '2026-03-31T00:00:00Z' });
+    const metrics = deriveStartabilityMetrics(t);
+    expect(metrics.chainComplete).toBe(true);
+    expect(metrics.missingTimestamps).toEqual([]);
+  });
+
+  it('missingTimestamps names the exact gaps when partial', () => {
+    const snap = submitApplicationSnapshot(freshDraft());
+    const t = deriveStartabilityTimeline(snap);
+    const metrics = deriveStartabilityMetrics(t);
+    expect(metrics.missingTimestamps).toContain('readinessAt');
+    expect(metrics.missingTimestamps).toContain('firstViewedAt');
+    expect(metrics.missingTimestamps).toContain('startedAt');
+  });
+
+  it('never returns a negative delta (rejects inverted timestamps)', () => {
+    // Invent an inverted timeline — start BEFORE submit.
+    const t = deriveStartabilityTimeline(
+      submitApplicationSnapshot(freshDraft({ createdAt: '2026-04-10T00:00:00Z' }), '2026-04-10T12:00:00Z'),
+      { readinessAt: '2026-04-20T00:00:00Z' }, // readiness AFTER submit, impossible
+    );
+    const metrics = deriveStartabilityMetrics(t);
+    expect(metrics.minutesToSubmit).toBeNull();
+  });
+});
+
+describe('deriveBlockerDurationTotals', () => {
+  it('counts refresh requests across the application lifetime', () => {
+    let snap = submitApplicationSnapshot(freshDraft());
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    snap = refreshApplicationSnapshot(snap, {}, { at: '2026-04-02T06:00:00Z' });
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-03T00:00:00Z',
+    });
+    const totals = deriveBlockerDurationTotals(snap);
+    expect(totals.refreshRequestCount).toBe(2);
+  });
+
+  it('sums closed refresh-wait intervals and leaves open waits null', () => {
+    let snap = submitApplicationSnapshot(freshDraft());
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    snap = refreshApplicationSnapshot(snap, {}, { at: '2026-04-02T06:00:00Z' });
+    // First wait closed: 6 hours = 360 minutes
+    const afterClosed = deriveBlockerDurationTotals(snap);
+    expect(afterClosed.minutesInRefreshWait).toBe(360);
+    expect(afterClosed.hasOpenWait).toBe(false);
+
+    // Open a second wait — should keep the 360 accumulated and mark open
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-03T00:00:00Z',
+    });
+    const afterOpen = deriveBlockerDurationTotals(snap);
+    expect(afterOpen.minutesInRefreshWait).toBe(360); // unchanged
+    expect(afterOpen.hasOpenWait).toBe(true);
+  });
+
+  it('returns null minutesInRefreshWait when no wait has ever closed', () => {
+    let snap = submitApplicationSnapshot(freshDraft());
+    snap = requestApplicationAction(snap, 'request_refresh', {
+      actor: 'employer',
+      at: '2026-04-02T00:00:00Z',
+    });
+    const totals = deriveBlockerDurationTotals(snap);
+    expect(totals.minutesInRefreshWait).toBeNull();
+    expect(totals.hasOpenWait).toBe(true);
+  });
+});

--- a/apps/web/app/api/pilot-request/route.ts
+++ b/apps/web/app/api/pilot-request/route.ts
@@ -1,27 +1,101 @@
-import { NextRequest, NextResponse } from 'next/server';
-
 /**
  * POST /api/pilot-request
  *
- * Stub — accepts pilot request form data.
- * TODO: persist to database, send notification email, write AuditEvent.
+ * Turns a buyer-submitted pilot request into a structured
+ * PilotRequestRecord with owner, next step, baseline skeleton, and
+ * canonical success criteria. Accepts both JSON bodies (from the
+ * hardened /pilot page fetch handler, future callers) and
+ * application/x-www-form-urlencoded (from the current HTML form
+ * fallback).
+ *
+ * Response on success (200):
+ *   { ok: true, record: PilotRequestRecord, confirmation: PilotConfirmationRenderModel }
+ *
+ * Response on validation failure (400):
+ *   { ok: false, errors: PilotIntakeInputError[] }
+ *
+ * Side effects are deliberately minimal — this wave produces the
+ * structured record and returns it. Persistence + email notification
+ * wiring is deferred to a separate wave ("do not build a full CRM").
  */
-export async function POST(request: NextRequest) {
-  const body = await request.json();
 
-  // Basic validation
-  const { organization, name, email } = body as Record<string, unknown>;
-  if (!organization || !name || !email) {
+import { NextResponse } from 'next/server';
+import {
+  createPilotRequestRecord,
+  validatePilotIntakeInput,
+  type PilotIntakeInput,
+} from '@/lib/pilot/pilot-intake';
+import { buildPilotConfirmationRenderModel } from '@/lib/pilot/pilot-confirmation-copy';
+
+async function readRequestBody(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const parsed = (await request.json()) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  // Form-encoded fallback — the existing /pilot page HTML form submits
+  // as application/x-www-form-urlencoded or multipart/form-data.
+  const form = await request.formData();
+  const record: Record<string, unknown> = {};
+  for (const [key, value] of form.entries()) {
+    record[key] = typeof value === 'string' ? value : value.name;
+  }
+  return record;
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === 'string' ? value : '';
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = await readRequestBody(request);
+
+  const input: PilotIntakeInput = {
+    orgName: readString(body, 'organization') || readString(body, 'orgName'),
+    contactName: readString(body, 'name') || readString(body, 'contactName'),
+    contactEmail: readString(body, 'email') || readString(body, 'contactEmail'),
+    orgId: readString(body, 'orgId') || null,
+    roleOrWorkflowTarget:
+      readString(body, 'roleOrWorkflowTarget')
+      || readString(body, 'usecase')
+      || 'Credentialing review',
+    sourceContext: readString(body, 'sourceContext') || '/pilot',
+  };
+
+  const errors = validatePilotIntakeInput(input);
+  if (errors.length > 0) {
     return NextResponse.json(
-      { ok: false, message: 'Organization, name, and email are required.' },
+      {
+        ok: false,
+        errors,
+        message: errors
+          .map((e) => e.reason)
+          .join(' '),
+      },
       { status: 400 },
     );
   }
 
-  // TODO: write AuditEvent, persist to DB, send notification
+  const record = createPilotRequestRecord(input);
+  const confirmation = buildPilotConfirmationRenderModel(record);
 
-  return NextResponse.json({
-    ok: true,
-    message: 'Pilot request received. We will reach out within 2 business days.',
-  });
+  return NextResponse.json(
+    {
+      ok: true,
+      record,
+      confirmation,
+      message: confirmation.acknowledgement,
+    },
+    { status: 200 },
+  );
 }

--- a/apps/web/app/api/pilot/proof-pack/route.ts
+++ b/apps/web/app/api/pilot/proof-pack/route.ts
@@ -1,0 +1,141 @@
+/**
+ * /api/pilot/proof-pack — Pilot proof-pack export route
+ *
+ * POST: Accepts an array of ApplicationSnapshot objects and returns a
+ * deterministic buyer-legible proof-pack artifact. Partial data is
+ * preserved as partial — limitation lines are honored, medians
+ * collapse to null when endpoints are missing.
+ *
+ * GET: Returns a proof pack for a zero-application set (demonstrates
+ * the "no applications" limitation response — useful for operators
+ * validating the export contract without supplying snapshots).
+ *
+ * Query / body options:
+ *   - `download=json` — sets Content-Disposition for browser download.
+ *   - `readiness` (POST body, optional) — Record<applicationId, ISO string>
+ *     used to populate readinessAt timestamps when the snapshot audit
+ *     log does not carry them.
+ *
+ * Doctrine (from Wave 243 mission):
+ *   - Deterministic output for identical input (serializePilotProofPack).
+ *   - Partial data stays partial — never upgraded to decision-grade.
+ *   - Limitation lines are always surfaced when any metric is null.
+ *   - Response shape is stable for diffable buyer deliverables.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  buildPilotProofPack,
+  serializePilotProofPack,
+  type PilotProofPack,
+} from '@/lib/proof/pilot-proof-pack';
+import type { ApplicationSnapshot } from '@/lib/apply/application-snapshot';
+
+interface ProofPackRequestBody {
+  applications?: ApplicationSnapshot[];
+  readiness?: Record<string, string | null>;
+  generatedAt?: string;
+}
+
+interface ProofPackResponse {
+  pack: PilotProofPack;
+  /** Deterministic serialization of `pack` for buyer deliverables. */
+  serialized: string;
+}
+
+function isApplicationSnapshot(value: unknown): value is ApplicationSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.applicationId === 'string'
+    && typeof v.subjectId === 'string'
+    && typeof v.employerId === 'string'
+    && typeof v.roleId === 'string'
+    && typeof v.snapshotHash === 'string'
+    && Array.isArray(v.includedLanes)
+    && Array.isArray(v.includedClaims)
+    && typeof v.proofTier === 'string'
+    && typeof v.completeness === 'number'
+    && typeof v.createdAt === 'string'
+    && typeof v.status === 'string'
+    && Array.isArray(v.auditLog)
+  );
+}
+
+function readDownloadParam(req: Request): string | null {
+  // Use plain URL parsing rather than NextRequest.nextUrl so the route
+  // is test-friendly under raw `new Request(url)` fixtures.
+  try {
+    return new URL(req.url).searchParams.get('download');
+  } catch {
+    return null;
+  }
+}
+
+function downloadResponse(
+  serialized: string,
+  generatedAt: string,
+): NextResponse {
+  const filename = `vitalcv-pilot-proof-pack-${generatedAt.slice(0, 10)}.json`;
+  return new NextResponse(serialized, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  });
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let body: ProofPackRequestBody;
+  try {
+    body = (await req.json()) as ProofPackRequestBody;
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON body. Expected { applications, readiness?, generatedAt? }.' },
+      { status: 400 },
+    );
+  }
+
+  const applications = Array.isArray(body.applications) ? body.applications : [];
+  const invalid = applications.findIndex((a) => !isApplicationSnapshot(a));
+  if (invalid !== -1) {
+    return NextResponse.json(
+      {
+        error: `applications[${invalid}] does not match the ApplicationSnapshot contract. Each entry requires applicationId, subjectId, employerId, roleId, snapshotHash, includedLanes, includedClaims, proofTier, completeness, createdAt, status, auditLog.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { pack } = buildPilotProofPack({
+    applications,
+    readinessByApplication: body.readiness,
+    generatedAt: body.generatedAt,
+  });
+  const serialized = serializePilotProofPack(pack);
+
+  if (readDownloadParam(req) === 'json') {
+    return downloadResponse(serialized, pack.generatedAt);
+  }
+
+  const response: ProofPackResponse = { pack, serialized };
+  return NextResponse.json(response, { status: 200 });
+}
+
+/**
+ * GET variant — zero-application pack. Demonstrates the honest-partial
+ * response when no evidence is available. Useful for operators
+ * validating the export route contract before real snapshots exist.
+ */
+export async function GET(req: Request): Promise<NextResponse> {
+  const { pack } = buildPilotProofPack({ applications: [] });
+  const serialized = serializePilotProofPack(pack);
+
+  if (readDownloadParam(req) === 'json') {
+    return downloadResponse(serialized, pack.generatedAt);
+  }
+
+  const response: ProofPackResponse = { pack, serialized };
+  return NextResponse.json(response, { status: 200 });
+}

--- a/apps/web/app/p/[slug]/page.tsx
+++ b/apps/web/app/p/[slug]/page.tsx
@@ -24,6 +24,7 @@ import { notFound } from 'next/navigation';
 import PassportShareActions from '@/components/passport/PassportShareActions';
 import { ApplyWithVitalCV } from '@/components/apply/ApplyWithVitalCV';
 import { EmployerTracker } from '@/components/telemetry/EmployerTracker';
+import { ACTION_OWNER, resolveBlockerOwnership } from '@/lib/trust/action-owner';
 
 // ── Shared types ──────────────────────────────────────────────────────────
 
@@ -661,10 +662,27 @@ export default async function PublicTrustProfilePage({ params, searchParams }: P
                         Gaps detected
                       </p>
                       {profile.readiness.missingRequirements.length > 0 && (
-                        <ul className="mt-2 space-y-1">
-                          {profile.readiness.missingRequirements.map((r) => (
-                            <li key={r} className="text-xs text-muted-foreground">· {r}</li>
-                          ))}
+                        <ul className="mt-2 space-y-2">
+                          {profile.readiness.missingRequirements.map((r) => {
+                            // Owner-attributed line when this string maps
+                            // to a known blocker in the actor-ownership
+                            // contract. Unknown strings render as bare
+                            // requirements — no ownership invented where
+                            // none is classified.
+                            const ownership = resolveBlockerOwnership(r);
+                            const hasKnownOwner =
+                              ownership.owner !== ACTION_OWNER.UNKNOWN;
+                            return (
+                              <li key={r} className="text-xs text-muted-foreground">
+                                <span>· {hasKnownOwner ? ownership.plainLabel : r}</span>
+                                {hasKnownOwner && (
+                                  <span className="block pl-3 mt-0.5 text-[10px] opacity-70">
+                                    {ownership.ownerPrefix}.
+                                  </span>
+                                )}
+                              </li>
+                            );
+                          })}
                         </ul>
                       )}
                     </div>

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -28,6 +28,7 @@ import { Input } from '@/components/ui/input';
 import { ShieldCheck } from 'lucide-react';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { TrustStatusBadge, type TrustBadgeStatus } from '@/components/ui/trust-status-badge';
+import { resolveRecoveryPath, type SourceLane } from '@/lib/trust/recovery-path';
 import { WhatsNextPanel } from '@/components/passport/WhatsNextPanel';
 import { useIngestStream, hydrateFromHomepagePreview, type IngestStreamState, type StreamPhase } from '@/hooks/useIngestStream';
 import {
@@ -165,31 +166,56 @@ function resolveSourceBadge(state: SourceState, displayValue: string): {
   };
 }
 
-function SourceRow({ label, state, value }: { label: string; state: SourceState; value?: string }) {
+function SourceRow({
+  label,
+  state,
+  value,
+  lane,
+}: {
+  label: string;
+  state: SourceState;
+  value?: string;
+  /** Canonical lane identifier. When provided, the row surfaces the
+   * recovery-path explanation below the badge when the source is in an
+   * error state — so the user reads "VitalCV will retry" instead of
+   * guessing at an ambiguous "Unavailable" badge. */
+  lane?: SourceLane;
+}) {
   const displayValue =
     state === 'checking' ? 'Checking…'
     : state === 'done' ? (value ?? 'Done')
     : state === 'error' ? 'Unavailable'
     : '—';
   const badge = resolveSourceBadge(state, displayValue);
+  const recoveryExplanation =
+    lane && state === 'error'
+      ? resolveRecoveryPath(lane, 'unavailable').explanation
+      : null;
 
   return (
-    <div className="flex items-center justify-between py-2 border-b border-border last:border-0">
-      <div className="flex items-center gap-2.5">
-        <span
-          className="w-1.5 h-1.5 rounded-full shrink-0"
-          style={{
-            backgroundColor:
-              state === 'done'     ? 'rgba(255,255,255,0.45)' :
-              state === 'checking' ? 'rgba(255,255,255,0.20)' :
-              state === 'error'    ? 'rgba(255,255,255,0.15)' :
-                                     'rgba(255,255,255,0.08)',
-          }}
-          aria-hidden
-        />
-        <span className="text-muted-foreground text-sm">{label}</span>
+    <div className="py-2 border-b border-border last:border-0">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <span
+            className="w-1.5 h-1.5 rounded-full shrink-0"
+            style={{
+              backgroundColor:
+                state === 'done'     ? 'rgba(255,255,255,0.45)' :
+                state === 'checking' ? 'rgba(255,255,255,0.20)' :
+                state === 'error'    ? 'rgba(255,255,255,0.15)' :
+                                       'rgba(255,255,255,0.08)',
+            }}
+            aria-hidden
+          />
+          <span className="text-muted-foreground text-sm">{label}</span>
+        </div>
+        <TrustStatusBadge status={badge.status} label={badge.label} size="sm" />
       </div>
-      <TrustStatusBadge status={badge.status} label={badge.label} size="sm" />
+      {recoveryExplanation && (
+        <p className="mt-1 pl-4 text-xs text-muted-foreground leading-relaxed">
+          {recoveryExplanation}
+        </p>
+      )}
     </div>
   );
 }
@@ -642,27 +668,36 @@ function PassportPageContent({
               </Card>
             )}
 
-          {/* Source status rows */}
+          {/* Source status rows. Each row carries the `lane` prop so the
+              row renders the recovery-path explanation
+              (lib/trust/recovery-path.ts) underneath the badge when the
+              source is in an error state — preventing "Unavailable" from
+              reading as a silent verdict rather than a retry-in-flight
+              VitalCV-owned state. */}
           <Card className="animate-panel-enter gap-0 rounded-none border-border bg-card px-4 py-2 shadow-none">
             <SourceRow
                 label="NPPES"
                 state={sources.nppes}
                 value={identityLabel}
+                lane="nppes"
               />
               <SourceRow
                 label="OIG / LEIE"
                 state={sources.oig}
                 value={exclusionLabel}
+                lane="oig"
               />
               <SourceRow
                 label="CMS PECOS"
                 state={sources.pecos}
                 value={enrollmentLabel}
+                lane="pecos"
               />
               <SourceRow
-                label="Configured state board lane"
+                label="State medical board"
                 state={resolveLicenseState(state)}
                 value={formatLicenseLabel(state, resolveLicenseState(state))}
+                lane="state_board"
               />
             </Card>
 

--- a/apps/web/app/pilot/page.tsx
+++ b/apps/web/app/pilot/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ArrowRight, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { buildPilotProofPack } from '@/lib/proof/pilot-proof-pack';
+import {
+  BUYER_PILOT_CTA,
+  BUYER_PILOT_KPI_COPY,
+  BUYER_PILOT_LIMITATIONS,
+} from '@/lib/pilot/buyer-pilot-copy';
 
 export const metadata: Metadata = {
   title: 'Start a Pilot',
@@ -32,7 +38,17 @@ const SCOPE_GUARDS = [
   'We do not replace your credentialing committee — VitalCV provides a verified head start, not a final credentialing decision',
 ];
 
+function formatNullable(value: number | null, suffix: string): string {
+  return value === null ? '\u2014' : `${value}${suffix}`;
+}
+
 export default function PilotPage() {
+  // Build the proof-pack baseline server-side. Real snapshots flow in
+  // via the /api/pilot/proof-pack POST route; this renders the
+  // honest-partial baseline for the buyer so they see how the
+  // limitation language surfaces under zero / partial data.
+  const { pack } = buildPilotProofPack({ applications: [] });
+
   return (
     <main className="bg-background px-6 py-16 text-foreground">
       <div className="mx-auto max-w-4xl space-y-10">
@@ -62,38 +78,125 @@ export default function PilotPage() {
           ))}
         </section>
 
-        <section className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-6">
+        {/* Lane D — Buyer CTA with the five required answers explicit
+            on the card. No vague "try it now" language. The request
+            form below is still the terminal action; this section
+            names exactly what happens when the buyer fills it out. */}
+        <section className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-6" data-slot="buyer-pilot-cta">
           <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-400">One next step</p>
-          <h2 className="mt-2 text-2xl font-semibold">Request pilot review setup</h2>
+          <h2 className="mt-2 text-2xl font-semibold">{BUYER_PILOT_CTA.headline}</h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Use a clinician NPI to create a review context and start the pilot motion immediately.
-            If you already have a shared passport link, you can open employer review directly.
+            {BUYER_PILOT_CTA.description}
           </p>
+
+          <dl className="mt-5 grid gap-4 md:grid-cols-2">
+            {([
+              ['What happens on request', BUYER_PILOT_CTA.answers.whatHappensOnRequest],
+              ['What VitalCV measures', BUYER_PILOT_CTA.answers.whatWeMeasure],
+              ['What you provide', BUYER_PILOT_CTA.answers.whatYouProvide],
+              ['Success criteria', BUYER_PILOT_CTA.answers.successCriteria],
+            ] as const).map(([term, definition]) => (
+              <div key={term} className="rounded-lg border border-emerald-400/20 bg-black/10 p-3">
+                <dt className="text-[10px] font-semibold uppercase tracking-widest text-emerald-300">
+                  {term}
+                </dt>
+                <dd className="mt-1.5 text-xs text-foreground/85 leading-relaxed">
+                  {definition}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="mt-5 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-amber-400">
+              Outside current coverage
+            </p>
+            <p className="mt-1.5 text-xs text-foreground/80 leading-relaxed">
+              {BUYER_PILOT_CTA.answers.outsideCurrentCoverage}
+            </p>
+          </div>
+
           <div className="mt-5 flex flex-wrap gap-3">
             <Link
-              href="/review/request"
+              href={BUYER_PILOT_CTA.primaryActionHref}
               className="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400"
             >
-              Request review
+              {BUYER_PILOT_CTA.primaryActionLabel}
               <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
-              href="/review"
+              href="/pilot/proof-pack"
               className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-5 py-2.5 text-sm font-medium text-muted-foreground transition hover:text-foreground"
             >
-              Open review entry
+              View proof-pack sample
             </Link>
           </div>
         </section>
 
-        {/* Scope guard */}
-        <section className="rounded-lg border border-border bg-muted/40 px-5 py-5">
+        {/* Lane C — What was measured. Honest-partial KPI summary
+            reading from the proof-pack builder. Metrics degrade to
+            "—" when endpoints are missing; never imputed. */}
+        <section className="rounded-2xl border border-border bg-card p-6" data-slot="buyer-pilot-kpi-summary">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            {BUYER_PILOT_KPI_COPY.sectionHeadline}
+          </p>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            {BUYER_PILOT_KPI_COPY.sectionDescription}
+          </p>
+
+          <div className="mt-5 grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.applicationsSubmitted.label}
+              value={String(pack.counts.applicationsSubmitted)}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.reviewsOpened.label}
+              value={String(pack.counts.reviewsOpened)}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.actionsTaken.label}
+              value={String(pack.counts.actionsTaken)}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.startReadyCount.label}
+              value={String(pack.counts.startReadyCount)}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.startedCount.label}
+              value={String(pack.counts.startedCount)}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.medianMinutesToFirstView.label}
+              value={formatNullable(pack.medians.medianMinutesToFirstView, ' min')}
+            />
+            <KpiTile
+              label={BUYER_PILOT_KPI_COPY.tileMeta.medianDaysToStarted.label}
+              value={formatNullable(pack.medians.medianDaysToStarted, ' days')}
+            />
+          </div>
+
+          {pack.applicationCount === 0 ? (
+            <p className="mt-5 text-xs text-muted-foreground leading-relaxed italic">
+              {BUYER_PILOT_KPI_COPY.emptyStateNote}
+            </p>
+          ) : pack.partialDataNotice ? (
+            <p className="mt-5 text-xs text-muted-foreground leading-relaxed italic">
+              {BUYER_PILOT_KPI_COPY.partialStateNote}
+            </p>
+          ) : null}
+        </section>
+
+        {/* Scope guard — merges the page's existing local SCOPE_GUARDS
+            with the canonical BUYER_PILOT_LIMITATIONS so the buyer sees
+            the same limitation language that the proof-pack builder
+            emits at runtime. Deduped by exact text match. */}
+        <section className="rounded-lg border border-border bg-muted/40 px-5 py-5" data-slot="buyer-pilot-limitations">
           <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
             <AlertTriangle className="h-4 w-4" />
-            Scope boundaries
+            Scope boundaries and limitations
           </h2>
           <ul className="mt-3 space-y-3">
-            {SCOPE_GUARDS.map((item) => (
+            {Array.from(new Set([...SCOPE_GUARDS, ...BUYER_PILOT_LIMITATIONS])).map((item) => (
               <li key={item} className="text-sm text-muted-foreground leading-relaxed">
                 {item}
               </li>
@@ -102,7 +205,7 @@ export default function PilotPage() {
         </section>
 
         {/* Request form */}
-        <section>
+        <section id="request-form">
           <h2 className="text-lg font-semibold text-foreground">
             Request access
           </h2>
@@ -178,5 +281,16 @@ export default function PilotPage() {
         </section>
       </div>
     </main>
+  );
+}
+
+function KpiTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-background px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums text-foreground">{value}</p>
+    </div>
   );
 }

--- a/apps/web/app/pilot/proof-pack/page.tsx
+++ b/apps/web/app/pilot/proof-pack/page.tsx
@@ -1,0 +1,238 @@
+/**
+ * /pilot/proof-pack — Operator-facing proof-pack view
+ *
+ * Renders the current pilot proof pack with honest-partial framing:
+ *   - counts + medians (null-safe; "—" when missing)
+ *   - tier context (decision-grade / partial / draft submit counts)
+ *   - blocker totals with open-wait flag
+ *   - limitations list surfaced as a bullet set
+ *   - download link for the deterministic JSON artifact
+ *
+ * This view is deliberately minimal. It reads from the GET variant of
+ * /api/pilot/proof-pack (zero-application demonstration of the partial-
+ * data response). A future wave wires real snapshots into the POST body.
+ */
+
+import type { Metadata } from 'next';
+import { buildPilotProofPack, serializePilotProofPack } from '@/lib/proof/pilot-proof-pack';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Pilot Proof Pack — VitalCV',
+  description:
+    'Deterministic proof-pack artifact for VitalCV pilot buyers. Counts, medians, tier context, and explicit limitations.',
+};
+
+function formatNullable(value: number | null, suffix: string): string {
+  return value === null ? '—' : `${value}${suffix}`;
+}
+
+export default function PilotProofPackPage() {
+  // Server-rendered from the same builder the API route consumes, so the
+  // page view and the downloaded JSON are byte-identical for the same
+  // input set. Real snapshots flow in via the /api/pilot/proof-pack POST
+  // route; this server page demonstrates the zero-snapshot baseline.
+  const { pack } = buildPilotProofPack({ applications: [] });
+  const serialized = serializePilotProofPack(pack);
+
+  return (
+    <main className="min-h-screen bg-[var(--vt-bg)] text-[var(--vt-text-primary)] pb-24">
+      <header className="border-b border-[var(--vt-border)] px-6 py-6 sm:px-8 sm:py-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Pilot Proof Pack
+        </p>
+        <h1 className="mt-1 text-2xl sm:text-3xl font-bold tracking-tight">
+          Buyer-legible pilot evidence
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground leading-relaxed">
+          This page renders the deterministic proof-pack artifact. Counts and medians are computed
+          only from recorded events — nothing is imputed. When a metric is missing, it renders as
+          &ldquo;—&rdquo; and the limitations list below names the gap explicitly.
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground font-mono">
+          Generated: {pack.generatedAt}
+        </p>
+      </header>
+
+      <section className="px-6 py-6 sm:px-8 sm:py-8 space-y-8 max-w-4xl">
+        {pack.partialDataNotice && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3"
+            data-slot="partial-data-notice"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-amber-600 mb-1">
+              Partial data
+            </p>
+            <p className="text-sm text-foreground leading-relaxed">{pack.partialDataNotice}</p>
+          </div>
+        )}
+
+        {/* Counts */}
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-3">
+            Counts
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <CountTile label="Applications submitted" value={pack.counts.applicationsSubmitted} />
+            <CountTile label="Reviews opened" value={pack.counts.reviewsOpened} />
+            <CountTile label="Actions taken" value={pack.counts.actionsTaken} />
+            <CountTile label="Advanced" value={pack.counts.advancedCount} />
+            <CountTile label="Start-ready" value={pack.counts.startReadyCount} />
+            <CountTile label="Started" value={pack.counts.startedCount} />
+          </div>
+        </div>
+
+        {/* Medians */}
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-3">
+            Median time deltas
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <MedianTile
+              label="Submit → first view"
+              value={formatNullable(pack.medians.medianMinutesToFirstView, ' min')}
+            />
+            <MedianTile
+              label="Submit → first action"
+              value={formatNullable(pack.medians.medianMinutesToFirstAction, ' min')}
+            />
+            <MedianTile
+              label="Submit → start-ready"
+              value={formatNullable(pack.medians.medianDaysToStartReady, ' days')}
+            />
+            <MedianTile
+              label="Submit → started"
+              value={formatNullable(pack.medians.medianDaysToStarted, ' days')}
+            />
+          </div>
+        </div>
+
+        {/* Tier context */}
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-3">
+            Tier context at submit
+          </h2>
+          <div className="grid grid-cols-3 gap-3">
+            <CountTile
+              label="Decision-grade"
+              value={pack.tierContext.decisionGradeAtSubmit}
+              tone="emerald"
+            />
+            <CountTile label="Partial" value={pack.tierContext.partialAtSubmit} tone="amber" />
+            <CountTile label="Draft" value={pack.tierContext.draftAtSubmit} tone="neutral" />
+          </div>
+        </div>
+
+        {/* Blockers */}
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-3">
+            Blockers
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <CountTile label="Refresh requests" value={pack.blockers.totalRefreshRequests} />
+            <CountTile
+              label="Missing-info requests"
+              value={pack.blockers.totalMissingInfoRequests}
+            />
+            <CountTile
+              label="Open waits"
+              value={pack.blockers.applicationsWithOpenWait}
+              tone={pack.blockers.applicationsWithOpenWait > 0 ? 'amber' : 'neutral'}
+            />
+            <MedianTile
+              label="Median refresh wait"
+              value={formatNullable(pack.blockers.medianMinutesInRefreshWait, ' min')}
+            />
+          </div>
+        </div>
+
+        {/* Limitations */}
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-3">
+            Limitations ({pack.limitations.length})
+          </h2>
+          {pack.limitations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No limitations recorded.</p>
+          ) : (
+            <ul className="space-y-2">
+              {pack.limitations.map((limit, i) => (
+                <li
+                  key={i}
+                  className="rounded-lg border border-[var(--vt-border)] bg-card px-4 py-3 text-sm text-foreground leading-relaxed"
+                >
+                  <span className="text-amber-500 mr-2" aria-hidden>
+                    ◦
+                  </span>
+                  {limit}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Download */}
+        <div className="pt-4 border-t border-[var(--vt-border)]">
+          <a
+            href="/api/pilot/proof-pack?download=json"
+            download
+            className="inline-flex items-center gap-2 rounded-lg border border-foreground bg-foreground px-6 py-3 text-sm font-semibold text-background hover:opacity-90 transition-opacity"
+          >
+            Download proof pack (JSON)
+          </a>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Deterministic for identical input. Safe to diff across exports.
+          </p>
+        </div>
+
+        {/* Raw JSON preview */}
+        <details className="rounded-lg border border-[var(--vt-border)] bg-card px-4 py-3">
+          <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+            Raw serialized pack
+          </summary>
+          <pre className="mt-3 overflow-auto rounded-md bg-black/30 p-3 text-xs font-mono text-foreground/80 leading-relaxed">
+            {serialized}
+          </pre>
+        </details>
+      </section>
+    </main>
+  );
+}
+
+function CountTile({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string;
+  value: number;
+  tone?: 'neutral' | 'emerald' | 'amber';
+}) {
+  const tonedClass =
+    tone === 'emerald'
+      ? 'border-emerald-500/20 bg-emerald-500/5'
+      : tone === 'amber'
+        ? 'border-amber-500/25 bg-amber-500/5'
+        : 'border-[var(--vt-border)] bg-card';
+  return (
+    <div className={`rounded-lg border px-4 py-3 ${tonedClass}`}>
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function MedianTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-[var(--vt-border)] bg-card px-4 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-xl font-semibold tabular-nums text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/components/passport/WhatsNextPanel.tsx
+++ b/apps/web/components/passport/WhatsNextPanel.tsx
@@ -14,6 +14,11 @@ import {
 import { Card } from '@/components/ui/card';
 import { TrustStatusBadge } from '@/components/ui/trust-status-badge';
 import type { IngestStreamState } from '@/hooks/ingestStreamState';
+import {
+  resolveRecoveryPath,
+  type SourceLane,
+  type SourceLaneState,
+} from '@/lib/trust/recovery-path';
 
 void React;
 
@@ -79,13 +84,45 @@ interface VerifiedSource {
   id: string;
   label: string;
   done: boolean;
+  /** Canonical lane state via the recovery-path contract. Used to render
+   * the badge + explanation so an error state never disguises as motion. */
+  lane: SourceLane;
+  laneState: SourceLaneState;
+}
+
+/** Map an ingest source state into the canonical recovery-path lane
+ * state. Error → unavailable (VitalCV owns the retry), done → checked,
+ * everything else → pending. Prevents error being silently relabeled
+ * as "Pending". */
+function toLaneState(raw: IngestStreamState['sources']['nppes']): SourceLaneState {
+  if (raw === 'error') return 'unavailable';
+  if (raw === 'done') return 'checked';
+  return 'pending';
 }
 
 function resolveVerifiedSources(state: IngestStreamState): VerifiedSource[] {
   return [
-    { id: 'nppes', label: 'NPPES Identity', done: state.sources.nppes === 'done' },
-    { id: 'oig', label: 'OIG / LEIE Exclusion', done: state.sources.oig === 'done' },
-    { id: 'pecos', label: 'CMS PECOS Enrollment', done: state.sources.pecos === 'done' },
+    {
+      id: 'nppes',
+      label: 'NPPES Identity',
+      done: state.sources.nppes === 'done',
+      lane: 'nppes',
+      laneState: toLaneState(state.sources.nppes),
+    },
+    {
+      id: 'oig',
+      label: 'OIG / LEIE Exclusion',
+      done: state.sources.oig === 'done',
+      lane: 'oig',
+      laneState: toLaneState(state.sources.oig),
+    },
+    {
+      id: 'pecos',
+      label: 'CMS PECOS Enrollment',
+      done: state.sources.pecos === 'done',
+      lane: 'pecos',
+      laneState: toLaneState(state.sources.pecos),
+    },
   ];
 }
 
@@ -302,19 +339,37 @@ export function WhatsNextPanel({ state }: WhatsNextPanelProps) {
           Automatically checked against federal and state data sources.
         </p>
         <div className="space-y-0">
-          {verifiedSources.map(source => (
-            <div
-              key={source.id}
-              className="flex items-center justify-between py-2 border-b border-border last:border-0"
-            >
-              <span className="text-sm text-muted-foreground">{source.label}</span>
-              <TrustStatusBadge
-                status={source.done ? 'checked' : 'pending'}
-                label={source.done ? 'Checked' : 'Pending'}
-                size="sm"
-              />
-            </div>
-          ))}
+          {verifiedSources.map(source => {
+            // Consume the recovery-path contract so a source in error
+            // state renders as "Source unavailable — retry" (VitalCV-
+            // owned retry) rather than the pre-doctrine "Pending"
+            // label which disguised failure as motion.
+            const recovery = resolveRecoveryPath(source.lane, source.laneState);
+            const badgeStatus =
+              source.laneState === 'unavailable' ? 'unavailable' as const
+              : source.laneState === 'checked' ? 'checked' as const
+              : 'pending' as const;
+            return (
+              <div
+                key={source.id}
+                className="py-2 border-b border-border last:border-0"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">{source.label}</span>
+                  <TrustStatusBadge
+                    status={badgeStatus}
+                    label={recovery.statusLabel}
+                    size="sm"
+                  />
+                </div>
+                {source.laneState === 'unavailable' && (
+                  <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+                    {recovery.explanation}
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </div>
       </Card>
 

--- a/apps/web/components/review/EmployerCockpit.tsx
+++ b/apps/web/components/review/EmployerCockpit.tsx
@@ -4,6 +4,11 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { AlertCircle, Clock, Database, CheckCircle2 } from 'lucide-react';
 import type { PassportData, DecisionPosture } from '@/lib/trust/passport-contract';
+import { resolveBlockerOwnership } from '@/lib/trust/action-owner';
+import {
+  resolveEmployerActionConsequence,
+  resolveProofTier,
+} from '@/lib/trust/employer-action-consequence';
 
 interface EmployerCockpitProps {
   passport: PassportData;
@@ -122,6 +127,36 @@ export function EmployerCockpit({ passport }: EmployerCockpitProps) {
     ...posture.missing.map((s) => ({ ...s, decisionGrade: false })),
   ];
 
+  // Owner-attributed blocker metadata. Each entry carries the owner,
+  // owner prefix ("You need to…", "VitalCV is retrying…", "Your
+  // institution covers…"), and the short action verb. Replaces the
+  // ownerless blocker strings the cockpit used to surface.
+  const blockerDetails = posture.blockers.map((b) => ({
+    raw: b,
+    ownership: resolveBlockerOwnership(b),
+  }));
+
+  // Proof-tier classification. Drives the banner + accept-button gating.
+  // Content-based, not count-based: any lane that is unavailable, review-
+  // required, access-required, stale, or no-record disqualifies
+  // decision-grade regardless of how many lanes have been checked.
+  const proofTier = resolveProofTier({
+    hasAnchor: Boolean(passport.entityId),
+    allRequiredLanesResolved: posture.status === 'READY',
+    hasUnresolvedBlockers: posture.blockers.length > 0,
+    anyLanePending: posture.missing.some((s) => s.state === 'pending'),
+    anyLaneReviewRequired: posture.missing.some((s) => s.state === 'reviewRequired'),
+    anyLaneAccessRequired: posture.missing.some(
+      (s) => s.state === 'accessRequired' || s.state === 'gated',
+    ),
+    anyLaneUnavailable: posture.missing.some((s) => s.state === 'unavailable'),
+    anyLaneStale: [...posture.proven, ...posture.missing].some((s) => s.state === 'stale'),
+    anyLaneNoRecord: posture.missing.some(
+      (s) => s.state === 'notDecisionGrade' || s.state === 'previewOnly',
+    ),
+    hasOpenDriftAlerts: false,
+  });
+
   return (
     <div className="min-h-screen bg-[var(--vt-bg)] text-[var(--vt-text-primary)] font-sans antialiased pb-24">
       {/* Header */}
@@ -147,6 +182,40 @@ export function EmployerCockpit({ passport }: EmployerCockpitProps) {
           </p>
         </div>
 
+        {/* Proof-tier banner. Content-based classification (not count-
+            based) — any access-required, unavailable, review-required,
+            stale, or no-record lane disqualifies decision-grade. Threads
+            resolveProofTier from employer-action-consequence so review
+            and /passport surfaces agree on tier. */}
+        <div
+          role="status"
+          aria-live="polite"
+          data-slot="proof-tier-banner"
+          className={`border-2 p-4 ${
+            proofTier.tier === 'decision_grade_proof_pack'
+              ? 'border-[var(--vt-status-resolved)] bg-[var(--vt-status-resolved)]/5'
+              : proofTier.tier === 'partial_proof_pack'
+                ? 'border-[var(--vt-severity-high)] bg-[var(--vt-severity-high)]/5'
+                : 'border-[var(--vt-severity-critical)] bg-[var(--vt-severity-critical)]/5'
+          }`}
+        >
+          <div className="text-[10px] font-bold uppercase tracking-widest opacity-60 mb-2">
+            Proof tier
+          </div>
+          <div className="text-lg font-bold uppercase tracking-tight">
+            {proofTier.label}
+          </div>
+          <p className="text-xs font-mono opacity-75 mt-2 leading-relaxed">
+            {proofTier.description}
+          </p>
+          {proofTier.acceptBlockedReason && (
+            <p className="text-xs font-mono mt-2 leading-relaxed text-[var(--vt-severity-critical)]">
+              <span className="font-bold uppercase tracking-wider">Accept blocked: </span>
+              {proofTier.acceptBlockedReason}
+            </p>
+          )}
+        </div>
+
         {/* Decision Posture Block */}
         <div className="border-2 bg-white/5 p-8 relative" style={{ borderColor: statusColor }}>
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 pb-8 border-b border-[var(--vt-border-subtle)] gap-6">
@@ -170,13 +239,24 @@ export function EmployerCockpit({ passport }: EmployerCockpitProps) {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
             <div>
               <h3 className="text-xs font-bold uppercase tracking-widest opacity-40 mb-4 flex items-center gap-2">
-                <AlertCircle className="w-4 h-4" /> Blockers ({posture.blockers.length})
+                <AlertCircle className="w-4 h-4" /> Blockers ({blockerDetails.length})
               </h3>
-              {posture.blockers.length > 0 ? (
-                <ul className="space-y-2 font-mono text-sm">
-                  {posture.blockers.map((b, i) => (
+              {blockerDetails.length > 0 ? (
+                <ul className="space-y-3 font-mono text-sm">
+                  {blockerDetails.map((entry, i) => (
                     <li key={i} className="flex items-start gap-2">
-                      <span className="text-[var(--vt-severity-critical)] mt-0.5">■</span> {b}
+                      <span className="text-[var(--vt-severity-critical)] mt-0.5 shrink-0">■</span>
+                      <div className="space-y-1">
+                        <div className="font-semibold">{entry.ownership.plainLabel}</div>
+                        <div className="text-xs opacity-75 leading-relaxed">
+                          {entry.ownership.ownerPrefix}.
+                        </div>
+                        {entry.ownership.etaOrDependency && (
+                          <div className="text-[10px] opacity-55">
+                            {entry.ownership.etaOrDependency}
+                          </div>
+                        )}
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -308,6 +388,62 @@ export function EmployerCockpit({ passport }: EmployerCockpitProps) {
           </div>
         )}
 
+        {/* Per-action consequence strip. Every button answers does /
+            assumes / audit / remains / ownerAfter before the click.
+            Sourced from resolveEmployerActionConsequence so the review
+            surface carries the same ownership doctrine as the rest of
+            the wedge. Accept carries an explicit NOT-included line. */}
+        <details
+          className="border border-[var(--vt-border)] bg-white/5 px-6 py-4"
+          data-slot="action-consequences"
+        >
+          <summary className="cursor-pointer text-xs font-bold uppercase tracking-[0.2em] opacity-60">
+            What each action does
+          </summary>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-6 font-mono text-xs">
+            {(['review', 'refresh', 'accept'] as const).map((actionKey) => {
+              const consequence = resolveEmployerActionConsequence(actionKey);
+              return (
+                <div key={actionKey} className="space-y-2">
+                  <p className="text-xs font-bold uppercase tracking-widest">
+                    {actionKey === 'accept'
+                      ? (proofTier.tier === 'decision_grade_proof_pack'
+                          ? 'Accept as Head Start'
+                          : 'Accept partial head start')
+                      : actionKey === 'refresh'
+                        ? 'Request Update'
+                        : 'Route to Credentialing'}
+                  </p>
+                  <p className="opacity-80 leading-relaxed">
+                    <span className="font-bold">Does: </span>
+                    {consequence.does}
+                  </p>
+                  <p className="opacity-70 leading-relaxed">
+                    <span className="font-bold">Assumes: </span>
+                    {consequence.assumes}
+                  </p>
+                  <p className="opacity-70 leading-relaxed">
+                    <span className="font-bold">Audit: </span>
+                    {consequence.auditEvent}
+                  </p>
+                  {consequence.remainsAfter && (
+                    <p className="opacity-70 leading-relaxed">
+                      <span className="font-bold">Remains: </span>
+                      {consequence.remainsAfter}
+                    </p>
+                  )}
+                  {consequence.acceptNotIncluded && (
+                    <p className="text-[var(--vt-severity-high)] leading-relaxed">
+                      <span className="font-bold">NOT included: </span>
+                      {consequence.acceptNotIncluded}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </details>
+
         {/* Action Panel */}
         <div className="border-t-4 border-[var(--vt-border)] pt-12 pb-12 sticky bottom-0 bg-[var(--vt-bg)] z-10 flex flex-col md:flex-row justify-between items-center gap-6 mt-24">
           <div>
@@ -337,10 +473,13 @@ export function EmployerCockpit({ passport }: EmployerCockpitProps) {
                 </button>
                 <button
                   onClick={() => setActionTaken('Accepted Head Start')}
-                  disabled={isBlocked}
+                  disabled={isBlocked || !proofTier.acceptAllowed}
+                  title={proofTier.acceptBlockedReason ?? undefined}
                   className="flex-1 md:flex-none border border-[var(--vt-text-primary)] bg-[var(--vt-text-primary)] text-[var(--vt-bg)] px-8 py-4 text-sm font-bold uppercase tracking-widest hover:opacity-90 disabled:opacity-20 disabled:cursor-not-allowed transition-colors"
                 >
-                  Accept as Head Start
+                  {proofTier.tier === 'decision_grade_proof_pack'
+                    ? 'Accept as Head Start'
+                    : 'Accept partial head start'}
                 </button>
               </>
             )}

--- a/apps/web/lib/apply/application-progress.ts
+++ b/apps/web/lib/apply/application-progress.ts
@@ -1,0 +1,279 @@
+/**
+ * Application progress-state copy.
+ *
+ * Each `ApplicationStatus` answers the three clinician-facing questions
+ * from the continuity wave:
+ *   1. What is the current state?
+ *   2. Who owns the next move?
+ *   3. What does the clinician see / do next?
+ *
+ * Owner attribution routes through the canonical `ActionOwner` enum
+ * established in the ownership wave. No new ownership taxonomy is
+ * introduced here — progress copy is a reader of the existing contract.
+ *
+ * Doctrine:
+ *   - No progress state is ownerless. Even terminal states name an
+ *     owner for the next move (or explicitly state none, honestly).
+ *   - Copy never promises that a partial application will become
+ *     decision-grade automatically. Any upgrade requires a refresh
+ *     event writing a new snapshot.
+ *   - "waiting_on_*" states are VitalCV/employer-owned, never
+ *     clinician-defect framing.
+ */
+
+import { ACTION_OWNER, type ActionOwner } from '@/lib/trust/action-owner';
+import type { ApplicationStatus } from './application-snapshot';
+
+export interface ApplicationProgressCopy {
+  status: ApplicationStatus;
+  /** Short label for badges / headers (e.g. "In review"). */
+  label: string;
+  /** One-sentence description of what the state means right now. */
+  description: string;
+  /** Who owns the next move after this state lands. */
+  nextOwner: ActionOwner;
+  /**
+   * What the clinician sees when their application is in this state.
+   * Keep concrete — never "we'll be in touch".
+   */
+  clinicianNextStep: string;
+  /** Whether the clinician can take an action from this state.
+   *  `false` for states where only VitalCV / employer / reviewer can
+   *  progress the application. */
+  clinicianCanAct: boolean;
+  /** Whether this status is terminal (no further transitions). */
+  terminal: boolean;
+}
+
+export function resolveApplicationProgress(
+  status: ApplicationStatus,
+): ApplicationProgressCopy {
+  switch (status) {
+    case 'draft':
+      return {
+        status,
+        label: 'Draft',
+        description:
+          'The application has been prepared but not yet sent to the employer.',
+        nextOwner: ACTION_OWNER.USER,
+        clinicianNextStep: 'Review what is included and submit when ready.',
+        clinicianCanAct: true,
+        terminal: false,
+      };
+
+    case 'submitted':
+      return {
+        status,
+        label: 'Submitted',
+        description:
+          'The application snapshot has been delivered to the employer. The snapshot freezes proof tier and included lanes at submit time.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'No action from you right now. The employer will open the application for review.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'viewed':
+      return {
+        status,
+        label: 'Viewed by employer',
+        description:
+          'The employer has opened the application in their review surface.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'No action from you right now. The employer is reviewing the evidence you submitted.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'in_review':
+      return {
+        status,
+        label: 'In review',
+        description:
+          'The employer is actively reviewing the submitted evidence against their hiring criteria.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'No action from you right now. The employer will advance, request a refresh, or route for manual review.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'waiting_on_refresh':
+      return {
+        status,
+        label: 'Waiting on refreshed data',
+        description:
+          'The employer requested updated source data. VitalCV is re-querying the relevant lanes; a new snapshot will be written when the refresh lands.',
+        nextOwner: ACTION_OWNER.VITALCV,
+        clinicianNextStep:
+          'No action from you right now. VitalCV is refreshing the source data the employer asked for.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'waiting_on_manual_review':
+      return {
+        status,
+        label: 'Waiting on manual review',
+        description:
+          'The employer routed the application to a human reviewer for interpretation of a finding or partial evidence.',
+        nextOwner: ACTION_OWNER.REVIEWER,
+        clinicianNextStep:
+          'A reviewer will contact you if they need additional information. No action from you right now.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'advanced':
+      return {
+        status,
+        label: 'Advanced',
+        description:
+          'The employer accepted the application for the next stage of their hiring workflow.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'The employer will move the application into credentialing. You will hear from them about start dates and onboarding.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'credentialing':
+      return {
+        status,
+        label: 'In credentialing',
+        description:
+          'The employer has moved the application into their credentialing workflow. VitalCV\u2019s pre-screen is complete; full privileging happens inside the employer\u2019s credentialing office.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'The employer\u2019s credentialing office may request additional documents directly. Watch for their communications.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'approved':
+      return {
+        status,
+        label: 'Approved',
+        description:
+          'Credentialing has completed. The employer has approved the application for start preparation.',
+        nextOwner: ACTION_OWNER.EMPLOYER,
+        clinicianNextStep:
+          'The employer will confirm a start date and any pre-start requirements.',
+        clinicianCanAct: false,
+        terminal: false,
+      };
+
+    case 'start_ready':
+      return {
+        status,
+        label: 'Start-ready',
+        description:
+          'All gating steps are complete. The clinician is cleared to begin on the employer\u2019s confirmed start date.',
+        nextOwner: ACTION_OWNER.USER,
+        clinicianNextStep:
+          'Confirm you are starting. The employer will mark the application as started once you begin.',
+        clinicianCanAct: true,
+        terminal: false,
+      };
+
+    case 'started':
+      return {
+        status,
+        label: 'Started',
+        description:
+          'The clinician has begun at the employer. The continuity loop is complete for this application.',
+        nextOwner: ACTION_OWNER.UNKNOWN,
+        clinicianNextStep:
+          'No further action on this application. Future employer reviews can reuse the frozen snapshot evidence.',
+        clinicianCanAct: false,
+        terminal: true,
+      };
+
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * For employer surfaces rendering an application-context review.
+ * Builds the copy line the employer reads: what state the application
+ * is in, what the safe next action is, and what remains unresolved.
+ */
+export interface EmployerApplicationContextCopy {
+  stateLabel: string;
+  /** One-line description the employer reads above the decision panel. */
+  contextHeadline: string;
+  /** Safe next action for the employer — never promotes partial to
+   *  decision-grade without a refresh. */
+  employerNextStep: string;
+}
+
+export function resolveEmployerApplicationContext(
+  status: ApplicationStatus,
+): EmployerApplicationContextCopy {
+  const progress = resolveApplicationProgress(status);
+
+  switch (status) {
+    case 'submitted':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'Clinician submitted this application. The snapshot below is frozen at submit time.',
+        employerNextStep:
+          'Open the review. You can advance, request refreshed data, request missing info, or route to manual review.',
+      };
+    case 'viewed':
+    case 'in_review':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'You have opened this application. The snapshot reflects the evidence at submit time.',
+        employerNextStep:
+          'Decide whether to advance on the current evidence or request a refresh / manual review before advancing.',
+      };
+    case 'waiting_on_refresh':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'You requested refreshed source data. A new snapshot will replace this view once the refresh lands.',
+        employerNextStep:
+          'Wait for the refresh. The updated snapshot will appear with a new hash and potentially a different proof tier.',
+      };
+    case 'waiting_on_manual_review':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'You routed this application to manual review. A reviewer is examining the evidence.',
+        employerNextStep:
+          'The reviewer will update the application when their assessment is complete.',
+      };
+    case 'advanced':
+    case 'credentialing':
+    case 'approved':
+    case 'start_ready':
+    case 'started':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'This application has progressed past initial review. The submitted snapshot is preserved for audit.',
+        employerNextStep:
+          'Further actions happen inside your credentialing / onboarding workflow, not on this review surface.',
+      };
+    case 'draft':
+      return {
+        stateLabel: progress.label,
+        contextHeadline:
+          'This application is still in draft on the clinician\u2019s side. It has not been submitted.',
+        employerNextStep:
+          'No action available until the clinician submits the application.',
+      };
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/web/lib/apply/application-snapshot.ts
+++ b/apps/web/lib/apply/application-snapshot.ts
@@ -1,0 +1,434 @@
+/**
+ * Application snapshot contract.
+ *
+ * An `ApplicationSnapshot` is the canonical, immutable record of what
+ * evidence existed at the moment a clinician submitted an application
+ * through Apply-with-VCV. It freezes proof-tier and included lanes
+ * exactly as they were at submit time — so the employer, when they
+ * open the application for review, sees the same truth the clinician
+ * saw when they clicked Submit.
+ *
+ * Doctrine (continuity wave — builds on the ownership / recovery /
+ * proof-tier contracts from the prior waves):
+ *   - Partial stays partial. A submitted snapshot never silently
+ *     upgrades to decision-grade without an explicit refresh writing
+ *     a new snapshot.
+ *   - Included lanes and claims are captured exactly. An excluded
+ *     lane at submit time remains excluded in the employer view.
+ *   - Proof tier at submit time is preserved verbatim. No post-hoc
+ *     recomputation under the same snapshotHash.
+ *   - Every mutation to the application status emits an audit event
+ *     with timestamp, actor, and transition.
+ *
+ * Hashing:
+ *   `snapshotHash` is a deterministic SHA-256 over the serialized
+ *   evidence set (subjectId + employerId + roleId + sorted included
+ *   lanes + sorted included claims + proofTier + createdAt). Two
+ *   snapshots with identical evidence produce identical hashes; any
+ *   mutation produces a new hash.
+ */
+
+import { createHash } from 'node:crypto';
+import type { ProofTier } from '@/lib/trust/employer-action-consequence';
+
+/** Progress states a submitted application can take. Mission-required
+ *  set — never silently extend this enum without doctrine review. */
+export type ApplicationStatus =
+  | 'draft'
+  | 'submitted'
+  | 'viewed'
+  | 'in_review'
+  | 'waiting_on_refresh'
+  | 'waiting_on_manual_review'
+  | 'advanced'
+  | 'credentialing'
+  | 'approved'
+  | 'start_ready'
+  | 'started';
+
+/** Lane identifiers that can be included in an application snapshot.
+ *  Mirrors `SourceLane` from recovery-path.ts but accepts additional
+ *  optional lanes that an application may attach. */
+export type ApplicationLane =
+  | 'nppes'
+  | 'oig'
+  | 'pecos'
+  | 'state_board'
+  | 'dea'
+  | 'npdb'
+  | 'abms'
+  | 'caqh';
+
+export interface ApplicationClaim {
+  /** Stable claim identifier. */
+  claimId: string;
+  /** Canonical source identifier for the claim (e.g. `NPPES`, `OIG_LEIE`). */
+  sourceId: string;
+  /** Claim kind: identity, safety, authority, eligibility, education, etc. */
+  kind: string;
+  /** ISO-8601 timestamp when the claim was last verified. */
+  verifiedAt: string | null;
+}
+
+export interface ApplicationAuditEntry {
+  at: string;
+  actor: 'clinician' | 'employer' | 'reviewer' | 'vitalcv' | 'source';
+  action:
+    | 'submitted'
+    | 'viewed'
+    | 'status_change'
+    | 'request_refresh'
+    | 'request_missing_info'
+    | 'route_to_review'
+    | 'refresh_landed'
+    | 'missing_info_provided';
+  from: ApplicationStatus | null;
+  to: ApplicationStatus | null;
+  note?: string;
+}
+
+export interface ApplicationSnapshot {
+  applicationId: string;
+  subjectId: string;
+  employerId: string;
+  roleId: string;
+  /** Deterministic SHA-256 hash over the evidence set. Frozen at
+   *  submit time; a refresh writes a new snapshot with a new hash. */
+  snapshotHash: string;
+  /** Lanes included in this submission, sorted ascending for hash
+   *  stability. Never modified post-submit under the same hash. */
+  includedLanes: ApplicationLane[];
+  /** Claims attached to the submission, sorted by claimId for hash
+   *  stability. Never modified post-submit under the same hash. */
+  includedClaims: ApplicationClaim[];
+  /** Proof tier frozen at submit time. Never silently upgrades. */
+  proofTier: ProofTier;
+  /** 0–100 completeness percent at submit time. */
+  completeness: number;
+  /** ISO-8601 timestamp when the snapshot was written. */
+  createdAt: string;
+  status: ApplicationStatus;
+  /** Ordered audit log. Every mutation appends one entry. */
+  auditLog: ApplicationAuditEntry[];
+}
+
+/**
+ * Build a deterministic hash over the evidence set. Two snapshots with
+ * identical evidence return the same hash; any difference (lane added,
+ * tier upgraded, claim verified at a new time) produces a new hash.
+ */
+export function computeApplicationSnapshotHash(input: {
+  subjectId: string;
+  employerId: string;
+  roleId: string;
+  includedLanes: ApplicationLane[];
+  includedClaims: ApplicationClaim[];
+  proofTier: ProofTier;
+  createdAt: string;
+}): string {
+  const sortedLanes = [...input.includedLanes].sort();
+  const sortedClaims = [...input.includedClaims]
+    .slice()
+    .sort((a, b) => a.claimId.localeCompare(b.claimId))
+    .map((c) => ({
+      claimId: c.claimId,
+      sourceId: c.sourceId,
+      kind: c.kind,
+      verifiedAt: c.verifiedAt,
+    }));
+
+  const payload = JSON.stringify({
+    subjectId: input.subjectId,
+    employerId: input.employerId,
+    roleId: input.roleId,
+    includedLanes: sortedLanes,
+    includedClaims: sortedClaims,
+    proofTier: input.proofTier,
+    createdAt: input.createdAt,
+  });
+
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+export interface CreateApplicationSnapshotInput {
+  applicationId: string;
+  subjectId: string;
+  employerId: string;
+  roleId: string;
+  includedLanes: ApplicationLane[];
+  includedClaims: ApplicationClaim[];
+  proofTier: ProofTier;
+  completeness: number;
+  createdAt?: string;
+}
+
+/**
+ * Create a fresh application snapshot in `draft` status. `submitted`
+ * transition goes through `submitApplicationSnapshot`.
+ */
+export function createApplicationSnapshot(
+  input: CreateApplicationSnapshotInput,
+): ApplicationSnapshot {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const sortedLanes = [...input.includedLanes].sort();
+  const sortedClaims = [...input.includedClaims]
+    .slice()
+    .sort((a, b) => a.claimId.localeCompare(b.claimId));
+  const snapshotHash = computeApplicationSnapshotHash({
+    subjectId: input.subjectId,
+    employerId: input.employerId,
+    roleId: input.roleId,
+    includedLanes: sortedLanes,
+    includedClaims: sortedClaims,
+    proofTier: input.proofTier,
+    createdAt,
+  });
+
+  return {
+    applicationId: input.applicationId,
+    subjectId: input.subjectId,
+    employerId: input.employerId,
+    roleId: input.roleId,
+    snapshotHash,
+    includedLanes: sortedLanes,
+    includedClaims: sortedClaims,
+    proofTier: input.proofTier,
+    completeness: Math.max(0, Math.min(100, Math.round(input.completeness))),
+    createdAt,
+    status: 'draft',
+    auditLog: [],
+  };
+}
+
+/**
+ * Advance a draft snapshot to `submitted`. Preserves every existing
+ * field verbatim — the only mutation is status + audit log. A
+ * submitted snapshot never reopens its evidence set; to change
+ * evidence, a new snapshot must be written via `refreshApplicationSnapshot`.
+ */
+export function submitApplicationSnapshot(
+  snapshot: ApplicationSnapshot,
+  at: string = new Date().toISOString(),
+): ApplicationSnapshot {
+  if (snapshot.status !== 'draft') {
+    throw new Error(
+      `ApplicationSnapshot ${snapshot.applicationId} cannot be submitted from status "${snapshot.status}" (only draft -> submitted is allowed).`,
+    );
+  }
+  return {
+    ...snapshot,
+    status: 'submitted',
+    auditLog: [
+      ...snapshot.auditLog,
+      {
+        at,
+        actor: 'clinician',
+        action: 'submitted',
+        from: 'draft',
+        to: 'submitted',
+      },
+    ],
+  };
+}
+
+/**
+ * Allowed status transitions. Keeps the loop honest — a submitted
+ * application cannot skip directly to `approved` without passing
+ * through review/credentialing states; a refresh request must be
+ * resolved before advancing.
+ */
+const ALLOWED_TRANSITIONS: Record<ApplicationStatus, ApplicationStatus[]> = {
+  draft: ['submitted'],
+  submitted: ['viewed', 'waiting_on_refresh', 'waiting_on_manual_review'],
+  viewed: ['in_review', 'waiting_on_refresh', 'waiting_on_manual_review'],
+  in_review: [
+    'waiting_on_refresh',
+    'waiting_on_manual_review',
+    'advanced',
+  ],
+  waiting_on_refresh: ['in_review', 'advanced'],
+  waiting_on_manual_review: ['in_review', 'advanced'],
+  advanced: ['credentialing'],
+  credentialing: ['approved'],
+  approved: ['start_ready'],
+  start_ready: ['started'],
+  started: [],
+};
+
+export function isTransitionAllowed(
+  from: ApplicationStatus,
+  to: ApplicationStatus,
+): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/**
+ * Transition a snapshot to a new status. Throws on disallowed
+ * transitions so the loop stays auditable. Appends an audit entry
+ * with the transition's actor and note.
+ */
+export function transitionApplicationStatus(
+  snapshot: ApplicationSnapshot,
+  to: ApplicationStatus,
+  input: {
+    actor: ApplicationAuditEntry['actor'];
+    at?: string;
+    note?: string;
+  },
+): ApplicationSnapshot {
+  if (!isTransitionAllowed(snapshot.status, to)) {
+    throw new Error(
+      `Disallowed transition: ${snapshot.status} -> ${to} for application ${snapshot.applicationId}`,
+    );
+  }
+  const at = input.at ?? new Date().toISOString();
+  return {
+    ...snapshot,
+    status: to,
+    auditLog: [
+      ...snapshot.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: 'status_change',
+        from: snapshot.status,
+        to,
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Record an employer's request — either `request_refresh` or
+ * `request_missing_info`. Moves the application into the correct
+ * waiting state and writes an audit entry naming the requester.
+ */
+export function requestApplicationAction(
+  snapshot: ApplicationSnapshot,
+  request: 'request_refresh' | 'request_missing_info' | 'route_to_review',
+  input: {
+    actor: ApplicationAuditEntry['actor'];
+    at?: string;
+    note?: string;
+  },
+): ApplicationSnapshot {
+  const targetStatus: ApplicationStatus =
+    request === 'request_refresh'
+      ? 'waiting_on_refresh'
+      : request === 'request_missing_info'
+        ? 'waiting_on_refresh'
+        : 'waiting_on_manual_review';
+
+  if (!isTransitionAllowed(snapshot.status, targetStatus)) {
+    throw new Error(
+      `Disallowed request: cannot ${request} from status "${snapshot.status}" for application ${snapshot.applicationId}`,
+    );
+  }
+
+  const at = input.at ?? new Date().toISOString();
+  return {
+    ...snapshot,
+    status: targetStatus,
+    auditLog: [
+      ...snapshot.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: request,
+        from: snapshot.status,
+        to: targetStatus,
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Apply an upstream refresh result. Produces a NEW snapshot (with a
+ * new hash) that reflects the refreshed evidence state. The previous
+ * snapshot's audit log is preserved and extended — the new snapshot
+ * carries forward the continuity chain.
+ *
+ * Critical: even if the refresh produces a stronger proof tier, the
+ * new snapshot is a separate artifact with its own hash. The employer
+ * can see exactly what changed between submissions.
+ */
+export function refreshApplicationSnapshot(
+  previous: ApplicationSnapshot,
+  refreshed: {
+    includedLanes?: ApplicationLane[];
+    includedClaims?: ApplicationClaim[];
+    proofTier?: ProofTier;
+    completeness?: number;
+  },
+  input: { at?: string; note?: string } = {},
+): ApplicationSnapshot {
+  if (previous.status !== 'waiting_on_refresh') {
+    throw new Error(
+      `Cannot apply refresh to application ${previous.applicationId} in status "${previous.status}". Refresh must be requested first.`,
+    );
+  }
+
+  const createdAt = input.at ?? new Date().toISOString();
+  const nextLanes = [...(refreshed.includedLanes ?? previous.includedLanes)].sort();
+  const nextClaims = [...(refreshed.includedClaims ?? previous.includedClaims)]
+    .slice()
+    .sort((a, b) => a.claimId.localeCompare(b.claimId));
+  const nextTier = refreshed.proofTier ?? previous.proofTier;
+  const nextCompleteness =
+    refreshed.completeness ?? previous.completeness;
+  const snapshotHash = computeApplicationSnapshotHash({
+    subjectId: previous.subjectId,
+    employerId: previous.employerId,
+    roleId: previous.roleId,
+    includedLanes: nextLanes,
+    includedClaims: nextClaims,
+    proofTier: nextTier,
+    createdAt,
+  });
+
+  return {
+    ...previous,
+    snapshotHash,
+    includedLanes: nextLanes,
+    includedClaims: nextClaims,
+    proofTier: nextTier,
+    completeness: Math.max(0, Math.min(100, Math.round(nextCompleteness))),
+    createdAt,
+    status: 'in_review',
+    auditLog: [
+      ...previous.auditLog,
+      {
+        at: createdAt,
+        actor: 'vitalcv',
+        action: 'refresh_landed',
+        from: 'waiting_on_refresh',
+        to: 'in_review',
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Guard used by employer-review surfaces to prove that they are
+ * rendering the exact snapshot the clinician submitted. Given the
+ * snapshot and the evidence currently rendered, recompute the hash
+ * and compare. Returns `true` only when the rendered evidence
+ * matches the stored snapshot hash — catches silent upgrades where
+ * the review surface re-resolves proof tier from live sources
+ * instead of the frozen snapshot.
+ */
+export function verifySnapshotIntegrity(snapshot: ApplicationSnapshot): boolean {
+  const recomputed = computeApplicationSnapshotHash({
+    subjectId: snapshot.subjectId,
+    employerId: snapshot.employerId,
+    roleId: snapshot.roleId,
+    includedLanes: snapshot.includedLanes,
+    includedClaims: snapshot.includedClaims,
+    proofTier: snapshot.proofTier,
+    createdAt: snapshot.createdAt,
+  });
+  return recomputed === snapshot.snapshotHash;
+}

--- a/apps/web/lib/pilot/buyer-pilot-copy.ts
+++ b/apps/web/lib/pilot/buyer-pilot-copy.ts
@@ -1,0 +1,182 @@
+/**
+ * Buyer-facing pilot copy contract.
+ *
+ * Every CTA on the employer/pilot shell must answer five concrete
+ * questions before the click:
+ *   1. What happens if I request a pilot?
+ *   2. What will VitalCV measure?
+ *   3. What do I (the buyer) need to provide?
+ *   4. What does success look like?
+ *   5. What remains outside current coverage?
+ *
+ * This module is the canonical source for those answers. Pilot surfaces
+ * import from here rather than inlining copy. A test file locks the
+ * rules:
+ *   - No fake customer names or fabricated traction language.
+ *   - Every answer is concrete (not "we'll be in touch").
+ *   - Coverage gaps are named explicitly.
+ *   - "Ready" / "fully verified" / "complete" never appear in partial-
+ *     data framings.
+ *
+ * Builds on the proof-tier + recovery-path + application-snapshot
+ * contracts established in previous waves. Does not invent new metrics
+ * or rebrand existing doctrine.
+ */
+
+export interface BuyerPilotCTA {
+  /** Short headline shown on the CTA card. */
+  headline: string;
+  /** One-line clarifier under the headline. */
+  description: string;
+  /** Primary button label. */
+  primaryActionLabel: string;
+  /** Where the primary button routes. */
+  primaryActionHref: string;
+  /** Answers the five buyer questions. */
+  answers: {
+    whatHappensOnRequest: string;
+    whatWeMeasure: string;
+    whatYouProvide: string;
+    successCriteria: string;
+    outsideCurrentCoverage: string;
+  };
+}
+
+export const BUYER_PILOT_CTA: BuyerPilotCTA = {
+  headline: 'Request a paid pilot',
+  description:
+    'A focused engagement using your NPIs, your review team, and a fixed measurement window. No demo data, no fabricated traction.',
+  primaryActionLabel: 'Request pilot setup',
+  primaryActionHref: '/pilot#request-form',
+  answers: {
+    whatHappensOnRequest:
+      'We reply within two business days to confirm scope and a start date. We do not auto-provision — pilot activation requires a signed scope document naming the NPIs, lanes, and measurement window.',
+    whatWeMeasure:
+      'Startability timeline events (submit, first view, first action, advanced, start-ready, started), median time deltas, refresh / missing-info request counts, and proof-tier distribution across submitted applications. All metrics derive from recorded events only — no imputed rows.',
+    whatYouProvide:
+      'A list of real clinician NPIs, a named review operator, your employer organization ID, and access to your review decision workflow. State-board lanes that require institutional agreements (Nursys, FSMB) are your employer to activate.',
+    successCriteria:
+      'A measurable drop in time-from-submission to first review action, a documented proof-pack export covering every submitted application, and an honest limitation list naming every lane that remained partial. Success is not a score — it is a comparable before/after delta the buyer team signs off on.',
+    outsideCurrentCoverage:
+      'NPDB, DEA registration, ABMS board certification, CAQH, SAM.gov, and per-state board coverage outside configured lanes. These remain the employer credentialing office\u2019s scope. Medicare enrollment (PECOS) is quarterly-refresh, so the data can be up to 90 days old.',
+  },
+};
+
+export interface BuyerPilotKpiSummaryCopy {
+  sectionHeadline: string;
+  sectionDescription: string;
+  /** Tile labels paired with the source of truth each one reads from. */
+  tileMeta: Record<
+    | 'applicationsSubmitted'
+    | 'reviewsOpened'
+    | 'actionsTaken'
+    | 'startReadyCount'
+    | 'startedCount'
+    | 'medianMinutesToFirstView'
+    | 'medianDaysToStarted',
+    { label: string; readsFrom: string }
+  >;
+  /** Boilerplate limitation line shown when the proof pack is empty. */
+  emptyStateNote: string;
+  /** Partial-data line that accompanies non-null limitation counts. */
+  partialStateNote: string;
+}
+
+export const BUYER_PILOT_KPI_COPY: BuyerPilotKpiSummaryCopy = {
+  sectionHeadline: 'What was measured',
+  sectionDescription:
+    'Every count and median is computed from recorded events in the pilot window. Metrics degrade to "\u2014" when endpoints are missing rather than imputing a value.',
+  tileMeta: {
+    applicationsSubmitted: {
+      label: 'Applications submitted',
+      readsFrom: 'ApplicationSnapshot.auditLog — submitted events',
+    },
+    reviewsOpened: {
+      label: 'Reviews opened',
+      readsFrom: 'firstViewedAt timestamps across submitted applications',
+    },
+    actionsTaken: {
+      label: 'Actions taken',
+      readsFrom: 'firstActionAt timestamps (request_refresh / request_missing_info / route_to_review / status_change)',
+    },
+    startReadyCount: {
+      label: 'Start-ready',
+      readsFrom: 'status_change → start_ready transitions',
+    },
+    startedCount: {
+      label: 'Started',
+      readsFrom: 'status_change → started transitions',
+    },
+    medianMinutesToFirstView: {
+      label: 'Median submit \u2192 first view',
+      readsFrom: 'Median across applications where both endpoints exist',
+    },
+    medianDaysToStarted: {
+      label: 'Median submit \u2192 started',
+      readsFrom: 'Median across applications where both endpoints exist',
+    },
+  },
+  emptyStateNote:
+    'No applications have moved through the pilot window yet. Metrics become available once submissions begin.',
+  partialStateNote:
+    'Some metrics are unavailable because the underlying events have not been recorded yet. This is not an error — it is honest-partial data. See the limitations list below.',
+};
+
+/**
+ * Words and phrases that must NEVER appear in buyer-facing pilot copy.
+ * The test suite uses this list to assert no fake / over-promising
+ * language slipped into the shell.
+ */
+export const BANNED_BUYER_PHRASES: readonly string[] = [
+  'fully verified',
+  'complete credentialing',
+  'all checks passed',
+  '100% verified',
+  'trusted by',
+  'used by leading',
+  'fortune 500',
+  'industry leader',
+  'market-leading',
+  'revolutionize',
+];
+
+/**
+ * Canonical limitation lines rendered on any buyer-facing pilot surface.
+ * Mirrors the limitation lines the proof-pack builder emits at runtime
+ * so static marketing and dynamic pack data stay in lockstep.
+ */
+export const BUYER_PILOT_LIMITATIONS: readonly string[] = [
+  'VitalCV does not replace credentialing committees. The proof pack is a pre-screen, not a final privileging decision.',
+  'State medical board lanes require per-state agreements. Lanes outside pilot scope render as access-required, not verified.',
+  'CMS PECOS refreshes quarterly. Enrollment data can be up to 90 days stale; the pack marks these lanes explicitly.',
+  'NPDB, DEA, ABMS, CAQH, and SAM.gov are not integrated. They remain the employer credentialing office\u2019s scope.',
+  'Medians are computed only from applications with both endpoints recorded. When a median reads "\u2014", the underlying event set did not support the calculation.',
+];
+
+/**
+ * Pilot conversion-safe verbs — the CTA must use one of these.
+ * Any other verb (e.g., "Get started", "Try it now") triggers the test
+ * suite as too vague for a paid-pilot commercial motion.
+ */
+export const ALLOWED_CTA_VERBS: readonly string[] = [
+  'Request pilot setup',
+  'Request a paid pilot',
+  'Request pilot scope call',
+  'Schedule pilot kickoff',
+];
+
+export function isAllowedCtaVerb(label: string): boolean {
+  return ALLOWED_CTA_VERBS.includes(label);
+}
+
+/**
+ * Whether a given string contains any banned buyer-facing phrase.
+ * Case-insensitive match; used by the test suite on rendered copy.
+ */
+export function containsBannedBuyerPhrase(text: string): string | null {
+  const normalized = text.toLowerCase();
+  for (const phrase of BANNED_BUYER_PHRASES) {
+    if (normalized.includes(phrase)) return phrase;
+  }
+  return null;
+}

--- a/apps/web/lib/pilot/pilot-confirmation-copy.ts
+++ b/apps/web/lib/pilot/pilot-confirmation-copy.ts
@@ -1,0 +1,116 @@
+/**
+ * Pilot confirmation copy contract.
+ *
+ * When a buyer submits the paid-pilot request form, the response
+ * page must answer four questions explicitly — without vague
+ * "we'll be in touch" language:
+ *   1. What happens next?
+ *   2. What will VitalCV measure?
+ *   3. What does the buyer need to provide?
+ *   4. What remains outside current coverage?
+ *
+ * This module carries that copy as structured data so the confirmation
+ * page and the structured API response stay in lockstep. Mirrors the
+ * buyer-pilot-copy contract from Wave 244 but scoped to the
+ * post-submission flow.
+ */
+
+import type { PilotRequestRecord } from './pilot-intake';
+
+export interface PilotConfirmationBullets {
+  whatHappensNext: string[];
+  whatVitalCvMeasures: string[];
+  whatYouProvide: string[];
+  outsideCoverage: string[];
+}
+
+export const PILOT_CONFIRMATION_BULLETS: PilotConfirmationBullets = {
+  whatHappensNext: [
+    'A VitalCV operator reviews your submission within two business days.',
+    'If scope is a fit, the operator schedules a scoping call to confirm NPIs, lanes, measurement window, and success criteria.',
+    'You receive a signed scope document before any measurement starts. No auto-provisioning.',
+  ],
+  whatVitalCvMeasures: [
+    'Startability timeline events across every application submitted during the window (submit, first view, first action, advanced, start-ready, started).',
+    'Median time deltas against your baseline numbers — never against a generic industry figure.',
+    'Refresh and missing-info request counts, with owner attribution on every request.',
+    'Proof-tier distribution at submit time (decision-grade vs partial vs draft).',
+  ],
+  whatYouProvide: [
+    'A list of real clinician NPIs for the measurement window.',
+    'A named review operator who will run decisions on the pilot applications.',
+    'Your current baseline numbers (time-to-start days, applications per month) — or an honest "we don\u2019t track this yet" so we can capture it from scratch.',
+    'Access to your review decision workflow (employer context, user identity).',
+  ],
+  outsideCoverage: [
+    'NPDB, DEA registration, ABMS board certification, CAQH, and SAM.gov — these remain your credentialing office\u2019s scope.',
+    'Per-state board coverage for states outside the configured pilot lanes. Nursys / FSMB activation requires institutional agreements your organization signs directly.',
+    'Final privileging decisions. VitalCV provides the pre-screen; your credentialing committee still owns the approval.',
+  ],
+};
+
+export interface PilotConfirmationRenderModel {
+  /** Short confirmation headline — "Request received". */
+  headline: string;
+  /** One-line acknowledgement with the buyer's org name + next-step window. */
+  acknowledgement: string;
+  bullets: PilotConfirmationBullets;
+  /** Operator-facing handoff summary. Shown to the buyer as a soft
+   *  reassurance that a human is on it, and shown to the operator in
+   *  the ops handoff surface as the record-level summary. */
+  operatorHandoff: {
+    owner: string;
+    ownerLabel: string;
+    nextStep: string;
+    ownerInboxLine: string;
+  };
+  /** Reference lines — pilotId, submissionHash — rendered in a small
+   *  monospace footer so the buyer can cite the request ID if they
+   *  follow up. */
+  reference: {
+    pilotId: string;
+    submissionHash: string;
+    requestedAt: string;
+  };
+}
+
+const OWNER_LABELS: Record<PilotRequestRecord['owner'], string> = {
+  pilot_ops: 'VitalCV Pilot Ops',
+  customer_success: 'VitalCV Customer Success',
+  solutions_engineer: 'VitalCV Solutions Engineer',
+  founder: 'VitalCV Founder',
+};
+
+const OWNER_INBOX_LINES: Record<PilotRequestRecord['owner'], string> = {
+  pilot_ops:
+    'Pilot Ops reviews new requests daily. Expect a scoping reply within two business days.',
+  customer_success:
+    'Customer Success holds active-pilot check-ins weekly. Expect a check-in invitation shortly.',
+  solutions_engineer:
+    'A Solutions Engineer handles scoping and baseline capture. Expect a scoping-call invitation within two business days.',
+  founder:
+    'The founder is handling this personally. Expect a direct reply.',
+};
+
+export function buildPilotConfirmationRenderModel(
+  record: PilotRequestRecord,
+): PilotConfirmationRenderModel {
+  const ownerLabel = OWNER_LABELS[record.owner];
+  const ownerInboxLine = OWNER_INBOX_LINES[record.owner];
+  return {
+    headline: 'Pilot request received',
+    acknowledgement: `Thanks — we have your request from ${record.orgName}. ${ownerInboxLine}`,
+    bullets: PILOT_CONFIRMATION_BULLETS,
+    operatorHandoff: {
+      owner: record.owner,
+      ownerLabel,
+      nextStep: record.nextStep,
+      ownerInboxLine,
+    },
+    reference: {
+      pilotId: record.pilotId,
+      submissionHash: record.submissionHash,
+      requestedAt: record.requestedAt,
+    },
+  };
+}

--- a/apps/web/lib/pilot/pilot-intake.ts
+++ b/apps/web/lib/pilot/pilot-intake.ts
@@ -1,0 +1,487 @@
+/**
+ * Pilot intake contract.
+ *
+ * A `PilotRequestRecord` is the canonical structured artifact produced
+ * when a buyer submits the paid-pilot request form. It answers the
+ * mission's five required dimensions — who, what, baseline, success,
+ * next step — before any operator picks it up.
+ *
+ * Doctrine:
+ *   - No ownerless pilot records. `owner` is assigned at creation time
+ *     via a round-robin / default rule; a record without an owner is
+ *     never persisted or returned.
+ *   - No fake success criteria. The caller either supplies explicit
+ *     criteria or the contract uses the canonical default that names
+ *     comparable before/after deltas, not absolute targets.
+ *   - Baseline metrics degrade honestly when partial. The baseline
+ *     section carries per-metric null-safe values and an explicit
+ *     "source" attribution per metric.
+ *   - Next step must be explicit. Every status has a canonical next
+ *     step string from `resolveNextStepForStatus`. A record with a
+ *     blank next step is rejected at construction time.
+ *
+ * This module is a WRITER contract — it produces structured records
+ * from request input. Reading / rendering those records for the
+ * operator surface lives in a separate module (kept tight per the
+ * mission's "do not build a full CRM" rule).
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+
+export type PilotStatus =
+  | 'requested'
+  | 'qualified'
+  | 'scoping'
+  | 'baseline_captured'
+  | 'ready_to_launch'
+  | 'active'
+  | 'completed'
+  | 'archived';
+
+/** Which operator role owns a pilot record at each status. Names
+ *  roles, not individuals — routing to a specific person happens in
+ *  the ops layer, not in the contract. */
+export type PilotOwnerRole =
+  | 'pilot_ops'
+  | 'customer_success'
+  | 'solutions_engineer'
+  | 'founder';
+
+export interface PilotBaselineMetric {
+  /** Canonical metric key — mirrors proof-pack median names when the
+   *  metric corresponds to a proof-pack measurement. */
+  key:
+    | 'current_time_to_start_days'
+    | 'current_time_to_first_review_days'
+    | 'applications_per_month'
+    | 'reviews_per_month'
+    | 'custom';
+  /** Human-readable label rendered on the operator surface. */
+  label: string;
+  /**
+   * Baseline value supplied by the buyer at request time. Null when
+   * the buyer does not know their current baseline — never imputed.
+   */
+  value: number | null;
+  /**
+   * Attribution of the baseline value. "buyer_reported" when the
+   * buyer filled it in; "unknown" when not supplied. Distinguishes
+   * absent-by-choice from absent-by-omission.
+   */
+  source: 'buyer_reported' | 'unknown';
+  /** Optional free-text note from the buyer (e.g. "45-90 days range, no variance data"). */
+  note?: string;
+}
+
+export interface PilotSuccessCriterion {
+  /** Short summary rendered as the criterion's headline. */
+  summary: string;
+  /**
+   * Kind of criterion. `comparable_delta` is the doctrine-preferred
+   * shape (buyer signs off on before/after); `absolute_target` and
+   * `qualitative_signal` are allowed but test-flagged if they drift
+   * into fabricated specificity ("reduce time-to-start by 40%" with
+   * no baseline).
+   */
+  kind: 'comparable_delta' | 'absolute_target' | 'qualitative_signal';
+  /**
+   * Whether this criterion depends on a baseline metric being
+   * captured first. If true, the pilot cannot transition out of
+   * `scoping` until `baselineMetrics` includes a non-null value for
+   * the dependency.
+   */
+  requiresBaseline: boolean;
+}
+
+export interface PilotRequestRecord {
+  pilotId: string;
+  orgId: string | null;
+  orgName: string;
+  contactName: string;
+  contactEmail: string;
+  /** What workflow the buyer wants the pilot to target — credentialing
+   *  review, locum placement, privileging, etc. */
+  roleOrWorkflowTarget: string;
+  /** Where the request originated (/pilot page, /employers, share link, etc.). */
+  sourceContext: string;
+  requestedAt: string;
+  /** Best-effort attribution of who submitted the request. Falls back
+   *  to the contact email when the request is not authenticated. */
+  requestedBy: string;
+  baselineMetrics: PilotBaselineMetric[];
+  successCriteria: PilotSuccessCriterion[];
+  owner: PilotOwnerRole;
+  status: PilotStatus;
+  nextStep: string;
+  /** Append-only audit log. Every status transition writes one entry. */
+  auditLog: Array<{
+    at: string;
+    actor: 'buyer' | 'operator' | 'vitalcv';
+    action: 'requested' | 'status_change' | 'owner_change' | 'baseline_updated';
+    from?: PilotStatus;
+    to?: PilotStatus;
+    note?: string;
+  }>;
+  /**
+   * Deterministic hash of the submission inputs. Used by operator
+   * surfaces to detect duplicate requests from the same org + email
+   * inside a short window.
+   */
+  submissionHash: string;
+}
+
+const ALLOWED_STATUS_TRANSITIONS: Record<PilotStatus, PilotStatus[]> = {
+  requested: ['qualified', 'archived'],
+  qualified: ['scoping', 'archived'],
+  scoping: ['baseline_captured', 'archived'],
+  baseline_captured: ['ready_to_launch', 'archived'],
+  ready_to_launch: ['active', 'archived'],
+  active: ['completed', 'archived'],
+  completed: ['archived'],
+  archived: [],
+};
+
+export function isPilotStatusTransitionAllowed(
+  from: PilotStatus,
+  to: PilotStatus,
+): boolean {
+  return ALLOWED_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/**
+ * Canonical next-step copy per status. Every status has an explicit
+ * next step — no record ever surfaces a blank nextStep.
+ */
+export function resolveNextStepForStatus(status: PilotStatus): string {
+  switch (status) {
+    case 'requested':
+      return 'VitalCV operator reviews the request and qualifies scope. Buyer hears back within two business days.';
+    case 'qualified':
+      return 'Operator schedules a scoping call with the buyer to confirm NPIs, lanes, measurement window, and success criteria.';
+    case 'scoping':
+      return 'Operator captures current-state baseline metrics from the buyer before any measurement starts.';
+    case 'baseline_captured':
+      return 'Operator confirms the pilot scope document and kickoff date with the buyer.';
+    case 'ready_to_launch':
+      return 'Kickoff scheduled. Buyer provides final NPI list and operator access; pilot becomes active on the confirmed date.';
+    case 'active':
+      return 'Pilot is running. Operator monitors the proof-pack against baseline + success criteria and holds regular check-ins.';
+    case 'completed':
+      return 'Final proof-pack delivered to buyer. Operator captures before/after summary and retention decision.';
+    case 'archived':
+      return 'No further action. Record preserved for audit.';
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Canonical owner-role assignment per status. A requested pilot
+ * lands with pilot_ops; a qualified pilot moves to solutions_engineer
+ * for scoping; an active pilot is customer_success; completed goes
+ * back to pilot_ops for the post-mortem. Deterministic — no round-
+ * robin randomness in the contract.
+ */
+export function resolveOwnerForStatus(status: PilotStatus): PilotOwnerRole {
+  switch (status) {
+    case 'requested':
+    case 'qualified':
+      return 'pilot_ops';
+    case 'scoping':
+    case 'baseline_captured':
+      return 'solutions_engineer';
+    case 'ready_to_launch':
+    case 'active':
+      return 'customer_success';
+    case 'completed':
+    case 'archived':
+      return 'pilot_ops';
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Default success-criteria set for a fresh pilot request. Uses
+ * `comparable_delta` shape so the criteria are honest pre-baseline —
+ * no absolute targets that imply data we don't yet have.
+ */
+export const DEFAULT_PILOT_SUCCESS_CRITERIA: readonly PilotSuccessCriterion[] = [
+  {
+    summary:
+      'Measurable drop in time from application submission to first employer review action, measured against the buyer-supplied baseline.',
+    kind: 'comparable_delta',
+    requiresBaseline: true,
+  },
+  {
+    summary:
+      'Documented proof-pack export covering every application submitted during the measurement window.',
+    kind: 'qualitative_signal',
+    requiresBaseline: false,
+  },
+  {
+    summary:
+      'Honest limitation list naming every lane that remained partial during the pilot window. Buyer signs off that the limitations match their operational reality.',
+    kind: 'qualitative_signal',
+    requiresBaseline: false,
+  },
+];
+
+/**
+ * Default baseline-metric skeleton. Every key is rendered with
+ * `value: null` and `source: 'unknown'` — the operator asks the
+ * buyer to fill these in during the scoping call. The skeleton
+ * itself never claims to know the baseline.
+ */
+export function buildDefaultBaselineSkeleton(): PilotBaselineMetric[] {
+  return [
+    {
+      key: 'current_time_to_start_days',
+      label: 'Current median days from hire to start',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'current_time_to_first_review_days',
+      label: 'Current median days from application to first review',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'applications_per_month',
+      label: 'Typical applications per month',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'reviews_per_month',
+      label: 'Typical reviews per month',
+      value: null,
+      source: 'unknown',
+    },
+  ];
+}
+
+export interface PilotIntakeInput {
+  orgName: string;
+  contactName: string;
+  contactEmail: string;
+  orgId?: string | null;
+  roleOrWorkflowTarget?: string;
+  sourceContext?: string;
+  requestedAt?: string;
+  baselineMetrics?: PilotBaselineMetric[];
+  successCriteria?: PilotSuccessCriterion[];
+  /** Override the default pilot_ops owner — e.g. when a known AE is
+   *  pre-assigned. Uncommon; most records route through the default. */
+  owner?: PilotOwnerRole;
+}
+
+export interface PilotIntakeInputError {
+  field: 'orgName' | 'contactName' | 'contactEmail';
+  reason: string;
+}
+
+export function validatePilotIntakeInput(
+  input: PilotIntakeInput,
+): PilotIntakeInputError[] {
+  const errors: PilotIntakeInputError[] = [];
+  if (!input.orgName || input.orgName.trim().length === 0) {
+    errors.push({ field: 'orgName', reason: 'Organization name is required.' });
+  }
+  if (!input.contactName || input.contactName.trim().length === 0) {
+    errors.push({ field: 'contactName', reason: 'Contact name is required.' });
+  }
+  const email = (input.contactEmail ?? '').trim();
+  if (email.length === 0) {
+    errors.push({ field: 'contactEmail', reason: 'Contact email is required.' });
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.push({
+      field: 'contactEmail',
+      reason: 'Contact email must be a valid address.',
+    });
+  }
+  return errors;
+}
+
+/**
+ * Deterministic submission hash over the identifying inputs.
+ * Two requests with the same org + email + workflow + source +
+ * requestedAt-second produce the same hash — enables de-dupe of
+ * rapid-repeat submissions without needing a cross-request store.
+ */
+export function computePilotSubmissionHash(input: {
+  orgName: string;
+  contactEmail: string;
+  roleOrWorkflowTarget: string;
+  sourceContext: string;
+  requestedAt: string;
+}): string {
+  const payload = JSON.stringify({
+    orgName: input.orgName.trim().toLowerCase(),
+    contactEmail: input.contactEmail.trim().toLowerCase(),
+    roleOrWorkflowTarget: input.roleOrWorkflowTarget.trim().toLowerCase(),
+    sourceContext: input.sourceContext.trim().toLowerCase(),
+    requestedAtSecond: input.requestedAt.slice(0, 19),
+  });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+export function createPilotRequestRecord(
+  input: PilotIntakeInput,
+): PilotRequestRecord {
+  const errors = validatePilotIntakeInput(input);
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid pilot intake input: ${errors.map((e) => `${e.field}: ${e.reason}`).join('; ')}`,
+    );
+  }
+
+  const requestedAt = input.requestedAt ?? new Date().toISOString();
+  const roleOrWorkflowTarget =
+    input.roleOrWorkflowTarget?.trim().length
+      ? input.roleOrWorkflowTarget.trim()
+      : 'Credentialing review';
+  const sourceContext = input.sourceContext ?? '/pilot';
+  const owner = input.owner ?? resolveOwnerForStatus('requested');
+  const status: PilotStatus = 'requested';
+  const nextStep = resolveNextStepForStatus(status);
+
+  const submissionHash = computePilotSubmissionHash({
+    orgName: input.orgName,
+    contactEmail: input.contactEmail,
+    roleOrWorkflowTarget,
+    sourceContext,
+    requestedAt,
+  });
+
+  const record: PilotRequestRecord = {
+    pilotId: `pilot_${randomUUID()}`,
+    orgId: input.orgId ?? null,
+    orgName: input.orgName.trim(),
+    contactName: input.contactName.trim(),
+    contactEmail: input.contactEmail.trim(),
+    roleOrWorkflowTarget,
+    sourceContext,
+    requestedAt,
+    requestedBy: input.contactEmail.trim(),
+    baselineMetrics:
+      input.baselineMetrics && input.baselineMetrics.length > 0
+        ? input.baselineMetrics
+        : buildDefaultBaselineSkeleton(),
+    successCriteria:
+      input.successCriteria && input.successCriteria.length > 0
+        ? input.successCriteria
+        : [...DEFAULT_PILOT_SUCCESS_CRITERIA],
+    owner,
+    status,
+    nextStep,
+    submissionHash,
+    auditLog: [
+      {
+        at: requestedAt,
+        actor: 'buyer',
+        action: 'requested',
+        to: status,
+      },
+    ],
+  };
+
+  // Final invariant check — a record without an owner or a blank
+  // next step cannot leave this function.
+  if (!record.owner) {
+    throw new Error('Ownerless pilot record — refusing to return.');
+  }
+  if (!record.nextStep || record.nextStep.trim().length === 0) {
+    throw new Error('Pilot record has no next step — refusing to return.');
+  }
+  return record;
+}
+
+/**
+ * Transition a pilot record to a new status. Enforces the allowed-
+ * transitions map, reassigns the canonical owner for the new status,
+ * refreshes the next-step copy, and appends an audit entry.
+ */
+export function transitionPilotStatus(
+  record: PilotRequestRecord,
+  to: PilotStatus,
+  input: {
+    actor: 'operator' | 'vitalcv';
+    at?: string;
+    note?: string;
+  },
+): PilotRequestRecord {
+  if (!isPilotStatusTransitionAllowed(record.status, to)) {
+    throw new Error(
+      `Disallowed pilot status transition: ${record.status} -> ${to} for ${record.pilotId}`,
+    );
+  }
+  const at = input.at ?? new Date().toISOString();
+  const owner = resolveOwnerForStatus(to);
+  const nextStep = resolveNextStepForStatus(to);
+  return {
+    ...record,
+    status: to,
+    owner,
+    nextStep,
+    auditLog: [
+      ...record.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: 'status_change',
+        from: record.status,
+        to,
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Update a pilot's baseline metrics once the scoping call captures
+ * real numbers. Only allowed during `scoping` — a pilot cannot have
+ * its baseline altered after `baseline_captured` without archiving
+ * and starting a new record.
+ */
+export function updatePilotBaseline(
+  record: PilotRequestRecord,
+  metrics: PilotBaselineMetric[],
+  input: { actor: 'operator' | 'vitalcv'; at?: string; note?: string },
+): PilotRequestRecord {
+  if (record.status !== 'scoping') {
+    throw new Error(
+      `Baseline can only be updated while status is "scoping" (current: ${record.status}).`,
+    );
+  }
+  const at = input.at ?? new Date().toISOString();
+  return {
+    ...record,
+    baselineMetrics: metrics,
+    auditLog: [
+      ...record.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: 'baseline_updated',
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Honest partial check — true when any baseline metric is still
+ * null / unknown. Consumers use this to gate transitions out of
+ * `scoping` and to surface partial-baseline warnings.
+ */
+export function isPilotBaselinePartial(record: PilotRequestRecord): boolean {
+  return record.baselineMetrics.some(
+    (m) => m.value === null || m.source === 'unknown',
+  );
+}

--- a/apps/web/lib/proof/pilot-proof-pack.ts
+++ b/apps/web/lib/proof/pilot-proof-pack.ts
@@ -1,0 +1,297 @@
+/**
+ * Pilot proof-pack export.
+ *
+ * Buyer-legible artifact aggregating application + review + action +
+ * start-ready + started counts, with median time deltas and explicit
+ * limitation lines when data is partial.
+ *
+ * Doctrine:
+ *   - Counts come from real events only. No imputed rows.
+ *   - Medians are computed only when at least one timeline in the set
+ *     has the requested delta. If every application is missing a
+ *     timestamp, the median is `null` and the `limitations` array
+ *     names the gap.
+ *   - `partialDataNotice` is always present when any application in
+ *     the set is missing any timestamp. The proof pack stays visibly
+ *     partial — never rendered as if it were decision-grade.
+ *   - Proof tier context is surfaced at the pack level (decision-grade
+ *     vs partial counts) so the buyer can tell at a glance how much
+ *     of the pilot ran on decision-grade evidence.
+ */
+
+import type {
+  ApplicationSnapshot,
+  ApplicationStatus,
+} from '@/lib/apply/application-snapshot';
+import type { ProofTier } from '@/lib/trust/employer-action-consequence';
+import {
+  deriveBlockerDurationTotals,
+  deriveStartabilityMetrics,
+  deriveStartabilityTimeline,
+  type BlockerDurationTotals,
+  type StartabilityMetrics,
+  type StartabilityTimeline,
+} from './startability-timeline';
+
+export interface PilotProofPackCounts {
+  applicationsSubmitted: number;
+  reviewsOpened: number;
+  actionsTaken: number;
+  advancedCount: number;
+  startReadyCount: number;
+  startedCount: number;
+}
+
+export interface PilotProofPackMedians {
+  /** Median minutes from submit to first employer view. Null when no
+   *  timeline in the set has both endpoints. */
+  medianMinutesToFirstView: number | null;
+  /** Median minutes from submit to first employer action. */
+  medianMinutesToFirstAction: number | null;
+  /** Median days from submit to start_ready. */
+  medianDaysToStartReady: number | null;
+  /** Median days from submit to started (full loop). */
+  medianDaysToStarted: number | null;
+}
+
+export interface PilotProofPackTierContext {
+  /** Count of applications submitted at decision-grade tier. */
+  decisionGradeAtSubmit: number;
+  /** Count of applications submitted at partial tier. */
+  partialAtSubmit: number;
+  /** Count of applications submitted at draft tier (no anchor). */
+  draftAtSubmit: number;
+}
+
+export interface PilotProofPackBlockers {
+  totalRefreshRequests: number;
+  totalMissingInfoRequests: number;
+  /** Applications currently in an open waiting state. */
+  applicationsWithOpenWait: number;
+  /** Median minutes spent in refresh waits across applications that
+   *  have at least one closed refresh-wait interval. Null when no
+   *  closed interval exists in the set. */
+  medianMinutesInRefreshWait: number | null;
+}
+
+export interface PilotProofPack {
+  generatedAt: string;
+  /** Count of applications considered in this pack. */
+  applicationCount: number;
+  counts: PilotProofPackCounts;
+  medians: PilotProofPackMedians;
+  tierContext: PilotProofPackTierContext;
+  blockers: PilotProofPackBlockers;
+  /**
+   * Honest-partial signal. Whenever any derived metric is null OR any
+   * application is missing timeline data, `partialDataNotice` names
+   * the gap so the buyer never reads the pack as decision-grade by
+   * accident.
+   */
+  partialDataNotice: string | null;
+  /**
+   * Explicit limitation lines a buyer can read. One per missing
+   * dimension. Empty when nothing is partial.
+   */
+  limitations: string[];
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round(((sorted[mid - 1] + sorted[mid]) / 2) * 10) / 10;
+  }
+  return sorted[mid];
+}
+
+function isSubmittedOrLater(status: ApplicationStatus): boolean {
+  return status !== 'draft';
+}
+
+function countStatusAtOrPast(
+  snapshots: ApplicationSnapshot[],
+  target: ApplicationStatus,
+): number {
+  // Counts applications that ever reached (or passed) the target
+  // status — reads from audit log, not just current status.
+  return snapshots.filter((s) =>
+    s.auditLog.some(
+      (e) => e.to === target || e.action === target,
+    ) || s.status === target,
+  ).length;
+}
+
+export interface BuildPilotProofPackInput {
+  applications: ApplicationSnapshot[];
+  /** Optional readiness timestamps per application. When absent,
+   *  `minutesToSubmit` metrics degrade to null. */
+  readinessByApplication?: Record<string, string | null>;
+  /** Timestamp for the generated pack. Defaults to now. */
+  generatedAt?: string;
+}
+
+export interface PilotProofPackInternals {
+  /** Per-application timelines and metrics used to build the pack.
+   *  Exposed for the export UI to render per-application detail while
+   *  the pack itself carries only the aggregated roll-up. */
+  timelines: StartabilityTimeline[];
+  metrics: StartabilityMetrics[];
+  blockerTotals: BlockerDurationTotals[];
+}
+
+export function buildPilotProofPack(
+  input: BuildPilotProofPackInput,
+): { pack: PilotProofPack; internals: PilotProofPackInternals } {
+  const applications = input.applications;
+  const readinessMap = input.readinessByApplication ?? {};
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+
+  const timelines = applications.map((snapshot) =>
+    deriveStartabilityTimeline(snapshot, {
+      readinessAt: readinessMap[snapshot.applicationId] ?? null,
+    }),
+  );
+  const metrics = timelines.map(deriveStartabilityMetrics);
+  const blockerTotals = applications.map(deriveBlockerDurationTotals);
+
+  const applicationsSubmitted = applications.filter((s) =>
+    isSubmittedOrLater(s.status) || s.auditLog.some((e) => e.action === 'submitted'),
+  ).length;
+  const reviewsOpened = timelines.filter((t) => t.firstViewedAt !== null).length;
+  const actionsTaken = timelines.filter((t) => t.firstActionAt !== null).length;
+  const advancedCount = countStatusAtOrPast(applications, 'advanced');
+  const startReadyCount = countStatusAtOrPast(applications, 'start_ready');
+  const startedCount = countStatusAtOrPast(applications, 'started');
+
+  const counts: PilotProofPackCounts = {
+    applicationsSubmitted,
+    reviewsOpened,
+    actionsTaken,
+    advancedCount,
+    startReadyCount,
+    startedCount,
+  };
+
+  const medians: PilotProofPackMedians = {
+    medianMinutesToFirstView: median(
+      metrics
+        .map((m) => m.minutesToFirstView)
+        .filter((v): v is number => v !== null),
+    ),
+    medianMinutesToFirstAction: median(
+      metrics
+        .map((m) => m.minutesToFirstAction)
+        .filter((v): v is number => v !== null),
+    ),
+    medianDaysToStartReady: median(
+      metrics
+        .map((m) => m.daysToStartReady)
+        .filter((v): v is number => v !== null),
+    ),
+    medianDaysToStarted: median(
+      metrics
+        .map((m) => m.daysToStarted)
+        .filter((v): v is number => v !== null),
+    ),
+  };
+
+  const tierCounts: Record<ProofTier, number> = {
+    draft_snapshot: 0,
+    partial_proof_pack: 0,
+    decision_grade_proof_pack: 0,
+  };
+  for (const app of applications) {
+    if (isSubmittedOrLater(app.status)) {
+      tierCounts[app.proofTier] += 1;
+    }
+  }
+  const tierContext: PilotProofPackTierContext = {
+    decisionGradeAtSubmit: tierCounts.decision_grade_proof_pack,
+    partialAtSubmit: tierCounts.partial_proof_pack,
+    draftAtSubmit: tierCounts.draft_snapshot,
+  };
+
+  const refreshWaitMinutes = blockerTotals
+    .map((b) => b.minutesInRefreshWait)
+    .filter((v): v is number => v !== null);
+  const blockers: PilotProofPackBlockers = {
+    totalRefreshRequests: blockerTotals.reduce(
+      (sum, b) => sum + b.refreshRequestCount,
+      0,
+    ),
+    totalMissingInfoRequests: blockerTotals.reduce(
+      (sum, b) => sum + b.missingInfoRequestCount,
+      0,
+    ),
+    applicationsWithOpenWait: blockerTotals.filter((b) => b.hasOpenWait).length,
+    medianMinutesInRefreshWait: median(refreshWaitMinutes),
+  };
+
+  // Limitations — explicit, not inferred. Each null metric or partial
+  // tier produces a reading line the buyer can see.
+  const limitations: string[] = [];
+  if (counts.applicationsSubmitted === 0) {
+    limitations.push(
+      'No applications have been submitted in the pilot window. All downstream counts and medians are unavailable.',
+    );
+  }
+  if (counts.reviewsOpened < counts.applicationsSubmitted) {
+    const pending = counts.applicationsSubmitted - counts.reviewsOpened;
+    limitations.push(
+      `${pending} submitted application${pending === 1 ? '' : 's'} have not been opened by an employer yet — first-view medians computed only from opened applications.`,
+    );
+  }
+  if (medians.medianMinutesToFirstView === null && counts.applicationsSubmitted > 0) {
+    limitations.push(
+      'No application in this pilot has a recorded first-view timestamp. medianMinutesToFirstView is unavailable.',
+    );
+  }
+  if (medians.medianDaysToStarted === null && counts.startedCount === 0) {
+    limitations.push(
+      'No application has reached started state yet. medianDaysToStarted is unavailable; the start-ready-to-started loop has not completed in this window.',
+    );
+  }
+  if (tierContext.partialAtSubmit > 0 || tierContext.draftAtSubmit > 0) {
+    const partialTotal = tierContext.partialAtSubmit + tierContext.draftAtSubmit;
+    limitations.push(
+      `${partialTotal} application${partialTotal === 1 ? '' : 's'} submitted at partial / draft proof tier. These are not decision-grade and remain visibly partial in this pack.`,
+    );
+  }
+  if (blockers.applicationsWithOpenWait > 0) {
+    limitations.push(
+      `${blockers.applicationsWithOpenWait} application${blockers.applicationsWithOpenWait === 1 ? '' : 's'} are still in an open waiting state (refresh or manual review). Blocker duration totals will change once those waits close.`,
+    );
+  }
+
+  const partialDataNotice =
+    limitations.length > 0
+      ? 'This proof pack contains partial data. See limitations for the specific gaps — medians and counts reflect only the evidence that was recorded.'
+      : null;
+
+  const pack: PilotProofPack = {
+    generatedAt,
+    applicationCount: applications.length,
+    counts,
+    medians,
+    tierContext,
+    blockers,
+    partialDataNotice,
+    limitations,
+  };
+
+  return {
+    pack,
+    internals: { timelines, metrics, blockerTotals },
+  };
+}
+
+/**
+ * Serialize a proof pack to a JSON string. Used by the export route.
+ * Deterministic (stable key ordering) so buyer-delivered artifacts
+ * are diffable between pack generations.
+ */
+export function serializePilotProofPack(pack: PilotProofPack): string {
+  return JSON.stringify(pack, null, 2);
+}

--- a/apps/web/lib/proof/startability-timeline.ts
+++ b/apps/web/lib/proof/startability-timeline.ts
@@ -1,0 +1,276 @@
+/**
+ * Startability timeline contract.
+ *
+ * Every application snapshot's lifecycle lays down seven canonical
+ * timestamps that together form the startability chain:
+ *
+ *   readinessAt             — clinician reached usable readiness posture
+ *   applicationSubmittedAt  — clinician submitted the snapshot
+ *   firstViewedAt           — first employer opened the review surface
+ *   firstActionAt           — first employer action (any kind)
+ *   reviewAdvancedAt        — employer advanced the application
+ *   startReadyAt            — clinician entered start_ready state
+ *   startedAt               — clinician started at the employer
+ *
+ * Rules:
+ *   - Every timestamp is attributable to a specific audit-log entry or
+ *     an explicit input. We never synthesize timestamps.
+ *   - Missing timestamps degrade honestly to `null`. Derived metrics
+ *     return `null` when any input in the delta is missing.
+ *   - Partial data stays partial: a proof-pack built from a timeline
+ *     with two missing timestamps must surface the gap, not paper over
+ *     it with "computed from partial data" averages.
+ *
+ * This module is a READER of the application-snapshot audit log, not
+ * a WRITER. Timestamps are extracted from events that the snapshot
+ * module already captures at mutation time.
+ */
+
+import type {
+  ApplicationAuditEntry,
+  ApplicationSnapshot,
+  ApplicationStatus,
+} from '@/lib/apply/application-snapshot';
+
+export interface StartabilityTimeline {
+  applicationId: string;
+  /** When the clinician reached usable readiness — passed in by the
+   *  caller (readiness lives outside the application audit chain). */
+  readinessAt: string | null;
+  applicationSubmittedAt: string | null;
+  firstViewedAt: string | null;
+  firstActionAt: string | null;
+  reviewAdvancedAt: string | null;
+  startReadyAt: string | null;
+  startedAt: string | null;
+}
+
+/**
+ * Extract the startability timeline from an application snapshot.
+ * Caller supplies `readinessAt` because readiness is computed on the
+ * passport/ingest side, not inside the application audit log.
+ *
+ * Every timestamp resolves to either a concrete ISO-8601 string from
+ * the audit log or `null` (not an empty string, not a placeholder).
+ */
+export function deriveStartabilityTimeline(
+  snapshot: ApplicationSnapshot,
+  options: { readinessAt?: string | null } = {},
+): StartabilityTimeline {
+  const log = snapshot.auditLog;
+
+  const firstBy = (
+    predicate: (entry: ApplicationAuditEntry) => boolean,
+  ): string | null => {
+    const match = log.find(predicate);
+    return match ? match.at : null;
+  };
+
+  const firstStatusTransitionTo = (to: ApplicationStatus): string | null =>
+    firstBy((e) => e.action === 'status_change' && e.to === to);
+
+  const applicationSubmittedAt = firstBy((e) => e.action === 'submitted');
+
+  // First view: either a status_change transitioning to "viewed", or
+  // a standalone "viewed" action if ever emitted separately.
+  const firstViewedAt =
+    firstStatusTransitionTo('viewed')
+    ?? firstBy((e) => e.action === 'viewed');
+
+  // First employer action: the earliest request_refresh /
+  // request_missing_info / route_to_review entry, OR the first
+  // employer-sourced status_change, whichever comes first.
+  const firstEmployerMutation = log.find(
+    (e) =>
+      (e.actor === 'employer' || e.actor === 'reviewer')
+      && (
+        e.action === 'request_refresh'
+        || e.action === 'request_missing_info'
+        || e.action === 'route_to_review'
+        || e.action === 'status_change'
+      ),
+  );
+  const firstActionAt = firstEmployerMutation ? firstEmployerMutation.at : null;
+
+  const reviewAdvancedAt = firstStatusTransitionTo('advanced');
+  const startReadyAt = firstStatusTransitionTo('start_ready');
+  const startedAt = firstStatusTransitionTo('started');
+
+  return {
+    applicationId: snapshot.applicationId,
+    readinessAt: options.readinessAt ?? null,
+    applicationSubmittedAt,
+    firstViewedAt,
+    firstActionAt,
+    reviewAdvancedAt,
+    startReadyAt,
+    startedAt,
+  };
+}
+
+/**
+ * Duration metrics derived from a single application's timeline.
+ * Every metric is `null` when either endpoint is missing.
+ *
+ * Never fabricate: when readinessAt is unknown and applicationSubmittedAt
+ * exists, `timeFromReadinessToSubmit` is `null`, not an optimistic "0".
+ */
+export interface StartabilityMetrics {
+  applicationId: string;
+  /** Minutes from clinician readiness to application submission. */
+  minutesToSubmit: number | null;
+  /** Minutes from application submission to first employer view. */
+  minutesToFirstView: number | null;
+  /** Minutes from application submission to first employer action. */
+  minutesToFirstAction: number | null;
+  /** Minutes from application submission to review advanced. */
+  minutesToReviewAdvanced: number | null;
+  /** Days from application submission to start_ready. */
+  daysToStartReady: number | null;
+  /** Days from application submission to started (the full loop). */
+  daysToStarted: number | null;
+  /** Whether this timeline has every timestamp (full chain). */
+  chainComplete: boolean;
+  /** Names of the missing timestamps, for honest partial rendering. */
+  missingTimestamps: Array<keyof StartabilityTimeline>;
+}
+
+function minutesBetween(a: string | null, b: string | null): number | null {
+  if (!a || !b) return null;
+  const start = new Date(a).getTime();
+  const end = new Date(b).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (end < start) return null;
+  return Math.round((end - start) / 60000);
+}
+
+function daysBetween(a: string | null, b: string | null): number | null {
+  const minutes = minutesBetween(a, b);
+  if (minutes === null) return null;
+  return Math.round(minutes / 1440 * 10) / 10; // one decimal
+}
+
+const TIMESTAMP_KEYS: Array<keyof StartabilityTimeline> = [
+  'readinessAt',
+  'applicationSubmittedAt',
+  'firstViewedAt',
+  'firstActionAt',
+  'reviewAdvancedAt',
+  'startReadyAt',
+  'startedAt',
+];
+
+export function deriveStartabilityMetrics(
+  timeline: StartabilityTimeline,
+): StartabilityMetrics {
+  const missingTimestamps = TIMESTAMP_KEYS.filter(
+    (k) => k !== 'applicationId' && timeline[k] === null,
+  );
+
+  return {
+    applicationId: timeline.applicationId,
+    minutesToSubmit: minutesBetween(
+      timeline.readinessAt,
+      timeline.applicationSubmittedAt,
+    ),
+    minutesToFirstView: minutesBetween(
+      timeline.applicationSubmittedAt,
+      timeline.firstViewedAt,
+    ),
+    minutesToFirstAction: minutesBetween(
+      timeline.applicationSubmittedAt,
+      timeline.firstActionAt,
+    ),
+    minutesToReviewAdvanced: minutesBetween(
+      timeline.applicationSubmittedAt,
+      timeline.reviewAdvancedAt,
+    ),
+    daysToStartReady: daysBetween(
+      timeline.applicationSubmittedAt,
+      timeline.startReadyAt,
+    ),
+    daysToStarted: daysBetween(
+      timeline.applicationSubmittedAt,
+      timeline.startedAt,
+    ),
+    chainComplete: missingTimestamps.length === 0,
+    missingTimestamps,
+  };
+}
+
+/**
+ * Blocker duration accounting. Sum of all `waiting_on_refresh` +
+ * `waiting_on_manual_review` intervals across the application's
+ * audit log. Returns null when the log has no waiting states OR
+ * when a waiting state was entered but never resolved (honest: we
+ * can't compute a duration for an open waiting state).
+ */
+export interface BlockerDurationTotals {
+  applicationId: string;
+  /** Total minutes spent in waiting_on_refresh across all occurrences. */
+  minutesInRefreshWait: number | null;
+  /** Total minutes spent in waiting_on_manual_review across all occurrences. */
+  minutesInManualReviewWait: number | null;
+  /** Count of refresh requests emitted during the application's life. */
+  refreshRequestCount: number;
+  /** Count of missing-info requests emitted. */
+  missingInfoRequestCount: number;
+  /** True when a waiting state is still open at the current status. */
+  hasOpenWait: boolean;
+}
+
+export function deriveBlockerDurationTotals(
+  snapshot: ApplicationSnapshot,
+): BlockerDurationTotals {
+  const log = snapshot.auditLog;
+
+  let refreshRequestCount = 0;
+  let missingInfoRequestCount = 0;
+
+  let refreshWaitStart: string | null = null;
+  let manualWaitStart: string | null = null;
+  let totalRefreshMinutes = 0;
+  let totalManualMinutes = 0;
+  let anyRefreshComputed = false;
+  let anyManualComputed = false;
+
+  for (const entry of log) {
+    if (entry.action === 'request_refresh') refreshRequestCount += 1;
+    if (entry.action === 'request_missing_info') missingInfoRequestCount += 1;
+
+    if (entry.to === 'waiting_on_refresh') {
+      refreshWaitStart = entry.at;
+    } else if (refreshWaitStart && entry.from === 'waiting_on_refresh') {
+      const mins = minutesBetween(refreshWaitStart, entry.at);
+      if (mins !== null) {
+        totalRefreshMinutes += mins;
+        anyRefreshComputed = true;
+      }
+      refreshWaitStart = null;
+    }
+
+    if (entry.to === 'waiting_on_manual_review') {
+      manualWaitStart = entry.at;
+    } else if (manualWaitStart && entry.from === 'waiting_on_manual_review') {
+      const mins = minutesBetween(manualWaitStart, entry.at);
+      if (mins !== null) {
+        totalManualMinutes += mins;
+        anyManualComputed = true;
+      }
+      manualWaitStart = null;
+    }
+  }
+
+  const hasOpenWait =
+    snapshot.status === 'waiting_on_refresh'
+    || snapshot.status === 'waiting_on_manual_review';
+
+  return {
+    applicationId: snapshot.applicationId,
+    minutesInRefreshWait: anyRefreshComputed ? totalRefreshMinutes : null,
+    minutesInManualReviewWait: anyManualComputed ? totalManualMinutes : null,
+    refreshRequestCount,
+    missingInfoRequestCount,
+    hasOpenWait,
+  };
+}

--- a/apps/web/lib/trust/action-owner.ts
+++ b/apps/web/lib/trust/action-owner.ts
@@ -1,0 +1,189 @@
+/**
+ * Canonical actor model for unresolved trust states.
+ *
+ * Every blocker, gap, source failure, or access gate must answer four
+ * questions:
+ *   1. What happened?
+ *   2. Who owns the fix?
+ *   3. What action is possible now?
+ *   4. What happens if the user continues anyway?
+ *
+ * Doctrine (from Launch Gate H5 + Source Coverage Matrix rule 6):
+ *   - System failure is never assigned to USER.
+ *   - Access-required is never a clinician defect.
+ *   - Stale source is not equivalent to user missing data.
+ *   - No ownerless blockers on live wedge surfaces.
+ */
+
+export const ACTION_OWNER = {
+  USER: 'USER',
+  VITALCV: 'VITALCV',
+  EMPLOYER: 'EMPLOYER',
+  SOURCE: 'SOURCE',
+  INSTITUTION: 'INSTITUTION',
+  REVIEWER: 'REVIEWER',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+export type ActionOwner = typeof ACTION_OWNER[keyof typeof ACTION_OWNER];
+
+export type ActionType =
+  | 'retry'      // VitalCV will retry a failed source call
+  | 'upload'     // user provides a document or identity claim
+  | 'contact'    // user contacts an external authority
+  | 'wait'       // user waits on a system or review
+  | 'external'   // user navigates to a third-party site
+  | 'none';      // no user-facing action possible
+
+export interface BlockerOwnership {
+  /** Canonical owner of the fix. */
+  owner: ActionOwner;
+  /** One-sentence reason this owner is responsible. */
+  rationale: string;
+  /** Plain-language blocker title (what the user reads). */
+  plainLabel: string;
+  /** Owner-prefixed sentence: "You need to…", "VitalCV is retrying…", etc. */
+  ownerPrefix: string;
+  /** Verb on the CTA. Never generic "Take Action". */
+  actionLabel: string;
+  /** Nature of the action — drives which surface handles it. */
+  actionType: ActionType;
+  /** Human-readable ETA or dependency note. Null when unknown. */
+  etaOrDependency: string | null;
+  /**
+   * Whether the user can continue to a passport view without resolving
+   * this blocker. Gated/access-required items typically allow a
+   * provisional continuation; active integrity failures (OIG exclusion)
+   * do not.
+   */
+  canProceed: boolean;
+}
+
+const UNKNOWN_OWNERSHIP: BlockerOwnership = {
+  owner: ACTION_OWNER.UNKNOWN,
+  rationale: 'Ownership of this gap has not been classified yet.',
+  plainLabel: 'Unclassified gap',
+  ownerPrefix: 'We need to classify this gap',
+  actionLabel: 'Review details',
+  actionType: 'none',
+  etaOrDependency: null,
+  canProceed: true,
+};
+
+/**
+ * Map an internal blocker string (from deriveBlockers) to ownership
+ * metadata. Exhaustive for every blocker the stream produces today.
+ */
+export function resolveBlockerOwnership(blocker: string): BlockerOwnership {
+  switch (blocker) {
+    case 'On OIG exclusion list':
+      return {
+        owner: ACTION_OWNER.USER,
+        rationale:
+          'A federal exclusion is attached to this NPI. Only the clinician can pursue a formal dispute with the OIG.',
+        plainLabel: 'Federal exclusion on record',
+        ownerPrefix: 'You need to resolve this exclusion with the OIG',
+        actionLabel: 'Open OIG dispute guide',
+        actionType: 'external',
+        etaOrDependency: 'OIG dispute process typically takes 30+ days',
+        canProceed: false,
+      };
+
+    case 'Exclusion check failed':
+      return {
+        owner: ACTION_OWNER.VITALCV,
+        rationale:
+          'The OIG/LEIE source did not return a usable response. VitalCV retries automatically on the next ingest.',
+        plainLabel: 'Exclusion check did not complete',
+        ownerPrefix: 'VitalCV is retrying the OIG check',
+        actionLabel: 'Retry OIG check',
+        actionType: 'retry',
+        etaOrDependency: 'Retries run on the next page load',
+        canProceed: true,
+      };
+
+    case 'Medicare enrollment unresolved':
+      return {
+        owner: ACTION_OWNER.SOURCE,
+        rationale:
+          'CMS PECOS has not returned a definitive enrollment status. PECOS refreshes quarterly — the record may exist but not yet reflect recent changes.',
+        plainLabel: 'Medicare enrollment not yet resolved',
+        ownerPrefix: 'CMS PECOS is refreshing',
+        actionLabel: 'Check PECOS directly',
+        actionType: 'external',
+        etaOrDependency: 'PECOS refreshes quarterly; direct check at CMS is real-time',
+        canProceed: true,
+      };
+
+    case 'Not enrolled in Medicare':
+      return {
+        owner: ACTION_OWNER.USER,
+        rationale:
+          'CMS returned a definitive "not enrolled" status. Only the clinician can submit a Medicare enrollment application through PECOS.',
+        plainLabel: 'Not enrolled in Medicare',
+        ownerPrefix: 'You need to enroll in Medicare through PECOS',
+        actionLabel: 'Open PECOS enrollment',
+        actionType: 'external',
+        etaOrDependency: 'Medicare enrollment typically takes 14 days after submission',
+        canProceed: true,
+      };
+
+    default: {
+      // Derived "N unresolved readiness items" pattern — owner unclear
+      // without upstream detail. Label honestly; do not imply ownership.
+      if (/^\d+ unresolved readiness items?$/.test(blocker)) {
+        return {
+          owner: ACTION_OWNER.UNKNOWN,
+          rationale:
+            'Upstream readiness engine reported unresolved items without per-item ownership. Detailed breakdown requires a full passport view.',
+          plainLabel: blocker,
+          ownerPrefix: 'Open the passport to see per-item detail',
+          actionLabel: 'View passport detail',
+          actionType: 'none',
+          etaOrDependency: null,
+          canProceed: true,
+        };
+      }
+      return { ...UNKNOWN_OWNERSHIP, plainLabel: blocker };
+    }
+  }
+}
+
+/**
+ * State-board access ownership. State boards are ACCESS_REQUIRED at the
+ * platform level (Source Coverage Matrix section 2) — per-state
+ * agreements are not in place for pilot. This is an institutional gate,
+ * never a clinician defect.
+ */
+export function resolveStateBoardOwnership(): BlockerOwnership {
+  return {
+    owner: ACTION_OWNER.INSTITUTION,
+    rationale:
+      'State medical boards require per-state agreements for programmatic access. VitalCV does not support this lane in the current passport flow.',
+    plainLabel: 'State board verification not yet supported',
+    ownerPrefix: 'Your employer or institution covers state-board verification for now',
+    actionLabel: 'Review state-board note',
+    actionType: 'none',
+    etaOrDependency: 'State-board coverage rolls out per pilot agreement',
+    canProceed: true,
+  };
+}
+
+/**
+ * Omega recompute upstream failure. When the action capsule landed
+ * locally but the Omega POST did not, VitalCV owns the retry on the
+ * next page load. User can continue; the next refresh reconciles.
+ */
+export function resolveOmegaRecomputeFailureOwnership(): BlockerOwnership {
+  return {
+    owner: ACTION_OWNER.VITALCV,
+    rationale:
+      'Your action was recorded locally, but the upstream decision view did not refresh. VitalCV retries on the next page load.',
+    plainLabel: 'Upstream decision view did not refresh',
+    ownerPrefix: 'VitalCV will retry the recompute',
+    actionLabel: 'Refresh now',
+    actionType: 'retry',
+    etaOrDependency: 'Retries automatically on the next navigation',
+    canProceed: true,
+  };
+}

--- a/apps/web/lib/trust/employer-action-consequence.ts
+++ b/apps/web/lib/trust/employer-action-consequence.ts
@@ -143,8 +143,34 @@ export function resolveEmployerActionConsequence(
  * Mirrors `resolvePassportContinuation` input/output shape so review
  * and passport surfaces agree on when a packet is draft / partial /
  * decision-grade. Never upgrades a packet silently.
+ *
+ * Two proof-tier vocabularies exist in the codebase by design:
+ *   - `ProofTier` (this module, long form) — narrative tier carried
+ *     by the review banner (`resolveProofTier → ProofTierMeta`). Used
+ *     for user-facing labels and acceptance gating.
+ *   - `ProofTierShortKey` (decision-copy.ts) — short key used by
+ *     `getEmployerActionLabel(action, { proofTier })` to pick between
+ *     "Accept as head start" and "Accept partial head start".
+ *
+ * `proofTierToShortKey()` is the canonical bridge. Callers must route
+ * through it rather than hardcoding the mapping inline.
  */
 export type ProofTier = 'draft_snapshot' | 'partial_proof_pack' | 'decision_grade_proof_pack';
+
+export function proofTierToShortKey(tier: ProofTier): ProofTierShortKey {
+  switch (tier) {
+    case 'draft_snapshot':
+      return 'draft';
+    case 'partial_proof_pack':
+      return 'partial';
+    case 'decision_grade_proof_pack':
+      return 'decision_grade';
+    default: {
+      const _exhaustive: never = tier;
+      return _exhaustive;
+    }
+  }
+}
 
 export interface ProofTierMeta {
   tier: ProofTier;

--- a/apps/web/lib/trust/employer-action-consequence.ts
+++ b/apps/web/lib/trust/employer-action-consequence.ts
@@ -1,0 +1,246 @@
+/**
+ * Consequence contract for employer review actions.
+ *
+ * Every action button on the employer review surface must answer four
+ * questions before the click:
+ *   1. What does this action do?
+ *   2. What evidence state does it assume?
+ *   3. What audit event gets written?
+ *   4. What remains unresolved after the action fires?
+ *   5. Who owns the next move?
+ *
+ * Doctrine (Launch Gate E1-E5 + review ownership wave):
+ *   - No action button without explicit consequence copy.
+ *   - "Accept as head start" must clearly distinguish what is being
+ *     accepted vs what is NOT being accepted.
+ *   - Every action must write an audit event before returning success
+ *     (per employer decision persistence gate).
+ *   - Partial proof pack never upgrades silently when an action fires.
+ */
+
+import { ACTION_OWNER, type ActionOwner } from './action-owner';
+
+/**
+ * Employer action keys. Self-contained in this module so the consequence
+ * contract does not depend on a shared `decision-copy` module that may
+ * live or move independently. Main's post-Liquid-Glass refactor removed
+ * the central decision-copy module; the consequence contract is now the
+ * source of truth for these action keys.
+ */
+export type EmployerActionCopyKey = 'accept' | 'refresh' | 'review' | 'pause' | 'reject';
+
+/**
+ * Short-form proof-tier key used by downstream callers that need to pick
+ * between decision-grade and partial acceptance copy. Mirrors the
+ * narrative `ProofTier` below via `proofTierToShortKey`.
+ */
+export type ProofTierShortKey = 'draft' | 'partial' | 'decision_grade';
+
+export interface EmployerActionConsequence {
+  /** Which action this describes (mirrors EmployerActionCopyKey). */
+  action: EmployerActionCopyKey;
+  /** One-line description of what the action does (present tense, concrete). */
+  does: string;
+  /** What evidence state the action assumes — the implicit precondition. */
+  assumes: string;
+  /** The audit event that lands before the action returns 2xx. */
+  auditEvent: string;
+  /** What remains unresolved after the action fires. Null when nothing. */
+  remainsAfter: string | null;
+  /** Who owns the next move after this action fires. */
+  ownerAfter: ActionOwner;
+  /**
+   * Extra "not being accepted" line for the accept action. For other
+   * actions this is null. Rule: accept must never imply the employer
+   * has absorbed risk they have not actually absorbed.
+   */
+  acceptNotIncluded: string | null;
+}
+
+export function resolveEmployerActionConsequence(
+  action: EmployerActionCopyKey,
+): EmployerActionConsequence {
+  switch (action) {
+    case 'accept':
+      return {
+        action,
+        does:
+          'When decision-grade proof is attached, records a head-start acceptance on this verification snapshot, writes a decision event and audit record, and returns the packet to the employer dashboard.',
+        assumes:
+          'Decision-grade proof has been rendered for the covered lanes. If the packet is still partial, the uncovered lanes remain outside the acceptance and this action stays blocked.',
+        auditEvent: 'EmployerDecisionEvent(type=ACCEPT) + AuditEvent',
+        remainsAfter:
+          'Final credentialing workflow still happens at the employer. VitalCV provides the pre-screen, not the full privileging decision.',
+        ownerAfter: ACTION_OWNER.EMPLOYER,
+        acceptNotIncluded:
+          'Head-start does NOT include NPDB, DEA registration, ABMS board certification, unresolved partial lanes, or full CAQH credentialing. These remain the employer\u2019s credentialing office to complete.',
+      };
+
+    case 'refresh':
+      return {
+        action,
+        does:
+          'Re-queries the upstream sources for fresh data, reruns the ingest, and surfaces any new findings in the review packet.',
+        assumes:
+          'Nothing — refresh is safe at any evidence state. Useful when a lane is stale or the clinician has taken recent action.',
+        auditEvent: 'EmployerDecisionEvent(type=REFRESH_REQUESTED) + AuditEvent',
+        remainsAfter:
+          'Refreshed data arrives asynchronously. You will see the new state when the next ingest completes.',
+        ownerAfter: ACTION_OWNER.VITALCV,
+        acceptNotIncluded: null,
+      };
+
+    case 'review':
+      return {
+        action,
+        does:
+          'Routes the packet to manual review with a reviewer-assigned follow-up. The clinician is notified that their packet is under review.',
+        assumes:
+          'A finding or gap exists that a human reviewer needs to interpret — a lane returned review_required, or the evidence tier does not match the employer\u2019s risk posture.',
+        auditEvent: 'EmployerDecisionEvent(type=ROUTE_TO_REVIEW) + AuditEvent',
+        remainsAfter:
+          'A reviewer will contact the clinician and update the packet. No head-start is recorded until review resolves.',
+        ownerAfter: ACTION_OWNER.REVIEWER,
+        acceptNotIncluded: null,
+      };
+
+    case 'pause':
+      return {
+        action,
+        does:
+          'Pauses the candidate in the employer pipeline without closing the record. No decision event is written; the packet remains visible.',
+        assumes:
+          'Nothing — pause is a non-decision. It preserves the packet while the employer gathers out-of-band context.',
+        auditEvent: 'EmployerDecisionEvent(type=PAUSE) + AuditEvent',
+        remainsAfter: 'The candidate is not advancing. Resume by taking any other action.',
+        ownerAfter: ACTION_OWNER.EMPLOYER,
+        acceptNotIncluded: null,
+      };
+
+    case 'reject':
+      return {
+        action,
+        does:
+          'Records a final "do not proceed" decision on this snapshot. The packet is closed for head-start acceptance in this employer context.',
+        assumes:
+          'The employer has concluded that the clinician cannot be advanced on this snapshot. Typically follows a review or a disqualifying finding.',
+        auditEvent: 'EmployerDecisionEvent(type=REJECT) + AuditEvent',
+        remainsAfter:
+          'The clinician remains eligible for other employer contexts. This action is scoped to the current employer.',
+        ownerAfter: ACTION_OWNER.EMPLOYER,
+        acceptNotIncluded: null,
+      };
+
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Proof tier parity with the /passport continuation states.
+ * Mirrors `resolvePassportContinuation` input/output shape so review
+ * and passport surfaces agree on when a packet is draft / partial /
+ * decision-grade. Never upgrades a packet silently.
+ */
+export type ProofTier = 'draft_snapshot' | 'partial_proof_pack' | 'decision_grade_proof_pack';
+
+export interface ProofTierMeta {
+  tier: ProofTier;
+  /** Short label rendered on the review tier chip. */
+  label: string;
+  /** One-line description of what this tier guarantees. */
+  description: string;
+  /** Whether head-start acceptance is allowed at this tier. */
+  acceptAllowed: boolean;
+  /** Human reason the employer cannot accept, null if acceptance is allowed. */
+  acceptBlockedReason: string | null;
+}
+
+export function resolveProofTier(input: {
+  hasAnchor: boolean;
+  allRequiredLanesResolved: boolean;
+  hasUnresolvedBlockers: boolean;
+  anyLanePending: boolean;
+  anyLaneReviewRequired: boolean;
+  anyLaneAccessRequired: boolean;
+  anyLaneUnavailable: boolean;
+  anyLaneStale: boolean;
+  anyLaneNoRecord: boolean;
+  hasOpenDriftAlerts?: boolean;
+}): ProofTierMeta {
+  const {
+    hasAnchor,
+    allRequiredLanesResolved,
+    hasUnresolvedBlockers,
+    anyLanePending,
+    anyLaneReviewRequired,
+    anyLaneAccessRequired,
+    anyLaneUnavailable,
+    anyLaneStale,
+    anyLaneNoRecord,
+    hasOpenDriftAlerts = false,
+  } = input;
+
+  if (!hasAnchor) {
+    return {
+      tier: 'draft_snapshot',
+      label: 'Draft snapshot',
+      description:
+        'No passport anchor has been written. Nothing on this surface is decision-grade.',
+      acceptAllowed: false,
+      acceptBlockedReason:
+        'Draft snapshot — no passport anchor exists. Head-start cannot be accepted.',
+    };
+  }
+
+  const decisionGrade =
+    allRequiredLanesResolved
+    && !hasUnresolvedBlockers
+    && !anyLanePending
+    && !anyLaneReviewRequired
+    && !anyLaneAccessRequired
+    && !anyLaneUnavailable
+    && !anyLaneStale
+    && !anyLaneNoRecord
+    && !hasOpenDriftAlerts;
+
+  if (decisionGrade) {
+    return {
+      tier: 'decision_grade_proof_pack',
+      label: 'Decision-grade proof pack',
+      description:
+        'All required lanes returned a clean result. Head-start acceptance is allowed for the covered lanes.',
+      acceptAllowed: true,
+      acceptBlockedReason: null,
+    };
+  }
+
+  // Everything else is partial. Compose the most specific reason the
+  // employer cannot accept head-start right now.
+  const reason = hasOpenDriftAlerts
+    ? 'Drift alerts are open. Resolve them before accepting.'
+    : anyLaneUnavailable
+      ? 'One or more sources could not be reached. Head-start requires decision-grade evidence.'
+      : anyLaneReviewRequired
+        ? 'One or more lanes need reviewer attention before head-start acceptance.'
+      : anyLaneAccessRequired
+        ? 'An access-required lane is not yet covered. Your institution covers that lane for now.'
+      : anyLaneStale
+        ? 'One or more lanes may be stale. Refresh before accepting as head-start.'
+      : anyLaneNoRecord
+        ? 'One or more records are missing. Request missing info before accepting.'
+      : anyLanePending
+        ? 'Verification is still running. Wait for lanes to resolve.'
+      : 'Unresolved blockers remain. Resolve them before accepting.';
+
+  return {
+    tier: 'partial_proof_pack',
+    label: 'Partial proof pack',
+    description:
+      'Some lanes are resolved; others are still pending, stale, access-required, or in review. This packet is not decision-grade yet.',
+    acceptAllowed: false,
+    acceptBlockedReason: `Partial head-start only — ${reason}`,
+  };
+}

--- a/apps/web/lib/trust/recovery-path.ts
+++ b/apps/web/lib/trust/recovery-path.ts
@@ -1,0 +1,326 @@
+/**
+ * Recovery-path contract for source lanes.
+ *
+ * Every source-row state (pending, unavailable, access_required, stale,
+ * no_record, review_required, checked) gets an explicit next behavior.
+ *
+ * Doctrine:
+ *   - pending: explain what is still running; no user action unless
+ *     retry/cancel is real.
+ *   - unavailable: say the source failed; show retry or continue-partial;
+ *     never disguise as motion.
+ *   - access_required: explain who controls access and what is blocked.
+ *   - stale: explain what is old; show refresh path; state whether
+ *     current evidence is still usable.
+ *   - no_record: explain what it means in plain language; show next
+ *     route (upload, claim identity, contact support).
+ *   - review_required: name the reviewer, what triggered review, what
+ *     to expect next.
+ *
+ * This module is source-agnostic: the `lane` identifier carries
+ * presentation, the `state` carries the recovery contract.
+ */
+
+import {
+  ACTION_OWNER,
+  resolveStateBoardOwnership,
+  type ActionOwner,
+  type ActionType,
+} from './action-owner';
+
+export type SourceLaneState =
+  | 'pending'
+  | 'checked'
+  | 'review_required'
+  | 'unavailable'
+  | 'access_required'
+  | 'stale'
+  | 'no_record';
+
+export type SourceLane = 'nppes' | 'oig' | 'pecos' | 'state_board';
+
+export interface RecoveryPath {
+  state: SourceLaneState;
+  /** Short plain-language lane name rendered in the source row. */
+  laneLabel: string;
+  /**
+   * Badge-style label for the lane state. Not a verdict — a truthful
+   * description of what happened. Never relabels failure as progress.
+   */
+  statusLabel: string;
+  /** Canonical owner for the recovery step, when one is needed. */
+  owner: ActionOwner;
+  /**
+   * One or two sentences answering "what happened and what it means"
+   * in the user's language. Never leaks internal error messages.
+   */
+  explanation: string;
+  /** The user-facing next step. Null when no action is currently possible. */
+  nextStep: string | null;
+  /** Button label for `nextStep`. Null when no CTA is rendered. */
+  ctaLabel: string | null;
+  /** Nature of the recovery action. */
+  actionType: ActionType;
+  /**
+   * Whether the passport can honestly continue without resolving this
+   * lane. A permanent exclusion cannot continue; a stale PECOS record can.
+   */
+  canContinuePartial: boolean;
+}
+
+const LANE_LABEL: Record<SourceLane, string> = {
+  nppes: 'NPI registry',
+  oig: 'Federal exclusions',
+  pecos: 'Medicare enrollment',
+  state_board: 'State board verification',
+};
+
+export function getLaneLabel(lane: SourceLane): string {
+  return LANE_LABEL[lane];
+}
+
+/**
+ * Canonical recovery contract per (lane, state). Exhaustive for the
+ * states the ingest stream can produce today. Out-of-band combinations
+ * fall through to a truthful "we do not know yet" contract instead of
+ * silently collapsing into `checked`.
+ */
+export function resolveRecoveryPath(
+  lane: SourceLane,
+  state: SourceLaneState,
+): RecoveryPath {
+  const laneLabel = LANE_LABEL[lane];
+
+  switch (state) {
+    case 'pending':
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'Not yet verified',
+        owner: ACTION_OWNER.VITALCV,
+        explanation: `${laneLabel} is not yet verified in this run.`,
+        nextStep: null,
+        ctaLabel: null,
+        actionType: 'none',
+        canContinuePartial: true,
+      };
+
+    case 'checked':
+      return {
+        state,
+        laneLabel,
+        statusLabel: lane === 'pecos' ? 'Enrolled' : 'Checked',
+        owner: ACTION_OWNER.VITALCV,
+        explanation: `${laneLabel} returned a clean result.`,
+        nextStep: null,
+        ctaLabel: null,
+        actionType: 'none',
+        canContinuePartial: true,
+      };
+
+    case 'unavailable':
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'Source unavailable — retry',
+        owner: ACTION_OWNER.VITALCV,
+        explanation: `${laneLabel} could not be reached this time. This is not a verdict on your record — VitalCV will retry.`,
+        nextStep: 'Retry this check',
+        ctaLabel: 'Retry check',
+        actionType: 'retry',
+        canContinuePartial: true,
+      };
+
+    case 'access_required':
+      if (lane === 'state_board') {
+        const ownership = resolveStateBoardOwnership();
+        return {
+          state,
+          laneLabel,
+          statusLabel: ownership.plainLabel,
+          owner: ownership.owner,
+          explanation: `${ownership.rationale} ${ownership.ownerPrefix}.`,
+          nextStep: null,
+          ctaLabel: null,
+          actionType: 'none',
+          canContinuePartial: true,
+        };
+      }
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'Access required',
+        owner: ACTION_OWNER.INSTITUTION,
+        explanation: `${laneLabel} requires institutional access that is not yet wired. The employer covers this lane for now.`,
+        nextStep: null,
+        ctaLabel: null,
+        actionType: 'none',
+        canContinuePartial: true,
+      };
+
+    case 'stale': {
+      const staleExplanation =
+        lane === 'pecos'
+          ? `${laneLabel} refreshes quarterly, so the record may be up to 90 days old. The current evidence is still usable for a provisional passport.`
+          : `${laneLabel} returned a cached result. The current evidence is still usable, but a refresh is recommended.`;
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'May be stale',
+        owner: ACTION_OWNER.SOURCE,
+        explanation: staleExplanation,
+        nextStep: 'Refresh directly from the source',
+        ctaLabel: 'Refresh now',
+        actionType: 'external',
+        canContinuePartial: true,
+      };
+    }
+
+    case 'no_record':
+      if (lane === 'nppes') {
+        return {
+          state,
+          laneLabel,
+          statusLabel: 'No NPPES record',
+          owner: ACTION_OWNER.USER,
+          explanation:
+            'NPPES did not return a record for this NPI. The number may be mistyped, or the registration may not yet be public.',
+          nextStep: 'Double-check the NPI and try again',
+          ctaLabel: 'Try a different NPI',
+          actionType: 'retry',
+          canContinuePartial: false,
+        };
+      }
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'No record found',
+        owner: ACTION_OWNER.USER,
+        explanation: `${laneLabel} has no record attached to this NPI yet.`,
+        nextStep: 'Upload supporting evidence',
+        ctaLabel: 'Upload evidence',
+        actionType: 'upload',
+        canContinuePartial: true,
+      };
+
+    case 'review_required':
+      return {
+        state,
+        laneLabel,
+        statusLabel: 'Review required',
+        owner: ACTION_OWNER.REVIEWER,
+        explanation: `${laneLabel} returned a finding that needs a reviewer to examine before this lane can be relied on.`,
+        nextStep: 'A reviewer will contact you',
+        ctaLabel: null,
+        actionType: 'wait',
+        canContinuePartial: false,
+      };
+
+    default: {
+      // Exhaustiveness guard — every SourceLaneState must be handled.
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Passport continuation state. Expresses honestly whether the current
+ * ingest produced a provisional snapshot, a partial passport, or a
+ * full decision-grade proof pack.
+ */
+export type PassportContinuationState =
+  | 'draft_snapshot'
+  | 'partial_passport'
+  | 'decision_grade';
+
+export interface PassportContinuationCopy {
+  state: PassportContinuationState;
+  /** Headline shown at the top of the CTA surface. */
+  headline: string;
+  /** One-line description of what the user is about to continue into. */
+  description: string;
+  /** CTA verb — never "Your passport is ready" unless decision-grade. */
+  ctaLabel: string;
+  /** Warning line rendered when not decision-grade. Null when decision-grade. */
+  provisionalNotice: string | null;
+}
+
+export function resolvePassportContinuation(input: {
+  hasAnchor: boolean;
+  allRequiredLanesResolved: boolean;
+  hasUnresolvedBlockers: boolean;
+  anyLanePending: boolean;
+  anyLaneReviewRequired: boolean;
+  anyLaneAccessRequired: boolean;
+  anyLaneUnavailable: boolean;
+  anyLaneStale: boolean;
+  anyLaneNoRecord: boolean;
+}): PassportContinuationCopy {
+  const {
+    hasAnchor,
+    allRequiredLanesResolved,
+    hasUnresolvedBlockers,
+    anyLanePending,
+    anyLaneReviewRequired,
+    anyLaneAccessRequired,
+    anyLaneUnavailable,
+    anyLaneStale,
+    anyLaneNoRecord,
+  } = input;
+
+  if (!hasAnchor) {
+    return {
+      state: 'draft_snapshot',
+      headline: 'Draft snapshot',
+      description:
+        'Identity has not resolved to a passport anchor yet. You can still see what VitalCV found so far.',
+      ctaLabel: 'Continue with draft snapshot',
+      provisionalNotice:
+        'No passport anchor has been written. Nothing on this draft is decision-grade.',
+    };
+  }
+
+  if (
+    allRequiredLanesResolved
+    && !hasUnresolvedBlockers
+    && !anyLanePending
+    && !anyLaneReviewRequired
+    && !anyLaneAccessRequired
+    && !anyLaneUnavailable
+    && !anyLaneStale
+    && !anyLaneNoRecord
+  ) {
+    return {
+      state: 'decision_grade',
+      headline: 'Decision-grade passport',
+      description:
+        'All required checks returned a clean result. This passport is decision-grade for the covered lanes.',
+      ctaLabel: 'View full passport',
+      provisionalNotice: null,
+    };
+  }
+
+  const notice = anyLaneUnavailable
+    ? 'One or more sources could not be reached this time. The covered lanes are still usable, but the passport is not decision-grade until they retry.'
+    : anyLaneAccessRequired
+      ? 'State board verification is not yet supported in this passport flow. Your employer or institution covers that lane for now.'
+      : anyLaneReviewRequired
+        ? 'One or more lanes need manual review before this passport can become decision-grade.'
+      : anyLaneNoRecord
+        ? 'One or more required records were not found yet. The covered lanes are still usable, but this passport is incomplete.'
+      : anyLaneStale
+        ? 'One or more covered lanes may be stale. The passport remains partial until fresher evidence lands.'
+      : anyLanePending
+        ? 'One or more lanes are not yet verified. The covered lanes are usable, but this passport is still incomplete.'
+      : 'Some lanes are still resolving or need review. The covered lanes are usable, but the passport is not decision-grade yet.';
+
+  return {
+    state: 'partial_passport',
+    headline: 'Partial passport',
+    description:
+      'The covered lanes are ready. Remaining lanes still need resolution before this passport is decision-grade.',
+    ctaLabel: 'Continue with partial passport',
+    provisionalNotice: notice,
+  };
+}


### PR DESCRIPTION
## Summary
- replace the public pilot intake stub with a real attributable handoff flow
- add explicit owner, next-step, and baseline-metric honesty contracts for pilot intake
- add regression coverage for route behavior and pilot confirmation rendering

## Validation
- `pnpm --dir apps/web exec vitest run __tests__/pilot-intake.test.ts __tests__/pilot-request-route.test.ts`

## Notes
- this PR is intentionally narrow to the pilot intake and operator handoff flow
- there is one unrelated untracked local file in the worktree: `apply-revenue.sh`