### PR TITLE
feat(issuer): add backend persistence decision boundary

### DIFF
--- a/apps/web/__tests__/issuer-backend-persistence-decision.test.ts
+++ b/apps/web/__tests__/issuer-backend-persistence-decision.test.ts
@@ -1,0 +1,393 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  asAdapterDecisionMetadata,
+  assertBackendPersistenceSafe,
+  buildBackendPersistenceDeferDecision,
+  evaluateBackendPersistenceReadiness,
+  explainBackendPersistenceDecision,
+} from '../lib/issuer-verification/backendPersistenceDecision';
+import type {
+  BackendPersistenceCapabilityCheck,
+  BackendPersistenceReadinessInput,
+} from '../lib/issuer-verification/backendPersistenceDecision';
+import {
+  previewRepositoryAdapterResultWithDecision,
+} from '../lib/issuer-verification/repositoryAuditAdapter';
+import { chooseIssuerAuditPersistenceAdapter } from '../lib/issuer-verification/auditPersistenceAdapter';
+import { buildIssuerAuditEventRecord } from '../lib/issuer-verification/auditPersistence';
+
+const BANNED = [
+  ['audit', 'event', 'recorded'].join(' '),
+  ['logged', 'to', 'audit', 'trail'].join(' '),
+  ['production', 'audit', 'trail'].join(' '),
+  ['persisted', 'by', 'default'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+  ['irreversible', 'proof'].join(' '),
+  ['global', 'credential', 'truth'].join(' '),
+  ['tamper', 'proof'].join('-'),
+];
+
+const ALL_CAPS_TRUE: BackendPersistenceReadinessInput['capabilities'] = {
+  stores_scoped_psv_receipt: true,
+  preserves_limitation_notes: true,
+  preserves_source_basis: true,
+  preserves_responder_attribution: true,
+  preserves_freshness_and_scope: true,
+  distinguishes_candidate_vs_receipt: true,
+  supports_audit_event_persistence: true,
+  exposes_server_only_writer: true,
+  has_test_coverage: true,
+};
+
+function evaluate(
+  caps: BackendPersistenceReadinessInput['capabilities'] = {},
+) {
+  return evaluateBackendPersistenceReadiness({
+    decidedAt: '2026-04-26T00:00:00.000Z',
+    capabilities: caps,
+  });
+}
+
+describe('evaluateBackendPersistenceReadiness — defaults', () => {
+  it('default (no capabilities) returns defer_until_contract_aligned', () => {
+    const result = evaluate();
+    expect(result.decision.status).toBe('defer_until_contract_aligned');
+    expect(result.allCapabilitiesSatisfied).toBe(false);
+  });
+
+  it('default decision implies repository_candidate adapter, never repository_enabled', () => {
+    const result = evaluate();
+    expect(result.decision.impliedAdapterKind).toBe('repository_candidate');
+    expect(result.decision.impliedAdapterKind).not.toBe('repository_enabled');
+  });
+
+  it('default decision lists every capability as unsatisfied', () => {
+    const result = evaluate();
+    for (const check of result.decision.capabilityChecks) {
+      expect(check.satisfied).toBe(false);
+      expect(check.mappedBlocker).toBeDefined();
+    }
+    expect(result.decision.capabilityChecks.length).toBe(9);
+  });
+
+  it('default decision blockers cover every category cited by the contract audit', () => {
+    const result = evaluate();
+    expect(result.decision.blockers).toEqual(
+      expect.arrayContaining([
+        'contract_shape_mismatch',
+        'missing_limitations',
+        'missing_source_basis',
+        'missing_responder_attribution',
+        'missing_freshness_scope',
+        'no_writer_confirmation',
+        'client_server_boundary_violation',
+        'untested_repository',
+      ]),
+    );
+  });
+
+  it('buildBackendPersistenceDeferDecision returns defer status with the supplied reason', () => {
+    const decision = buildBackendPersistenceDeferDecision({
+      decidedAt: '2026-04-26T00:00:00.000Z',
+      reason: 'demo defer reason',
+    });
+    expect(decision.status).toBe('defer_until_contract_aligned');
+    expect(decision.reason).toBe('demo defer reason');
+  });
+});
+
+describe('evaluateBackendPersistenceReadiness — single-capability gates', () => {
+  it.each<{
+    capability: keyof NonNullable<BackendPersistenceReadinessInput['capabilities']>;
+    expectedBlocker: string;
+  }>([
+    {
+      capability: 'preserves_limitation_notes',
+      expectedBlocker: 'missing_limitations',
+    },
+    {
+      capability: 'preserves_source_basis',
+      expectedBlocker: 'missing_source_basis',
+    },
+    {
+      capability: 'preserves_responder_attribution',
+      expectedBlocker: 'missing_responder_attribution',
+    },
+    {
+      capability: 'preserves_freshness_and_scope',
+      expectedBlocker: 'missing_freshness_scope',
+    },
+    {
+      capability: 'supports_audit_event_persistence',
+      expectedBlocker: 'no_writer_confirmation',
+    },
+    {
+      capability: 'exposes_server_only_writer',
+      expectedBlocker: 'client_server_boundary_violation',
+    },
+    {
+      capability: 'has_test_coverage',
+      expectedBlocker: 'untested_repository',
+    },
+  ])(
+    'missing $capability surfaces blocker $expectedBlocker',
+    ({ capability, expectedBlocker }) => {
+      // Set every capability satisfied EXCEPT the one under test.
+      const caps: NonNullable<BackendPersistenceReadinessInput['capabilities']> = {
+        ...ALL_CAPS_TRUE,
+        [capability]: false,
+      };
+      const result = evaluate(caps);
+      expect(result.decision.status).not.toBe('implement_now');
+      expect(result.decision.blockers).toContain(expectedBlocker);
+    },
+  );
+
+  it('client/server boundary violation alone produces status=unsafe', () => {
+    const caps: NonNullable<BackendPersistenceReadinessInput['capabilities']> = {
+      ...ALL_CAPS_TRUE,
+      exposes_server_only_writer: false,
+    };
+    const result = evaluate(caps);
+    expect(result.decision.status).toBe('unsafe');
+  });
+
+  it('missing audit-event persistence (without boundary violation) routes to needs_backend_adapter', () => {
+    const caps: NonNullable<BackendPersistenceReadinessInput['capabilities']> = {
+      ...ALL_CAPS_TRUE,
+      supports_audit_event_persistence: false,
+    };
+    const result = evaluate(caps);
+    expect(result.decision.status).toBe('needs_backend_adapter');
+  });
+});
+
+describe('evaluateBackendPersistenceReadiness — implement_now path', () => {
+  it('with every capability satisfied returns implement_now', () => {
+    const result = evaluate(ALL_CAPS_TRUE);
+    expect(result.decision.status).toBe('implement_now');
+    expect(result.allCapabilitiesSatisfied).toBe(true);
+    expect(result.decision.impliedAdapterKind).toBe('repository_enabled');
+    expect(result.decision.blockers).toEqual([]);
+  });
+
+  it('implement_now recommendation still requires writer confirmation per row', () => {
+    const result = evaluate(ALL_CAPS_TRUE);
+    const text = result.decision.recommendation.summary.toLowerCase();
+    expect(text).toContain('writer confirmation');
+  });
+
+  it('reason override is preserved verbatim', () => {
+    const result = evaluateBackendPersistenceReadiness({
+      decidedAt: '2026-04-26T00:00:00.000Z',
+      capabilities: ALL_CAPS_TRUE,
+      reason: 'explicit reason from caller',
+    });
+    expect(result.decision.reason).toBe('explicit reason from caller');
+  });
+});
+
+describe('assertBackendPersistenceSafe', () => {
+  it('throws unless status is implement_now', () => {
+    const defer = evaluate().decision;
+    expect(() => assertBackendPersistenceSafe(defer)).toThrow(/implement_now/);
+  });
+
+  it('does not throw when status is implement_now', () => {
+    const ready = evaluate(ALL_CAPS_TRUE).decision;
+    expect(() => assertBackendPersistenceSafe(ready)).not.toThrow();
+  });
+});
+
+describe('explainBackendPersistenceDecision', () => {
+  it('includes status / blockers / recommendation summary', () => {
+    const decision = evaluate().decision;
+    const text = explainBackendPersistenceDecision(decision);
+    expect(text.toLowerCase()).toContain('defer_until_contract_aligned');
+    expect(text.toLowerCase()).toContain('contract_shape_mismatch');
+  });
+
+  it('does not contain banned phrases for any capability configuration', () => {
+    const decisions = [
+      evaluate().decision,
+      evaluate(ALL_CAPS_TRUE).decision,
+      evaluate({ ...ALL_CAPS_TRUE, exposes_server_only_writer: false }).decision,
+      evaluate({
+        ...ALL_CAPS_TRUE,
+        supports_audit_event_persistence: false,
+      }).decision,
+    ];
+    for (const decision of decisions) {
+      const text = explainBackendPersistenceDecision(decision).toLowerCase();
+      for (const phrase of BANNED) {
+        expect(text).not.toContain(phrase.toLowerCase());
+      }
+    }
+  });
+});
+
+describe('Decision purity — no I/O, no DB, no network', () => {
+  it('helper source contains no fetch/axios/prisma/db/AuditEvent/email/SMS/webhook tokens', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/backendPersistenceDecision.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const banned = [
+      'fetch(',
+      'axios',
+      'XMLHttpRequest',
+      'navigator.sendBeacon',
+      'prisma.',
+      'createMany',
+      'insertOne',
+      "import('@/",
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('helper does not statically import any backend module', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/backendPersistenceDecision.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(src).not.toMatch(/from ['"]apps\/api/);
+    expect(src).not.toMatch(/from ['"]@vitalcv\/psv['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*prisma_client['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*psvReceipts\.repo['"]/);
+  });
+});
+
+describe('Cannot upgrade truth tier', () => {
+  it('decision payload carries no decisionGrade / proofTier / globalCredentialTruth fields', () => {
+    const decision = evaluate(ALL_CAPS_TRUE).decision;
+    expect((decision as Record<string, unknown>).decisionGrade).toBeUndefined();
+    expect((decision as Record<string, unknown>).proofTier).toBeUndefined();
+    expect(
+      (decision as Record<string, unknown>).globalCredentialTruth,
+    ).toBeUndefined();
+  });
+
+  it('capability check items carry no truth-tier fields', () => {
+    const decision = evaluate().decision;
+    for (const check of decision.capabilityChecks) {
+      expect((check as Record<string, unknown>).decisionGrade).toBeUndefined();
+      expect((check as Record<string, unknown>).proofTier).toBeUndefined();
+      expect(
+        (check as Record<string, unknown>).globalCredentialTruth,
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe('asAdapterDecisionMetadata', () => {
+  it('defer decision maps to repository_candidate kind in adapter metadata', () => {
+    const meta = asAdapterDecisionMetadata(evaluate().decision);
+    expect(meta.kind).toBe('repository_candidate');
+    expect(meta.reason.toLowerCase()).toContain('defer_until_contract_aligned');
+  });
+
+  it('implement_now decision maps to repository_enabled kind', () => {
+    const meta = asAdapterDecisionMetadata(evaluate(ALL_CAPS_TRUE).decision);
+    expect(meta.kind).toBe('repository_enabled');
+    expect(meta.wiringDescription?.toLowerCase()).toContain(
+      'backend persistence enabled',
+    );
+  });
+
+  it('repository adapter preview surfaces the upstream defer summary verbatim', () => {
+    const decision = evaluate().decision;
+    const adapterDecision = chooseIssuerAuditPersistenceAdapter({
+      mode: 'repository',
+    });
+    const record = buildIssuerAuditEventRecord({
+      eventId: 'ev-1',
+      correlation: { correlationId: 'c-1', requestId: 'r-1' },
+      actor: {
+        actorId: 'a-1',
+        displayName: 'demo',
+        role: 'demo',
+      },
+      eventType: 'consent_recorded',
+      occurredAt: '2026-04-26T00:00:00.000Z',
+      source: 'attested',
+    });
+    const result = previewRepositoryAdapterResultWithDecision(
+      adapterDecision,
+      record,
+      {
+        status: decision.status,
+        blockers: [...decision.blockers],
+        reason: decision.recommendation.summary,
+      },
+    );
+    expect(result.persisted).toBe(false);
+    expect(result.message.toLowerCase()).toContain(
+      'defer_until_contract_aligned',
+    );
+    expect(result.message.toLowerCase()).toContain(
+      'contract_shape_mismatch',
+    );
+  });
+});
+
+describe('Knowledge Trust Graph — ISSUER-9 alignment', () => {
+  it('keeps the backend persistence nodes and rules parseable and aligned', async () => {
+    const raw = await import(
+      '../../../docs/architecture/vitalcv-knowledge-trust-graph.json'
+    );
+    const graph = raw.default ?? raw;
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        'BackendPersistenceDecision',
+        'BackendPersistenceCapabilityCheck',
+        'BackendPersistenceBlocker',
+        'ServerRepositoryAuditAdapter',
+        'WriterConfirmation',
+        'ContractAlignment',
+      ]),
+    );
+    expect(graph.rules).toEqual(
+      expect.arrayContaining([
+        "Backend repository compatibility is not persistence; only a writer's confirmation makes a record persisted.",
+        'Real backend persistence requires writer confirmation per row; absence of confirmation keeps the record at pending_not_written.',
+        'No client-side path may write audit records; the persistence boundary lives on the server.',
+        'Deferring backend persistence is safer than wiring a contract-misaligned writer; defer is the documented default.',
+        'Every BackendPersistenceCapabilityCheck must be satisfied before a BackendPersistenceDecision returns implement_now.',
+        'ServerRepositoryAuditAdapter exists only after contract alignment; this slice does not ship one.',
+      ]),
+    );
+  });
+});
+
+describe('Capability check shape', () => {
+  it('every default capability check carries notes and a mappedBlocker when unsatisfied', () => {
+    const decision = evaluate().decision;
+    for (const check of decision.capabilityChecks) {
+      expect(check.notes.length).toBeGreaterThan(0);
+      const ck = check as BackendPersistenceCapabilityCheck;
+      expect(ck.mappedBlocker).toBeDefined();
+    }
+  });
+
+  it('a satisfied capability check has no mappedBlocker', () => {
+    const decision = evaluate(ALL_CAPS_TRUE).decision;
+    for (const check of decision.capabilityChecks) {
+      expect(check.satisfied).toBe(true);
+      expect(check.mappedBlocker).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/app/issuer/backend-persistence/[requestId]/page.tsx
+++ b/apps/web/app/issuer/backend-persistence/[requestId]/page.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import {
+  buildBackendPersistenceDeferDecision,
+  evaluateBackendPersistenceReadiness,
+  explainBackendPersistenceDecision,
+} from '@/lib/issuer-verification/backendPersistenceDecision';
+import type {
+  BackendPersistenceCapabilityCheck,
+  BackendPersistenceDecision,
+} from '@/lib/issuer-verification/backendPersistenceDecision';
+
+/**
+ * ISSUER-9 — Backend persistence decision surface (demo render).
+ *
+ * The page renders both:
+ *   1. The default decision (no capabilities satisfied) — what
+ *      operators see today.
+ *   2. A hypothetical fully-satisfied decision — what the surface
+ *      WOULD show if every capability were proven.
+ *
+ * The page does not write anything, does not call any service, and
+ * does not claim a row was persisted.
+ */
+
+interface PageProps {
+  params: Promise<{ requestId: string }>;
+}
+
+export default async function BackendPersistencePage({ params }: PageProps) {
+  const { requestId } = await params;
+  const decidedAt = '2026-04-26T00:00:00.000Z';
+
+  const deferDecision = buildBackendPersistenceDeferDecision({
+    decidedAt,
+    reason:
+      'Default backend persistence readiness — no capabilities satisfied.',
+  });
+
+  const hypotheticalReady = evaluateBackendPersistenceReadiness({
+    decidedAt,
+    reason:
+      'Hypothetical: every backend persistence capability proven satisfied.',
+    capabilities: {
+      stores_scoped_psv_receipt: true,
+      preserves_limitation_notes: true,
+      preserves_source_basis: true,
+      preserves_responder_attribution: true,
+      preserves_freshness_and_scope: true,
+      distinguishes_candidate_vs_receipt: true,
+      supports_audit_event_persistence: true,
+      exposes_server_only_writer: true,
+      has_test_coverage: true,
+    },
+  }).decision;
+
+  function renderDecisionCard(
+    label: string,
+    decision: BackendPersistenceDecision,
+  ) {
+    return (
+      <section
+        className="rounded-2xl border border-border bg-card p-5 space-y-3"
+        aria-label={`Decision: ${label}`}
+        data-decision-label={label}
+        data-decision-status={decision.status}
+        data-implied-adapter-kind={decision.impliedAdapterKind}
+        data-blocker-count={String(decision.blockers.length)}
+      >
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            {label}
+          </p>
+          <p className="text-sm text-foreground">
+            status: {decision.status}; implied adapter kind:{' '}
+            {decision.impliedAdapterKind}
+          </p>
+          <p
+            className="text-xs text-muted-foreground italic"
+            data-testid={`decision-explanation-${label}`}
+          >
+            {explainBackendPersistenceDecision(decision)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Capability checks
+          </p>
+          <ul className="space-y-1" data-testid={`capability-checks-${label}`}>
+            {decision.capabilityChecks.map(
+              (check: BackendPersistenceCapabilityCheck) => (
+                <li
+                  key={check.capability}
+                  className="text-[11px] text-muted-foreground"
+                  data-capability={check.capability}
+                  data-capability-satisfied={String(check.satisfied)}
+                  data-mapped-blocker={check.mappedBlocker ?? ''}
+                >
+                  {check.satisfied ? '✓' : '·'} {check.capability}
+                  {!check.satisfied && check.mappedBlocker
+                    ? ` — blocker: ${check.mappedBlocker}`
+                    : ''}
+                </li>
+              ),
+            )}
+          </ul>
+        </div>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Blockers
+          </p>
+          {decision.blockers.length === 0 ? (
+            <p className="text-xs text-muted-foreground italic">
+              No blockers recorded for this decision.
+            </p>
+          ) : (
+            <ul className="text-xs text-muted-foreground space-y-1">
+              {decision.blockers.map((b) => (
+                <li key={b} data-blocker={b}>
+                  • {b}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Recommendation
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {decision.recommendation.summary}
+          </p>
+          <ol className="mt-1 text-[11px] text-muted-foreground/80 list-decimal pl-5 space-y-0.5">
+            {decision.recommendation.nextSteps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <main
+      className="min-h-screen bg-background"
+      data-testid="backend-persistence-page"
+      data-request-id={requestId}
+      data-default-decision-status={deferDecision.status}
+      data-hypothetical-decision-status={hypotheticalReady.status}
+    >
+      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
+        <header className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+            Backend persistence
+          </p>
+          <h1 className="text-xl font-semibold text-foreground">
+            Decision for request {requestId}
+          </h1>
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="backend-persistence-warning"
+          >
+            Backend persistence is not active unless a server-side writer
+            confirms the write. Repository compatibility alone is not an audit
+            trail.
+          </p>
+        </header>
+
+        {renderDecisionCard('default', deferDecision)}
+
+        {renderDecisionCard('hypothetical-ready', hypotheticalReady)}
+
+        <section className="text-[11px] text-muted-foreground/70">
+          <p data-testid="defer-memo-pointer">
+            See docs/architecture/vitalcv-backend-persistence-defer-decision.md for
+            the full defer rationale, adapter acceptance criteria, and the
+            next safe implementation wave.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/issuer-verification/backendPersistenceDecision.ts
+++ b/apps/web/lib/issuer-verification/backendPersistenceDecision.ts
@@ -1,0 +1,419 @@
+import type {
+  IssuerAuditPersistenceAdapterKind,
+  IssuerPersistenceAdapterDecision,
+} from './auditPersistenceAdapter';
+
+/**
+ * ISSUER-9 — Backend persistence decision boundary.
+ *
+ * This module evaluates whether the existing backend repository
+ * (apps/api/backend/repositories/psvReceipts.repo.ts) can safely
+ * persist issuer audit events / PSV receipt artifacts produced by
+ * the ISSUER-1..8 chain, and emits a structured decision.
+ *
+ * Truth contract:
+ *   - Default decision is `defer_until_contract_aligned`. Backend
+ *     repository compatibility is NOT persistence — even if the repo
+ *     accepts a row, that does not by itself constitute a persisted
+ *     audit record under VitalCV's truth contract.
+ *   - Real persistence requires (a) contract alignment, (b) a
+ *     server-only writer with no client-bundle crossing, and (c) the
+ *     writer to confirm each row.
+ *   - This module is a pure transform — no fetches, no DB writes,
+ *     no dynamic-import of backend modules, no real I/O.
+ *   - The decision NEVER returns `implement_now` unless every
+ *     required `BackendPersistenceCapabilityCheck` is satisfied.
+ *   - A decision artifact is action-history metadata about the
+ *     adapter wiring; it never changes any claim's `proofTier`,
+ *     `decisionGrade`, or `globalCredentialTruth`.
+ */
+
+export type BackendPersistenceDecisionStatus =
+  | 'implement_now'
+  | 'defer_until_contract_aligned'
+  | 'unavailable'
+  | 'unsafe'
+  | 'needs_backend_adapter';
+
+/**
+ * The discrete reasons backend persistence is blocked. A decision
+ * may carry multiple blockers; each maps to a concrete next-step.
+ */
+export type BackendPersistenceBlocker =
+  | 'contract_shape_mismatch'
+  | 'missing_limitations'
+  | 'missing_source_basis'
+  | 'missing_responder_attribution'
+  | 'missing_freshness_scope'
+  | 'no_writer_confirmation'
+  | 'client_server_boundary_violation'
+  | 'untested_repository'
+  | 'migration_required';
+
+/**
+ * One capability the backend repository must offer before persistence
+ * can be safely turned on. Each capability is checked independently.
+ */
+export interface BackendPersistenceCapabilityCheck {
+  capability:
+    | 'stores_scoped_psv_receipt'
+    | 'preserves_limitation_notes'
+    | 'preserves_source_basis'
+    | 'preserves_responder_attribution'
+    | 'preserves_freshness_and_scope'
+    | 'distinguishes_candidate_vs_receipt'
+    | 'supports_audit_event_persistence'
+    | 'exposes_server_only_writer'
+    | 'has_test_coverage';
+  satisfied: boolean;
+  notes: string;
+  /** When `satisfied: false`, the blocker the gap maps to. */
+  mappedBlocker?: BackendPersistenceBlocker;
+}
+
+/**
+ * Plain-language recommendation surfaced verbatim by the review
+ * page. Always neutral — never claims persistence is on.
+ */
+export interface BackendPersistenceRecommendation {
+  /** Plain-language summary, e.g., "Defer until contract alignment". */
+  summary: string;
+  /** Ordered list of next safe steps. */
+  nextSteps: ReadonlyArray<string>;
+}
+
+export interface BackendPersistenceDecision {
+  status: BackendPersistenceDecisionStatus;
+  /**
+   * The persistence adapter kind this decision implies for the
+   * audit boundary. Always `noop`/`demo`/`repository_candidate`/
+   * `unavailable` until status === 'implement_now'.
+   */
+  impliedAdapterKind: IssuerAuditPersistenceAdapterKind;
+  capabilityChecks: ReadonlyArray<BackendPersistenceCapabilityCheck>;
+  blockers: ReadonlyArray<BackendPersistenceBlocker>;
+  recommendation: BackendPersistenceRecommendation;
+  decidedAt: string;
+  /** Caller-controlled note: why this decision was emitted. */
+  reason: string;
+}
+
+/**
+ * Result of `evaluateBackendPersistenceReadiness` — the decision
+ * itself plus the structured input used to compute it. Useful for
+ * tests asserting the decision is deterministic over a config.
+ */
+export interface BackendPersistenceReadinessResult {
+  decision: BackendPersistenceDecision;
+  /** True iff every capability check is satisfied. */
+  allCapabilitiesSatisfied: boolean;
+}
+
+/**
+ * Caller-supplied evidence describing what the backend repo
+ * actually supports. The decision is computed entirely from this
+ * input — there are no environment lookups, no implicit feature
+ * flags, no I/O.
+ *
+ * Default: every capability is `satisfied: false`, modeling the
+ * baseline VitalCV state where the legacy backend repo predates
+ * the ISSUER-1..8 contract and has not been aligned.
+ */
+export interface BackendPersistenceReadinessInput {
+  decidedAt: string;
+  /**
+   * Per-capability satisfaction flags. Any capability not listed is
+   * treated as `false` — defaults are deliberately strict.
+   */
+  capabilities?: Partial<
+    Record<BackendPersistenceCapabilityCheck['capability'], boolean>
+  >;
+  /**
+   * Optional per-capability override notes (used by tests and the
+   * review surface). When omitted, a default note is supplied per
+   * capability.
+   */
+  notes?: Partial<
+    Record<BackendPersistenceCapabilityCheck['capability'], string>
+  >;
+  /**
+   * When set, drives the impliedAdapterKind explicitly (caller has
+   * already chosen an adapter). Otherwise the decision derives the
+   * kind from the capability flags.
+   */
+  impliedAdapterKind?: IssuerAuditPersistenceAdapterKind;
+  /**
+   * Caller-supplied reason for emitting the decision, surfaced
+   * verbatim by the review page. Defaults to a stock string.
+   */
+  reason?: string;
+}
+
+const CAPABILITY_TO_BLOCKER: Record<
+  BackendPersistenceCapabilityCheck['capability'],
+  BackendPersistenceBlocker
+> = {
+  stores_scoped_psv_receipt: 'contract_shape_mismatch',
+  preserves_limitation_notes: 'missing_limitations',
+  preserves_source_basis: 'missing_source_basis',
+  preserves_responder_attribution: 'missing_responder_attribution',
+  preserves_freshness_and_scope: 'missing_freshness_scope',
+  distinguishes_candidate_vs_receipt: 'contract_shape_mismatch',
+  supports_audit_event_persistence: 'no_writer_confirmation',
+  exposes_server_only_writer: 'client_server_boundary_violation',
+  has_test_coverage: 'untested_repository',
+};
+
+const CAPABILITY_DEFAULT_NOTES: Record<
+  BackendPersistenceCapabilityCheck['capability'],
+  string
+> = {
+  stores_scoped_psv_receipt:
+    'Backend repository (apps/api/backend/repositories/psvReceipts.repo.ts) stores the legacy PsvReceiptSnapshot shape, which is not the scoped PSVReceipt shape produced by ISSUER-4.',
+  preserves_limitation_notes:
+    'Backend row has no `limitations` array; ISSUER-4 PSVReceipt requires one.',
+  preserves_source_basis:
+    'Backend row has `source_authority` (a string enum) but no contracted-agent vs source distinction; ISSUER-2/3 require both.',
+  preserves_responder_attribution:
+    'Backend row has `attestor_id` but no AttributedResponder shape (name / role / attributedAt / attributionMethod).',
+  preserves_freshness_and_scope:
+    'Backend row has `ttl_seconds` but no scope object (covers / doesNotCover / sourceOrganizationName).',
+  distinguishes_candidate_vs_receipt:
+    'Backend repository stores PSV-receipt rows only; it does not distinguish PSVReceiptCandidate from a promoted PSVReceipt or carry the policy-review provenance.',
+  supports_audit_event_persistence:
+    'Backend repository does not model IssuerAuditEventRecord; there is no audit-event table or writer.',
+  exposes_server_only_writer:
+    'Importing the backend repository into apps/web would pull server-only Prisma into the client bundle. A client-safe RPC boundary or server action is required.',
+  has_test_coverage:
+    'No automated tests cover the backend repository in PR-time CI; persistence behavior is not verified.',
+};
+
+const RECOMMENDATION_BY_STATUS: Record<
+  BackendPersistenceDecisionStatus,
+  BackendPersistenceRecommendation
+> = {
+  implement_now: {
+    summary:
+      'All capability checks are satisfied. A server-only writer may be wired in this slice. Persistence still requires writer confirmation per row.',
+    nextSteps: [
+      'Wire a server-only writer that confirms each row.',
+      'Toggle the persistence adapter kind to repository_enabled.',
+      'Verify writer confirmation under tests before exposing to operators.',
+    ],
+  },
+  defer_until_contract_aligned: {
+    summary:
+      'Backend repository compatibility is not persistence. Defer until contract alignment is complete.',
+    nextSteps: [
+      'Align backend repository shape with ISSUER-2..5 PSVReceipt and ISSUER-7 audit-event types.',
+      'Add limitation, source basis, responder attribution, scope, and candidate-vs-receipt distinction to the persistence schema.',
+      'Add a server-only writer that confirms each row before reporting persisted status.',
+      'Add tests proving every truth-contract field round-trips.',
+      'Re-evaluate the decision once each capability check flips to satisfied.',
+    ],
+  },
+  unavailable: {
+    summary:
+      'No backend persistence adapter is wired in this environment. Persistence is unavailable.',
+    nextSteps: [
+      'Decide whether to add a server-only writer or to keep persistence as a deferred decision.',
+    ],
+  },
+  unsafe: {
+    summary:
+      'A backend persistence path was attempted but is unsafe under the truth contract. Persistence remains off.',
+    nextSteps: [
+      'Read the blocker list and address each one.',
+      'Do not turn on persistence until every blocker is resolved.',
+    ],
+  },
+  needs_backend_adapter: {
+    summary:
+      'A backend adapter implementation is required before persistence may be enabled.',
+    nextSteps: [
+      'Implement a server-only adapter that maps issuer artifacts to a contract-aligned schema.',
+      'Add tests for the adapter; confirm zero client-bundle imports.',
+      'Re-run readiness evaluation once the adapter exists.',
+    ],
+  },
+};
+
+function buildCapabilityCheck(
+  capability: BackendPersistenceCapabilityCheck['capability'],
+  satisfied: boolean,
+  note: string | undefined,
+): BackendPersistenceCapabilityCheck {
+  return {
+    capability,
+    satisfied,
+    notes: note ?? CAPABILITY_DEFAULT_NOTES[capability],
+    mappedBlocker: satisfied ? undefined : CAPABILITY_TO_BLOCKER[capability],
+  };
+}
+
+const ALL_CAPABILITIES: ReadonlyArray<BackendPersistenceCapabilityCheck['capability']> = [
+  'stores_scoped_psv_receipt',
+  'preserves_limitation_notes',
+  'preserves_source_basis',
+  'preserves_responder_attribution',
+  'preserves_freshness_and_scope',
+  'distinguishes_candidate_vs_receipt',
+  'supports_audit_event_persistence',
+  'exposes_server_only_writer',
+  'has_test_coverage',
+];
+
+function decideStatus(
+  allSatisfied: boolean,
+  blockers: ReadonlyArray<BackendPersistenceBlocker>,
+  satisfiedCount: number,
+  totalCount: number,
+): BackendPersistenceDecisionStatus {
+  if (allSatisfied) return 'implement_now';
+
+  // Escalation thresholds: the `unsafe` and `needs_backend_adapter`
+  // statuses describe an operator who has CLEARLY tried to enable
+  // persistence (most gates satisfied) but is blocked by a specific
+  // capability. With most gates still missing, the broad default is
+  // `defer_until_contract_aligned`.
+  const onlyOneMissing = satisfiedCount === totalCount - 1;
+  if (onlyOneMissing && blockers.includes('client_server_boundary_violation')) {
+    return 'unsafe';
+  }
+  if (onlyOneMissing && blockers.includes('no_writer_confirmation')) {
+    return 'needs_backend_adapter';
+  }
+  return 'defer_until_contract_aligned';
+}
+
+function impliedAdapterKindFor(
+  status: BackendPersistenceDecisionStatus,
+): IssuerAuditPersistenceAdapterKind {
+  switch (status) {
+    case 'implement_now':
+      return 'repository_enabled';
+    case 'defer_until_contract_aligned':
+      return 'repository_candidate';
+    case 'needs_backend_adapter':
+      return 'repository_candidate';
+    case 'unsafe':
+      return 'unavailable';
+    case 'unavailable':
+      return 'unavailable';
+    default:
+      return 'noop';
+  }
+}
+
+/**
+ * Pure: evaluate readiness from caller-supplied evidence. Default
+ * (every capability missing) returns `defer_until_contract_aligned`.
+ */
+export function evaluateBackendPersistenceReadiness(
+  input: BackendPersistenceReadinessInput,
+): BackendPersistenceReadinessResult {
+  const checks = ALL_CAPABILITIES.map((cap) =>
+    buildCapabilityCheck(
+      cap,
+      input.capabilities?.[cap] === true,
+      input.notes?.[cap],
+    ),
+  );
+  const allSatisfied = checks.every((c) => c.satisfied);
+  const blockers = checks
+    .filter((c) => !c.satisfied && c.mappedBlocker)
+    .map((c) => c.mappedBlocker as BackendPersistenceBlocker);
+  const dedupedBlockers = Array.from(new Set(blockers));
+  const satisfiedCount = checks.filter((c) => c.satisfied).length;
+  const status = decideStatus(
+    allSatisfied,
+    dedupedBlockers,
+    satisfiedCount,
+    checks.length,
+  );
+  const impliedAdapterKind =
+    input.impliedAdapterKind ?? impliedAdapterKindFor(status);
+  const recommendation = RECOMMENDATION_BY_STATUS[status];
+  const reason =
+    input.reason ??
+    (allSatisfied
+      ? 'All backend persistence capability checks pass.'
+      : 'Backend persistence is deferred pending contract alignment.');
+
+  return {
+    decision: {
+      status,
+      impliedAdapterKind,
+      capabilityChecks: checks,
+      blockers: dedupedBlockers,
+      recommendation,
+      decidedAt: input.decidedAt,
+      reason,
+    },
+    allCapabilitiesSatisfied: allSatisfied,
+  };
+}
+
+/**
+ * Pure: convenience builder for the canonical defer decision used
+ * by the review surface and the no-op adapter path.
+ */
+export function buildBackendPersistenceDeferDecision(input: {
+  decidedAt: string;
+  reason?: string;
+}): BackendPersistenceDecision {
+  return evaluateBackendPersistenceReadiness({
+    decidedAt: input.decidedAt,
+    reason: input.reason,
+  }).decision;
+}
+
+/**
+ * Plain-language explanation surfaced verbatim by the review surface.
+ */
+export function explainBackendPersistenceDecision(
+  decision: BackendPersistenceDecision,
+): string {
+  const blockerSummary =
+    decision.blockers.length === 0
+      ? '(no blockers)'
+      : decision.blockers.join(', ');
+  return (
+    `Status: ${decision.status}. Implied adapter kind: ${decision.impliedAdapterKind}. ` +
+    `Blockers: ${blockerSummary}. ${decision.recommendation.summary}`
+  );
+}
+
+/**
+ * Pure: defensive guard. Throws unless the decision says
+ * `implement_now`. Use at the point where a real persistence call
+ * would be made — so a buggy caller cannot bypass the gate.
+ */
+export function assertBackendPersistenceSafe(
+  decision: BackendPersistenceDecision,
+): void {
+  if (decision.status !== 'implement_now') {
+    throw new Error(
+      `assertBackendPersistenceSafe refused: backend persistence decision is ${decision.status}; only implement_now permits real writes.`,
+    );
+  }
+}
+
+/**
+ * Pure: surface the implied adapter decision metadata for the
+ * persistence-adapter boundary. Can be plugged into
+ * IssuerAuditWriteResult.adapterDecision so callers can show which
+ * decision drove the adapter wiring.
+ */
+export function asAdapterDecisionMetadata(
+  decision: BackendPersistenceDecision,
+): Pick<IssuerPersistenceAdapterDecision, 'kind' | 'reason' | 'wiringDescription'> {
+  return {
+    kind: decision.impliedAdapterKind,
+    reason: explainBackendPersistenceDecision(decision),
+    wiringDescription:
+      decision.status === 'implement_now'
+        ? 'Backend persistence enabled — server-only writer wired and confirmed by tests.'
+        : 'Backend persistence deferred — see backendPersistenceDecision blockers.',
+  };
+}

--- a/apps/web/lib/issuer-verification/repositoryAuditAdapter.ts
+++ b/apps/web/lib/issuer-verification/repositoryAuditAdapter.ts
@@ -213,3 +213,38 @@ export function previewRepositoryAdapterResult(
       'Preview only. No repository writer was invoked; no row was persisted.',
   };
 }
+
+/**
+ * ISSUER-9 — surface the upstream backend persistence decision.
+ *
+ * Callers from the persistence-adapter boundary may pass the
+ * `BackendPersistenceDecision` (built by
+ * `evaluateBackendPersistenceReadiness` in
+ * `backendPersistenceDecision.ts`) so the adapter can carry the
+ * deferred-bridge blockers verbatim in its message. The adapter
+ * NEVER returns `persisted: true` here regardless of the upstream
+ * decision — this helper only enriches the explanatory message.
+ */
+export interface RepositoryAdapterDecisionSummary {
+  status: string;
+  blockers: ReadonlyArray<string>;
+  reason: string;
+}
+
+export function previewRepositoryAdapterResultWithDecision(
+  decision: IssuerPersistenceAdapterDecision,
+  record: IssuerAuditEventRecord,
+  upstreamDecision: RepositoryAdapterDecisionSummary,
+): RepositoryAuditAdapterResult {
+  const base = previewRepositoryAdapterResult(decision, record);
+  const blockerSummary =
+    upstreamDecision.blockers.length === 0
+      ? '(no blockers)'
+      : upstreamDecision.blockers.join(', ');
+  return {
+    ...base,
+    message:
+      `${base.message} Upstream backend persistence decision: ${upstreamDecision.status}. ` +
+      `Blockers: ${blockerSummary}. ${upstreamDecision.reason}`,
+  };
+}

--- a/docs/architecture/vitalcv-backend-persistence-defer-decision.md
+++ b/docs/architecture/vitalcv-backend-persistence-defer-decision.md
@@ -1,0 +1,122 @@
+# VitalCV — Backend Persistence Defer Decision (ISSUER-9)
+
+**Decision**: `defer_until_contract_aligned`
+**Decided**: 2026-04-26 (during ISSUER-9 build)
+**Implied adapter kind**: `repository_candidate`
+**Outcome**: No real backend persistence is wired in this slice. The no-op audit writer remains the default. The persistence adapter for `apps/web` stays at `repository_candidate` until the conditions below are satisfied.
+
+This memo is the canonical source of truth for **why** VitalCV does not turn on backend persistence for issuer audit / PSV receipt artifacts in ISSUER-9, **what** must change first, and **how** to re-evaluate.
+
+---
+
+## Context
+
+The ISSUER-1..8 chain produces seven structured artifacts at the web layer (`apps/web/lib/issuer-verification/`):
+
+- `ReceiptCandidate` (ISSUER-2)
+- `PolicyReviewDecision` and `PSVReceiptCandidate` (ISSUER-3)
+- `PSVReceipt` with scope / limitations / freshness / `globalCredentialTruth: false` literal (ISSUER-4)
+- `PSVReceiptReuseDecision` with revocation / supersession state (ISSUER-5)
+- `IssuerRequestTimeline` and `IssuerRequestLifecycleEvent` (ISSUER-6)
+- `IssuerAuditEventRecord` and `IssuerLifecycleReplay` (ISSUER-7)
+- `IssuerAuditPersistenceAdapter` decision (ISSUER-8)
+
+The existing backend repository (`apps/api/backend/repositories/psvReceipts.repo.ts`) is Prisma-bound, lives in the `chai-vc-platform-backend` package, and predates the issuer-verification chain. It stores the legacy `PsvReceiptSnapshot` shape (snake_case `receipt_id`, `fetched_at`, `ttl_seconds`, `revoked`, `source_authority`, `attestor_id`, `verification_request_id`).
+
+ISSUER-9 was scoped to either implement or explicitly defer real backend persistence. After contract audit, **defer is the only safe path**.
+
+---
+
+## Why defer
+
+The backend repository contract is structurally incompatible with the issuer-verification truth contract. Each of these blockers is independently sufficient to defer; together they require either a major schema change or a parallel, contract-aligned schema.
+
+### 1. `contract_shape_mismatch`
+- Backend `PsvReceiptSnapshot` is a flat snake_case row keyed by `receipt_id`.
+- ISSUER-4 `PSVReceipt` is a nested camelCase object: `psvReceiptId`, `psvCandidateId`, `receiptCandidateId`, `requestId`, `claimId`, `claimType`, `promotedAt`, `promotedBy`, `sourceBasis`, `attributedResponder`, `scope`, `limitations`, `freshness`, `proofTier`, `decisionGrade`, `globalCredentialTruth`, `auditMetadata`.
+- The two shapes do not intersect on most fields. A blind row write would silently drop the truth-contract fields the issuer chain depends on.
+
+### 2. `missing_limitations`
+- Backend row has no `limitations` array. ISSUER-4 mandates an array of `PSVReceiptLimitation` (`legally_only`, `partial_confirmation`, `contracted_agent`, `access_required`, `jurisdictional_scope`, `other`).
+- A receipt without its limitations is structurally unsafe — e.g., a `legally_only` response stripped of its limitation could be misread as a full clinical confirmation.
+
+### 3. `missing_source_basis`
+- Backend row has `source_authority` (a string enum: `OIG_LEIE`, `STATE_BOARD`, etc.). ISSUER-2/3 require `SourceBasis` carrying both the source-of-record and any contracted-agent layer (`isContractedAgent`, `agentName`, `agentActsFor`).
+- Persisting only `source_authority` collapses the contracted-agent / source distinction. The truth contract forbids that collapse.
+
+### 4. `missing_responder_attribution`
+- Backend row has `attestor_id` (string). ISSUER-2 requires `AttributedResponder` (`name`, `role`, `attributedAt`, `attributionMethod`).
+- An `attestor_id` without the attribution method (`self_attested` / `directory_match` / `partner_assertion` / `unknown`) drops the load-bearing attribution-quality signal.
+
+### 5. `missing_freshness_scope`
+- Backend row has `ttl_seconds` (number). ISSUER-4 requires `FreshnessPolicy` (`ttlDays`, `issuedAt`, `staleAfter`) AND `PSVReceiptScope` (`claimType`, `covers`, `doesNotCover`, `sourceOrganizationName`).
+- A TTL without scope language cannot bound the credential claim the receipt supports.
+
+### 6. `no_writer_confirmation`
+- Backend repo has no audit-event table; there is no writer that confirms an `IssuerAuditEventRecord` was persisted. ISSUER-7's truth contract requires a writer to flip `persistenceStatus` to `'persisted'`.
+
+### 7. `client_server_boundary_violation`
+- Importing the backend repository into `apps/web/lib/issuer-verification/` would pull server-only Prisma into the web client bundle and break Next.js builds. ISSUER-8 closed this boundary explicitly and tests assert no static import of `apps/api/`, `@vitalcv/psv`, `prisma_client`, or `psvReceipts.repo`.
+- A client-safe RPC boundary (server action, REST endpoint, or RPC) is required first.
+
+### 8. `untested_repository`
+- The backend repository has no test coverage in PR-time CI. Persistence behavior — including the failure modes this defer memo cares about (idempotency, partial writes, error handling) — is not verified.
+
+### 9. `migration_required`
+- Aligning the backend schema requires adding columns/tables for: `limitations` (jsonb array), `source_basis` (jsonb), `attributed_responder` (jsonb), `scope` (jsonb), `freshness` (jsonb), candidate-vs-receipt distinction (column or separate table), and an audit-event table. This is a schema migration outside the scope of any single issuer wave.
+
+---
+
+## What re-enabling persistence requires
+
+Each of the following must be true before `evaluateBackendPersistenceReadiness` returns `implement_now`:
+
+1. **Schema alignment** — backend persistence has columns/tables matching the ISSUER-2..7 contracts (limitations, source basis, responder attribution, scope, freshness, audit events, candidate vs receipt).
+2. **Server-only writer** — `apps/web/lib/issuer-verification/serverRepositoryAuditAdapter.ts` exists, is server-only (Next.js server action or RPC route), confirms each row before reporting `persisted`, and is under test.
+3. **Client/server boundary tests** — automated proof that no backend module is imported into the client bundle.
+4. **Repository test coverage** — backend repository has tests asserting every truth-contract field round-trips and partial writes fail loud.
+5. **Operator opt-in** — the persistence adapter requires `enableRepositoryWrites: true` AND a separate operator-controlled flag before the adapter transitions to `repository_enabled`.
+
+When all five are true, set the corresponding `BackendPersistenceCapabilityCheck` flags to `satisfied: true` in the readiness input. The decision will flip to `implement_now`.
+
+---
+
+## Adapter acceptance criteria
+
+A future server-only adapter MUST satisfy:
+
+- ✅ Returns `persisted: true` only when a real row was written and confirmed by the underlying repository.
+- ✅ Carries the `IssuerAuditEventRecord` and `PSVReceipt` truth-contract fields verbatim (no field-dropping).
+- ✅ Refuses to run from client code (verified by build-time checks).
+- ✅ Reports `failed` with an error code when the repository rejects a row.
+- ✅ Surfaces the `BackendPersistenceDecision` artifact alongside the write result for audit-trail provenance.
+- ✅ Has tests covering: success path, failure path, partial-write rollback, double-write idempotency, schema-mismatch detection.
+
+---
+
+## Next safe implementation wave
+
+ISSUER-10 (or named follow-up) should:
+
+1. Open a parallel schema track that introduces the contract-aligned tables (`issuer_audit_event`, `psv_receipt_v2`, etc.) WITHOUT breaking the existing `psvReceipts.repo.ts`.
+2. Land a server-only writer module under `apps/api/backend/` (NOT `apps/web/`).
+3. Wire a Next.js server action or RPC under `apps/web/app/api/` that the persistence adapter can call from client code without crossing the bundle boundary.
+4. Add adapter tests proving:
+   - persisted=true only after writer confirmation
+   - all truth-contract fields preserved
+   - no client-bundle imports of backend modules
+5. Re-run `evaluateBackendPersistenceReadiness` with all capabilities `satisfied: true` and confirm the decision flips to `implement_now`.
+6. Toggle the persistence adapter from `repository_candidate` to `repository_enabled` — and only then.
+
+---
+
+## Status of this memo
+
+This memo is **authoritative documentation**. The defer decision is encoded in:
+
+- `apps/web/lib/issuer-verification/backendPersistenceDecision.ts` — runtime decision helpers.
+- `apps/web/__tests__/issuer-backend-persistence-decision.test.ts` — tests asserting the defer path is the default.
+- `apps/web/app/issuer/backend-persistence/[requestId]/page.tsx` — review surface that renders the decision.
+- `docs/architecture/vitalcv-knowledge-trust-graph.{md,json}` — graph nodes / edges / rules / boundaries.
+
+If a future change updates the runtime defaults, this memo MUST be updated in the same wave.

--- a/docs/architecture/vitalcv-knowledge-trust-graph.json
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.json
@@ -80,7 +80,13 @@
     "PersistenceAdapterDecision",
     "RepositoryCapability",
     "PersistedAuditRecord",
-    "PersistenceConfiguration"
+    "PersistenceConfiguration",
+    "BackendPersistenceDecision",
+    "BackendPersistenceCapabilityCheck",
+    "BackendPersistenceBlocker",
+    "ServerRepositoryAuditAdapter",
+    "WriterConfirmation",
+    "ContractAlignment"
   ],
   "edges": [
     { "source": "Clinician", "relation": "HAS_NPI", "target": "NPI" },
@@ -165,6 +171,13 @@
     { "source": "PersistenceAdapterDecision", "relation": "SELECTS", "target": "IssuerAuditPersistenceMode" },
     { "source": "PersistedAuditRecord", "relation": "REQUIRES", "target": "WriterConfirmation" },
     { "source": "PersistenceConfiguration", "relation": "DRIVES", "target": "PersistenceAdapterDecision" },
+    { "source": "BackendPersistenceDecision", "relation": "EVALUATES", "target": "RepositoryAuditAdapter" },
+    { "source": "RepositoryAuditAdapter", "relation": "REQUIRES", "target": "ContractAlignment" },
+    { "source": "WriterConfirmation", "relation": "REQUIRED_FOR", "target": "PersistedAuditRecord" },
+    { "source": "BackendPersistenceBlocker", "relation": "BLOCKS", "target": "PersistenceAdapterDecision" },
+    { "source": "BackendPersistenceCapabilityCheck", "relation": "GATES", "target": "BackendPersistenceDecision" },
+    { "source": "ServerRepositoryAuditAdapter", "relation": "MAY_PRODUCE", "target": "PersistedAuditRecord" },
+    { "source": "ContractAlignment", "relation": "PRECEDES", "target": "ServerRepositoryAuditAdapter" },
     { "source": "IssuerAuditPersistenceAdapter", "relation": "EMITS", "target": "PersistenceAdapterDecision" },
     { "source": "IssuerResponse", "relation": "HAS_SOURCE_BASIS", "target": "SourceBasis" },
     { "source": "ContractedAgent", "relation": "ACTS_FOR", "target": "SourceOrIssuer" },
@@ -243,7 +256,13 @@
     "Adapter availability does not imply active persistence; a writer must invoke and confirm.",
     "The frontend/web layer must not silently import a backend DB writer into the client bundle; a client-safe boundary is required first.",
     "No UI may claim an audit trail exists without a persisted persistence status from a repository or external writer.",
-    "An adapter cannot upgrade proofTier or set globalCredentialTruth=true."
+    "An adapter cannot upgrade proofTier or set globalCredentialTruth=true.",
+    "Backend repository compatibility is not persistence; only a writer's confirmation makes a record persisted.",
+    "Real backend persistence requires writer confirmation per row; absence of confirmation keeps the record at pending_not_written.",
+    "No client-side path may write audit records; the persistence boundary lives on the server.",
+    "Deferring backend persistence is safer than wiring a contract-misaligned writer; defer is the documented default.",
+    "Every BackendPersistenceCapabilityCheck must be satisfied before a BackendPersistenceDecision returns implement_now.",
+    "ServerRepositoryAuditAdapter exists only after contract alignment; this slice does not ship one."
   ],
   "knownLimitations": [
     "Machine-readable stub is documentation-grade only, not integrated into runtime types."

--- a/docs/architecture/vitalcv-knowledge-trust-graph.md
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.md
@@ -77,6 +77,12 @@ The conceptual graph defining how truth moves through VitalCV.
 72. **Repository Capability**: A specific capability an adapter is designed to support — `write_audit_event`, `write_psv_receipt`, `replay_lifecycle`, `hash_payload`, `preserve_limitations`, `preserve_source_basis`, `preserve_responder_attribution`.
 73. **Persisted Audit Record**: An audit event record whose write was confirmed by a repository or external writer. Only `repository_enabled` adapters may produce one.
 74. **Persistence Configuration**: The caller-supplied input that drives the adapter decision. There are no environment lookups, no implicit feature flags — the operator must explicitly opt in to repository writes.
+75. **Backend Persistence Decision**: The structured outcome of `evaluateBackendPersistenceReadiness` — status (implement_now / defer_until_contract_aligned / unavailable / unsafe / needs_backend_adapter), implied adapter kind, capability checks, blockers, recommendation. Default is defer.
+76. **Backend Persistence Capability Check**: A single capability the backend repository must offer before persistence is enabled (stores scoped PSV receipt, preserves limitation notes / source basis / responder attribution / freshness scope, distinguishes candidate vs receipt, supports audit event persistence, exposes server-only writer, has test coverage).
+77. **Backend Persistence Blocker**: A discrete reason persistence is blocked (contract shape mismatch, missing limitations / source basis / responder attribution / freshness scope, no writer confirmation, client/server boundary violation, untested repository, migration required).
+78. **Server Repository Audit Adapter**: A future server-only writer that confirms each row. Does NOT exist in this slice; named in the graph so the deferred bridge has a target.
+79. **Writer Confirmation**: The signal a writer emits when a real row was persisted. Required before any record's `persistenceStatus` may be `'persisted'`.
+80. **Contract Alignment**: The shape-compatibility precondition between the legacy backend repository and the issuer-verification truth contract. Must be satisfied before a server adapter may be wired.
 
 
 ## Edges
@@ -162,6 +168,13 @@ The conceptual graph defining how truth moves through VitalCV.
 * `Persistence Adapter Decision` SELECTS `Issuer Audit Persistence Mode`
 * `Persisted Audit Record` REQUIRES `Writer Confirmation`
 * `Persistence Configuration` DRIVES `Persistence Adapter Decision`
+* `Backend Persistence Decision` EVALUATES `Repository Audit Adapter`
+* `Repository Audit Adapter` REQUIRES `Contract Alignment`
+* `Writer Confirmation` REQUIRED_FOR `Persisted Audit Record`
+* `Backend Persistence Blocker` BLOCKS `Persistence Adapter Decision`
+* `Backend Persistence Capability Check` GATES `Backend Persistence Decision`
+* `Server Repository Audit Adapter` MAY_PRODUCE `Persisted Audit Record`
+* `Contract Alignment` PRECEDES `Server Repository Audit Adapter`
 * `Issuer Audit Persistence Adapter` EMITS `Persistence Adapter Decision`
 * `Contracted Agent` ACTS_FOR `Source`
 
@@ -219,4 +232,8 @@ The conceptual graph defining how truth moves through VitalCV.
 50. **Operator Opt-In Boundary**: `enableRepositoryWrites: true` is necessary but not sufficient. Even with the operator flag set, this slice keeps the adapter `unavailable` until a client-safe writer is wired (a future wave).
 51. **No Backend Bundle Crossing Boundary**: The web layer must not import a backend DB writer (Prisma client) into the client bundle. The repository adapter stub documents the deferred bridge and refuses to import any backend module.
 52. **Adapter Cannot Upgrade Truth Tier Boundary**: An adapter never sets `decisionGrade=true`, never changes `proofTier`, and never sets `globalCredentialTruth=true`. The audit boundary's role is action-history persistence — clinical truth invariants live in ISSUER-2/3/4/5.
+53. **Backend Compatibility Is Not Persistence Boundary**: Whether the backend repository can structurally accept a row is independent of whether VitalCV persisted one. Only a writer's confirmation makes a record persisted.
+54. **Defer Is The Default Boundary**: `evaluateBackendPersistenceReadiness` returns `defer_until_contract_aligned` by default. Every capability check must be explicitly satisfied before the decision flips to `implement_now`.
+55. **Server-Only Writer Boundary**: No client-side path may write audit records. A writer is server-only by construction; client code may invoke it only through a Next.js server action / RPC route, never via direct repository import.
+56. **Capability-Gated Implementation Boundary**: The nine `BackendPersistenceCapabilityCheck` capabilities are independent gates. A blocker on any one of them prevents `implement_now`, regardless of how many others are satisfied.
 


### PR DESCRIPTION
## Summary
- add `backendPersistenceDecision.ts` with `evaluateBackendPersistenceReadiness`, capability checks, blockers, and `assertBackendPersistenceSafe` guard
- defer real backend persistence: contract audit shows 9 blockers (shape mismatch, missing limitations / source basis / responder attribution / freshness scope, no writer confirmation, client/server boundary violation, untested repository, migration required)
- ship the defer memo at `docs/architecture/vitalcv-backend-persistence-defer-decision.md` with adapter acceptance criteria and the next safe implementation wave
- add `/issuer/backend-persistence/[requestId]` review surface (default-defer + hypothetical-ready decisions side-by-side)
- update Knowledge Trust Graph with 6 new nodes, 7 new edges, 6 new rules, boundaries 53-56
- add 31 tests proving defer is the default and that real persistence requires writer confirmation

## Truth rules
- backend repository compatibility is not persistence
- persisted status requires writer confirmation
- no client-side path may write audit records
- deferred decision is safer than fake persistence
- nine independent capability checks gate `implement_now`

## Validation
- graph JSON parses
- 287/287 issuer tests pass across 9 suites
- `pnpm turbo run build --filter @vitalcv/web` (13/13 tasks; `/issuer/backend-persistence/[requestId]` in route manifest)
- banned-string sweep on diff lines: zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)