### PR TITLE
feat(psv): align domain receipt contract with issuer trust model

### DIFF
--- a/apps/api/backend/repositories/psvReceipts.repo.ts
+++ b/apps/api/backend/repositories/psvReceipts.repo.ts
@@ -1,3 +1,34 @@
+// BACKEND-1 boundary note (2026-04-26):
+//
+// This repository does not yet persist the full issuer PSVReceipt
+// contract.
+//
+// The rows written here are the LEGACY `PSVReceiptSnapshot` shape
+// (receipt_id / source_authority / access_or_license_id /
+// transaction_id / fetched_at / response_hash / ttl_seconds /
+// revoked, plus optional lane / verification_check /
+// verification_outcome / failure_reason / source / attestor_id /
+// verification_request_id). They do NOT carry the issuer
+// trust-contract fields:
+//   - limitations[] (ISSUER-2/4)
+//   - sourceBasis with contracted-agent vs source distinction (ISSUER-2)
+//   - attributedResponder with attributionMethod (ISSUER-2)
+//   - scope (covers / doesNotCover / sourceOrganizationName) (ISSUER-4)
+//   - freshness (ttlDays / issuedAt / staleAfter) (ISSUER-4)
+//   - candidate-vs-receipt distinction (ISSUER-3/4)
+//   - writerConfirmation as the persistence gate (ISSUER-7/8)
+//
+// Persistence here MUST NOT be interpreted as a persisted issuer
+// PSVReceipt under the truth contract — see
+// docs/architecture/vitalcv-backend-persistence-defer-decision.md and
+// packages/domain-core/psvReceiptMapping.ts (mapLegacySnapshotToDomainReceipt
+// always emits a `legacy_snapshot_only` contract gap).
+//
+// A future wave is required to (a) add a contract-aligned schema, and
+// (b) add a server-only writer that confirms each row before reporting
+// persisted status. This file remains untouched in BACKEND-1 except
+// for this header.
+
 import {
   PSVReceipt,
   type AppendReceiptInput,

--- a/docs/architecture/vitalcv-backend-persistence-defer-decision.md
+++ b/docs/architecture/vitalcv-backend-persistence-defer-decision.md
@@ -120,3 +120,42 @@ This memo is **authoritative documentation**. The defer decision is encoded in:
 - `docs/architecture/vitalcv-knowledge-trust-graph.{md,json}` — graph nodes / edges / rules / boundaries.
 
 If a future change updates the runtime defaults, this memo MUST be updated in the same wave.
+
+---
+
+## BACKEND-1 status update (2026-04-26)
+
+### What is now satisfied
+
+- **Domain contract aligned at the type level.** `packages/domain-core/psvReceipts.ts` adds (additively, alongside the legacy `PsvReceiptSnapshot`):
+  - `DomainPsvReceipt` with required `scope`, `limitations`, `sourceBasis`, `responderAttribution`, `freshness`, optional `candidateReference`, optional `writerConfirmation`.
+  - `DomainPsvReceiptStatus` (`pending_not_persisted` / `candidate` / `persisted` / `failed_persistence` / `unavailable`).
+  - `DomainPsvReceiptWriterConfirmation` with `writerMode` constrained to `'repository' | 'external'`.
+  - `DomainPsvReceiptContractGap` with 10 explicit gap kinds.
+- **Mapper and validator land in `packages/domain-core/psvReceiptMapping.ts`.** `mapIssuerPsvReceiptToDomainReceipt` maps an issuer-shape PSVReceipt without fabricating fields — every missing field surfaces a contract gap. `validateDomainPsvReceiptContract` emits gaps independently of the mapper. `mapLegacySnapshotToDomainReceipt` always emits a `legacy_snapshot_only` gap so the legacy backend snapshot cannot be silently treated as a full domain receipt.
+- **Persisted status is gated.** A domain receipt can carry `status: 'persisted'` ONLY when (a) every required field is present AND (b) a `writerConfirmation` with `writerMode in {repository, external}` is supplied. Any structural gap blocks persisted; an invalid writer mode blocks persisted.
+- **Frozen tests pin the contract.** `packages/domain-common/__tests__/psvReceipt.frozen.test.ts` adds tests asserting: missing limitations / sourceBasis / responderAttribution / freshness / scope each produce a gap; mapper does not fabricate missing fields; writer confirmation gates persisted; legacy snapshot is not a full receipt; `globalCredentialTruth` is dropped if upstream supplies it; `proofTier` and `decisionGrade` are not present on the domain receipt.
+- **Backend repository carries an honesty header.** `apps/api/backend/repositories/psvReceipts.repo.ts` now opens with a comment block stating that the rows it persists are the legacy snapshot shape and MUST NOT be interpreted as a persisted issuer PSVReceipt under the truth contract. No behavioral change.
+
+### What remains blocked
+
+- **`stores_scoped_psv_receipt`** — the Prisma schema still stores `PsvReceiptSnapshot`; a contract-aligned schema does not exist yet.
+- **`distinguishes_candidate_vs_receipt`** — the Prisma schema does not yet model `PSVReceiptCandidate` separately from a promoted `PSVReceipt`.
+- **`supports_audit_event_persistence`** — there is no `issuer_audit_event` table or writer.
+- **`exposes_server_only_writer`** — no client-safe RPC / server action exists; the persistence boundary still lives across the apps/api ↔ apps/web crossing.
+- **`has_test_coverage`** for the legacy backend repository — the existing repo's behavior is still untested in PR-time CI.
+
+### Acceptance criteria for a real backend writer
+
+A future server-only writer MUST:
+
+1. Accept a `DomainPsvReceipt` (the BACKEND-1 type) plus an internally-generated `writerConfirmation`.
+2. Refuse to write if `validateDomainPsvReceiptContract` returns any gaps.
+3. Map the domain receipt onto a contract-aligned schema (new tables / columns; no overloading the legacy `psvReceipt` row).
+4. Return `persisted: true` only after the underlying repository confirms the row.
+5. Live behind a Next.js server action / RPC route in `apps/web/app/api/...`; `apps/web/lib/issuer-verification/` MUST NOT import the writer directly.
+6. Have tests covering: success path, structural-gap refusal, writer-mode invalidation, partial-write failure, double-write idempotency, no-client-bundle-import.
+
+### Decision still in force
+
+The runtime decision returned by `evaluateBackendPersistenceReadiness` defaults to `defer_until_contract_aligned`. BACKEND-1 closes the **type-level** contract gap; it does not close the **schema-level** or **writer-level** gaps. Real persistence remains off in production code paths.

--- a/packages/domain-common/__tests__/psvReceipt.frozen.test.ts
+++ b/packages/domain-common/__tests__/psvReceipt.frozen.test.ts
@@ -401,3 +401,264 @@ describe('FROZEN: PSVReceipt required fields', () => {
     expect(baseReceipt().hashAnchor).toBeTruthy();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// BACKEND-1 — Domain PSV Receipt contract alignment frozen tests.
+//
+// These tests pin the domain-core mapper / validator behavior. They
+// do NOT exercise the live backend repository; the backend remains
+// untouched in this slice. See
+// docs/architecture/vitalcv-backend-persistence-defer-decision.md.
+// ─────────────────────────────────────────────────────────────────────
+
+// Use a relative path because @vitalcv/domain-common does not list
+// @vitalcv/domain-core in its package.json deps; relative imports
+// work in workspace tests without changing lockfiles.
+import {
+  mapIssuerPsvReceiptToDomainReceipt,
+  mapLegacySnapshotToDomainReceipt,
+  validateDomainPsvReceiptContract,
+  explainDomainPsvReceiptContractGap,
+  type IssuerPsvReceiptShape,
+  type DomainPsvReceipt,
+  type DomainPsvReceiptWriterConfirmation,
+  type PsvReceiptSnapshot,
+} from '../../domain-core';
+
+function fullIssuerInput(): IssuerPsvReceiptShape {
+  return {
+    psvReceiptId: 'psv-receipt-1',
+    psvCandidateId: 'psv-cand-1',
+    receiptCandidateId: 'rc-1',
+    requestId: 'req-1',
+    claimId: 'claim-1',
+    claimType: 'residency',
+    scope: {
+      claimType: 'residency',
+      covers: 'Internal Medicine residency 2018-2021.',
+      doesNotCover:
+        'Does not cover board certification, license status, or malpractice history.',
+      sourceOrganizationName: 'Demo GME Office',
+    },
+    limitations: [],
+    sourceBasis: {
+      sourceOrganizationName: 'Demo GME Office',
+      isContractedAgent: false,
+    },
+    attributedResponder: {
+      name: 'J. Doe',
+      role: 'Program Coordinator',
+      attributedAt: '2026-04-26T01:00:00.000Z',
+      attributionMethod: 'self_attested',
+    },
+    freshness: {
+      ttlDays: 365,
+      issuedAt: '2026-04-26T01:00:00.000Z',
+      staleAfter: '2027-04-26T01:00:00.000Z',
+    },
+  };
+}
+
+function repoConfirmation(): DomainPsvReceiptWriterConfirmation {
+  return {
+    confirmedAt: '2026-04-26T02:00:00.000Z',
+    confirmedBy: 'demo-writer',
+    writerMode: 'repository',
+    persistedRowId: 'row-1',
+  };
+}
+
+describe('BACKEND-1 mapper — required fields surface contract gaps when missing', () => {
+  it('missing limitations produces a missing_limitations gap', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      limitations: undefined,
+    };
+    const { gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(gaps.map((g) => g.kind)).toContain('missing_limitations');
+  });
+
+  it('missing sourceBasis produces a missing_source_basis gap', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      sourceBasis: undefined,
+    };
+    const { gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(gaps.map((g) => g.kind)).toContain('missing_source_basis');
+  });
+
+  it('missing attributedResponder produces a missing_responder_attribution gap', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      attributedResponder: undefined,
+    };
+    const { gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(gaps.map((g) => g.kind)).toContain('missing_responder_attribution');
+  });
+
+  it('missing freshness produces a missing_freshness gap', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      freshness: undefined,
+    };
+    const { gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(gaps.map((g) => g.kind)).toContain('missing_freshness');
+  });
+
+  it('missing scope produces a missing_scope gap', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      scope: undefined,
+    };
+    const { gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(gaps.map((g) => g.kind)).toContain('missing_scope');
+  });
+});
+
+describe('BACKEND-1 mapper — writer confirmation gates persisted status', () => {
+  it('without writerConfirmation, the result is candidate (when candidate refs exist)', () => {
+    const result = mapIssuerPsvReceiptToDomainReceipt(fullIssuerInput());
+    expect(result.contractAligned).toBe(true);
+    expect(result.receipt.status).toBe('candidate');
+  });
+
+  it('with valid repository writerConfirmation AND no gaps, the result is persisted', () => {
+    const result = mapIssuerPsvReceiptToDomainReceipt(fullIssuerInput(), {
+      writerConfirmation: repoConfirmation(),
+    });
+    expect(result.receipt.status).toBe('persisted');
+    expect(result.receipt.writerConfirmation).toEqual(repoConfirmation());
+  });
+
+  it('with writerConfirmation BUT structural gaps, refuses to mark persisted', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      sourceBasis: undefined,
+    };
+    const result = mapIssuerPsvReceiptToDomainReceipt(input, {
+      writerConfirmation: repoConfirmation(),
+    });
+    expect(result.receipt.status).not.toBe('persisted');
+    expect(result.gaps.map((g) => g.kind)).toContain('missing_source_basis');
+  });
+
+  it('writerConfirmation with invalid writerMode is rejected', () => {
+    const result = mapIssuerPsvReceiptToDomainReceipt(fullIssuerInput(), {
+      writerConfirmation: {
+        ...repoConfirmation(),
+        writerMode: 'demo' as unknown as 'repository',
+      },
+    });
+    expect(result.receipt.status).not.toBe('persisted');
+    expect(result.gaps.map((g) => g.kind)).toContain('invalid_writer_mode');
+  });
+});
+
+describe('BACKEND-1 mapper — does not fabricate missing fields', () => {
+  it('missing limitations: receipt.limitations stays undefined (no synthesized empty array)', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      limitations: undefined,
+    };
+    const { receipt } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(receipt.limitations).toBeUndefined();
+  });
+
+  it('missing sourceBasis: receipt.sourceBasis stays undefined', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      sourceBasis: undefined,
+    };
+    const { receipt } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(receipt.sourceBasis).toBeUndefined();
+  });
+
+  it('missing attributedResponder: receipt.responderAttribution stays undefined', () => {
+    const input: IssuerPsvReceiptShape = {
+      ...fullIssuerInput(),
+      attributedResponder: undefined,
+    };
+    const { receipt } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect(receipt.responderAttribution).toBeUndefined();
+  });
+});
+
+describe('BACKEND-1 mapper — does not introduce globalCredentialTruth', () => {
+  it('upstream globalCredentialTruth is dropped and a gap is emitted', () => {
+    const input = {
+      ...fullIssuerInput(),
+      globalCredentialTruth: false,
+    } as IssuerPsvReceiptShape;
+    const { receipt, gaps } = mapIssuerPsvReceiptToDomainReceipt(input);
+    expect((receipt as Record<string, unknown>).globalCredentialTruth).toBeUndefined();
+    expect(gaps.map((g) => g.kind)).toContain(
+      'forbidden_global_credential_truth_field',
+    );
+  });
+
+  it('DomainPsvReceipt type carries no proofTier or decisionGrade fields', () => {
+    const result = mapIssuerPsvReceiptToDomainReceipt(fullIssuerInput(), {
+      writerConfirmation: repoConfirmation(),
+    });
+    const receipt = result.receipt as Record<string, unknown>;
+    expect(receipt.proofTier).toBeUndefined();
+    expect(receipt.decisionGrade).toBeUndefined();
+    expect(receipt.globalCredentialTruth).toBeUndefined();
+  });
+});
+
+describe('BACKEND-1 mapper — legacy PsvReceiptSnapshot is not a full PSVReceipt', () => {
+  it('mapLegacySnapshotToDomainReceipt always emits legacy_snapshot_only gap', () => {
+    const snapshot: PsvReceiptSnapshot = {
+      receiptId: 'legacy-1',
+      fetchedAt: '2026-04-01T00:00:00.000Z',
+      ttlSeconds: 365 * 24 * 60 * 60,
+      revoked: false,
+    };
+    const { gaps, contractAligned } = mapLegacySnapshotToDomainReceipt(snapshot);
+    expect(contractAligned).toBe(false);
+    expect(gaps.map((g) => g.kind)).toContain('legacy_snapshot_only');
+    expect(gaps.map((g) => g.kind)).toContain('missing_limitations');
+    expect(gaps.map((g) => g.kind)).toContain('missing_source_basis');
+    expect(gaps.map((g) => g.kind)).toContain('missing_responder_attribution');
+    expect(gaps.map((g) => g.kind)).toContain('missing_scope');
+  });
+
+  it('legacy snapshot result is pending_not_persisted regardless of writer claim', () => {
+    const snapshot: PsvReceiptSnapshot = {
+      receiptId: 'legacy-1',
+      fetchedAt: '2026-04-01T00:00:00.000Z',
+      ttlSeconds: 100,
+      revoked: false,
+    };
+    const { receipt } = mapLegacySnapshotToDomainReceipt(snapshot);
+    expect(receipt.status).toBe('pending_not_persisted');
+    expect(receipt.writerConfirmation).toBeUndefined();
+  });
+});
+
+describe('BACKEND-1 validator', () => {
+  it('flags missing fields on a persisted receipt', () => {
+    const partial: DomainPsvReceipt = Object.freeze({
+      receiptId: 'r-1',
+      status: 'persisted',
+    });
+    const gaps = validateDomainPsvReceiptContract(partial);
+    const kinds = gaps.map((g) => g.kind);
+    expect(kinds).toContain('missing_scope');
+    expect(kinds).toContain('missing_limitations');
+    expect(kinds).toContain('missing_source_basis');
+    expect(kinds).toContain('missing_responder_attribution');
+    expect(kinds).toContain('missing_freshness');
+    expect(kinds).toContain('missing_writer_confirmation_for_persisted');
+  });
+
+  it('explainDomainPsvReceiptContractGap returns a non-empty string', () => {
+    const text = explainDomainPsvReceiptContractGap({
+      kind: 'missing_limitations',
+      field: 'limitations',
+      message: 'demo',
+    });
+    expect(text.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/domain-core/index.ts
+++ b/packages/domain-core/index.ts
@@ -13,7 +13,30 @@ export {
   type PsvReceiptSnapshot,
   type ValidReceiptSet,
   validateReceiptSet,
+  // BACKEND-1 — domain PSV receipt contract alignment
+  type DomainPsvReceipt,
+  type DomainPsvReceiptStatus,
+  type DomainPsvReceiptLimitationKind,
+  type DomainPsvReceiptLimitation,
+  type DomainPsvReceiptScope,
+  type DomainPsvReceiptFreshness,
+  type DomainPsvReceiptSourceBasis,
+  type DomainPsvReceiptResponderAttribution,
+  type DomainPsvReceiptCandidateReference,
+  type DomainPsvReceiptWriterConfirmation,
+  type DomainPsvReceiptContractGap,
+  type DomainPsvReceiptContractGapKind,
 } from './psvReceipts';
+
+export {
+  type IssuerPsvReceiptShape,
+  type MapIssuerToDomainOptions,
+  type MapIssuerToDomainResult,
+  mapIssuerPsvReceiptToDomainReceipt,
+  mapLegacySnapshotToDomainReceipt,
+  validateDomainPsvReceiptContract,
+  explainDomainPsvReceiptContractGap,
+} from './psvReceiptMapping';
 
 export {
   START_READY_CRS_THRESHOLD,

--- a/packages/domain-core/psvReceiptMapping.ts
+++ b/packages/domain-core/psvReceiptMapping.ts
@@ -165,28 +165,30 @@ function pickLimitations(
     );
     return undefined;
   }
-  return Object.freeze(
-    input.limitations.map((l) => {
-      if (!l.kind || !l.description) {
-        // Surface the gap but do not fabricate values.
-        gaps.push(
-          gap(
-            'missing_limitations',
-            'limitations[].kind|description',
-            'Each limitation entry requires both `kind` and `description`.',
-          ),
-        );
-        return Object.freeze({
-          kind: 'other' as const,
-          description: l.description ?? '(missing description)',
-        });
-      }
-      return Object.freeze({
+  // Skip malformed entries entirely — the mapper must not fabricate
+  // a `kind` or substitute a placeholder `description`. Each
+  // malformed entry surfaces a gap; the output array contains only
+  // the well-formed entries.
+  const validEntries: DomainPsvReceiptLimitation[] = [];
+  for (const l of input.limitations) {
+    if (!l.kind || !l.description) {
+      gaps.push(
+        gap(
+          'missing_limitations',
+          'limitations[].kind|description',
+          'Each limitation entry requires both `kind` and `description`. Malformed entries are dropped, not synthesized.',
+        ),
+      );
+      continue;
+    }
+    validEntries.push(
+      Object.freeze({
         kind: l.kind,
         description: l.description,
-      });
-    }),
-  );
+      }),
+    );
+  }
+  return Object.freeze(validEntries);
 }
 
 function pickSourceBasis(
@@ -325,12 +327,16 @@ function decideStatus(
     return 'pending_not_persisted';
   }
   // If structural gaps exist, refuse to mark persisted.
+  // missing_candidate_reference covers the missing psvReceiptId
+  // case (no honest id to persist against).
   const blockingKinds: DomainPsvReceiptContractGapKind[] = [
     'missing_limitations',
     'missing_source_basis',
     'missing_responder_attribution',
     'missing_freshness',
     'missing_scope',
+    'missing_candidate_reference',
+    'invalid_writer_mode',
   ];
   if (gaps.some((g) => blockingKinds.includes(g.kind))) {
     return 'pending_not_persisted';
@@ -415,13 +421,16 @@ export function mapIssuerPsvReceiptToDomainReceipt(
   const gaps: DomainPsvReceiptContractGap[] = [];
   checkForbiddenFields(input, gaps);
 
-  const receiptId = input.psvReceiptId ?? '(missing)';
+  // Empty string is the honest "absent id" representation. The
+  // mapper does NOT synthesize a placeholder string. The missing
+  // id surfaces both as `receiptId: ''` AND as an explicit gap.
+  const receiptId = input.psvReceiptId ?? '';
   if (!input.psvReceiptId) {
     gaps.push(
       gap(
         'missing_candidate_reference',
         'psvReceiptId',
-        'IssuerPsvReceiptShape.psvReceiptId is required for mapping; the mapper does not fabricate one.',
+        'IssuerPsvReceiptShape.psvReceiptId is required for mapping; the mapper does not fabricate one. Result will carry receiptId="" and cannot reach status="persisted".',
       ),
     );
   }

--- a/packages/domain-core/psvReceiptMapping.ts
+++ b/packages/domain-core/psvReceiptMapping.ts
@@ -1,0 +1,552 @@
+import type {
+  DomainPsvReceipt,
+  DomainPsvReceiptCandidateReference,
+  DomainPsvReceiptContractGap,
+  DomainPsvReceiptContractGapKind,
+  DomainPsvReceiptFreshness,
+  DomainPsvReceiptLimitation,
+  DomainPsvReceiptResponderAttribution,
+  DomainPsvReceiptScope,
+  DomainPsvReceiptSourceBasis,
+  DomainPsvReceiptStatus,
+  DomainPsvReceiptWriterConfirmation,
+  PsvReceiptSnapshot,
+} from './psvReceipts';
+
+/**
+ * BACKEND-1 — Domain PSV Receipt mapper / validator.
+ *
+ * Truth contract:
+ *   - This module is a pure transform — no fetches, no DB writes,
+ *     no I/O of any kind. It does NOT enable persistence.
+ *   - The mapper does NOT fabricate missing fields. If the upstream
+ *     issuer PSVReceipt omits limitations / sourceBasis /
+ *     responderAttribution / freshness / scope, the corresponding
+ *     `DomainPsvReceiptContractGap` is emitted instead of a synthesized
+ *     value.
+ *   - A receipt may be marked `status: 'persisted'` ONLY when an
+ *     explicit `DomainPsvReceiptWriterConfirmation` is present AND
+ *     the writer mode is `'repository'` or `'external'`.
+ *   - The legacy `PsvReceiptSnapshot` is NOT a full domain receipt.
+ *     `mapLegacySnapshotToDomainReceipt` always emits a
+ *     `legacy_snapshot_only` gap so the caller cannot mistake the
+ *     legacy shape for the aligned issuer trust contract.
+ *   - The mapper refuses to introduce a `globalCredentialTruth`
+ *     field. If the upstream object has one, the mapper drops it
+ *     and surfaces `forbidden_global_credential_truth_field`.
+ */
+
+/**
+ * The shape we accept as input from the issuer trust contract
+ * (apps/web/lib/issuer-verification/psvReceipt.ts). Defined here as
+ * a structural alias so domain-core does not statically depend on
+ * the apps/web package — keeping the module reusable from any
+ * server context.
+ */
+export interface IssuerPsvReceiptShape {
+  psvReceiptId?: string;
+  psvCandidateId?: string;
+  receiptCandidateId?: string;
+  requestId?: string;
+  claimId?: string;
+  claimType?: string;
+  scope?: {
+    claimType?: string;
+    covers?: string;
+    doesNotCover?: string;
+    sourceOrganizationName?: string;
+  };
+  limitations?: ReadonlyArray<{
+    kind?:
+      | 'legally_only'
+      | 'partial_confirmation'
+      | 'contracted_agent'
+      | 'access_required'
+      | 'jurisdictional_scope'
+      | 'other';
+    description?: string;
+  }>;
+  sourceBasis?: {
+    sourceOrganizationName?: string;
+    isContractedAgent?: boolean;
+    agentName?: string;
+    agentActsFor?: string;
+    basisNote?: string;
+  };
+  attributedResponder?: {
+    name?: string;
+    role?: string;
+    attributedAt?: string;
+    attributionMethod?:
+      | 'self_attested'
+      | 'directory_match'
+      | 'partner_assertion'
+      | 'unknown';
+  };
+  freshness?: {
+    ttlDays?: number;
+    issuedAt?: string;
+    staleAfter?: string;
+  };
+  /**
+   * INTENTIONALLY NOT mapped. If present on the upstream object,
+   * the mapper drops it AND emits a contract gap so the legacy
+   * truth invariant cannot leak into the domain shape.
+   */
+  globalCredentialTruth?: unknown;
+  proofTier?: unknown;
+  decisionGrade?: unknown;
+}
+
+export interface MapIssuerToDomainOptions {
+  /**
+   * Optional writer confirmation. The mapper will set
+   * `status: 'persisted'` only when this is present AND its
+   * `writerMode` is `'repository'` or `'external'`.
+   */
+  writerConfirmation?: DomainPsvReceiptWriterConfirmation;
+}
+
+export interface MapIssuerToDomainResult {
+  receipt: DomainPsvReceipt;
+  gaps: ReadonlyArray<DomainPsvReceiptContractGap>;
+  /** True iff `gaps` is empty. */
+  contractAligned: boolean;
+}
+
+function gap(
+  kind: DomainPsvReceiptContractGapKind,
+  field: string,
+  message: string,
+): DomainPsvReceiptContractGap {
+  return Object.freeze({ kind, field, message });
+}
+
+function pickScope(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): DomainPsvReceiptScope | undefined {
+  const s = input.scope;
+  if (
+    !s ||
+    !s.claimType ||
+    !s.covers ||
+    !s.doesNotCover ||
+    !s.sourceOrganizationName
+  ) {
+    gaps.push(
+      gap(
+        'missing_scope',
+        'scope',
+        'DomainPsvReceipt requires a scope with claimType / covers / doesNotCover / sourceOrganizationName.',
+      ),
+    );
+    return undefined;
+  }
+  return Object.freeze({
+    claimType: s.claimType,
+    covers: s.covers,
+    doesNotCover: s.doesNotCover,
+    sourceOrganizationName: s.sourceOrganizationName,
+  });
+}
+
+function pickLimitations(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): ReadonlyArray<DomainPsvReceiptLimitation> | undefined {
+  if (!input.limitations) {
+    gaps.push(
+      gap(
+        'missing_limitations',
+        'limitations',
+        'DomainPsvReceipt requires a limitations array (may be empty if the upstream had none, but the field itself is required).',
+      ),
+    );
+    return undefined;
+  }
+  return Object.freeze(
+    input.limitations.map((l) => {
+      if (!l.kind || !l.description) {
+        // Surface the gap but do not fabricate values.
+        gaps.push(
+          gap(
+            'missing_limitations',
+            'limitations[].kind|description',
+            'Each limitation entry requires both `kind` and `description`.',
+          ),
+        );
+        return Object.freeze({
+          kind: 'other' as const,
+          description: l.description ?? '(missing description)',
+        });
+      }
+      return Object.freeze({
+        kind: l.kind,
+        description: l.description,
+      });
+    }),
+  );
+}
+
+function pickSourceBasis(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): DomainPsvReceiptSourceBasis | undefined {
+  const s = input.sourceBasis;
+  if (
+    !s ||
+    !s.sourceOrganizationName ||
+    typeof s.isContractedAgent !== 'boolean'
+  ) {
+    gaps.push(
+      gap(
+        'missing_source_basis',
+        'sourceBasis',
+        'DomainPsvReceipt requires a sourceBasis with sourceOrganizationName and isContractedAgent.',
+      ),
+    );
+    return undefined;
+  }
+  if (s.isContractedAgent && (!s.agentName || !s.agentActsFor)) {
+    gaps.push(
+      gap(
+        'missing_source_basis',
+        'sourceBasis.agentName|agentActsFor',
+        'A contracted-agent sourceBasis requires both agentName and agentActsFor.',
+      ),
+    );
+  }
+  return Object.freeze({
+    sourceOrganizationName: s.sourceOrganizationName,
+    isContractedAgent: s.isContractedAgent,
+    agentName: s.agentName,
+    agentActsFor: s.agentActsFor,
+    basisNote: s.basisNote,
+  });
+}
+
+function pickResponderAttribution(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): DomainPsvReceiptResponderAttribution | undefined {
+  const r = input.attributedResponder;
+  if (!r || !r.name || !r.attributedAt || !r.attributionMethod) {
+    gaps.push(
+      gap(
+        'missing_responder_attribution',
+        'attributedResponder',
+        'DomainPsvReceipt requires attributedResponder with name, attributedAt, and attributionMethod.',
+      ),
+    );
+    return undefined;
+  }
+  return Object.freeze({
+    name: r.name,
+    role: r.role,
+    attributedAt: r.attributedAt,
+    attributionMethod: r.attributionMethod,
+  });
+}
+
+function pickFreshness(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): DomainPsvReceiptFreshness | undefined {
+  const f = input.freshness;
+  if (
+    !f ||
+    typeof f.ttlDays !== 'number' ||
+    !f.issuedAt ||
+    !f.staleAfter
+  ) {
+    gaps.push(
+      gap(
+        'missing_freshness',
+        'freshness',
+        'DomainPsvReceipt requires freshness with ttlDays, issuedAt, and staleAfter.',
+      ),
+    );
+    return undefined;
+  }
+  return Object.freeze({
+    ttlDays: f.ttlDays,
+    issuedAt: f.issuedAt,
+    staleAfter: f.staleAfter,
+  });
+}
+
+function pickCandidateReference(
+  input: IssuerPsvReceiptShape,
+): DomainPsvReceiptCandidateReference | undefined {
+  if (
+    !input.psvCandidateId &&
+    !input.receiptCandidateId &&
+    !input.requestId
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    psvCandidateId: input.psvCandidateId,
+    receiptCandidateId: input.receiptCandidateId,
+    requestId: input.requestId,
+  });
+}
+
+function checkForbiddenFields(
+  input: IssuerPsvReceiptShape,
+  gaps: DomainPsvReceiptContractGap[],
+): void {
+  if (Object.prototype.hasOwnProperty.call(input, 'globalCredentialTruth')) {
+    gaps.push(
+      gap(
+        'forbidden_global_credential_truth_field',
+        'globalCredentialTruth',
+        'DomainPsvReceipt does not carry a globalCredentialTruth field; the mapper drops it.',
+      ),
+    );
+  }
+}
+
+function decideStatus(
+  gaps: ReadonlyArray<DomainPsvReceiptContractGap>,
+  writerConfirmation: DomainPsvReceiptWriterConfirmation | undefined,
+  hasUpstreamCandidate: boolean,
+): DomainPsvReceiptStatus {
+  // No writer confirmation → never persisted.
+  if (!writerConfirmation) {
+    return hasUpstreamCandidate ? 'candidate' : 'pending_not_persisted';
+  }
+  // Writer confirmation present but bad mode → not persisted.
+  if (
+    writerConfirmation.writerMode !== 'repository' &&
+    writerConfirmation.writerMode !== 'external'
+  ) {
+    return 'pending_not_persisted';
+  }
+  // If structural gaps exist, refuse to mark persisted.
+  const blockingKinds: DomainPsvReceiptContractGapKind[] = [
+    'missing_limitations',
+    'missing_source_basis',
+    'missing_responder_attribution',
+    'missing_freshness',
+    'missing_scope',
+  ];
+  if (gaps.some((g) => blockingKinds.includes(g.kind))) {
+    return 'pending_not_persisted';
+  }
+  return 'persisted';
+}
+
+/**
+ * Pure: validate that a (possibly partial) DomainPsvReceipt satisfies
+ * the contract for its declared status. Returns the gap list. Empty
+ * array means the receipt is valid for that status.
+ */
+export function validateDomainPsvReceiptContract(
+  receipt: DomainPsvReceipt,
+): ReadonlyArray<DomainPsvReceiptContractGap> {
+  const gaps: DomainPsvReceiptContractGap[] = [];
+  if (!receipt.scope) {
+    gaps.push(
+      gap('missing_scope', 'scope', 'scope is required for non-pending receipts.'),
+    );
+  }
+  if (!receipt.limitations) {
+    gaps.push(
+      gap(
+        'missing_limitations',
+        'limitations',
+        'limitations array is required for non-pending receipts (may be empty).',
+      ),
+    );
+  }
+  if (!receipt.sourceBasis) {
+    gaps.push(
+      gap(
+        'missing_source_basis',
+        'sourceBasis',
+        'sourceBasis is required for non-pending receipts.',
+      ),
+    );
+  }
+  if (!receipt.responderAttribution) {
+    gaps.push(
+      gap(
+        'missing_responder_attribution',
+        'responderAttribution',
+        'responderAttribution is required for non-pending receipts.',
+      ),
+    );
+  }
+  if (!receipt.freshness) {
+    gaps.push(
+      gap('missing_freshness', 'freshness', 'freshness is required for non-pending receipts.'),
+    );
+  }
+  if (
+    receipt.status === 'persisted' &&
+    (!receipt.writerConfirmation ||
+      (receipt.writerConfirmation.writerMode !== 'repository' &&
+        receipt.writerConfirmation.writerMode !== 'external'))
+  ) {
+    gaps.push(
+      gap(
+        'missing_writer_confirmation_for_persisted',
+        'writerConfirmation',
+        'A receipt with status=persisted requires writerConfirmation with writerMode in {repository, external}.',
+      ),
+    );
+  }
+  return Object.freeze(gaps);
+}
+
+/**
+ * Pure: map an issuer-shape PSVReceipt into the domain receipt. Does
+ * NOT fabricate missing fields. Caller may pass an explicit
+ * `writerConfirmation` to permit the result to carry
+ * `status: 'persisted'`; absence keeps it at `candidate` (or
+ * `pending_not_persisted` if no candidate reference is present).
+ */
+export function mapIssuerPsvReceiptToDomainReceipt(
+  input: IssuerPsvReceiptShape,
+  options: MapIssuerToDomainOptions = {},
+): MapIssuerToDomainResult {
+  const gaps: DomainPsvReceiptContractGap[] = [];
+  checkForbiddenFields(input, gaps);
+
+  const receiptId = input.psvReceiptId ?? '(missing)';
+  if (!input.psvReceiptId) {
+    gaps.push(
+      gap(
+        'missing_candidate_reference',
+        'psvReceiptId',
+        'IssuerPsvReceiptShape.psvReceiptId is required for mapping; the mapper does not fabricate one.',
+      ),
+    );
+  }
+
+  const scope = pickScope(input, gaps);
+  const limitations = pickLimitations(input, gaps);
+  const sourceBasis = pickSourceBasis(input, gaps);
+  const responderAttribution = pickResponderAttribution(input, gaps);
+  const freshness = pickFreshness(input, gaps);
+  const candidateReference = pickCandidateReference(input);
+  const writerConfirmation = options.writerConfirmation;
+
+  if (
+    writerConfirmation &&
+    writerConfirmation.writerMode !== 'repository' &&
+    writerConfirmation.writerMode !== 'external'
+  ) {
+    gaps.push(
+      gap(
+        'invalid_writer_mode',
+        'writerConfirmation.writerMode',
+        'writerMode must be one of {repository, external} to support a persisted status.',
+      ),
+    );
+  }
+
+  const status = decideStatus(
+    gaps,
+    writerConfirmation,
+    Boolean(candidateReference),
+  );
+
+  if (status !== 'persisted' && writerConfirmation) {
+    // Writer was supplied but the result cannot be persisted because
+    // structural gaps remain. Surface a gap so callers see it.
+    gaps.push(
+      gap(
+        'missing_writer_confirmation_for_persisted',
+        'status',
+        'writerConfirmation was supplied but structural gaps prevent the receipt from reaching status=persisted.',
+      ),
+    );
+  }
+
+  const receipt: DomainPsvReceipt = Object.freeze({
+    receiptId,
+    status,
+    scope,
+    limitations,
+    sourceBasis,
+    responderAttribution,
+    freshness,
+    candidateReference,
+    writerConfirmation: status === 'persisted' ? writerConfirmation : undefined,
+  });
+
+  return {
+    receipt,
+    gaps: Object.freeze(gaps),
+    contractAligned: gaps.length === 0,
+  };
+}
+
+/**
+ * Pure: map a legacy `PsvReceiptSnapshot` to a `DomainPsvReceipt`.
+ * Always emits a `legacy_snapshot_only` gap because the legacy
+ * shape does not carry the issuer trust-contract fields. The
+ * resulting domain receipt is `pending_not_persisted` regardless of
+ * any writer confirmation — the legacy snapshot cannot be the basis
+ * of a persisted issuer-aligned receipt.
+ */
+export function mapLegacySnapshotToDomainReceipt(
+  snapshot: PsvReceiptSnapshot,
+): MapIssuerToDomainResult {
+  const gaps: DomainPsvReceiptContractGap[] = [
+    gap(
+      'legacy_snapshot_only',
+      'PsvReceiptSnapshot',
+      'PsvReceiptSnapshot is the legacy shape (receiptId / fetchedAt / ttlSeconds / revoked); it does not carry limitations / sourceBasis / responderAttribution / scope. A full DomainPsvReceipt requires the issuer trust-contract fields.',
+    ),
+    gap(
+      'missing_limitations',
+      'limitations',
+      'Legacy snapshot has no limitations array.',
+    ),
+    gap(
+      'missing_source_basis',
+      'sourceBasis',
+      'Legacy snapshot has no source basis.',
+    ),
+    gap(
+      'missing_responder_attribution',
+      'responderAttribution',
+      'Legacy snapshot has no responder attribution.',
+    ),
+    gap(
+      'missing_scope',
+      'scope',
+      'Legacy snapshot has no scope object.',
+    ),
+  ];
+  const receipt: DomainPsvReceipt = Object.freeze({
+    receiptId: snapshot.receiptId,
+    status: 'pending_not_persisted',
+    freshness: Object.freeze({
+      ttlDays: Math.max(1, Math.round(snapshot.ttlSeconds / 86400)),
+      issuedAt: snapshot.fetchedAt,
+      staleAfter: new Date(
+        Date.parse(snapshot.fetchedAt) + snapshot.ttlSeconds * 1000,
+      ).toISOString(),
+    }),
+  });
+  return {
+    receipt,
+    gaps: Object.freeze(gaps),
+    contractAligned: false,
+  };
+}
+
+/**
+ * Plain-language explanation of a contract gap. Surfaced verbatim by
+ * the persistence-decision review surface.
+ */
+export function explainDomainPsvReceiptContractGap(
+  gap: DomainPsvReceiptContractGap,
+): string {
+  return `[${gap.kind}] ${gap.field}: ${gap.message}`;
+}

--- a/packages/domain-core/psvReceipts.ts
+++ b/packages/domain-core/psvReceipts.ts
@@ -83,3 +83,160 @@ export function validateReceiptSet(
     lastVerifiedAt,
   });
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// BACKEND-1 — Domain PSV Receipt contract alignment.
+//
+// Additive types that align the domain-core PSV receipt model with
+// the issuer trust-contract chain (ISSUER-2..9) so a future backend
+// writer can be wired without contract drift.
+//
+// Truth contract:
+//   - A DomainPsvReceipt is scoped evidence, not global credential
+//     truth. There is intentionally NO globalCredentialTruth field.
+//   - limitations / sourceBasis / responderAttribution / freshness /
+//     scope are required on a `persisted` receipt. Missing any of
+//     them surfaces a DomainPsvReceiptContractGap.
+//   - writerConfirmation is required before a receipt may carry
+//     status === 'persisted'. The mapper does NOT fabricate this.
+//   - The legacy PsvReceiptSnapshot above is intentionally NOT a
+//     full DomainPsvReceipt. It is the legacy shape the existing
+//     backend repository currently stores; mapping to the issuer
+//     trust contract requires explicit upstream input that the
+//     legacy snapshot does not carry.
+//   - This module is a pure transform — no fetches, no DB writes,
+//     no I/O. Adding these types does NOT enable persistence.
+// ─────────────────────────────────────────────────────────────────────
+
+export type DomainPsvReceiptStatus =
+  | 'pending_not_persisted'
+  | 'candidate'
+  | 'persisted'
+  | 'failed_persistence'
+  | 'unavailable';
+
+export type DomainPsvReceiptLimitationKind =
+  | 'legally_only'
+  | 'partial_confirmation'
+  | 'contracted_agent'
+  | 'access_required'
+  | 'jurisdictional_scope'
+  | 'other';
+
+export type DomainPsvReceiptLimitation = Readonly<{
+  kind: DomainPsvReceiptLimitationKind;
+  description: string;
+}>;
+
+export type DomainPsvReceiptScope = Readonly<{
+  /** Plain-language: the claim type this receipt covers. */
+  claimType: string;
+  /** Plain-language: what the receipt covers. */
+  covers: string;
+  /** Plain-language: what the receipt does NOT cover. */
+  doesNotCover: string;
+  /** The source-of-record organization name. */
+  sourceOrganizationName: string;
+}>;
+
+export type DomainPsvReceiptFreshness = Readonly<{
+  ttlDays: number;
+  issuedAt: string;
+  staleAfter: string;
+}>;
+
+export type DomainPsvReceiptSourceBasis = Readonly<{
+  /** Authoritative source-of-record the response speaks for. */
+  sourceOrganizationName: string;
+  isContractedAgent: boolean;
+  /** Required when isContractedAgent is true. */
+  agentName?: string;
+  /** Required when isContractedAgent is true — the source the agent acts for. */
+  agentActsFor?: string;
+  basisNote?: string;
+}>;
+
+export type DomainPsvReceiptResponderAttribution = Readonly<{
+  name: string;
+  role?: string;
+  attributedAt: string;
+  attributionMethod:
+    | 'self_attested'
+    | 'directory_match'
+    | 'partner_assertion'
+    | 'unknown';
+}>;
+
+export type DomainPsvReceiptCandidateReference = Readonly<{
+  /** Identifier of the upstream PSVReceiptCandidate, if any. */
+  psvCandidateId?: string;
+  /** Identifier of the originating ReceiptCandidate, if any. */
+  receiptCandidateId?: string;
+  /** Identifier of the IssuerVerificationRequest, if any. */
+  requestId?: string;
+  /** Identifier of the policy review decision that accepted the candidate, if any. */
+  policyReviewDecisionId?: string;
+}>;
+
+/**
+ * Confirmation issued by a real writer when a row was persisted.
+ * Without this artifact, a DomainPsvReceipt MUST NOT carry
+ * status === 'persisted'.
+ */
+export type DomainPsvReceiptWriterConfirmation = Readonly<{
+  confirmedAt: string;
+  confirmedBy: string;
+  /** Writer kind — must be a real persistence path. */
+  writerMode: 'repository' | 'external';
+  /** Identifier the persistence layer assigned to the row. */
+  persistedRowId: string;
+}>;
+
+/**
+ * The aligned domain PSV receipt. A `persisted` receipt MUST carry
+ * limitations, sourceBasis, responderAttribution, freshness, scope,
+ * and writerConfirmation. Other statuses MAY omit fields — but the
+ * mapper / validator will surface explicit `DomainPsvReceiptContractGap`
+ * entries for what's missing.
+ */
+export type DomainPsvReceipt = Readonly<{
+  receiptId: string;
+  status: DomainPsvReceiptStatus;
+  /** Required for any non-pending receipt. */
+  scope?: DomainPsvReceiptScope;
+  /** Required, possibly empty array, for any non-pending receipt. */
+  limitations?: ReadonlyArray<DomainPsvReceiptLimitation>;
+  /** Required for any non-pending receipt. */
+  sourceBasis?: DomainPsvReceiptSourceBasis;
+  /** Required for any non-pending receipt. */
+  responderAttribution?: DomainPsvReceiptResponderAttribution;
+  /** Required for any non-pending receipt. */
+  freshness?: DomainPsvReceiptFreshness;
+  /** Optional pointer back to the upstream candidate / request. */
+  candidateReference?: DomainPsvReceiptCandidateReference;
+  /** Required ONLY when status === 'persisted'. */
+  writerConfirmation?: DomainPsvReceiptWriterConfirmation;
+}>;
+
+/**
+ * A discrete contract gap surfaced by the mapper / validator.
+ * Surfaced verbatim by the persistence-decision review surface.
+ */
+export type DomainPsvReceiptContractGapKind =
+  | 'missing_limitations'
+  | 'missing_source_basis'
+  | 'missing_responder_attribution'
+  | 'missing_freshness'
+  | 'missing_scope'
+  | 'missing_candidate_reference'
+  | 'missing_writer_confirmation_for_persisted'
+  | 'legacy_snapshot_only'
+  | 'forbidden_global_credential_truth_field'
+  | 'invalid_writer_mode';
+
+export type DomainPsvReceiptContractGap = Readonly<{
+  kind: DomainPsvReceiptContractGapKind;
+  field: string;
+  message: string;
+}>;
+


### PR DESCRIPTION
## Summary
- close the **type-level** gap between the legacy backend PSV-receipt shape (`PsvReceiptSnapshot`) and the issuer trust contract (ISSUER-2..9)
- add `DomainPsvReceipt` + 11 related types (status, limitation kind, scope, freshness, source basis, responder attribution, candidate reference, writer confirmation, contract gap kind, contract gap)
- add `psvReceiptMapping.ts` with `mapIssuerPsvReceiptToDomainReceipt`, `mapLegacySnapshotToDomainReceipt`, `validateDomainPsvReceiptContract`, `explainDomainPsvReceiptContractGap`
- pin the contract with 18 new frozen tests
- add an honesty header to `apps/api/backend/repositories/psvReceipts.repo.ts` documenting that its rows are the legacy snapshot shape (no behavior change)
- update the defer memo with the BACKEND-1 status section

## Truth rules
- PSVReceipt is scoped evidence, not global credential truth
- the mapper does not fabricate missing fields — every missing required field surfaces an explicit `DomainPsvReceiptContractGap`
- `status: 'persisted'` requires both (a) every required field present AND (b) a `writerConfirmation` with `writerMode in {repository, external}`
- the legacy `PsvReceiptSnapshot` is not a full `DomainPsvReceipt` — `mapLegacySnapshotToDomainReceipt` always emits a `legacy_snapshot_only` gap
- no real DB writes, no migrations, no persistence enabled

## Validation
- 59/59 frozen tests pass in `@vitalcv/domain-common` (41 pre-existing + 18 new BACKEND-1 cases)
- 31/31 issuer backend persistence decision tests still pass on `apps/web`
- `pnpm turbo run build --filter @vitalcv/web` — 13/13 tasks succeed
- banned-string sweep on diff lines: zero hits across 14 phrases

## Notes
- `apps/web/lib/issuer-verification/*` runtime defer decision remains unchanged — `evaluateBackendPersistenceReadiness` still returns `defer_until_contract_aligned` because schema-level and writer-level gaps remain.
- A future ISSUER-10 (or named follow-up) is required to land the contract-aligned schema and a server-only writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)