### PR TITLE
feat(issuer): add server persistence writer confirmation boundary

### DIFF
--- a/apps/web/__tests__/issuer-server-persistence-writer.test.ts
+++ b/apps/web/__tests__/issuer-server-persistence-writer.test.ts
@@ -1,0 +1,516 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  asAuditWriteResult,
+  buildServerPsvReceiptWriteInput,
+  canUseServerPsvReceiptWriter,
+  createDeferredServerPsvReceiptWriter,
+  createUnavailableServerPsvReceiptWriter,
+  explainServerWriterResult,
+  writePsvReceiptWithConfirmation,
+} from '../lib/issuer-verification/serverPsvReceiptWriter';
+import type {
+  ServerPsvReceiptWriter,
+  ServerPsvReceiptWriteInput,
+  ServerPsvReceiptWriteResult,
+  ServerPsvReceiptWriterConfirmation,
+} from '../lib/issuer-verification/serverPsvReceiptWriter';
+import type {
+  PolicyReviewActor,
+  PSVReceipt,
+} from '../lib/issuer-verification/types';
+
+const ACTOR: PolicyReviewActor = {
+  actorId: 'actor-1',
+  displayName: 'Pat Reviewer',
+  role: 'policy_reviewer',
+};
+
+function fullReceipt(): ServerPsvReceiptWriteInput['receipt'] {
+  return {
+    psvReceiptId: 'psv-receipt-1',
+    psvCandidateId: 'psv-cand-1',
+    receiptCandidateId: 'rc-1',
+    requestId: 'req-1',
+    claimId: 'claim-1',
+    claimType: 'residency',
+    promotedAt: '2026-04-26T03:00:00.000Z',
+    promotedBy: ACTOR,
+    sourceBasis: {
+      sourceOrganizationName: 'Demo GME Office',
+      isContractedAgent: false,
+      basisNote: 'Direct from source.',
+    },
+    attributedResponder: {
+      name: 'J. Doe',
+      role: 'Program Coordinator',
+      attributedAt: '2026-04-26T01:00:00.000Z',
+      attributionMethod: 'self_attested',
+    },
+    scope: {
+      claimType: 'residency',
+      covers: 'Residency program completion 2018-2021.',
+      doesNotCover:
+        'Does not cover board certification, license status, or malpractice history.',
+      sourceOrganizationName: 'Demo GME Office',
+    },
+    limitations: [],
+    freshness: {
+      ttlDays: 365,
+      issuedAt: '2026-04-26T03:00:00.000Z',
+      staleAfter: '2027-04-26T03:00:00.000Z',
+    },
+  };
+}
+
+function validInput(
+  overrides: Partial<ServerPsvReceiptWriteInput> = {},
+): ServerPsvReceiptWriteInput {
+  return {
+    receipt: fullReceipt(),
+    correlationId: 'corr-1',
+    ...overrides,
+  };
+}
+
+describe('canUseServerPsvReceiptWriter — structural gates', () => {
+  it('valid input passes', () => {
+    expect(canUseServerPsvReceiptWriter(validInput())).toBeUndefined();
+  });
+
+  it.each([
+    ['psvReceiptId', 'missing_required_field'] as const,
+    ['scope', 'missing_required_field'] as const,
+    ['limitations', 'missing_required_field'] as const,
+    ['sourceBasis', 'missing_required_field'] as const,
+    ['attributedResponder', 'missing_required_field'] as const,
+    ['freshness', 'missing_required_field'] as const,
+  ])('missing %s on receipt is refused as %s', (field, expected) => {
+    const r = { ...fullReceipt() } as Record<string, unknown>;
+    delete r[field];
+    const failure = canUseServerPsvReceiptWriter({
+      receipt: r as ServerPsvReceiptWriteInput['receipt'],
+      correlationId: 'corr-1',
+    });
+    expect(failure).toBe(expected);
+  });
+
+  it('missing correlationId is refused as missing_required_field', () => {
+    const failure = canUseServerPsvReceiptWriter({
+      receipt: fullReceipt(),
+      correlationId: '',
+    });
+    expect(failure).toBe('missing_required_field');
+  });
+
+  it('input carrying decisionGrade on the receipt is refused as forbidden_truth_tier_field', () => {
+    const r = { ...fullReceipt(), decisionGrade: true } as unknown as ServerPsvReceiptWriteInput['receipt'];
+    expect(
+      canUseServerPsvReceiptWriter({ receipt: r, correlationId: 'corr-1' }),
+    ).toBe('forbidden_truth_tier_field');
+  });
+
+  it('input carrying proofTier on the receipt is refused', () => {
+    const r = { ...fullReceipt(), proofTier: 'psv_receipt' } as unknown as ServerPsvReceiptWriteInput['receipt'];
+    expect(
+      canUseServerPsvReceiptWriter({ receipt: r, correlationId: 'corr-1' }),
+    ).toBe('forbidden_truth_tier_field');
+  });
+
+  it('input carrying globalCredentialTruth on the receipt is refused', () => {
+    const r = { ...fullReceipt(), globalCredentialTruth: false } as unknown as ServerPsvReceiptWriteInput['receipt'];
+    expect(
+      canUseServerPsvReceiptWriter({ receipt: r, correlationId: 'corr-1' }),
+    ).toBe('forbidden_truth_tier_field');
+  });
+
+  it('client-supplied persisted flag is refused', () => {
+    const tampered = {
+      ...validInput(),
+      persisted: true,
+    } as unknown as ServerPsvReceiptWriteInput;
+    expect(canUseServerPsvReceiptWriter(tampered)).toBe(
+      'client_supplied_persisted_flag',
+    );
+  });
+
+  it('client-supplied confirmation field is refused', () => {
+    const tampered = {
+      ...validInput(),
+      confirmation: {
+        confirmedAt: '2026-04-26T03:00:00.000Z',
+        confirmedBy: 'demo',
+        writerMode: 'repository',
+        persistedRowId: 'row-1',
+      },
+    } as unknown as ServerPsvReceiptWriteInput;
+    expect(canUseServerPsvReceiptWriter(tampered)).toBe(
+      'client_supplied_persisted_flag',
+    );
+  });
+});
+
+describe('buildServerPsvReceiptWriteInput — strips forbidden truth-tier fields', () => {
+  it('returns a clean receipt object even if input had truth-tier fields', () => {
+    const dirty = {
+      ...fullReceipt(),
+      decisionGrade: true,
+      proofTier: 'psv_receipt',
+      globalCredentialTruth: false,
+    } as unknown as ServerPsvReceiptWriteInput['receipt'];
+    const built = buildServerPsvReceiptWriteInput({
+      receipt: dirty,
+      correlationId: 'corr-1',
+    });
+    const r = built.receipt as Record<string, unknown>;
+    expect(r.decisionGrade).toBeUndefined();
+    expect(r.proofTier).toBeUndefined();
+    expect(r.globalCredentialTruth).toBeUndefined();
+    // But the well-formed fields are still there.
+    expect(built.receipt.psvReceiptId).toBe('psv-receipt-1');
+    expect(built.receipt.scope).toBeDefined();
+  });
+});
+
+describe('createDeferredServerPsvReceiptWriter — never persists', () => {
+  it('valid input → status=deferred, persisted=false', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const result = await writer.attempt(validInput());
+    expect(result.status).toBe('deferred');
+    expect(result.persisted).toBe(false);
+    expect(result.message.toLowerCase()).toContain('deferred pending schema');
+    expect(result.preservedReceipt).toEqual(fullReceipt());
+  });
+
+  it('invalid input (missing field) → status=failed, persisted=false', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const result = await writer.attempt({
+      receipt: { ...fullReceipt(), psvReceiptId: '' },
+      correlationId: 'corr-1',
+    });
+    expect(result.status).toBe('failed');
+    expect(result.persisted).toBe(false);
+    expect(result.failureReason).toBe('missing_required_field');
+  });
+
+  it('input with forbidden truth-tier field → status=failed', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const result = await writer.attempt({
+      receipt: { ...fullReceipt(), globalCredentialTruth: true } as unknown as ServerPsvReceiptWriteInput['receipt'],
+      correlationId: 'corr-1',
+    });
+    expect(result.status).toBe('failed');
+    expect(result.failureReason).toBe('forbidden_truth_tier_field');
+  });
+
+  it('dryRun=true → status=dry_run, persisted=false', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const result = await writer.attempt({ ...validInput(), dryRun: true });
+    expect(result.status).toBe('dry_run');
+    expect(result.persisted).toBe(false);
+  });
+
+  it('preserves limitations / source basis / responder attribution / freshness / scope verbatim on every outcome', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const limitations = [
+      { kind: 'legally_only' as const, description: 'Demo legally-only.' },
+    ];
+    const input = validInput({
+      receipt: {
+        ...fullReceipt(),
+        limitations,
+      },
+    });
+    const result = await writer.attempt(input);
+    expect(result.preservedReceipt.limitations).toEqual(limitations);
+    expect(result.preservedReceipt.sourceBasis).toEqual(
+      input.receipt.sourceBasis,
+    );
+    expect(result.preservedReceipt.attributedResponder).toEqual(
+      input.receipt.attributedResponder,
+    );
+    expect(result.preservedReceipt.freshness).toEqual(input.receipt.freshness);
+    expect(result.preservedReceipt.scope).toEqual(input.receipt.scope);
+  });
+
+  it('result type carries no decisionGrade / proofTier / globalCredentialTruth', async () => {
+    const writer = createDeferredServerPsvReceiptWriter();
+    const result = await writer.attempt(validInput());
+    expect((result as Record<string, unknown>).decisionGrade).toBeUndefined();
+    expect((result as Record<string, unknown>).proofTier).toBeUndefined();
+    expect(
+      (result as Record<string, unknown>).globalCredentialTruth,
+    ).toBeUndefined();
+    expect(
+      (result.preservedReceipt as Record<string, unknown>).globalCredentialTruth,
+    ).toBeUndefined();
+  });
+});
+
+describe('createUnavailableServerPsvReceiptWriter', () => {
+  it('always returns status=unavailable, persisted=false', async () => {
+    const writer = createUnavailableServerPsvReceiptWriter();
+    const result = await writer.attempt(validInput());
+    expect(result.status).toBe('unavailable');
+    expect(result.persisted).toBe(false);
+    expect(result.failureReason).toBe('writer_unavailable');
+  });
+
+  it('cannot be tricked into persisted by tampered input', async () => {
+    const writer = createUnavailableServerPsvReceiptWriter();
+    const tampered = {
+      ...validInput(),
+      persisted: true,
+      confirmation: {
+        confirmedAt: '2026-04-26T00:00:00.000Z',
+        confirmedBy: 'demo',
+        writerMode: 'repository',
+        persistedRowId: 'row-1',
+      },
+    } as unknown as ServerPsvReceiptWriteInput;
+    const result = await writer.attempt(tampered);
+    expect(result.persisted).toBe(false);
+  });
+});
+
+describe('writePsvReceiptWithConfirmation — orchestrator gates', () => {
+  function liarWriter(
+    overrides: Partial<ServerPsvReceiptWriteResult> = {},
+  ): ServerPsvReceiptWriter {
+    return {
+      kind: 'demo',
+      async attempt(input: ServerPsvReceiptWriteInput) {
+        return {
+          status: 'persisted',
+          persisted: true,
+          message: 'lying writer claims persisted',
+          preservedReceipt: input.receipt,
+          ...overrides,
+        };
+      },
+    };
+  }
+
+  function honestRepoWriter(): ServerPsvReceiptWriter {
+    return {
+      kind: 'repository',
+      async attempt(input: ServerPsvReceiptWriteInput) {
+        const confirmation: ServerPsvReceiptWriterConfirmation = {
+          confirmedAt: '2026-04-26T03:30:00.000Z',
+          confirmedBy: 'real-writer',
+          writerMode: 'repository',
+          persistedRowId: 'row-1',
+        };
+        return {
+          status: 'persisted',
+          persisted: true,
+          message: 'persisted by repository writer',
+          confirmation,
+          preservedReceipt: input.receipt,
+        };
+      },
+    };
+  }
+
+  it('writer claims persisted=true without confirmation → boundary downgrades to failed', async () => {
+    const result = await writePsvReceiptWithConfirmation({
+      writer: liarWriter(),
+      input: validInput(),
+    });
+    expect(result.persisted).toBe(false);
+    expect(result.status).toBe('failed');
+    expect(result.failureReason).toBe('invalid_writer_confirmation');
+  });
+
+  it('writer claims persisted with bad writerMode → boundary downgrades', async () => {
+    const result = await writePsvReceiptWithConfirmation({
+      writer: liarWriter({
+        confirmation: {
+          confirmedAt: '2026-04-26T03:00:00.000Z',
+          confirmedBy: 'demo',
+          writerMode: 'demo' as unknown as 'repository',
+          persistedRowId: 'row-1',
+        },
+      }),
+      input: validInput(),
+    });
+    expect(result.persisted).toBe(false);
+    expect(result.failureReason).toBe('invalid_writer_confirmation');
+  });
+
+  it('writer status mismatched with persisted flag → boundary downgrades', async () => {
+    const result = await writePsvReceiptWithConfirmation({
+      writer: {
+        kind: 'demo',
+        async attempt(input) {
+          return {
+            status: 'deferred',
+            persisted: true,
+            message: 'inconsistent claim',
+            preservedReceipt: input.receipt,
+          };
+        },
+      },
+      input: validInput(),
+    });
+    expect(result.persisted).toBe(false);
+    expect(result.failureReason).toBe('invalid_writer_confirmation');
+  });
+
+  it('honest repository writer with confirmation → persisted=true', async () => {
+    const result = await writePsvReceiptWithConfirmation({
+      writer: honestRepoWriter(),
+      input: validInput(),
+    });
+    expect(result.persisted).toBe(true);
+    expect(result.status).toBe('persisted');
+    expect(result.confirmation?.writerMode).toBe('repository');
+  });
+
+  it('default deferred writer through the orchestrator → still deferred', async () => {
+    const result = await writePsvReceiptWithConfirmation({
+      writer: createDeferredServerPsvReceiptWriter(),
+      input: validInput(),
+    });
+    expect(result.persisted).toBe(false);
+    expect(result.status).toBe('deferred');
+  });
+
+  it('orchestrator preserves the receipt input verbatim across deferred / failed / persisted', async () => {
+    const input = validInput({
+      receipt: {
+        ...fullReceipt(),
+        limitations: [
+          { kind: 'partial_confirmation', description: 'Demo partial.' },
+        ],
+      },
+    });
+    const deferred = await writePsvReceiptWithConfirmation({
+      writer: createDeferredServerPsvReceiptWriter(),
+      input,
+    });
+    expect(deferred.preservedReceipt).toEqual(input.receipt);
+    const failed = await writePsvReceiptWithConfirmation({
+      writer: liarWriter(),
+      input,
+    });
+    expect(failed.preservedReceipt).toEqual(input.receipt);
+    const persisted = await writePsvReceiptWithConfirmation({
+      writer: honestRepoWriter(),
+      input,
+    });
+    expect(persisted.preservedReceipt).toEqual(input.receipt);
+  });
+});
+
+describe('explainServerWriterResult', () => {
+  it('produces a non-empty plain-language summary', async () => {
+    const result = await createDeferredServerPsvReceiptWriter().attempt(
+      validInput(),
+    );
+    const text = explainServerWriterResult(result);
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('deferred');
+    expect(text).toContain('persisted=false');
+  });
+});
+
+describe('asAuditWriteResult', () => {
+  it('persisted result maps to mode=repository', async () => {
+    const result: ServerPsvReceiptWriteResult = {
+      status: 'persisted',
+      persisted: true,
+      message: 'ok',
+      confirmation: {
+        confirmedAt: '2026-04-26T03:00:00.000Z',
+        confirmedBy: 'real-writer',
+        writerMode: 'repository',
+        persistedRowId: 'row-1',
+      },
+      preservedReceipt: fullReceipt(),
+    };
+    const audit = asAuditWriteResult(result);
+    expect(audit.persisted).toBe(true);
+    expect(audit.mode).toBe('repository');
+    expect(audit.status).toBe('persisted');
+  });
+
+  it('deferred result maps to mode=demo and persisted=false', async () => {
+    const result = await createDeferredServerPsvReceiptWriter().attempt(
+      validInput(),
+    );
+    const audit = asAuditWriteResult(result);
+    expect(audit.persisted).toBe(false);
+    expect(audit.mode).toBe('demo');
+    expect(audit.status).toBe('pending_not_written');
+  });
+});
+
+describe('Module purity — no I/O in the writer module', () => {
+  it('source contains no fetch/axios/prisma/db/AuditEvent/email/SMS/webhook/node:fs tokens', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/serverPsvReceiptWriter.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const banned = [
+      'fetch(',
+      'axios',
+      'XMLHttpRequest',
+      'navigator.sendBeacon',
+      'prisma.',
+      'createMany',
+      'insertOne',
+      "import('@/",
+      'node:fs',
+      'node:net',
+      'node:http',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('module does NOT statically import any backend module', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/serverPsvReceiptWriter.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(src).not.toMatch(/from ['"]apps\/api/);
+    expect(src).not.toMatch(/from ['"]@vitalcv\/psv['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*prisma_client['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*psvReceipts\.repo['"]/);
+  });
+});
+
+describe('Knowledge Trust Graph — BACKEND-2 alignment', () => {
+  it('keeps the writer-boundary nodes and rules parseable and aligned', async () => {
+    const raw = await import(
+      '../../../docs/architecture/vitalcv-knowledge-trust-graph.json'
+    );
+    const graph = raw.default ?? raw;
+    expect(graph.nodes).toEqual(
+      expect.arrayContaining([
+        'ServerPsvReceiptWriter',
+        'DryRunPersistenceAttempt',
+        'FailedPersistenceAttempt',
+        'DeferredPersistenceAttempt',
+      ]),
+    );
+    expect(graph.rules).toEqual(
+      expect.arrayContaining([
+        'The ServerPsvReceiptWriter boundary defines the writer contract; the default deferred writer never persists.',
+        'A persisted ServerPsvReceiptWriteResult requires a ServerPsvReceiptWriterConfirmation with writerMode in {repository, external}.',
+        'The boundary defensively downgrades any persisted=true claim from a writer that did not emit a valid confirmation.',
+        'DryRun, deferred, unavailable, and failed write attempts NEVER produce a PersistedAuditRecord.',
+        'Client-supplied persisted/confirmation flags are refused by canUseServerPsvReceiptWriter; only a real writer may emit a confirmation.',
+        'Forbidden truth-tier fields (decisionGrade, proofTier, globalCredentialTruth) on ServerPsvReceiptWriteInput are refused by the boundary.',
+      ]),
+    );
+  });
+});

--- a/apps/web/lib/issuer-verification/serverPsvReceiptWriter.ts
+++ b/apps/web/lib/issuer-verification/serverPsvReceiptWriter.ts
@@ -1,0 +1,426 @@
+import type {
+  IssuerAuditEventRecord,
+  IssuerAuditWriteResult,
+} from './auditPersistence';
+import type { PSVReceipt } from './types';
+
+/**
+ * BACKEND-2 — Server-side PSV receipt writer + confirmation boundary.
+ *
+ * Truth contract:
+ *   - This module defines the WRITER BOUNDARY. The default
+ *     implementation is the "deferred" writer: it returns
+ *     `status: 'deferred'` with `persisted: false` and never writes
+ *     a row. Real persistence remains off until the schema-level
+ *     blockers documented in
+ *     docs/architecture/vitalcv-backend-persistence-defer-decision.md
+ *     are closed.
+ *   - A `persisted` status requires `ServerPsvReceiptWriterConfirmation`
+ *     emitted by a real writer that talked to a real repository. The
+ *     boundary helper REFUSES to fabricate a confirmation, refuses
+ *     `persisted` from the deferred writer, and refuses any
+ *     client-supplied `persisted` flag.
+ *   - The writer NEVER sets `globalCredentialTruth=true`,
+ *     `decisionGrade=true`, or any proof-tier upgrade. Those fields
+ *     are not even part of `ServerPsvReceiptWriteInput`.
+ *   - Limitations / source basis / responder attribution / freshness /
+ *     scope MUST be preserved verbatim from input to result. A
+ *     dropped field is a structural failure, not a silent rewrite.
+ *
+ * This module is a pure transform — no fetches, no DB writes, no
+ * dynamic imports of backend modules, no real I/O. Adding these
+ * types does NOT enable persistence.
+ */
+
+export type ServerPsvReceiptWriteStatus =
+  | 'persisted'
+  | 'failed'
+  | 'unavailable'
+  | 'dry_run'
+  | 'deferred';
+
+export type ServerPsvReceiptWriterFailureReason =
+  | 'writer_unavailable'
+  | 'writer_deferred_pending_schema_alignment'
+  | 'missing_required_field'
+  | 'client_supplied_persisted_flag'
+  | 'forbidden_truth_tier_field'
+  | 'invalid_writer_confirmation'
+  | 'repository_write_failed';
+
+/**
+ * Confirmation a real writer emits AFTER a row is persisted. The
+ * boundary helper accepts a confirmation only when its `writerMode`
+ * is `'repository'` or `'external'` — `'demo'`, `'noop'`, etc. are
+ * rejected.
+ */
+export interface ServerPsvReceiptWriterConfirmation {
+  confirmedAt: string;
+  confirmedBy: string;
+  writerMode: 'repository' | 'external';
+  /** Identifier the persistence layer assigned to the row. */
+  persistedRowId: string;
+  /** Optional cryptographic anchor / row hash. */
+  anchor?: string;
+}
+
+/**
+ * Caller-supplied input for a write attempt. The shape mirrors
+ * `PSVReceipt` (ISSUER-4) — but the truth-contract literal fields
+ * (`decisionGrade`, `proofTier`, `globalCredentialTruth`) are
+ * INTENTIONALLY OMITTED. The boundary refuses any input that smuggles
+ * them in.
+ */
+export interface ServerPsvReceiptWriteInput {
+  /** Source of record — copied verbatim into the persisted row. */
+  receipt: Pick<
+    PSVReceipt,
+    | 'psvReceiptId'
+    | 'psvCandidateId'
+    | 'receiptCandidateId'
+    | 'requestId'
+    | 'claimId'
+    | 'claimType'
+    | 'promotedAt'
+    | 'promotedBy'
+    | 'sourceBasis'
+    | 'attributedResponder'
+    | 'scope'
+    | 'limitations'
+    | 'freshness'
+  >;
+  /** Caller-controlled correlation ID for downstream audit correlation. */
+  correlationId: string;
+  /**
+   * Optional audit-event record to be co-persisted alongside the
+   * receipt. Same boundary rules apply.
+   */
+  auditEvent?: IssuerAuditEventRecord;
+  /** Caller-controlled idempotency key. */
+  idempotencyKey?: string;
+  /**
+   * If `true`, the writer attempts a dry run — validates input shape
+   * and returns `status: 'dry_run'` without writing. Useful for
+   * preview surfaces.
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * Result of a write attempt. `persisted` is the load-bearing flag.
+ * Always inspect it explicitly; do not rely on `status` alone.
+ */
+export interface ServerPsvReceiptWriteResult {
+  status: ServerPsvReceiptWriteStatus;
+  /** True iff a real row was written AND the writer confirmed it. */
+  persisted: boolean;
+  /** Set on every refusal. */
+  failureReason?: ServerPsvReceiptWriterFailureReason;
+  /** Free-text explanation; surfaced verbatim by review surfaces. */
+  message: string;
+  /** Set ONLY when status === 'persisted'. */
+  confirmation?: ServerPsvReceiptWriterConfirmation;
+  /** The receipt input is preserved verbatim on every outcome. */
+  preservedReceipt: ServerPsvReceiptWriteInput['receipt'];
+}
+
+export interface ServerPsvReceiptWriter {
+  kind: 'deferred' | 'demo' | 'repository' | 'external';
+  attempt(
+    input: ServerPsvReceiptWriteInput,
+  ): Promise<ServerPsvReceiptWriteResult>;
+}
+
+const DEFER_MESSAGE =
+  'Server-side PSV receipt persistence is deferred pending schema ' +
+  'alignment (see docs/architecture/vitalcv-backend-persistence-defer-decision.md). ' +
+  'No row was written; the receipt is preserved for replay context only.';
+
+const UNAVAILABLE_MESSAGE =
+  'No server-side PSV receipt writer is wired in this environment. ' +
+  'Persistence is unavailable.';
+
+/**
+ * Pure: predicate that returns the failure reason a write attempt
+ * would surface, or `undefined` if input passes structural checks.
+ * Does NOT call any writer.
+ */
+export function canUseServerPsvReceiptWriter(
+  input: ServerPsvReceiptWriteInput,
+): ServerPsvReceiptWriterFailureReason | undefined {
+  // Structural check: input must carry the required ISSUER-4 fields.
+  if (!input.receipt) return 'missing_required_field';
+  if (!input.receipt.psvReceiptId) return 'missing_required_field';
+  if (!input.receipt.scope) return 'missing_required_field';
+  if (!input.receipt.limitations) return 'missing_required_field';
+  if (!input.receipt.sourceBasis) return 'missing_required_field';
+  if (!input.receipt.attributedResponder) return 'missing_required_field';
+  if (!input.receipt.freshness) return 'missing_required_field';
+  if (!input.correlationId) return 'missing_required_field';
+
+  // Forbidden truth-tier fields. Even though the type omits them,
+  // a JS caller can still pass them at runtime; refuse loudly.
+  const receiptKeys = Object.keys(input.receipt as Record<string, unknown>);
+  if (
+    receiptKeys.includes('globalCredentialTruth') ||
+    receiptKeys.includes('decisionGrade') ||
+    receiptKeys.includes('proofTier')
+  ) {
+    return 'forbidden_truth_tier_field';
+  }
+
+  // Caller-supplied "persisted" intent. Even though the type omits
+  // it, refuse defensively.
+  const inputKeys = Object.keys(input as unknown as Record<string, unknown>);
+  if (inputKeys.includes('persisted') || inputKeys.includes('confirmation')) {
+    return 'client_supplied_persisted_flag';
+  }
+
+  return undefined;
+}
+
+interface BuildInputOptions {
+  receipt: ServerPsvReceiptWriteInput['receipt'];
+  correlationId: string;
+  auditEvent?: IssuerAuditEventRecord;
+  idempotencyKey?: string;
+  dryRun?: boolean;
+}
+
+/**
+ * Pure: build a well-formed write input. Strips any forbidden
+ * truth-tier fields the caller may have included on the receipt.
+ */
+export function buildServerPsvReceiptWriteInput(
+  options: BuildInputOptions,
+): ServerPsvReceiptWriteInput {
+  // Strip forbidden fields defensively; the caller is then refused
+  // by canUseServerPsvReceiptWriter only if they passed forbidden
+  // fields directly through some other path. This prevents a buggy
+  // caller from accidentally upgrading the receipt's truth tier
+  // through this helper.
+  const {
+    psvReceiptId,
+    psvCandidateId,
+    receiptCandidateId,
+    requestId,
+    claimId,
+    claimType,
+    promotedAt,
+    promotedBy,
+    sourceBasis,
+    attributedResponder,
+    scope,
+    limitations,
+    freshness,
+  } = options.receipt as ServerPsvReceiptWriteInput['receipt'];
+  return {
+    receipt: {
+      psvReceiptId,
+      psvCandidateId,
+      receiptCandidateId,
+      requestId,
+      claimId,
+      claimType,
+      promotedAt,
+      promotedBy,
+      sourceBasis,
+      attributedResponder,
+      scope,
+      limitations,
+      freshness,
+    },
+    correlationId: options.correlationId,
+    auditEvent: options.auditEvent,
+    idempotencyKey: options.idempotencyKey,
+    dryRun: options.dryRun,
+  };
+}
+
+/**
+ * The reference deferred writer. This is the BACKEND-2 default. It
+ * NEVER persists. Returns `status: 'deferred'` for valid input,
+ * `status: 'failed'` with a structural reason for invalid input,
+ * `status: 'dry_run'` when the caller asked for a dry run.
+ */
+export function createDeferredServerPsvReceiptWriter(): ServerPsvReceiptWriter {
+  return {
+    kind: 'deferred',
+    async attempt(
+      input: ServerPsvReceiptWriteInput,
+    ): Promise<ServerPsvReceiptWriteResult> {
+      const failure = canUseServerPsvReceiptWriter(input);
+      const preservedReceipt = input.receipt;
+
+      if (failure) {
+        return {
+          status: 'failed',
+          persisted: false,
+          failureReason: failure,
+          message:
+            failure === 'forbidden_truth_tier_field'
+              ? 'Input carries a forbidden truth-tier field (decisionGrade / proofTier / globalCredentialTruth). The boundary refuses; no row was written.'
+              : failure === 'client_supplied_persisted_flag'
+                ? 'Input carries a client-supplied persisted/confirmation field. The boundary refuses; only a real writer may emit a confirmation.'
+                : 'Input is missing one or more required fields (psvReceiptId / scope / limitations / sourceBasis / attributedResponder / freshness / correlationId). The boundary refuses; no row was written.',
+          preservedReceipt,
+        };
+      }
+
+      if (input.dryRun) {
+        return {
+          status: 'dry_run',
+          persisted: false,
+          message:
+            'Dry run only. Input shape passed structural validation; no row was written.',
+          preservedReceipt,
+        };
+      }
+
+      return {
+        status: 'deferred',
+        persisted: false,
+        message: DEFER_MESSAGE,
+        preservedReceipt,
+      };
+    },
+  };
+}
+
+/**
+ * The reference unavailable writer. Used when the environment has
+ * no writer configured at all.
+ */
+export function createUnavailableServerPsvReceiptWriter(): ServerPsvReceiptWriter {
+  return {
+    kind: 'deferred',
+    async attempt(
+      input: ServerPsvReceiptWriteInput,
+    ): Promise<ServerPsvReceiptWriteResult> {
+      return {
+        status: 'unavailable',
+        persisted: false,
+        failureReason: 'writer_unavailable',
+        message: UNAVAILABLE_MESSAGE,
+        preservedReceipt: input.receipt,
+      };
+    },
+  };
+}
+
+interface WriteWithConfirmationOptions {
+  writer: ServerPsvReceiptWriter;
+  input: ServerPsvReceiptWriteInput;
+}
+
+/**
+ * Pure orchestrator: invoke a writer and validate its result. The
+ * boundary refuses any "persisted" claim that does not carry a
+ * confirmation with `writerMode in {repository, external}`. This
+ * catches a buggy or hostile writer that returns persisted=true
+ * without confirming.
+ */
+export async function writePsvReceiptWithConfirmation(
+  options: WriteWithConfirmationOptions,
+): Promise<ServerPsvReceiptWriteResult> {
+  const result = await options.writer.attempt(options.input);
+
+  if (result.status === 'persisted') {
+    if (!result.confirmation) {
+      // Buggy/hostile writer claim. Downgrade defensively.
+      return {
+        status: 'failed',
+        persisted: false,
+        failureReason: 'invalid_writer_confirmation',
+        message:
+          "Writer reported status='persisted' without a confirmation. The boundary downgraded the result; no row is treated as persisted.",
+        preservedReceipt: result.preservedReceipt,
+      };
+    }
+    if (
+      result.confirmation.writerMode !== 'repository' &&
+      result.confirmation.writerMode !== 'external'
+    ) {
+      return {
+        status: 'failed',
+        persisted: false,
+        failureReason: 'invalid_writer_confirmation',
+        message:
+          "Writer confirmation has an invalid writerMode (must be 'repository' or 'external'). The boundary downgraded the result; no row is treated as persisted.",
+        preservedReceipt: result.preservedReceipt,
+      };
+    }
+    if (result.persisted !== true) {
+      // Status says persisted but flag says not. Trust the flag.
+      return {
+        status: 'failed',
+        persisted: false,
+        failureReason: 'invalid_writer_confirmation',
+        message:
+          "Writer reported status='persisted' but persisted=false. The boundary downgraded the result.",
+        preservedReceipt: result.preservedReceipt,
+      };
+    }
+  } else if (result.persisted === true) {
+    // Non-persisted status with persisted=true. Reject.
+    return {
+      status: 'failed',
+      persisted: false,
+      failureReason: 'invalid_writer_confirmation',
+      message:
+        "Writer reported persisted=true with a non-persisted status. The boundary downgraded the result.",
+      preservedReceipt: result.preservedReceipt,
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Plain-language explanation of a result. Surfaced verbatim by the
+ * review surface and route handler.
+ */
+export function explainServerWriterResult(
+  result: ServerPsvReceiptWriteResult,
+): string {
+  const head = `[${result.status}] persisted=${String(result.persisted)}`;
+  const reason = result.failureReason
+    ? ` (failureReason=${result.failureReason})`
+    : '';
+  const confirmation = result.confirmation
+    ? ` (writerMode=${result.confirmation.writerMode}, persistedRowId=${result.confirmation.persistedRowId})`
+    : '';
+  return `${head}${reason}${confirmation}: ${result.message}`;
+}
+
+/**
+ * Helper for surfacing the boundary's contribution into an
+ * IssuerAuditWriteResult (see auditPersistence.ts). The boundary
+ * never claims persistence; this maps a deferred result to the
+ * audit-write contract for downstream replay surfaces.
+ */
+export function asAuditWriteResult(
+  result: ServerPsvReceiptWriteResult,
+): IssuerAuditWriteResult {
+  return {
+    status:
+      result.status === 'persisted'
+        ? 'persisted'
+        : result.status === 'failed'
+          ? 'failed'
+          : result.status === 'unavailable'
+            ? 'unavailable'
+            : 'pending_not_written',
+    mode:
+      result.status === 'persisted'
+        ? 'repository'
+        : result.status === 'unavailable'
+          ? 'none'
+          : 'demo',
+    persisted: result.persisted,
+    message: result.message,
+    error: result.failureReason
+      ? { code: result.failureReason, message: result.message }
+      : undefined,
+  };
+}

--- a/docs/architecture/vitalcv-backend-persistence-defer-decision.md
+++ b/docs/architecture/vitalcv-backend-persistence-defer-decision.md
@@ -159,3 +159,46 @@ A future server-only writer MUST:
 ### Decision still in force
 
 The runtime decision returned by `evaluateBackendPersistenceReadiness` defaults to `defer_until_contract_aligned`. BACKEND-1 closes the **type-level** contract gap; it does not close the **schema-level** or **writer-level** gaps. Real persistence remains off in production code paths.
+
+---
+
+## BACKEND-2 status update (2026-04-27)
+
+### Decision: defer the real writer; ship the boundary only
+
+BACKEND-2 was scoped to either implement a real server-side writer OR ship a writer boundary with a deferred default. After re-auditing the contract readiness against BACKEND-1's still-open blockers, the safe path is **boundary only**.
+
+### Why the writer is still deferred
+
+The schema-level blockers identified in the original memo are unchanged. A "real" writer at this point would have to choose one of three unsafe paths:
+
+1. **Write to the legacy `psvReceipt` table.** This silently drops `limitations`, `sourceBasis` (with contracted-agent vs source distinction), `attributedResponder` (with `attributionMethod`), `scope`, `freshness`, and the candidate-vs-receipt distinction. That is a truth-contract violation — the persisted row would not be a `PSVReceipt` under ISSUER-4 semantics.
+2. **Run a Prisma migration to create a contract-aligned table.** The BACKEND-2 brief explicitly forbids broad migrations: "DO NOT add broad migrations". A migration is the right answer for the next wave; it is not in scope here.
+3. **Write to filesystem JSON or in-memory state.** That is fake persistence — the truth contract requires writer confirmation from a real repository, which JSON files / in-memory stores do not provide.
+
+All three paths violate the truth contract. The boundary-only outcome is the only safe option for this wave.
+
+### What BACKEND-2 ships
+
+**`apps/web/lib/issuer-verification/serverPsvReceiptWriter.ts`** — the writer boundary, with:
+- `ServerPsvReceiptWriter` interface, `ServerPsvReceiptWriteInput`, `ServerPsvReceiptWriteResult`, `ServerPsvReceiptWriteStatus` (`persisted` / `failed` / `unavailable` / `dry_run` / `deferred`), `ServerPsvReceiptWriterFailureReason` (7 reasons), `ServerPsvReceiptWriterConfirmation` (with `writerMode in {repository, external}`).
+- `canUseServerPsvReceiptWriter()` — pure structural gate; refuses missing required fields, refuses forbidden truth-tier fields (`globalCredentialTruth`/`decisionGrade`/`proofTier`), refuses client-supplied `persisted`/`confirmation` flags.
+- `buildServerPsvReceiptWriteInput()` — pure builder; strips forbidden truth-tier fields defensively.
+- `writePsvReceiptWithConfirmation()` — orchestrator that invokes a writer AND validates its result. **Defensively downgrades** any writer that returns `persisted=true` without a valid `writerMode in {repository, external}` confirmation.
+- `createDeferredServerPsvReceiptWriter()` — the BACKEND-2 default. Returns `'deferred'` for valid input, `'failed'` for invalid input, `'dry_run'` when requested. **NEVER returns `persisted=true`.**
+- `createUnavailableServerPsvReceiptWriter()` — returns `'unavailable'` for environments with no writer wired.
+
+**No API route ships.** `apps/web/app/api/issuer/psv-receipt/persist/route.ts` is intentionally NOT created. Per the BACKEND-2 STEP 4 rule, the unsafe path is "do not create route" — and we are unsafe because the table doesn't exist.
+
+### Acceptance criteria for the next wave (BACKEND-3 or named follow-up)
+
+The next wave that turns persistence ON must:
+
+1. Land a Prisma migration that creates a contract-aligned schema (new table(s); no overloading the legacy `psvReceipt` row).
+2. Implement a real server-only writer that accepts a `ServerPsvReceiptWriteInput`, talks to the new table, and returns a `ServerPsvReceiptWriterConfirmation` with `writerMode === 'repository'`.
+3. Land a Next.js server action / API route under `apps/web/app/api/issuer/psv-receipt/persist/` that the persistence-adapter boundary can call from server components — never imported by client code.
+4. Add tests covering: success path, structural-gap refusal, writer-mode invalidation, partial-write rollback, double-write idempotency, no-client-bundle-import, audit-event co-persistence.
+5. Update `evaluateBackendPersistenceReadiness` to return `implement_now` once every capability check is satisfied.
+6. Update `createRepositoryAuditAdapter` to flip from `unavailable` to `repository_enabled` (still requiring per-row writer confirmation).
+
+The BACKEND-2 boundary is designed to drop into that future wave with no API change — the deferred writer just gets replaced by the real one.

--- a/docs/architecture/vitalcv-knowledge-trust-graph.json
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.json
@@ -86,7 +86,11 @@
     "BackendPersistenceBlocker",
     "ServerRepositoryAuditAdapter",
     "WriterConfirmation",
-    "ContractAlignment"
+    "ContractAlignment",
+    "ServerPsvReceiptWriter",
+    "DryRunPersistenceAttempt",
+    "FailedPersistenceAttempt",
+    "DeferredPersistenceAttempt"
   ],
   "edges": [
     { "source": "Clinician", "relation": "HAS_NPI", "target": "NPI" },
@@ -178,6 +182,13 @@
     { "source": "BackendPersistenceCapabilityCheck", "relation": "GATES", "target": "BackendPersistenceDecision" },
     { "source": "ServerRepositoryAuditAdapter", "relation": "MAY_PRODUCE", "target": "PersistedAuditRecord" },
     { "source": "ContractAlignment", "relation": "PRECEDES", "target": "ServerRepositoryAuditAdapter" },
+    { "source": "ServerPsvReceiptWriter", "relation": "MAY_PRODUCE", "target": "PersistedAuditRecord" },
+    { "source": "ServerPsvReceiptWriter", "relation": "EMITS", "target": "WriterConfirmation" },
+    { "source": "WriterConfirmation", "relation": "REQUIRED_FOR", "target": "PersistedAuditRecord" },
+    { "source": "DryRunPersistenceAttempt", "relation": "DOES_NOT_PRODUCE", "target": "PersistedAuditRecord" },
+    { "source": "FailedPersistenceAttempt", "relation": "DOES_NOT_PRODUCE", "target": "PersistedAuditRecord" },
+    { "source": "DeferredPersistenceAttempt", "relation": "DOES_NOT_PRODUCE", "target": "PersistedAuditRecord" },
+    { "source": "ContractAlignment", "relation": "PRECEDES", "target": "ServerPsvReceiptWriter" },
     { "source": "IssuerAuditPersistenceAdapter", "relation": "EMITS", "target": "PersistenceAdapterDecision" },
     { "source": "IssuerResponse", "relation": "HAS_SOURCE_BASIS", "target": "SourceBasis" },
     { "source": "ContractedAgent", "relation": "ACTS_FOR", "target": "SourceOrIssuer" },
@@ -262,7 +273,13 @@
     "No client-side path may write audit records; the persistence boundary lives on the server.",
     "Deferring backend persistence is safer than wiring a contract-misaligned writer; defer is the documented default.",
     "Every BackendPersistenceCapabilityCheck must be satisfied before a BackendPersistenceDecision returns implement_now.",
-    "ServerRepositoryAuditAdapter exists only after contract alignment; this slice does not ship one."
+    "ServerRepositoryAuditAdapter exists only after contract alignment; this slice does not ship one.",
+    "The ServerPsvReceiptWriter boundary defines the writer contract; the default deferred writer never persists.",
+    "A persisted ServerPsvReceiptWriteResult requires a ServerPsvReceiptWriterConfirmation with writerMode in {repository, external}.",
+    "The boundary defensively downgrades any persisted=true claim from a writer that did not emit a valid confirmation.",
+    "DryRun, deferred, unavailable, and failed write attempts NEVER produce a PersistedAuditRecord.",
+    "Client-supplied persisted/confirmation flags are refused by canUseServerPsvReceiptWriter; only a real writer may emit a confirmation.",
+    "Forbidden truth-tier fields (decisionGrade, proofTier, globalCredentialTruth) on ServerPsvReceiptWriteInput are refused by the boundary."
   ],
   "knownLimitations": [
     "Machine-readable stub is documentation-grade only, not integrated into runtime types."

--- a/docs/architecture/vitalcv-knowledge-trust-graph.md
+++ b/docs/architecture/vitalcv-knowledge-trust-graph.md
@@ -83,6 +83,10 @@ The conceptual graph defining how truth moves through VitalCV.
 78. **Server Repository Audit Adapter**: A future server-only writer that confirms each row. Does NOT exist in this slice; named in the graph so the deferred bridge has a target.
 79. **Writer Confirmation**: The signal a writer emits when a real row was persisted. Required before any record's `persistenceStatus` may be `'persisted'`.
 80. **Contract Alignment**: The shape-compatibility precondition between the legacy backend repository and the issuer-verification truth contract. Must be satisfied before a server adapter may be wired.
+81. **Server PSV Receipt Writer**: BACKEND-2's writer-boundary contract. Defines `ServerPsvReceiptWriter`, `ServerPsvReceiptWriteInput`, `ServerPsvReceiptWriteResult`, and `ServerPsvReceiptWriterConfirmation`. The default deferred writer NEVER persists; a future repository-backed writer is required to flip `persisted=true`.
+82. **Dry-Run Persistence Attempt**: A write-attempt result with `status: 'dry_run'` and `persisted: false`. Used to validate input shape without writing.
+83. **Failed Persistence Attempt**: A write-attempt result with `status: 'failed'` and `persisted: false`. Set when input is malformed, when the writer rejected the row, or when the boundary downgraded a buggy writer claim.
+84. **Deferred Persistence Attempt**: A write-attempt result with `status: 'deferred'` and `persisted: false`. The BACKEND-2 default; signals that contract alignment is incomplete and the writer cannot run safely.
 
 
 ## Edges
@@ -175,6 +179,12 @@ The conceptual graph defining how truth moves through VitalCV.
 * `Backend Persistence Capability Check` GATES `Backend Persistence Decision`
 * `Server Repository Audit Adapter` MAY_PRODUCE `Persisted Audit Record`
 * `Contract Alignment` PRECEDES `Server Repository Audit Adapter`
+* `Server PSV Receipt Writer` MAY_PRODUCE `Persisted Audit Record`
+* `Server PSV Receipt Writer` EMITS `Writer Confirmation`
+* `Dry-Run Persistence Attempt` DOES_NOT_PRODUCE `Persisted Audit Record`
+* `Failed Persistence Attempt` DOES_NOT_PRODUCE `Persisted Audit Record`
+* `Deferred Persistence Attempt` DOES_NOT_PRODUCE `Persisted Audit Record`
+* `Contract Alignment` PRECEDES `Server PSV Receipt Writer`
 * `Issuer Audit Persistence Adapter` EMITS `Persistence Adapter Decision`
 * `Contracted Agent` ACTS_FOR `Source`
 
@@ -236,4 +246,8 @@ The conceptual graph defining how truth moves through VitalCV.
 54. **Defer Is The Default Boundary**: `evaluateBackendPersistenceReadiness` returns `defer_until_contract_aligned` by default. Every capability check must be explicitly satisfied before the decision flips to `implement_now`.
 55. **Server-Only Writer Boundary**: No client-side path may write audit records. A writer is server-only by construction; client code may invoke it only through a Next.js server action / RPC route, never via direct repository import.
 56. **Capability-Gated Implementation Boundary**: The nine `BackendPersistenceCapabilityCheck` capabilities are independent gates. A blocker on any one of them prevents `implement_now`, regardless of how many others are satisfied.
+57. **Writer Boundary Boundary**: The `ServerPsvReceiptWriter` interface defines the writer contract. The default deferred writer NEVER returns `persisted=true`. Replacing the deferred writer with a repository-backed writer is the load-bearing transition for real persistence.
+58. **Confirmation Required Boundary**: A `ServerPsvReceiptWriteResult` may carry `status: 'persisted'` ONLY if the writer also emits a `ServerPsvReceiptWriterConfirmation` with `writerMode in {repository, external}`. The boundary's `writePsvReceiptWithConfirmation` orchestrator defensively downgrades any persisted claim that lacks a valid confirmation.
+59. **No Client-Persisted-Flag Boundary**: `canUseServerPsvReceiptWriter` refuses input that carries a client-supplied `persisted` or `confirmation` field. Only a real writer may emit a confirmation; clients cannot self-report persistence.
+60. **No Forbidden Truth Tier Boundary**: `ServerPsvReceiptWriteInput` does not type `decisionGrade`/`proofTier`/`globalCredentialTruth`, AND the boundary refuses input that smuggles them in at runtime. The writer cannot upgrade a claim's truth tier under any circumstance.
 


### PR DESCRIPTION
## Summary
- add `apps/web/lib/issuer-verification/serverPsvReceiptWriter.ts` — the writer boundary contract (types + helpers + a deferred-by-default writer)
- preserve no-op/deferred behavior unless a real writer emits a valid `ServerPsvReceiptWriterConfirmation` with `writerMode in {repository, external}`
- add 34 tests proving persistence cannot be claimed without writer confirmation, that client input cannot force `persisted=true`, that forbidden truth-tier fields (`decisionGrade`/`proofTier`/`globalCredentialTruth`) are refused, and that the boundary defensively downgrades buggy/hostile writer claims
- update Knowledge Trust Graph (4 new nodes, 8 new edges, 6 new rules, boundaries 57-60) and the backend persistence defer memo

## Decision
**Writer boundary only — real persistence still deferred.** All schema-level blockers from BACKEND-1's defer memo remain open (no contract-aligned Prisma table, no audit-event table, no client-safe RPC, no backend repo test coverage). A real writer at this point would have to (1) write to the legacy `psvReceipt` table — silently dropping ISSUER-4 truth-contract fields (truth-contract violation), (2) run a Prisma migration — explicitly forbidden by the BACKEND-2 brief, or (3) write to fake storage — not a real audit trail. None are acceptable; ship the boundary instead.

**No API route ships.** `apps/web/app/api/issuer/psv-receipt/persist/route.ts` is intentionally NOT created — per the BACKEND-2 brief: "if unsafe, do not create route".

## Truth rules
- `persisted` status requires server-side writer confirmation
- `dry_run` / `deferred` / `unavailable` / `failed` are NOT persisted
- client input cannot force persisted status
- forbidden truth-tier fields are refused at the boundary
- the boundary defensively downgrades buggy or hostile writer claims
- no global credential truth introduced

## Validation
- graph JSON parses
- **321/321 issuer tests pass** across 10 suites (verification + receipt-candidate + policy-review + psv-receipt + psv-reuse + request-lifecycle + audit-persistence + persistence-adapter + backend-persistence-decision + **server-persistence-writer**)
- `pnpm turbo run build --filter @vitalcv/web` — 13/13 tasks succeed
- banned-string sweep on diff lines: zero hits across 13 phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)