### PR TITLE
fix(copy): remove wallet/real-time wording from passport entry

### DIFF
--- a/apps/web/__tests__/passport-copy-cleanup.test.ts
+++ b/apps/web/__tests__/passport-copy-cleanup.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(process.cwd(), '../..');
+const PASSPORT_PAGE_PATH = 'apps/web/app/passport/page.tsx';
+
+const BANNED_PASSPORT_COPY = [
+  'Wallet entry',
+  'Real-time visual feedback',
+] as const;
+
+describe('passport copy cleanup (TRUTH-CLEANUP-2)', () => {
+  it('removes wallet and real-time wording from the passport entry source', () => {
+    const source = fs.readFileSync(
+      path.resolve(REPO_ROOT, PASSPORT_PAGE_PATH),
+      'utf8',
+    );
+
+    for (const phrase of BANNED_PASSPORT_COPY) {
+      expect(source).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -3,7 +3,7 @@
 export const dynamic = 'force-dynamic';
 
 /**
- * /passport — Wallet entry + live ingest hydration
+ * /passport — Readiness check entry + live ingest hydration
  *
  * Flow: TYPE → SEE → TRUST → SHARE
  *
@@ -511,7 +511,7 @@ function PassportPageContent({
                       placeholder="Enter 10-digit NPI"
                       className="h-14 w-full rounded-none border-border bg-card px-4 text-lg font-mono tracking-widest text-foreground placeholder:text-muted-foreground/30 shadow-none focus-visible:ring-ring"
                     />
-                    {/* Real-time visual feedback */}
+                    {/* Current readiness feedback */}
                     {npi.length > 0 && (
                       <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-mono text-muted-foreground/50">
                         {npi.length}/10


### PR DESCRIPTION
## Summary
- Replace two banned-phrase comments in `apps/web/app/passport/page.tsx`:
  - "Wallet entry" → "Readiness check entry" (file header docblock)
  - "Real-time visual feedback" → "Current readiness feedback" (NPI input)
- Add `apps/web/__tests__/passport-copy-cleanup.test.ts` as a copy regression guard that reads the passport page source and asserts neither banned phrase reappears.

## Why
VitalCV does **not** ship a wallet, and the passport NPI input does **not** provide real-time streaming verification — it provides a current readiness check (character count + Luhn checksum on local validation). The prior comments leaked unsupported capability framing that contradicts the truth contract in `CLAUDE.md` and the knowledge trust graph (`docs/architecture/vitalcv-knowledge-trust-graph.md`).

The phrases lived in code comments only — **no user-visible UI copy changed** — but they leaked banned framing into the source and into AI orchestration runs that read the file.

## Scope discipline (TRUTH-CLEANUP-2 supervisor brief)
This PR is intentionally narrow:
- ✅ Passport entry source (4 lines in `apps/web/app/passport/page.tsx`)
- ✅ One copy regression test (24 lines in `apps/web/__tests__/passport-copy-cleanup.test.ts`)
- ❌ No `claude-instructions.md` change (deferred — that file is internal orchestration guidance, not passport copy)
- ❌ No rendered UI copy change, behavior change, type change, or unrelated cleanup

Replacement copy ("Readiness check entry", "Current readiness feedback") does not imply wallet ownership or real-time verification capability — it accurately describes the local Luhn-style readiness check the input performs.

## Test plan
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/passport-copy-cleanup.test.ts` passes (1/1, 578ms)
- [ ] Vercel preview build green
- [ ] Codex SAFE verification (implementation / diff / copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)