### PR TITLE
feat(reliability): RELIABILITY-1 — passport source health + unavailable lane recovery

### DIFF
--- a/apps/web/__tests__/source-health/aggregateLaneHealth.test.ts
+++ b/apps/web/__tests__/source-health/aggregateLaneHealth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateLaneHealth } from '@/lib/source-health/aggregateLaneHealth';
+import type {
+  SourceHealthSnapshot,
+  SourceId,
+} from '@/lib/source-health/sourceHealthTypes';
+
+function snap(
+  sourceId: SourceId,
+  state: SourceHealthSnapshot['state'],
+  overrides: Partial<SourceHealthSnapshot> = {},
+): SourceHealthSnapshot {
+  return {
+    sourceId,
+    state,
+    reason: 'test',
+    lastSuccessAt: state === 'LIVE' ? '2024-01-01T00:00:00.000Z' : null,
+    lastErrorAt: state === 'LIVE' ? null : '2024-01-01T00:00:00.000Z',
+    lastLatencyMs: 10,
+    observedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('aggregateLaneHealth', () => {
+  it('marks allHealthy when every snapshot is LIVE', () => {
+    const result = aggregateLaneHealth([
+      snap('NPPES', 'LIVE'),
+      snap('OIG_LEIE', 'LIVE'),
+      snap('PECOS', 'LIVE'),
+      snap('STATE_BOARD', 'LIVE'),
+    ]);
+    expect(result.allHealthy).toBe(true);
+    expect(result.unavailableLanes).toEqual([]);
+  });
+
+  it('reports unavailable lanes for every non-LIVE snapshot in input order', () => {
+    const result = aggregateLaneHealth([
+      snap('NPPES', 'LIVE'),
+      snap('OIG_LEIE', 'DEGRADED'),
+      snap('PECOS', 'UNAVAILABLE'),
+      snap('STATE_BOARD', 'UNKNOWN'),
+    ]);
+    expect(result.allHealthy).toBe(false);
+    expect(result.unavailableLanes.map((l) => l.sourceId)).toEqual([
+      'OIG_LEIE',
+      'PECOS',
+      'STATE_BOARD',
+    ]);
+    expect(result.unavailableLanes.map((l) => l.state)).toEqual([
+      'DEGRADED',
+      'UNAVAILABLE',
+      'UNKNOWN',
+    ]);
+  });
+
+  it('treats RATE_LIMITED as not healthy', () => {
+    const result = aggregateLaneHealth([snap('NPPES', 'RATE_LIMITED')]);
+    expect(result.allHealthy).toBe(false);
+    expect(result.unavailableLanes).toHaveLength(1);
+    expect(result.unavailableLanes[0]!.state).toBe('RATE_LIMITED');
+    expect(result.unavailableLanes[0]!.retryPolicy.canRetryNow).toBe(false);
+  });
+
+  it('returns allHealthy=false on empty input (nothing observed)', () => {
+    const result = aggregateLaneHealth([]);
+    expect(result.allHealthy).toBe(false);
+    expect(result.unavailableLanes).toEqual([]);
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [snap('NPPES', 'DEGRADED')];
+    const result = aggregateLaneHealth(input);
+    expect(result.snapshots).not.toBe(input);
+    expect(result.snapshots).toEqual(input);
+  });
+});

--- a/apps/web/__tests__/source-health/runProbe.test.ts
+++ b/apps/web/__tests__/source-health/runProbe.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  runProbe,
+  type ProbeFetcher,
+} from '@/lib/source-health/probes/runProbe';
+
+const fixedNow = () => new Date('2024-06-01T12:00:00.000Z');
+
+function makeFetcher(impl: ProbeFetcher): ProbeFetcher {
+  return impl;
+}
+
+describe('runProbe state mapping', () => {
+  it('maps 2xx to LIVE', async () => {
+    const fetcher = makeFetcher(async () => ({ status: 200, ok: true }));
+    const snap = await runProbe('NPPES', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('LIVE');
+    expect(snap.lastSuccessAt).toBe('2024-06-01T12:00:00.000Z');
+    expect(snap.lastErrorAt).toBeNull();
+    expect(snap.reason).toBe('http_200');
+  });
+
+  it('maps 5xx to DEGRADED', async () => {
+    const fetcher = makeFetcher(async () => ({ status: 503, ok: false }));
+    const snap = await runProbe('OIG_LEIE', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('DEGRADED');
+    expect(snap.lastSuccessAt).toBeNull();
+    expect(snap.lastErrorAt).toBe('2024-06-01T12:00:00.000Z');
+    expect(snap.reason).toBe('http_503');
+  });
+
+  it('maps 429 to RATE_LIMITED', async () => {
+    const fetcher = makeFetcher(async () => ({ status: 429, ok: false }));
+    const snap = await runProbe('PECOS', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('RATE_LIMITED');
+    expect(snap.reason).toBe('http_429');
+  });
+
+  it('maps a network error (rejection) to UNAVAILABLE', async () => {
+    const fetcher = makeFetcher(async () => {
+      throw new Error('ECONNRESET');
+    });
+    const snap = await runProbe('NPPES', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('UNAVAILABLE');
+    expect(snap.reason).toBe('network_error');
+  });
+
+  it('maps a network error reported via outcome.error to UNAVAILABLE', async () => {
+    const fetcher = makeFetcher(async () => ({ error: new Error('boom') }));
+    const snap = await runProbe('NPPES', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('UNAVAILABLE');
+    expect(snap.reason).toBe('network_error');
+  });
+
+  it('maps timeout (signal aborted) to UNAVAILABLE', async () => {
+    const fetcher = makeFetcher(({ signal }) => {
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'));
+        });
+      });
+    });
+    const snap = await runProbe('NPPES', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 5,
+    });
+    expect(snap.state).toBe('UNAVAILABLE');
+    expect(snap.reason).toBe('probe_timeout');
+  });
+
+  it('maps an unrecognized response (no status, no error) to UNKNOWN', async () => {
+    const fetcher = makeFetcher(async () => ({}));
+    const snap = await runProbe('STATE_BOARD', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.state).toBe('UNKNOWN');
+    expect(snap.reason).toBe('no_status');
+  });
+
+  it('never throws even when fetcher rejects synchronously', async () => {
+    const fetcher = makeFetcher(() => {
+      throw new Error('synchronous boom');
+    });
+    await expect(
+      runProbe('NPPES', fetcher, {
+        fetchImpl: (() => {}) as unknown as typeof fetch,
+        now: fixedNow,
+        timeoutMs: 1000,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('records lastLatencyMs as a non-negative number', async () => {
+    const fetcher = makeFetcher(async () => ({ status: 200, ok: true }));
+    const snap = await runProbe('NPPES', fetcher, {
+      fetchImpl: (() => {}) as unknown as typeof fetch,
+      now: fixedNow,
+      timeoutMs: 1000,
+    });
+    expect(snap.lastLatencyMs).not.toBeNull();
+    expect(snap.lastLatencyMs!).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/__tests__/source-health/sourceHealth.truthTable.test.ts
+++ b/apps/web/__tests__/source-health/sourceHealth.truthTable.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_SOURCE_HEALTH_STATES,
+  ALL_SOURCE_IDS,
+  canEvidenceBeUpgraded,
+  isHealthy,
+  type SourceHealthState,
+  type SourceId,
+} from '@/lib/source-health/sourceHealthTypes';
+import { unavailableLane } from '@/lib/source-health/unavailableLane';
+
+describe('SourceHealth truth table — 4 sources × 5 states', () => {
+  for (const sourceId of ALL_SOURCE_IDS) {
+    for (const state of ALL_SOURCE_HEALTH_STATES) {
+      it(`(${sourceId}, ${state}) honors evidence-upgrade and unavailable-lane invariants`, () => {
+        // canEvidenceBeUpgraded is true ONLY for LIVE
+        if (state === 'LIVE') {
+          expect(canEvidenceBeUpgraded(state)).toBe(true);
+          expect(isHealthy(state)).toBe(true);
+        } else {
+          expect(canEvidenceBeUpgraded(state)).toBe(false);
+          expect(isHealthy(state)).toBe(false);
+
+          const lane = unavailableLane({
+            sourceId: sourceId as SourceId,
+            state: state as Exclude<SourceHealthState, 'LIVE'>,
+            reason: 'truth_table_test',
+            lastSeenAt: '2024-01-01T00:00:00.000Z',
+          });
+
+          expect(lane.sourceId).toBe(sourceId);
+          expect(lane.state).toBe(state);
+          expect(lane.lastSeenAt).toBe('2024-01-01T00:00:00.000Z');
+          expect(typeof lane.userFacingMessage).toBe('string');
+          expect(lane.userFacingMessage.length).toBeGreaterThan(0);
+
+          // Sane retry policy
+          expect(lane.retryPolicy.suggestedRetryAfterMs).toBeGreaterThan(0);
+          expect(lane.retryPolicy.suggestedRetryAfterMs).toBeLessThanOrEqual(
+            10 * 60_000,
+          );
+          expect(typeof lane.retryPolicy.canRetryNow).toBe('boolean');
+
+          // RATE_LIMITED must back off (canRetryNow=false)
+          if (state === 'RATE_LIMITED') {
+            expect(lane.retryPolicy.canRetryNow).toBe(false);
+          }
+        }
+      });
+    }
+  }
+});

--- a/apps/web/__tests__/source-health/unavailableLane.bannedPhrases.test.ts
+++ b/apps/web/__tests__/source-health/unavailableLane.bannedPhrases.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_SOURCE_HEALTH_STATES,
+  ALL_SOURCE_IDS,
+  type SourceHealthState,
+} from '@/lib/source-health/sourceHealthTypes';
+import {
+  BANNED_USER_FACING_PHRASES,
+  unavailableLane,
+} from '@/lib/source-health/unavailableLane';
+
+describe('unavailableLane banned-phrase contract', () => {
+  for (const sourceId of ALL_SOURCE_IDS) {
+    for (const state of ALL_SOURCE_HEALTH_STATES) {
+      if (state === 'LIVE') continue;
+      it(`(${sourceId}, ${state}) contains no banned phrase`, () => {
+        const lane = unavailableLane({
+          sourceId,
+          state: state as Exclude<SourceHealthState, 'LIVE'>,
+          reason: 'banned_phrase_test',
+          lastSeenAt: null,
+        });
+        const haystack = lane.userFacingMessage.toLowerCase();
+        for (const phrase of BANNED_USER_FACING_PHRASES) {
+          expect(haystack.includes(phrase.toLowerCase())).toBe(false);
+        }
+      });
+    }
+  }
+
+  it('exhaustively rejects every banned phrase across all (sourceId, state) pairs', () => {
+    const failures: string[] = [];
+    for (const sourceId of ALL_SOURCE_IDS) {
+      for (const state of ALL_SOURCE_HEALTH_STATES) {
+        if (state === 'LIVE') continue;
+        const lane = unavailableLane({
+          sourceId,
+          state: state as Exclude<SourceHealthState, 'LIVE'>,
+          reason: 'banned_phrase_test',
+          lastSeenAt: null,
+        });
+        const haystack = lane.userFacingMessage.toLowerCase();
+        for (const phrase of BANNED_USER_FACING_PHRASES) {
+          if (haystack.includes(phrase.toLowerCase())) {
+            failures.push(
+              `(${sourceId}, ${state}) leaked banned phrase "${phrase}" in: ${lane.userFacingMessage}`,
+            );
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/apps/web/app/employer/dashboard/page.tsx
+++ b/apps/web/app/employer/dashboard/page.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
+import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
+
 export default function EmployerDashboardPage() {
   return (
     <div className="p-8 text-foreground bg-background">
       <h1 className="text-3xl font-bold mb-8">Employer Dashboard</h1>
-      
+
+      <div className="mb-8">
+        <LaneHealthMount heading="Source operational state (employer view)" />
+      </div>
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="p-6 border rounded-lg shadow-sm">
           <h2 className="text-xl font-semibold mb-4">Applications by State</h2>

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -29,6 +29,7 @@ import { ShieldCheck } from 'lucide-react';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { TrustStatusBadge, type TrustBadgeStatus } from '@/components/ui/trust-status-badge';
 import { WhatsNextPanel } from '@/components/passport/WhatsNextPanel';
+import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
 import { useIngestStream, hydrateFromHomepagePreview, type IngestStreamState, type StreamPhase } from '@/hooks/useIngestStream';
 import {
   buildEmployerReviewHref,
@@ -744,6 +745,9 @@ function PassportPageContent({
             {canViewPassport && (
               <WhatsNextPanel state={state} />
             )}
+
+            {/* Source operational state — provenance-safe; reports lane health only */}
+            <LaneHealthMount />
 
             {/* Terminal no-profile state */}
             {noProfileYet && (

--- a/apps/web/components/source-health/LaneHealthBadge.tsx
+++ b/apps/web/components/source-health/LaneHealthBadge.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type {
+  SourceHealthSnapshot,
+  SourceHealthState,
+  SourceId,
+} from '@/lib/source-health/sourceHealthTypes';
+
+const SOURCE_LABEL: Record<SourceId, string> = {
+  NPPES: 'NPPES',
+  OIG_LEIE: 'OIG / LEIE',
+  PECOS: 'PECOS',
+  STATE_BOARD: 'State board',
+};
+
+const STATE_LABEL: Record<SourceHealthState, string> = {
+  LIVE: 'Live',
+  DEGRADED: 'Degraded',
+  UNAVAILABLE: 'Unavailable',
+  UNKNOWN: 'Unknown',
+  RATE_LIMITED: 'Rate limited',
+};
+
+type BadgeVariant = React.ComponentProps<typeof Badge>['variant'];
+
+function variantFor(state: SourceHealthState): BadgeVariant {
+  switch (state) {
+    case 'LIVE':
+      return 'trust-green';
+    case 'DEGRADED':
+    case 'RATE_LIMITED':
+      return 'trust-yellow';
+    case 'UNAVAILABLE':
+      return 'trust-red';
+    case 'UNKNOWN':
+    default:
+      return 'outline';
+  }
+}
+
+function relativeFromNow(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return 'no successful read';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return 'no successful read';
+  const deltaMs = Math.max(0, now.getTime() - t);
+  const sec = Math.floor(deltaMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+export interface LaneHealthBadgeProps {
+  snapshot: SourceHealthSnapshot;
+  className?: string;
+}
+
+/**
+ * Compact lane health badge. Provenance-safe: NEVER renders verified-style
+ * chrome for non-LIVE states. The badge shows source + state + relative
+ * lastSuccessAt, with the `reason` exposed via title (tooltip).
+ */
+export function LaneHealthBadge({ snapshot, className }: LaneHealthBadgeProps) {
+  const sourceLabel = SOURCE_LABEL[snapshot.sourceId];
+  const stateLabel = STATE_LABEL[snapshot.state];
+  const relative = relativeFromNow(snapshot.lastSuccessAt);
+  const variant = variantFor(snapshot.state);
+
+  const title = [
+    `Source: ${sourceLabel}`,
+    `State: ${stateLabel}`,
+    `Reason: ${snapshot.reason}`,
+    `Observed: ${snapshot.observedAt}`,
+    `Last success: ${snapshot.lastSuccessAt ?? 'none'}`,
+  ].join('\n');
+
+  return (
+    <span
+      className={cn('inline-flex items-center gap-2', className)}
+      title={title}
+      data-source-id={snapshot.sourceId}
+      data-source-state={snapshot.state}
+    >
+      <Badge variant={variant}>
+        <span className="font-medium">{sourceLabel}</span>
+        <span aria-hidden="true" className="mx-1 opacity-50">
+          ·
+        </span>
+        <span>{stateLabel}</span>
+      </Badge>
+      <span className="text-xs text-muted-foreground">{relative}</span>
+    </span>
+  );
+}
+
+export default LaneHealthBadge;

--- a/apps/web/components/source-health/LaneHealthMount.tsx
+++ b/apps/web/components/source-health/LaneHealthMount.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+
+import { getLaneSnapshots } from '@/lib/source-health/getLaneSnapshots';
+import { LaneHealthSection } from './LaneHealthSection';
+
+/**
+ * Page-side mount wrapper. Uses the deterministic placeholder seed from
+ * `getLaneSnapshots` until live probe results are wired in. Kept as its
+ * own component so existing pages can drop this in with a one-line diff.
+ */
+export function LaneHealthMount({ heading }: { heading?: string }) {
+  // Memoize so repeated renders don't shift `observedAt` strings.
+  const snapshots = React.useMemo(() => getLaneSnapshots(), []);
+  return <LaneHealthSection snapshots={snapshots} heading={heading} />;
+}
+
+export default LaneHealthMount;

--- a/apps/web/components/source-health/LaneHealthSection.tsx
+++ b/apps/web/components/source-health/LaneHealthSection.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import { aggregateLaneHealth } from '@/lib/source-health/aggregateLaneHealth';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+import { LaneHealthBadge } from './LaneHealthBadge';
+
+export interface LaneHealthSectionProps {
+  snapshots: SourceHealthSnapshot[];
+  /** Optional heading override; defaults to a neutral, non-claim-y label. */
+  heading?: string;
+}
+
+/**
+ * Lists per-lane health badges and renders an UnavailableLane notice block
+ * when any lane is non-LIVE. Pure presentation; no claims of verification.
+ */
+export function LaneHealthSection({
+  snapshots,
+  heading = 'Source operational state',
+}: LaneHealthSectionProps) {
+  const { unavailableLanes, allHealthy } = aggregateLaneHealth(snapshots);
+
+  return (
+    <section
+      aria-label="Source operational state"
+      className="rounded-lg border border-border/40 bg-card/40 p-4"
+    >
+      <header className="flex items-center justify-between gap-3 mb-3">
+        <h3 className="text-sm font-semibold text-foreground">{heading}</h3>
+        <span className="text-xs text-muted-foreground">
+          {allHealthy ? 'All lanes responding' : 'Some lanes are not live'}
+        </span>
+      </header>
+
+      <ul className="flex flex-wrap gap-2 mb-3" role="list">
+        {snapshots.map((snap) => (
+          <li key={snap.sourceId}>
+            <LaneHealthBadge snapshot={snap} />
+          </li>
+        ))}
+      </ul>
+
+      {unavailableLanes.length > 0 && (
+        <ul
+          role="list"
+          className="space-y-2 border-t border-border/40 pt-3"
+          aria-label="Lanes that are not currently live"
+        >
+          {unavailableLanes.map((lane) => (
+            <li
+              key={lane.sourceId}
+              className="text-xs text-muted-foreground leading-relaxed"
+              data-unavailable-source={lane.sourceId}
+              data-unavailable-state={lane.state}
+            >
+              <span className="font-medium text-foreground">
+                {lane.sourceId}
+              </span>
+              <span aria-hidden="true"> — </span>
+              <span>{lane.userFacingMessage}</span>
+              {lane.retryPolicy.canRetryNow ? (
+                <span className="ml-1 italic">
+                  Retry suggested in ~
+                  {Math.round(lane.retryPolicy.suggestedRetryAfterMs / 1000)}s.
+                </span>
+              ) : (
+                <span className="ml-1 italic">
+                  Backing off for ~
+                  {Math.round(lane.retryPolicy.suggestedRetryAfterMs / 1000)}s
+                  before retry.
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default LaneHealthSection;

--- a/apps/web/lib/source-health/README.md
+++ b/apps/web/lib/source-health/README.md
@@ -1,0 +1,101 @@
+# source-health
+
+Operational health for upstream credentialing sources (NPPES, OIG/LEIE, PECOS,
+state boards).
+
+> **Scope, in plain words:** this module reports whether a source is currently
+> reachable. It does **not** make verification, certification, or compliance
+> claims about provider data. Verification chrome (e.g. "VERIFIED") MUST NOT be
+> driven by this module's output for non-`LIVE` states.
+
+## State machine
+
+| State          | Meaning                                                              | `isHealthy` | `canEvidenceBeUpgraded` |
+| -------------- | -------------------------------------------------------------------- | ----------- | ----------------------- |
+| `LIVE`         | Last probe got a 2xx response.                                       | true        | **true**                |
+| `DEGRADED`     | Last probe got a 5xx response (server error).                        | false       | false                   |
+| `UNAVAILABLE`  | Network error, timeout, or no response.                              | false       | false                   |
+| `RATE_LIMITED` | Last probe got a 429.                                                | false       | false                   |
+| `UNKNOWN`      | No reading, or response we cannot classify (no status, etc.).        | false       | false                   |
+
+Truth invariant (encoded as predicates and tested in
+`__tests__/source-health/sourceHealth.truthTable.test.ts`):
+
+- `canEvidenceBeUpgraded(state)` is `true` **only** when `state === 'LIVE'`.
+- `isHealthy(state)` is `true` **only** when `state === 'LIVE'`. `DEGRADED` is
+  *not* healthy.
+
+A 4 × 5 truth table (`SourceId × SourceHealthState`) is exhaustively tested.
+
+## Banned-phrase contract
+
+`unavailableLane()` produces user-facing copy via a deterministic table per
+`(sourceId, state)`. The output **must never** contain any of the following
+(case-insensitive), enforced by
+`__tests__/source-health/unavailableLane.bannedPhrases.test.ts`:
+
+- `real-time`, `real time`
+- `live verification`
+- `guaranteed`
+- `always available`
+- `verified`, `certified`
+- `instant`
+- `tamper-proof`
+- `hipaa compliant`
+- `soc2 certified`
+- `ncqa verified`
+
+If you need to update copy, edit the `copyFor()` table in
+`unavailableLane.ts`. Do **not** weaken the banned-phrase test.
+
+## Probes
+
+Each probe under `probes/` exports `async function probe(deps)` and returns a
+`SourceHealthSnapshot`. All probes:
+
+- accept dependency-injected `fetchImpl`, `now`, and `timeoutMs` for tests
+- never throw — failures are absorbed and reflected in `state` / `reason`
+- delegate state classification to `runProbe()` so mappings are consistent
+
+State mapping (in `runProbe.ts`):
+
+| Outcome                  | State          |
+| ------------------------ | -------------- |
+| 2xx                      | `LIVE`         |
+| 429                      | `RATE_LIMITED` |
+| 5xx                      | `DEGRADED`     |
+| network error / timeout  | `UNAVAILABLE`  |
+| anything else            | `UNKNOWN`      |
+
+The state-board probe is intentionally a no-op until per-state probes are
+wired; it returns `UNKNOWN`. We do **not** fake `LIVE`.
+
+## Aggregator
+
+`aggregateLaneHealth(snapshots)` is pure and deterministic. It returns:
+
+- `snapshots` — defensive copy of the input
+- `unavailableLanes` — one `UnavailableLane` per non-`LIVE` snapshot, in
+  input order
+- `allHealthy` — `true` only if the input is non-empty and every snapshot is
+  `LIVE`
+
+## How to add a new source
+
+1. Add the new id to `SourceId` in `sourceHealthTypes.ts` and to
+   `ALL_SOURCE_IDS`.
+2. Add a copy entry for every non-`LIVE` state in `unavailableLane.ts`
+   (`SOURCE_DISPLAY_NAME` + `copyFor()` if the language differs).
+3. Create `probes/<source>Probe.ts` that calls `runProbe(<id>, fetcher, deps)`.
+4. Re-export from `probes/index.ts`.
+5. Re-run the truth-table and banned-phrase tests — both iterate
+   `ALL_SOURCE_IDS` × `ALL_SOURCE_HEALTH_STATES` and will automatically cover
+   the new source.
+
+## What this module does NOT do
+
+- It does not make verification claims.
+- It does not certify providers or data.
+- It does not promise availability ("always available", "guaranteed", etc.).
+- It does not replace the existing `lib/status/sourceOps.ts` ops report; that
+  module is a separate, broader operator-facing surface.

--- a/apps/web/lib/source-health/aggregateLaneHealth.ts
+++ b/apps/web/lib/source-health/aggregateLaneHealth.ts
@@ -1,0 +1,46 @@
+import {
+  isHealthy,
+  type SourceHealthSnapshot,
+} from './sourceHealthTypes';
+import { unavailableLane, type UnavailableLane } from './unavailableLane';
+
+export interface AggregatedLaneHealth {
+  snapshots: SourceHealthSnapshot[];
+  unavailableLanes: UnavailableLane[];
+  allHealthy: boolean;
+}
+
+/**
+ * Pure, deterministic aggregator. Preserves input snapshot order and emits
+ * an UnavailableLane record for every non-LIVE snapshot.
+ */
+export function aggregateLaneHealth(
+  snapshots: SourceHealthSnapshot[],
+): AggregatedLaneHealth {
+  const unavailableLanes: UnavailableLane[] = [];
+  let allHealthy = snapshots.length > 0;
+
+  for (const snap of snapshots) {
+    if (!isHealthy(snap.state)) {
+      allHealthy = false;
+      unavailableLanes.push(
+        unavailableLane({
+          sourceId: snap.sourceId,
+          // After isHealthy=false, state cannot be 'LIVE'. Cast is safe.
+          state: snap.state as Exclude<
+            SourceHealthSnapshot['state'],
+            'LIVE'
+          >,
+          reason: snap.reason,
+          lastSeenAt: snap.lastSuccessAt,
+        }),
+      );
+    }
+  }
+
+  return {
+    snapshots: snapshots.slice(),
+    unavailableLanes,
+    allHealthy,
+  };
+}

--- a/apps/web/lib/source-health/getLaneSnapshots.ts
+++ b/apps/web/lib/source-health/getLaneSnapshots.ts
@@ -1,0 +1,63 @@
+import type { SourceHealthSnapshot } from './sourceHealthTypes';
+
+/**
+ * PLACEHOLDER deterministic seed for SourceHealth snapshots.
+ *
+ * This is NOT live data. Until the probe scheduler is wired up to a runtime
+ * health store, surfaces render this seed so the UI shape can be exercised
+ * without making false claims about source liveness.
+ *
+ * Honest defaults:
+ *   - NPPES, OIG_LEIE, PECOS: posture is "configured", but we do NOT mark
+ *     them LIVE without a real probe reading. We mark them UNKNOWN with a
+ *     reason that says exactly that.
+ *   - STATE_BOARD: UNKNOWN — there is no generic state-board probe yet.
+ *
+ * When real probes land, replace this with a server-side reader that returns
+ * the latest probe result per source.
+ */
+export function getLaneSnapshots(
+  options: { now?: () => Date } = {},
+): SourceHealthSnapshot[] {
+  const now = options.now ?? (() => new Date());
+  const observedAt = now().toISOString();
+
+  return [
+    {
+      sourceId: 'NPPES',
+      state: 'UNKNOWN',
+      reason: 'placeholder_seed_no_live_probe',
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastLatencyMs: null,
+      observedAt,
+    },
+    {
+      sourceId: 'OIG_LEIE',
+      state: 'UNKNOWN',
+      reason: 'placeholder_seed_no_live_probe',
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastLatencyMs: null,
+      observedAt,
+    },
+    {
+      sourceId: 'PECOS',
+      state: 'UNKNOWN',
+      reason: 'placeholder_seed_no_live_probe',
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastLatencyMs: null,
+      observedAt,
+    },
+    {
+      sourceId: 'STATE_BOARD',
+      state: 'UNKNOWN',
+      reason: 'no_generic_state_board_probe_wired',
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastLatencyMs: null,
+      observedAt,
+    },
+  ];
+}

--- a/apps/web/lib/source-health/index.ts
+++ b/apps/web/lib/source-health/index.ts
@@ -1,0 +1,23 @@
+export {
+  ALL_SOURCE_HEALTH_STATES,
+  ALL_SOURCE_IDS,
+  assertNever,
+  canEvidenceBeUpgraded,
+  isHealthy,
+  type SourceHealthSnapshot,
+  type SourceHealthState,
+  type SourceId,
+} from './sourceHealthTypes';
+
+export {
+  BANNED_USER_FACING_PHRASES,
+  unavailableLane,
+  type UnavailableLane,
+} from './unavailableLane';
+
+export {
+  aggregateLaneHealth,
+  type AggregatedLaneHealth,
+} from './aggregateLaneHealth';
+
+export { getLaneSnapshots } from './getLaneSnapshots';

--- a/apps/web/lib/source-health/probes/index.ts
+++ b/apps/web/lib/source-health/probes/index.ts
@@ -1,0 +1,11 @@
+export { runProbe } from './runProbe';
+export type {
+  ProbeDeps,
+  ProbeFetchOutcome,
+  ProbeFetcher,
+} from './runProbe';
+
+export { probe as nppesProbe } from './nppesProbe';
+export { probe as oigProbe } from './oigProbe';
+export { probe as pecosProbe } from './pecosProbe';
+export { probe as stateBoardProbe } from './stateBoardProbe';

--- a/apps/web/lib/source-health/probes/nppesProbe.ts
+++ b/apps/web/lib/source-health/probes/nppesProbe.ts
@@ -1,0 +1,16 @@
+import type { SourceHealthSnapshot } from '../sourceHealthTypes';
+import { runProbe, type ProbeDeps } from './runProbe';
+
+const NPPES_HEALTH_URL =
+  'https://npiregistry.cms.hhs.gov/api/?version=2.1&number=1234567893';
+
+export async function probe(deps: ProbeDeps = {}): Promise<SourceHealthSnapshot> {
+  return runProbe('NPPES', async ({ fetchImpl, signal }) => {
+    try {
+      const res = await fetchImpl(NPPES_HEALTH_URL, { signal });
+      return { status: res.status, ok: res.ok };
+    } catch (error) {
+      return { error };
+    }
+  }, deps);
+}

--- a/apps/web/lib/source-health/probes/oigProbe.ts
+++ b/apps/web/lib/source-health/probes/oigProbe.ts
@@ -1,0 +1,18 @@
+import type { SourceHealthSnapshot } from '../sourceHealthTypes';
+import { runProbe, type ProbeDeps } from './runProbe';
+
+const OIG_HEALTH_URL = 'https://oig.hhs.gov/exclusions/exclusions_list.asp';
+
+export async function probe(deps: ProbeDeps = {}): Promise<SourceHealthSnapshot> {
+  return runProbe('OIG_LEIE', async ({ fetchImpl, signal }) => {
+    try {
+      const res = await fetchImpl(OIG_HEALTH_URL, {
+        method: 'HEAD',
+        signal,
+      });
+      return { status: res.status, ok: res.ok };
+    } catch (error) {
+      return { error };
+    }
+  }, deps);
+}

--- a/apps/web/lib/source-health/probes/pecosProbe.ts
+++ b/apps/web/lib/source-health/probes/pecosProbe.ts
@@ -1,0 +1,18 @@
+import type { SourceHealthSnapshot } from '../sourceHealthTypes';
+import { runProbe, type ProbeDeps } from './runProbe';
+
+const PECOS_HEALTH_URL = 'https://data.cms.gov/provider-enrollment';
+
+export async function probe(deps: ProbeDeps = {}): Promise<SourceHealthSnapshot> {
+  return runProbe('PECOS', async ({ fetchImpl, signal }) => {
+    try {
+      const res = await fetchImpl(PECOS_HEALTH_URL, {
+        method: 'HEAD',
+        signal,
+      });
+      return { status: res.status, ok: res.ok };
+    } catch (error) {
+      return { error };
+    }
+  }, deps);
+}

--- a/apps/web/lib/source-health/probes/runProbe.ts
+++ b/apps/web/lib/source-health/probes/runProbe.ts
@@ -1,0 +1,109 @@
+import type {
+  SourceHealthSnapshot,
+  SourceHealthState,
+  SourceId,
+} from '../sourceHealthTypes';
+
+export interface ProbeDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+}
+
+export interface ProbeFetchOutcome {
+  status?: number; // HTTP status when a response was received
+  ok?: boolean;
+  error?: unknown; // network error, abort, etc.
+  timedOut?: boolean;
+}
+
+export type ProbeFetcher = (input: {
+  fetchImpl: typeof fetch;
+  signal: AbortSignal;
+}) => Promise<ProbeFetchOutcome>;
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+function classify(outcome: ProbeFetchOutcome): {
+  state: SourceHealthState;
+  reason: string;
+} {
+  if (outcome.timedOut) {
+    return { state: 'UNAVAILABLE', reason: 'probe_timeout' };
+  }
+  if (outcome.error !== undefined) {
+    return { state: 'UNAVAILABLE', reason: 'network_error' };
+  }
+  const status = outcome.status;
+  if (typeof status !== 'number') {
+    return { state: 'UNKNOWN', reason: 'no_status' };
+  }
+  if (status === 429) {
+    return { state: 'RATE_LIMITED', reason: 'http_429' };
+  }
+  if (status >= 200 && status < 300) {
+    return { state: 'LIVE', reason: `http_${status}` };
+  }
+  if (status >= 500 && status < 600) {
+    return { state: 'DEGRADED', reason: `http_${status}` };
+  }
+  return { state: 'UNKNOWN', reason: `http_${status}` };
+}
+
+/**
+ * Runs a probe and translates the outcome into a SourceHealthSnapshot.
+ *
+ * Guarantees:
+ *  - never throws (errors are absorbed and reflected as UNAVAILABLE/UNKNOWN)
+ *  - records `observedAt` and `lastLatencyMs`
+ *  - dependency-injects fetch, clock, and timeout for tests
+ */
+export async function runProbe(
+  sourceId: SourceId,
+  fetcher: ProbeFetcher,
+  deps: ProbeDeps = {},
+): Promise<SourceHealthSnapshot> {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  const now = deps.now ?? (() => new Date());
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const startedAt = now();
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  let outcome: ProbeFetchOutcome;
+  try {
+    outcome = await fetcher({ fetchImpl, signal: controller.signal });
+    if (timedOut) {
+      outcome = { ...outcome, timedOut: true };
+    }
+  } catch (error) {
+    outcome = timedOut
+      ? { timedOut: true }
+      : { error: error ?? new Error('unknown_probe_error') };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const finishedAt = now();
+  const lastLatencyMs = Math.max(
+    0,
+    finishedAt.getTime() - startedAt.getTime(),
+  );
+  const observedAt = finishedAt.toISOString();
+  const { state, reason } = classify(outcome);
+
+  return {
+    sourceId,
+    state,
+    reason,
+    lastSuccessAt: state === 'LIVE' ? observedAt : null,
+    lastErrorAt: state === 'LIVE' ? null : observedAt,
+    lastLatencyMs,
+    observedAt,
+  };
+}

--- a/apps/web/lib/source-health/probes/stateBoardProbe.ts
+++ b/apps/web/lib/source-health/probes/stateBoardProbe.ts
@@ -1,0 +1,22 @@
+import type { SourceHealthSnapshot } from '../sourceHealthTypes';
+import { runProbe, type ProbeDeps } from './runProbe';
+
+/**
+ * State licensing boards are NOT a single endpoint. There are 50+ jurisdictions
+ * each with their own portal, many without machine-readable APIs. This probe
+ * is intentionally conservative: it does not pretend to have a generic check.
+ *
+ * Until per-state probes are wired in, this returns an UNKNOWN-shaped outcome
+ * (no status), which `runProbe` maps to `state = UNKNOWN`. This is the honest
+ * answer — we do not know.
+ */
+export async function probe(deps: ProbeDeps = {}): Promise<SourceHealthSnapshot> {
+  return runProbe(
+    'STATE_BOARD',
+    async () => {
+      // Intentionally no network call; per-state probes are not yet wired.
+      return { /* no status, no error */ };
+    },
+    deps,
+  );
+}

--- a/apps/web/lib/source-health/sourceHealthTypes.ts
+++ b/apps/web/lib/source-health/sourceHealthTypes.ts
@@ -1,0 +1,86 @@
+/**
+ * SourceHealth — operational state of an upstream credentialing source.
+ *
+ * IMPORTANT: this module reports source *operational* state only. It does NOT
+ * make verification, certification, or compliance claims about provider data.
+ * See `README.md` and the banned-phrase contract in `unavailableLane.ts`.
+ */
+
+export type SourceHealthState =
+  | 'LIVE'
+  | 'DEGRADED'
+  | 'UNAVAILABLE'
+  | 'UNKNOWN'
+  | 'RATE_LIMITED';
+
+export type SourceId = 'NPPES' | 'OIG_LEIE' | 'PECOS' | 'STATE_BOARD';
+
+export interface SourceHealthSnapshot {
+  sourceId: SourceId;
+  state: SourceHealthState;
+  reason: string;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastLatencyMs: number | null;
+  observedAt: string;
+}
+
+export const ALL_SOURCE_IDS: readonly SourceId[] = [
+  'NPPES',
+  'OIG_LEIE',
+  'PECOS',
+  'STATE_BOARD',
+] as const;
+
+export const ALL_SOURCE_HEALTH_STATES: readonly SourceHealthState[] = [
+  'LIVE',
+  'DEGRADED',
+  'UNAVAILABLE',
+  'UNKNOWN',
+  'RATE_LIMITED',
+] as const;
+
+/**
+ * Truth invariant: evidence may only be upgraded when the source is LIVE.
+ * Any other state — including UNKNOWN — must NOT promote evidence.
+ */
+export function canEvidenceBeUpgraded(state: SourceHealthState): boolean {
+  switch (state) {
+    case 'LIVE':
+      return true;
+    case 'DEGRADED':
+    case 'UNAVAILABLE':
+    case 'UNKNOWN':
+    case 'RATE_LIMITED':
+      return false;
+    default:
+      return assertNever(state);
+  }
+}
+
+/**
+ * Truth invariant: only LIVE is healthy. DEGRADED is *not* healthy.
+ */
+export function isHealthy(state: SourceHealthState): boolean {
+  switch (state) {
+    case 'LIVE':
+      return true;
+    case 'DEGRADED':
+    case 'UNAVAILABLE':
+    case 'UNKNOWN':
+    case 'RATE_LIMITED':
+      return false;
+    default:
+      return assertNever(state);
+  }
+}
+
+/**
+ * Exhaustiveness helper. If the union grows and a switch forgets a case, this
+ * will fail to compile.
+ */
+export function assertNever(value: never): never {
+  throw new Error(
+    `Unhandled SourceHealth value: ${JSON.stringify(value)}`,
+  );
+}

--- a/apps/web/lib/source-health/unavailableLane.ts
+++ b/apps/web/lib/source-health/unavailableLane.ts
@@ -1,0 +1,104 @@
+import {
+  type SourceHealthState,
+  type SourceId,
+  assertNever,
+} from './sourceHealthTypes';
+
+export interface UnavailableLane {
+  sourceId: SourceId;
+  state: Exclude<SourceHealthState, 'LIVE'>;
+  userFacingMessage: string;
+  retryPolicy: {
+    suggestedRetryAfterMs: number;
+    canRetryNow: boolean;
+  };
+  lastSeenAt: string | null;
+}
+
+/**
+ * Banned phrases that must NEVER appear in any user-facing copy emitted by
+ * this module. Enforced by `unavailableLane.bannedPhrases.test.ts`.
+ *
+ * These claims are either marketing puffery or compliance assertions we are
+ * not entitled to make from operational state alone.
+ */
+export const BANNED_USER_FACING_PHRASES: readonly string[] = [
+  'real-time',
+  'real time',
+  'live verification',
+  'guaranteed',
+  'always available',
+  'verified',
+  'certified',
+  'instant',
+  'tamper-proof',
+  'hipaa compliant',
+  'soc2 certified',
+  'ncqa verified',
+] as const;
+
+const SOURCE_DISPLAY_NAME: Record<SourceId, string> = {
+  NPPES: 'NPPES (CMS provider registry)',
+  OIG_LEIE: 'OIG exclusion list',
+  PECOS: 'PECOS enrollment lookup',
+  STATE_BOARD: 'state licensing board lookup',
+};
+
+// Deterministic copy table per (sourceId, state). Honest, neutral language.
+// Do NOT use words like "verified", "guaranteed", "real-time", etc. (see test).
+function copyFor(
+  sourceId: SourceId,
+  state: Exclude<SourceHealthState, 'LIVE'>,
+): string {
+  const source = SOURCE_DISPLAY_NAME[sourceId];
+  switch (state) {
+    case 'DEGRADED':
+      return `The ${source} lookup is responding more slowly than expected. We will keep trying; readiness signals from this source may lag.`;
+    case 'UNAVAILABLE':
+      return `The ${source} lookup did not respond. We cannot refresh signals from this source right now.`;
+    case 'RATE_LIMITED':
+      return `The ${source} lookup is throttling requests. We will back off and try again shortly.`;
+    case 'UNKNOWN':
+      return `We do not have a recent operational reading for the ${source}. Treat any cached signal from this source as a snapshot rather than a fresh reading.`;
+    default:
+      return assertNever(state);
+  }
+}
+
+function retryPolicyFor(
+  state: Exclude<SourceHealthState, 'LIVE'>,
+): UnavailableLane['retryPolicy'] {
+  switch (state) {
+    case 'DEGRADED':
+      return { suggestedRetryAfterMs: 30_000, canRetryNow: true };
+    case 'UNAVAILABLE':
+      return { suggestedRetryAfterMs: 60_000, canRetryNow: true };
+    case 'RATE_LIMITED':
+      return { suggestedRetryAfterMs: 120_000, canRetryNow: false };
+    case 'UNKNOWN':
+      return { suggestedRetryAfterMs: 30_000, canRetryNow: true };
+    default:
+      return assertNever(state);
+  }
+}
+
+/**
+ * Build an UnavailableLane record. The `reason` parameter is captured in the
+ * snapshot but NOT echoed to the user — we render only deterministic copy
+ * from the table above to keep banned phrases out of user-facing surfaces.
+ */
+export function unavailableLane(input: {
+  sourceId: SourceId;
+  state: Exclude<SourceHealthState, 'LIVE'>;
+  reason: string;
+  lastSeenAt: string | null;
+}): UnavailableLane {
+  const { sourceId, state, lastSeenAt } = input;
+  return {
+    sourceId,
+    state,
+    userFacingMessage: copyFor(sourceId, state),
+    retryPolicy: retryPolicyFor(state),
+    lastSeenAt,
+  };
+}


### PR DESCRIPTION
## RELIABILITY-1 — passport source health + unavailable lane recovery

Adds an additive `apps/web/lib/source-health` module that makes upstream source state honest and recoverable.

### What it ships
- **5-state SourceHealth state machine** — `LIVE | DEGRADED | UNAVAILABLE | UNKNOWN | RATE_LIMITED`. `canEvidenceBeUpgraded` returns true ONLY for `LIVE`.
- **`unavailableLane` contract** — deterministic, table-driven user-facing copy with a hard banned-phrase invariant.
- **Probe wrappers** for NPPES / OIG / PECOS / state-board. Dependency-injected (`fetchImpl`/`now`/`timeoutMs`), never throw. State-board returns `UNKNOWN` until adapter ships — no faked `LIVE`.
- **Pure aggregator** `aggregateLaneHealth`.
- **UI components** — `LaneHealthBadge`, `LaneHealthSection`, `LaneHealthMount`. Non-LIVE states never render verified/certified chrome.
- **Surface mounts** — minimal 5-line additions to `/passport` and `/employer/dashboard`. No refactors.
- **Placeholder seed** returns `UNKNOWN` for all four sources until live probes are scheduled.
- **README** with state machine table, banned-phrase contract, and add-a-source checklist.

### Tests
- **51/51 source-health tests pass**: 20 truth-table (4 sources × 5 states), 17 banned-phrase regression (case-insensitive, exhaustive: "real-time", "live verification", "guaranteed", "always available", "verified", "certified", "instant", "tamper-proof", "hipaa compliant", "soc2 certified", "ncqa verified"), 9 `runProbe`, 5 aggregator.
- Lint: clean. Typecheck: zero errors on changed files.

### Codex verdict: **SAFE**
- Diff scope clean (no forbidden paths touched).
- All truth invariants honored.
- No critical findings.

### Out of scope (intentionally)
- No mobile, marketing, sales, or clinician-foundation file changes.
- `apps/web/lib/status/sourceOps.ts` not modified.
- No live probe scheduling — that's a follow-up wave.

### Pre-existing baseline (NOT this PR)
Codex noted two banned-phrase hits in `apps/web/app/passport/page.tsx` (line 6 "Wallet entry", line 514 "Real-time visual feedback") that are present on `main` HEAD `599c821`. Filed for a separate cleanup ticket.

### Wave gate
- ✅ Codex SAFE
- ⏳ CI run starting on push
- ⏳ Awaiting human merge approval (BOOT rule #1)
- ❌ No deploy