### PR TITLE
fix(copy): remove unsupported passport wallet and real-time wording

### DIFF
--- a/apps/web/__tests__/passport-copy-truth.test.ts
+++ b/apps/web/__tests__/passport-copy-truth.test.ts
@@ -1,0 +1,93 @@
+/**
+ * TRUTH-CLEANUP-2 — passport page copy-truth invariants.
+ *
+ * VitalCV does not ship a wallet protocol (no OID4VP / DIDComm / key
+ * management) and does not perform real-time source verification (the
+ * source-health classifier is scheduled, not real-time, and is
+ * classification telemetry — not credential verification). The
+ * passport page must therefore not carry "Wallet entry" framing or a
+ * generic "real-time" claim, even in code comments, because comments
+ * propagate via grep and shape future contributors' mental models.
+ *
+ * This suite reads the page source as text and asserts the banned
+ * phrases do not appear, and that any retained "wallet"/"real-time"
+ * substrings are accounted for by allow-listed exact strings (e.g.
+ * the NPI checksum-feedback comment).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PAGE_PATH = resolve(__dirname, '..', 'app', 'passport', 'page.tsx');
+
+function readPage(): string {
+  return readFileSync(PAGE_PATH, 'utf-8');
+}
+
+describe('passport page copy truth', () => {
+  it('does not contain the bare phrase "Wallet entry"', () => {
+    const src = readPage();
+    expect(src).not.toMatch(/Wallet entry/);
+  });
+
+  it('does not contain the phrase "Real-time visual feedback"', () => {
+    const src = readPage();
+    expect(src).not.toMatch(/Real-time visual feedback/);
+  });
+
+  it('does not claim a wallet is ready or shipped', () => {
+    const src = readPage().toLowerCase();
+    expect(src).not.toContain('wallet ready');
+    expect(src).not.toContain('credential wallet');
+    expect(src).not.toContain('self-sovereign wallet');
+  });
+
+  it('does not make generic real-time / live-verification claims in user-facing copy', () => {
+    const src = readPage().toLowerCase();
+    // Bare "real-time" / "real time" must not appear; the source-health
+    // probe schedule is every-six-hours, not real-time.
+    expect(src).not.toMatch(/\breal-?time\b/);
+    expect(src).not.toContain('live verification');
+    expect(src).not.toContain('real-time source verification');
+  });
+
+  it('does not introduce DID/VC/crypto/biometric/identity-proofing claims', () => {
+    const src = readPage();
+    const banned = [
+      'self-sovereign',
+      'cryptographic audit trail',
+      'Merkle audit trail',
+      'blockchain verified',
+      'government ID verified',
+      'biometric verified',
+      'liveness verified',
+      'OID4VP',
+      'OID4VCI',
+      'SD-JWT',
+      'W3C VC',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('does not contain blanket truth-contract banned phrases', () => {
+    const src = readPage().toLowerCase();
+    const banned = [
+      'guaranteed verification',
+      'instant credentialing',
+      'complete credentialing',
+      'legally accepted',
+      'risk transferred',
+      'hipaa compliant',
+      'soc2 certified',
+      'ncqa verified',
+      'irreversible proof',
+      'tamper-proof',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -3,7 +3,7 @@
 export const dynamic = 'force-dynamic';
 
 /**
- * /passport — Wallet entry + live ingest hydration
+ * /passport — Passport entry + live ingest hydration
  *
  * Flow: TYPE → SEE → TRUST → SHARE
  *
@@ -511,7 +511,7 @@ function PassportPageContent({
                       placeholder="Enter 10-digit NPI"
                       className="h-14 w-full rounded-none border-border bg-card px-4 text-lg font-mono tracking-widest text-foreground placeholder:text-muted-foreground/30 shadow-none focus-visible:ring-ring"
                     />
-                    {/* Real-time visual feedback */}
+                    {/* NPI input length + checksum feedback */}
                     {npi.length > 0 && (
                       <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-mono text-muted-foreground/50">
                         {npi.length}/10


### PR DESCRIPTION
## Summary
Remove two strings on \`apps/web/app/passport/page.tsx\` that implied capabilities VitalCV does not ship:

| Before | After | Why |
|---|---|---|
| `* /passport — Wallet entry + live ingest hydration` (file header comment) | `* /passport — Passport entry + live ingest hydration` | No wallet protocol ships (no OID4VP, no DIDComm, no key management) |
| `{/* Real-time visual feedback */}` (JSX comment over an NPI input length+checksum indicator) | `{/* NPI input length + checksum feedback */}` | The source-health classifier (#186/#187) is scheduled every 6 hours, not real-time, and is classification telemetry — not credential verification |

Both were code comments, not user-rendered text. They're patched anyway because comments propagate via grep and shape future contributors' mental models — leaving them in place would re-leak banned framing into new copy.

## New test
\`apps/web/__tests__/passport-copy-truth.test.ts\` (6 tests) asserts the page source does not contain:
- \"Wallet entry\"
- \"Real-time visual feedback\"
- bare \"real-time\" / \"real time\" / \"live verification\"
- \"wallet ready\", \"credential wallet\", \"self-sovereign wallet\"
- DID/VC/SD-JWT/OID4VC labels
- biometric / liveness / government-ID claims
- blanket truth-contract banned phrases (HIPAA compliant, SOC2 certified, NCQA verified, instant credentialing, complete credentialing, legally accepted, risk transferred, etc.)

## Truth rules
- no wallet capability is implied
- no real-time source verification is implied
- no crypto/DID/VC claims introduced
- no identity proofing claims introduced
- no backend / source-health / clinician code touched

## Validation
- \`pnpm --filter @vitalcv/web exec vitest run __tests__/passport-copy-truth.test.ts\` → **6/6 pass**
- \`pnpm turbo run build --filter @vitalcv/web\` → **13/13 tasks** (full Next.js production build with TypeScript + ESLint enforcement on)
- Diff scope: 1 modified (\`apps/web/app/passport/page.tsx\`) + 1 new test file (95 insertions / 2 deletions)
- Reject-list scan: no backend / source-health / clinician / migration / secret / config changes