### PR TITLE
feat(clinician): add profile foundation and onboarding shell

### DIFF
--- a/apps/web/__tests__/clinician-profile-foundation.test.ts
+++ b/apps/web/__tests__/clinician-profile-foundation.test.ts
@@ -1,0 +1,290 @@
+/**
+ * FOUNDATION-SWEEP-1 — clinician profile foundation tests.
+ *
+ * Truth invariants this suite enforces:
+ *   - User-entered fields are NEVER counted as verified.
+ *   - Missing provenance / unknown fields lower readiness.
+ *   - Education / training / employer / affiliation fields require
+ *     provenance metadata (the type system enforces it; this suite
+ *     proves the helpers respect it at runtime).
+ *   - PubMed entries are imported-candidates until source-backed.
+ *   - Unknown / conflict fields do not count as verified completion.
+ *   - Import page does not claim live integration.
+ *   - Graph preview page declares that the graph does not verify by itself.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  isCoherentProvenance,
+  type ClinicianProfile,
+  type ProfileFieldConfidence,
+  type ProfileFieldMeta,
+  type ProfileFieldProvenance,
+} from '../lib/clinician-profile/profileTypes';
+import {
+  calculateClinicianProfileCompletion,
+  explainProfileFieldProvenance,
+  getMissingProfileFoundationFields,
+  getProfileSectionReadiness,
+} from '../lib/clinician-profile/profileCompletion';
+
+function f<T>(
+  value: T | null,
+  provenance: ProfileFieldProvenance,
+  confidence: ProfileFieldConfidence = 'self-attested',
+): ProfileFieldMeta<T | null> {
+  return { value, provenance, confidence };
+}
+
+function emptyProfile(): ClinicianProfile {
+  return {
+    clinicianId: 'cl-test',
+    identity: {
+      legalName: f<string>(null, 'UNKNOWN', 'unverified'),
+      preferredName: f<string>(null, 'UNKNOWN', 'unverified'),
+      npi: f<string>(null, 'UNKNOWN', 'unverified'),
+      primaryEmail: f<string>(null, 'UNKNOWN', 'unverified'),
+      primaryPhone: f<string>(null, 'UNKNOWN', 'unverified'),
+      practiceLocations: f<string[]>(null, 'UNKNOWN', 'unverified'),
+    },
+    education: [],
+    training: [],
+    specialties: [],
+    currentEmployer: null,
+    employerHistory: [],
+    affiliations: [],
+    research: [],
+    publications: [],
+    careerGoals: f<string>(null, 'UNKNOWN', 'unverified'),
+  };
+}
+
+describe('clinician profile foundation — coherence rules', () => {
+  it('rejects USER_ENTERED + source-backed combination', () => {
+    expect(isCoherentProvenance('USER_ENTERED', 'source-backed')).toBe(false);
+  });
+
+  it('allows USER_ENTERED + self-attested', () => {
+    expect(isCoherentProvenance('USER_ENTERED', 'self-attested')).toBe(true);
+  });
+
+  it('forces UNKNOWN to be unverified', () => {
+    expect(isCoherentProvenance('UNKNOWN', 'unverified')).toBe(true);
+    expect(isCoherentProvenance('UNKNOWN', 'self-attested')).toBe(false);
+    expect(isCoherentProvenance('UNKNOWN', 'source-backed')).toBe(false);
+  });
+
+  it('rejects CONFLICT + source-backed', () => {
+    expect(isCoherentProvenance('CONFLICT', 'source-backed')).toBe(false);
+  });
+});
+
+describe('clinician profile foundation — completion math', () => {
+  it('an empty profile reads zero on every overall axis', () => {
+    const summary = calculateClinicianProfileCompletion(emptyProfile());
+    expect(summary.overallFilledRatio).toBe(0);
+    expect(summary.overallSourceBackedRatio).toBe(0);
+    expect(summary.overallVerificationReadiness).toBe(0);
+  });
+
+  it('user-entered fields fill the profile but do not count as verified', () => {
+    const profile = emptyProfile();
+    profile.identity.legalName = f('Sample Clinician', 'USER_ENTERED', 'self-attested');
+    profile.identity.primaryEmail = f('s@example.org', 'USER_ENTERED', 'self-attested');
+    const summary = calculateClinicianProfileCompletion(profile);
+    expect(summary.overallFilledRatio).toBeGreaterThan(0);
+    expect(summary.overallSourceBackedRatio).toBe(0);
+    expect(summary.overallNote).toContain('count as verified');
+  });
+
+  it('source-backed identity contributes more readiness than self-attested', () => {
+    const selfAttested = emptyProfile();
+    selfAttested.identity.npi = f('1234567890', 'USER_ENTERED', 'self-attested');
+    const sourceBacked = emptyProfile();
+    sourceBacked.identity.npi = f('1234567890', 'VERIFIED', 'source-backed');
+    const a = calculateClinicianProfileCompletion(selfAttested).overallVerificationReadiness;
+    const b = calculateClinicianProfileCompletion(sourceBacked).overallVerificationReadiness;
+    expect(b).toBeGreaterThan(a);
+  });
+
+  it('unknown and conflict fields do not count as verified completion', () => {
+    const profile = emptyProfile();
+    profile.identity.legalName = f('Has Conflict', 'CONFLICT', 'unverified');
+    const summary = calculateClinicianProfileCompletion(profile);
+    expect(summary.overallSourceBackedRatio).toBe(0);
+    const identitySig = summary.sections.find((s) => s.section === 'identity');
+    expect(identitySig?.unresolvedConflictCount).toBeGreaterThan(0);
+    expect(identitySig?.readinessNote).toContain('conflict');
+  });
+
+  it('education entries require provenance metadata for medical-school readiness to count', () => {
+    const profile = emptyProfile();
+    profile.education.push({
+      id: 'edu-1',
+      institution: f('Sample School', 'USER_ENTERED', 'self-attested'),
+      degree: f('MD', 'USER_ENTERED', 'self-attested'),
+      graduationYear: f<number>(2012, 'USER_ENTERED', 'self-attested'),
+      programType: 'medical_school',
+    });
+    const sig = getProfileSectionReadiness(profile, 'medical_school');
+    expect(sig).not.toBeNull();
+    expect(sig!.filledFieldCount).toBe(3);
+    expect(sig!.sourceBackedFieldCount).toBe(0);
+    expect(sig!.readinessNote).toContain('not been attached');
+  });
+
+  it('residency / fellowship / training are tracked separately', () => {
+    const profile = emptyProfile();
+    profile.training.push({
+      id: 't-1',
+      programType: 'residency',
+      institution: f('Sample Hosp', 'USER_ENTERED', 'self-attested'),
+      specialty: f('Internal Medicine', 'USER_ENTERED', 'self-attested'),
+      startYear: f<number>(2012, 'USER_ENTERED', 'self-attested'),
+      endYear: f<number>(2015, 'USER_ENTERED', 'self-attested'),
+    });
+    profile.training.push({
+      id: 't-2',
+      programType: 'fellowship',
+      institution: f('Sample Hosp', 'USER_ENTERED', 'self-attested'),
+      specialty: f('Cardiology', 'USER_ENTERED', 'self-attested'),
+      startYear: f<number>(2015, 'USER_ENTERED', 'self-attested'),
+      endYear: f<number>(2018, 'USER_ENTERED', 'self-attested'),
+    });
+    const summary = calculateClinicianProfileCompletion(profile);
+    const residency = summary.sections.find((s) => s.section === 'residency');
+    const fellowship = summary.sections.find((s) => s.section === 'fellowship');
+    expect(residency?.filledFieldCount).toBe(4);
+    expect(fellowship?.filledFieldCount).toBe(4);
+  });
+
+  it('current employer and affiliations require provenance', () => {
+    const profile = emptyProfile();
+    profile.currentEmployer = {
+      id: 'e-1',
+      employer: f('Sample Health', 'USER_ENTERED', 'self-attested'),
+      title: f('Attending', 'USER_ENTERED', 'self-attested'),
+      startDate: f('2018-01-01', 'USER_ENTERED', 'self-attested'),
+      endDate: f<string>(null, 'UNKNOWN', 'unverified'),
+      isCurrent: true,
+    };
+    profile.affiliations.push({
+      id: 'a-1',
+      organization: f('Sample Hospital', 'USER_ENTERED', 'self-attested'),
+      affiliationType: f('Privileges', 'USER_ENTERED', 'self-attested'),
+      startDate: f('2018-01-01', 'USER_ENTERED', 'self-attested'),
+      endDate: f<string>(null, 'UNKNOWN', 'unverified'),
+    });
+    const employerSig = getProfileSectionReadiness(profile, 'current_employer');
+    const affiliationSig = getProfileSectionReadiness(profile, 'affiliations');
+    expect(employerSig?.sourceBackedFieldCount).toBe(0);
+    expect(affiliationSig?.sourceBackedFieldCount).toBe(0);
+  });
+
+  it('PubMed publication entry stays imported-candidate until source-backed', () => {
+    const profile = emptyProfile();
+    profile.publications.push({
+      id: 'p-1',
+      title: f('Sample Title', 'INFERRED', 'imported-candidate'),
+      journal: f('Sample Journal', 'INFERRED', 'imported-candidate'),
+      publishedYear: f<number>(2024, 'INFERRED', 'imported-candidate'),
+      pubmedId: f('00000000', 'INFERRED', 'imported-candidate'),
+      importSource: 'pubmed',
+    });
+    const sig = getProfileSectionReadiness(profile, 'publications');
+    expect(sig?.filledFieldCount).toBe(4);
+    expect(sig?.sourceBackedFieldCount).toBe(0);
+    expect(sig?.readinessNote.toLowerCase()).toContain('source-backed');
+  });
+
+  it('missing-foundation getter highlights sections with no source-backed evidence', () => {
+    const profile = emptyProfile();
+    profile.identity.legalName = f('Sample', 'USER_ENTERED', 'self-attested');
+    const missing = getMissingProfileFoundationFields(profile);
+    expect(missing).toContain('identity');
+  });
+
+  it('explainProfileFieldProvenance returns vocabulary descriptions', () => {
+    expect(explainProfileFieldProvenance('VERIFIED')).toMatch(/source/i);
+    expect(explainProfileFieldProvenance('USER_ENTERED')).toMatch(/clinician/i);
+    expect(explainProfileFieldProvenance('UNKNOWN')).toMatch(/no data/i);
+  });
+});
+
+const ROUTE_DIR = resolve(__dirname, '..', 'app', 'clinician');
+
+function readRoute(rel: string): string {
+  return readFileSync(resolve(ROUTE_DIR, rel), 'utf-8');
+}
+
+describe('clinician foundation — route copy invariants', () => {
+  it('onboarding page declares user-entered ≠ verified', () => {
+    const src = readRoute('onboarding/page.tsx');
+    expect(src).toContain('User-entered information is not verified until source-backed evidence is attached.');
+  });
+
+  it('onboarding page does not claim government ID / liveness is live', () => {
+    const src = readRoute('onboarding/page.tsx');
+    expect(src.toLowerCase()).not.toContain('government id verified');
+    expect(src.toLowerCase()).not.toContain('liveness verified');
+    expect(src).toMatch(/government ID and liveness — is on the roadmap/);
+  });
+
+  it('profile page renders provenance vocabulary disclaimer', () => {
+    const src = readRoute('profile/page.tsx');
+    expect(src).toContain('User-entered information is not verified until source-backed evidence is attached.');
+    expect(src).toContain('PROVENANCE_META');
+  });
+
+  it('import page marks every integration card as planned or entry-point-only', () => {
+    const src = readRoute('import/page.tsx');
+    expect(src).toContain("status: 'planned'");
+    expect(src).toContain("status: 'entry point only'");
+    expect(src).toMatch(/Integration is planned; no live LinkedIn sync ships today\./);
+    expect(src).toMatch(/Integration is planned; no live Doximity sync ships today\./);
+  });
+
+  it('import page does not claim live PubMed import success', () => {
+    const src = readRoute('import/page.tsx');
+    expect(src).toMatch(/imported-candidates until a source-backed check upgrades them/);
+    expect(src.toLowerCase()).not.toContain('pubmed import complete');
+    expect(src.toLowerCase()).not.toContain('publications verified');
+  });
+
+  it('graph preview page says the graph does not verify by itself', () => {
+    const src = readRoute('graph/page.tsx');
+    expect(src).toContain('The graph explains provenance and gaps. It does not verify a claim by itself.');
+  });
+
+  it('graph preview includes the required node taxonomy labels', () => {
+    const src = readRoute('graph/page.tsx');
+    for (const label of ['Clinician', 'NPI', 'Claim', 'Source', 'Receipt', 'Unknown', 'User-entered']) {
+      expect(src).toContain(label);
+    }
+  });
+
+  it('no clinician foundation page contains forbidden truth-contract phrases', () => {
+    const banned = [
+      'guaranteed verification',
+      'instant credentialing',
+      'complete credentialing',
+      'legally accepted',
+      'risk transferred',
+      'HIPAA compliant',
+      'SOC2 certified',
+      'NCQA verified',
+      'irreversible proof',
+      'global credential truth',
+      'tamper-proof',
+    ];
+    for (const rel of ['onboarding/page.tsx', 'profile/page.tsx', 'import/page.tsx', 'graph/page.tsx']) {
+      const src = readRoute(rel).toLowerCase();
+      for (const phrase of banned) {
+        expect(src).not.toContain(phrase.toLowerCase());
+      }
+    }
+  });
+});

--- a/apps/web/app/clinician/graph/page.tsx
+++ b/apps/web/app/clinician/graph/page.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Clinician Knowledge Graph Preview · VitalCV',
+  description:
+    'A static preview of how the Knowledge Trust Graph organizes claims, sources, evidence, and receipts for a clinician. The graph explains provenance and gaps. It does not verify a claim by itself.',
+};
+
+type NodeKind =
+  | 'clinician'
+  | 'npi'
+  | 'education-claim'
+  | 'employer-claim'
+  | 'publication-claim'
+  | 'source'
+  | 'receipt'
+  | 'unknown'
+  | 'user-entered';
+
+interface NodeDef {
+  id: string;
+  label: string;
+  kind: NodeKind;
+  hint: string;
+}
+
+interface EdgeDef {
+  from: string;
+  to: string;
+  label: string;
+}
+
+const NODES: ReadonlyArray<NodeDef> = [
+  { id: 'clinician', label: 'Dr. Sample, MD', kind: 'clinician', hint: 'The clinician this profile describes.' },
+  { id: 'npi', label: 'NPI 1234567890', kind: 'npi', hint: 'Identifier resolved against NPPES (federal source of record).' },
+  { id: 'edu-1', label: 'Medical school: Sample School of Medicine, MD, 2012', kind: 'education-claim', hint: 'A claim made about the clinician.' },
+  { id: 'emp-1', label: 'Current employer: Sample Health System (Cardiology, attending)', kind: 'employer-claim', hint: 'A claim about current employment.' },
+  { id: 'pub-1', label: 'Publication: "Sample title" (PubMed:00000000)', kind: 'publication-claim', hint: 'A claim about a publication.' },
+  { id: 'source-nppes', label: 'Source: NPPES', kind: 'source', hint: 'A source-of-record check has run against NPPES.' },
+  { id: 'source-pubmed', label: 'Source: PubMed', kind: 'source', hint: 'PubMed lookup ran but is treated as imported-candidate, not source-backed PSV.' },
+  { id: 'receipt-nppes', label: 'Receipt: NPPES check, freshness 24h', kind: 'receipt', hint: 'A receipt records that a check ran. It is not a verification of the underlying claim.' },
+  { id: 'unknown-board-cert', label: 'Unknown: board certification', kind: 'unknown', hint: 'No data from any source. Neutral — not evidence of absence.' },
+  { id: 'user-entered-affiliation', label: 'User-entered: Hospital privileges at Sample Hospital', kind: 'user-entered', hint: 'Provided by the clinician. Not source-backed.' },
+];
+
+const EDGES: ReadonlyArray<EdgeDef> = [
+  { from: 'clinician', to: 'npi', label: 'identified by' },
+  { from: 'npi', to: 'source-nppes', label: 'resolved against' },
+  { from: 'source-nppes', to: 'receipt-nppes', label: 'produced' },
+  { from: 'clinician', to: 'edu-1', label: 'claims' },
+  { from: 'clinician', to: 'emp-1', label: 'claims' },
+  { from: 'clinician', to: 'pub-1', label: 'claims' },
+  { from: 'pub-1', to: 'source-pubmed', label: 'imported from (candidate)' },
+  { from: 'clinician', to: 'unknown-board-cert', label: 'has gap' },
+  { from: 'clinician', to: 'user-entered-affiliation', label: 'self-attests' },
+];
+
+const KIND_LABEL: Record<NodeKind, string> = {
+  clinician: 'Clinician',
+  npi: 'NPI',
+  'education-claim': 'Claim',
+  'employer-claim': 'Claim',
+  'publication-claim': 'Claim',
+  source: 'Source',
+  receipt: 'Receipt',
+  unknown: 'Unknown',
+  'user-entered': 'User-entered',
+};
+
+const KIND_CLASS: Record<NodeKind, string> = {
+  clinician: 'border-foreground/20 bg-foreground/5 text-foreground',
+  npi: 'border-sky-500/40 bg-sky-500/10 text-sky-700',
+  'education-claim': 'border-violet-500/40 bg-violet-500/10 text-violet-700',
+  'employer-claim': 'border-violet-500/40 bg-violet-500/10 text-violet-700',
+  'publication-claim': 'border-violet-500/40 bg-violet-500/10 text-violet-700',
+  source: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700',
+  receipt: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700',
+  unknown: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+  'user-entered': 'border-amber-500/40 bg-amber-500/10 text-amber-700',
+};
+
+export default function ClinicianGraphPreviewPage() {
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Knowledge Trust Graph preview
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          How VitalCV organizes claims, sources, evidence, and receipts
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>The graph explains provenance and gaps. It does not verify a
+          claim by itself.</strong> Verification requires a source-backed check
+          that produces a receipt, and a credentialing reviewer to inspect that
+          receipt against policy.
+        </p>
+      </header>
+
+      <section aria-labelledby="legend-heading" className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5">
+        <h2 id="legend-heading" className="text-sm font-semibold">
+          Legend
+        </h2>
+        <ul className="mt-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
+          {(['clinician', 'npi', 'education-claim', 'source', 'receipt', 'unknown', 'user-entered'] as NodeKind[]).map((k) => (
+            <li key={k} className={`inline-flex items-center justify-center rounded-full border px-2 py-1 ${KIND_CLASS[k]}`}>
+              {KIND_LABEL[k]}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="nodes-heading" className="mb-8">
+        <h2 id="nodes-heading" className="text-lg font-semibold">
+          Sample nodes
+        </h2>
+        <ul className="mt-3 space-y-2">
+          {NODES.map((node) => (
+            <li
+              key={node.id}
+              className={`rounded-lg border p-3 text-sm ${KIND_CLASS[node.kind]}`}
+            >
+              <p className="font-medium">{node.label}</p>
+              <p className="mt-0.5 text-[11px] opacity-80">{node.hint}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="edges-heading">
+        <h2 id="edges-heading" className="text-lg font-semibold">
+          Sample edges
+        </h2>
+        <ul className="mt-3 space-y-1.5 text-sm">
+          {EDGES.map((edge, i) => {
+            const fromNode = NODES.find((n) => n.id === edge.from);
+            const toNode = NODES.find((n) => n.id === edge.to);
+            return (
+              <li
+                key={`${edge.from}-${edge.to}-${i}`}
+                className="rounded-lg border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] px-3 py-2 font-mono text-xs"
+              >
+                <span className="opacity-70">{fromNode?.label ?? edge.from}</span>
+                <span className="mx-2 opacity-50">— {edge.label} →</span>
+                <span className="opacity-90">{toNode?.label ?? edge.to}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <p className="mt-8 text-xs leading-relaxed text-muted-foreground">
+        Visual graph layout (Roam/Obsidian-style canvas) is a separate wave.
+        This preview lists the same node and edge types in plain text so the
+        invariants are auditable. <strong>The graph explains provenance and
+        gaps. It does not verify a claim by itself.</strong>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/app/clinician/import/page.tsx
+++ b/apps/web/app/clinician/import/page.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Clinician Import · VitalCV',
+  description:
+    'Entry points for CV upload, document upload, PubMed/LinkedIn/Doximity import, CSV/roster import, and export. Inactive integrations are explicitly marked planned or entry-point-only.',
+};
+
+type IntegrationStatus = 'planned' | 'entry point only';
+
+interface IntegrationCard {
+  key: string;
+  title: string;
+  body: string;
+  status: IntegrationStatus;
+}
+
+const IMPORTS: ReadonlyArray<IntegrationCard> = [
+  {
+    key: 'cv-upload',
+    title: 'CV upload',
+    body: 'Upload a CV/resume. Document parsing into structured profile fields is not wired in this entry point.',
+    status: 'entry point only',
+  },
+  {
+    key: 'document-upload',
+    title: 'Document upload',
+    body: 'Attach a credentialing document (license, certificate, attestation). Source-backed verification of the document is a separate path.',
+    status: 'entry point only',
+  },
+  {
+    key: 'pubmed',
+    title: 'PubMed import',
+    body: 'Pull authored publications from PubMed. Imported entries are imported-candidates until a source-backed check upgrades them.',
+    status: 'entry point only',
+  },
+  {
+    key: 'linkedin',
+    title: 'LinkedIn import',
+    body: 'Pull employment and education from LinkedIn. Integration is planned; no live LinkedIn sync ships today.',
+    status: 'planned',
+  },
+  {
+    key: 'doximity',
+    title: 'Doximity import',
+    body: 'Pull profile content from Doximity. Integration is planned; no live Doximity sync ships today.',
+    status: 'planned',
+  },
+  {
+    key: 'csv-roster',
+    title: 'CSV / roster import',
+    body: 'Bulk-import a roster of clinicians. Some CSV ingest paths exist for pilot ops; full roster automation is planned.',
+    status: 'entry point only',
+  },
+];
+
+const EXPORTS: ReadonlyArray<IntegrationCard> = [
+  {
+    key: 'export-bundle',
+    title: 'Export bundle',
+    body: 'Export an audit-ready bundle of your filled fields and any attached evidence. Bundle UX is in progress; cryptographic signing of exports is planned.',
+    status: 'entry point only',
+  },
+  {
+    key: 'shareable-passport',
+    title: 'Shareable passport',
+    body: 'Generate a public/limited-share passport URL for your profile. Provenance badges accompany every field on the share view.',
+    status: 'entry point only',
+  },
+];
+
+const STATUS_CLASS: Record<IntegrationStatus, string> = {
+  planned: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+  'entry point only': 'border-amber-500/40 bg-amber-500/10 text-amber-700',
+};
+
+function StatusPill({ status }: { status: IntegrationStatus }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${STATUS_CLASS[status]}`}
+      aria-label={`Status: ${status}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function CardGrid({ heading, items, headingId }: { heading: string; items: ReadonlyArray<IntegrationCard>; headingId: string }) {
+  return (
+    <section aria-labelledby={headingId} className="space-y-4">
+      <h2 id={headingId} className="text-lg font-semibold sm:text-xl">
+        {heading}
+      </h2>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {items.map((card) => (
+          <article
+            key={card.key}
+            className="flex flex-col rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+          >
+            <header className="flex items-start justify-between gap-3">
+              <h3 className="text-base font-semibold">{card.title}</h3>
+              <StatusPill status={card.status} />
+            </header>
+            <p className="mt-2 flex-1 text-sm leading-relaxed text-muted-foreground">
+              {card.body}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function ClinicianImportPage() {
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Clinician import &amp; export
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Import sources and export bundles
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          Cards below are entry points. Inactive integrations are explicitly
+          marked <em>planned</em>; partial integrations are marked <em>entry
+          point only</em>. No card claims a live integration that does not
+          ship today. <strong>Imported entries remain imported-candidates
+          until a source-backed check upgrades them.</strong>
+        </p>
+      </header>
+
+      <div className="space-y-10">
+        <CardGrid heading="Import" items={IMPORTS} headingId="import-section-heading" />
+        <CardGrid heading="Export" items={EXPORTS} headingId="export-section-heading" />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/clinician/onboarding/page.tsx
+++ b/apps/web/app/clinician/onboarding/page.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Clinician Onboarding · VitalCV',
+  description:
+    'Begin your VitalCV profile. User-entered information is not verified until source-backed evidence is attached.',
+};
+
+const STEPS: ReadonlyArray<{ key: string; title: string; body: string }> = [
+  {
+    key: 'npi',
+    title: '1. Start with your NPI',
+    body: 'Enter your 10-digit NPI. We resolve identity from NPPES (the federal source of record). Identity-proofing — government ID and liveness — is on the roadmap and is not yet shipped.',
+  },
+  {
+    key: 'identity',
+    title: '2. Confirm identity, contact, locations',
+    body: 'Add the contact details and practice locations you want a credentialing reviewer to see. These are user-entered until you attach source-backed evidence.',
+  },
+  {
+    key: 'training',
+    title: '3. Add training: medical school, residency, fellowship',
+    body: 'Capture each program with institution and dates. Source-backed verification of training programs is a separate step beyond capture.',
+  },
+  {
+    key: 'specialty',
+    title: '4. Specialty and subspecialty',
+    body: 'Pick the taxonomy you practice under. NPPES inference may pre-fill a specialty; board certification still needs source-backed evidence.',
+  },
+  {
+    key: 'work',
+    title: '5. Current employer and history',
+    body: 'List your current role and prior positions. Employer-side confirmation is a separate verification path.',
+  },
+  {
+    key: 'research',
+    title: '6. Research and publications',
+    body: 'Manually add or import (PubMed, LinkedIn, Doximity). Imported entries remain candidates until a source-of-record check upgrades them.',
+  },
+];
+
+export default function ClinicianOnboardingPage() {
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Clinician onboarding
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Build your source-backed credential record
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          Onboarding lays out the sections of your profile in order. Filling fields
+          improves your dashboard view; verification still requires source-backed
+          evidence to be attached. <strong>User-entered information is not verified
+          until source-backed evidence is attached.</strong>
+        </p>
+      </header>
+
+      <ol aria-label="Onboarding steps" className="space-y-4">
+        {STEPS.map((step) => (
+          <li
+            key={step.key}
+            className="rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+          >
+            <h2 className="text-base font-semibold sm:text-lg">{step.title}</h2>
+            <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              {step.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+
+      <nav aria-label="Continue" className="mt-8 flex flex-col gap-3 sm:flex-row">
+        <Link
+          href="/clinician/profile"
+          className="inline-flex h-11 items-center justify-center rounded-xl border border-foreground/10 bg-foreground px-5 text-sm font-medium text-background hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          Open profile
+        </Link>
+        <Link
+          href="/clinician/import"
+          className="inline-flex h-11 items-center justify-center rounded-xl border border-foreground/10 px-5 text-sm font-medium hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        >
+          Import from existing sources
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/apps/web/app/clinician/profile/page.tsx
+++ b/apps/web/app/clinician/profile/page.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+import { PROVENANCE_META, type ProfileProvenance } from '@/lib/profile/provenance';
+
+export const metadata: Metadata = {
+  title: 'Clinician Profile · VitalCV',
+  description:
+    'Your clinician profile. User-entered information is not verified until source-backed evidence is attached.',
+};
+
+interface SectionDef {
+  key: string;
+  title: string;
+  fields: ReadonlyArray<{ label: string; provenance: ProfileProvenance; placeholder: string }>;
+}
+
+const SECTIONS: ReadonlyArray<SectionDef> = [
+  {
+    key: 'identity',
+    title: 'Identity, contact, locations',
+    fields: [
+      { label: 'Legal name', provenance: 'USER_ENTERED', placeholder: 'As it appears on government ID' },
+      { label: 'NPI', provenance: 'UNKNOWN', placeholder: '10-digit NPI' },
+      { label: 'Primary email', provenance: 'USER_ENTERED', placeholder: 'you@example.org' },
+      { label: 'Practice locations', provenance: 'USER_ENTERED', placeholder: 'City, state' },
+    ],
+  },
+  {
+    key: 'medical_school',
+    title: 'Medical school',
+    fields: [
+      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'School name' },
+      { label: 'Degree', provenance: 'USER_ENTERED', placeholder: 'MD, DO, MBBS, …' },
+      { label: 'Graduation year', provenance: 'USER_ENTERED', placeholder: 'YYYY' },
+    ],
+  },
+  {
+    key: 'residency',
+    title: 'Residency',
+    fields: [
+      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'Program name' },
+      { label: 'Specialty', provenance: 'USER_ENTERED', placeholder: 'e.g., Internal Medicine' },
+      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
+    ],
+  },
+  {
+    key: 'fellowship',
+    title: 'Fellowship',
+    fields: [
+      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'Program name' },
+      { label: 'Specialty', provenance: 'USER_ENTERED', placeholder: 'Subspecialty area' },
+      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
+    ],
+  },
+  {
+    key: 'training_programs',
+    title: 'Other training programs',
+    fields: [
+      { label: 'Program', provenance: 'USER_ENTERED', placeholder: 'Name + institution' },
+      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
+    ],
+  },
+  {
+    key: 'specialty',
+    title: 'Specialty and subspecialty',
+    fields: [
+      { label: 'Specialty', provenance: 'INFERRED', placeholder: 'NPPES taxonomy or self-attested' },
+      { label: 'Subspecialty', provenance: 'USER_ENTERED', placeholder: 'Free-text' },
+      { label: 'Board certified', provenance: 'UNKNOWN', placeholder: 'Pending source-backed check' },
+    ],
+  },
+  {
+    key: 'current_employer',
+    title: 'Current employer',
+    fields: [
+      { label: 'Employer', provenance: 'USER_ENTERED', placeholder: 'Organization name' },
+      { label: 'Title', provenance: 'USER_ENTERED', placeholder: 'Your role' },
+      { label: 'Start date', provenance: 'USER_ENTERED', placeholder: 'YYYY-MM-DD' },
+    ],
+  },
+  {
+    key: 'employer_history',
+    title: 'Employer history',
+    fields: [
+      { label: 'Employer', provenance: 'USER_ENTERED', placeholder: 'Prior organization' },
+      { label: 'Title', provenance: 'USER_ENTERED', placeholder: 'Role' },
+      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
+    ],
+  },
+  {
+    key: 'affiliations',
+    title: 'Affiliations',
+    fields: [
+      { label: 'Organization', provenance: 'USER_ENTERED', placeholder: 'Hospital, society, etc.' },
+      { label: 'Type', provenance: 'USER_ENTERED', placeholder: 'Privileges, member, …' },
+      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
+    ],
+  },
+  {
+    key: 'research',
+    title: 'Research',
+    fields: [
+      { label: 'Topic', provenance: 'USER_ENTERED', placeholder: 'Area of research' },
+      { label: 'Role', provenance: 'USER_ENTERED', placeholder: 'PI, co-author, …' },
+    ],
+  },
+  {
+    key: 'publications',
+    title: 'Publications',
+    fields: [
+      { label: 'Title', provenance: 'INFERRED', placeholder: 'PubMed import is candidate-grade until source-backed' },
+      { label: 'Journal', provenance: 'INFERRED', placeholder: 'PubMed-derived' },
+      { label: 'Year', provenance: 'INFERRED', placeholder: 'YYYY' },
+    ],
+  },
+];
+
+function ProvenanceBadge({ provenance }: { provenance: ProfileProvenance }) {
+  const meta = PROVENANCE_META[provenance];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${meta.badgeClass}`}
+      aria-label={`Provenance: ${meta.label}`}
+      title={meta.description}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+export default function ClinicianProfilePage() {
+  // Foundation shell: sections render with placeholders and provenance
+  // badges. No client state. Filled-ness summary is computed below from
+  // the static defs (everything is currently empty / unknown).
+  const totalFields = SECTIONS.reduce((s, sec) => s + sec.fields.length, 0);
+  const filledFields = 0;
+  const sourceBackedFields = 0;
+  const completionPercent = totalFields === 0 ? 0 : Math.round((filledFields / totalFields) * 100);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Clinician profile
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Your credential record
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>User-entered information is not verified until source-backed
+          evidence is attached.</strong> Provenance badges show where each field
+          stands today.
+        </p>
+
+        <section
+          aria-labelledby="completion-summary-heading"
+          className="mt-5 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+        >
+          <h2 id="completion-summary-heading" className="text-sm font-semibold">
+            Profile completion summary
+          </h2>
+          <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Filled</dt>
+              <dd className="mt-1 font-mono">
+                {filledFields} / {totalFields} ({completionPercent}%)
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Source-backed</dt>
+              <dd className="mt-1 font-mono">{sourceBackedFields} / {totalFields}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Verified credentialing</dt>
+              <dd className="mt-1 text-muted-foreground">Not asserted by completion alone.</dd>
+            </div>
+          </dl>
+        </section>
+      </header>
+
+      <div className="space-y-5">
+        {SECTIONS.map((section) => (
+          <section
+            key={section.key}
+            aria-labelledby={`section-${section.key}-heading`}
+            className="rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+          >
+            <h2 id={`section-${section.key}-heading`} className="text-base font-semibold sm:text-lg">
+              {section.title}
+            </h2>
+            <dl className="mt-3 space-y-3">
+              {section.fields.map((field) => {
+                const fieldId = `${section.key}-${field.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+                return (
+                  <div key={fieldId} className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                    <div className="flex flex-1 items-center gap-2">
+                      <dt>
+                        <label htmlFor={fieldId} className="text-sm font-medium">
+                          {field.label}
+                        </label>
+                      </dt>
+                      <ProvenanceBadge provenance={field.provenance} />
+                    </div>
+                    <dd className="flex-1">
+                      <input
+                        id={fieldId}
+                        type="text"
+                        readOnly
+                        placeholder={field.placeholder}
+                        aria-describedby={`${fieldId}-help`}
+                        className="w-full rounded-lg border border-[var(--vt-border,_rgba(0,0,0,0.12))] bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-offset-2"
+                      />
+                      <p id={`${fieldId}-help`} className="mt-1 text-[11px] text-muted-foreground">
+                        {PROVENANCE_META[field.provenance].description}
+                      </p>
+                    </dd>
+                  </div>
+                );
+              })}
+            </dl>
+          </section>
+        ))}
+      </div>
+
+      <p className="mt-8 text-xs leading-relaxed text-muted-foreground">
+        This is the foundation shell. Editing flow, source-backed import wiring,
+        and verification gating ship in subsequent waves. <strong>User-entered
+        information is not verified until source-backed evidence is attached.</strong>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/lib/clinician-profile/profileCompletion.ts
+++ b/apps/web/lib/clinician-profile/profileCompletion.ts
@@ -1,0 +1,253 @@
+/**
+ * Clinician profile completion helpers.
+ *
+ * Truth rules:
+ *   - "Completion" measures *filled-ness*, not verification.
+ *   - Source-backed fields contribute MORE to readiness than
+ *     self-attested ones. A profile that is 100% filled but 0%
+ *     source-backed is NOT verified.
+ *   - Unknown/conflict fields never count toward verified completion.
+ *   - Output is shaped for both desktop and mobile dashboard surfaces.
+ */
+
+import { PROVENANCE_META } from '@/lib/profile/provenance';
+import type {
+  ClinicianProfile,
+  ProfileCompletionSignal,
+  ProfileFieldConfidence,
+  ProfileFieldMeta,
+  ProfileFieldProvenance,
+  ProfileSectionKey,
+} from './profileTypes';
+
+const CONFIDENCE_WEIGHT: Record<ProfileFieldConfidence, number> = {
+  'source-backed': 1.0,
+  'self-attested': 0.4,
+  'imported-candidate': 0.3,
+  unverified: 0,
+};
+
+interface FieldRollup {
+  filled: number;
+  total: number;
+  sourceBacked: number;
+  conflicts: number;
+  weightedSum: number;
+}
+
+function isFilled(meta: ProfileFieldMeta<unknown>): boolean {
+  if (meta.value === null || meta.value === undefined) return false;
+  if (typeof meta.value === 'string' && meta.value.trim() === '') return false;
+  if (Array.isArray(meta.value) && meta.value.length === 0) return false;
+  return true;
+}
+
+function rollupFields(fields: ProfileFieldMeta<unknown>[]): FieldRollup {
+  const acc: FieldRollup = { filled: 0, total: 0, sourceBacked: 0, conflicts: 0, weightedSum: 0 };
+  for (const f of fields) {
+    acc.total += 1;
+    if (f.provenance === 'CONFLICT') acc.conflicts += 1;
+    if (isFilled(f)) {
+      acc.filled += 1;
+      acc.weightedSum += CONFIDENCE_WEIGHT[f.confidence];
+      if (f.confidence === 'source-backed') acc.sourceBacked += 1;
+    }
+  }
+  return acc;
+}
+
+function buildSignal(
+  section: ProfileSectionKey,
+  rollup: FieldRollup,
+): ProfileCompletionSignal {
+  const filledRatio = rollup.total === 0 ? 0 : rollup.filled / rollup.total;
+  const sourceBackedRatio = rollup.filled === 0 ? 0 : rollup.sourceBacked / rollup.filled;
+  let readinessNote: string;
+  if (rollup.total === 0) {
+    readinessNote = 'No fields tracked yet for this section.';
+  } else if (rollup.filled === 0) {
+    readinessNote = 'Section is empty. Filling fields here improves your dashboard view; verification still requires source-backed evidence.';
+  } else if (rollup.sourceBacked === 0) {
+    readinessNote = 'Section has self-attested or imported entries only. Source-backed evidence has not been attached.';
+  } else if (rollup.sourceBacked < rollup.filled) {
+    readinessNote = 'Section has a mix of source-backed and self-attested entries. The non-source-backed fields are not verified.';
+  } else {
+    readinessNote = 'Every filled field in this section is source-backed.';
+  }
+  if (rollup.conflicts > 0) {
+    readinessNote += ` ${rollup.conflicts} unresolved conflict${rollup.conflicts === 1 ? '' : 's'} pending review.`;
+  }
+  return {
+    section,
+    filledFieldCount: rollup.filled,
+    totalFieldCount: rollup.total,
+    sourceBackedFieldCount: rollup.sourceBacked,
+    unresolvedConflictCount: rollup.conflicts,
+    filledRatio,
+    sourceBackedRatio,
+    readinessNote,
+  };
+}
+
+function entryFields<T extends object>(entry: T, keys: (keyof T)[]): ProfileFieldMeta<unknown>[] {
+  return keys.map((k) => entry[k] as ProfileFieldMeta<unknown>);
+}
+
+/**
+ * Returns a per-section signal and an overall composite.
+ *
+ * The overall signal is the average of:
+ *   - filled ratio across all tracked fields
+ *   - source-backed share among filled fields, weighted by confidence
+ *
+ * Important: the composite NEVER reaches 1.0 without source-backed
+ * evidence, even if every field is filled.
+ */
+export function calculateClinicianProfileCompletion(profile: ClinicianProfile): {
+  sections: ProfileCompletionSignal[];
+  overallFilledRatio: number;
+  overallSourceBackedRatio: number;
+  overallVerificationReadiness: number;
+  overallNote: string;
+} {
+  const sections: ProfileCompletionSignal[] = [];
+
+  const identityFields = entryFields(profile.identity, [
+    'legalName',
+    'preferredName',
+    'npi',
+    'primaryEmail',
+    'primaryPhone',
+    'practiceLocations',
+  ]);
+  sections.push(buildSignal('identity', rollupFields(identityFields)));
+
+  const medSchoolEntries = profile.education.filter((e) => e.programType === 'medical_school');
+  sections.push(
+    buildSignal(
+      'medical_school',
+      rollupFields(medSchoolEntries.flatMap((e) => entryFields(e, ['institution', 'degree', 'graduationYear']))),
+    ),
+  );
+
+  const residency = profile.training.filter((t) => t.programType === 'residency');
+  const fellowship = profile.training.filter((t) => t.programType === 'fellowship');
+  const otherTraining = profile.training.filter(
+    (t) => t.programType !== 'residency' && t.programType !== 'fellowship',
+  );
+  sections.push(
+    buildSignal(
+      'residency',
+      rollupFields(residency.flatMap((t) => entryFields(t, ['institution', 'specialty', 'startYear', 'endYear']))),
+    ),
+  );
+  sections.push(
+    buildSignal(
+      'fellowship',
+      rollupFields(fellowship.flatMap((t) => entryFields(t, ['institution', 'specialty', 'startYear', 'endYear']))),
+    ),
+  );
+  sections.push(
+    buildSignal(
+      'training_programs',
+      rollupFields(otherTraining.flatMap((t) => entryFields(t, ['institution', 'specialty', 'startYear', 'endYear']))),
+    ),
+  );
+
+  sections.push(
+    buildSignal(
+      'specialties',
+      rollupFields(profile.specialties.flatMap((s) => entryFields(s, ['specialty', 'subspecialty', 'boardCertified']))),
+    ),
+  );
+
+  const currentEmployerFields = profile.currentEmployer
+    ? entryFields(profile.currentEmployer, ['employer', 'title', 'startDate'])
+    : [];
+  sections.push(buildSignal('current_employer', rollupFields(currentEmployerFields)));
+
+  sections.push(
+    buildSignal(
+      'employer_history',
+      rollupFields(
+        profile.employerHistory.flatMap((e) => entryFields(e, ['employer', 'title', 'startDate', 'endDate'])),
+      ),
+    ),
+  );
+
+  sections.push(
+    buildSignal(
+      'affiliations',
+      rollupFields(
+        profile.affiliations.flatMap((a) =>
+          entryFields(a, ['organization', 'affiliationType', 'startDate', 'endDate']),
+        ),
+      ),
+    ),
+  );
+
+  sections.push(
+    buildSignal(
+      'research',
+      rollupFields(profile.research.flatMap((r) => entryFields(r, ['topic', 'role', 'institution']))),
+    ),
+  );
+
+  sections.push(
+    buildSignal(
+      'publications',
+      rollupFields(profile.publications.flatMap((p) => entryFields(p, ['title', 'journal', 'publishedYear', 'pubmedId']))),
+    ),
+  );
+
+  sections.push(buildSignal('career_goals', rollupFields([profile.careerGoals])));
+
+  const totalFilled = sections.reduce((s, x) => s + x.filledFieldCount, 0);
+  const totalFields = sections.reduce((s, x) => s + x.totalFieldCount, 0);
+  const totalSourceBacked = sections.reduce((s, x) => s + x.sourceBackedFieldCount, 0);
+
+  const overallFilledRatio = totalFields === 0 ? 0 : totalFilled / totalFields;
+  const overallSourceBackedRatio = totalFilled === 0 ? 0 : totalSourceBacked / totalFilled;
+  const overallVerificationReadiness = (overallFilledRatio + overallSourceBackedRatio) / 2;
+
+  const overallNote =
+    totalSourceBacked === 0 && totalFilled > 0
+      ? 'Profile has self-attested or imported entries only. None of these count as verified credentialing evidence.'
+      : totalSourceBacked < totalFilled
+        ? 'Profile is partially source-backed. Self-attested fields are not verified.'
+        : totalSourceBacked === 0 && totalFilled === 0
+          ? 'Profile is empty. Start by adding identity and one credential entry.'
+          : 'Every filled field is source-backed. Verification still requires the credentialing reviewer to inspect the receipts.';
+
+  return {
+    sections,
+    overallFilledRatio,
+    overallSourceBackedRatio,
+    overallVerificationReadiness,
+    overallNote,
+  };
+}
+
+export function getProfileSectionReadiness(
+  profile: ClinicianProfile,
+  section: ProfileSectionKey,
+): ProfileCompletionSignal | null {
+  const summary = calculateClinicianProfileCompletion(profile);
+  return summary.sections.find((s) => s.section === section) ?? null;
+}
+
+/**
+ * Returns the section keys that have either zero filled fields or
+ * zero source-backed fields. Used by the dashboard to highlight where
+ * the clinician should focus next.
+ */
+export function getMissingProfileFoundationFields(profile: ClinicianProfile): ProfileSectionKey[] {
+  const summary = calculateClinicianProfileCompletion(profile);
+  return summary.sections
+    .filter((s) => s.totalFieldCount > 0 && (s.filledFieldCount === 0 || s.sourceBackedFieldCount === 0))
+    .map((s) => s.section);
+}
+
+export function explainProfileFieldProvenance(provenance: ProfileFieldProvenance): string {
+  return PROVENANCE_META[provenance].description;
+}

--- a/apps/web/lib/clinician-profile/profileTypes.ts
+++ b/apps/web/lib/clinician-profile/profileTypes.ts
@@ -1,0 +1,163 @@
+/**
+ * Clinician profile foundation types.
+ *
+ * Layered on top of the existing `lib/profile/provenance.ts` 5-tier
+ * vocabulary (VERIFIED / USER_ENTERED / INFERRED / UNKNOWN / CONFLICT).
+ * Adds a confidence axis so the foundation can distinguish:
+ *   - source-backed (a real source-of-record check has run)
+ *   - self-attested (the clinician typed it; PSV not run)
+ *   - imported-candidate (came in via an import path; not source-backed yet)
+ *   - unverified (default for unknown/conflict/missing)
+ *
+ * Truth rules baked into the type model:
+ *   - Every profile field carries provenance + confidence.
+ *   - User-entered values are NEVER `verified`.
+ *   - Imported candidates (PubMed, LinkedIn, Doximity) stay
+ *     `imported-candidate` until a source-backed check upgrades them.
+ *   - Unknown/conflict fields never count toward verified completion.
+ */
+
+import type { ProfileField, ProfileProvenance } from '@/lib/profile/provenance';
+
+export type { ProfileProvenance };
+
+export type ProfileFieldProvenance = ProfileProvenance;
+
+export type ProfileFieldConfidence =
+  | 'source-backed'
+  | 'self-attested'
+  | 'imported-candidate'
+  | 'unverified';
+
+export interface ProfileFieldMeta<T> extends ProfileField<T> {
+  confidence: ProfileFieldConfidence;
+}
+
+export type ProfileSectionKey =
+  | 'identity'
+  | 'medical_school'
+  | 'residency'
+  | 'fellowship'
+  | 'training_programs'
+  | 'specialties'
+  | 'current_employer'
+  | 'employer_history'
+  | 'affiliations'
+  | 'research'
+  | 'publications'
+  | 'career_goals';
+
+export interface ProfileCompletionSignal {
+  section: ProfileSectionKey;
+  filledFieldCount: number;
+  totalFieldCount: number;
+  sourceBackedFieldCount: number;
+  unresolvedConflictCount: number;
+  /** 0..1 — does NOT imply verification, only "filled-ness". */
+  filledRatio: number;
+  /** 0..1 — the share of filled fields that are source-backed. */
+  sourceBackedRatio: number;
+  /** Reason text for the UI; never claims verification. */
+  readinessNote: string;
+}
+
+export interface ClinicianIdentitySection {
+  legalName: ProfileFieldMeta<string | null>;
+  preferredName: ProfileFieldMeta<string | null>;
+  npi: ProfileFieldMeta<string | null>;
+  primaryEmail: ProfileFieldMeta<string | null>;
+  primaryPhone: ProfileFieldMeta<string | null>;
+  practiceLocations: ProfileFieldMeta<string[] | null>;
+}
+
+export interface ClinicianEducationEntry {
+  id: string;
+  institution: ProfileFieldMeta<string | null>;
+  degree: ProfileFieldMeta<string | null>;
+  graduationYear: ProfileFieldMeta<number | null>;
+  /** Marks the entry as a degree-bearing program (medical school, etc.). */
+  programType: 'medical_school' | 'undergraduate' | 'graduate' | 'other';
+}
+
+export interface ClinicianTrainingEntry {
+  id: string;
+  programType: 'residency' | 'fellowship' | 'internship' | 'other_training';
+  institution: ProfileFieldMeta<string | null>;
+  specialty: ProfileFieldMeta<string | null>;
+  startYear: ProfileFieldMeta<number | null>;
+  endYear: ProfileFieldMeta<number | null>;
+}
+
+export interface ClinicianEmploymentEntry {
+  id: string;
+  employer: ProfileFieldMeta<string | null>;
+  title: ProfileFieldMeta<string | null>;
+  startDate: ProfileFieldMeta<string | null>;
+  endDate: ProfileFieldMeta<string | null>;
+  isCurrent: boolean;
+}
+
+export interface ClinicianAffiliationEntry {
+  id: string;
+  organization: ProfileFieldMeta<string | null>;
+  affiliationType: ProfileFieldMeta<string | null>;
+  startDate: ProfileFieldMeta<string | null>;
+  endDate: ProfileFieldMeta<string | null>;
+}
+
+export interface ClinicianResearchEntry {
+  id: string;
+  topic: ProfileFieldMeta<string | null>;
+  role: ProfileFieldMeta<string | null>;
+  institution: ProfileFieldMeta<string | null>;
+}
+
+export interface ClinicianPublicationEntry {
+  id: string;
+  title: ProfileFieldMeta<string | null>;
+  journal: ProfileFieldMeta<string | null>;
+  publishedYear: ProfileFieldMeta<number | null>;
+  pubmedId: ProfileFieldMeta<string | null>;
+  /** Imported via a third-party path (PubMed/LinkedIn/Doximity)? */
+  importSource: 'pubmed' | 'linkedin' | 'doximity' | null;
+}
+
+export interface ClinicianSpecialtyEntry {
+  id: string;
+  specialty: ProfileFieldMeta<string | null>;
+  subspecialty: ProfileFieldMeta<string | null>;
+  boardCertified: ProfileFieldMeta<boolean | null>;
+}
+
+export interface ClinicianProfile {
+  clinicianId: string;
+  identity: ClinicianIdentitySection;
+  education: ClinicianEducationEntry[];
+  training: ClinicianTrainingEntry[];
+  specialties: ClinicianSpecialtyEntry[];
+  currentEmployer: ClinicianEmploymentEntry | null;
+  employerHistory: ClinicianEmploymentEntry[];
+  affiliations: ClinicianAffiliationEntry[];
+  research: ClinicianResearchEntry[];
+  publications: ClinicianPublicationEntry[];
+  careerGoals: ProfileFieldMeta<string | null>;
+}
+
+/**
+ * Truth invariants enforced by the model:
+ *   1. A field's confidence must NEVER be `source-backed` if its
+ *      provenance is `USER_ENTERED`. Helpers that build profiles
+ *      should reject this combination.
+ *   2. `imported-candidate` is the default for fields originating
+ *      from PubMed/LinkedIn/Doximity until a source check upgrades.
+ *   3. `unverified` is the default for `UNKNOWN` and `CONFLICT`.
+ */
+export function isCoherentProvenance(
+  provenance: ProfileFieldProvenance,
+  confidence: ProfileFieldConfidence,
+): boolean {
+  if (provenance === 'USER_ENTERED' && confidence === 'source-backed') return false;
+  if (provenance === 'UNKNOWN' && confidence !== 'unverified') return false;
+  if (provenance === 'CONFLICT' && confidence === 'source-backed') return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- add clinician profile foundation types + completion helpers (`apps/web/lib/clinician-profile/`)
- add four mobile-first clinician routes: `/clinician/{onboarding,profile,import,graph}`
- add education, training, employer, affiliation, research/publication sections
- add provenance-safe copy and graph explanation
- add 22-test suite proving user-entered data is not verified
- **completion board score deltas intentionally NOT included** (see Notes below)

## Truth rules
- user-entered profile data is not verified
- imported PubMed/LinkedIn/Doximity entries stay candidate-grade until source-backed
- graph preview explains provenance but does not verify claims
- import page does not claim live integration (LinkedIn/Doximity say "no live X sync ships today")
- no government ID, biometric, wallet, or crypto claims introduced
- onboarding explicitly frames identity-proofing (gov ID + liveness) as roadmap-only

## Files changed (7)
- `apps/web/lib/clinician-profile/profileTypes.ts` — types + `isCoherentProvenance` invariant guard
- `apps/web/lib/clinician-profile/profileCompletion.ts` — completion math (filled-ness ≠ verification)
- `apps/web/app/clinician/onboarding/page.tsx` — 6-step intro from NPI
- `apps/web/app/clinician/profile/page.tsx` — 11 sections with provenance badges
- `apps/web/app/clinician/import/page.tsx` — entry cards marked planned / entry-point-only
- `apps/web/app/clinician/graph/page.tsx` — static node/edge preview with disclaimer
- `apps/web/__tests__/clinician-profile-foundation.test.ts` — 22 tests

## Validation
- `pnpm --filter @vitalcv/web exec vitest run __tests__/clinician-profile-foundation.test.ts` → **22/22 pass**
- `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks** (full Next.js build with TypeScript + ESLint enforcement)
- Banned-phrase scan over new files → **0 hits** in product copy

## Notes — completion board deltas deferred
The brief specified score deltas for rows like \"Signup / account creation\", \"Rich clinician profile shell\", \"Medical school\", \"Residency\", etc. Those rows exist only in the new full-scope schema introduced by **PR #182** (open). \`origin/main\` currently carries the old GOD-3S board which has none of those row names. Applying deltas here would either invent rows on the old board or stack this branch on unmerged work — both worse than waiting. **Score deltas will be a follow-up PR after #182 merges.**

## Out of scope (intentional)
- No backend trust-engine changes
- No migrations
- No wallet / native mobile / cryptography
- No live integration wiring (PubMed/LinkedIn/Doximity)