### PR TITLE
feat(reliability): add scheduled source health probes

### DIFF
--- a/.github/workflows/source-health-probe.yml
+++ b/.github/workflows/source-health-probe.yml
@@ -1,0 +1,56 @@
+# Scheduled source-health probe.
+#
+# Required GitHub repository secrets:
+#   - CRON_SECRET: must match the CRON_SECRET configured on the deployed
+#     Vercel/Next.js app. Used as the Bearer token to authenticate this
+#     scheduled caller.
+#   - PROBE_URL: https origin of the deployed web app, e.g.
+#     "https://app.vitalcv.example". The workflow appends
+#     /api/internal/source-health/probe.
+#
+# Truth contract:
+#   - This workflow does NOT classify clinicians. It triggers an
+#     internal endpoint that classifies the operational health of
+#     upstream credentialing sources only. A DEGRADED / UNAVAILABLE
+#     lane is a property of the source, never a clinician defect.
+#   - The Bearer token is the only credential sent. The response body
+#     is echoed for operator visibility but contains only safe
+#     metadata (already redacted by the server). The secret itself is
+#     NEVER echoed.
+
+name: Source Health Probe
+
+on:
+  schedule:
+    # Every 15 minutes.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Trigger source-health probe
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST /api/internal/source-health/probe
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          PROBE_URL: ${{ secrets.PROBE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRON_SECRET:-}" ] || [ -z "${PROBE_URL:-}" ]; then
+            echo "Missing CRON_SECRET or PROBE_URL secret." >&2
+            exit 1
+          fi
+          # -fsS: fail on non-2xx, silent progress, show errors.
+          # Authorization header is consumed by the server's checkAuth.
+          response="$(curl -fsS -X POST \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${PROBE_URL}/api/internal/source-health/probe")"
+          # Echo response for operator visibility. Body contains only
+          # safe metadata; secret is not echoed.
+          echo "$response"

--- a/apps/web/__tests__/source-health/noFakeLive.test.ts
+++ b/apps/web/__tests__/source-health/noFakeLive.test.ts
@@ -1,0 +1,113 @@
+/**
+ * TRUTH INVARIANT: LIVE is emitted ONLY by a confirmed 2xx probe response.
+ *
+ * Specifically:
+ *   - With an empty store, getLaneSnapshots() returns ZERO LIVE snapshots.
+ *   - With runAllProbes mocked so every source fails (5xx, timeout, 429,
+ *     network), the result and the store contain ZERO LIVE snapshots.
+ *   - With ONE source returning 2xx and the others failing, only that one
+ *     source is LIVE; the others are NOT.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { getLaneSnapshots } from '@/lib/source-health/getLaneSnapshots';
+import { runAllProbes } from '@/lib/source-health/runner/runAllProbes';
+import {
+  clearAllSnapshots,
+  getAllSnapshots,
+} from '@/lib/source-health/store/snapshotStore';
+import { runProbe } from '@/lib/source-health/probes/runProbe';
+import type { SourceId } from '@/lib/source-health/sourceHealthTypes';
+
+type Outcome = '2xx' | '5xx' | '429' | 'timeout' | 'network';
+
+function makeProbe(sourceId: SourceId, outcome: Outcome) {
+  return async () =>
+    runProbe(
+      sourceId,
+      async ({ signal }) => {
+        switch (outcome) {
+          case '2xx':
+            return { status: 200, ok: true };
+          case '5xx':
+            return { status: 503, ok: false };
+          case '429':
+            return { status: 429, ok: false };
+          case 'timeout':
+            return new Promise((_resolve, reject) => {
+              signal.addEventListener('abort', () => reject(new Error('aborted')));
+            });
+          case 'network':
+            return { error: new TypeError('network failure') };
+        }
+      },
+      { timeoutMs: 5 },
+    );
+}
+
+describe('TRUTH INVARIANT: no fake LIVE', () => {
+  beforeEach(() => {
+    clearAllSnapshots();
+  });
+
+  it('cold store: getLaneSnapshots returns zero LIVE (4 UNKNOWN)', () => {
+    const lanes = getLaneSnapshots();
+    expect(lanes).toHaveLength(4);
+    const liveCount = lanes.filter((s) => s.state === 'LIVE').length;
+    expect(liveCount).toBe(0);
+    const unknownCount = lanes.filter((s) => s.state === 'UNKNOWN').length;
+    expect(unknownCount).toBe(4);
+  });
+
+  it('all probes fail (5xx, timeout, 429, network): zero LIVE in result and store', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbe('NPPES', '5xx') },
+      { sourceId: 'OIG_LEIE' as const, probe: makeProbe('OIG_LEIE', 'timeout') },
+      { sourceId: 'PECOS' as const, probe: makeProbe('PECOS', '429') },
+      { sourceId: 'STATE_BOARD' as const, probe: makeProbe('STATE_BOARD', 'network') },
+    ];
+    const res = await runAllProbes({ probes, timeoutMs: 5 });
+    const liveInResult = res.snapshots.filter((s) => s.state === 'LIVE').length;
+    expect(liveInResult).toBe(0);
+
+    const stored = getAllSnapshots();
+    const liveInStore = stored.filter((s) => s.state === 'LIVE').length;
+    expect(liveInStore).toBe(0);
+
+    // And the surface fallback also returns zero LIVE.
+    const lanes = getLaneSnapshots();
+    const liveInSurface = lanes.filter((s) => s.state === 'LIVE').length;
+    expect(liveInSurface).toBe(0);
+  });
+
+  it('only the 2xx source is LIVE; the others are NOT', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbe('NPPES', '2xx') },
+      { sourceId: 'OIG_LEIE' as const, probe: makeProbe('OIG_LEIE', '5xx') },
+      { sourceId: 'PECOS' as const, probe: makeProbe('PECOS', '429') },
+      { sourceId: 'STATE_BOARD' as const, probe: makeProbe('STATE_BOARD', 'network') },
+    ];
+    const res = await runAllProbes({ probes });
+    const live = res.snapshots.filter((s) => s.state === 'LIVE');
+    expect(live).toHaveLength(1);
+    expect(live[0].sourceId).toBe('NPPES');
+
+    const others = res.snapshots.filter((s) => s.sourceId !== 'NPPES');
+    for (const o of others) {
+      expect(o.state).not.toBe('LIVE');
+    }
+  });
+
+  it('placeholder seed never returns LIVE (cold store includes STATE_BOARD UNKNOWN reason)', () => {
+    const lanes = getLaneSnapshots();
+    const stateBoard = lanes.find((s) => s.sourceId === 'STATE_BOARD');
+    expect(stateBoard?.state).toBe('UNKNOWN');
+    expect(stateBoard?.reason).toBe('no_generic_state_board_probe_wired');
+
+    // None of the placeholder seeds may be LIVE
+    for (const s of lanes) {
+      expect(s.state).not.toBe('LIVE');
+    }
+  });
+});

--- a/apps/web/__tests__/source-health/probeRoute.test.ts
+++ b/apps/web/__tests__/source-health/probeRoute.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import { __handleForTests } from '@/app/api/internal/source-health/probe/route';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+
+const FAKE_SNAPSHOT: SourceHealthSnapshot = {
+  sourceId: 'NPPES',
+  state: 'LIVE',
+  reason: 'http_200',
+  lastSuccessAt: '2024-06-01T12:00:00.000Z',
+  lastErrorAt: null,
+  lastLatencyMs: 42,
+  observedAt: '2024-06-01T12:00:00.000Z',
+};
+
+const FAKE_RESULT = {
+  snapshots: [FAKE_SNAPSHOT],
+  durationMs: 100,
+  errors: [],
+};
+
+const stubRunner = async () => FAKE_RESULT;
+
+describe('POST /api/internal/source-health/probe — auth', () => {
+  it('401 when no auth headers and a secret IS configured', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'unauthorized' });
+  });
+
+  it('401 on wrong Bearer token', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer wrong' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('401 on wrong x-monitoring-secret', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { 'x-monitoring-secret': 'wrong' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('200 with safe snapshot shape on correct Bearer token', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-cron' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.snapshots).toHaveLength(1);
+    expect(body.snapshots[0].sourceId).toBe('NPPES');
+    expect(body.snapshots[0].state).toBe('LIVE');
+    expect(body.durationMs).toBe(100);
+    expect(body.errors).toEqual([]);
+  });
+
+  it('200 on correct x-monitoring-secret', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { 'x-monitoring-secret': 'good-mon' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('GET also works for cron callers', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer good-cron' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('500 when both env secrets are unset', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer anything' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: undefined, monitoringSecret: undefined },
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'no probe auth configured' });
+  });
+
+  it('still 500 when both secrets are empty strings', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer anything' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: '', monitoringSecret: '' },
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it('only cronSecret configured: monitoring header rejected, bearer accepted', async () => {
+    const baseEnv = { cronSecret: 'only-cron', monitoringSecret: undefined };
+    const req1 = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { 'x-monitoring-secret': 'anything' },
+    });
+    const r1 = await __handleForTests(req1, {
+      runProbes: stubRunner,
+      authEnv: baseEnv,
+    });
+    expect(r1.status).toBe(401);
+
+    const req2 = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer only-cron' },
+    });
+    const r2 = await __handleForTests(req2, {
+      runProbes: stubRunner,
+      authEnv: baseEnv,
+    });
+    expect(r2.status).toBe(200);
+  });
+
+  it('response body MUST NOT contain raw payload, headers, npi, or PII fields', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/probe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer good-cron' },
+    });
+    const res = await __handleForTests(req, {
+      runProbes: stubRunner,
+      authEnv: { cronSecret: 'good-cron', monitoringSecret: 'good-mon' },
+    });
+    const text = await res.text();
+    const lowered = text.toLowerCase();
+    for (const banned of [
+      '"headers"',
+      '"body"',
+      '"payload"',
+      '"npi"',
+      '"firstname"',
+      '"lastname"',
+      '"first_name"',
+      '"last_name"',
+      '"email"',
+      '"ssn"',
+      '"dob"',
+    ]) {
+      expect(lowered).not.toContain(banned);
+    }
+    // sanity: shape we DO expect
+    expect(lowered).toContain('"snapshots"');
+    expect(lowered).toContain('"durationms"');
+  });
+});

--- a/apps/web/__tests__/source-health/probeRoute.test.ts
+++ b/apps/web/__tests__/source-health/probeRoute.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { __handleForTests } from '@/app/api/internal/source-health/probe/route';
+import { __handleForTests } from '@/app/api/internal/source-health/probe/_handler';
 import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
 
 const FAKE_SNAPSHOT: SourceHealthSnapshot = {

--- a/apps/web/__tests__/source-health/runAllProbes.test.ts
+++ b/apps/web/__tests__/source-health/runAllProbes.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { runAllProbes } from '@/lib/source-health/runner/runAllProbes';
+import {
+  clearAllSnapshots,
+  getAllSnapshots,
+} from '@/lib/source-health/store/snapshotStore';
+import { runProbe } from '@/lib/source-health/probes/runProbe';
+import type {
+  ProbeDeps,
+} from '@/lib/source-health/probes/runProbe';
+import type {
+  SourceHealthSnapshot,
+  SourceId,
+} from '@/lib/source-health/sourceHealthTypes';
+
+type FetchOutcome =
+  | { kind: '2xx' }
+  | { kind: '5xx' }
+  | { kind: '429' }
+  | { kind: 'timeout' }
+  | { kind: 'network' };
+
+function makeProbeFor(
+  sourceId: SourceId,
+  outcome: FetchOutcome,
+): (deps?: ProbeDeps) => Promise<SourceHealthSnapshot> {
+  return async (deps?: ProbeDeps) =>
+    runProbe(
+      sourceId,
+      async ({ signal }) => {
+        switch (outcome.kind) {
+          case '2xx':
+            return { status: 200, ok: true };
+          case '5xx':
+            return { status: 503, ok: false };
+          case '429':
+            return { status: 429, ok: false };
+          case 'timeout':
+            // Wait for abort. runProbe's setTimeout will trigger.
+            return new Promise((_resolve, reject) => {
+              signal.addEventListener('abort', () => {
+                reject(new Error('aborted'));
+              });
+            });
+          case 'network':
+            return { error: new TypeError('network failure') };
+        }
+      },
+      deps,
+    );
+}
+
+const fixedNow = () => new Date('2024-06-01T12:00:00.000Z');
+
+describe('runAllProbes', () => {
+  beforeEach(() => {
+    clearAllSnapshots();
+  });
+
+  it('runs all four lanes in canonical order', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '2xx' }) },
+      { sourceId: 'OIG_LEIE' as const, probe: makeProbeFor('OIG_LEIE', { kind: '2xx' }) },
+      { sourceId: 'PECOS' as const, probe: makeProbeFor('PECOS', { kind: '2xx' }) },
+      { sourceId: 'STATE_BOARD' as const, probe: makeProbeFor('STATE_BOARD', { kind: '2xx' }) },
+    ];
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.snapshots.map((s) => s.sourceId)).toEqual([
+      'NPPES',
+      'OIG_LEIE',
+      'PECOS',
+      'STATE_BOARD',
+    ]);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('maps 2xx → LIVE', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '2xx' }) },
+    ];
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.snapshots[0].state).toBe('LIVE');
+  });
+
+  it('maps 5xx → DEGRADED', async () => {
+    const probes = [
+      { sourceId: 'PECOS' as const, probe: makeProbeFor('PECOS', { kind: '5xx' }) },
+    ];
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.snapshots[0].state).toBe('DEGRADED');
+  });
+
+  it('maps 429 → RATE_LIMITED', async () => {
+    const probes = [
+      { sourceId: 'OIG_LEIE' as const, probe: makeProbeFor('OIG_LEIE', { kind: '429' }) },
+    ];
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.snapshots[0].state).toBe('RATE_LIMITED');
+  });
+
+  it('maps timeout → UNAVAILABLE', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: 'timeout' }) },
+    ];
+    const res = await runAllProbes({ probes, timeoutMs: 5 });
+    expect(res.snapshots[0].state).toBe('UNAVAILABLE');
+    expect(res.snapshots[0].reason).toBe('probe_timeout');
+  });
+
+  it('maps network error → UNAVAILABLE', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: 'network' }) },
+    ];
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.snapshots[0].state).toBe('UNAVAILABLE');
+    expect(res.snapshots[0].reason).toBe('network_error');
+  });
+
+  it('does not throw when an underlying probe rejects synchronously', async () => {
+    const throwingProbe = async () => {
+      throw new Error('boom');
+    };
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: throwingProbe },
+    ];
+    await expect(runAllProbes({ probes, now: fixedNow })).resolves.toBeDefined();
+    const res = await runAllProbes({ probes, now: fixedNow });
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].sourceId).toBe('NPPES');
+    // UNKNOWN state recorded for the failed source
+    const found = res.snapshots.find((s) => s.sourceId === 'NPPES');
+    expect(found?.state).toBe('UNKNOWN');
+  });
+
+  it('measures durationMs via injected now()', async () => {
+    let tick = 0;
+    const ticks = [
+      new Date('2024-06-01T12:00:00.000Z'),
+      new Date('2024-06-01T12:00:00.100Z'), // probe start
+      new Date('2024-06-01T12:00:00.200Z'), // probe finish
+      new Date('2024-06-01T12:00:00.300Z'), // batch finish
+    ];
+    const now = () => ticks[Math.min(tick++, ticks.length - 1)];
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '2xx' }) },
+    ];
+    const res = await runAllProbes({ probes, now });
+    expect(res.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records every snapshot in the store', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '2xx' }) },
+      { sourceId: 'PECOS' as const, probe: makeProbeFor('PECOS', { kind: '5xx' }) },
+    ];
+    await runAllProbes({ probes, now: fixedNow });
+    const stored = getAllSnapshots();
+    expect(stored.find((s) => s.sourceId === 'NPPES')?.state).toBe('LIVE');
+    expect(stored.find((s) => s.sourceId === 'PECOS')?.state).toBe(
+      'DEGRADED',
+    );
+  });
+
+  it('respects an injected store override', async () => {
+    const recorded: SourceHealthSnapshot[] = [];
+    const store = {
+      recordSnapshot: (s: SourceHealthSnapshot) => {
+        recorded.push(s);
+      },
+      getAllSnapshots: () => recorded,
+    };
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '2xx' }) },
+    ];
+    const res = await runAllProbes({ probes, store, now: fixedNow });
+    expect(recorded).toHaveLength(1);
+    expect(res.snapshots).toHaveLength(1);
+  });
+
+  it('never produces LIVE when every probe fails', async () => {
+    const probes = [
+      { sourceId: 'NPPES' as const, probe: makeProbeFor('NPPES', { kind: '5xx' }) },
+      { sourceId: 'OIG_LEIE' as const, probe: makeProbeFor('OIG_LEIE', { kind: '429' }) },
+      { sourceId: 'PECOS' as const, probe: makeProbeFor('PECOS', { kind: 'network' }) },
+      { sourceId: 'STATE_BOARD' as const, probe: makeProbeFor('STATE_BOARD', { kind: 'timeout' }) },
+    ];
+    const res = await runAllProbes({ probes, timeoutMs: 5 });
+    const liveCount = res.snapshots.filter((s) => s.state === 'LIVE').length;
+    expect(liveCount).toBe(0);
+  });
+});

--- a/apps/web/__tests__/source-health/snapshotStore.test.ts
+++ b/apps/web/__tests__/source-health/snapshotStore.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearAllSnapshots,
+  getAllSnapshots,
+  getSnapshot,
+  recordSnapshot,
+} from '@/lib/source-health/store/snapshotStore';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+
+function snap(
+  partial: Partial<SourceHealthSnapshot> &
+    Pick<SourceHealthSnapshot, 'sourceId' | 'state' | 'observedAt'>,
+): SourceHealthSnapshot {
+  return {
+    reason: 'test',
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastLatencyMs: null,
+    ...partial,
+  } as SourceHealthSnapshot;
+}
+
+describe('snapshotStore', () => {
+  beforeEach(() => {
+    clearAllSnapshots();
+  });
+
+  it('records and reads back a single snapshot', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        observedAt: '2024-06-01T12:00:00.000Z',
+      }),
+    );
+
+    const got = getSnapshot('NPPES');
+    expect(got?.state).toBe('LIVE');
+    expect(getAllSnapshots()).toHaveLength(1);
+  });
+
+  it('clearAllSnapshots empties the store', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        observedAt: '2024-06-01T12:00:00.000Z',
+      }),
+    );
+    clearAllSnapshots();
+    expect(getAllSnapshots()).toHaveLength(0);
+    expect(getSnapshot('NPPES')).toBeUndefined();
+  });
+
+  it('LIVE snapshot sets lastSuccessAt to observedAt', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'OIG_LEIE',
+        state: 'LIVE',
+        observedAt: '2024-06-01T12:00:00.000Z',
+      }),
+    );
+    expect(getSnapshot('OIG_LEIE')?.lastSuccessAt).toBe(
+      '2024-06-01T12:00:00.000Z',
+    );
+  });
+
+  it('carries forward lastSuccessAt when next snapshot is non-LIVE with null', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        observedAt: '2024-06-01T12:00:00.000Z',
+      }),
+    );
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'UNAVAILABLE',
+        observedAt: '2024-06-01T13:00:00.000Z',
+        lastSuccessAt: null,
+      }),
+    );
+    const got = getSnapshot('NPPES');
+    expect(got?.state).toBe('UNAVAILABLE');
+    expect(got?.lastSuccessAt).toBe('2024-06-01T12:00:00.000Z');
+  });
+
+  it('updates lastErrorAt on DEGRADED / UNAVAILABLE / RATE_LIMITED', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'PECOS',
+        state: 'DEGRADED',
+        observedAt: '2024-06-01T14:00:00.000Z',
+        lastErrorAt: null,
+      }),
+    );
+    expect(getSnapshot('PECOS')?.lastErrorAt).toBe(
+      '2024-06-01T14:00:00.000Z',
+    );
+
+    recordSnapshot(
+      snap({
+        sourceId: 'OIG_LEIE',
+        state: 'RATE_LIMITED',
+        observedAt: '2024-06-01T15:00:00.000Z',
+        lastErrorAt: null,
+      }),
+    );
+    expect(getSnapshot('OIG_LEIE')?.lastErrorAt).toBe(
+      '2024-06-01T15:00:00.000Z',
+    );
+  });
+
+  it('does not set lastErrorAt for UNKNOWN', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'STATE_BOARD',
+        state: 'UNKNOWN',
+        observedAt: '2024-06-01T16:00:00.000Z',
+        lastErrorAt: null,
+      }),
+    );
+    expect(getSnapshot('STATE_BOARD')?.lastErrorAt).toBeNull();
+  });
+
+  it('returns snapshots in canonical SourceId order', () => {
+    // Insert in scrambled order
+    recordSnapshot(
+      snap({
+        sourceId: 'STATE_BOARD',
+        state: 'UNKNOWN',
+        observedAt: '2024-06-01T10:00:00.000Z',
+      }),
+    );
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        observedAt: '2024-06-01T10:01:00.000Z',
+      }),
+    );
+    recordSnapshot(
+      snap({
+        sourceId: 'PECOS',
+        state: 'DEGRADED',
+        observedAt: '2024-06-01T10:02:00.000Z',
+      }),
+    );
+    recordSnapshot(
+      snap({
+        sourceId: 'OIG_LEIE',
+        state: 'LIVE',
+        observedAt: '2024-06-01T10:03:00.000Z',
+      }),
+    );
+
+    const ids = getAllSnapshots().map((s) => s.sourceId);
+    expect(ids).toEqual(['NPPES', 'OIG_LEIE', 'PECOS', 'STATE_BOARD']);
+  });
+
+  it('LIVE after UNAVAILABLE advances lastSuccessAt and keeps prior lastErrorAt available via store update', () => {
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'UNAVAILABLE',
+        observedAt: '2024-06-01T17:00:00.000Z',
+      }),
+    );
+    expect(getSnapshot('NPPES')?.lastErrorAt).toBe(
+      '2024-06-01T17:00:00.000Z',
+    );
+
+    recordSnapshot(
+      snap({
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        observedAt: '2024-06-01T18:00:00.000Z',
+        lastErrorAt: null,
+      }),
+    );
+    const got = getSnapshot('NPPES');
+    expect(got?.state).toBe('LIVE');
+    expect(got?.lastSuccessAt).toBe('2024-06-01T18:00:00.000Z');
+    // New LIVE snapshot's own lastErrorAt (null) wins.
+    expect(got?.lastErrorAt).toBeNull();
+  });
+});

--- a/apps/web/__tests__/source-health/snapshotsRoute.test.ts
+++ b/apps/web/__tests__/source-health/snapshotsRoute.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { __handleForTests } from '@/app/api/internal/source-health/snapshots/route';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+
+const env = { cronSecret: 'good-cron', monitoringSecret: 'good-mon' };
+
+describe('GET /api/internal/source-health/snapshots', () => {
+  it('401 without auth headers', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/snapshots');
+    const res = await __handleForTests(req, {
+      getAllSnapshots: () => [],
+      authEnv: env,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('200 honest empty array when store is cold', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/snapshots', {
+      headers: { Authorization: 'Bearer good-cron' },
+    });
+    const res = await __handleForTests(req, {
+      getAllSnapshots: () => [],
+      authEnv: env,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.snapshots).toEqual([]);
+    expect(body.observedAt).toBeNull();
+  });
+
+  it('200 with snapshots and newest observedAt', async () => {
+    const snaps: SourceHealthSnapshot[] = [
+      {
+        sourceId: 'NPPES',
+        state: 'LIVE',
+        reason: 'http_200',
+        lastSuccessAt: '2024-06-01T12:00:00.000Z',
+        lastErrorAt: null,
+        lastLatencyMs: 30,
+        observedAt: '2024-06-01T12:00:00.000Z',
+      },
+      {
+        sourceId: 'PECOS',
+        state: 'DEGRADED',
+        reason: 'http_503',
+        lastSuccessAt: null,
+        lastErrorAt: '2024-06-01T13:00:00.000Z',
+        lastLatencyMs: 50,
+        observedAt: '2024-06-01T13:00:00.000Z',
+      },
+    ];
+    const req = new Request('https://x.test/api/internal/source-health/snapshots', {
+      headers: { 'x-monitoring-secret': 'good-mon' },
+    });
+    const res = await __handleForTests(req, {
+      getAllSnapshots: () => snaps,
+      authEnv: env,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.snapshots).toHaveLength(2);
+    expect(body.observedAt).toBe('2024-06-01T13:00:00.000Z');
+
+    const text = JSON.stringify(body).toLowerCase();
+    for (const banned of [
+      '"headers"',
+      '"body"',
+      '"payload"',
+      '"npi"',
+      '"firstname"',
+      '"lastname"',
+    ]) {
+      expect(text).not.toContain(banned);
+    }
+  });
+
+  it('500 when both auth secrets unset', async () => {
+    const req = new Request('https://x.test/api/internal/source-health/snapshots', {
+      headers: { Authorization: 'Bearer anything' },
+    });
+    const res = await __handleForTests(req, {
+      getAllSnapshots: () => [],
+      authEnv: { cronSecret: undefined, monitoringSecret: undefined },
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'no probe auth configured' });
+  });
+});

--- a/apps/web/__tests__/source-health/snapshotsRoute.test.ts
+++ b/apps/web/__tests__/source-health/snapshotsRoute.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { __handleForTests } from '@/app/api/internal/source-health/snapshots/route';
+import { __handleForTests } from '@/app/api/internal/source-health/snapshots/_handler';
 import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
 
 const env = { cronSecret: 'good-cron', monitoringSecret: 'good-mon' };

--- a/apps/web/app/api/internal/source-health/_auth.ts
+++ b/apps/web/app/api/internal/source-health/_auth.ts
@@ -1,0 +1,93 @@
+/**
+ * Internal route auth for source-health endpoints.
+ *
+ * Accepts EITHER:
+ *   - `Authorization: Bearer <CRON_SECRET>` (preferred for scheduled callers)
+ *   - `x-monitoring-secret: <MONITORING_SECRET>` (legacy/manual operator path)
+ *
+ * Returns one of:
+ *   - { ok: true } when an env-configured secret matches
+ *   - { ok: false, status: 401, body: { error: 'unauthorized' } }
+ *   - { ok: false, status: 500, body: { error: 'no probe auth configured' } }
+ *     when both env secrets are unset (defensive — fail closed).
+ *
+ * Constant-time compare via `crypto.timingSafeEqual` when buffers match
+ * length; otherwise we still fail closed (no early return mismatch).
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+export interface AuthEnv {
+  cronSecret?: string;
+  monitoringSecret?: string;
+}
+
+export interface AuthHeaders {
+  authorization?: string | null;
+  monitoring?: string | null;
+}
+
+export type AuthResult =
+  | { ok: true }
+  | { ok: false; status: 401; body: { error: 'unauthorized' } }
+  | { ok: false; status: 500; body: { error: 'no probe auth configured' } };
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf-8');
+  const bBuf = Buffer.from(b, 'utf-8');
+  if (aBuf.length !== bBuf.length) {
+    // Still consume time — Node's timingSafeEqual requires equal length.
+    // Compare aBuf to itself as a placeholder, then fail.
+    timingSafeEqual(aBuf, aBuf);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function parseBearer(header: string | null | undefined): string | null {
+  if (!header) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return m ? m[1].trim() : null;
+}
+
+export function checkAuth(
+  headers: AuthHeaders,
+  env: AuthEnv,
+): AuthResult {
+  const cronSecret = (env.cronSecret ?? '').trim();
+  const monitoringSecret = (env.monitoringSecret ?? '').trim();
+
+  if (!cronSecret && !monitoringSecret) {
+    return {
+      ok: false,
+      status: 500,
+      body: { error: 'no probe auth configured' },
+    };
+  }
+
+  const bearer = parseBearer(headers.authorization);
+  if (bearer && cronSecret && safeEqual(bearer, cronSecret)) {
+    return { ok: true };
+  }
+
+  const monitoring = (headers.monitoring ?? '').trim();
+  if (monitoring && monitoringSecret && safeEqual(monitoring, monitoringSecret)) {
+    return { ok: true };
+  }
+
+  return { ok: false, status: 401, body: { error: 'unauthorized' } };
+}
+
+export function readAuthEnv(): AuthEnv {
+  return {
+    cronSecret: process.env.CRON_SECRET,
+    monitoringSecret: process.env.MONITORING_SECRET,
+  };
+}
+
+export function readAuthHeaders(req: Request): AuthHeaders {
+  return {
+    authorization: req.headers.get('authorization'),
+    monitoring: req.headers.get('x-monitoring-secret'),
+  };
+}

--- a/apps/web/app/api/internal/source-health/probe/_handler.ts
+++ b/apps/web/app/api/internal/source-health/probe/_handler.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal probe-route handler. Lives in a non-route file (`_handler.ts`)
+ * so route.ts can stay narrowly typed to Next.js's allowed exports
+ * (GET/POST/etc. + `runtime`/`dynamic`). Tests import the
+ * `__handleForTests` shim from here.
+ */
+
+import { NextResponse } from 'next/server';
+
+import {
+  checkAuth,
+  readAuthEnv,
+  readAuthHeaders,
+} from '../_auth';
+import { runAllProbes } from '@/lib/source-health/runner/runAllProbes';
+import type { RunAllProbesDeps } from '@/lib/source-health/runner/runAllProbes';
+
+export interface ProbeRouteDeps {
+  runProbes?: (deps?: RunAllProbesDeps) => ReturnType<typeof runAllProbes>;
+  authEnv?: ReturnType<typeof readAuthEnv>;
+}
+
+export async function handleProbe(
+  req: Request,
+  deps: ProbeRouteDeps = {},
+): Promise<NextResponse> {
+  const env = deps.authEnv ?? readAuthEnv();
+  const auth = checkAuth(readAuthHeaders(req), env);
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status });
+  }
+
+  const runner = deps.runProbes ?? runAllProbes;
+  const result = await runner();
+
+  return NextResponse.json(
+    {
+      snapshots: result.snapshots,
+      durationMs: result.durationMs,
+      errors: result.errors,
+    },
+    { status: 200 },
+  );
+}
+
+/** Test-only shim — invoked directly by route tests with DI'd deps. */
+export async function __handleForTests(
+  req: Request,
+  deps: ProbeRouteDeps,
+): Promise<NextResponse> {
+  return handleProbe(req, deps);
+}

--- a/apps/web/app/api/internal/source-health/probe/route.ts
+++ b/apps/web/app/api/internal/source-health/probe/route.ts
@@ -7,64 +7,24 @@
  *
  * Returns ONLY safe metadata: snapshots already strip raw upstream payloads
  * at the runProbe layer, and we never echo headers or request bodies.
+ *
+ * The handler implementation lives in `_handler.ts` so this file stays
+ * narrowly typed to Next.js's allowed Route exports (GET/POST/etc. +
+ * `runtime`/`dynamic`). Tests import the `__handleForTests` shim from
+ * `_handler.ts`.
  */
 
-import { NextResponse } from 'next/server';
+import type { NextResponse } from 'next/server';
 
-import {
-  checkAuth,
-  readAuthEnv,
-  readAuthHeaders,
-} from '../_auth';
-import { runAllProbes } from '@/lib/source-health/runner/runAllProbes';
-import type { RunAllProbesDeps } from '@/lib/source-health/runner/runAllProbes';
+import { handleProbe } from './_handler';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export interface ProbeRouteDeps {
-  runProbes?: (deps?: RunAllProbesDeps) => ReturnType<typeof runAllProbes>;
-  authEnv?: ReturnType<typeof readAuthEnv>;
-}
-
-async function handle(
-  req: Request,
-  deps: ProbeRouteDeps = {},
-): Promise<NextResponse> {
-  const env = deps.authEnv ?? readAuthEnv();
-  const auth = checkAuth(readAuthHeaders(req), env);
-  if (!auth.ok) {
-    return NextResponse.json(auth.body, { status: auth.status });
-  }
-
-  const runner = deps.runProbes ?? runAllProbes;
-  const result = await runner();
-
-  // Safe shape: snapshots already use the canonical SourceHealthSnapshot
-  // type; runProbe never carries raw payloads or headers. errors[] is a
-  // redacted token list. Do not include req body, headers, or env.
-  return NextResponse.json(
-    {
-      snapshots: result.snapshots,
-      durationMs: result.durationMs,
-      errors: result.errors,
-    },
-    { status: 200 },
-  );
-}
-
 export async function GET(req: Request): Promise<NextResponse> {
-  return handle(req);
+  return handleProbe(req);
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
-  return handle(req);
-}
-
-/** Test-only export — invoked directly by route tests with DI'd deps. */
-export async function __handleForTests(
-  req: Request,
-  deps: ProbeRouteDeps,
-): Promise<NextResponse> {
-  return handle(req, deps);
+  return handleProbe(req);
 }

--- a/apps/web/app/api/internal/source-health/probe/route.ts
+++ b/apps/web/app/api/internal/source-health/probe/route.ts
@@ -1,0 +1,70 @@
+/**
+ * POST/GET /api/internal/source-health/probe
+ *
+ * Internal endpoint that runs the source-health probe batch. Triggered by
+ * scheduled callers (GitHub Actions cron) via POST with a Bearer token,
+ * or by manual operator paths via the x-monitoring-secret header.
+ *
+ * Returns ONLY safe metadata: snapshots already strip raw upstream payloads
+ * at the runProbe layer, and we never echo headers or request bodies.
+ */
+
+import { NextResponse } from 'next/server';
+
+import {
+  checkAuth,
+  readAuthEnv,
+  readAuthHeaders,
+} from '../_auth';
+import { runAllProbes } from '@/lib/source-health/runner/runAllProbes';
+import type { RunAllProbesDeps } from '@/lib/source-health/runner/runAllProbes';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export interface ProbeRouteDeps {
+  runProbes?: (deps?: RunAllProbesDeps) => ReturnType<typeof runAllProbes>;
+  authEnv?: ReturnType<typeof readAuthEnv>;
+}
+
+async function handle(
+  req: Request,
+  deps: ProbeRouteDeps = {},
+): Promise<NextResponse> {
+  const env = deps.authEnv ?? readAuthEnv();
+  const auth = checkAuth(readAuthHeaders(req), env);
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status });
+  }
+
+  const runner = deps.runProbes ?? runAllProbes;
+  const result = await runner();
+
+  // Safe shape: snapshots already use the canonical SourceHealthSnapshot
+  // type; runProbe never carries raw payloads or headers. errors[] is a
+  // redacted token list. Do not include req body, headers, or env.
+  return NextResponse.json(
+    {
+      snapshots: result.snapshots,
+      durationMs: result.durationMs,
+      errors: result.errors,
+    },
+    { status: 200 },
+  );
+}
+
+export async function GET(req: Request): Promise<NextResponse> {
+  return handle(req);
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  return handle(req);
+}
+
+/** Test-only export — invoked directly by route tests with DI'd deps. */
+export async function __handleForTests(
+  req: Request,
+  deps: ProbeRouteDeps,
+): Promise<NextResponse> {
+  return handle(req, deps);
+}

--- a/apps/web/app/api/internal/source-health/snapshots/_handler.ts
+++ b/apps/web/app/api/internal/source-health/snapshots/_handler.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal snapshots-route handler. Lives in a non-route file (`_handler.ts`)
+ * so route.ts can stay narrowly typed to Next.js's allowed exports
+ * (GET/POST/etc. + `runtime`/`dynamic`). Tests import the
+ * `__handleForTests` shim from here.
+ */
+
+import { NextResponse } from 'next/server';
+
+import {
+  checkAuth,
+  readAuthEnv,
+  readAuthHeaders,
+} from '../_auth';
+import { getAllSnapshots as defaultGetAllSnapshots } from '@/lib/source-health/store/snapshotStore';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+
+export interface SnapshotsRouteDeps {
+  getAllSnapshots?: () => SourceHealthSnapshot[];
+  authEnv?: ReturnType<typeof readAuthEnv>;
+}
+
+function newestObservedAt(snaps: readonly SourceHealthSnapshot[]): string | null {
+  if (snaps.length === 0) return null;
+  let newest = snaps[0].observedAt;
+  for (const s of snaps) {
+    if (s.observedAt > newest) newest = s.observedAt;
+  }
+  return newest;
+}
+
+export async function handleSnapshots(
+  req: Request,
+  deps: SnapshotsRouteDeps = {},
+): Promise<NextResponse> {
+  const env = deps.authEnv ?? readAuthEnv();
+  const auth = checkAuth(readAuthHeaders(req), env);
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status });
+  }
+
+  const getter = deps.getAllSnapshots ?? defaultGetAllSnapshots;
+  const snapshots = getter();
+
+  return NextResponse.json(
+    {
+      snapshots,
+      observedAt: newestObservedAt(snapshots),
+    },
+    { status: 200 },
+  );
+}
+
+/** Test-only shim — invoked directly by route tests with DI'd deps. */
+export async function __handleForTests(
+  req: Request,
+  deps: SnapshotsRouteDeps,
+): Promise<NextResponse> {
+  return handleSnapshots(req, deps);
+}

--- a/apps/web/app/api/internal/source-health/snapshots/route.ts
+++ b/apps/web/app/api/internal/source-health/snapshots/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/internal/source-health/snapshots
+ *
+ * Returns the latest snapshot per source from the in-memory store. The store
+ * is ephemeral (cold-start resets) — an empty snapshots array is the HONEST
+ * answer when no probe has run yet. We never invent snapshots.
+ *
+ * Returns ONLY safe metadata. No raw upstream payloads, no headers, no PII.
+ */
+
+import { NextResponse } from 'next/server';
+
+import {
+  checkAuth,
+  readAuthEnv,
+  readAuthHeaders,
+} from '../_auth';
+import { getAllSnapshots as defaultGetAllSnapshots } from '@/lib/source-health/store/snapshotStore';
+import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export interface SnapshotsRouteDeps {
+  getAllSnapshots?: () => SourceHealthSnapshot[];
+  authEnv?: ReturnType<typeof readAuthEnv>;
+}
+
+function newestObservedAt(snaps: readonly SourceHealthSnapshot[]): string | null {
+  if (snaps.length === 0) return null;
+  let newest = snaps[0].observedAt;
+  for (const s of snaps) {
+    if (s.observedAt > newest) newest = s.observedAt;
+  }
+  return newest;
+}
+
+async function handle(
+  req: Request,
+  deps: SnapshotsRouteDeps = {},
+): Promise<NextResponse> {
+  const env = deps.authEnv ?? readAuthEnv();
+  const auth = checkAuth(readAuthHeaders(req), env);
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status });
+  }
+
+  const getter = deps.getAllSnapshots ?? defaultGetAllSnapshots;
+  const snapshots = getter();
+
+  return NextResponse.json(
+    {
+      snapshots,
+      observedAt: newestObservedAt(snapshots),
+    },
+    { status: 200 },
+  );
+}
+
+export async function GET(req: Request): Promise<NextResponse> {
+  return handle(req);
+}
+
+/** Test-only export — invoked directly by route tests with DI'd deps. */
+export async function __handleForTests(
+  req: Request,
+  deps: SnapshotsRouteDeps,
+): Promise<NextResponse> {
+  return handle(req, deps);
+}

--- a/apps/web/app/api/internal/source-health/snapshots/route.ts
+++ b/apps/web/app/api/internal/source-health/snapshots/route.ts
@@ -6,65 +6,18 @@
  * answer when no probe has run yet. We never invent snapshots.
  *
  * Returns ONLY safe metadata. No raw upstream payloads, no headers, no PII.
+ *
+ * The handler implementation lives in `_handler.ts` so this file stays
+ * narrowly typed to Next.js's allowed Route exports.
  */
 
-import { NextResponse } from 'next/server';
+import type { NextResponse } from 'next/server';
 
-import {
-  checkAuth,
-  readAuthEnv,
-  readAuthHeaders,
-} from '../_auth';
-import { getAllSnapshots as defaultGetAllSnapshots } from '@/lib/source-health/store/snapshotStore';
-import type { SourceHealthSnapshot } from '@/lib/source-health/sourceHealthTypes';
+import { handleSnapshots } from './_handler';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export interface SnapshotsRouteDeps {
-  getAllSnapshots?: () => SourceHealthSnapshot[];
-  authEnv?: ReturnType<typeof readAuthEnv>;
-}
-
-function newestObservedAt(snaps: readonly SourceHealthSnapshot[]): string | null {
-  if (snaps.length === 0) return null;
-  let newest = snaps[0].observedAt;
-  for (const s of snaps) {
-    if (s.observedAt > newest) newest = s.observedAt;
-  }
-  return newest;
-}
-
-async function handle(
-  req: Request,
-  deps: SnapshotsRouteDeps = {},
-): Promise<NextResponse> {
-  const env = deps.authEnv ?? readAuthEnv();
-  const auth = checkAuth(readAuthHeaders(req), env);
-  if (!auth.ok) {
-    return NextResponse.json(auth.body, { status: auth.status });
-  }
-
-  const getter = deps.getAllSnapshots ?? defaultGetAllSnapshots;
-  const snapshots = getter();
-
-  return NextResponse.json(
-    {
-      snapshots,
-      observedAt: newestObservedAt(snapshots),
-    },
-    { status: 200 },
-  );
-}
-
 export async function GET(req: Request): Promise<NextResponse> {
-  return handle(req);
-}
-
-/** Test-only export — invoked directly by route tests with DI'd deps. */
-export async function __handleForTests(
-  req: Request,
-  deps: SnapshotsRouteDeps,
-): Promise<NextResponse> {
-  return handle(req, deps);
+  return handleSnapshots(req);
 }

--- a/apps/web/lib/source-health/README.md
+++ b/apps/web/lib/source-health/README.md
@@ -99,3 +99,86 @@ wired; it returns `UNKNOWN`. We do **not** fake `LIVE`.
 - It does not promise availability ("always available", "guaranteed", etc.).
 - It does not replace the existing `lib/status/sourceOps.ts` ops report; that
   module is a separate, broader operator-facing surface.
+
+## Live Probe Scheduling (RELIABILITY-2)
+
+### Architecture
+
+```
+GitHub Actions (cron every 15m on main)
+        │
+        │  POST  Authorization: Bearer ${{ secrets.CRON_SECRET }}
+        ▼
+/api/internal/source-health/probe
+        │
+        ▼
+runAllProbes()  ──► nppesProbe / oigProbe / pecosProbe / stateBoardProbe
+        │                          │
+        │                          ▼
+        │                   runProbe() — classifies
+        │                   2xx → LIVE, 5xx → DEGRADED,
+        │                   429 → RATE_LIMITED,
+        │                   timeout/network → UNAVAILABLE,
+        │                   else → UNKNOWN
+        ▼
+snapshotStore (in-memory, module-scope Map)
+        ▲
+        │
+GET /api/internal/source-health/snapshots ◄── operator/dashboard
+getLaneSnapshots() ◄── UI surfaces (UNKNOWN placeholder when cold)
+```
+
+### Cold-start truth
+
+Snapshots are ephemeral. Vercel serverless cold starts reset the
+in-memory store. This is acceptable for v1; durable persistence is
+the next layer. When the store is cold, `getLaneSnapshots()` returns
+four UNKNOWN placeholder snapshots — never LIVE — and the
+`/snapshots` endpoint returns an empty array with `observedAt: null`.
+This is the honest answer.
+
+### Authentication
+
+Both `/api/internal/source-health/probe` and `/snapshots` accept:
+
+- `Authorization: Bearer <CRON_SECRET>` — preferred for scheduled
+  callers (GitHub Actions, Vercel Cron).
+- `x-monitoring-secret: <MONITORING_SECRET>` — legacy/manual operator
+  path consistent with `/api/pilot-kpi-export`.
+
+If neither header matches, the route returns 401. If both env
+secrets are unset on the server, the route returns 500
+(`no probe auth configured`) — fail closed.
+
+### Secret rotation
+
+`CRON_SECRET`:
+1. Generate a new high-entropy value (e.g. `openssl rand -hex 32`).
+2. Set the new value in the Vercel project env (Production +
+   Preview), then redeploy.
+3. Update the matching GitHub Actions repository secret
+   `CRON_SECRET`.
+4. Trigger a manual `workflow_dispatch` of "Source Health Probe" to
+   confirm 200.
+5. After confirmation, retire the old value.
+
+`MONITORING_SECRET`:
+1. Same generate-and-rotate pattern in Vercel.
+2. Update any operator tooling and `/api/pilot-kpi-export` callers
+   that depend on this secret. (This module is one consumer; not
+   the only one — coordinate with `pilot-ops`.)
+
+### Classification telemetry — required note
+
+> Scheduled probe snapshots are classification telemetry, not
+> credential verification and not clinician defects. A `DEGRADED`
+> or `UNAVAILABLE` lane reflects upstream source health only — it
+> never invalidates a clinician's profile, NPI, or any
+> source-backed evidence captured during a `LIVE` window.
+
+### Truth invariant restated
+
+`LIVE` is emitted ONLY by a confirmed 2xx probe response from
+`runProbe`. The placeholder seed in `getLaneSnapshots` returns
+UNKNOWN for every source and never LIVE. The store never
+fabricates a LIVE on cold start.

--- a/apps/web/lib/source-health/getLaneSnapshots.ts
+++ b/apps/web/lib/source-health/getLaneSnapshots.ts
@@ -1,20 +1,26 @@
-import type { SourceHealthSnapshot } from './sourceHealthTypes';
+import { getAllSnapshots } from './store/snapshotStore';
+import {
+  ALL_SOURCE_IDS,
+  type SourceHealthSnapshot,
+  type SourceId,
+} from './sourceHealthTypes';
 
 /**
- * PLACEHOLDER deterministic seed for SourceHealth snapshots.
+ * Returns lane snapshots for surfaces that consume source health.
  *
- * This is NOT live data. Until the probe scheduler is wired up to a runtime
- * health store, surfaces render this seed so the UI shape can be exercised
- * without making false claims about source liveness.
+ * Order of precedence:
+ *   1. Snapshots present in the in-memory store (set by the probe runner).
+ *      Sources missing from the store fall through to the placeholder seed
+ *      below.
+ *   2. Placeholder seed: UNKNOWN for every source. This is the HONEST
+ *      default before any probe has run. It NEVER returns LIVE.
  *
- * Honest defaults:
- *   - NPPES, OIG_LEIE, PECOS: posture is "configured", but we do NOT mark
- *     them LIVE without a real probe reading. We mark them UNKNOWN with a
- *     reason that says exactly that.
- *   - STATE_BOARD: UNKNOWN — there is no generic state-board probe yet.
- *
- * When real probes land, replace this with a server-side reader that returns
- * the latest probe result per source.
+ * Truth invariants:
+ *   - The placeholder seed must remain UNKNOWN for every source. LIVE
+ *     can only originate from a confirmed 2xx probe response.
+ *   - Cold-start (empty store) → 4×UNKNOWN. Tests assert this.
+ *   - State board lane has no live adapter; it always falls through to
+ *     UNKNOWN with a "no_generic_state_board_probe_wired" reason.
  */
 export function getLaneSnapshots(
   options: { now?: () => Date } = {},
@@ -22,42 +28,39 @@ export function getLaneSnapshots(
   const now = options.now ?? (() => new Date());
   const observedAt = now().toISOString();
 
-  return [
-    {
-      sourceId: 'NPPES',
-      state: 'UNKNOWN',
-      reason: 'placeholder_seed_no_live_probe',
-      lastSuccessAt: null,
-      lastErrorAt: null,
-      lastLatencyMs: null,
-      observedAt,
-    },
-    {
-      sourceId: 'OIG_LEIE',
-      state: 'UNKNOWN',
-      reason: 'placeholder_seed_no_live_probe',
-      lastSuccessAt: null,
-      lastErrorAt: null,
-      lastLatencyMs: null,
-      observedAt,
-    },
-    {
-      sourceId: 'PECOS',
-      state: 'UNKNOWN',
-      reason: 'placeholder_seed_no_live_probe',
-      lastSuccessAt: null,
-      lastErrorAt: null,
-      lastLatencyMs: null,
-      observedAt,
-    },
-    {
-      sourceId: 'STATE_BOARD',
+  const stored = getAllSnapshots();
+  const byId = new Map<SourceId, SourceHealthSnapshot>();
+  for (const snap of stored) byId.set(snap.sourceId, snap);
+
+  return ALL_SOURCE_IDS.map((sourceId) => {
+    const fromStore = byId.get(sourceId);
+    if (fromStore) return fromStore;
+    return placeholderSeed(sourceId, observedAt);
+  });
+}
+
+function placeholderSeed(
+  sourceId: SourceId,
+  observedAt: string,
+): SourceHealthSnapshot {
+  if (sourceId === 'STATE_BOARD') {
+    return {
+      sourceId,
       state: 'UNKNOWN',
       reason: 'no_generic_state_board_probe_wired',
       lastSuccessAt: null,
       lastErrorAt: null,
       lastLatencyMs: null,
       observedAt,
-    },
-  ];
+    };
+  }
+  return {
+    sourceId,
+    state: 'UNKNOWN',
+    reason: 'placeholder_seed_no_live_probe',
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastLatencyMs: null,
+    observedAt,
+  };
 }

--- a/apps/web/lib/source-health/runner/runAllProbes.ts
+++ b/apps/web/lib/source-health/runner/runAllProbes.ts
@@ -1,0 +1,138 @@
+/**
+ * RELIABILITY-2 — Probe orchestrator.
+ *
+ * Runs every shipped lane probe sequentially, records the result in
+ * the snapshot store, and returns a summary. Never throws.
+ *
+ * Truth invariants:
+ *   1. A LIVE snapshot is produced ONLY by the underlying `runProbe`
+ *      classifying a 2xx response. This module never invents LIVE.
+ *   2. Synchronous probe failures do not throw out — they produce an
+ *      UNKNOWN snapshot for the offending source and an entry in
+ *      `errors[]` with a redacted reason string.
+ *   3. The summary contains only safe metadata: snapshots already
+ *      strip raw payloads at the runProbe layer.
+ */
+
+import {
+  nppesProbe,
+  oigProbe,
+  pecosProbe,
+  stateBoardProbe,
+  type ProbeDeps,
+} from '../probes';
+import {
+  recordSnapshot as defaultRecordSnapshot,
+  getAllSnapshots as defaultGetAllSnapshots,
+} from '../store/snapshotStore';
+import type {
+  SourceHealthSnapshot,
+  SourceId,
+} from '../sourceHealthTypes';
+
+export type ProbeFn = (deps?: ProbeDeps) => Promise<SourceHealthSnapshot>;
+
+interface OrderedProbe {
+  sourceId: SourceId;
+  probe: ProbeFn;
+}
+
+const DEFAULT_PROBES: OrderedProbe[] = [
+  { sourceId: 'NPPES', probe: nppesProbe },
+  { sourceId: 'OIG_LEIE', probe: oigProbe },
+  { sourceId: 'PECOS', probe: pecosProbe },
+  { sourceId: 'STATE_BOARD', probe: stateBoardProbe },
+];
+
+export interface RunAllProbesStore {
+  recordSnapshot: (snap: SourceHealthSnapshot) => void;
+  getAllSnapshots: () => SourceHealthSnapshot[];
+}
+
+export interface RunAllProbesDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  timeoutMs?: number;
+  /** Override the snapshot store (used by tests to isolate state). */
+  store?: RunAllProbesStore;
+  /** Override the ordered probe list (used by tests). */
+  probes?: OrderedProbe[];
+}
+
+export interface RunAllProbesResult {
+  snapshots: SourceHealthSnapshot[];
+  durationMs: number;
+  errors: Array<{ sourceId: SourceId; error: string }>;
+}
+
+/**
+ * Reduce any thrown value to a short, safe token. Raw error objects,
+ * stack traces, and free-form messages MUST NOT leak.
+ */
+function redactError(err: unknown): string {
+  if (err == null) return 'unknown_error';
+  if (typeof err === 'object') {
+    const name = String(
+      (err as { name?: unknown }).name ?? '',
+    ).toLowerCase();
+    if (name.includes('abort')) return 'aborted';
+    if (name.includes('timeout')) return 'probe_timeout';
+    if (name.includes('typeerror')) return 'network_error';
+  }
+  return 'redacted_error';
+}
+
+export async function runAllProbes(
+  deps: RunAllProbesDeps = {},
+): Promise<RunAllProbesResult> {
+  const now = deps.now ?? (() => new Date());
+  const store: RunAllProbesStore = deps.store ?? {
+    recordSnapshot: defaultRecordSnapshot,
+    getAllSnapshots: defaultGetAllSnapshots,
+  };
+  const probes = deps.probes ?? DEFAULT_PROBES;
+
+  const probeDeps: ProbeDeps = {};
+  if (deps.fetchImpl) probeDeps.fetchImpl = deps.fetchImpl;
+  if (deps.now) probeDeps.now = deps.now;
+  if (typeof deps.timeoutMs === 'number') {
+    probeDeps.timeoutMs = deps.timeoutMs;
+  }
+
+  const startedAt = now().getTime();
+  const errors: Array<{ sourceId: SourceId; error: string }> = [];
+
+  for (const { sourceId, probe } of probes) {
+    let snap: SourceHealthSnapshot;
+    try {
+      snap = await probe(probeDeps);
+    } catch (err) {
+      const observedAt = now().toISOString();
+      errors.push({ sourceId, error: redactError(err) });
+      snap = {
+        sourceId,
+        state: 'UNKNOWN',
+        reason: 'probe_threw',
+        lastSuccessAt: null,
+        lastErrorAt: observedAt,
+        lastLatencyMs: null,
+        observedAt,
+      };
+    }
+    try {
+      store.recordSnapshot(snap);
+    } catch {
+      // Store failure must not crash the batch.
+      errors.push({ sourceId, error: 'store_record_failed' });
+    }
+  }
+
+  const finishedAt = now().getTime();
+  const durationMs = Math.max(0, finishedAt - startedAt);
+
+  return {
+    snapshots: store.getAllSnapshots(),
+    durationMs,
+    errors,
+  };
+}

--- a/apps/web/lib/source-health/store/snapshotStore.ts
+++ b/apps/web/lib/source-health/store/snapshotStore.ts
@@ -1,0 +1,95 @@
+/**
+ * RELIABILITY-2 — In-memory snapshot store.
+ *
+ * Module-scope cache of the most recent SourceHealthSnapshot per source.
+ * Ephemeral: serverless cold starts will reset this. Acceptable for v1
+ * per the brief; durable persistence is the next layer.
+ *
+ * Truth invariants (do not weaken):
+ *   1. `lastSuccessAt` is ONLY advanced on a LIVE snapshot. Non-LIVE
+ *      snapshots carry forward the prior `lastSuccessAt` if their own
+ *      is null.
+ *   2. `lastErrorAt` is updated whenever the new state is a degraded
+ *      one (DEGRADED, UNAVAILABLE, RATE_LIMITED).
+ *   3. Read order is deterministic: canonical ordering of SourceId.
+ *   4. Store stores ONLY safe metadata that already lives on
+ *      SourceHealthSnapshot. No raw payloads, headers, or PII.
+ */
+
+import {
+  ALL_SOURCE_IDS,
+  type SourceHealthSnapshot,
+  type SourceId,
+} from '../sourceHealthTypes';
+
+const store = new Map<SourceId, SourceHealthSnapshot>();
+
+const DEGRADED_STATES = new Set<SourceHealthSnapshot['state']>([
+  'DEGRADED',
+  'UNAVAILABLE',
+  'RATE_LIMITED',
+]);
+
+/**
+ * Record a new snapshot, applying carry-forward rules.
+ *
+ * - LIVE: set lastSuccessAt = observedAt; do not touch lastErrorAt
+ *   from prior (the new snapshot's own lastErrorAt wins, which for
+ *   a LIVE snapshot from runProbe is null).
+ * - Non-LIVE with null lastSuccessAt: preserve prior lastSuccessAt.
+ * - DEGRADED/UNAVAILABLE/RATE_LIMITED: ensure lastErrorAt is set
+ *   (default to observedAt if the incoming snapshot has none).
+ */
+export function recordSnapshot(snap: SourceHealthSnapshot): void {
+  const prior = store.get(snap.sourceId);
+
+  let lastSuccessAt = snap.lastSuccessAt;
+  if (snap.state === 'LIVE') {
+    lastSuccessAt = snap.observedAt;
+  } else if (lastSuccessAt === null && prior) {
+    lastSuccessAt = prior.lastSuccessAt;
+  }
+
+  let lastErrorAt = snap.lastErrorAt;
+  if (DEGRADED_STATES.has(snap.state)) {
+    if (lastErrorAt === null) {
+      lastErrorAt = snap.observedAt;
+    }
+  }
+
+  const next: SourceHealthSnapshot = {
+    sourceId: snap.sourceId,
+    state: snap.state,
+    reason: snap.reason,
+    lastSuccessAt,
+    lastErrorAt,
+    lastLatencyMs: snap.lastLatencyMs,
+    observedAt: snap.observedAt,
+  };
+
+  store.set(snap.sourceId, next);
+}
+
+/**
+ * Returns all snapshots in canonical SourceId order.
+ * Sources with no recorded snapshot are omitted (honest: empty when cold).
+ */
+export function getAllSnapshots(): SourceHealthSnapshot[] {
+  const out: SourceHealthSnapshot[] = [];
+  for (const id of ALL_SOURCE_IDS) {
+    const snap = store.get(id);
+    if (snap) out.push(snap);
+  }
+  return out;
+}
+
+export function getSnapshot(
+  sourceId: SourceId,
+): SourceHealthSnapshot | undefined {
+  return store.get(sourceId);
+}
+
+/** Test-only — clears the module store. */
+export function clearAllSnapshots(): void {
+  store.clear();
+}


### PR DESCRIPTION
## Summary
- add in-memory source-health snapshot store (ephemeral; cold-start returns UNKNOWN, never LIVE)
- add \`runAllProbes\` orchestrator that runs every shipped lane probe sequentially and never throws
- add \`/api/internal/source-health/probe\` and \`/snapshots\` internal routes (Bearer CRON_SECRET preferred; x-monitoring-secret legacy fallback; 500 fail-closed when both unset)
- add GitHub Actions scheduled + workflow_dispatch workflow that triggers the probe route via Bearer auth
- wire \`getLaneSnapshots\` to read from the snapshot store as a fallback
- add tests proving source outages do not become clinician defects and that LIVE only comes from a confirmed 2xx

## Truth rules
- scheduled probe snapshots are classification telemetry, **not credential verification and not clinician defects**
- LIVE only on confirmed successful probe (no synthetic LIVE; placeholder/cold store returns UNKNOWN)
- batch never throws when one lane fails — failed lane gets UNAVAILABLE with a redacted reason
- no raw upstream payloads, no headers, no PII leave the runner; tokens stay short and alphanumeric
- tests do not call live APIs (probes injected; auth deps injected)
- no Vercel cron, no deploy workflow changes in this wave
- workflow runs on \`schedule\` only when on \`refs/heads/main\` and uses Bearer auth with secrets

## Files changed (15)
**Library (3 new + 1 modified)**
- \`apps/web/lib/source-health/store/snapshotStore.ts\` — in-memory snapshot store
- \`apps/web/lib/source-health/runner/runAllProbes.ts\` — orchestrator
- \`apps/web/lib/source-health/getLaneSnapshots.ts\` — modified to fall back to store
- \`apps/web/lib/source-health/README.md\` — \"Live Probe Scheduling\" section + classification-telemetry note

**Internal API (5 new)**
- \`apps/web/app/api/internal/source-health/_auth.ts\`
- \`apps/web/app/api/internal/source-health/probe/route.ts\`
- \`apps/web/app/api/internal/source-health/probe/_handler.ts\` — handler split out so \`route.ts\` carries only Next.js-allowed exports (this PR's only diff vs the concurrent agent's commits)
- \`apps/web/app/api/internal/source-health/snapshots/route.ts\`
- \`apps/web/app/api/internal/source-health/snapshots/_handler.ts\`

**Workflow (1 new)**
- \`.github/workflows/source-health-probe.yml\` — schedule + workflow_dispatch; gated to \`refs/heads/main\`; secrets-required (CRON_SECRET, PROBE_URL); never echoes secrets

**Tests (5 new — 88 tests added across 9 files in domain)**
- \`__tests__/source-health/runAllProbes.test.ts\`
- \`__tests__/source-health/snapshotStore.test.ts\`
- \`__tests__/source-health/probeRoute.test.ts\`
- \`__tests__/source-health/snapshotsRoute.test.ts\`
- \`__tests__/source-health/noFakeLive.test.ts\`

## Validation
- \`pnpm --filter @vitalcv/web exec vitest run __tests__/source-health/\` → **88/88 pass** (9 files)
- \`pnpm turbo run build --filter @vitalcv/web --force\` → **13/13 tasks** (full Next.js build with TypeScript + ESLint enforcement on)
- Diff scope: source-health surface only — no clinician/profile/mobile/marketing files, no secrets, no \`vercel.json\`, no migrations
- Overclaim scan: matches only inside \`unavailableLane.ts\` banned-phrase contract list and \`README.md\` documentation that explicitly says \"not credential verification and not clinician defects\"

## Notes on the route refactor
The concurrent agent's first pass put a \`__handleForTests\` export in \`route.ts\` so route tests could DI the auth env + probe runner. Next.js App Router rejects any export from \`route.ts\` that isn't on its allow-list, so \`next build\` failed with: *\"\\\"__handleForTests\\\" is not a valid Route export field\"*. This PR's final commit moves \`handleProbe\` / \`handleSnapshots\` and the test shim into sibling \`_handler.ts\` files (same underscore convention as \`_auth.ts\`). Tests now import from \`_handler\`. No behavior change.