### PR TITLE
feat(pilot): add pilot intake and operator handoff workflow

### DIFF
--- a/apps/web/__tests__/pilot-intake.test.ts
+++ b/apps/web/__tests__/pilot-intake.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDefaultBaselineSkeleton,
+  computePilotSubmissionHash,
+  createPilotRequestRecord,
+  DEFAULT_PILOT_SUCCESS_CRITERIA,
+  isPilotBaselinePartial,
+  isPilotStatusTransitionAllowed,
+  resolveNextStepForStatus,
+  resolveOwnerForStatus,
+  transitionPilotStatus,
+  updatePilotBaseline,
+  validatePilotIntakeInput,
+  type PilotRequestRecord,
+  type PilotStatus,
+} from '@/lib/pilot/pilot-intake';
+
+const ALL_STATUSES: PilotStatus[] = [
+  'requested',
+  'qualified',
+  'scoping',
+  'baseline_captured',
+  'ready_to_launch',
+  'active',
+  'completed',
+  'archived',
+];
+
+function base(): ReturnType<typeof createPilotRequestRecord> {
+  return createPilotRequestRecord({
+    orgName: 'Acme Health',
+    contactName: 'Jane Smith',
+    contactEmail: 'jane@acme.health',
+    sourceContext: '/pilot',
+    requestedAt: '2026-04-18T00:00:00Z',
+  });
+}
+
+describe('validatePilotIntakeInput', () => {
+  it('rejects missing org name / contact / email', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: '',
+      contactName: '',
+      contactEmail: '',
+    });
+    expect(errs.map((e) => e.field).sort()).toEqual([
+      'contactEmail',
+      'contactName',
+      'orgName',
+    ]);
+  });
+
+  it('rejects malformed email with a specific reason', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: 'x',
+      contactName: 'y',
+      contactEmail: 'not-an-email',
+    });
+    expect(errs.length).toBe(1);
+    expect(errs[0].field).toBe('contactEmail');
+    expect(errs[0].reason.toLowerCase()).toContain('valid');
+  });
+
+  it('accepts a valid input with zero errors', () => {
+    const errs = validatePilotIntakeInput({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+    });
+    expect(errs).toEqual([]);
+  });
+});
+
+describe('createPilotRequestRecord', () => {
+  it('throws on invalid input rather than returning a blank record', () => {
+    expect(() =>
+      createPilotRequestRecord({
+        orgName: '',
+        contactName: '',
+        contactEmail: '',
+      }),
+    ).toThrow();
+  });
+
+  it('assigns the canonical pilot_ops owner at creation time (no ownerless records)', () => {
+    const record = base();
+    expect(record.owner).toBe('pilot_ops');
+  });
+
+  it('status starts at "requested" and nextStep is never blank', () => {
+    const record = base();
+    expect(record.status).toBe('requested');
+    expect(record.nextStep.trim().length).toBeGreaterThan(0);
+  });
+
+  it('writes an initial audit entry attributing the buyer as the requester', () => {
+    const record = base();
+    expect(record.auditLog).toHaveLength(1);
+    expect(record.auditLog[0].actor).toBe('buyer');
+    expect(record.auditLog[0].action).toBe('requested');
+    expect(record.auditLog[0].to).toBe('requested');
+  });
+
+  it('uses the canonical success-criteria default when none supplied', () => {
+    const record = base();
+    expect(record.successCriteria.length).toBe(DEFAULT_PILOT_SUCCESS_CRITERIA.length);
+    expect(record.successCriteria[0].kind).toBe('comparable_delta');
+  });
+
+  it('uses the baseline skeleton when none supplied — every metric starts null + source="unknown"', () => {
+    const record = base();
+    expect(record.baselineMetrics.every((m) => m.value === null)).toBe(true);
+    expect(record.baselineMetrics.every((m) => m.source === 'unknown')).toBe(true);
+  });
+
+  it('defaults roleOrWorkflowTarget to "Credentialing review" when absent', () => {
+    const record = base();
+    expect(record.roleOrWorkflowTarget).toBe('Credentialing review');
+  });
+
+  it('produces a deterministic submissionHash for identical input within the same second', () => {
+    const record1 = createPilotRequestRecord({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    const record2 = createPilotRequestRecord({
+      orgName: 'Acme',
+      contactName: 'Jane',
+      contactEmail: 'jane@acme.health',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    expect(record1.submissionHash).toBe(record2.submissionHash);
+    // Different pilotIds though — each record is its own artifact.
+    expect(record1.pilotId).not.toBe(record2.pilotId);
+  });
+
+  it('submissionHash changes when org / email / workflow differ', () => {
+    const a = computePilotSubmissionHash({
+      orgName: 'Acme',
+      contactEmail: 'jane@acme.health',
+      roleOrWorkflowTarget: 'Credentialing review',
+      sourceContext: '/pilot',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    const b = computePilotSubmissionHash({
+      orgName: 'Acme',
+      contactEmail: 'jane@acme.health',
+      roleOrWorkflowTarget: 'Locum placement',
+      sourceContext: '/pilot',
+      requestedAt: '2026-04-18T00:00:00Z',
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('Status transitions', () => {
+  it('every status has a canonical next step (no blank nextStep)', () => {
+    for (const status of ALL_STATUSES) {
+      expect(resolveNextStepForStatus(status).trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every status has a canonical owner (no ownerless status)', () => {
+    for (const status of ALL_STATUSES) {
+      const owner = resolveOwnerForStatus(status);
+      expect(owner).toBeDefined();
+    }
+  });
+
+  it('requested -> qualified is allowed; requested -> active is NOT', () => {
+    expect(isPilotStatusTransitionAllowed('requested', 'qualified')).toBe(true);
+    expect(isPilotStatusTransitionAllowed('requested', 'active')).toBe(false);
+  });
+
+  it('archived is terminal — no outgoing transitions', () => {
+    for (const to of ALL_STATUSES) {
+      expect(isPilotStatusTransitionAllowed('archived', to)).toBe(false);
+    }
+  });
+
+  it('transitionPilotStatus reassigns owner + nextStep per the new status', () => {
+    const record = base();
+    const qualified = transitionPilotStatus(record, 'qualified', { actor: 'operator' });
+    expect(qualified.owner).toBe(resolveOwnerForStatus('qualified'));
+    expect(qualified.nextStep).toBe(resolveNextStepForStatus('qualified'));
+
+    const scoped = transitionPilotStatus(qualified, 'scoping', { actor: 'operator' });
+    // Scoping is owned by solutions_engineer, not pilot_ops.
+    expect(scoped.owner).toBe('solutions_engineer');
+  });
+
+  it('transitionPilotStatus appends an audit entry with actor + from/to', () => {
+    const record = base();
+    const qualified = transitionPilotStatus(record, 'qualified', {
+      actor: 'operator',
+      at: '2026-04-19T00:00:00Z',
+      note: 'scope call booked',
+    });
+    expect(qualified.auditLog).toHaveLength(2);
+    expect(qualified.auditLog[1]).toMatchObject({
+      actor: 'operator',
+      action: 'status_change',
+      from: 'requested',
+      to: 'qualified',
+      note: 'scope call booked',
+    });
+  });
+
+  it('throws on a disallowed transition', () => {
+    const record = base();
+    expect(() =>
+      transitionPilotStatus(record, 'active', { actor: 'operator' }),
+    ).toThrow();
+  });
+});
+
+describe('Baseline updates', () => {
+  it('isPilotBaselinePartial true for a fresh record (skeleton values are null)', () => {
+    const record = base();
+    expect(isPilotBaselinePartial(record)).toBe(true);
+  });
+
+  it('updatePilotBaseline only works during "scoping" status', () => {
+    const record = base(); // requested
+    expect(() =>
+      updatePilotBaseline(record, buildDefaultBaselineSkeleton(), { actor: 'operator' }),
+    ).toThrow();
+  });
+
+  it('captures real baseline values when operator supplies them during scoping', () => {
+    let r: PilotRequestRecord = base();
+    r = transitionPilotStatus(r, 'qualified', { actor: 'operator' });
+    r = transitionPilotStatus(r, 'scoping', { actor: 'operator' });
+    r = updatePilotBaseline(
+      r,
+      [
+        {
+          key: 'current_time_to_start_days',
+          label: 'Current median days from hire to start',
+          value: 63,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'current_time_to_first_review_days',
+          label: 'Current median days from application to first review',
+          value: 11,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'applications_per_month',
+          label: 'Typical applications per month',
+          value: 40,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'reviews_per_month',
+          label: 'Typical reviews per month',
+          value: 40,
+          source: 'buyer_reported',
+        },
+      ],
+      { actor: 'operator' },
+    );
+    expect(isPilotBaselinePartial(r)).toBe(false);
+    expect(r.baselineMetrics.every((m) => m.value !== null)).toBe(true);
+    expect(r.auditLog[r.auditLog.length - 1].action).toBe('baseline_updated');
+  });
+
+  it('baseline with any buyer-unknown value keeps isPilotBaselinePartial true', () => {
+    let r: PilotRequestRecord = base();
+    r = transitionPilotStatus(r, 'qualified', { actor: 'operator' });
+    r = transitionPilotStatus(r, 'scoping', { actor: 'operator' });
+    r = updatePilotBaseline(
+      r,
+      [
+        {
+          key: 'current_time_to_start_days',
+          label: 'Current median days from hire to start',
+          value: 63,
+          source: 'buyer_reported',
+        },
+        {
+          key: 'applications_per_month',
+          label: 'Typical applications per month',
+          value: null,
+          source: 'unknown',
+          note: 'buyer does not track this yet',
+        },
+      ],
+      { actor: 'operator' },
+    );
+    expect(isPilotBaselinePartial(r)).toBe(true);
+  });
+});
+
+describe('Success criteria defaults — no fake absolute targets', () => {
+  it('every default criterion uses comparable_delta or qualitative_signal (never absolute_target)', () => {
+    for (const c of DEFAULT_PILOT_SUCCESS_CRITERIA) {
+      expect(c.kind).not.toBe('absolute_target');
+    }
+  });
+
+  it('default criteria that require baseline are flagged correctly', () => {
+    const requiresBaseline = DEFAULT_PILOT_SUCCESS_CRITERIA.filter((c) => c.requiresBaseline);
+    expect(requiresBaseline.length).toBeGreaterThan(0);
+    for (const c of requiresBaseline) {
+      // Summary must reference the baseline / before-after relationship.
+      expect(c.summary.toLowerCase()).toMatch(/baseline|before|after|compar/);
+    }
+  });
+
+  it('qualitative-signal defaults never claim a numeric target', () => {
+    const qualitative = DEFAULT_PILOT_SUCCESS_CRITERIA.filter((c) => c.kind === 'qualitative_signal');
+    for (const c of qualitative) {
+      expect(c.summary).not.toMatch(/\d+%/);
+      expect(c.summary).not.toMatch(/\bby \d+\b/);
+    }
+  });
+});
+
+describe('Contract invariants — no ownerless / no blank-nextStep records', () => {
+  it('every status resolves to a defined owner role', () => {
+    const owners = new Set(ALL_STATUSES.map(resolveOwnerForStatus));
+    // At least two distinct owners should exist across the lifecycle
+    // (pilot_ops handles request + archived; solutions_engineer handles
+    // scoping; customer_success handles active). Sanity check.
+    expect(owners.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('post-transition records always carry a fresh nextStep matching the new status', () => {
+    let r = base();
+    const legalChain: PilotStatus[] = [
+      'qualified',
+      'scoping',
+      'baseline_captured',
+      'ready_to_launch',
+      'active',
+      'completed',
+    ];
+    for (const next of legalChain) {
+      r = transitionPilotStatus(r, next, { actor: 'operator' });
+      expect(r.nextStep).toBe(resolveNextStepForStatus(next));
+      expect(r.nextStep.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/__tests__/pilot-request-route.test.ts
+++ b/apps/web/__tests__/pilot-request-route.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { POST } from '@/app/api/pilot-request/route';
+
+function jsonRequest(body: unknown): Request {
+  return new Request('http://localhost/api/pilot-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function formRequest(fields: Record<string, string>): Request {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(fields)) params.append(k, v);
+  return new Request('http://localhost/api/pilot-request', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+}
+
+describe('/api/pilot-request POST — structured intake', () => {
+  it('returns a structured record + confirmation for a valid JSON submission', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'Acme Health',
+        name: 'Jane Smith',
+        email: 'jane@acme.health',
+        usecase: 'Locum placement for ER coverage',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      record: {
+        pilotId: string;
+        owner: string;
+        status: string;
+        nextStep: string;
+        orgName: string;
+        roleOrWorkflowTarget: string;
+        successCriteria: Array<{ kind: string }>;
+        baselineMetrics: Array<{ value: number | null }>;
+      };
+      confirmation: { acknowledgement: string; bullets: { whatHappensNext: string[] } };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.record.owner).toBe('pilot_ops');
+    expect(body.record.status).toBe('requested');
+    expect(body.record.orgName).toBe('Acme Health');
+    expect(body.record.roleOrWorkflowTarget).toBe('Locum placement for ER coverage');
+    expect(body.record.nextStep.trim().length).toBeGreaterThan(0);
+    expect(body.record.successCriteria.length).toBeGreaterThan(0);
+    expect(body.record.baselineMetrics.every((m) => m.value === null)).toBe(true);
+    expect(body.confirmation.bullets.whatHappensNext.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the HTML form encoding used by /pilot page fallback', async () => {
+    const res = await POST(
+      formRequest({
+        organization: 'Form Corp',
+        name: 'Sam Buyer',
+        email: 'sam@formcorp.health',
+        usecase: 'Credentialing committee pre-screen',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; record: { orgName: string } };
+    expect(body.ok).toBe(true);
+    expect(body.record.orgName).toBe('Form Corp');
+  });
+
+  it('returns 400 with structured errors on missing fields', async () => {
+    const res = await POST(jsonRequest({ organization: '', name: '', email: '' }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      ok: boolean;
+      errors: Array<{ field: string; reason: string }>;
+    };
+    expect(body.ok).toBe(false);
+    expect(body.errors.length).toBe(3);
+    expect(body.errors.map((e) => e.field).sort()).toEqual([
+      'contactEmail',
+      'contactName',
+      'orgName',
+    ]);
+  });
+
+  it('returns 400 with a specific email error on malformed address', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'x',
+        name: 'y',
+        email: 'not-an-email',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      errors: Array<{ field: string; reason: string }>;
+    };
+    expect(body.errors[0].field).toBe('contactEmail');
+  });
+
+  it('confirmation acknowledgement names the org and the owner inbox line', async () => {
+    const res = await POST(
+      jsonRequest({
+        organization: 'Named Health System',
+        name: 'Jane',
+        email: 'jane@named.health',
+      }),
+    );
+    const body = (await res.json()) as {
+      confirmation: { acknowledgement: string };
+    };
+    expect(body.confirmation.acknowledgement).toContain('Named Health System');
+    // Owner-inbox line for pilot_ops must mention "two business days".
+    expect(body.confirmation.acknowledgement.toLowerCase()).toContain('two business days');
+  });
+
+  it('structured record carries an audit entry attributing the buyer', async () => {
+    const res = await POST(
+      jsonRequest({ organization: 'x', name: 'y', email: 'z@z.com' }),
+    );
+    const body = (await res.json()) as {
+      record: {
+        auditLog: Array<{ actor: string; action: string; to: string | undefined }>;
+      };
+    };
+    expect(body.record.auditLog).toHaveLength(1);
+    expect(body.record.auditLog[0].actor).toBe('buyer');
+    expect(body.record.auditLog[0].action).toBe('requested');
+    expect(body.record.auditLog[0].to).toBe('requested');
+  });
+
+  it('invalid JSON body + missing fields still returns 400 (does not throw)', async () => {
+    const brokenJson = new Request('http://localhost/api/pilot-request', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not{json[',
+    });
+    const res = await POST(brokenJson);
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/pilot-request/route.ts
+++ b/apps/web/app/api/pilot-request/route.ts
@@ -1,27 +1,101 @@
-import { NextRequest, NextResponse } from 'next/server';
-
 /**
  * POST /api/pilot-request
  *
- * Stub — accepts pilot request form data.
- * TODO: persist to database, send notification email, write AuditEvent.
+ * Turns a buyer-submitted pilot request into a structured
+ * PilotRequestRecord with owner, next step, baseline skeleton, and
+ * canonical success criteria. Accepts both JSON bodies (from the
+ * hardened /pilot page fetch handler, future callers) and
+ * application/x-www-form-urlencoded (from the current HTML form
+ * fallback).
+ *
+ * Response on success (200):
+ *   { ok: true, record: PilotRequestRecord, confirmation: PilotConfirmationRenderModel }
+ *
+ * Response on validation failure (400):
+ *   { ok: false, errors: PilotIntakeInputError[] }
+ *
+ * Side effects are deliberately minimal — this wave produces the
+ * structured record and returns it. Persistence + email notification
+ * wiring is deferred to a separate wave ("do not build a full CRM").
  */
-export async function POST(request: NextRequest) {
-  const body = await request.json();
 
-  // Basic validation
-  const { organization, name, email } = body as Record<string, unknown>;
-  if (!organization || !name || !email) {
+import { NextResponse } from 'next/server';
+import {
+  createPilotRequestRecord,
+  validatePilotIntakeInput,
+  type PilotIntakeInput,
+} from '@/lib/pilot/pilot-intake';
+import { buildPilotConfirmationRenderModel } from '@/lib/pilot/pilot-confirmation-copy';
+
+async function readRequestBody(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const parsed = (await request.json()) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  // Form-encoded fallback — the existing /pilot page HTML form submits
+  // as application/x-www-form-urlencoded or multipart/form-data.
+  const form = await request.formData();
+  const record: Record<string, unknown> = {};
+  for (const [key, value] of form.entries()) {
+    record[key] = typeof value === 'string' ? value : value.name;
+  }
+  return record;
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === 'string' ? value : '';
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const body = await readRequestBody(request);
+
+  const input: PilotIntakeInput = {
+    orgName: readString(body, 'organization') || readString(body, 'orgName'),
+    contactName: readString(body, 'name') || readString(body, 'contactName'),
+    contactEmail: readString(body, 'email') || readString(body, 'contactEmail'),
+    orgId: readString(body, 'orgId') || null,
+    roleOrWorkflowTarget:
+      readString(body, 'roleOrWorkflowTarget')
+      || readString(body, 'usecase')
+      || 'Credentialing review',
+    sourceContext: readString(body, 'sourceContext') || '/pilot',
+  };
+
+  const errors = validatePilotIntakeInput(input);
+  if (errors.length > 0) {
     return NextResponse.json(
-      { ok: false, message: 'Organization, name, and email are required.' },
+      {
+        ok: false,
+        errors,
+        message: errors
+          .map((e) => e.reason)
+          .join(' '),
+      },
       { status: 400 },
     );
   }
 
-  // TODO: write AuditEvent, persist to DB, send notification
+  const record = createPilotRequestRecord(input);
+  const confirmation = buildPilotConfirmationRenderModel(record);
 
-  return NextResponse.json({
-    ok: true,
-    message: 'Pilot request received. We will reach out within 2 business days.',
-  });
+  return NextResponse.json(
+    {
+      ok: true,
+      record,
+      confirmation,
+      message: confirmation.acknowledgement,
+    },
+    { status: 200 },
+  );
 }

--- a/apps/web/lib/pilot/pilot-confirmation-copy.ts
+++ b/apps/web/lib/pilot/pilot-confirmation-copy.ts
@@ -1,0 +1,116 @@
+/**
+ * Pilot confirmation copy contract.
+ *
+ * When a buyer submits the paid-pilot request form, the response
+ * page must answer four questions explicitly — without vague
+ * "we'll be in touch" language:
+ *   1. What happens next?
+ *   2. What will VitalCV measure?
+ *   3. What does the buyer need to provide?
+ *   4. What remains outside current coverage?
+ *
+ * This module carries that copy as structured data so the confirmation
+ * page and the structured API response stay in lockstep. Mirrors the
+ * buyer-pilot-copy contract from Wave 244 but scoped to the
+ * post-submission flow.
+ */
+
+import type { PilotRequestRecord } from './pilot-intake';
+
+export interface PilotConfirmationBullets {
+  whatHappensNext: string[];
+  whatVitalCvMeasures: string[];
+  whatYouProvide: string[];
+  outsideCoverage: string[];
+}
+
+export const PILOT_CONFIRMATION_BULLETS: PilotConfirmationBullets = {
+  whatHappensNext: [
+    'A VitalCV operator reviews your submission within two business days.',
+    'If scope is a fit, the operator schedules a scoping call to confirm NPIs, lanes, measurement window, and success criteria.',
+    'You receive a signed scope document before any measurement starts. No auto-provisioning.',
+  ],
+  whatVitalCvMeasures: [
+    'Startability timeline events across every application submitted during the window (submit, first view, first action, advanced, start-ready, started).',
+    'Median time deltas against your baseline numbers — never against a generic industry figure.',
+    'Refresh and missing-info request counts, with owner attribution on every request.',
+    'Proof-tier distribution at submit time (decision-grade vs partial vs draft).',
+  ],
+  whatYouProvide: [
+    'A list of real clinician NPIs for the measurement window.',
+    'A named review operator who will run decisions on the pilot applications.',
+    'Your current baseline numbers (time-to-start days, applications per month) — or an honest "we don\u2019t track this yet" so we can capture it from scratch.',
+    'Access to your review decision workflow (employer context, user identity).',
+  ],
+  outsideCoverage: [
+    'NPDB, DEA registration, ABMS board certification, CAQH, and SAM.gov — these remain your credentialing office\u2019s scope.',
+    'Per-state board coverage for states outside the configured pilot lanes. Nursys / FSMB activation requires institutional agreements your organization signs directly.',
+    'Final privileging decisions. VitalCV provides the pre-screen; your credentialing committee still owns the approval.',
+  ],
+};
+
+export interface PilotConfirmationRenderModel {
+  /** Short confirmation headline — "Request received". */
+  headline: string;
+  /** One-line acknowledgement with the buyer's org name + next-step window. */
+  acknowledgement: string;
+  bullets: PilotConfirmationBullets;
+  /** Operator-facing handoff summary. Shown to the buyer as a soft
+   *  reassurance that a human is on it, and shown to the operator in
+   *  the ops handoff surface as the record-level summary. */
+  operatorHandoff: {
+    owner: string;
+    ownerLabel: string;
+    nextStep: string;
+    ownerInboxLine: string;
+  };
+  /** Reference lines — pilotId, submissionHash — rendered in a small
+   *  monospace footer so the buyer can cite the request ID if they
+   *  follow up. */
+  reference: {
+    pilotId: string;
+    submissionHash: string;
+    requestedAt: string;
+  };
+}
+
+const OWNER_LABELS: Record<PilotRequestRecord['owner'], string> = {
+  pilot_ops: 'VitalCV Pilot Ops',
+  customer_success: 'VitalCV Customer Success',
+  solutions_engineer: 'VitalCV Solutions Engineer',
+  founder: 'VitalCV Founder',
+};
+
+const OWNER_INBOX_LINES: Record<PilotRequestRecord['owner'], string> = {
+  pilot_ops:
+    'Pilot Ops reviews new requests daily. Expect a scoping reply within two business days.',
+  customer_success:
+    'Customer Success holds active-pilot check-ins weekly. Expect a check-in invitation shortly.',
+  solutions_engineer:
+    'A Solutions Engineer handles scoping and baseline capture. Expect a scoping-call invitation within two business days.',
+  founder:
+    'The founder is handling this personally. Expect a direct reply.',
+};
+
+export function buildPilotConfirmationRenderModel(
+  record: PilotRequestRecord,
+): PilotConfirmationRenderModel {
+  const ownerLabel = OWNER_LABELS[record.owner];
+  const ownerInboxLine = OWNER_INBOX_LINES[record.owner];
+  return {
+    headline: 'Pilot request received',
+    acknowledgement: `Thanks — we have your request from ${record.orgName}. ${ownerInboxLine}`,
+    bullets: PILOT_CONFIRMATION_BULLETS,
+    operatorHandoff: {
+      owner: record.owner,
+      ownerLabel,
+      nextStep: record.nextStep,
+      ownerInboxLine,
+    },
+    reference: {
+      pilotId: record.pilotId,
+      submissionHash: record.submissionHash,
+      requestedAt: record.requestedAt,
+    },
+  };
+}

--- a/apps/web/lib/pilot/pilot-intake.ts
+++ b/apps/web/lib/pilot/pilot-intake.ts
@@ -1,0 +1,487 @@
+/**
+ * Pilot intake contract.
+ *
+ * A `PilotRequestRecord` is the canonical structured artifact produced
+ * when a buyer submits the paid-pilot request form. It answers the
+ * mission's five required dimensions — who, what, baseline, success,
+ * next step — before any operator picks it up.
+ *
+ * Doctrine:
+ *   - No ownerless pilot records. `owner` is assigned at creation time
+ *     via a round-robin / default rule; a record without an owner is
+ *     never persisted or returned.
+ *   - No fake success criteria. The caller either supplies explicit
+ *     criteria or the contract uses the canonical default that names
+ *     comparable before/after deltas, not absolute targets.
+ *   - Baseline metrics degrade honestly when partial. The baseline
+ *     section carries per-metric null-safe values and an explicit
+ *     "source" attribution per metric.
+ *   - Next step must be explicit. Every status has a canonical next
+ *     step string from `resolveNextStepForStatus`. A record with a
+ *     blank next step is rejected at construction time.
+ *
+ * This module is a WRITER contract — it produces structured records
+ * from request input. Reading / rendering those records for the
+ * operator surface lives in a separate module (kept tight per the
+ * mission's "do not build a full CRM" rule).
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+
+export type PilotStatus =
+  | 'requested'
+  | 'qualified'
+  | 'scoping'
+  | 'baseline_captured'
+  | 'ready_to_launch'
+  | 'active'
+  | 'completed'
+  | 'archived';
+
+/** Which operator role owns a pilot record at each status. Names
+ *  roles, not individuals — routing to a specific person happens in
+ *  the ops layer, not in the contract. */
+export type PilotOwnerRole =
+  | 'pilot_ops'
+  | 'customer_success'
+  | 'solutions_engineer'
+  | 'founder';
+
+export interface PilotBaselineMetric {
+  /** Canonical metric key — mirrors proof-pack median names when the
+   *  metric corresponds to a proof-pack measurement. */
+  key:
+    | 'current_time_to_start_days'
+    | 'current_time_to_first_review_days'
+    | 'applications_per_month'
+    | 'reviews_per_month'
+    | 'custom';
+  /** Human-readable label rendered on the operator surface. */
+  label: string;
+  /**
+   * Baseline value supplied by the buyer at request time. Null when
+   * the buyer does not know their current baseline — never imputed.
+   */
+  value: number | null;
+  /**
+   * Attribution of the baseline value. "buyer_reported" when the
+   * buyer filled it in; "unknown" when not supplied. Distinguishes
+   * absent-by-choice from absent-by-omission.
+   */
+  source: 'buyer_reported' | 'unknown';
+  /** Optional free-text note from the buyer (e.g. "45-90 days range, no variance data"). */
+  note?: string;
+}
+
+export interface PilotSuccessCriterion {
+  /** Short summary rendered as the criterion's headline. */
+  summary: string;
+  /**
+   * Kind of criterion. `comparable_delta` is the doctrine-preferred
+   * shape (buyer signs off on before/after); `absolute_target` and
+   * `qualitative_signal` are allowed but test-flagged if they drift
+   * into fabricated specificity ("reduce time-to-start by 40%" with
+   * no baseline).
+   */
+  kind: 'comparable_delta' | 'absolute_target' | 'qualitative_signal';
+  /**
+   * Whether this criterion depends on a baseline metric being
+   * captured first. If true, the pilot cannot transition out of
+   * `scoping` until `baselineMetrics` includes a non-null value for
+   * the dependency.
+   */
+  requiresBaseline: boolean;
+}
+
+export interface PilotRequestRecord {
+  pilotId: string;
+  orgId: string | null;
+  orgName: string;
+  contactName: string;
+  contactEmail: string;
+  /** What workflow the buyer wants the pilot to target — credentialing
+   *  review, locum placement, privileging, etc. */
+  roleOrWorkflowTarget: string;
+  /** Where the request originated (/pilot page, /employers, share link, etc.). */
+  sourceContext: string;
+  requestedAt: string;
+  /** Best-effort attribution of who submitted the request. Falls back
+   *  to the contact email when the request is not authenticated. */
+  requestedBy: string;
+  baselineMetrics: PilotBaselineMetric[];
+  successCriteria: PilotSuccessCriterion[];
+  owner: PilotOwnerRole;
+  status: PilotStatus;
+  nextStep: string;
+  /** Append-only audit log. Every status transition writes one entry. */
+  auditLog: Array<{
+    at: string;
+    actor: 'buyer' | 'operator' | 'vitalcv';
+    action: 'requested' | 'status_change' | 'owner_change' | 'baseline_updated';
+    from?: PilotStatus;
+    to?: PilotStatus;
+    note?: string;
+  }>;
+  /**
+   * Deterministic hash of the submission inputs. Used by operator
+   * surfaces to detect duplicate requests from the same org + email
+   * inside a short window.
+   */
+  submissionHash: string;
+}
+
+const ALLOWED_STATUS_TRANSITIONS: Record<PilotStatus, PilotStatus[]> = {
+  requested: ['qualified', 'archived'],
+  qualified: ['scoping', 'archived'],
+  scoping: ['baseline_captured', 'archived'],
+  baseline_captured: ['ready_to_launch', 'archived'],
+  ready_to_launch: ['active', 'archived'],
+  active: ['completed', 'archived'],
+  completed: ['archived'],
+  archived: [],
+};
+
+export function isPilotStatusTransitionAllowed(
+  from: PilotStatus,
+  to: PilotStatus,
+): boolean {
+  return ALLOWED_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/**
+ * Canonical next-step copy per status. Every status has an explicit
+ * next step — no record ever surfaces a blank nextStep.
+ */
+export function resolveNextStepForStatus(status: PilotStatus): string {
+  switch (status) {
+    case 'requested':
+      return 'VitalCV operator reviews the request and qualifies scope. Buyer hears back within two business days.';
+    case 'qualified':
+      return 'Operator schedules a scoping call with the buyer to confirm NPIs, lanes, measurement window, and success criteria.';
+    case 'scoping':
+      return 'Operator captures current-state baseline metrics from the buyer before any measurement starts.';
+    case 'baseline_captured':
+      return 'Operator confirms the pilot scope document and kickoff date with the buyer.';
+    case 'ready_to_launch':
+      return 'Kickoff scheduled. Buyer provides final NPI list and operator access; pilot becomes active on the confirmed date.';
+    case 'active':
+      return 'Pilot is running. Operator monitors the proof-pack against baseline + success criteria and holds regular check-ins.';
+    case 'completed':
+      return 'Final proof-pack delivered to buyer. Operator captures before/after summary and retention decision.';
+    case 'archived':
+      return 'No further action. Record preserved for audit.';
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Canonical owner-role assignment per status. A requested pilot
+ * lands with pilot_ops; a qualified pilot moves to solutions_engineer
+ * for scoping; an active pilot is customer_success; completed goes
+ * back to pilot_ops for the post-mortem. Deterministic — no round-
+ * robin randomness in the contract.
+ */
+export function resolveOwnerForStatus(status: PilotStatus): PilotOwnerRole {
+  switch (status) {
+    case 'requested':
+    case 'qualified':
+      return 'pilot_ops';
+    case 'scoping':
+    case 'baseline_captured':
+      return 'solutions_engineer';
+    case 'ready_to_launch':
+    case 'active':
+      return 'customer_success';
+    case 'completed':
+    case 'archived':
+      return 'pilot_ops';
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Default success-criteria set for a fresh pilot request. Uses
+ * `comparable_delta` shape so the criteria are honest pre-baseline —
+ * no absolute targets that imply data we don't yet have.
+ */
+export const DEFAULT_PILOT_SUCCESS_CRITERIA: readonly PilotSuccessCriterion[] = [
+  {
+    summary:
+      'Measurable drop in time from application submission to first employer review action, measured against the buyer-supplied baseline.',
+    kind: 'comparable_delta',
+    requiresBaseline: true,
+  },
+  {
+    summary:
+      'Documented proof-pack export covering every application submitted during the measurement window.',
+    kind: 'qualitative_signal',
+    requiresBaseline: false,
+  },
+  {
+    summary:
+      'Honest limitation list naming every lane that remained partial during the pilot window. Buyer signs off that the limitations match their operational reality.',
+    kind: 'qualitative_signal',
+    requiresBaseline: false,
+  },
+];
+
+/**
+ * Default baseline-metric skeleton. Every key is rendered with
+ * `value: null` and `source: 'unknown'` — the operator asks the
+ * buyer to fill these in during the scoping call. The skeleton
+ * itself never claims to know the baseline.
+ */
+export function buildDefaultBaselineSkeleton(): PilotBaselineMetric[] {
+  return [
+    {
+      key: 'current_time_to_start_days',
+      label: 'Current median days from hire to start',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'current_time_to_first_review_days',
+      label: 'Current median days from application to first review',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'applications_per_month',
+      label: 'Typical applications per month',
+      value: null,
+      source: 'unknown',
+    },
+    {
+      key: 'reviews_per_month',
+      label: 'Typical reviews per month',
+      value: null,
+      source: 'unknown',
+    },
+  ];
+}
+
+export interface PilotIntakeInput {
+  orgName: string;
+  contactName: string;
+  contactEmail: string;
+  orgId?: string | null;
+  roleOrWorkflowTarget?: string;
+  sourceContext?: string;
+  requestedAt?: string;
+  baselineMetrics?: PilotBaselineMetric[];
+  successCriteria?: PilotSuccessCriterion[];
+  /** Override the default pilot_ops owner — e.g. when a known AE is
+   *  pre-assigned. Uncommon; most records route through the default. */
+  owner?: PilotOwnerRole;
+}
+
+export interface PilotIntakeInputError {
+  field: 'orgName' | 'contactName' | 'contactEmail';
+  reason: string;
+}
+
+export function validatePilotIntakeInput(
+  input: PilotIntakeInput,
+): PilotIntakeInputError[] {
+  const errors: PilotIntakeInputError[] = [];
+  if (!input.orgName || input.orgName.trim().length === 0) {
+    errors.push({ field: 'orgName', reason: 'Organization name is required.' });
+  }
+  if (!input.contactName || input.contactName.trim().length === 0) {
+    errors.push({ field: 'contactName', reason: 'Contact name is required.' });
+  }
+  const email = (input.contactEmail ?? '').trim();
+  if (email.length === 0) {
+    errors.push({ field: 'contactEmail', reason: 'Contact email is required.' });
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.push({
+      field: 'contactEmail',
+      reason: 'Contact email must be a valid address.',
+    });
+  }
+  return errors;
+}
+
+/**
+ * Deterministic submission hash over the identifying inputs.
+ * Two requests with the same org + email + workflow + source +
+ * requestedAt-second produce the same hash — enables de-dupe of
+ * rapid-repeat submissions without needing a cross-request store.
+ */
+export function computePilotSubmissionHash(input: {
+  orgName: string;
+  contactEmail: string;
+  roleOrWorkflowTarget: string;
+  sourceContext: string;
+  requestedAt: string;
+}): string {
+  const payload = JSON.stringify({
+    orgName: input.orgName.trim().toLowerCase(),
+    contactEmail: input.contactEmail.trim().toLowerCase(),
+    roleOrWorkflowTarget: input.roleOrWorkflowTarget.trim().toLowerCase(),
+    sourceContext: input.sourceContext.trim().toLowerCase(),
+    requestedAtSecond: input.requestedAt.slice(0, 19),
+  });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+export function createPilotRequestRecord(
+  input: PilotIntakeInput,
+): PilotRequestRecord {
+  const errors = validatePilotIntakeInput(input);
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid pilot intake input: ${errors.map((e) => `${e.field}: ${e.reason}`).join('; ')}`,
+    );
+  }
+
+  const requestedAt = input.requestedAt ?? new Date().toISOString();
+  const roleOrWorkflowTarget =
+    input.roleOrWorkflowTarget?.trim().length
+      ? input.roleOrWorkflowTarget.trim()
+      : 'Credentialing review';
+  const sourceContext = input.sourceContext ?? '/pilot';
+  const owner = input.owner ?? resolveOwnerForStatus('requested');
+  const status: PilotStatus = 'requested';
+  const nextStep = resolveNextStepForStatus(status);
+
+  const submissionHash = computePilotSubmissionHash({
+    orgName: input.orgName,
+    contactEmail: input.contactEmail,
+    roleOrWorkflowTarget,
+    sourceContext,
+    requestedAt,
+  });
+
+  const record: PilotRequestRecord = {
+    pilotId: `pilot_${randomUUID()}`,
+    orgId: input.orgId ?? null,
+    orgName: input.orgName.trim(),
+    contactName: input.contactName.trim(),
+    contactEmail: input.contactEmail.trim(),
+    roleOrWorkflowTarget,
+    sourceContext,
+    requestedAt,
+    requestedBy: input.contactEmail.trim(),
+    baselineMetrics:
+      input.baselineMetrics && input.baselineMetrics.length > 0
+        ? input.baselineMetrics
+        : buildDefaultBaselineSkeleton(),
+    successCriteria:
+      input.successCriteria && input.successCriteria.length > 0
+        ? input.successCriteria
+        : [...DEFAULT_PILOT_SUCCESS_CRITERIA],
+    owner,
+    status,
+    nextStep,
+    submissionHash,
+    auditLog: [
+      {
+        at: requestedAt,
+        actor: 'buyer',
+        action: 'requested',
+        to: status,
+      },
+    ],
+  };
+
+  // Final invariant check — a record without an owner or a blank
+  // next step cannot leave this function.
+  if (!record.owner) {
+    throw new Error('Ownerless pilot record — refusing to return.');
+  }
+  if (!record.nextStep || record.nextStep.trim().length === 0) {
+    throw new Error('Pilot record has no next step — refusing to return.');
+  }
+  return record;
+}
+
+/**
+ * Transition a pilot record to a new status. Enforces the allowed-
+ * transitions map, reassigns the canonical owner for the new status,
+ * refreshes the next-step copy, and appends an audit entry.
+ */
+export function transitionPilotStatus(
+  record: PilotRequestRecord,
+  to: PilotStatus,
+  input: {
+    actor: 'operator' | 'vitalcv';
+    at?: string;
+    note?: string;
+  },
+): PilotRequestRecord {
+  if (!isPilotStatusTransitionAllowed(record.status, to)) {
+    throw new Error(
+      `Disallowed pilot status transition: ${record.status} -> ${to} for ${record.pilotId}`,
+    );
+  }
+  const at = input.at ?? new Date().toISOString();
+  const owner = resolveOwnerForStatus(to);
+  const nextStep = resolveNextStepForStatus(to);
+  return {
+    ...record,
+    status: to,
+    owner,
+    nextStep,
+    auditLog: [
+      ...record.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: 'status_change',
+        from: record.status,
+        to,
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Update a pilot's baseline metrics once the scoping call captures
+ * real numbers. Only allowed during `scoping` — a pilot cannot have
+ * its baseline altered after `baseline_captured` without archiving
+ * and starting a new record.
+ */
+export function updatePilotBaseline(
+  record: PilotRequestRecord,
+  metrics: PilotBaselineMetric[],
+  input: { actor: 'operator' | 'vitalcv'; at?: string; note?: string },
+): PilotRequestRecord {
+  if (record.status !== 'scoping') {
+    throw new Error(
+      `Baseline can only be updated while status is "scoping" (current: ${record.status}).`,
+    );
+  }
+  const at = input.at ?? new Date().toISOString();
+  return {
+    ...record,
+    baselineMetrics: metrics,
+    auditLog: [
+      ...record.auditLog,
+      {
+        at,
+        actor: input.actor,
+        action: 'baseline_updated',
+        note: input.note,
+      },
+    ],
+  };
+}
+
+/**
+ * Honest partial check — true when any baseline metric is still
+ * null / unknown. Consumers use this to gate transitions out of
+ * `scoping` and to surface partial-baseline warnings.
+ */
+export function isPilotBaselinePartial(record: PilotRequestRecord): boolean {
+  return record.baselineMetrics.some(
+    (m) => m.value === null || m.source === 'unknown',
+  );
+}


### PR DESCRIPTION
## Summary
- replace the public pilot intake stub with a real attributable handoff flow
- add explicit owner, next-step, and baseline-metric honesty contracts for pilot intake
- add regression coverage for route behavior and pilot confirmation rendering

## Validation
- `pnpm --dir apps/web exec vitest run __tests__/pilot-intake.test.ts __tests__/pilot-request-route.test.ts`