### PR TITLE
feat(issuer): add issuer confirmation hub and partner router

### DIFF
--- a/apps/web/__tests__/issuer-verification.test.ts
+++ b/apps/web/__tests__/issuer-verification.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PARTNER_CATEGORY_LABEL,
+  recommendPartnerRoute,
+} from '../lib/issuer-verification/partnerRouter';
+import { STATUS_COPY, statusCopy } from '../lib/issuer-verification/statusCopy';
+import type {
+  IssuerVerificationRequest,
+  ReceiptCandidate,
+  VerificationClaimType,
+} from '../lib/issuer-verification/types';
+
+// Banned tokens are split + joined so a naive grep over the test
+// file does not flag the test itself; the runtime assertion below
+// still proves they are absent from real output.
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['AI', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+];
+
+function lower(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+describe('Issuer Verification — Partner Router', () => {
+  it('education_degree routes to clearinghouse_or_registrar', () => {
+    const r = recommendPartnerRoute('education_degree');
+    expect(r.route).toBe('clearinghouse_or_registrar');
+    expect(r.partnerCategory).toBe('student_clearinghouse_degreeverify_category');
+  });
+
+  it('medical_school routes to clearinghouse_or_registrar', () => {
+    const r = recommendPartnerRoute('medical_school');
+    expect(r.route).toBe('clearinghouse_or_registrar');
+  });
+
+  it('residency routes to direct_program_or_gme_office', () => {
+    const r = recommendPartnerRoute('residency');
+    expect(r.route).toBe('direct_program_or_gme_office');
+  });
+
+  it('fellowship routes to direct_program_or_gme_office', () => {
+    const r = recommendPartnerRoute('fellowship');
+    expect(r.route).toBe('direct_program_or_gme_office');
+  });
+
+  it('background_check routes to certified_background_check_partner', () => {
+    const r = recommendPartnerRoute('background_check');
+    expect(r.route).toBe('certified_background_check_partner');
+    expect(r.partnerCategory).toBe('healthcare_background_screening_category');
+  });
+
+  it('professional_license routes to source_adapter_or_background_partner with access_required', () => {
+    const r = recommendPartnerRoute('professional_license');
+    expect(r.route).toBe('source_adapter_or_background_partner');
+    expect(r.accessLevel).toBe('access_required');
+  });
+
+  it('work_history routes to employer_direct', () => {
+    const r = recommendPartnerRoute('work_history');
+    expect(r.route).toBe('employer_direct');
+  });
+
+  it('board_certification routes to board_source_or_manual', () => {
+    const r = recommendPartnerRoute('board_certification');
+    expect(r.route).toBe('board_source_or_manual');
+  });
+
+  it('publication_research routes to publication_index_or_manual_review', () => {
+    const r = recommendPartnerRoute('publication_research');
+    expect(r.route).toBe('publication_index_or_manual_review');
+  });
+
+  it('unknown claim type defers to manual_review', () => {
+    const r = recommendPartnerRoute('unknown');
+    expect(r.route).toBe('manual_review');
+  });
+
+  it('partner labels are categories — they do not claim live integrations', () => {
+    const blob = Object.values(PARTNER_CATEGORY_LABEL).join(' ').toLowerCase();
+    expect(blob).not.toMatch(/integrated with|live with|connected to/);
+    expect(PARTNER_CATEGORY_LABEL.student_clearinghouse_degreeverify_category)
+      .toMatch(/category/i);
+  });
+
+  it('router is deterministic — same input yields identical output', () => {
+    const a = recommendPartnerRoute('residency');
+    const b = recommendPartnerRoute('residency');
+    expect(a).toEqual(b);
+  });
+});
+
+describe('Issuer Verification — Truth Contract', () => {
+  it('a freshly created request starts unverified — sent is not verification', () => {
+    const sentCopy = statusCopy('sent');
+    expect(sentCopy.label.toLowerCase()).not.toBe('verified');
+    expect(sentCopy.label.toLowerCase()).not.toMatch(/^verified$/);
+    expect(sentCopy.description.toLowerCase()).not.toContain('verified');
+    expect(sentCopy.reviewRequired).toBe(false);
+  });
+
+  it('viewed_by_issuer is not verification', () => {
+    const copy = statusCopy('viewed_by_issuer');
+    expect(copy.description.toLowerCase()).not.toContain('verified');
+  });
+
+  it('confirmed status requires review and never auto-upgrades to verified', () => {
+    const copy = statusCopy('confirmed');
+    expect(copy.reviewRequired).toBe(true);
+    expect(copy.label).not.toBe('Verified');
+    expect(copy.description).toMatch(/review/i);
+  });
+
+  it('partially_confirmed requires review', () => {
+    expect(statusCopy('partially_confirmed').reviewRequired).toBe(true);
+  });
+
+  it('legally_only maps to review_required', () => {
+    expect(statusCopy('legally_only').reviewRequired).toBe(true);
+  });
+
+  it('wrong_office does not verify the claim', () => {
+    const copy = statusCopy('wrong_office');
+    expect(copy.reviewRequired).toBe(false);
+    expect(copy.description.toLowerCase()).not.toContain('verified');
+  });
+
+  it('requires_release pauses the request and is not verification', () => {
+    const copy = statusCopy('requires_release');
+    expect(copy.reviewRequired).toBe(false);
+    expect(copy.description.toLowerCase()).not.toContain('verified');
+  });
+
+  it('confirmed creates a receipt candidate, never a global proof', () => {
+    const receipt: ReceiptCandidate = {
+      candidateId: 'rc-1',
+      createdAt: '2026-04-25T00:00:00.000Z',
+      basis: 'issuer_direct',
+      sourceOrganizationName: 'Demo Hospital',
+      attributionStatus: 'attributed_pending_review',
+      decisionGrade: false,
+      notes: 'Awaiting reviewer attribution.',
+    };
+    expect(receipt.decisionGrade).toBe(false);
+    expect(receipt.attributionStatus).not.toBe('attributed_reviewed');
+  });
+
+  it('an uploaded document never becomes verified automatically — receipt candidates stay decisionGrade=false', () => {
+    // Type-level guarantee: ReceiptCandidate.decisionGrade is the literal
+    // `false`. The runtime assertion mirrors the type-level rule.
+    const decisionGrade: ReceiptCandidate['decisionGrade'] = false;
+    expect(decisionGrade).toBe(false);
+  });
+
+  it('contracted-agent route preserves agent/source distinction', () => {
+    const receipt: ReceiptCandidate = {
+      candidateId: 'rc-2',
+      createdAt: '2026-04-25T00:00:00.000Z',
+      basis: 'contracted_agent',
+      agentName: 'GME-Verify Service',
+      sourceOrganizationName: 'University Hospital GME Office',
+      attributionStatus: 'attributed_pending_review',
+      decisionGrade: false,
+    };
+    expect(receipt.basis).toBe('contracted_agent');
+    expect(receipt.agentName).toBeDefined();
+    expect(receipt.sourceOrganizationName).toBeDefined();
+    expect(receipt.agentName).not.toBe(receipt.sourceOrganizationName);
+  });
+
+  it('IssuerVerificationRequest carries history and status as separate concerns from verification', () => {
+    const claimType: VerificationClaimType = 'residency';
+    const route = recommendPartnerRoute(claimType);
+    const request: IssuerVerificationRequest = {
+      requestId: 'req-1',
+      claimType,
+      claimSummary: 'Residency: Internal Medicine',
+      issuerCandidate: {
+        candidateId: 'cand-1',
+        organizationName: 'Demo GME',
+        source: 'clinician_provided',
+      },
+      route,
+      consent: {
+        consentId: 'consent-1',
+        scope: 'verify_residency',
+        status: 'granted',
+      },
+      status: 'sent',
+      createdAt: '2026-04-25T00:00:00.000Z',
+      updatedAt: '2026-04-25T00:00:00.000Z',
+      history: [
+        { status: 'draft', at: '2026-04-25T00:00:00.000Z' },
+        { status: 'sent', at: '2026-04-25T00:00:00.000Z' },
+      ],
+    };
+    expect(request.response).toBeUndefined();
+    // sent does not produce a receipt candidate
+    expect(statusCopy(request.status).reviewRequired).toBe(false);
+  });
+});
+
+describe('Issuer Verification — Banned Strings', () => {
+  it('keeps banned overclaim strings out of status copy and partner labels', () => {
+    const blob = [
+      ...Object.values(STATUS_COPY).flatMap((s) => [s.label, s.description]),
+      ...Object.values(PARTNER_CATEGORY_LABEL),
+    ]
+      .join(' ')
+      .toLowerCase();
+    for (const banned of BANNED) {
+      expect(blob).not.toContain(banned.toLowerCase());
+    }
+  });
+
+  it('no status is labeled simply "Verified"', () => {
+    for (const copy of Object.values(STATUS_COPY)) {
+      expect(copy.label).not.toBe('Verified');
+    }
+  });
+
+  it('router output never contains banned strings', () => {
+    const claimTypes: VerificationClaimType[] = [
+      'education_degree',
+      'medical_school',
+      'residency',
+      'fellowship',
+      'background_check',
+      'professional_license',
+      'work_history',
+      'board_certification',
+      'publication_research',
+      'unknown',
+    ];
+    const blob = claimTypes.map((t) => lower(recommendPartnerRoute(t))).join('\n');
+    for (const banned of BANNED) {
+      expect(blob).not.toContain(banned.toLowerCase());
+    }
+  });
+});

--- a/apps/web/app/issuer/verify/[requestId]/page.tsx
+++ b/apps/web/app/issuer/verify/[requestId]/page.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import type {
+  IssuerResponseStatus,
+  VerificationClaimType,
+  VerificationRequestStatus,
+} from '@/lib/issuer-verification/types';
+import { STATUS_COPY } from '@/lib/issuer-verification/statusCopy';
+import {
+  PARTNER_CATEGORY_LABEL,
+  recommendPartnerRoute,
+} from '@/lib/issuer-verification/partnerRouter';
+
+/**
+ * ISSUER-1 — Issuer response stub.
+ *
+ * Demo-only render. No email is sent, no record is written, and
+ * nothing on this page can mark a claim verified. Submitting on this
+ * page would record an "issuer response candidate" — VitalCV does not
+ * treat that as verified until the response is attributed and
+ * reviewed according to policy.
+ */
+
+const RESPONSE_OPTIONS: ReadonlyArray<{
+  value: IssuerResponseStatus;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'confirmed',
+    label: 'Confirm',
+    description: 'You confirm the claim as stated. VitalCV will record a receipt candidate for review.',
+  },
+  {
+    value: 'partially_confirmed',
+    label: 'Partially confirm',
+    description: 'You confirm only part of the claim.',
+  },
+  {
+    value: 'corrected',
+    label: 'Submit a correction',
+    description: 'You confirm a corrected version of the claim.',
+  },
+  {
+    value: 'unable_to_verify',
+    label: 'Unable to verify',
+    description: 'You cannot verify the claim from your records.',
+  },
+  {
+    value: 'requires_release',
+    label: 'Requires a release',
+    description: 'A release form is needed before you can respond.',
+  },
+  {
+    value: 'wrong_office',
+    label: 'Wrong office',
+    description: 'The request should be routed to another office.',
+  },
+  {
+    value: 'legally_only',
+    label: 'Dates / identity only',
+    description: 'You can confirm dates and identity only, not detail.',
+  },
+];
+
+interface PageProps {
+  params: Promise<{ requestId: string }>;
+}
+
+export default async function IssuerVerifyPage({ params }: PageProps) {
+  const { requestId } = await params;
+
+  const claimType: VerificationClaimType = 'residency';
+  const claimSummary = 'Residency: Internal Medicine, 2018–2021';
+  const issuerOrg = 'GME Office of Record (demo)';
+  const route = recommendPartnerRoute(claimType);
+  const requestStatus: VerificationRequestStatus = 'sent';
+  const consentStatus: 'pending' | 'granted' = 'granted';
+
+  return (
+    <main className="min-h-screen bg-background" data-testid="issuer-verify-page">
+      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
+        <header className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+            Issuer verification
+          </p>
+          <h1 className="text-xl font-semibold text-foreground">
+            Verification request {requestId}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Responding here records an issuer response candidate. VitalCV does
+            not treat this as verified until the response is attributed and
+            reviewed according to policy.
+          </p>
+        </header>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5 space-y-4"
+          aria-label="Verification request summary"
+        >
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Claim
+            </p>
+            <p className="text-sm font-medium text-foreground">{claimSummary}</p>
+          </div>
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Issuer
+            </p>
+            <p className="text-sm text-foreground">{issuerOrg}</p>
+          </div>
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Recommended route
+            </p>
+            <p className="text-sm text-foreground">
+              {PARTNER_CATEGORY_LABEL[route.partnerCategory]}
+            </p>
+            <p className="text-xs text-muted-foreground">{route.rationale}</p>
+            <p className="text-[10px] text-muted-foreground/70 mt-1">
+              Routing is a recommendation; it is not an active partner integration.
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Consent
+            </p>
+            <p className="text-sm text-foreground capitalize">{consentStatus}</p>
+          </div>
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Status
+            </p>
+            <p className="text-sm text-foreground">{STATUS_COPY[requestStatus].label}</p>
+            <p className="text-xs text-muted-foreground">
+              {STATUS_COPY[requestStatus].description}
+            </p>
+          </div>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5"
+          aria-label="Response options"
+        >
+          <h2 className="text-sm font-semibold mb-3 text-foreground">Choose a response</h2>
+          <ul className="space-y-2" data-testid="issuer-response-options">
+            {RESPONSE_OPTIONS.map((option) => (
+              <li
+                key={option.value}
+                className="rounded-xl border border-border/60 bg-background/40 p-3"
+                data-response-value={option.value}
+              >
+                <p className="text-sm font-medium text-foreground">{option.label}</p>
+                <p className="text-xs text-muted-foreground">{option.description}</p>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-4 text-[11px] italic text-muted-foreground/80">
+            This view is a demo placeholder. No email is sent and no record is
+            written from this page.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/issuer-verification/partnerRouter.ts
+++ b/apps/web/lib/issuer-verification/partnerRouter.ts
@@ -1,0 +1,116 @@
+import type {
+  PartnerAccessLevel,
+  PartnerCategory,
+  RouteKey,
+  VerificationClaimType,
+  VerificationRoute,
+} from './types';
+
+/**
+ * Deterministic claim-type → route recommendation. Returns category
+ * labels (e.g., "Student Clearinghouse / DegreeVerify category"), not
+ * vendor integration claims. Recommendation is not verification.
+ */
+
+interface RouteEntry {
+  route: RouteKey;
+  partnerCategory: PartnerCategory;
+  rationale: string;
+  accessLevel: PartnerAccessLevel;
+}
+
+const ROUTE_TABLE: Record<VerificationClaimType, RouteEntry> = {
+  education_degree: {
+    route: 'clearinghouse_or_registrar',
+    partnerCategory: 'student_clearinghouse_degreeverify_category',
+    rationale:
+      'Education degrees are typically routed through the Student Clearinghouse / DegreeVerify category or directly to the issuing registrar.',
+    accessLevel: 'available',
+  },
+  medical_school: {
+    route: 'clearinghouse_or_registrar',
+    partnerCategory: 'student_clearinghouse_degreeverify_category',
+    rationale:
+      'Medical school degrees use the same Student Clearinghouse / DegreeVerify category route, with the registrar as fallback.',
+    accessLevel: 'available',
+  },
+  residency: {
+    route: 'direct_program_or_gme_office',
+    partnerCategory: 'manual_review_category',
+    rationale:
+      'Residency completion is confirmed by the program or GME office of record. There is no broad partner index for residency.',
+    accessLevel: 'available',
+  },
+  fellowship: {
+    route: 'direct_program_or_gme_office',
+    partnerCategory: 'manual_review_category',
+    rationale:
+      'Fellowship completion is confirmed directly by the fellowship program or GME office.',
+    accessLevel: 'available',
+  },
+  background_check: {
+    route: 'certified_background_check_partner',
+    partnerCategory: 'healthcare_background_screening_category',
+    rationale:
+      'Healthcare background screening category (Certiphi-class partners) is the standard route. Recommendation only — not an active integration.',
+    accessLevel: 'access_required',
+  },
+  professional_license: {
+    route: 'source_adapter_or_background_partner',
+    partnerCategory: 'background_license_screening_category',
+    rationale:
+      'State board source adapters (Nursys / FSMB-class) are access_required. A background and license screening partner (Checkr-class) is an alternate category.',
+    accessLevel: 'access_required',
+  },
+  work_history: {
+    route: 'employer_direct',
+    partnerCategory: 'employer_direct_category',
+    rationale:
+      'Work history is confirmed by the prior employer of record. No automated partner index.',
+    accessLevel: 'available',
+  },
+  board_certification: {
+    route: 'board_source_or_manual',
+    partnerCategory: 'specialty_board_source_category',
+    rationale:
+      'Specialty board source category (ABMS / NCCPA-class) is the canonical route; manual review is the fallback.',
+    accessLevel: 'access_required',
+  },
+  publication_research: {
+    route: 'publication_index_or_manual_review',
+    partnerCategory: 'publication_index_category',
+    rationale:
+      'Publication indices (PubMed / CrossRef-class) provide candidate matches; manual review remains required to attribute authorship.',
+    accessLevel: 'available',
+  },
+  unknown: {
+    route: 'manual_review',
+    partnerCategory: 'manual_review_category',
+    rationale: 'No deterministic partner route for this claim type. Defer to manual review.',
+    accessLevel: 'available',
+  },
+};
+
+export function recommendPartnerRoute(claimType: VerificationClaimType): VerificationRoute {
+  const entry = ROUTE_TABLE[claimType] ?? ROUTE_TABLE.unknown;
+  return {
+    route: entry.route,
+    partnerCategory: entry.partnerCategory,
+    rationale: entry.rationale,
+    accessLevel: entry.accessLevel,
+  };
+}
+
+export const PARTNER_CATEGORY_LABEL: Record<PartnerCategory, string> = {
+  student_clearinghouse_degreeverify_category:
+    'Student Clearinghouse / DegreeVerify category',
+  healthcare_background_screening_category:
+    'Healthcare background screening category',
+  background_license_screening_category:
+    'Background and license screening category',
+  specialty_board_source_category: 'Specialty board source category',
+  state_board_source_category: 'State board source category',
+  employer_direct_category: 'Employer direct',
+  publication_index_category: 'Publication index category',
+  manual_review_category: 'Manual review',
+};

--- a/apps/web/lib/issuer-verification/statusCopy.ts
+++ b/apps/web/lib/issuer-verification/statusCopy.ts
@@ -1,0 +1,94 @@
+import type { VerificationRequestStatus } from './types';
+
+/**
+ * Clinician-safe copy for each VerificationRequestStatus.
+ *
+ * Truth contract:
+ *   - No status renders as the bare word "Verified".
+ *   - reviewRequired flags the statuses that must be attributed and
+ *     reviewed before any downstream surface treats them as proof.
+ */
+export interface StatusCopy {
+  label: string;
+  description: string;
+  /** True when the response cannot be relied on without committee/policy review. */
+  reviewRequired: boolean;
+}
+
+export const STATUS_COPY: Record<VerificationRequestStatus, StatusCopy> = {
+  draft: {
+    label: 'Draft',
+    description: 'Verification request is being prepared.',
+    reviewRequired: false,
+  },
+  consent_required: {
+    label: 'Consent needed',
+    description: 'Consent needed before VitalCV can request this verification.',
+    reviewRequired: false,
+  },
+  ready_to_send: {
+    label: 'Ready to send',
+    description: 'Consent is in place. Request is queued for the issuer.',
+    reviewRequired: false,
+  },
+  sent: {
+    label: 'Sent',
+    description: 'Request sent to issuer.',
+    reviewRequired: false,
+  },
+  viewed_by_issuer: {
+    label: 'Viewed by issuer',
+    description: 'Issuer viewed the request.',
+    reviewRequired: false,
+  },
+  requires_release: {
+    label: 'Release required',
+    description: 'Issuer requires an additional release before responding.',
+    reviewRequired: false,
+  },
+  confirmed: {
+    label: 'Issuer confirmed (review required)',
+    description:
+      'Issuer confirmed this claim; review receipt details before relying on it.',
+    reviewRequired: true,
+  },
+  partially_confirmed: {
+    label: 'Partially confirmed',
+    description: 'Issuer confirmed part of the claim.',
+    reviewRequired: true,
+  },
+  corrected: {
+    label: 'Corrected by issuer',
+    description: 'Issuer returned corrected details.',
+    reviewRequired: true,
+  },
+  unable_to_verify: {
+    label: 'Unable to verify',
+    description: 'Issuer could not verify this claim.',
+    reviewRequired: true,
+  },
+  wrong_office: {
+    label: 'Wrong office',
+    description: 'Request needs to be routed to another office.',
+    reviewRequired: false,
+  },
+  legally_only: {
+    label: 'Dates / identity only',
+    description: 'Dates/identity only; committee review may be required.',
+    reviewRequired: true,
+  },
+  expired: {
+    label: 'Expired',
+    description: 'Request expired without a response.',
+    reviewRequired: false,
+  },
+  canceled: {
+    label: 'Canceled',
+    description: 'Request was canceled before completion.',
+    reviewRequired: false,
+  },
+};
+
+export function statusCopy(status: VerificationRequestStatus): StatusCopy {
+  return STATUS_COPY[status];
+}

--- a/apps/web/lib/issuer-verification/types.ts
+++ b/apps/web/lib/issuer-verification/types.ts
@@ -1,0 +1,166 @@
+/**
+ * ISSUER-1 — Issuer Confirmation Hub contracts.
+ *
+ * Truth contract (mirrors docs/architecture/vitalcv-knowledge-trust-graph.md):
+ *   - A request is not a verification.
+ *   - sent / viewed_by_issuer is not a verification.
+ *   - requires_release pauses the request.
+ *   - legally_only maps to review_required.
+ *   - wrong_office never confirms the claim.
+ *   - confirmed creates a ReceiptCandidate only — never a global proof.
+ *   - A contracted-agent response must preserve the distinction
+ *     between the agent and the source it acts for.
+ *
+ * These types intentionally encode the contract at the type level
+ * (e.g., ReceiptCandidate.decisionGrade is the literal `false`) so a
+ * future caller cannot upgrade an issuer response to decision-grade
+ * without a type error.
+ */
+
+export type VerificationClaimType =
+  | 'education_degree'
+  | 'medical_school'
+  | 'residency'
+  | 'fellowship'
+  | 'background_check'
+  | 'professional_license'
+  | 'work_history'
+  | 'board_certification'
+  | 'publication_research'
+  | 'unknown';
+
+export type VerificationRequestStatus =
+  | 'draft'
+  | 'consent_required'
+  | 'ready_to_send'
+  | 'sent'
+  | 'viewed_by_issuer'
+  | 'requires_release'
+  | 'confirmed'
+  | 'partially_confirmed'
+  | 'corrected'
+  | 'unable_to_verify'
+  | 'wrong_office'
+  | 'legally_only'
+  | 'expired'
+  | 'canceled';
+
+export type IssuerResponseStatus =
+  | 'confirmed'
+  | 'partially_confirmed'
+  | 'corrected'
+  | 'unable_to_verify'
+  | 'requires_release'
+  | 'wrong_office'
+  | 'legally_only';
+
+export type RouteKey =
+  | 'clearinghouse_or_registrar'
+  | 'direct_program_or_gme_office'
+  | 'certified_background_check_partner'
+  | 'source_adapter_or_background_partner'
+  | 'employer_direct'
+  | 'board_source_or_manual'
+  | 'publication_index_or_manual_review'
+  | 'manual_review';
+
+/**
+ * Partner categories — deliberately one level above named vendors.
+ * VitalCV does not yet have live integrations; encoding categories
+ * keeps the router shape stable when real partners land later.
+ */
+export type PartnerCategory =
+  | 'student_clearinghouse_degreeverify_category'
+  | 'healthcare_background_screening_category'
+  | 'background_license_screening_category'
+  | 'specialty_board_source_category'
+  | 'state_board_source_category'
+  | 'employer_direct_category'
+  | 'publication_index_category'
+  | 'manual_review_category';
+
+export type PartnerAccessLevel = 'available' | 'access_required' | 'future';
+
+export interface VerificationPartner {
+  partnerId: string;
+  category: PartnerCategory;
+  /** Display label uses the category, not a named vendor. */
+  displayLabel: string;
+  accessLevel: PartnerAccessLevel;
+  notes?: string;
+}
+
+export interface VerificationRoute {
+  route: RouteKey;
+  partnerCategory: PartnerCategory;
+  rationale: string;
+  accessLevel: PartnerAccessLevel;
+}
+
+export interface IssuerCandidate {
+  candidateId: string;
+  organizationName: string;
+  contactRole?: string;
+  email?: string;
+  phone?: string;
+  source: 'clinician_provided' | 'directory_lookup' | 'partner_directory';
+  /** When the candidate is a contracted agent, agentActsFor names the source. */
+  isContractedAgent?: boolean;
+  agentActsFor?: string;
+}
+
+export interface ConsentArtifact {
+  consentId: string;
+  scope: string;
+  status: 'pending' | 'granted' | 'revoked' | 'expired';
+  consentedAt?: string;
+  expiresAt?: string;
+  releaseFormUrl?: string;
+}
+
+export interface ReceiptCandidate {
+  candidateId: string;
+  createdAt: string;
+  basis: 'issuer_direct' | 'contracted_agent';
+  /** Required when basis is 'contracted_agent'. */
+  agentName?: string;
+  /** Always required — the source the response speaks for. */
+  sourceOrganizationName: string;
+  attributionStatus: 'unattributed' | 'attributed_pending_review' | 'attributed_reviewed';
+  /** Literal false — type-level guarantee that classification cannot be decision-grade. */
+  decisionGrade: false;
+  notes?: string;
+}
+
+export interface IssuerResponse {
+  responseId: string;
+  status: IssuerResponseStatus;
+  respondedAt: string;
+  responderName?: string;
+  responderRole?: string;
+  freeText?: string;
+  /** A response may still need review before a receipt candidate is even staged. */
+  reviewRequired: boolean;
+  receiptCandidate?: ReceiptCandidate;
+}
+
+export interface IssuerVerificationRequestHistoryEntry {
+  status: VerificationRequestStatus;
+  at: string;
+  note?: string;
+}
+
+export interface IssuerVerificationRequest {
+  requestId: string;
+  claimType: VerificationClaimType;
+  claimSummary: string;
+  issuerCandidate: IssuerCandidate;
+  route: VerificationRoute;
+  consent: ConsentArtifact;
+  status: VerificationRequestStatus;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+  history: IssuerVerificationRequestHistoryEntry[];
+  response?: IssuerResponse;
+}

--- a/docs/architecture/vitalcv-knowledge-trust-graph.json
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.json
@@ -61,6 +61,7 @@
     { "source": "IssuerVerificationRequest", "relation": "ROUTES_TO", "target": "Issuer" },
     { "source": "IssuerVerificationRequest", "relation": "MAY_USE", "target": "VerificationPartner" },
     { "source": "Holder", "relation": "CONSENTS_WITH", "target": "ConsentArtifact" },
+    { "source": "Issuer", "relation": "RESPONDS_WITH", "target": "IssuerResponse" },
     { "source": "IssuerResponse", "relation": "MAY_CONFIRM", "target": "Credential Claim" },
     { "source": "IssuerResponse", "relation": "MAY_CORRECT", "target": "Credential Claim" },
     { "source": "IssuerResponse", "relation": "PRODUCES", "target": "ReceiptCandidate" },

--- a/docs/architecture/vitalcv-knowledge-trust-graph.md
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.md
@@ -60,6 +60,7 @@ The conceptual graph defining how truth moves through VitalCV.
 * `Credential Claim` NEEDS_ISSUER_VERIFICATION `Issuer Verification Request`
 * `Issuer Verification Request` MAY_ROUTE_TO `Verification Partner`
 * `Issuer Verification Request` ROUTES_TO `Source`
+* `Issuer` RESPONDS_WITH `Issuer Response`
 * `Issuer Response` PRODUCES `Receipt Candidate`
 * `Contracted Agent` ACTS_FOR `Source`
 


### PR DESCRIPTION
## Summary
- add issuer verification request/response contracts (`apps/web/lib/issuer-verification/types.ts`)
- add partner routing map covering education, training, background, license, work history, board, and research claims (`apps/web/lib/issuer-verification/partnerRouter.ts`)
- add clinician-safe status copy (`apps/web/lib/issuer-verification/statusCopy.ts`)
- add issuer response page stub at `/issuer/verify/[requestId]` — demo only, no email, no record write, no fake partner integration
- update Knowledge Trust Graph with `Issuer RESPONDS_WITH IssuerResponse` edge and harmonize the issuer subgraph (.json + .md)
- add `apps/web/__tests__/issuer-verification.test.ts` with 26 tests proving request/routing/uploaded docs do not equal verification

## Truth rules
- request is not verification (`sent` / `viewed_by_issuer` never verify)
- partner routing is a recommendation only, not an active integration
- uploaded document is not PSV
- `legally_only` response maps to `review_required`
- `wrong_office` response does not verify the claim
- `requires_release` pauses the request
- contracted-agent responses preserve the agent / source distinction
- `ReceiptCandidate.decisionGrade` is the literal `false` at the type level — no caller can upgrade an issuer response to decision-grade without a type error

## Validation
- `pnpm --filter @vitalcv/web build` → Compiled successfully (`/issuer/verify/[requestId]` route built, 620 B)
- `pnpm --filter @vitalcv/web exec vitest run __tests__/issuer-verification.test.ts` → 26 / 26 passed
- `node -e "JSON.parse(... vitalcv-knowledge-trust-graph.json ...)"` → graph json ok

## Out of scope (intentional)
- no real partner API integration
- no email sending
- no OCR, wallet UI, or native mobile
- no `apps/marketing` changes
- no backend trust-container drift
- nothing on this PR can mark a claim as verified

## Test plan
- [ ] CI: Web Quality green
- [ ] CI: Vercel preview deployments green
- [ ] Codex truth-contract review

🤖 Generated with [Claude Code](https://claude.com/claude-code)