### PR TITLE
feat(issuer): add persistence adapter decision boundary

### DIFF
--- a/apps/web/__tests__/issuer-persistence-adapter.test.ts
+++ b/apps/web/__tests__/issuer-persistence-adapter.test.ts
@@ -1,0 +1,451 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanUseRepositoryAdapter,
+  buildRepositoryCandidateDecision,
+  chooseIssuerAuditPersistenceAdapter,
+  createPersistenceAdapter,
+  explainPersistenceAdapterDecision,
+  getIssuerPersistenceAdapterCapabilities,
+} from '../lib/issuer-verification/auditPersistenceAdapter';
+import type {
+  IssuerAuditPersistenceAdapterKind,
+  IssuerPersistenceAdapterCapability,
+} from '../lib/issuer-verification/auditPersistenceAdapter';
+import {
+  createRepositoryAuditAdapter,
+  findRepositoryPayloadOmissions,
+  mapRecordToRepositoryPayload,
+  previewRepositoryAdapterResult,
+  REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON,
+} from '../lib/issuer-verification/repositoryAuditAdapter';
+import {
+  buildIssuerAuditEventRecord,
+  createNoopIssuerAuditWriter,
+  getIssuerAuditPersistenceStatus,
+} from '../lib/issuer-verification/auditPersistence';
+import type { IssuerAuditEventRecord } from '../lib/issuer-verification/auditPersistence';
+import type { IssuerRequestLifecycleActor } from '../lib/issuer-verification/requestLifecycle';
+
+// Banned tokens via split-join.
+const BANNED = [
+  ['audit', 'event', 'recorded'].join(' '),
+  ['logged', 'to', 'audit', 'trail'].join(' '),
+  ['production', 'audit', 'trail'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+  ['irreversible', 'proof'].join(' '),
+  ['global', 'credential', 'truth'].join(' '),
+  ['tamper', 'proof'].join('-'),
+  ['persisted', 'by', 'default'].join(' '),
+];
+
+const ACTOR: IssuerRequestLifecycleActor = {
+  actorId: 'a-1',
+  displayName: 'Pat Actor',
+  role: 'requester',
+};
+
+function makeRecord(
+  overrides: Partial<IssuerAuditEventRecord> = {},
+): IssuerAuditEventRecord {
+  return {
+    ...buildIssuerAuditEventRecord({
+      eventId: 'ev-1',
+      correlation: {
+        correlationId: 'corr-1',
+        requestId: 'req-1',
+        subjectId: 'sub-1',
+      },
+      actor: ACTOR,
+      eventType: 'consent_recorded',
+      occurredAt: '2026-04-26T00:00:00.000Z',
+      source: 'attested',
+      payloadHash: 'sha256-abc',
+      limitationNote: 'Demo limitation note.',
+      relatedArtifactId: 'rc-1',
+    }),
+    ...overrides,
+  };
+}
+
+describe('chooseIssuerAuditPersistenceAdapter', () => {
+  it('default config returns noop', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter();
+    expect(decision.kind).toBe('noop');
+    expect(decision.resultMode).toBe('noop');
+  });
+
+  it('mode=demo returns demo adapter', () => {
+    expect(chooseIssuerAuditPersistenceAdapter({ mode: 'demo' }).kind).toBe('demo');
+  });
+
+  it('mode=none returns unavailable', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({ mode: 'none' });
+    expect(decision.kind).toBe('unavailable');
+    expect(decision.resultMode).toBe('none');
+  });
+
+  it('mode=repository without enable flag returns repository_candidate', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({ mode: 'repository' });
+    expect(decision.kind).toBe('repository_candidate');
+    expect(decision.resultMode).toBe('demo');
+  });
+
+  it('mode=repository with enableRepositoryWrites=true returns repository_enabled', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    expect(decision.kind).toBe('repository_enabled');
+    expect(decision.resultMode).toBe('repository');
+  });
+
+  it('repository_candidate is NOT persisted (cannot be tricked into it)', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({ mode: 'repository' });
+    const adapter = createPersistenceAdapter(decision);
+    const result = adapter.attempt(makeRecord());
+    expect(result.persisted).toBe(false);
+  });
+});
+
+describe('Capability matrix', () => {
+  it('noop and demo carry replay_lifecycle only', () => {
+    expect(getIssuerPersistenceAdapterCapabilities('noop')).toEqual([
+      'replay_lifecycle',
+    ]);
+    expect(getIssuerPersistenceAdapterCapabilities('demo')).toEqual([
+      'replay_lifecycle',
+    ]);
+  });
+
+  it('unavailable adapter has no capabilities', () => {
+    expect(getIssuerPersistenceAdapterCapabilities('unavailable')).toEqual([]);
+  });
+
+  it('repository_candidate carries preservation capabilities but not write capabilities', () => {
+    const caps = getIssuerPersistenceAdapterCapabilities('repository_candidate');
+    expect(caps).toContain('preserve_limitations');
+    expect(caps).toContain('preserve_source_basis');
+    expect(caps).toContain('preserve_responder_attribution');
+    expect(caps).not.toContain('write_audit_event');
+    expect(caps).not.toContain('write_psv_receipt');
+  });
+
+  it('repository_enabled is the only kind with write_audit_event AND write_psv_receipt', () => {
+    const kinds: IssuerAuditPersistenceAdapterKind[] = [
+      'noop',
+      'demo',
+      'repository_candidate',
+      'repository_enabled',
+      'unavailable',
+    ];
+    const writeCaps: IssuerPersistenceAdapterCapability[] = [
+      'write_audit_event',
+      'write_psv_receipt',
+    ];
+    for (const kind of kinds) {
+      const caps = getIssuerPersistenceAdapterCapabilities(kind);
+      const hasAll = writeCaps.every((c) => caps.includes(c));
+      expect(hasAll).toBe(kind === 'repository_enabled');
+    }
+  });
+});
+
+describe('assertCanUseRepositoryAdapter', () => {
+  it('throws for noop / demo / candidate / unavailable', () => {
+    const kinds: IssuerAuditPersistenceAdapterKind[] = [
+      'noop',
+      'demo',
+      'repository_candidate',
+      'unavailable',
+    ];
+    for (const kind of kinds) {
+      const decision = chooseIssuerAuditPersistenceAdapter(
+        kind === 'repository_candidate'
+          ? { mode: 'repository' }
+          : kind === 'unavailable'
+            ? { mode: 'none' }
+            : { mode: kind === 'noop' ? 'noop' : 'demo' },
+      );
+      expect(() => assertCanUseRepositoryAdapter(decision)).toThrow(
+        /repository_enabled/,
+      );
+    }
+  });
+
+  it('does not throw for repository_enabled', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    expect(() => assertCanUseRepositoryAdapter(decision)).not.toThrow();
+  });
+});
+
+describe('buildRepositoryCandidateDecision', () => {
+  it('returns kind=repository_candidate with the supplied wiring description', () => {
+    const decision = buildRepositoryCandidateDecision({
+      wiringDescription: 'Demo Prisma writer',
+    });
+    expect(decision.kind).toBe('repository_candidate');
+    expect(decision.wiringDescription).toBe('Demo Prisma writer');
+  });
+});
+
+describe('createPersistenceAdapter', () => {
+  it('attempt() never returns persisted=true regardless of input record', () => {
+    const decisions = [
+      chooseIssuerAuditPersistenceAdapter({ mode: 'noop' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'demo' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'none' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'repository' }),
+      chooseIssuerAuditPersistenceAdapter({
+        mode: 'repository',
+        enableRepositoryWrites: true,
+      }),
+    ];
+    const tampered: IssuerAuditEventRecord = {
+      ...makeRecord(),
+      // Pretend the caller pre-marked this record as persisted.
+      persistenceStatus: 'persisted',
+      persistenceMode: 'repository',
+    };
+    for (const decision of decisions) {
+      const result = createPersistenceAdapter(decision).attempt(tampered);
+      expect(result.persisted).toBe(false);
+    }
+  });
+
+  it('repository_enabled adapter still returns persisted=false (no writer wired)', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    const result = createPersistenceAdapter(decision).attempt(makeRecord());
+    expect(result.persisted).toBe(false);
+    // The status reflects "pending" — a writer has not run.
+    expect(result.status).toBe('pending_not_written');
+  });
+
+  it('explanation never claims persistence', () => {
+    const decisions = [
+      chooseIssuerAuditPersistenceAdapter({ mode: 'noop' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'demo' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'repository' }),
+    ];
+    for (const d of decisions) {
+      const text = explainPersistenceAdapterDecision(d).toLowerCase();
+      expect(text).not.toMatch(/audit row was written/);
+      expect(text).not.toMatch(/persisted to/);
+    }
+  });
+});
+
+describe('createRepositoryAuditAdapter (stub)', () => {
+  it('default config returns repository_candidate (NOT enabled)', () => {
+    const adapter = createRepositoryAuditAdapter();
+    expect(adapter.decision.kind).toBe('repository_candidate');
+  });
+
+  it('with enableRepositoryWrites=true the slice keeps adapter unavailable + cites the bridge gap', () => {
+    const adapter = createRepositoryAuditAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    expect(adapter.decision.kind).toBe('unavailable');
+    expect(adapter.decision.reason.toLowerCase()).toContain(
+      'no client-safe repository adapter is wired',
+    );
+    expect(adapter.decision.wiringDescription?.toLowerCase()).toContain(
+      'backend prisma',
+    );
+  });
+
+  it('non-repository config falls through to the chosen adapter', () => {
+    const adapter = createRepositoryAuditAdapter({ mode: 'demo' });
+    expect(adapter.decision.kind).toBe('demo');
+  });
+
+  it('attempt() never persists', () => {
+    const adapter = createRepositoryAuditAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    const result = adapter.attempt(makeRecord());
+    expect(result.persisted).toBe(false);
+  });
+
+  it('preview helper does not persist either', () => {
+    const adapter = createRepositoryAuditAdapter();
+    const preview = previewRepositoryAdapterResult(adapter.decision, makeRecord());
+    expect(preview.persisted).toBe(false);
+  });
+});
+
+describe('mapRecordToRepositoryPayload', () => {
+  it('preserves limitations / source basis / responder attribution-equivalent fields', () => {
+    const record = makeRecord({
+      limitationNote: 'Issuer confirmed only dates.',
+      relatedArtifactId: 'psv-receipt-1',
+      payloadHash: 'sha256-deadbeef',
+    });
+    const payload = mapRecordToRepositoryPayload(record);
+    expect(payload.limitationNote).toBe(record.limitationNote);
+    expect(payload.relatedArtifactId).toBe(record.relatedArtifactId);
+    expect(payload.actorId).toBe(record.actor.actorId);
+    expect(payload.actorRole).toBe(record.actorRole);
+    expect(payload.payloadHash).toBe(record.payloadHash);
+    expect(findRepositoryPayloadOmissions(record, payload)).toEqual([]);
+  });
+
+  it('omitting any field is detectable', () => {
+    const record = makeRecord();
+    const payload = mapRecordToRepositoryPayload(record);
+    const broken = { ...payload, limitationNote: 'tampered' };
+    const missing = findRepositoryPayloadOmissions(record, broken);
+    expect(missing).toContain('limitationNote');
+  });
+
+  it('payload type does NOT carry decisionGrade / proofTier / globalCredentialTruth fields', () => {
+    const payload = mapRecordToRepositoryPayload(makeRecord());
+    expect((payload as Record<string, unknown>).decisionGrade).toBeUndefined();
+    expect((payload as Record<string, unknown>).proofTier).toBeUndefined();
+    expect(
+      (payload as Record<string, unknown>).globalCredentialTruth,
+    ).toBeUndefined();
+  });
+});
+
+describe('Repository adapter stub does not call network/db', () => {
+  it('source contains no fetch / axios / prisma / db / Prisma / pg / mysql tokens', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/repositoryAuditAdapter.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const banned = [
+      'fetch(',
+      'axios',
+      'XMLHttpRequest',
+      'navigator.sendBeacon',
+      "import('@/",
+      'require(',
+      'pg.',
+      'mysql',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('explicitly does not import the backend repository module', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/repositoryAuditAdapter.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    // Static import lines should never reference apps/api, backend
+    // repos, prisma_client, or the @vitalcv/psv workspace package.
+    expect(src).not.toMatch(/from ['"]apps\/api/);
+    expect(src).not.toMatch(/from ['"]@vitalcv\/psv['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*prisma_client['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*psvReceipts\.repo['"]/);
+  });
+
+  it('the unavailable-reason constant cites why the bridge is deferred', () => {
+    expect(REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON.toLowerCase()).toContain(
+      'prisma',
+    );
+    expect(REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON.toLowerCase()).toContain(
+      'client bundle',
+    );
+  });
+});
+
+describe('Adapter cannot upgrade truth tier or set globalCredentialTruth', () => {
+  it('write result has no decisionGrade / proofTier / globalCredentialTruth fields', () => {
+    const decision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: true,
+    });
+    const adapter = createPersistenceAdapter(decision);
+    const result = adapter.attempt(makeRecord());
+    expect((result as Record<string, unknown>).decisionGrade).toBeUndefined();
+    expect((result as Record<string, unknown>).proofTier).toBeUndefined();
+    expect(
+      (result as Record<string, unknown>).globalCredentialTruth,
+    ).toBeUndefined();
+  });
+});
+
+describe('Banned-string sweep on adapter explanations', () => {
+  it('explanations across every adapter kind avoid banned phrases', () => {
+    const decisions = [
+      chooseIssuerAuditPersistenceAdapter({ mode: 'noop' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'demo' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'none' }),
+      chooseIssuerAuditPersistenceAdapter({ mode: 'repository' }),
+      chooseIssuerAuditPersistenceAdapter({
+        mode: 'repository',
+        enableRepositoryWrites: true,
+      }),
+      buildRepositoryCandidateDecision({
+        wiringDescription: 'demo wiring',
+      }),
+    ];
+    for (const decision of decisions) {
+      const text = explainPersistenceAdapterDecision(decision).toLowerCase();
+      for (const phrase of BANNED) {
+        expect(text).not.toContain(phrase.toLowerCase());
+      }
+    }
+  });
+});
+
+describe('Adapter decision flows through audit persistence boundary', () => {
+  it('noop writer + adapter decision: persisted stays false', () => {
+    const writer = createNoopIssuerAuditWriter({ mode: 'demo' });
+    const result = getIssuerAuditPersistenceStatus(makeRecord(), writer);
+    expect(result.persisted).toBe(false);
+  });
+});
+
+describe('Knowledge Trust Graph — ISSUER-8 alignment', () => {
+  it('keeps the adapter nodes and rules parseable and aligned', async () => {
+    const raw = await import(
+      '../../../docs/architecture/vitalcv-knowledge-trust-graph.json'
+    );
+    const graph = raw.default ?? raw;
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        'IssuerAuditPersistenceAdapter',
+        'RepositoryAuditAdapter',
+        'PersistenceAdapterDecision',
+        'RepositoryCapability',
+        'PersistedAuditRecord',
+        'PersistenceConfiguration',
+      ]),
+    );
+    expect(graph.rules).toEqual(
+      expect.arrayContaining([
+        'Default persistence adapter is noop; active persistence is off unless explicitly turned on via configuration.',
+        'repository_candidate is not active persistence; it means a repository-shaped writer could be wired but is not yet.',
+        'Only repository_enabled may produce a persisted write status, and even then the actual write requires writer confirmation.',
+        'Adapter availability does not imply active persistence; a writer must invoke and confirm.',
+        'The frontend/web layer must not silently import a backend DB writer into the client bundle; a client-safe boundary is required first.',
+        'No UI may claim an audit trail exists without a persisted persistence status from a repository or external writer.',
+        'An adapter cannot upgrade proofTier or set globalCredentialTruth=true.',
+      ]),
+    );
+  });
+});

--- a/apps/web/app/issuer/persistence-adapter/[requestId]/page.tsx
+++ b/apps/web/app/issuer/persistence-adapter/[requestId]/page.tsx
@@ -1,0 +1,261 @@
+import * as React from 'react';
+import {
+  buildIssuerAuditEventRecord,
+  createNoopIssuerAuditWriter,
+  getIssuerAuditPersistenceStatus,
+} from '@/lib/issuer-verification/auditPersistence';
+import {
+  chooseIssuerAuditPersistenceAdapter,
+  createPersistenceAdapter,
+  explainPersistenceAdapterDecision,
+  getIssuerPersistenceAdapterCapabilities,
+} from '@/lib/issuer-verification/auditPersistenceAdapter';
+import type { IssuerPersistenceAdapterCapability } from '@/lib/issuer-verification/auditPersistenceAdapter';
+import {
+  createRepositoryAuditAdapter,
+  REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON,
+} from '@/lib/issuer-verification/repositoryAuditAdapter';
+
+/**
+ * ISSUER-8 — Persistence adapter review surface (demo render).
+ *
+ * The page does not write rows. The default adapter is the no-op
+ * adapter; the repository adapter renders as `repository_candidate`
+ * because no client-safe writer is wired in this slice.
+ */
+
+const ALL_CAPABILITIES: ReadonlyArray<IssuerPersistenceAdapterCapability> = [
+  'write_audit_event',
+  'write_psv_receipt',
+  'replay_lifecycle',
+  'hash_payload',
+  'preserve_limitations',
+  'preserve_source_basis',
+  'preserve_responder_attribution',
+];
+
+interface PageProps {
+  params: Promise<{ requestId: string }>;
+}
+
+export default async function PersistenceAdapterPage({ params }: PageProps) {
+  const { requestId } = await params;
+
+  // Default decision (no config)
+  const defaultDecision = chooseIssuerAuditPersistenceAdapter();
+
+  // Repository candidate decision — type-safe stub, not enabled
+  const repoCandidate = createRepositoryAuditAdapter({ mode: 'repository' }).decision;
+
+  // Repository "enabled" attempt — even with the operator opt-in flag,
+  // this slice keeps the adapter unavailable because no writer is
+  // wired. The page renders this honestly.
+  const repoEnabledAttempt = createRepositoryAuditAdapter({
+    mode: 'repository',
+    enableRepositoryWrites: true,
+  }).decision;
+
+  // Demo write through the no-op writer — confirms the adapter
+  // decision flows through to the audit persistence boundary.
+  const demoRecord = buildIssuerAuditEventRecord({
+    eventId: `ev-${requestId}`,
+    correlation: {
+      correlationId: `corr-${requestId}`,
+      requestId,
+      subjectId: 'demo-subject',
+    },
+    actor: {
+      actorId: 'demo-actor',
+      displayName: 'Demo Actor',
+      role: 'demo',
+    },
+    eventType: 'consent_recorded',
+    occurredAt: '2026-04-26T00:00:00.000Z',
+    source: 'attested',
+  });
+  const demoWriter = createNoopIssuerAuditWriter({ mode: 'demo' });
+  const demoResult = getIssuerAuditPersistenceStatus(demoRecord, demoWriter);
+
+  // Adapter preview through the repository_candidate adapter.
+  const repoCandidateAdapter = createPersistenceAdapter(repoCandidate);
+  const repoCandidatePreview = repoCandidateAdapter.attempt(demoRecord);
+
+  function renderCapabilityRow(
+    label: string,
+    caps: ReadonlyArray<IssuerPersistenceAdapterCapability>,
+  ) {
+    return (
+      <li
+        className="rounded-xl border border-border/60 bg-background/40 p-3"
+        data-row-label={label}
+      >
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <ul className="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
+          {ALL_CAPABILITIES.map((cap) => {
+            const present = caps.includes(cap);
+            return (
+              <li
+                key={cap}
+                className="text-[11px] text-muted-foreground"
+                data-capability={cap}
+                data-capability-present={String(present)}
+              >
+                {present ? '✓' : '·'} {cap}
+              </li>
+            );
+          })}
+        </ul>
+      </li>
+    );
+  }
+
+  return (
+    <main
+      className="min-h-screen bg-background"
+      data-testid="persistence-adapter-page"
+      data-request-id={requestId}
+      data-default-adapter-kind={defaultDecision.kind}
+      data-repository-candidate-kind={repoCandidate.kind}
+      data-repository-enabled-kind={repoEnabledAttempt.kind}
+      data-demo-write-persisted={String(demoResult.persisted)}
+      data-repo-candidate-persisted={String(repoCandidatePreview.persisted)}
+    >
+      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
+        <header className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+            Persistence adapter
+          </p>
+          <h1 className="text-xl font-semibold text-foreground">
+            Adapter decision for request {requestId}
+          </h1>
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="persistence-adapter-warning"
+          >
+            Repository persistence is disabled unless explicitly configured
+            and confirmed by a writer. Until then, events remain pending or
+            demo-only.
+          </p>
+        </header>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5 space-y-3"
+          aria-label="Default adapter"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Default adapter
+          </p>
+          <p className="text-sm text-foreground">
+            kind: {defaultDecision.kind} (resultMode: {defaultDecision.resultMode})
+          </p>
+          <p className="text-xs text-muted-foreground italic">
+            {explainPersistenceAdapterDecision(defaultDecision)}
+          </p>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5 space-y-3"
+          aria-label="Repository candidate"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Repository adapter (candidate)
+          </p>
+          <p className="text-sm text-foreground">
+            kind: {repoCandidate.kind} (resultMode: {repoCandidate.resultMode})
+          </p>
+          <p className="text-xs text-muted-foreground italic">
+            {explainPersistenceAdapterDecision(repoCandidate)}
+          </p>
+          <p
+            className="text-[11px] text-muted-foreground/80"
+            data-testid="repo-candidate-preview"
+            data-persisted={String(repoCandidatePreview.persisted)}
+          >
+            Preview attempt under this adapter: persisted={String(repoCandidatePreview.persisted)};
+            status={repoCandidatePreview.status}; mode={repoCandidatePreview.mode}.
+          </p>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5 space-y-3"
+          aria-label="Repository enabled (with operator flag)"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Repository adapter (operator opt-in attempted)
+          </p>
+          <p className="text-sm text-foreground">
+            kind: {repoEnabledAttempt.kind} (resultMode: {repoEnabledAttempt.resultMode})
+          </p>
+          <p
+            className="text-xs text-muted-foreground italic"
+            data-testid="repo-enabled-explanation"
+          >
+            {explainPersistenceAdapterDecision(repoEnabledAttempt)}
+          </p>
+          <p className="text-[11px] text-muted-foreground/80">
+            Even with the operator opt-in flag, this slice intentionally keeps
+            the adapter unavailable because no client-safe repository writer
+            exists yet.
+          </p>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5"
+          aria-label="Capability matrix"
+        >
+          <h2 className="text-sm font-semibold mb-3 text-foreground">
+            Capability matrix
+          </h2>
+          <ul className="space-y-2" data-testid="capability-matrix">
+            {renderCapabilityRow('noop', getIssuerPersistenceAdapterCapabilities('noop'))}
+            {renderCapabilityRow('demo', getIssuerPersistenceAdapterCapabilities('demo'))}
+            {renderCapabilityRow(
+              'repository_candidate',
+              getIssuerPersistenceAdapterCapabilities('repository_candidate'),
+            )}
+            {renderCapabilityRow(
+              'repository_enabled',
+              getIssuerPersistenceAdapterCapabilities('repository_enabled'),
+            )}
+            {renderCapabilityRow(
+              'unavailable',
+              getIssuerPersistenceAdapterCapabilities('unavailable'),
+            )}
+          </ul>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card p-5"
+          aria-label="What enabling persistence requires"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            What enabling persistence requires
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON}
+          </p>
+        </section>
+
+        <section
+          className="rounded-2xl border border-border bg-card/60 p-4"
+          aria-label="Demo write outcome"
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Demo write outcome (no-op writer)
+          </p>
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="demo-write-result"
+            data-persisted={String(demoResult.persisted)}
+          >
+            persisted={String(demoResult.persisted)}; status={demoResult.status};
+            mode={demoResult.mode}.
+          </p>
+          <p className="text-[11px] italic text-muted-foreground/80 mt-1">
+            {demoResult.message}
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/issuer-verification/auditPersistence.ts
+++ b/apps/web/lib/issuer-verification/auditPersistence.ts
@@ -161,6 +161,24 @@ export interface IssuerAuditWriteResult {
   persistedId?: string;
   /** Optional error info when status === 'failed'. */
   error?: { code: string; message: string };
+  /**
+   * ISSUER-8 — Optional adapter decision metadata. When a writer
+   * was selected via the persistence-adapter boundary
+   * (auditPersistenceAdapter.ts), the decision payload is surfaced
+   * here so callers can show the operator which adapter ran. Setting
+   * this field does NOT change the persistence guarantee — the
+   * `persisted` flag remains the load-bearing signal.
+   */
+  adapterDecision?: {
+    kind:
+      | 'noop'
+      | 'demo'
+      | 'repository_candidate'
+      | 'repository_enabled'
+      | 'unavailable';
+    reason: string;
+    wiringDescription?: string;
+  };
 }
 
 /**

--- a/apps/web/lib/issuer-verification/auditPersistenceAdapter.ts
+++ b/apps/web/lib/issuer-verification/auditPersistenceAdapter.ts
@@ -1,0 +1,333 @@
+import type {
+  IssuerAuditEventRecord,
+  IssuerAuditPersistenceMode,
+  IssuerAuditWriteResult,
+  IssuerAuditWriteStatus,
+} from './auditPersistence';
+
+/**
+ * ISSUER-8 — Persistence adapter decision boundary.
+ *
+ * Truth contract:
+ *   - Default adapter is `noop`. Active persistence is OFF unless
+ *     explicitly turned on via configuration.
+ *   - `repository_candidate` is NOT active persistence. It means a
+ *     repository-shaped writer COULD be wired, but is not yet.
+ *   - `repository_enabled` is the only kind that may yield a
+ *     `persisted` write status — and even then, the actual write
+ *     result must come from the writer (this module never claims
+ *     persistence on the writer's behalf).
+ *   - Missing config produces `unavailable` or `noop`, never
+ *     `persisted`.
+ *   - The adapter MUST preserve limitations, source basis, and
+ *     responder attribution from the originating record. The
+ *     adapter cannot upgrade `proofTier` or set
+ *     `globalCredentialTruth: true`.
+ *   - The adapter cannot claim an audit row was written when no
+ *     writer was invoked.
+ *
+ * This module is a pure transform — no fetches, no DB writes, no
+ * dynamic imports, no real I/O.
+ */
+
+/**
+ * The kind of adapter selected for this environment. The
+ * persistence boundary uses this to decide what statuses are
+ * possible:
+ *
+ * - `noop` — reference no-op; never persists.
+ * - `demo` — demo writer; never persists.
+ * - `repository_candidate` — a repository-shaped writer is *available*
+ *   in code but is not enabled for active writes.
+ * - `repository_enabled` — a repository-shaped writer is enabled and
+ *   is the only kind that may produce `persisted`.
+ * - `unavailable` — config requested a writer that cannot be wired in
+ *   this environment (missing dependency, missing env, etc.).
+ */
+export type IssuerAuditPersistenceAdapterKind =
+  | 'noop'
+  | 'demo'
+  | 'repository_candidate'
+  | 'repository_enabled'
+  | 'unavailable';
+
+export type IssuerPersistenceAdapterCapability =
+  | 'write_audit_event'
+  | 'write_psv_receipt'
+  | 'replay_lifecycle'
+  | 'hash_payload'
+  | 'preserve_limitations'
+  | 'preserve_source_basis'
+  | 'preserve_responder_attribution';
+
+/**
+ * Static capability matrix per adapter kind. Capabilities listed
+ * here describe what the adapter is *designed* to support — not
+ * whether any particular write actually happened.
+ *
+ * Truth invariant: `noop` and `demo` never carry `write_audit_event`
+ * or `write_psv_receipt` capabilities. `repository_candidate`
+ * carries them in spirit (it would, if enabled) but is gated;
+ * callers MUST treat the candidate's capabilities as advisory
+ * until the kind transitions to `repository_enabled`.
+ */
+const CAPABILITIES_BY_KIND: Record<
+  IssuerAuditPersistenceAdapterKind,
+  ReadonlyArray<IssuerPersistenceAdapterCapability>
+> = {
+  noop: ['replay_lifecycle'],
+  demo: ['replay_lifecycle'],
+  repository_candidate: [
+    'replay_lifecycle',
+    'preserve_limitations',
+    'preserve_source_basis',
+    'preserve_responder_attribution',
+  ],
+  repository_enabled: [
+    'write_audit_event',
+    'write_psv_receipt',
+    'replay_lifecycle',
+    'preserve_limitations',
+    'preserve_source_basis',
+    'preserve_responder_attribution',
+  ],
+  unavailable: [],
+};
+
+/**
+ * Caller-supplied configuration. The persistence adapter decision
+ * is driven entirely by this input; there are no environment
+ * lookups, no `process.env` reads, no implicit feature flags.
+ *
+ * - `mode === 'noop' | 'demo'` selects the corresponding adapter.
+ * - `mode === 'repository'` selects either `repository_candidate`
+ *   or `repository_enabled` depending on `enableRepositoryWrites`.
+ * - `mode === 'none'` selects `unavailable`.
+ */
+export interface IssuerAuditPersistenceAdapterConfig {
+  mode: 'none' | 'noop' | 'demo' | 'repository';
+  /**
+   * When `mode === 'repository'`, this flag must be set to `true`
+   * for the adapter to transition from `repository_candidate` to
+   * `repository_enabled`. Required because enabling real persistence
+   * is an operator decision, not an inferred default.
+   */
+  enableRepositoryWrites?: boolean;
+  /**
+   * Optional human-readable description of the wiring (e.g.,
+   * "Prisma-backed `chai-vc-platform-backend` repository at
+   * apps/api/backend/repositories/psvReceipts.repo.ts"). Surfaced
+   * verbatim by the review surface.
+   */
+  wiringDescription?: string;
+  /**
+   * Optional hint about why the adapter is unavailable, used when
+   * `mode === 'repository'` but the writer cannot run in this
+   * runtime (e.g., the repository module imports a server-only
+   * dependency that cannot be loaded into the client bundle).
+   */
+  unavailableReason?: string;
+}
+
+/**
+ * Decision payload produced by `chooseIssuerAuditPersistenceAdapter`.
+ * Surfaces both the selected `kind` and a plain-language `reason`
+ * the review surface can render verbatim.
+ */
+export interface IssuerPersistenceAdapterDecision {
+  kind: IssuerAuditPersistenceAdapterKind;
+  /** The persistence mode this adapter would feed back to the writer. */
+  resultMode: IssuerAuditPersistenceMode;
+  reason: string;
+  capabilities: ReadonlyArray<IssuerPersistenceAdapterCapability>;
+  /** Carried-through wiring description for the review surface. */
+  wiringDescription?: string;
+}
+
+/**
+ * Result of attempting to use an adapter — wraps a writer's
+ * `IssuerAuditWriteResult` plus the decision metadata.
+ */
+export interface IssuerAuditPersistenceAdapterResult {
+  decision: IssuerPersistenceAdapterDecision;
+  /**
+   * The persistence outcome reported by the underlying writer (or
+   * synthesized by this module when no writer was invoked). Always
+   * carries `persisted: false` unless the adapter is
+   * `repository_enabled` AND a writer confirmed persistence.
+   */
+  writeResult: IssuerAuditWriteResult;
+}
+
+/**
+ * The adapter interface itself. Adapters are pure: they accept a
+ * record and return a synthesized write result. They do NOT call
+ * the network, the database, or any external API directly.
+ */
+export interface IssuerAuditPersistenceAdapter {
+  decision: IssuerPersistenceAdapterDecision;
+  /**
+   * Pure transform: returns the write result the adapter would feed
+   * back if invoked under the current configuration. Adapters of
+   * kind `noop`, `demo`, `repository_candidate`, and `unavailable`
+   * MUST always return `persisted: false`.
+   */
+  attempt(record: IssuerAuditEventRecord): IssuerAuditWriteResult;
+}
+
+const DECISION_REASONS: Record<IssuerAuditPersistenceAdapterKind, string> = {
+  noop: 'No-op adapter selected. Replay-only; nothing is persisted.',
+  demo: 'Demo adapter selected. Replay-only; nothing is persisted.',
+  repository_candidate:
+    'Repository writer is in scope but not enabled. Persistence stays off until enableRepositoryWrites is set.',
+  repository_enabled:
+    'Repository writer is enabled. Actual persistence still requires the writer to confirm each row.',
+  unavailable:
+    'No adapter is wired in this environment. Persistence is unavailable.',
+};
+
+const DECISION_RESULT_MODE: Record<
+  IssuerAuditPersistenceAdapterKind,
+  IssuerAuditPersistenceMode
+> = {
+  noop: 'noop',
+  demo: 'demo',
+  repository_candidate: 'demo',
+  repository_enabled: 'repository',
+  unavailable: 'none',
+};
+
+const DECISION_WRITE_STATUS: Record<
+  IssuerAuditPersistenceAdapterKind,
+  IssuerAuditWriteStatus
+> = {
+  noop: 'demo_not_persisted',
+  demo: 'demo_not_persisted',
+  repository_candidate: 'demo_not_persisted',
+  repository_enabled: 'pending_not_written',
+  unavailable: 'unavailable',
+};
+
+/**
+ * Pure: derive the adapter kind for a given config.
+ */
+function pickAdapterKind(
+  config: IssuerAuditPersistenceAdapterConfig,
+): IssuerAuditPersistenceAdapterKind {
+  if (config.mode === 'none') return 'unavailable';
+  if (config.mode === 'noop') return 'noop';
+  if (config.mode === 'demo') return 'demo';
+  if (config.mode === 'repository') {
+    return config.enableRepositoryWrites === true
+      ? 'repository_enabled'
+      : 'repository_candidate';
+  }
+  return 'unavailable';
+}
+
+/**
+ * Pure: build the decision payload for a given config. Default
+ * config (no argument) returns the no-op decision.
+ */
+export function chooseIssuerAuditPersistenceAdapter(
+  config: IssuerAuditPersistenceAdapterConfig = { mode: 'noop' },
+): IssuerPersistenceAdapterDecision {
+  const kind = pickAdapterKind(config);
+  const baseReason = DECISION_REASONS[kind];
+  const reason =
+    kind === 'unavailable' && config.unavailableReason
+      ? `${baseReason} ${config.unavailableReason}`
+      : baseReason;
+  return {
+    kind,
+    resultMode: DECISION_RESULT_MODE[kind],
+    reason,
+    capabilities: CAPABILITIES_BY_KIND[kind],
+    wiringDescription: config.wiringDescription,
+  };
+}
+
+/**
+ * Pure: capability lookup helper. Equivalent to reading
+ * `decision.capabilities`, surfaced separately so the review surface
+ * can ask "does this kind have capability X?" without knowing the
+ * full table.
+ */
+export function getIssuerPersistenceAdapterCapabilities(
+  kind: IssuerAuditPersistenceAdapterKind,
+): ReadonlyArray<IssuerPersistenceAdapterCapability> {
+  return CAPABILITIES_BY_KIND[kind];
+}
+
+/**
+ * Pure: defensive guard that throws when a caller tries to use a
+ * repository adapter without confirming `enableRepositoryWrites`.
+ * Use at the point where real persistence would be invoked.
+ */
+export function assertCanUseRepositoryAdapter(
+  decision: IssuerPersistenceAdapterDecision,
+): void {
+  if (decision.kind !== 'repository_enabled') {
+    throw new Error(
+      `assertCanUseRepositoryAdapter refused: adapter kind is ${decision.kind}; only repository_enabled may perform real writes.`,
+    );
+  }
+}
+
+/**
+ * Pure: convenience builder for a `repository_candidate` decision.
+ * Useful when a caller wants to *describe* the repository wiring
+ * without enabling it.
+ */
+export function buildRepositoryCandidateDecision(input: {
+  wiringDescription: string;
+}): IssuerPersistenceAdapterDecision {
+  return chooseIssuerAuditPersistenceAdapter({
+    mode: 'repository',
+    enableRepositoryWrites: false,
+    wiringDescription: input.wiringDescription,
+  });
+}
+
+/**
+ * Plain-language explanation of an adapter decision. Surfaced
+ * verbatim by the review surface.
+ */
+export function explainPersistenceAdapterDecision(
+  decision: IssuerPersistenceAdapterDecision,
+): string {
+  const wiring = decision.wiringDescription
+    ? ` Wiring: ${decision.wiringDescription}.`
+    : '';
+  return `${decision.reason}${wiring}`;
+}
+
+/**
+ * Build a no-op adapter from a decision. Always returns
+ * `persisted: false` regardless of the record passed in. The result
+ * status follows the static `DECISION_WRITE_STATUS` table.
+ */
+export function createPersistenceAdapter(
+  decision: IssuerPersistenceAdapterDecision,
+): IssuerAuditPersistenceAdapter {
+  return {
+    decision,
+    attempt(_record: IssuerAuditEventRecord): IssuerAuditWriteResult {
+      void _record;
+      // Defense-in-depth: this module can never produce
+      // `persisted: true` on its own. A real repository_enabled
+      // adapter is provided by `repositoryAuditAdapter.ts` and even
+      // there, persistence requires writer confirmation that does
+      // not exist in this slice.
+      return {
+        status: DECISION_WRITE_STATUS[decision.kind],
+        mode: decision.resultMode,
+        persisted: false,
+        message:
+          decision.kind === 'unavailable'
+            ? decision.reason
+            : `${decision.reason} No row was persisted by this adapter.`,
+      };
+    },
+  };
+}

--- a/apps/web/lib/issuer-verification/repositoryAuditAdapter.ts
+++ b/apps/web/lib/issuer-verification/repositoryAuditAdapter.ts
@@ -1,0 +1,215 @@
+import type {
+  IssuerAuditEventRecord,
+  IssuerAuditPersistenceMode,
+  IssuerAuditWriteResult,
+} from './auditPersistence';
+import type {
+  IssuerAuditPersistenceAdapter,
+  IssuerAuditPersistenceAdapterConfig,
+  IssuerPersistenceAdapterDecision,
+} from './auditPersistenceAdapter';
+import {
+  chooseIssuerAuditPersistenceAdapter,
+  createPersistenceAdapter,
+} from './auditPersistenceAdapter';
+
+/**
+ * ISSUER-8 — Repository audit adapter stub.
+ *
+ * This module DELIBERATELY does NOT import the existing backend
+ * repository (`apps/api/backend/repositories/psvReceipts.repo.ts`).
+ *
+ * Why not:
+ *   - That repository imports `prisma` (server-only) and is bound to
+ *     the `chai-vc-platform-backend` package. Importing it here would
+ *     pull a server-only dependency into the web client bundle and
+ *     break Next.js builds.
+ *   - The backend repo's shape is the legacy snake_case
+ *     `PsvReceiptSnapshot` (`receipt_id`, `fetched_at`, `ttl_seconds`,
+ *     `revoked`) that predates the issuer-verification chain. It does
+ *     not currently model `IssuerAuditEventRecord` at all.
+ *   - Bridging the two shapes is a real architectural decision that
+ *     belongs to a future wave (with its own brief and own Codex pass).
+ *
+ * What this module DOES:
+ *   - Defines the type-only shape `RepositoryAuditEventPayload` that a
+ *     future repository writer would produce from an
+ *     `IssuerAuditEventRecord`.
+ *   - Provides `mapRecordToRepositoryPayload` as a pure transform.
+ *   - Exposes `createRepositoryAuditAdapter` which always returns a
+ *     `repository_candidate` (or `unavailable`) decision until an
+ *     operator explicitly opts into `enableRepositoryWrites: true` AND
+ *     a real writer is wired (which this slice does not do).
+ *   - Carries an `availability` description that the review surface
+ *     renders verbatim so reviewers see exactly what would be needed
+ *     to enable persistence.
+ *
+ * What this module does NOT:
+ *   - Import any database driver, ORM client, or HTTP client.
+ *   - Dynamic-import any backend module.
+ *   - Write a real audit row.
+ *   - Claim `persisted: true` from any code path here.
+ */
+
+/**
+ * The shape a future repository writer would persist. This is
+ * deliberately decoupled from the legacy backend `PsvReceiptSnapshot`
+ * shape — bridging the two is a separate decision.
+ */
+export interface RepositoryAuditEventPayload {
+  eventId: string;
+  correlationId: string;
+  requestId: string;
+  subjectId?: string;
+  actorId: string;
+  actorRole: IssuerAuditEventRecord['actorRole'];
+  eventType: IssuerAuditEventRecord['eventType'];
+  occurredAt: string;
+  source: IssuerAuditEventRecord['source'];
+  payloadHash: string;
+  limitationNote?: string;
+  relatedArtifactId?: string;
+}
+
+/**
+ * The result a future real repository write would return. Always
+ * carries `persisted: boolean` so callers must inspect it
+ * explicitly.
+ */
+export interface RepositoryAuditAdapterResult extends IssuerAuditWriteResult {
+  /** True iff a row was actually written to the repository. */
+  persisted: boolean;
+  /** Optional id assigned by the repository on successful write. */
+  persistedRowId?: string;
+}
+
+/**
+ * Why a repository writer may be unavailable in the current build.
+ * Surfaced verbatim by the review surface.
+ */
+export const REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON =
+  'No client-safe repository adapter is wired. The existing backend ' +
+  'repository at apps/api/backend/repositories/psvReceipts.repo.ts is ' +
+  'Prisma-bound and lives in the chai-vc-platform-backend package; ' +
+  'importing it here would pull server-only dependencies into the web ' +
+  'client bundle. A separate wave is required to (a) add a ' +
+  'client-safe RPC boundary or server action, and (b) reconcile the ' +
+  'legacy PsvReceiptSnapshot shape with IssuerAuditEventRecord.';
+
+/**
+ * Pure transform: map an `IssuerAuditEventRecord` to the structural
+ * payload a repository writer would persist. Does NOT write
+ * anything. Does NOT call any service.
+ */
+export function mapRecordToRepositoryPayload(
+  record: IssuerAuditEventRecord,
+): RepositoryAuditEventPayload {
+  return {
+    eventId: record.eventId,
+    correlationId: record.correlationId,
+    requestId: record.requestId,
+    subjectId: record.subjectId,
+    actorId: record.actor.actorId,
+    actorRole: record.actorRole,
+    eventType: record.eventType,
+    occurredAt: record.occurredAt,
+    source: record.source,
+    payloadHash: record.payloadHash,
+    limitationNote: record.limitationNote,
+    relatedArtifactId: record.relatedArtifactId,
+  };
+}
+
+/**
+ * Inverse helper for tests: confirm a payload preserves every
+ * record field listed by the truth contract. Returns the missing
+ * field names (empty array means all preserved).
+ */
+export function findRepositoryPayloadOmissions(
+  record: IssuerAuditEventRecord,
+  payload: RepositoryAuditEventPayload,
+): string[] {
+  const missing: string[] = [];
+  if (payload.eventId !== record.eventId) missing.push('eventId');
+  if (payload.correlationId !== record.correlationId) missing.push('correlationId');
+  if (payload.requestId !== record.requestId) missing.push('requestId');
+  if (payload.subjectId !== record.subjectId) missing.push('subjectId');
+  if (payload.actorId !== record.actor.actorId) missing.push('actorId');
+  if (payload.actorRole !== record.actorRole) missing.push('actorRole');
+  if (payload.eventType !== record.eventType) missing.push('eventType');
+  if (payload.occurredAt !== record.occurredAt) missing.push('occurredAt');
+  if (payload.source !== record.source) missing.push('source');
+  if (payload.payloadHash !== record.payloadHash) missing.push('payloadHash');
+  if (payload.limitationNote !== record.limitationNote)
+    missing.push('limitationNote');
+  if (payload.relatedArtifactId !== record.relatedArtifactId)
+    missing.push('relatedArtifactId');
+  return missing;
+}
+
+/**
+ * Build the repository-shaped adapter. Without an explicit
+ * `enableRepositoryWrites: true`, this returns a
+ * `repository_candidate` adapter — type-safe, never persists, never
+ * imports backend code.
+ *
+ * Even when `enableRepositoryWrites: true` is supplied, this slice
+ * keeps the adapter in `unavailable` mode (with an explanatory
+ * reason) because the underlying writer does not exist yet. This
+ * is intentional and load-bearing for the truth contract.
+ */
+export function createRepositoryAuditAdapter(
+  config: IssuerAuditPersistenceAdapterConfig = { mode: 'repository' },
+): IssuerAuditPersistenceAdapter {
+  if (config.mode !== 'repository') {
+    return createPersistenceAdapter(
+      chooseIssuerAuditPersistenceAdapter(config),
+    );
+  }
+
+  if (config.enableRepositoryWrites === true) {
+    // Even when an operator opts in, this slice keeps persistence
+    // off because no real writer exists. Future ISSUER-9 (or
+    // similar) is responsible for wiring a client-safe RPC boundary
+    // and toggling the kind to `repository_enabled` for real.
+    const decision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'none',
+      unavailableReason: REPOSITORY_AUDIT_ADAPTER_UNAVAILABLE_REASON,
+      wiringDescription:
+        config.wiringDescription ??
+        'Backend Prisma repository (chai-vc-platform-backend) — bridge pending.',
+    });
+    return createPersistenceAdapter(decision);
+  }
+
+  return createPersistenceAdapter(
+    chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+      enableRepositoryWrites: false,
+      wiringDescription:
+        config.wiringDescription ??
+        'Backend Prisma repository (chai-vc-platform-backend) — type-safe candidate only.',
+    }),
+  );
+}
+
+/**
+ * Pure: a sentinel that returns the repository adapter's
+ * write-result shape without invoking any writer. Useful for the
+ * review surface to display "what would the result look like" without
+ * any side effect.
+ */
+export function previewRepositoryAdapterResult(
+  decision: IssuerPersistenceAdapterDecision,
+  record: IssuerAuditEventRecord,
+): RepositoryAuditAdapterResult {
+  void record;
+  const baseMode: IssuerAuditPersistenceMode = decision.resultMode;
+  return {
+    status: decision.kind === 'unavailable' ? 'unavailable' : 'demo_not_persisted',
+    mode: baseMode,
+    persisted: false,
+    message:
+      'Preview only. No repository writer was invoked; no row was persisted.',
+  };
+}

--- a/docs/architecture/vitalcv-knowledge-trust-graph.json
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.json
@@ -74,7 +74,13 @@
     "IssuerLifecycleReplay",
     "IssuerAuditCorrelation",
     "PayloadHash",
-    "ReplaySafeEvent"
+    "ReplaySafeEvent",
+    "IssuerAuditPersistenceAdapter",
+    "RepositoryAuditAdapter",
+    "PersistenceAdapterDecision",
+    "RepositoryCapability",
+    "PersistedAuditRecord",
+    "PersistenceConfiguration"
   ],
   "edges": [
     { "source": "Clinician", "relation": "HAS_NPI", "target": "NPI" },
@@ -153,6 +159,13 @@
     { "source": "IssuerAuditCorrelation", "relation": "GROUPS", "target": "IssuerRequestLifecycleEvent" },
     { "source": "IssuerAuditEventRecord", "relation": "HAS_MODE", "target": "IssuerAuditPersistenceMode" },
     { "source": "ReplaySafeEvent", "relation": "MAY_BE_INCLUDED_IN", "target": "IssuerLifecycleReplay" },
+    { "source": "IssuerAuditWriter", "relation": "MAY_USE", "target": "IssuerAuditPersistenceAdapter" },
+    { "source": "IssuerAuditPersistenceAdapter", "relation": "EVALUATES", "target": "RepositoryCapability" },
+    { "source": "RepositoryAuditAdapter", "relation": "MAY_WRITE", "target": "PersistedAuditRecord" },
+    { "source": "PersistenceAdapterDecision", "relation": "SELECTS", "target": "IssuerAuditPersistenceMode" },
+    { "source": "PersistedAuditRecord", "relation": "REQUIRES", "target": "WriterConfirmation" },
+    { "source": "PersistenceConfiguration", "relation": "DRIVES", "target": "PersistenceAdapterDecision" },
+    { "source": "IssuerAuditPersistenceAdapter", "relation": "EMITS", "target": "PersistenceAdapterDecision" },
     { "source": "IssuerResponse", "relation": "HAS_SOURCE_BASIS", "target": "SourceBasis" },
     { "source": "ContractedAgent", "relation": "ACTS_FOR", "target": "SourceOrIssuer" },
     { "source": "Start Outcome", "relation": "CLOSES_LOOP", "target": "Employer Review" }
@@ -223,7 +236,14 @@
     "Persistence requires a real writer's confirmation; demo and no-op writers cannot return persisted=true.",
     "No UI may claim an audit write occurred without a persisted persistence status from a repository or external writer.",
     "An audit event record never changes a claim's proof tier and never sets globalCredentialTruth=true.",
-    "PayloadHash is empty by default; it is fabricated only by a writer with cryptographic anchoring (future wave)."
+    "PayloadHash is empty by default; it is fabricated only by a writer with cryptographic anchoring (future wave).",
+    "Default persistence adapter is noop; active persistence is off unless explicitly turned on via configuration.",
+    "repository_candidate is not active persistence; it means a repository-shaped writer could be wired but is not yet.",
+    "Only repository_enabled may produce a persisted write status, and even then the actual write requires writer confirmation.",
+    "Adapter availability does not imply active persistence; a writer must invoke and confirm.",
+    "The frontend/web layer must not silently import a backend DB writer into the client bundle; a client-safe boundary is required first.",
+    "No UI may claim an audit trail exists without a persisted persistence status from a repository or external writer.",
+    "An adapter cannot upgrade proofTier or set globalCredentialTruth=true."
   ],
   "knownLimitations": [
     "Machine-readable stub is documentation-grade only, not integrated into runtime types."

--- a/docs/architecture/vitalcv-knowledge-trust-graph.md
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.md
@@ -71,6 +71,12 @@ The conceptual graph defining how truth moves through VitalCV.
 66. **Issuer Audit Correlation**: The grouping (correlationId + requestId + optional subjectId) that threads lifecycle events into a single replay.
 67. **Payload Hash**: Optional cryptographic anchoring for an audit event payload. Empty placeholder by default; only fabricated by a writer with anchoring support (future wave).
 68. **Replay-Safe Event**: An audit event record marked safe to include in a lifecycle replay. Replay-safe is context, not proof.
+69. **Issuer Audit Persistence Adapter**: The decision boundary that selects which writer kind (`noop` / `demo` / `repository_candidate` / `repository_enabled` / `unavailable`) to use for an audit event record. Default is `noop`.
+70. **Repository Audit Adapter**: A type-safe stub that describes what a repository-backed writer would persist. This slice does not import the existing backend repository — it documents the deferred bridge.
+71. **Persistence Adapter Decision**: The structured outcome of an adapter selection (kind, resultMode, reason, capabilities, optional wiring description).
+72. **Repository Capability**: A specific capability an adapter is designed to support — `write_audit_event`, `write_psv_receipt`, `replay_lifecycle`, `hash_payload`, `preserve_limitations`, `preserve_source_basis`, `preserve_responder_attribution`.
+73. **Persisted Audit Record**: An audit event record whose write was confirmed by a repository or external writer. Only `repository_enabled` adapters may produce one.
+74. **Persistence Configuration**: The caller-supplied input that drives the adapter decision. There are no environment lookups, no implicit feature flags — the operator must explicitly opt in to repository writes.
 
 
 ## Edges
@@ -150,6 +156,13 @@ The conceptual graph defining how truth moves through VitalCV.
 * `Issuer Audit Correlation` GROUPS `Issuer Request Lifecycle Event`
 * `Issuer Audit Event Record` HAS_MODE `Issuer Audit Persistence Mode`
 * `Replay-Safe Event` MAY_BE_INCLUDED_IN `Issuer Lifecycle Replay`
+* `Issuer Audit Writer` MAY_USE `Issuer Audit Persistence Adapter`
+* `Issuer Audit Persistence Adapter` EVALUATES `Repository Capability`
+* `Repository Audit Adapter` MAY_WRITE `Persisted Audit Record`
+* `Persistence Adapter Decision` SELECTS `Issuer Audit Persistence Mode`
+* `Persisted Audit Record` REQUIRES `Writer Confirmation`
+* `Persistence Configuration` DRIVES `Persistence Adapter Decision`
+* `Issuer Audit Persistence Adapter` EMITS `Persistence Adapter Decision`
 * `Contracted Agent` ACTS_FOR `Source`
 
 
@@ -201,4 +214,9 @@ The conceptual graph defining how truth moves through VitalCV.
 45. **Replay-Safe Is Not Legal Proof Boundary**: `replaySafe` means an event MAY be included in a timeline replay for context. It does NOT mean legal proof; the replay disclaimer makes this explicit.
 46. **No Fake Persistence Boundary**: Demo, no-op, and `none` writers cannot return `persisted: true`. The boundary helper enforces this at runtime regardless of what the writer claims.
 47. **Payload Hash Honesty Boundary**: `payloadHash` is an empty-string placeholder by default. A non-empty hash is fabricated only by a writer with cryptographic anchoring; this slice does not ship one.
+48. **Persistence Adapter Default Boundary**: The default adapter is `noop`. There are no environment lookups, no implicit feature flags — turning real persistence on requires explicit operator configuration.
+49. **Repository Candidate Boundary**: `repository_candidate` is NOT active persistence. It documents that a repository-shaped writer could be wired and provides type-safe payload mapping; it does not invoke a writer and cannot return `persisted: true`.
+50. **Operator Opt-In Boundary**: `enableRepositoryWrites: true` is necessary but not sufficient. Even with the operator flag set, this slice keeps the adapter `unavailable` until a client-safe writer is wired (a future wave).
+51. **No Backend Bundle Crossing Boundary**: The web layer must not import a backend DB writer (Prisma client) into the client bundle. The repository adapter stub documents the deferred bridge and refuses to import any backend module.
+52. **Adapter Cannot Upgrade Truth Tier Boundary**: An adapter never sets `decisionGrade=true`, never changes `proofTier`, and never sets `globalCredentialTruth=true`. The audit boundary's role is action-history persistence — clinical truth invariants live in ISSUER-2/3/4/5.
 


### PR DESCRIPTION
## Summary
- add issuer persistence adapter decision boundary (chooseIssuerAuditPersistenceAdapter, capabilities, decision payload, no-op default)
- add repository adapter stub (server-safe, no Prisma/HTTP/DB driver imports — type-safe payload mapping only; documents the deferred bridge to the existing backend repository)
- preserve no-op audit writer as the default; narrowly extend IssuerAuditWriteResult with optional adapterDecision metadata
- add persistence adapter review surface
- update Knowledge Trust Graph with adapter / capability / persisted-record / configuration concepts (6 nodes, 8 edges, 7 rules, boundaries 48-52)
- add 31 tests proving repository candidates do not equal persisted audit records

## Truth rules
- default adapter is noop
- repository_candidate is NOT persisted
- only repository_enabled may produce a persisted status, and even then a writer must confirm — this slice keeps the operator-opt-in path `unavailable` because no client-safe writer is wired
- adapter availability does not imply active persistence
- frontend/web layer does NOT import any backend DB writer into the client bundle
- adapter cannot upgrade proofTier or set globalCredentialTruth=true
- no audit trail claim without persisted status

## Validation
- graph JSON parses
- 256/256 issuer tests pass across 8 suites
- pnpm turbo run build --filter @vitalcv/web (13/13 tasks; /issuer/persistence-adapter/[requestId] in route manifest)
- banned-string sweep on diff lines: zero hits across all 14 banned phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)