### PR TITLE
feat(foundation): add recovery mobile and admin foundations

### DIFF
--- a/apps/web/__tests__/foundation-sweep-3.test.ts
+++ b/apps/web/__tests__/foundation-sweep-3.test.ts
@@ -1,0 +1,370 @@
+/**
+ * FOUNDATION-SWEEP-3 — recovery / mobile / degraded / support / demo
+ * foundation tests.
+ *
+ * Truth invariants enforced:
+ *   - Account recovery is foundation-only (no live method, no
+ *     production recovery claim).
+ *   - Biometric recovery is not present and not claimed.
+ *   - Recovery includes the holder-notification + distinct-from-auth
+ *     requirements.
+ *   - Mobile capture says native capture is not live; checklist
+ *     includes touch targets, reduced motion, and degraded-network
+ *     notice.
+ *   - Degraded-state policy says offline sync is not implemented and
+ *     never produces a clinician-defect signal.
+ *   - Support / admin plan is foundation-only with no live staffed
+ *     support.
+ *   - Demo reset plan is non-production AND non-destructive across
+ *     every scope.
+ *   - Routes carry the required safe copy.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAccountRecoveryFoundationPolicy,
+  evaluateAccountRecoveryReadiness,
+  explainAccountRecoveryMethod,
+  type AccountRecoveryMethod,
+} from '../lib/account-recovery/accountRecoveryFoundation';
+import {
+  buildMobileCaptureFoundationPlan,
+  explainMobileCaptureStatus,
+  type MobileCaptureCapability,
+} from '../lib/mobile/mobileCaptureFoundation';
+import {
+  buildDegradedStateFoundationPolicy,
+  explainDegradedState,
+  type DegradedStateKind,
+} from '../lib/degraded-state/degradedStateFoundation';
+import {
+  buildSupportAdminFoundationPlan,
+  explainSupportAdminStatus,
+} from '../lib/support-admin/supportAdminFoundation';
+import {
+  buildDemoResetFoundationPlan,
+  explainDemoResetSafety,
+} from '../lib/demo/demoResetFoundation';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Account recovery
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('account recovery foundation', () => {
+  const policy = buildAccountRecoveryFoundationPolicy();
+
+  it('includes saved code, issued code, contact, repeated proofing, and support review methods', () => {
+    const expected: AccountRecoveryMethod[] = [
+      'saved_recovery_code',
+      'issued_recovery_code',
+      'recovery_contact',
+      'repeated_identity_proofing',
+      'support_review',
+    ];
+    const actual = policy.methods.map((m) => m.method).sort();
+    expect(actual).toEqual(expected.sort());
+  });
+
+  it('does not claim production account recovery', () => {
+    expect(policy.disclaimers.some((d) => /Production account recovery is not enabled/.test(d))).toBe(true);
+    for (const m of policy.methods) {
+      expect(m.isLive).toBe(false);
+    }
+  });
+
+  it('does not claim biometric recovery is live', () => {
+    const text = JSON.stringify(policy);
+    // No biometric_recovery method enum, and the disclaimer explicitly negates it
+    expect(policy.methods.find((m) => /biometric/i.test(m.method))).toBeUndefined();
+    expect(policy.disclaimers.some((d) => /Biometric recovery is not implemented/.test(d))).toBe(true);
+    // Defensive: no live=true biometric anywhere
+    expect(text.toLowerCase()).not.toContain('biometric recovery live');
+  });
+
+  it('includes the holder-notification requirement', () => {
+    const req = policy.requirements.find((r) => r.id === 'holder_notification');
+    expect(req).toBeDefined();
+    expect(req!.meetsToday).toBe(false);
+  });
+
+  it('declares recovery distinct from authentication', () => {
+    const req = policy.requirements.find((r) => r.id === 'recovery_distinct_from_auth');
+    expect(req).toBeDefined();
+    expect(req!.explanation).toMatch(/does not itself authorize a session/);
+    for (const m of policy.methods) {
+      expect(m.reauthorizesSessionOnSuccess).toBe(false);
+    }
+  });
+
+  it('readiness caps at foundation_ready and never returns productionReady=true', () => {
+    const r = evaluateAccountRecoveryReadiness({
+      hasSavedRecoveryCode: true,
+      hasRecoveryContact: true,
+      identityProofingFoundationReady: true,
+    });
+    expect(r.readiness).toBe('foundation_ready');
+    expect(r.productionReady).toBe(false);
+  });
+
+  it('explainAccountRecoveryMethod returns text for every method', () => {
+    const all: AccountRecoveryMethod[] = [
+      'saved_recovery_code',
+      'issued_recovery_code',
+      'recovery_contact',
+      'repeated_identity_proofing',
+      'support_review',
+    ];
+    for (const m of all) {
+      expect(explainAccountRecoveryMethod(m).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Mobile capture
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('mobile capture foundation', () => {
+  const plan = buildMobileCaptureFoundationPlan();
+
+  it('scope is mobile web / PWA only — never claims native', () => {
+    expect(plan.scope).toBe('mobile_web_pwa_only');
+    expect(plan.disclaimers.some((d) => /Native iOS and Android apps are not shipped/.test(d))).toBe(true);
+  });
+
+  it('does not claim native camera capture is live', () => {
+    expect(plan.disclaimers.some((d) => /Native camera workflows are not enabled/.test(d))).toBe(true);
+    for (const r of plan.requirements) {
+      expect(r.isLive).toBe(false);
+    }
+  });
+
+  it('includes the required capability set', () => {
+    const required: MobileCaptureCapability[] = [
+      'responsive_file_upload',
+      'camera_capture_placeholder',
+      'document_preview',
+      'upload_error_handling',
+      'mobile_touch_targets',
+      'reduced_motion',
+      'degraded_network_notice',
+    ];
+    const present = plan.requirements.map((r) => r.capability);
+    for (const c of required) expect(present).toContain(c);
+  });
+
+  it('explainMobileCaptureStatus returns text for every status', () => {
+    expect(explainMobileCaptureStatus('foundation_planned').length).toBeGreaterThan(0);
+    expect(explainMobileCaptureStatus('foundation_ready').length).toBeGreaterThan(0);
+    expect(explainMobileCaptureStatus('partial').length).toBeGreaterThan(0);
+    expect(explainMobileCaptureStatus('unavailable').length).toBeGreaterThan(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Degraded state
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('degraded state foundation', () => {
+  const policy = buildDegradedStateFoundationPolicy();
+
+  it('declares offline sync is not implemented', () => {
+    expect(policy.offlineSyncImplemented).toBe(false);
+    expect(policy.disclaimers.some((d) => /Offline sync is not implemented/.test(d))).toBe(true);
+  });
+
+  it('never treats source outage as a clinician defect', () => {
+    expect(policy.sourceOutageIsClinicianDefect).toBe(false);
+    expect(policy.disclaimers.some((d) => /not a defect of the clinician/.test(d))).toBe(true);
+    const text = JSON.stringify(policy).toLowerCase();
+    expect(text).not.toContain('clinician defect');
+  });
+
+  it('every notice has a user-safe heading + body + remediation (no raw payload / stack / secret)', () => {
+    for (const n of policy.notices) {
+      expect(n.heading.length).toBeGreaterThan(0);
+      expect(n.heading.length).toBeLessThanOrEqual(64);
+      expect(n.body.length).toBeGreaterThan(0);
+      expect(n.remediation.length).toBeGreaterThan(0);
+      const txt = JSON.stringify(n).toLowerCase();
+      expect(txt).not.toContain('stack');
+      expect(txt).not.toContain('secret');
+      expect(txt).not.toContain('token');
+    }
+  });
+
+  it('explainDegradedState returns the matching notice for every kind', () => {
+    const kinds: DegradedStateKind[] = [
+      'offline',
+      'upstream_unavailable',
+      'upload_failed',
+      'source_probe_unknown',
+      'retry_required',
+      'local_draft_only',
+    ];
+    for (const k of kinds) {
+      const n = explainDegradedState(k);
+      expect(n.kind).toBe(k);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Support / admin
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('support / admin foundation', () => {
+  const plan = buildSupportAdminFoundationPlan();
+
+  it('is foundation-only — staffed=false and productionAdminEnabled=false', () => {
+    expect(plan.staffed).toBe(false);
+    expect(plan.productionAdminEnabled).toBe(false);
+  });
+
+  it('every capability is foundation_planned, none isLive', () => {
+    for (const r of plan.requirements) {
+      expect(r.isLive).toBe(false);
+      expect(r.status).toBe('foundation_planned');
+    }
+  });
+
+  it('includes the required capability set', () => {
+    const required = [
+      'support_intake',
+      'issue_triage',
+      'admin_review_queue',
+      'audit_safe_note',
+      'demo_reset_request',
+      'escalation_policy',
+    ];
+    const present = plan.requirements.map((r) => r.capability);
+    for (const c of required) expect(present).toContain(c);
+  });
+
+  it('disclaimers say not staffed and non-destructive', () => {
+    expect(plan.disclaimers.some((d) => /Support and admin are foundation-only/.test(d))).toBe(true);
+    expect(plan.disclaimers.some((d) => /No destructive database changes/.test(d))).toBe(true);
+  });
+
+  it('explainSupportAdminStatus returns text for every status', () => {
+    expect(explainSupportAdminStatus('foundation_planned').length).toBeGreaterThan(0);
+    expect(explainSupportAdminStatus('foundation_ready').length).toBeGreaterThan(0);
+    expect(explainSupportAdminStatus('partial').length).toBeGreaterThan(0);
+    expect(explainSupportAdminStatus('unavailable').length).toBeGreaterThan(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Demo reset
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('demo reset foundation', () => {
+  const plan = buildDemoResetFoundationPlan();
+
+  it('plan is non-production and non-destructive across every scope', () => {
+    expect(plan.productionResetEnabled).toBe(false);
+    expect(plan.destructive).toBe(false);
+    for (const s of plan.scopes) {
+      expect(s.isLive).toBe(false);
+      expect(s.destructiveToProduction).toBe(false);
+      expect(s.requiresOperatorConfirmation).toBe(true);
+    }
+  });
+
+  it('includes the documented scopes', () => {
+    const required = [
+      'demo_session',
+      'demo_clinician_profile',
+      'demo_issuer_request',
+      'demo_review_decision',
+      'demo_import_inbox',
+    ];
+    const present = plan.scopes.map((s) => s.scope);
+    for (const c of required) expect(present).toContain(c);
+  });
+
+  it('disclaimers explicitly bound the scope to demo data + operator confirmation', () => {
+    expect(plan.disclaimers.some((d) => /non-production and require explicit operator confirmation/.test(d))).toBe(true);
+    expect(plan.disclaimers.some((d) => /No destructive database changes/.test(d))).toBe(true);
+    expect(plan.disclaimers.some((d) => /Real clinician records.*out of every demo reset scope/.test(d))).toBe(true);
+  });
+
+  it('explainDemoResetSafety mentions demo bounds + operator confirmation for each scope', () => {
+    for (const s of plan.scopes) {
+      const explanation = explainDemoResetSafety(s);
+      expect(explanation).toMatch(/bounded to demo data/);
+      expect(explanation).toMatch(/operator confirmation/);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Route copy invariants
+// ────────────────────────────────────────────────────────────────────────────
+
+const APP_ROOT = resolve(__dirname, '..', 'app');
+const readRoute = (rel: string) => readFileSync(resolve(APP_ROOT, rel), 'utf-8');
+
+describe('route copy invariants', () => {
+  it('account/recovery page renders the production-not-enabled disclaimer', () => {
+    const src = readRoute('account/recovery/page.tsx');
+    expect(src).toContain('This page describes recovery foundations. Production account recovery is not enabled yet.');
+  });
+
+  it('account/recovery page does not claim biometric recovery is live', () => {
+    const src = readRoute('account/recovery/page.tsx').toLowerCase();
+    expect(src).not.toContain('biometric recovery live');
+    expect(src).not.toContain('production account recovery is live');
+  });
+
+  it('clinician/mobile-capture page renders the web/PWA-foundation disclaimer', () => {
+    const src = readRoute('clinician/mobile-capture/page.tsx');
+    expect(src).toContain('Mobile document capture is a web/PWA foundation. Native camera workflows are not enabled yet.');
+  });
+
+  it('clinician/mobile-capture page does not claim native camera capture or offline sync is live', () => {
+    const src = readRoute('clinician/mobile-capture/page.tsx').toLowerCase();
+    expect(src).not.toContain('native camera capture live');
+    expect(src).not.toContain('offline sync implemented');
+  });
+
+  it('support page renders the foundation-only disclaimer', () => {
+    const src = readRoute('support/page.tsx');
+    expect(src).toContain('Support and admin are foundation-only this wave. No staffed support is live and no production admin powers are exposed.');
+  });
+
+  it('admin/demo-reset page renders the non-production + operator-confirmation disclaimer', () => {
+    const src = readRoute('admin/demo-reset/page.tsx');
+    expect(src).toContain('Demo reset plans are non-production and require explicit operator confirmation.');
+  });
+
+  it('no foundation-sweep-3 route contains blanket truth-contract banned phrases', () => {
+    const banned = [
+      'guaranteed verification',
+      'instant credentialing',
+      'complete credentialing',
+      'legally accepted',
+      'risk transferred',
+      'hipaa compliant',
+      'soc2 certified',
+      'ncqa verified',
+      'irreversible proof',
+      'tamper-proof',
+      'destructive reset',
+      'production admin enabled',
+      'staffed support live',
+    ];
+    for (const rel of [
+      'account/recovery/page.tsx',
+      'clinician/mobile-capture/page.tsx',
+      'support/page.tsx',
+      'admin/demo-reset/page.tsx',
+    ]) {
+      const src = readRoute(rel).toLowerCase();
+      for (const phrase of banned) expect(src).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web/app/account/recovery/page.tsx
+++ b/apps/web/app/account/recovery/page.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import {
+  buildAccountRecoveryFoundationPolicy,
+  evaluateAccountRecoveryReadiness,
+} from '@/lib/account-recovery/accountRecoveryFoundation';
+
+export const metadata: Metadata = {
+  title: 'Account Recovery · VitalCV',
+  description:
+    'Account recovery foundation policy. Production account recovery is not enabled yet.',
+};
+
+export default function AccountRecoveryPage() {
+  const policy = buildAccountRecoveryFoundationPolicy();
+  const sampleReadiness = evaluateAccountRecoveryReadiness({
+    hasSavedRecoveryCode: false,
+    hasRecoveryContact: false,
+    identityProofingFoundationReady: true,
+  });
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Account recovery
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Recovery foundation policy
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>{`This page describes recovery foundations. Production account recovery is not enabled yet.`}</strong>
+          {' '}Recovery is distinct from authentication: a successful recovery
+          requires repeated identity proofing before a session is re-authorized.
+          Biometric recovery is not implemented and is not part of any flow today.
+        </p>
+      </header>
+
+      <section
+        aria-labelledby="readiness-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="readiness-heading" className="text-base font-semibold sm:text-lg">
+          Foundation readiness
+        </h2>
+        <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-muted-foreground">Sample readiness</dt>
+            <dd className="mt-1 font-mono">{sampleReadiness.readiness}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wider text-muted-foreground">Production ready</dt>
+            <dd className="mt-1 text-muted-foreground">false (foundation only)</dd>
+          </div>
+        </dl>
+        {sampleReadiness.notes.length > 0 && (
+          <ul className="mt-3 list-disc pl-5 text-xs text-muted-foreground">
+            {sampleReadiness.notes.map((n, i) => <li key={i}>{n}</li>)}
+          </ul>
+        )}
+      </section>
+
+      <section
+        aria-labelledby="methods-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="methods-heading" className="text-base font-semibold sm:text-lg">
+          Recovery methods
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {policy.methods.map((m) => (
+            <li key={m.method} className="text-sm">
+              <p className="font-medium">
+                {m.label}{' '}
+                <span
+                  className="ml-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider border-slate-400/40 bg-slate-500/10 text-slate-600"
+                  aria-label="Status: planned"
+                >
+                  planned
+                </span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{m.description}</p>
+              <p className="mt-1 text-[11px] text-muted-foreground/80">Blocked by: {m.blockedBy}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="requirements-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="requirements-heading" className="text-base font-semibold sm:text-lg">
+          Requirements
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {policy.requirements.map((r) => (
+            <li key={r.id} className="text-sm">
+              <p className="font-medium">{r.label}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{r.explanation}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="disclaimers-heading"
+        className="rounded-xl border border-amber-500/15 bg-amber-500/5 p-4 sm:p-5"
+      >
+        <h2 id="disclaimers-heading" className="text-sm font-semibold">
+          Disclaimers
+        </h2>
+        <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+          {policy.disclaimers.map((d, i) => <li key={i}>· {d}</li>)}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/admin/demo-reset/page.tsx
+++ b/apps/web/app/admin/demo-reset/page.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import { buildDemoResetFoundationPlan } from '@/lib/demo/demoResetFoundation';
+
+export const metadata: Metadata = {
+  title: 'Demo Reset · VitalCV',
+  description:
+    'Demo reset foundation plan. Non-production. Requires explicit operator confirmation. No destructive database changes.',
+};
+
+export default function AdminDemoResetPage() {
+  const plan = buildDemoResetFoundationPlan();
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Admin / demo reset
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Demo reset foundation
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>{`Demo reset plans are non-production and require explicit operator confirmation.`}</strong>
+          {' '}No reset action runs from this page. Every scope is bounded to demo data;
+          real clinician records, real PSV receipts, and real audit-boundary records are
+          out of every demo reset scope by construction.
+        </p>
+      </header>
+
+      <section
+        aria-labelledby="scopes-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="scopes-heading" className="text-base font-semibold sm:text-lg">
+          Reset scopes (foundation only)
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {plan.scopes.map((s) => (
+            <li key={s.scope} className="text-sm">
+              <p className="font-medium">
+                {s.label}{' '}
+                <span
+                  className="ml-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider border-slate-400/40 bg-slate-500/10 text-slate-600"
+                  aria-label={`Status: ${s.status}`}
+                >
+                  {s.status.replace(/_/g, ' ')}
+                </span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{s.description}</p>
+              <p className="mt-1 text-[11px] text-muted-foreground/80">
+                Bounded to demo data · cannot reach production · requires operator confirmation
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="safety-heading"
+        className="rounded-xl border border-amber-500/15 bg-amber-500/5 p-4 sm:p-5"
+      >
+        <h2 id="safety-heading" className="text-sm font-semibold">
+          Safety contract
+        </h2>
+        <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+          {plan.disclaimers.map((d, i) => <li key={i}>· {d}</li>)}
+        </ul>
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          Implementation note: <code>productionResetEnabled = false</code> and{' '}
+          <code>destructive = false</code> across the entire plan. No flow ships that
+          can change production state from this page.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/clinician/mobile-capture/page.tsx
+++ b/apps/web/app/clinician/mobile-capture/page.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import {
+  buildMobileCaptureFoundationPlan,
+  explainMobileCaptureStatus,
+} from '@/lib/mobile/mobileCaptureFoundation';
+import { explainDegradedState } from '@/lib/degraded-state/degradedStateFoundation';
+
+export const metadata: Metadata = {
+  title: 'Mobile Document Capture · VitalCV',
+  description:
+    'Mobile document capture is a web/PWA foundation. Native camera workflows are not enabled yet.',
+};
+
+export default function ClinicianMobileCapturePage() {
+  const plan = buildMobileCaptureFoundationPlan();
+  const offlineNotice = explainDegradedState('offline');
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Mobile document capture
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Web / PWA capture foundation
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>{`Mobile document capture is a web/PWA foundation. Native camera workflows are not enabled yet.`}</strong>
+          {' '}Native iOS and Android apps are not shipped. Offline sync is not implemented;
+          working without a connection stays in a local draft until you reconnect.
+        </p>
+      </header>
+
+      <section
+        aria-labelledby="capabilities-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="capabilities-heading" className="text-base font-semibold sm:text-lg">
+          Capabilities (foundation only)
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {plan.requirements.map((r) => (
+            <li key={r.capability} className="text-sm">
+              <p className="font-medium">
+                {r.label}{' '}
+                <span
+                  className="ml-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider border-slate-400/40 bg-slate-500/10 text-slate-600"
+                  aria-label={`Status: ${r.status}`}
+                  title={explainMobileCaptureStatus(r.status)}
+                >
+                  {r.status.replace(/_/g, ' ')}
+                </span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{r.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="degraded-heading"
+        className="mb-6 rounded-xl border border-amber-500/15 bg-amber-500/5 p-4 sm:p-5"
+      >
+        <h2 id="degraded-heading" className="text-base font-semibold sm:text-lg">
+          {offlineNotice.heading}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">{offlineNotice.body}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{offlineNotice.remediation}</p>
+      </section>
+
+      <section
+        aria-labelledby="disclaimers-heading"
+        className="rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="disclaimers-heading" className="text-sm font-semibold">
+          Disclaimers
+        </h2>
+        <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+          {plan.disclaimers.map((d, i) => <li key={i}>· {d}</li>)}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import {
+  buildSupportAdminFoundationPlan,
+  explainSupportAdminStatus,
+} from '@/lib/support-admin/supportAdminFoundation';
+
+export const metadata: Metadata = {
+  title: 'Support · VitalCV',
+  description:
+    'Support and admin foundation plan. Foundation only — no live staffed support and no production admin powers.',
+};
+
+export default function SupportPage() {
+  const plan = buildSupportAdminFoundationPlan();
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
+      <header className="mb-8 sm:mb-10">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Support &amp; admin
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
+          Foundation plan
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          <strong>{`Support and admin are foundation-only this wave. No staffed support is live and no production admin powers are exposed.`}</strong>
+          {' '}This page documents the support intake, triage, review queue, and escalation
+          shapes; it does not route a real case anywhere today.
+        </p>
+      </header>
+
+      <section
+        aria-labelledby="capabilities-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="capabilities-heading" className="text-base font-semibold sm:text-lg">
+          Capabilities (foundation only)
+        </h2>
+        <ul className="mt-3 space-y-3">
+          {plan.requirements.map((r) => (
+            <li key={r.capability} className="text-sm">
+              <p className="font-medium">
+                {r.label}{' '}
+                <span
+                  className="ml-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider border-slate-400/40 bg-slate-500/10 text-slate-600"
+                  aria-label={`Status: ${r.status}`}
+                  title={explainSupportAdminStatus(r.status)}
+                >
+                  {r.status.replace(/_/g, ' ')}
+                </span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{r.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="disclaimers-heading"
+        className="rounded-xl border border-amber-500/15 bg-amber-500/5 p-4 sm:p-5"
+      >
+        <h2 id="disclaimers-heading" className="text-sm font-semibold">
+          Disclaimers
+        </h2>
+        <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+          {plan.disclaimers.map((d, i) => <li key={i}>· {d}</li>)}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/account-recovery/accountRecoveryFoundation.ts
+++ b/apps/web/lib/account-recovery/accountRecoveryFoundation.ts
@@ -1,0 +1,254 @@
+/**
+ * FOUNDATION-SWEEP-3 — account recovery foundation policy.
+ *
+ * Truth invariants:
+ *   1. This is a POLICY foundation, not a production recovery flow.
+ *      No method here triggers a real reset; nothing here changes
+ *      auth state.
+ *   2. No method may imply *live* recovery without a shipped
+ *      implementation. Each method carries an `isLive: boolean`
+ *      that is `false` for every method in this foundation.
+ *   3. Biometric recovery is NOT live. There is no biometric
+ *      recovery method on the live shelf and there is no
+ *      `isLive: true` row anywhere in this module.
+ *   4. Recovery is DISTINCT from authentication. A successful
+ *      recovery yields a re-attestation step; it does NOT itself
+ *      authorize a session.
+ *   5. Every recovery action requires a notification policy entry
+ *      so the holder is informed out-of-band.
+ */
+
+export type AccountRecoveryMethod =
+  | 'saved_recovery_code'
+  | 'issued_recovery_code'
+  | 'recovery_contact'
+  | 'repeated_identity_proofing'
+  | 'support_review';
+
+export type AccountRecoveryStatus =
+  | 'not_started'
+  | 'policy_defined'
+  | 'awaiting_holder_action'
+  | 'awaiting_support_review'
+  | 'requires_repeated_identity_proofing'
+  | 'blocked'
+  | 'unavailable';
+
+export type AccountRecoveryRiskLevel = 'low' | 'moderate' | 'high' | 'critical';
+
+export interface AccountRecoveryRequirement {
+  id:
+    | 'holder_notification'
+    | 'session_revocation'
+    | 'repeated_identity_proofing'
+    | 'support_review_log'
+    | 'recovery_distinct_from_auth';
+  label: string;
+  /** Plain-language statement of the requirement. */
+  explanation: string;
+  /** Is the requirement met by a shipped control today? */
+  meetsToday: boolean;
+}
+
+export interface AccountRecoveryMethodSpec {
+  method: AccountRecoveryMethod;
+  label: string;
+  description: string;
+  /** Is this method shipped + live today? Always false in this foundation. */
+  isLive: boolean;
+  /** What additional control or wave is required to make this live. */
+  blockedBy: string;
+  /** Risk level if used incorrectly (informs ordering, not enabling). */
+  riskLevel: AccountRecoveryRiskLevel;
+  /** Whether this method on its own re-authorizes a session. Always false. */
+  reauthorizesSessionOnSuccess: false;
+}
+
+export interface AccountRecoveryFoundationPolicy {
+  status: AccountRecoveryStatus;
+  summary: string;
+  methods: AccountRecoveryMethodSpec[];
+  requirements: AccountRecoveryRequirement[];
+  /** Required UI disclaimers, rendered verbatim. */
+  disclaimers: string[];
+}
+
+const PRODUCTION_DISCLAIMER =
+  'This page describes recovery foundations. Production account recovery is not enabled yet.';
+const BIOMETRIC_DISCLAIMER =
+  'Biometric recovery is not implemented and is not part of any flow today.';
+const DISTINCT_FROM_AUTH_DISCLAIMER =
+  'Recovery is distinct from authentication. A successful recovery requires repeated identity proofing before a session is re-authorized.';
+const NOTIFICATION_DISCLAIMER =
+  'Every recovery attempt requires an out-of-band notification to the holder.';
+
+export function buildAccountRecoveryFoundationPolicy(): AccountRecoveryFoundationPolicy {
+  const methods: AccountRecoveryMethodSpec[] = [
+    {
+      method: 'saved_recovery_code',
+      label: 'Holder-saved recovery code',
+      description:
+        'A one-time recovery code generated at enrollment and stored by the holder.',
+      isLive: false,
+      blockedBy:
+        'Auth slice does not yet generate or store recovery codes; planned with the auth wave.',
+      riskLevel: 'low',
+      reauthorizesSessionOnSuccess: false,
+    },
+    {
+      method: 'issued_recovery_code',
+      label: 'Operator-issued recovery code',
+      description:
+        'A short-lived recovery code issued by support after a manual review.',
+      isLive: false,
+      blockedBy:
+        'Support tooling not yet shipped; depends on Support / admin foundation.',
+      riskLevel: 'moderate',
+      reauthorizesSessionOnSuccess: false,
+    },
+    {
+      method: 'recovery_contact',
+      label: 'Out-of-band recovery contact',
+      description:
+        'A pre-registered email or phone number used to send a recovery challenge.',
+      isLive: false,
+      blockedBy:
+        'No challenge transport (email/SMS) is wired in this foundation; planned.',
+      riskLevel: 'moderate',
+      reauthorizesSessionOnSuccess: false,
+    },
+    {
+      method: 'repeated_identity_proofing',
+      label: 'Repeated identity proofing',
+      description:
+        'Re-run the identity proofing controls (NPI lookup + planned government ID + planned liveness) before recovery completes.',
+      isLive: false,
+      blockedBy:
+        'Government ID and liveness controls are planned (FOUNDATION-SWEEP-2 identity policy).',
+      riskLevel: 'high',
+      reauthorizesSessionOnSuccess: false,
+    },
+    {
+      method: 'support_review',
+      label: 'Manual support review',
+      description:
+        'A queued case for support to review before any recovery action proceeds.',
+      isLive: false,
+      blockedBy:
+        'Support intake + audit-safe note are foundation-only this wave.',
+      riskLevel: 'critical',
+      reauthorizesSessionOnSuccess: false,
+    },
+  ];
+
+  const requirements: AccountRecoveryRequirement[] = [
+    {
+      id: 'holder_notification',
+      label: 'Out-of-band holder notification',
+      explanation:
+        'Every recovery attempt notifies the holder via a registered out-of-band channel before the recovery proceeds.',
+      meetsToday: false,
+    },
+    {
+      id: 'session_revocation',
+      label: 'Session revocation on recovery',
+      explanation:
+        'Successful recovery revokes any existing sessions associated with the account.',
+      meetsToday: false,
+    },
+    {
+      id: 'repeated_identity_proofing',
+      label: 'Repeated identity proofing required',
+      explanation:
+        'Recovery completes only after the identity proofing controls have re-run (per FOUNDATION-SWEEP-2 identity policy).',
+      meetsToday: false,
+    },
+    {
+      id: 'support_review_log',
+      label: 'Support review audit-safe log',
+      explanation:
+        'Support reviews of recovery cases produce an audit-safe note (no raw PII / no secrets in the log).',
+      meetsToday: false,
+    },
+    {
+      id: 'recovery_distinct_from_auth',
+      label: 'Recovery distinct from authentication',
+      explanation:
+        'A successful recovery does not itself authorize a session; the holder must re-authenticate after recovery.',
+      meetsToday: false,
+    },
+  ];
+
+  return {
+    status: 'policy_defined',
+    summary:
+      'Account recovery policy is documented with five methods, all currently isLive: false. Recovery is distinct from authentication. No live recovery flow ships today.',
+    methods,
+    requirements,
+    disclaimers: [
+      PRODUCTION_DISCLAIMER,
+      BIOMETRIC_DISCLAIMER,
+      DISTINCT_FROM_AUTH_DISCLAIMER,
+      NOTIFICATION_DISCLAIMER,
+    ],
+  };
+}
+
+export function explainAccountRecoveryMethod(method: AccountRecoveryMethod): string {
+  switch (method) {
+    case 'saved_recovery_code':
+      return 'A one-time recovery code generated at enrollment and stored by the holder.';
+    case 'issued_recovery_code':
+      return 'A short-lived recovery code issued by support after a manual review.';
+    case 'recovery_contact':
+      return 'A pre-registered email or phone number used to send a recovery challenge.';
+    case 'repeated_identity_proofing':
+      return 'Re-run the identity proofing controls (NPI lookup + planned government ID + planned liveness) before recovery completes.';
+    case 'support_review':
+      return 'A queued case for support to review before any recovery action proceeds.';
+  }
+}
+
+export interface AccountRecoveryReadinessInput {
+  hasSavedRecoveryCode: boolean;
+  hasRecoveryContact: boolean;
+  identityProofingFoundationReady: boolean;
+}
+
+export interface AccountRecoveryReadinessResult {
+  readiness: 'foundation_not_ready' | 'foundation_ready';
+  /** Always false in this foundation — readiness is foundation_ready at most. */
+  productionReady: false;
+  notes: string[];
+}
+
+/**
+ * Evaluates how close the holder is to having the *foundation* in
+ * place. NEVER returns "production ready" — even with all inputs
+ * true, the strongest result is `foundation_ready`.
+ */
+export function evaluateAccountRecoveryReadiness(
+  input: AccountRecoveryReadinessInput,
+): AccountRecoveryReadinessResult {
+  const notes: string[] = [];
+  if (!input.hasSavedRecoveryCode) {
+    notes.push('No holder-saved recovery code on file.');
+  }
+  if (!input.hasRecoveryContact) {
+    notes.push('No out-of-band recovery contact on file.');
+  }
+  if (!input.identityProofingFoundationReady) {
+    notes.push('Identity proofing foundation is not yet at foundation_ready.');
+  }
+  const readiness: AccountRecoveryReadinessResult['readiness'] =
+    input.hasSavedRecoveryCode &&
+    input.hasRecoveryContact &&
+    input.identityProofingFoundationReady
+      ? 'foundation_ready'
+      : 'foundation_not_ready';
+  return {
+    readiness,
+    productionReady: false,
+    notes,
+  };
+}

--- a/apps/web/lib/degraded-state/degradedStateFoundation.ts
+++ b/apps/web/lib/degraded-state/degradedStateFoundation.ts
@@ -1,0 +1,112 @@
+/**
+ * FOUNDATION-SWEEP-3 — degraded-state foundation policy.
+ *
+ * Truth invariants:
+ *   - Offline sync is NOT implemented. The "offline" degraded state
+ *     keeps work in a local draft only; it does not transparently
+ *     synchronise on reconnect.
+ *   - A source outage is NEVER a clinician defect. The
+ *     "source_probe_unknown" / "upstream_unavailable" states surface
+ *     the source-health classifier's findings, not a holder-quality
+ *     signal.
+ *   - Each state carries a user-safe explanation + a retry-or-not
+ *     hint. Raw error payloads / stack traces / secrets must not
+ *     appear in any notice produced here.
+ */
+
+export type DegradedStateKind =
+  | 'offline'
+  | 'upstream_unavailable'
+  | 'upload_failed'
+  | 'source_probe_unknown'
+  | 'retry_required'
+  | 'local_draft_only';
+
+export interface DegradedStateNotice {
+  kind: DegradedStateKind;
+  /** UI heading for the notice (≤ 64 chars). */
+  heading: string;
+  /** User-safe body text; never includes raw payload / stack / secret. */
+  body: string;
+  /** Recommended next action the holder can take. */
+  remediation: string;
+  /** Whether retrying the same action might succeed. */
+  retryable: boolean;
+}
+
+export interface DegradedStatePolicy {
+  /** Is offline sync implemented? Always false in this foundation. */
+  offlineSyncImplemented: false;
+  /** Whether a source outage produces a clinician-defect signal. Always false. */
+  sourceOutageIsClinicianDefect: false;
+  notices: DegradedStateNotice[];
+  /** UI disclaimers rendered verbatim. */
+  disclaimers: string[];
+}
+
+const OFFLINE_SYNC_DISCLAIMER =
+  'Offline sync is not implemented. Working without a connection stays in a local draft until you reconnect.';
+const SOURCE_OUTAGE_DISCLAIMER =
+  'A source outage is a property of the upstream source, not a defect of the clinician. Lane state never changes a credential decision on its own.';
+
+const NOTICES: DegradedStateNotice[] = [
+  {
+    kind: 'offline',
+    heading: "You're offline",
+    body: 'No network connection detected. Your changes are kept as a local draft and are not synced.',
+    remediation: 'Reconnect to a stable network, then submit again.',
+    retryable: true,
+  },
+  {
+    kind: 'upstream_unavailable',
+    heading: 'Upstream source unavailable',
+    body: 'A source-of-record check (NPPES / OIG / PECOS / state board) returned an unavailable state.',
+    remediation: 'Try again later; the source-health classifier will retry on its schedule.',
+    retryable: true,
+  },
+  {
+    kind: 'upload_failed',
+    heading: 'Upload did not complete',
+    body: 'A file upload was interrupted before it finished.',
+    remediation: 'Reselect the file and try again. If the problem persists, switch to a different network.',
+    retryable: true,
+  },
+  {
+    kind: 'source_probe_unknown',
+    heading: 'Source health unknown',
+    body: 'No recent source-health snapshot is available for one or more lanes. This is not a credential decision.',
+    remediation: 'Wait for the next scheduled probe; no holder action is required.',
+    retryable: false,
+  },
+  {
+    kind: 'retry_required',
+    heading: 'Retry required',
+    body: 'A transient error prevented the request from completing.',
+    remediation: 'Wait a moment and try again.',
+    retryable: true,
+  },
+  {
+    kind: 'local_draft_only',
+    heading: 'Local draft only',
+    body: 'This entry is kept on your device and has not been submitted.',
+    remediation: 'Open the entry and submit when you are ready.',
+    retryable: true,
+  },
+];
+
+export function buildDegradedStateFoundationPolicy(): DegradedStatePolicy {
+  return {
+    offlineSyncImplemented: false,
+    sourceOutageIsClinicianDefect: false,
+    notices: NOTICES.map((n) => ({ ...n })),
+    disclaimers: [OFFLINE_SYNC_DISCLAIMER, SOURCE_OUTAGE_DISCLAIMER],
+  };
+}
+
+export function explainDegradedState(kind: DegradedStateKind): DegradedStateNotice {
+  const notice = NOTICES.find((n) => n.kind === kind);
+  if (!notice) {
+    throw new Error(`Unknown degraded state kind: ${kind}`);
+  }
+  return { ...notice };
+}

--- a/apps/web/lib/demo/demoResetFoundation.ts
+++ b/apps/web/lib/demo/demoResetFoundation.ts
@@ -1,0 +1,124 @@
+/**
+ * FOUNDATION-SWEEP-3 — demo reset foundation plan.
+ *
+ * Truth invariants:
+ *   - Demo reset is PLANNED / FOUNDATION ONLY. No production reset
+ *     ships in this wave.
+ *   - No method here performs a destructive database change. Every
+ *     reset action requires explicit operator confirmation.
+ *   - "Production" data (real clinician records, real PSV receipts,
+ *     real audit-boundary records) is OUT of every demo reset
+ *     scope by construction.
+ */
+
+export type DemoResetScope =
+  | 'demo_session'
+  | 'demo_clinician_profile'
+  | 'demo_issuer_request'
+  | 'demo_review_decision'
+  | 'demo_import_inbox';
+
+export type DemoResetStatus =
+  | 'foundation_planned'
+  | 'foundation_ready_pending_confirmation'
+  | 'unavailable';
+
+export interface DemoResetSpec {
+  scope: DemoResetScope;
+  label: string;
+  description: string;
+  /** Is the reset for this scope shipped and runnable today? Always false. */
+  isLive: boolean;
+  /** Is this scope ever destructive to production data? Always false. */
+  destructiveToProduction: false;
+  /** Does this scope require explicit operator confirmation? Always true. */
+  requiresOperatorConfirmation: true;
+  status: DemoResetStatus;
+}
+
+export interface DemoResetPlan {
+  /** Is any demo reset shipped + runnable today? Always false. */
+  productionResetEnabled: false;
+  /** Is any demo reset ever destructive to production data? Always false. */
+  destructive: false;
+  scopes: DemoResetSpec[];
+  /** UI disclaimers rendered verbatim. */
+  disclaimers: string[];
+}
+
+const NON_PRODUCTION_DISCLAIMER =
+  'Demo reset plans are non-production and require explicit operator confirmation.';
+const NO_DESTRUCTIVE_DISCLAIMER =
+  'No destructive database changes ship in this wave. Every scope is bounded to demo data only.';
+const PRODUCTION_DATA_DISCLAIMER =
+  'Real clinician records, real PSV receipts, and real audit-boundary records are out of every demo reset scope by construction.';
+
+export function buildDemoResetFoundationPlan(): DemoResetPlan {
+  const scopes: DemoResetSpec[] = [
+    {
+      scope: 'demo_session',
+      label: 'Demo session reset',
+      description:
+        'Clears the local demo session for the current operator. Does not touch any persisted record.',
+      isLive: false,
+      destructiveToProduction: false,
+      requiresOperatorConfirmation: true,
+      status: 'foundation_planned',
+    },
+    {
+      scope: 'demo_clinician_profile',
+      label: 'Demo clinician profile reset',
+      description:
+        'Resets demo-only clinician profile fields. Real clinician profiles are out of scope.',
+      isLive: false,
+      destructiveToProduction: false,
+      requiresOperatorConfirmation: true,
+      status: 'foundation_planned',
+    },
+    {
+      scope: 'demo_issuer_request',
+      label: 'Demo issuer request reset',
+      description:
+        'Resets demo-only issuer request state. No production issuer request is touched.',
+      isLive: false,
+      destructiveToProduction: false,
+      requiresOperatorConfirmation: true,
+      status: 'foundation_planned',
+    },
+    {
+      scope: 'demo_review_decision',
+      label: 'Demo review decision reset',
+      description:
+        'Resets demo-only review decision state. No production review decision is touched.',
+      isLive: false,
+      destructiveToProduction: false,
+      requiresOperatorConfirmation: true,
+      status: 'foundation_planned',
+    },
+    {
+      scope: 'demo_import_inbox',
+      label: 'Demo import inbox reset',
+      description:
+        'Clears the demo-only import inbox queue. Real import data is out of scope.',
+      isLive: false,
+      destructiveToProduction: false,
+      requiresOperatorConfirmation: true,
+      status: 'foundation_planned',
+    },
+  ];
+
+  return {
+    productionResetEnabled: false,
+    destructive: false,
+    scopes,
+    disclaimers: [
+      NON_PRODUCTION_DISCLAIMER,
+      NO_DESTRUCTIVE_DISCLAIMER,
+      PRODUCTION_DATA_DISCLAIMER,
+    ],
+  };
+}
+
+export function explainDemoResetSafety(spec: DemoResetSpec): string {
+  return `Scope "${spec.label}" is bounded to demo data; cannot reach production records; requires explicit operator confirmation.`;
+}

--- a/apps/web/lib/mobile/mobileCaptureFoundation.ts
+++ b/apps/web/lib/mobile/mobileCaptureFoundation.ts
@@ -1,0 +1,134 @@
+/**
+ * FOUNDATION-SWEEP-3 — mobile capture foundation.
+ *
+ * Truth invariants:
+ *   - Native iOS and Android apps are NOT shipped. This foundation
+ *     is mobile web / PWA only.
+ *   - Native camera capture is NOT live. The "camera_capture_placeholder"
+ *     capability documents the placeholder behavior and explicitly
+ *     marks itself as `isLive: false`.
+ *   - Offline sync is NOT implemented (see degraded-state foundation
+ *     for the cross-cutting policy).
+ *   - This module describes capability shape; it does not invoke
+ *     device APIs.
+ */
+
+export type MobileCaptureCapability =
+  | 'responsive_file_upload'
+  | 'camera_capture_placeholder'
+  | 'document_preview'
+  | 'upload_error_handling'
+  | 'mobile_touch_targets'
+  | 'reduced_motion'
+  | 'degraded_network_notice';
+
+export type MobileCaptureStatus =
+  | 'foundation_planned'
+  | 'foundation_ready'
+  | 'partial'
+  | 'unavailable';
+
+export interface MobileCaptureRequirement {
+  capability: MobileCaptureCapability;
+  label: string;
+  /** What the foundation guarantees for this capability today. */
+  description: string;
+  /** Is this capability live (shipped + verified) today? */
+  isLive: boolean;
+  /** Phase label for the row, derived from isLive + scope. */
+  status: MobileCaptureStatus;
+}
+
+export interface MobileCaptureFoundationPlan {
+  scope: 'mobile_web_pwa_only';
+  requirements: MobileCaptureRequirement[];
+  /** UI disclaimers rendered verbatim. */
+  disclaimers: string[];
+}
+
+const NATIVE_DISCLAIMER =
+  'Mobile document capture is a web/PWA foundation. Native camera workflows are not enabled yet.';
+const NATIVE_APP_DISCLAIMER =
+  'Native iOS and Android apps are not shipped. This page runs in mobile web / PWA only.';
+const OFFLINE_DISCLAIMER =
+  'Offline sync is not implemented. Working in degraded-network conditions stays in a local draft until a connection is restored.';
+
+export function buildMobileCaptureFoundationPlan(): MobileCaptureFoundationPlan {
+  const requirements: MobileCaptureRequirement[] = [
+    {
+      capability: 'responsive_file_upload',
+      label: 'Responsive file upload',
+      description:
+        'A mobile-friendly file picker that accepts images and PDFs from the device gallery or files app.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'camera_capture_placeholder',
+      label: 'Camera capture placeholder',
+      description:
+        'A clearly-labeled placeholder for native camera capture. NOT a working camera; clicking surfaces a "planned" notice.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'document_preview',
+      label: 'Document preview',
+      description:
+        'A foundation-level preview of an uploaded image / PDF for the holder to confirm before submission.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'upload_error_handling',
+      label: 'Upload error handling',
+      description:
+        'Surfaces user-safe error messages from the import-export foundation (no raw payload, stack, or secret).',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'mobile_touch_targets',
+      label: 'Mobile touch targets',
+      description:
+        'All interactive controls follow the accessibility-foundation touch-target rule (≥ 44×44 CSS px on touch viewports).',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'reduced_motion',
+      label: 'Reduced motion respect',
+      description:
+        'Animations gate on prefers-reduced-motion: reduce per the accessibility foundation.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'degraded_network_notice',
+      label: 'Degraded network notice',
+      description:
+        'Surfaces the degraded-state foundation policy when the network is offline or upstream is unavailable.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+  ];
+
+  return {
+    scope: 'mobile_web_pwa_only',
+    requirements,
+    disclaimers: [NATIVE_DISCLAIMER, NATIVE_APP_DISCLAIMER, OFFLINE_DISCLAIMER],
+  };
+}
+
+export function explainMobileCaptureStatus(status: MobileCaptureStatus): string {
+  switch (status) {
+    case 'foundation_planned':
+      return 'Foundation is documented; capability has not shipped.';
+    case 'foundation_ready':
+      return 'Foundation is in place; capability is wired but not yet certified end-to-end.';
+    case 'partial':
+      return 'Capability ships in some flows; not yet uniform across mobile surfaces.';
+    case 'unavailable':
+      return 'Capability is unavailable in this environment.';
+  }
+}

--- a/apps/web/lib/support-admin/supportAdminFoundation.ts
+++ b/apps/web/lib/support-admin/supportAdminFoundation.ts
@@ -1,0 +1,121 @@
+/**
+ * FOUNDATION-SWEEP-3 — support / admin foundation plan.
+ *
+ * Truth invariants:
+ *   - This is a FOUNDATION-only plan. No live staffed support is
+ *     shipped today. No production admin powers are exposed.
+ *   - Audit-safe notes never include raw PII, secrets, or upstream
+ *     payloads.
+ *   - Demo reset requests are non-destructive and require explicit
+ *     operator confirmation (see demoResetFoundation).
+ *   - Escalation policy documents who may act, not what they may
+ *     irreversibly do.
+ */
+
+export type SupportAdminCapability =
+  | 'support_intake'
+  | 'issue_triage'
+  | 'admin_review_queue'
+  | 'audit_safe_note'
+  | 'demo_reset_request'
+  | 'escalation_policy';
+
+export type SupportAdminStatus =
+  | 'foundation_planned'
+  | 'foundation_ready'
+  | 'partial'
+  | 'unavailable';
+
+export interface SupportAdminRequirement {
+  capability: SupportAdminCapability;
+  label: string;
+  description: string;
+  /** Is this capability shipped + staffed today? Always false. */
+  isLive: boolean;
+  status: SupportAdminStatus;
+}
+
+export interface SupportAdminFoundationPlan {
+  staffed: false;
+  productionAdminEnabled: false;
+  requirements: SupportAdminRequirement[];
+  disclaimers: string[];
+}
+
+const NOT_LIVE_DISCLAIMER =
+  'Support and admin are foundation-only this wave. No staffed support is live and no production admin powers are exposed.';
+const NON_DESTRUCTIVE_DISCLAIMER =
+  'Demo reset plans are non-production and require explicit operator confirmation. No destructive database changes ship in this foundation.';
+
+export function buildSupportAdminFoundationPlan(): SupportAdminFoundationPlan {
+  const requirements: SupportAdminRequirement[] = [
+    {
+      capability: 'support_intake',
+      label: 'Support intake',
+      description:
+        'A documented intake shape for support cases. No live ticketing system is wired.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'issue_triage',
+      label: 'Issue triage',
+      description:
+        'A documented triage flow that classifies a case before any holder-visible action.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'admin_review_queue',
+      label: 'Admin review queue',
+      description:
+        'A read-only foundation for an operator review queue. No production admin powers are exposed.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'audit_safe_note',
+      label: 'Audit-safe support note',
+      description:
+        'A note shape that captures the case decision without raw PII / secrets / upstream payload.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'demo_reset_request',
+      label: 'Demo reset request',
+      description:
+        'Routes a demo-reset request through the demo reset foundation (non-production, non-destructive).',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+    {
+      capability: 'escalation_policy',
+      label: 'Escalation policy',
+      description:
+        'Documents who may act on each case class. Does NOT grant any new production powers.',
+      isLive: false,
+      status: 'foundation_planned',
+    },
+  ];
+
+  return {
+    staffed: false,
+    productionAdminEnabled: false,
+    requirements,
+    disclaimers: [NOT_LIVE_DISCLAIMER, NON_DESTRUCTIVE_DISCLAIMER],
+  };
+}
+
+export function explainSupportAdminStatus(status: SupportAdminStatus): string {
+  switch (status) {
+    case 'foundation_planned':
+      return 'Foundation is documented; capability has not shipped.';
+    case 'foundation_ready':
+      return 'Foundation is in place; capability is wired but not yet certified end-to-end.';
+    case 'partial':
+      return 'Capability ships in some flows; not uniform across surfaces.';
+    case 'unavailable':
+      return 'Capability is unavailable in this environment.';
+  }
+}

--- a/docs/ops/vitalcv-completion-board.md
+++ b/docs/ops/vitalcv-completion-board.md
@@ -128,11 +128,11 @@ Status vocabulary: emoji phase derived from Current % per the [Status Lexicon](#
 | Mobile web / PWA | 35 | 90 | 55 | +0 | +0 | Responsive layout; PWA manifest foundation per Wave GOD-2; no installability/offline shell verified | 🧱 Foundation |
 | Native iOS app | 0 | 90 | 90 | +0 | +0 | None shipped | 🧊 Planned |
 | Native Android app | 0 | 90 | 90 | +0 | +0 | None shipped | 🧊 Planned |
-| Mobile document capture | 0 | 90 | 90 | +0 | +0 | None | 🧊 Planned |
+| Mobile document capture | 25 | 90 | 65 | +0 | +25 | (FOUNDATION-SWEEP-3) `apps/web/lib/mobile/mobileCaptureFoundation.ts` defines the web/PWA scope + 7-capability checklist with explicit `Native iOS and Android apps are not shipped` and `Native camera workflows are not enabled yet` disclaimers; surfaced on `/clinician/mobile-capture` route | 🧱 Foundation |
 | Device trust / App Attest / Play Integrity | 0 | 90 | 90 | +0 | +0 | None | 🧊 Planned |
 | Biometric gating | 0 | 90 | 90 | +0 | +0 | None | 🧊 Planned |
 | Push notification readiness | 0 | 90 | 90 | +0 | +0 | None | 🧊 Planned |
-| Offline / degraded-state handling | 25 | 90 | 65 | +0 | +0 | Some 5xx graceful fallbacks (#LIVE-100C/D) but no offline data shell | 🧱 Foundation |
+| Offline / degraded-state handling | 25 | 90 | 65 | +0 | +0 | 5xx graceful fallbacks (#LIVE-100C/D) + (FOUNDATION-SWEEP-3) `degradedStateFoundation.ts` defines a 6-state policy (offline / upstream_unavailable / upload_failed / source_probe_unknown / retry_required / local_draft_only) with `offlineSyncImplemented: false` and `sourceOutageIsClinicianDefect: false` invariants; no offline data shell yet | 🧱 Foundation |
 
 ---
 
@@ -144,7 +144,7 @@ Status vocabulary: emoji phase derived from Current % per the [Status Lexicon](#
 | Selfie / liveness | 0 | 90 | 90 | +0 | +0 | None | 🧊 Planned |
 | Clinician-to-NPI binding | 28 | 90 | 62 | +0 | +13 | NPI lookup exists + (FOUNDATION-SWEEP-2) `evaluateClinicianNpiBindingReadiness` returns `foundation_ready` for identifier-resolved+self-attested input; explicit `gov_id_required`/`liveness_required` placeholders for planned controls; no proven-person-to-NPI binding still | 🧱 Foundation |
 | Identity proofing policy | 25 | 90 | 65 | +0 | +15 | (FOUNDATION-SWEEP-2) `apps/web/lib/identity/identityProofingPolicy.ts` defines `IdentityProofingPolicyDecision` with NPI-lookup + self-attested-name as the only `isLive: true` controls; government ID + liveness explicitly `isLive: false`; no IAL2/IAL3 asserted; `/clinician/identity` route renders the policy summary | 🧱 Foundation |
-| Account recovery | 10 | 90 | 80 | +0 | +0 | Tied to broken auth slice | 🌱 Seed |
+| Account recovery | 25 | 90 | 65 | +0 | +15 | Tied to broken auth slice + (FOUNDATION-SWEEP-3) `accountRecoveryFoundation.ts` defines 5 recovery methods (saved_recovery_code / issued_recovery_code / recovery_contact / repeated_identity_proofing / support_review) all `isLive: false`; explicit holder-notification + recovery-distinct-from-auth requirements; surfaced on `/account/recovery` route; no production recovery flow ships | 🧱 Foundation |
 | Session security | 20 | 90 | 70 | +0 | +0 | Default Next/Clerk session handling, not hardened | 🌱 Seed |
 | OWASP ASVS baseline | 15 | 90 | 75 | +0 | +0 | No published ASVS scorecard | 🌱 Seed |
 | Security headers / secure defaults | 35 | 90 | 55 | +0 | +0 | Some headers via Next defaults; no audited CSP | 🧱 Foundation |
@@ -245,13 +245,13 @@ Status vocabulary: emoji phase derived from Current % per the [Status Lexicon](#
 | Pricing / paywall | 5 | 90 | 85 | +0 | +0 | None | 🌱 Seed |
 | Self-serve signup | 10 | 90 | 80 | +0 | +0 | Tied to auth slice | 🌱 Seed |
 | Onboarding | 15 | 90 | 75 | +0 | +0 | No audited onboarding flow | 🌱 Seed |
-| Support / admin | 10 | 90 | 80 | +0 | +0 | No support surface | 🌱 Seed |
+| Support / admin | 25 | 90 | 65 | +0 | +15 | (FOUNDATION-SWEEP-3) `supportAdminFoundation.ts` defines 6-capability plan (intake / triage / review queue / audit-safe note / demo reset request / escalation policy) with `staffed: false` and `productionAdminEnabled: false` invariants; surfaced on `/support` route; no live staffed support | 🧱 Foundation |
 | Pilot ops | 50 | 90 | 40 | +0 | +0 | `/pilot` CTA live; no funnel instrumentation | 🛠️ Buildout |
 | Analytics | 20 | 90 | 70 | +0 | +0 | No PostHog product-analytics events confirmed end-to-end | 🌱 Seed |
 | Docs / status page | 15 | 90 | 75 | +0 | +0 | No public status page | 🌱 Seed |
 | Legal pages | 60 | 90 | 30 | +0 | +0 | `/privacy` and `/terms` live (#LIVE-100C) | 🛠️ Buildout |
 | Sales / pilot collateral | 25 | 90 | 65 | +0 | +0 | Some pilot pages; no proof-pack | 🧱 Foundation |
-| Demo data / reset flow | 20 | 90 | 70 | +0 | +0 | Issuer review surface uses `recordedBy:'demo'` | 🌱 Seed |
+| Demo data / reset flow | 28 | 90 | 62 | +0 | +8 | Issuer review surface uses `recordedBy:'demo'` + (FOUNDATION-SWEEP-3) `demoResetFoundation.ts` defines 5 demo-bounded reset scopes with `productionResetEnabled: false`, `destructive: false`, and `requiresOperatorConfirmation: true` invariants; surfaced on `/admin/demo-reset` route; no destructive reset logic ships | 🧱 Foundation |
 
 ---
 


### PR DESCRIPTION
## Summary
Five new foundation libraries + four new routes + 31 tests + evidence-backed completion-board deltas on five rows.

| Layer | What ships |
|---|---|
| **Account recovery** (`lib/account-recovery/accountRecoveryFoundation.ts`) | 5 recovery methods (saved code · operator-issued code · recovery contact · repeated identity proofing · support review). Every method `isLive: false`. 5 typed requirements (holder notification · session revocation · repeated identity proofing · support review log · **recovery distinct from authentication**). `evaluateAccountRecoveryReadiness` caps at \`foundation_ready\`; `productionReady: false` always. Disclaimers explicitly negate biometric recovery and any production-recovery claim. |
| **Mobile capture** (`lib/mobile/mobileCaptureFoundation.ts`) | 7-capability checklist (responsive_file_upload · camera_capture_placeholder · document_preview · upload_error_handling · mobile_touch_targets · reduced_motion · degraded_network_notice). Scope hard-coded to `mobile_web_pwa_only`. Disclaimers say native iOS/Android apps not shipped, native camera workflows not enabled, offline sync not implemented. |
| **Degraded state** (`lib/degraded-state/degradedStateFoundation.ts`) | 6-state policy (offline · upstream_unavailable · upload_failed · source_probe_unknown · retry_required · local_draft_only). `offlineSyncImplemented: false` and `sourceOutageIsClinicianDefect: false` invariants are typed literals. Notices carry user-safe heading/body/remediation — no raw stack/payload/secret/token. |
| **Support / admin** (`lib/support-admin/supportAdminFoundation.ts`) | 6-capability plan (intake · triage · review queue · audit-safe note · demo reset request · escalation policy). `staffed: false` and `productionAdminEnabled: false` invariants are typed literals. |
| **Demo reset** (`lib/demo/demoResetFoundation.ts`) | 5 demo-bounded reset scopes. Plan-level `productionResetEnabled: false` and `destructive: false`. Each scope `destructiveToProduction: false` + `requiresOperatorConfirmation: true` as typed literals. |

## New routes (mobile-first, accessibility baseline, semantic regions)
- `/account/recovery` — *"This page describes recovery foundations. Production account recovery is not enabled yet."*
- `/clinician/mobile-capture` — *"Mobile document capture is a web/PWA foundation. Native camera workflows are not enabled yet."*
- `/support` — *"Support and admin are foundation-only this wave. No staffed support is live and no production admin powers are exposed."*
- `/admin/demo-reset` — *"Demo reset plans are non-production and require explicit operator confirmation."*

## Truth rules enforced by tests (31/31 pass)
- Production account recovery is NOT live
- Biometric recovery is NOT live (no method enum, explicit disclaimer)
- Native camera capture is NOT live, native iOS/Android NOT shipped
- Offline sync is NOT implemented
- Support/admin is foundation-only — `staffed: false`, `productionAdminEnabled: false`
- Demo reset is non-production AND non-destructive across every scope
- Recovery is distinct from authentication — typed `reauthorizesSessionOnSuccess: false` on every method
- No source outage produces a clinician-defect signal — typed `sourceOutageIsClinicianDefect: false`

## Completion board deltas (evidence-backed, no row above 90)
| Row | Before | After | Δ | New phase |
|---|---:|---:|---:|---|
| Account recovery | 10 | 25 | **+15** | 🧱 Foundation |
| Mobile document capture | 0 | 25 | **+25** | 🧊 → 🧱 Foundation |
| Offline / degraded-state handling | 25 | 25 | +0 | 🧱 Foundation (evidence note only) |
| Support / admin | 10 | 25 | **+15** | 🧱 Foundation |
| Demo data / reset flow | 20 | 28 | **+8** | 🧱 Foundation |

**Did NOT move** (no implementation evidence shipped this wave): Native iOS app, Native Android app, Biometric gating, Government ID verification, Selfie/liveness, Push notification readiness, Device trust / App Attest / Play Integrity.

## Validation
- `pnpm --filter @vitalcv/web exec vitest run __tests__/foundation-sweep-3.test.ts` → **31/31 pass**
- `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks** (full Next.js production build with TypeScript + ESLint enforcement on per `next.config.mjs`)
- Diff scope: foundation-sweep-3 surface only (5 new lib files, 4 new routes, 1 new test, 1 modified docs file). No backend / source-health / reliability / production-recovery / native-app / secret / migration changes.
- Overclaim scan matches only inside test scaffolding + doc comments + board evidence cells that *describe what's not claimed* — no positive overclaim in user-facing copy.