### PR TITLE
fix(smoke-test): WorkspaceMembership relations + Prisma field names

### DIFF
--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -308,7 +308,8 @@ model PersonProfile {
   completeness      Int                @default(0)
   createdAt         DateTime           @default(now()) @map("created_at")
   updatedAt         DateTime           @updatedAt @map("updated_at")
-  providerLocations ProviderLocation[]
+  providerLocations    ProviderLocation[]
+  workspaceMemberships WorkspaceMembership[]
 
   @@index([npi])
   @@index([userId])
@@ -344,7 +345,8 @@ model OrganizationProfile {
   verified              Boolean              @default(false)
   createdAt             DateTime             @default(now()) @map("created_at")
   updatedAt             DateTime             @updatedAt @map("updated_at")
-  institution           Institution?
+  institution          Institution?
+  workspaceMemberships WorkspaceMembership[]
 
   @@index([npi])
   @@index([organizationId])
@@ -477,15 +479,17 @@ model ProviderBoundaryAssignment {
 
 /// Links a person to an organization with a role
 model WorkspaceMembership {
-  id                    String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  personProfileId       String         @map("person_profile_id") @db.Uuid
-  organizationProfileId String         @map("organization_profile_id") @db.Uuid
-  role                  MembershipRole @default(VERIFIER)
-  active                Boolean        @default(true)
-  invitedAt             DateTime?      @map("invited_at")
-  acceptedAt            DateTime?      @map("accepted_at")
-  createdAt             DateTime       @default(now()) @map("created_at")
-  updatedAt             DateTime       @default(now()) @updatedAt @map("updated_at")
+  id                    String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  personProfileId       String              @map("person_profile_id") @db.Uuid
+  organizationProfileId String              @map("organization_profile_id") @db.Uuid
+  role                  MembershipRole      @default(VERIFIER)
+  active                Boolean             @default(true)
+  invitedAt             DateTime?           @map("invited_at")
+  acceptedAt            DateTime?           @map("accepted_at")
+  createdAt             DateTime            @default(now()) @map("created_at")
+  updatedAt             DateTime            @default(now()) @updatedAt @map("updated_at")
+  personProfile         PersonProfile       @relation(fields: [personProfileId], references: [id])
+  organizationProfile   OrganizationProfile @relation(fields: [organizationProfileId], references: [id])
 
   @@unique([personProfileId, organizationProfileId], map: "workspace_memberships_person_org_key")
   @@index([organizationProfileId], map: "workspace_memberships_org_idx")

--- a/apps/api/backend/src/services/intelligence/providerIntelligenceService.ts
+++ b/apps/api/backend/src/services/intelligence/providerIntelligenceService.ts
@@ -108,8 +108,8 @@ type GraphEdgeRow = {
 type ResidencyProgramRow = {
   name: string;
   specialty: string;
-  acgme_code: string;
-  hospital_affiliation: string;
+  acgmeCode: string | null;
+  hospitalAffiliation: string | null;
 };
 
 type OrganizationRow = {
@@ -529,8 +529,8 @@ async function loadResidencyPrograms(
       select: {
         name: true,
         specialty: true,
-        acgme_code: true,
-        hospital_affiliation: true,
+        acgmeCode: true,
+        hospitalAffiliation: true,
       },
       take: 1_000,
     });
@@ -1121,15 +1121,15 @@ function buildIdentityLayer(input: {
   };
 
   const ensureTraining = (program: ResidencyProgramRow) => {
-    const entityId = trainingEntityId(program.acgme_code);
+    const entityId = trainingEntityId(program.acgmeCode);
     if (!entities.has(entityId)) {
       entities.set(entityId, createIdentityEntity({
         entityId,
         entityType: 'training',
         label: program.name,
         metadata: {
-          acgmeCode: program.acgme_code,
-          hospitalAffiliation: program.hospital_affiliation,
+          acgmeCode: program.acgmeCode,
+          hospitalAffiliation: program.hospitalAffiliation,
           specialty: program.specialty,
         },
       }));
@@ -1159,7 +1159,7 @@ function buildIdentityLayer(input: {
   }
 
   for (const residency of input.residencies) {
-    const institutionId = ensureInstitution(residency.hospital_affiliation);
+    const institutionId = ensureInstitution(residency.hospitalAffiliation);
     const trainingId = ensureTraining(residency);
     const specialtyId = ensureSpecialty(residency.specialty);
     relations.set(`${trainingId}->${institutionId}`, createIdentityRelation({
@@ -1167,14 +1167,14 @@ function buildIdentityLayer(input: {
       targetEntityId: institutionId,
       relationType: 'hosted_by',
       directed: true,
-      metadata: { acgmeCode: residency.acgme_code },
+      metadata: { acgmeCode: residency.acgmeCode },
     }));
     relations.set(`${trainingId}->${specialtyId}`, createIdentityRelation({
       sourceEntityId: trainingId,
       targetEntityId: specialtyId,
       relationType: 'trains_for',
       directed: true,
-      metadata: { acgmeCode: residency.acgme_code },
+      metadata: { acgmeCode: residency.acgmeCode },
     }));
   }
 

--- a/apps/api/backend/src/services/predictions/predictionEngineService.ts
+++ b/apps/api/backend/src/services/predictions/predictionEngineService.ts
@@ -187,7 +187,7 @@ async function loadResidencyProgramsByInstitution(
 ): Promise<ResidencyProgramInstitutionBucket[]> {
   try {
     const rows = await prismaClient.residencyProgram.groupBy({
-      by: ['hospital_affiliation'],
+      by: ['hospitalAffiliation'],
       _count: { _all: true },
     });
     return rows as ResidencyProgramInstitutionBucket[];


### PR DESCRIPTION
## Summary

- Add `personProfile`/`organizationProfile` `@relation` fields to `WorkspaceMembership` in Prisma schema so `rebuildEngine` can filter via `personProfile.npi` — previously caused a runtime `PrismaClientValidationError: Unknown argument personProfile`
- Fix `predictionEngineService.ts` `groupBy` to use Prisma camelCase field name `hospitalAffiliation` instead of DB column name `hospital_affiliation` — was causing an **unhandled promise rejection** that crashed the Railway Deploy Preflight QA process (exit code 1)
- Fix `providerIntelligenceService.ts` `ResidencyProgram` select to use `acgmeCode`/`hospitalAffiliation` instead of `acgme_code`/`hospital_affiliation` — was causing runtime 500s on all intelligence aggregate endpoints

These three commits were pushed to `feat/acceptance-graph-learning-clean` after that PR was already merged. This PR brings them into `main`.

## Test plan

- [ ] Railway Deploy Preflight passes (QA suite no longer crashes on predictionEngineService groupBy)
- [ ] `/api/graph/:npi` returns 200 (WorkspaceMembership relations allow Prisma filter)
- [ ] `/api/intelligence/aggregates/*` returns 200 (ResidencyProgram select uses correct field names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)