### PR TITLE
feat(labs): acceptance-graph — predictive acceptance & routing

### DIFF
--- a/apps/web/app/labs/acceptance-graph/AcceptanceGraphLabClient.tsx
+++ b/apps/web/app/labs/acceptance-graph/AcceptanceGraphLabClient.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+/**
+ * Acceptance Graph & Predictive Routing — Labs demo surface.
+ *
+ * Composes the four NEW capabilities directly without mutating the
+ * existing sandbox ClinicianPassport / EmployerReviewDashboard surfaces.
+ *
+ *   1. Predictive Acceptance Widget    (clinician)
+ *   2. Facility Policy Overlay         (employer)
+ *   3. Network Consensus Indicator     (employer)
+ *   4. Time-to-Start Leaderboard       (clinician, triggered from Feature 1)
+ *
+ * Fixtures live in components/sandbox/lib/acceptance-graph.ts and are
+ * imported directly — no API dependency.
+ */
+
+import { useState } from "react";
+import { Building2, CheckCircle2, AlertCircle, Clock, Activity, Download, ArrowRight } from "lucide-react";
+import { motion } from "framer-motion";
+
+import PredictiveAcceptancePanel from "@/components/sandbox/PredictiveAcceptancePanel";
+import VelocityLeaderboardModal from "@/components/sandbox/VelocityLeaderboardModal";
+import NetworkConsensusIndicator from "@/components/sandbox/NetworkConsensusIndicator";
+import FacilityPolicyDrawer from "@/components/sandbox/FacilityPolicyDrawer";
+import {
+  DEMO_NETWORK_CONSENSUS,
+  type NetworkConsensus,
+} from "@/components/sandbox/lib/acceptance-graph";
+import { cn } from "@/components/sandbox/lib/utils";
+
+type ViewMode = "clinician" | "employer";
+
+interface DemoPacket {
+  clinicianName: string;
+  npi: string;
+  specialty: string;
+  status: "READY" | "PARTIAL" | "BLOCKED";
+  submissionDate: string;
+  timeToStart: string;
+  synthesis: {
+    verifiedCredentials: string;
+    identifiedGaps: string;
+    timeline: string;
+  };
+  networkConsensus: NetworkConsensus;
+  defaultFacilityId: string;
+}
+
+const DEMO_PACKETS: DemoPacket[] = [
+  {
+    clinicianName: "Dr. John Smith, MD",
+    npi: "1234567890",
+    specialty: "Internal Medicine",
+    status: "PARTIAL",
+    submissionDate: new Date().toISOString(),
+    timeToStart: "14 Days",
+    synthesis: {
+      verifiedCredentials: "NPPES Identity checked. CA State License (MD12345678) checked. OIG/LEIE checked.",
+      identifiedGaps: "PECOS Enrollment status is PENDING. DEA and Board Certification are UNAVAILABLE.",
+      timeline: "Safe to interview conditionally. Not safe to start.",
+    },
+    networkConsensus: DEMO_NETWORK_CONSENSUS["1234567890"],
+    defaultFacilityId: "FAC-CEDAR-SF",
+  },
+  {
+    clinicianName: "Dr. Sarah Chen, DO",
+    npi: "1003000126",
+    specialty: "Emergency Medicine",
+    status: "READY",
+    submissionDate: new Date(Date.now() - 86400000 * 2).toISOString(),
+    timeToStart: "0 Days",
+    synthesis: {
+      verifiedCredentials: "All primary sources verified and active.",
+      identifiedGaps: "None.",
+      timeline: "Cleared to start immediately.",
+    },
+    networkConsensus: DEMO_NETWORK_CONSENSUS["1003000126"],
+    defaultFacilityId: "FAC-KAISER-IRV",
+  },
+  {
+    clinicianName: "Dr. Emily Davis, MD",
+    npi: "9876543210",
+    specialty: "Cardiology",
+    status: "BLOCKED",
+    submissionDate: new Date(Date.now() - 86400000 * 10).toISOString(),
+    timeToStart: "TBD",
+    synthesis: {
+      verifiedCredentials: "NPPES Identity confirmed.",
+      identifiedGaps: "State license expired. Requires manual intervention.",
+      timeline: "Blocked until license renewal is verified.",
+    },
+    networkConsensus: DEMO_NETWORK_CONSENSUS["9876543210"],
+    defaultFacilityId: "FAC-SUTTER-SAC",
+  },
+];
+
+export default function AcceptanceGraphLabClient() {
+  const [viewMode, setViewMode] = useState<ViewMode>("clinician");
+  const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
+  const [policyPacket, setPolicyPacket] = useState<DemoPacket | null>(null);
+  const [expandedNpi, setExpandedNpi] = useState<string | null>(null);
+
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      {/* Lab header */}
+      <header className="border-b border-line">
+        <div className="max-w-5xl mx-auto px-6 py-6 flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 opacity-40">
+              <span className="text-[10px] font-bold uppercase tracking-widest font-mono">
+                Labs · Acceptance Graph
+              </span>
+            </div>
+            <h1 className="text-3xl font-bold tracking-tighter uppercase">
+              Predictive Acceptance &amp; Routing
+            </h1>
+            <p className="text-xs opacity-60 font-mono max-w-2xl">
+              Live demo of the four acceptance-graph capabilities — predictive probability,
+              local policy alignment, network consensus, and velocity routing.
+            </p>
+          </div>
+          <div className="inline-flex border border-line">
+            {(["clinician", "employer"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setViewMode(mode)}
+                aria-pressed={viewMode === mode}
+                className={cn(
+                  "px-5 py-3 text-[10px] font-bold uppercase tracking-widest transition-colors",
+                  viewMode === mode
+                    ? "bg-ink text-bg"
+                    : "bg-transparent text-ink/70 hover:bg-ink/5",
+                )}
+              >
+                {mode === "clinician" ? "Clinician View" : "Employer View"}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-6 py-12">
+        {viewMode === "clinician" ? (
+          <div className="space-y-12">
+            {/* Feature 1 — Predictive Acceptance */}
+            <PredictiveAcceptancePanel
+              onOptimizeVelocity={() => setIsLeaderboardOpen(true)}
+            />
+          </div>
+        ) : (
+          <div className="space-y-12">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 opacity-40">
+                <span className="text-[10px] font-bold uppercase tracking-widest font-mono">
+                  Clinician Packets · Employer Review
+                </span>
+              </div>
+              <h2 className="text-2xl font-bold tracking-tighter uppercase">Incoming Packets</h2>
+              <p className="text-xs opacity-60 font-mono max-w-2xl">
+                Each packet carries its global verification state plus network consensus.
+                Open the policy drawer on a row to see local bylaws alignment for that facility.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {DEMO_PACKETS.map((packet) => (
+                <PacketCard
+                  key={packet.npi}
+                  packet={packet}
+                  expanded={expandedNpi === packet.npi}
+                  onToggleExpand={() =>
+                    setExpandedNpi((prev) => (prev === packet.npi ? null : packet.npi))
+                  }
+                  onOpenPolicy={() => setPolicyPacket(packet)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </main>
+
+      {/* Feature 4 — Velocity Leaderboard drawer */}
+      <VelocityLeaderboardModal
+        open={isLeaderboardOpen}
+        onClose={() => setIsLeaderboardOpen(false)}
+      />
+
+      {/* Feature 2 — Facility Policy drawer */}
+      <FacilityPolicyDrawer
+        open={Boolean(policyPacket)}
+        onClose={() => setPolicyPacket(null)}
+        clinicianName={policyPacket?.clinicianName}
+        npi={policyPacket?.npi}
+        defaultFacilityId={policyPacket?.defaultFacilityId}
+      />
+
+      <footer className="border-t border-line mt-12">
+        <div className="max-w-5xl mx-auto px-6 py-6 flex items-center justify-between text-[9px] font-mono uppercase tracking-widest opacity-30">
+          <span>Labs · acceptance-graph · 4 capabilities · live fixture data</span>
+          <span>local !== federal · separation enforced</span>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function PacketCard({
+  packet,
+  expanded,
+  onToggleExpand,
+  onOpenPolicy,
+}: {
+  packet: DemoPacket;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onOpenPolicy: () => void;
+}) {
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="border border-line p-6 hover:bg-ink/5 transition-colors cursor-pointer"
+      onClick={onToggleExpand}
+    >
+      <div className="flex flex-col md:flex-row justify-between gap-6">
+        <div className="space-y-2 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h3 className="text-xl font-bold tracking-tight">{packet.clinicianName}</h3>
+            <StatusChip status={packet.status} />
+            {/* Feature 3 — inline chip */}
+            <NetworkConsensusIndicator consensus={packet.networkConsensus} variant="chip" />
+          </div>
+          <div className="flex items-center gap-4 text-[10px] font-mono opacity-60 flex-wrap">
+            <span>NPI: {packet.npi}</span>
+            <span>·</span>
+            <span>{packet.specialty}</span>
+            <span>·</span>
+            <span>Submitted: {new Date(packet.submissionDate).toLocaleDateString()}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-6 shrink-0">
+          <div className="text-right hidden sm:block">
+            <div className="text-[9px] font-bold uppercase tracking-widest opacity-40 mb-1">
+              Est. Start
+            </div>
+            <div className="text-lg font-bold font-mono">{packet.timeToStart}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenPolicy();
+              }}
+              className="p-3 border border-indigo-500/30 dark:border-indigo-400/30 hover:bg-slate-500/10 transition-colors text-ink"
+              aria-label="Open local policy alignment"
+              title="Local Policy Alignment"
+            >
+              <Building2 className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                // Placeholder export
+                const blob = new Blob([JSON.stringify(packet, null, 2)], {
+                  type: "application/json",
+                });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = `clinician-packet-${packet.npi}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+              }}
+              className="p-3 border border-line hover:bg-ink/5 transition-colors text-ink"
+              aria-label="Export packet data"
+              title="Export packet data"
+            >
+              <Download className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              className="p-3 bg-ink text-bg hover:opacity-90 transition-opacity"
+              aria-label={expanded ? "Collapse details" : "Expand details"}
+            >
+              <motion.div animate={{ rotate: expanded ? 90 : 0 }} transition={{ duration: 0.2 }}>
+                <ArrowRight className="w-4 h-4" />
+              </motion.div>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {expanded && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          exit={{ opacity: 0, height: 0 }}
+          onClick={(e) => e.stopPropagation()}
+          className="mt-8 pt-8 border-t border-line space-y-8"
+        >
+          {/* Feature 3 — expanded callout */}
+          <NetworkConsensusIndicator consensus={packet.networkConsensus} variant="callout" />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <SynthesisCell
+              Icon={Activity}
+              title="Verified Credentials"
+              body={packet.synthesis.verifiedCredentials}
+            />
+            <SynthesisCell
+              Icon={AlertCircle}
+              title="Identified Gaps"
+              body={packet.synthesis.identifiedGaps}
+            />
+            <SynthesisCell Icon={Clock} title="Timeline" body={packet.synthesis.timeline} />
+          </div>
+        </motion.div>
+      )}
+    </motion.article>
+  );
+}
+
+function StatusChip({ status }: { status: DemoPacket["status"] }) {
+  const meta =
+    status === "READY"
+      ? { Icon: CheckCircle2, classes: "border-green-500 text-green-600 dark:text-green-400 bg-green-500/10" }
+      : status === "PARTIAL"
+        ? { Icon: Clock, classes: "border-amber-500 text-amber-600 dark:text-amber-400 bg-amber-500/10" }
+        : { Icon: AlertCircle, classes: "border-red-500 text-red-600 dark:text-red-400 bg-red-500/10" };
+  const { Icon, classes } = meta;
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest px-2 py-0.5 rounded-full border",
+        classes,
+      )}
+    >
+      <Icon className="w-3 h-3" />
+      {status}
+    </span>
+  );
+}
+
+function SynthesisCell({
+  Icon,
+  title,
+  body,
+}: {
+  Icon: typeof Activity;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-[10px] font-bold uppercase tracking-widest opacity-40 flex items-center gap-2">
+        <Icon className="w-3 h-3" /> {title}
+      </h4>
+      <p className="font-mono text-xs leading-relaxed opacity-80">{body}</p>
+    </div>
+  );
+}

--- a/apps/web/app/labs/acceptance-graph/page.tsx
+++ b/apps/web/app/labs/acceptance-graph/page.tsx
@@ -1,0 +1,11 @@
+import AcceptanceGraphLabClient from './AcceptanceGraphLabClient';
+
+export const metadata = {
+  title: 'Acceptance Graph & Predictive Routing — VitalCV Labs',
+  description:
+    'Predictive acceptance, local policy alignment, network consensus, and time-to-start routing.',
+};
+
+export default function AcceptanceGraphLabPage() {
+  return <AcceptanceGraphLabClient />;
+}

--- a/apps/web/components/sandbox/FacilityPolicyDrawer.tsx
+++ b/apps/web/components/sandbox/FacilityPolicyDrawer.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  X,
+  Building2,
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  Lock,
+  ChevronDown,
+} from "lucide-react";
+import { cn } from "@/components/sandbox/lib/utils";
+import {
+  DEMO_FACILITY_POLICIES,
+  requirementsByScope,
+  type FacilityPolicy,
+  type FacilityPolicyRequirement,
+  type PolicyScope,
+} from "@/components/sandbox/lib/acceptance-graph";
+
+export interface FacilityPolicyDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  clinicianName?: string;
+  npi?: string;
+  policies?: FacilityPolicy[];
+  defaultFacilityId?: string;
+}
+
+const SCOPE_META: Record<PolicyScope, { label: string; hint: string }> = {
+  FEDERAL: { label: "Federal", hint: "Federal registries (OIG, NPDB, SAM.gov)" },
+  STATE: { label: "State", hint: "State medical board & CSR" },
+  LOCAL: { label: "Local · Facility Bylaws", hint: "Medical Staff / P&P requirements — facility-specific" },
+};
+
+/**
+ * Facility Policy Alignment (Feature 2) — maps the clinician's global
+ * passport against a facility's Medical Staff bylaws. Fed/State rows keep
+ * their semantic verification color (green/amber/red). Local rows render
+ * with a Lock icon and muted outline so the credentialing manager can
+ * immediately separate "national blocker" from "this-hospital's paperwork".
+ */
+export default function FacilityPolicyDrawer({
+  open,
+  onClose,
+  clinicianName,
+  npi,
+  policies = DEMO_FACILITY_POLICIES,
+  defaultFacilityId,
+}: FacilityPolicyDrawerProps) {
+  const [facilityId, setFacilityId] = useState<string>(defaultFacilityId ?? policies[0]?.facilityId ?? "");
+
+  useEffect(() => {
+    if (defaultFacilityId) setFacilityId(defaultFacilityId);
+  }, [defaultFacilityId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  const policy = useMemo(
+    () => policies.find((p) => p.facilityId === facilityId) ?? policies[0],
+    [policies, facilityId],
+  );
+
+  if (!policy) return null;
+
+  const grouped = requirementsByScope(policy);
+  const missingLocal = grouped.LOCAL.filter((r) => r.status === "MISSING").length;
+  const metLocal = grouped.LOCAL.filter((r) => r.status === "MET").length;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            aria-hidden
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-40 bg-ink/40 backdrop-blur-sm"
+          />
+          <motion.aside
+            role="dialog"
+            aria-modal
+            aria-label="Facility policy alignment"
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ duration: 0.32, ease: [0.25, 1, 0.3, 1] }}
+            className="fixed right-0 top-0 z-50 h-full w-full max-w-[640px] flex flex-col bg-bg border-l border-line shadow-[0_0_60px_rgba(0,0,0,0.45)]"
+          >
+            <header className="border-b border-line px-6 py-5 flex items-start justify-between gap-4">
+              <div className="space-y-1 min-w-0">
+                <div className="flex items-center gap-2 opacity-40">
+                  <Building2 className="w-3 h-3" />
+                  <span className="text-[10px] font-bold uppercase tracking-widest font-mono">
+                    Local Policy Alignment
+                  </span>
+                </div>
+                <h3 className="text-2xl font-bold tracking-tighter uppercase truncate">
+                  {policy.facilityName}
+                </h3>
+                {clinicianName && (
+                  <p className="text-[10px] font-mono opacity-50 truncate">
+                    Packet · {clinicianName}
+                    {npi && <> · NPI {npi}</>}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close policy alignment"
+                className="shrink-0 p-2 border border-line hover:bg-ink/5 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </header>
+
+            {/* Facility selector */}
+            <div className="border-b border-line px-6 py-4 flex items-center gap-3">
+              <label
+                htmlFor="facility-policy-select"
+                className="text-[9px] font-bold uppercase tracking-widest opacity-40 shrink-0"
+              >
+                Map against
+              </label>
+              <div className="relative flex-1">
+                <select
+                  id="facility-policy-select"
+                  value={facilityId}
+                  onChange={(e) => setFacilityId(e.target.value)}
+                  className="w-full appearance-none bg-transparent border-b border-line py-2 pr-8 text-xs font-mono focus:outline-none focus:border-ink transition-colors"
+                >
+                  {policies.map((p) => (
+                    <option key={p.facilityId} value={p.facilityId}>
+                      {p.facilityName}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  className="w-3 h-3 absolute right-0 top-1/2 -translate-y-1/2 opacity-40 pointer-events-none"
+                  aria-hidden="true"
+                />
+              </div>
+            </div>
+
+            {/* Bylaws summary + counters */}
+            <div className="border-b border-line px-6 py-4 space-y-3">
+              <p className="text-[11px] font-mono leading-relaxed opacity-70">{policy.bylawSummary}</p>
+              <div className="grid grid-cols-3 gap-2 text-[9px] font-mono uppercase tracking-widest">
+                <Counter label="Local MET" value={metLocal} tone="neutral" />
+                <Counter label="Local MISSING" value={missingLocal} tone="alert" />
+                <Counter
+                  label="Fed+State"
+                  value={grouped.FEDERAL.length + grouped.STATE.length}
+                  tone="neutral"
+                />
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              {(Object.keys(SCOPE_META) as PolicyScope[]).map((scope) => {
+                const list = grouped[scope];
+                if (list.length === 0) return null;
+                return (
+                  <section key={scope} className="border-b border-line/60">
+                    <div className="px-6 py-3 bg-ink/5 flex items-baseline justify-between">
+                      <div>
+                        <h4 className="text-[10px] font-bold uppercase tracking-widest font-mono">
+                          {SCOPE_META[scope].label}
+                        </h4>
+                        <p className="text-[9px] font-mono opacity-40 mt-0.5">{SCOPE_META[scope].hint}</p>
+                      </div>
+                      <span className="text-[9px] font-mono opacity-40 tabular-nums">
+                        {list.length} item{list.length === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                    <ul className="divide-y divide-line/40">
+                      {list.map((req) => (
+                        <RequirementRow key={req.id} req={req} />
+                      ))}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+
+            <footer className="border-t border-line px-6 py-4 text-[9px] font-mono opacity-30 uppercase tracking-widest flex items-center justify-between">
+              <span>live mapping · bylaws v{policy.requirements.length}</span>
+              <span>local !== federal · separation enforced</span>
+            </footer>
+          </motion.aside>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function Counter({ label, value, tone }: { label: string; value: number; tone: "neutral" | "alert" }) {
+  return (
+    <div
+      className={cn(
+        "border px-2 py-1.5",
+        tone === "alert" && value > 0
+          ? "border-indigo-500/40 dark:border-indigo-400/30 bg-slate-500/10 dark:bg-slate-400/5"
+          : "border-line",
+      )}
+    >
+      <div className="opacity-40">{label}</div>
+      <div className="text-lg font-bold font-mono tabular-nums tracking-tight">
+        {String(value).padStart(2, "0")}
+      </div>
+    </div>
+  );
+}
+
+function RequirementRow({ req }: { req: FacilityPolicyRequirement }) {
+  if (req.scope === "LOCAL") return <LocalRequirementRow req={req} />;
+  return <FedStateRequirementRow req={req} />;
+}
+
+/**
+ * Fed/State rows keep the existing verification vocabulary (green/amber/red)
+ * because the credentialing manager already reads those colors as "this is
+ * a national-level verification state".
+ */
+function FedStateRequirementRow({ req }: { req: FacilityPolicyRequirement }) {
+  const statusMeta =
+    req.status === "MET"
+      ? { Icon: CheckCircle2, color: "text-green-600 dark:text-green-400" }
+      : req.status === "PENDING"
+        ? { Icon: Clock, color: "text-amber-600 dark:text-amber-400" }
+        : { Icon: AlertCircle, color: "text-red-600 dark:text-red-400" };
+  const { Icon, color } = statusMeta;
+  return (
+    <li className="flex items-start gap-3 px-6 py-3">
+      <Icon className={cn("w-4 h-4 shrink-0 mt-0.5", color)} aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-bold tracking-tight truncate">{req.label}</span>
+          <span className={cn("text-[9px] font-mono uppercase tracking-widest shrink-0", color)}>
+            {req.status}
+          </span>
+        </div>
+        {req.sourceClause && (
+          <div className="text-[10px] font-mono opacity-40 mt-0.5">{req.sourceClause}</div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * LOCAL requirements render with a Lock icon + muted outline. Crucially
+ * they never use red — the visual language has to say "this is paperwork
+ * for this hospital, not a national red flag".
+ */
+function LocalRequirementRow({ req }: { req: FacilityPolicyRequirement }) {
+  const isMissing = req.status === "MISSING";
+  const isPending = req.status === "PENDING";
+
+  return (
+    <li className={cn("flex items-start gap-3 px-6 py-3 transition-colors", isMissing && "bg-ink/5")}>
+      <div
+        className={cn(
+          "shrink-0 mt-0.5 w-5 h-5 border flex items-center justify-center",
+          isMissing
+            ? "border-indigo-500/40 dark:border-indigo-400/30 text-indigo-600 dark:text-indigo-400"
+            : isPending
+              ? "border-line text-ink/50"
+              : "border-green-600/40 text-green-600 dark:text-green-400",
+        )}
+        aria-hidden="true"
+      >
+        {isMissing ? <Lock className="w-3 h-3" /> : isPending ? <Clock className="w-3 h-3" /> : <CheckCircle2 className="w-3 h-3" />}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <span className={cn("text-sm font-bold tracking-tight truncate", isMissing && "text-slate-700 dark:text-slate-300")}>
+            {req.label}
+          </span>
+          <span
+            className={cn(
+              "text-[9px] font-mono uppercase tracking-widest shrink-0 border px-1.5 py-0.5",
+              isMissing
+                ? "border-indigo-500/40 dark:border-indigo-400/30 text-indigo-600 dark:text-indigo-400"
+                : isPending
+                  ? "border-line opacity-60"
+                  : "border-green-600/40 text-green-600 dark:text-green-400",
+            )}
+          >
+            {isMissing ? "Local Requirement" : req.status}
+          </span>
+        </div>
+        {req.sourceClause && <div className="text-[10px] font-mono opacity-40 mt-0.5">{req.sourceClause}</div>}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/components/sandbox/NetworkConsensusIndicator.tsx
+++ b/apps/web/components/sandbox/NetworkConsensusIndicator.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import { Network } from "lucide-react";
+import { cn } from "@/components/sandbox/lib/utils";
+import type { NetworkConsensus } from "@/components/sandbox/lib/acceptance-graph";
+
+export interface NetworkConsensusIndicatorProps {
+  consensus?: NetworkConsensus;
+  /** Compact = inline chip for row headers. Expanded = the slate/indigo callout. */
+  variant?: "chip" | "callout";
+  className?: string;
+}
+
+/**
+ * Network Consensus (Feature 3) — "This identical packet was accepted by N
+ * other JC-accredited facilities in the last 90d". Intentionally muted: the
+ * job is to lend psychological safety, not to celebrate. Slate background,
+ * subtle indigo border. Not green — green is reserved for federal/state
+ * verification throughout the rest of the dashboard.
+ */
+export default function NetworkConsensusIndicator({
+  consensus,
+  variant = "chip",
+  className,
+}: NetworkConsensusIndicatorProps) {
+  if (!consensus || consensus.acceptedCount <= 0) return null;
+
+  if (variant === "chip") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full",
+          "text-[9px] font-bold uppercase tracking-widest font-mono",
+          "bg-slate-500/10 dark:bg-slate-400/10",
+          "border border-indigo-500/40 dark:border-indigo-400/30",
+          "text-slate-700 dark:text-slate-300",
+          className,
+        )}
+        title={`Accepted by ${consensus.acceptedCount} ${consensus.accreditationType} facilities in the ${consensus.timeframe}`}
+      >
+        <Network className="w-3 h-3 text-indigo-500 dark:text-indigo-400" aria-hidden="true" />
+        <span>Network · {consensus.acceptedCount}</span>
+      </span>
+    );
+  }
+
+  return (
+    <div
+      role="note"
+      aria-label="Network intelligence summary"
+      className={cn(
+        "relative border px-4 py-3 flex items-start gap-3",
+        "bg-slate-500/10 dark:bg-slate-400/5",
+        "border-indigo-500/40 dark:border-indigo-400/30",
+        className,
+      )}
+    >
+      <div className="shrink-0 p-1.5 border border-indigo-500/30 dark:border-indigo-400/30 bg-bg">
+        <Network className="w-3.5 h-3.5 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] font-bold uppercase tracking-widest font-mono text-indigo-600 dark:text-indigo-400">
+            Network Intelligence
+          </span>
+          <span className="text-[9px] font-mono opacity-40">
+            packet: {consensus.packetFingerprint}
+          </span>
+        </div>
+        <p className="mt-1 text-xs font-mono leading-relaxed text-slate-700 dark:text-slate-300">
+          This identical cryptographic packet was accepted by{" "}
+          <strong className="tabular-nums">{consensus.acceptedCount}</strong> other{" "}
+          {consensus.accreditationType} facilit{consensus.acceptedCount === 1 ? "y" : "ies"} in the {consensus.timeframe}.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/sandbox/PredictiveAcceptancePanel.tsx
+++ b/apps/web/components/sandbox/PredictiveAcceptancePanel.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+import { Target, Zap } from "lucide-react";
+import { cn } from "@/components/sandbox/lib/utils";
+import {
+  DEMO_ACCEPTANCE_PREDICTIONS,
+  DEMO_FACILITIES,
+  type AcceptancePrediction,
+  type TargetFacility,
+  facilityById,
+} from "@/components/sandbox/lib/acceptance-graph";
+
+export interface PredictiveAcceptancePanelProps {
+  predictions?: AcceptancePrediction[];
+  facilities?: TargetFacility[];
+  onOptimizeVelocity?: () => void;
+}
+
+/**
+ * Acceptance Predictor — a terminal-style, monochrome readout of the
+ * probability that the clinician's current evidence clears each facility's
+ * bylaws. Deliberately not a gauge / meter / consumer element — all signal
+ * is carried by raw key:value pairs in JetBrains Mono.
+ *
+ * Semantic verification colors (green/amber/red) are reserved for
+ * federal/state verification status elsewhere in the passport. This panel
+ * stays monochrome so "Acceptance Probability" never gets confused with
+ * "Source Verification".
+ */
+export default function PredictiveAcceptancePanel({
+  predictions = DEMO_ACCEPTANCE_PREDICTIONS,
+  facilities = DEMO_FACILITIES,
+  onOptimizeVelocity,
+}: PredictiveAcceptancePanelProps) {
+  const rows = predictions
+    .map((p) => ({ prediction: p, facility: facilityById(p.facilityId) ?? facilities[0] }))
+    .filter((r) => Boolean(r.facility))
+    .sort((a, b) => b.prediction.acceptanceProbability - a.prediction.acceptanceProbability);
+
+  return (
+    <section aria-labelledby="acceptance-predictor-heading">
+      <div className="flex items-start justify-between gap-6 mb-8">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 opacity-40">
+            <Target className="w-3 h-3" />
+            <span className="text-[10px] font-bold uppercase tracking-widest font-mono">
+              Network Predictor · Live
+            </span>
+          </div>
+          <h3 id="acceptance-predictor-heading" className="text-2xl font-bold tracking-tighter uppercase">
+            Acceptance Predictor
+          </h3>
+          <p className="text-xs opacity-60 font-mono max-w-xl">
+            Probability the current evidence packet clears each facility&apos;s live medical-staff bylaws.
+            No gauges, no theater — raw terminal output.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOptimizeVelocity}
+          className="shrink-0 bg-ink text-bg px-5 py-3 font-bold uppercase tracking-widest text-[10px] flex items-center gap-2 hover:opacity-90 transition-all"
+          aria-label="Open Optimize for Velocity leaderboard"
+        >
+          <Zap className="w-3 h-3" />
+          Optimize for Velocity
+        </button>
+      </div>
+
+      <div className="border border-line divide-y divide-line/60">
+        {rows.map(({ prediction, facility }, index) => (
+          <PredictionRow key={prediction.facilityId} prediction={prediction} facility={facility} index={index} />
+        ))}
+      </div>
+
+      <p className="text-[10px] font-mono opacity-30 mt-4 uppercase tracking-widest">
+        Source: facility bylaws / policies · packet hash referenced against live registry
+      </p>
+    </section>
+  );
+}
+
+function PredictionRow({
+  prediction,
+  facility,
+  index,
+}: {
+  prediction: AcceptancePrediction;
+  facility: TargetFacility;
+  index: number;
+}) {
+  const probability = Math.max(0, Math.min(100, Math.round(prediction.acceptanceProbability)));
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.04 * index }}
+      className="grid grid-cols-12 gap-6 p-5 bg-white/5 dark:bg-white/5 hover:bg-ink/5 transition-colors"
+    >
+      <div className="col-span-12 md:col-span-4 space-y-1">
+        <div className="flex items-baseline gap-3">
+          <span className="text-[9px] font-mono opacity-30 tabular-nums">
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <span className="text-sm font-bold tracking-tight">{facility.facilityName}</span>
+        </div>
+        <div className="flex items-center gap-3 text-[10px] font-mono opacity-40 pl-7">
+          <span>{facility.region}</span>
+          <span>·</span>
+          <span className="uppercase tracking-widest">{facility.accreditation.join(" / ")}</span>
+        </div>
+      </div>
+
+      <div className="col-span-12 md:col-span-4 flex flex-col justify-center">
+        <TerminalLine label="Acceptance_Probability" value={`${probability}%`} />
+        <TerminalLine label="Est_Time_to_Clear" value={prediction.estTimeToClear} />
+        <div
+          className="mt-2 h-[2px] w-full bg-ink/10"
+          role="progressbar"
+          aria-valuenow={probability}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Acceptance probability for ${facility.facilityName}`}
+        >
+          <div className="h-full bg-ink" style={{ width: `${probability}%` }} />
+        </div>
+      </div>
+
+      <div className="col-span-12 md:col-span-4 min-w-0">
+        <span className="text-[9px] font-bold uppercase tracking-widest opacity-40">Policy Gap</span>
+        <p className={cn("mt-1 font-mono text-xs leading-relaxed break-words", prediction.policyGap ? "opacity-80" : "opacity-30")}>
+          {prediction.policyGap ?? "// No gaps identified"}
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+function TerminalLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="font-mono text-sm flex items-baseline gap-1.5">
+      <span className="opacity-40">{label}:</span>
+      <span className="font-bold tracking-tight">{value}</span>
+    </div>
+  );
+}

--- a/apps/web/components/sandbox/VelocityLeaderboardModal.tsx
+++ b/apps/web/components/sandbox/VelocityLeaderboardModal.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Zap, Rocket, CheckCircle2 } from "lucide-react";
+import { cn } from "@/components/sandbox/lib/utils";
+import {
+  DEMO_OPEN_REQUISITIONS,
+  sortRequisitionsByVelocity,
+  type OpenRequisition,
+} from "@/components/sandbox/lib/acceptance-graph";
+
+export interface VelocityLeaderboardModalProps {
+  open: boolean;
+  onClose: () => void;
+  requisitions?: OpenRequisition[];
+  onApply?: (req: OpenRequisition) => void;
+}
+
+/**
+ * Optimize for Velocity — a right-side drawer that ranks open requisitions
+ * strictly by time-to-start given the clinician's current evidence. The
+ * table is intentionally terminal-styled (snake_case column keys, font-mono
+ * values) so the drawer reads as an operations console, not a job board.
+ */
+export default function VelocityLeaderboardModal({
+  open,
+  onClose,
+  requisitions = DEMO_OPEN_REQUISITIONS,
+  onApply,
+}: VelocityLeaderboardModalProps) {
+  const ranked = useMemo(() => sortRequisitionsByVelocity(requisitions), [requisitions]);
+  const [applied, setApplied] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  const handleApply = (req: OpenRequisition) => {
+    setApplied((prev) => {
+      const next = new Set(prev);
+      next.add(req.facilityId);
+      return next;
+    });
+    onApply?.(req);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            aria-hidden
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+            className="fixed inset-0 z-40 bg-ink/40 backdrop-blur-sm"
+          />
+          <motion.aside
+            role="dialog"
+            aria-modal
+            aria-label="Velocity leaderboard"
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ duration: 0.32, ease: [0.25, 1, 0.3, 1] }}
+            className="fixed right-0 top-0 z-50 h-full w-full max-w-[820px] flex flex-col bg-bg border-l border-line shadow-[0_0_60px_rgba(0,0,0,0.45)]"
+          >
+            <header className="border-b border-line px-8 py-6 flex items-start justify-between gap-6">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 opacity-40">
+                  <Rocket className="w-3 h-3" />
+                  <span className="text-[10px] font-bold uppercase tracking-widest font-mono">
+                    Optimize for Velocity
+                  </span>
+                </div>
+                <h3 className="text-3xl font-bold tracking-tighter uppercase">Time-to-Start Leaderboard</h3>
+                <p className="text-xs opacity-60 font-mono max-w-lg">
+                  Open requisitions ranked strictly by estimated days to start given your current
+                  verified evidence. One-click apply sends a signed snapshot of the packet.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close leaderboard"
+                className="p-2 border border-line hover:bg-ink/5 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </header>
+
+            <div className="flex-1 overflow-y-auto">
+              <div className="px-8 py-6">
+                <table className="w-full border border-line" aria-label="Open requisitions ranked by time to start">
+                  <thead>
+                    <tr className="border-b border-line bg-ink/5">
+                      <TerminalHeader>Rank</TerminalHeader>
+                      <TerminalHeader>Facility_ID</TerminalHeader>
+                      <TerminalHeader>Role</TerminalHeader>
+                      <TerminalHeader>Required_Delta</TerminalHeader>
+                      <TerminalHeader className="text-right">Est_Start_Velocity</TerminalHeader>
+                      <TerminalHeader className="text-right">Action</TerminalHeader>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ranked.map((req, i) => {
+                      const isApplied = applied.has(req.facilityId);
+                      return (
+                        <tr
+                          key={req.facilityId}
+                          className="border-b border-line/40 last:border-b-0 hover:bg-ink/5 transition-colors"
+                        >
+                          <td className="px-4 py-4 font-mono text-xs opacity-40 tabular-nums">
+                            {String(i + 1).padStart(2, "0")}
+                          </td>
+                          <td className="px-4 py-4 font-mono text-xs">
+                            <div className="font-bold">{req.facilityId}</div>
+                            <div className="opacity-50 text-[10px] mt-0.5">{req.facilityName}</div>
+                          </td>
+                          <td className="px-4 py-4 font-mono text-xs">{req.role}</td>
+                          <td className="px-4 py-4 font-mono text-xs opacity-80">
+                            {req.requiredDelta === "None" ? (
+                              <span className="opacity-40">{'// none'}</span>
+                            ) : (
+                              req.requiredDelta
+                            )}
+                          </td>
+                          <td className="px-4 py-4 font-mono text-lg font-bold tracking-tight tabular-nums text-right">
+                            {req.estStartVelocity}
+                          </td>
+                          <td className="px-4 py-4 text-right">
+                            <button
+                              type="button"
+                              onClick={() => handleApply(req)}
+                              disabled={isApplied}
+                              className={cn(
+                                "inline-flex items-center gap-2 px-3 py-2 text-[10px] font-bold uppercase tracking-widest transition-all",
+                                isApplied
+                                  ? "border border-green-600/40 text-green-600 dark:text-green-400 bg-green-600/5 cursor-default"
+                                  : "bg-ink text-bg hover:opacity-90",
+                              )}
+                              aria-label={
+                                isApplied
+                                  ? `Application sent to ${req.facilityName}`
+                                  : `Apply with 1-Click Snapshot to ${req.facilityName}`
+                              }
+                            >
+                              {isApplied ? (
+                                <>
+                                  <CheckCircle2 className="w-3 h-3" />
+                                  Snapshot Sent
+                                </>
+                              ) : (
+                                <>
+                                  <Zap className="w-3 h-3" />
+                                  Apply with 1-Click Snapshot
+                                </>
+                              )}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+
+                <div className="mt-4 flex items-center justify-between text-[9px] font-mono uppercase tracking-widest opacity-30">
+                  <span>
+                    {ranked.length} requisition{ranked.length === 1 ? "" : "s"} · sorted by est_start_days asc
+                  </span>
+                  <span>snapshot: sd-jwt · detached-proofs</span>
+                </div>
+              </div>
+            </div>
+          </motion.aside>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function TerminalHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <th
+      scope="col"
+      className={cn("px-4 py-3 text-left text-[9px] font-bold uppercase tracking-widest font-mono opacity-60", className)}
+    >
+      {children}
+    </th>
+  );
+}

--- a/apps/web/components/sandbox/lib/acceptance-graph.ts
+++ b/apps/web/components/sandbox/lib/acceptance-graph.ts
@@ -1,0 +1,163 @@
+/**
+ * acceptance-graph.ts
+ *
+ * Single source of truth for the Acceptance Graph & Predictive Routing
+ * wave. Holds the narrow domain types and the demo fixtures that power:
+ *
+ *   1. Predictive Acceptance Widget   (clinician passport)
+ *   2. Facility Policy Overlay         (employer review)
+ *   3. Network Consensus Indicator     (employer review)
+ *   4. Time-to-Start Leaderboard       (clinician passport)
+ *
+ * Types are kept flat and serializable so fixtures can later be swapped
+ * for a real API without touching the presentation layer.
+ */
+
+// ── Facilities ────────────────────────────────────────────────────────
+
+export interface TargetFacility {
+  facilityId: string;
+  facilityName: string;
+  region: string;
+  accreditation: ReadonlyArray<"JointCommission" | "DNV" | "CIHQ">;
+}
+
+// ── Predictive Acceptance (Feature 1) ─────────────────────────────────
+
+export interface AcceptancePrediction {
+  facilityId: string;
+  acceptanceProbability: number; // integer 0–100
+  estTimeToClear: string; // e.g. "3-5 days"
+  policyGap: string | null; // null when nothing is missing
+}
+
+// ── Facility Policy (Feature 2) ───────────────────────────────────────
+
+export type PolicyScope = "FEDERAL" | "STATE" | "LOCAL";
+export type PolicyStatus = "MET" | "MISSING" | "PENDING";
+
+export interface FacilityPolicyRequirement {
+  id: string;
+  label: string;
+  scope: PolicyScope;
+  status: PolicyStatus;
+  sourceClause?: string; // citation in the bylaws
+}
+
+export interface FacilityPolicy {
+  facilityId: string;
+  facilityName: string;
+  bylawSummary: string;
+  requirements: FacilityPolicyRequirement[];
+}
+
+// ── Network Consensus (Feature 3) ─────────────────────────────────────
+
+export interface NetworkConsensus {
+  accreditationType: string; // "Joint Commission-accredited"
+  acceptedCount: number;
+  timeframe: string; // "last 90 days"
+  packetFingerprint: string; // first 8 chars of sha256 of the packet
+  sampleFacilities: string[]; // anonymized / redacted names
+}
+
+// ── Leaderboard (Feature 4) ───────────────────────────────────────────
+
+export interface OpenRequisition {
+  facilityId: string;
+  facilityName: string;
+  role: string;
+  requiredDelta: string; // what is missing, joined by " · "
+  estStartVelocity: string; // display, e.g. "3d"
+  estStartDays: number; // integer, for sort
+}
+
+// ── Fixture data ──────────────────────────────────────────────────────
+
+export const DEMO_FACILITIES: TargetFacility[] = [
+  { facilityId: "FAC-CEDAR-SF", facilityName: "Cedar Health", region: "SF Bay Area", accreditation: ["JointCommission"] },
+  { facilityId: "FAC-KAISER-IRV", facilityName: "Kaiser Permanente — Irvine", region: "Orange County", accreditation: ["JointCommission"] },
+  { facilityId: "FAC-SUTTER-SAC", facilityName: "Sutter Health — Sacramento", region: "Sacramento Valley", accreditation: ["DNV"] },
+  { facilityId: "FAC-DIGNITY-PHX", facilityName: "Dignity Health — Phoenix", region: "Phoenix Metro", accreditation: ["JointCommission"] },
+  { facilityId: "FAC-STANFORD", facilityName: "Stanford Hospital", region: "Palo Alto", accreditation: ["JointCommission"] },
+];
+
+export const DEMO_ACCEPTANCE_PREDICTIONS: AcceptancePrediction[] = [
+  { facilityId: "FAC-CEDAR-SF", acceptanceProbability: 94, estTimeToClear: "3-5 days", policyGap: "Missing: Current PPD Skin Test required by Cedar Health bylaws." },
+  { facilityId: "FAC-KAISER-IRV", acceptanceProbability: 88, estTimeToClear: "5-7 days", policyGap: "Missing: Facility-specific HIPAA training (Kaiser P&P 14.3)." },
+  { facilityId: "FAC-SUTTER-SAC", acceptanceProbability: 72, estTimeToClear: "9-12 days", policyGap: "Missing: Local background check + BLS re-cert (<2y)." },
+  { facilityId: "FAC-DIGNITY-PHX", acceptanceProbability: 61, estTimeToClear: "12-18 days", policyGap: "Missing: AZ state license, facility HIPAA, fit test." },
+];
+
+export const DEMO_FACILITY_POLICIES: FacilityPolicy[] = [
+  {
+    facilityId: "FAC-CEDAR-SF",
+    facilityName: "Cedar Health",
+    bylawSummary: "Medical Staff Bylaws § 4.2 — PPD skin test, facility HIPAA, and two-peer attestations within 180d of appointment.",
+    requirements: [
+      { id: "cedar-ppd", label: "Current PPD Skin Test (<1y)", scope: "LOCAL", status: "MISSING", sourceClause: "§4.2(a)" },
+      { id: "cedar-hipaa", label: "Facility-specific HIPAA training", scope: "LOCAL", status: "MET", sourceClause: "§4.2(b)" },
+      { id: "cedar-peer", label: "Two peer attestations", scope: "LOCAL", status: "MET", sourceClause: "§4.2(c)" },
+      { id: "cedar-npdb", label: "NPDB continuous query", scope: "FEDERAL", status: "MET" },
+      { id: "cedar-ca-license", label: "CA Medical Board license", scope: "STATE", status: "MET" },
+    ],
+  },
+  {
+    facilityId: "FAC-KAISER-IRV",
+    facilityName: "Kaiser Permanente — Irvine",
+    bylawSummary: "Kaiser P&P 14.3 — facility HIPAA + code-of-conduct attestation refreshed annually; EMR-specific onboarding module required pre-start.",
+    requirements: [
+      { id: "kaiser-hipaa", label: "Facility-specific HIPAA training", scope: "LOCAL", status: "MISSING", sourceClause: "P&P 14.3" },
+      { id: "kaiser-emr", label: "EMR onboarding module (Epic)", scope: "LOCAL", status: "PENDING", sourceClause: "P&P 14.4" },
+      { id: "kaiser-conduct", label: "Code-of-conduct attestation", scope: "LOCAL", status: "MET" },
+      { id: "kaiser-npdb", label: "NPDB continuous query", scope: "FEDERAL", status: "MET" },
+      { id: "kaiser-ca-license", label: "CA Medical Board license", scope: "STATE", status: "MET" },
+    ],
+  },
+  {
+    facilityId: "FAC-SUTTER-SAC",
+    facilityName: "Sutter Health — Sacramento",
+    bylawSummary: "Medical Staff Bylaws § 6 — local background check (vendor-specific), BLS re-cert within 24 months, fit-test for N95.",
+    requirements: [
+      { id: "sutter-bg", label: "Local background check", scope: "LOCAL", status: "MISSING", sourceClause: "§6.1" },
+      { id: "sutter-bls", label: "BLS re-cert (<24m)", scope: "LOCAL", status: "MISSING", sourceClause: "§6.2" },
+      { id: "sutter-fit", label: "N95 fit-test", scope: "LOCAL", status: "MET", sourceClause: "§6.3" },
+      { id: "sutter-oig", label: "OIG/LEIE exclusion check", scope: "FEDERAL", status: "MET" },
+      { id: "sutter-ca-license", label: "CA Medical Board license", scope: "STATE", status: "MET" },
+    ],
+  },
+];
+
+export const DEMO_NETWORK_CONSENSUS: Record<string, NetworkConsensus> = {
+  "1234567890": { accreditationType: "Joint Commission-accredited", acceptedCount: 3, timeframe: "last 90 days", packetFingerprint: "0x8f2c3e14", sampleFacilities: ["JC-Facility-A", "JC-Facility-B", "JC-Facility-C"] },
+  "1003000126": { accreditationType: "Joint Commission-accredited", acceptedCount: 7, timeframe: "last 60 days", packetFingerprint: "0x3d91e7aa", sampleFacilities: ["JC-Facility-D", "JC-Facility-E"] },
+  "9876543210": { accreditationType: "DNV-accredited", acceptedCount: 1, timeframe: "last 120 days", packetFingerprint: "0x61b27f05", sampleFacilities: ["DNV-Facility-F"] },
+};
+
+export const DEMO_OPEN_REQUISITIONS: OpenRequisition[] = [
+  { facilityId: "FAC-CEDAR-SF", facilityName: "Cedar Health", role: "Attending Hospitalist", requiredDelta: "PPD", estStartVelocity: "3d", estStartDays: 3 },
+  { facilityId: "FAC-KAISER-IRV", facilityName: "Kaiser Permanente — Irvine", role: "Hospitalist — Nights", requiredDelta: "Facility HIPAA", estStartVelocity: "5d", estStartDays: 5 },
+  { facilityId: "FAC-STANFORD", facilityName: "Stanford Hospital", role: "Locums Hospitalist", requiredDelta: "None", estStartVelocity: "2d", estStartDays: 2 },
+  { facilityId: "FAC-SUTTER-SAC", facilityName: "Sutter Health — Sacramento", role: "Internist — Outpatient", requiredDelta: "Local BG · BLS", estStartVelocity: "11d", estStartDays: 11 },
+  { facilityId: "FAC-DIGNITY-PHX", facilityName: "Dignity Health — Phoenix", role: "Hospitalist Lead", requiredDelta: "AZ license · HIPAA · Fit-test", estStartVelocity: "18d", estStartDays: 18 },
+];
+
+// ── Selectors / small pure helpers ─────────────────────────────────────
+
+export function facilityById(id: string): TargetFacility | undefined {
+  return DEMO_FACILITIES.find((f) => f.facilityId === id);
+}
+
+export function sortRequisitionsByVelocity(reqs: readonly OpenRequisition[]): OpenRequisition[] {
+  return [...reqs].sort((a, b) => a.estStartDays - b.estStartDays);
+}
+
+export function requirementsByScope(policy: FacilityPolicy): Record<PolicyScope, FacilityPolicyRequirement[]> {
+  const grouped: Record<PolicyScope, FacilityPolicyRequirement[]> = { FEDERAL: [], STATE: [], LOCAL: [] };
+  for (const r of policy.requirements) grouped[r.scope].push(r);
+  return grouped;
+}
+
+export function policyGapCount(policy: FacilityPolicy): number {
+  return policy.requirements.filter((r) => r.scope === "LOCAL" && r.status === "MISSING").length;
+}


### PR DESCRIPTION
## Summary

Adds the **Acceptance Graph & Predictive Routing** mega wave under [/labs/acceptance-graph](https://github.com/ctol3r/vitalcv/tree/pr/acceptance-graph/apps/web/app/labs/acceptance-graph) — four composable capabilities that move the passport from "verification" into "predictive acceptance", visible at `/labs/acceptance-graph`.

| # | Capability | Component |
|---|---|---|
| 1 | Predictive Acceptance Widget — per-facility probability, time-to-clear, policy gap | `PredictiveAcceptancePanel` |
| 2 | Facility Policy Overlay — Local · State · Federal scope separation with `Lock` treatment on missing local | `FacilityPolicyDrawer` |
| 3 | Network Consensus Indicator — "accepted by N JC-accredited facilities" chip + slate/indigo callout | `NetworkConsensusIndicator` |
| 4 | Time-to-Start Leaderboard — open requisitions sorted by velocity + 1-click snapshot apply | `VelocityLeaderboardModal` |

Fixtures and pure selectors live in `components/sandbox/lib/acceptance-graph.ts`. The demo surface at `app/labs/acceptance-graph` composes all four against demo packets with a Clinician ↔ Employer view toggle — no API dependency.

## Design invariants honored

- **Typography & semantic trust colors untouched** — Inter + JetBrains Mono preserved globally; green/amber/red reserved for federal/state verification status.
- **Local policy requirements never borrow red** — they render with `Lock` icon + indigo/slate outline + "Local Requirement" chip. Visual language signals "this hospital's paperwork", not "national blocker".
- **Acceptance probability stays monochrome `ink`** — a thin one-pixel progress line scales with value, but the colorway never overlaps with verification. No gauges, meters, or consumer-style elements.
- **Terminal grammar is load-bearing** — `Acceptance_Probability:`, `Facility_ID`, `Est_Start_Velocity`. snake_case keys in `font-mono` keep the aesthetic operational rather than gamified.

## Changes

7 files, +1,274 LOC, all net-new — no existing sandbox files modified:

```
apps/web/app/labs/acceptance-graph/
  ├── page.tsx
  └── AcceptanceGraphLabClient.tsx   ← composes all four features + view toggle
apps/web/components/sandbox/
  ├── lib/acceptance-graph.ts        ← types, fixtures, pure helpers
  ├── PredictiveAcceptancePanel.tsx  ← Feature 1
  ├── VelocityLeaderboardModal.tsx   ← Feature 4
  ├── NetworkConsensusIndicator.tsx  ← Feature 3
  └── FacilityPolicyDrawer.tsx       ← Feature 2
```

## Test plan

- [ ] Visit `/labs/acceptance-graph` in both Clinician and Employer modes
- [ ] Clinician view: confirm 4 facility rows render with monochrome probability lines and exact policy-gap copy (e.g. "Missing: Current PPD Skin Test required by Cedar Health bylaws.")
- [ ] Click **Optimize for Velocity** — drawer opens with columns `Rank · Facility_ID · Role · Required_Delta · Est_Start_Velocity · Action`, rows sorted asc by days (Stanford 2d → Dignity 18d)
- [ ] Click **Apply with 1-Click Snapshot** — button transitions to `Snapshot Sent` with green outline
- [ ] Employer view: confirm `Network · N` chips render inline next to each packet's status badge
- [ ] Expand a packet — confirm slate/indigo `Network Intelligence` callout with the exact spec copy
- [ ] Click the **Local Policy Alignment** icon on a packet — drawer opens with three scope sections. Verify Local missing items render with `Lock` icon + indigo outline, never red. Switch facilities via the dropdown and confirm counters remap
- [ ] Toggle dark mode — all four features preserve the Liquid Glass / Antigravity aesthetic
- [ ] `pnpm typecheck` (no compile regressions from the 7 new files)

## Notes for reviewers

- All fixtures are JSON-serializable so swapping to a real API later is presentation-layer-invisible.
- The `bg-bg` / `text-ink` / `border-line` token family is the sandbox's brutalist vocabulary — this PR intentionally does not reach for the `vt-*` tokens used by the infra-tier passport route; those are a different aesthetic surface.
- No changes to Clerk, API routes, Prisma schema, or global config.