### PR TITLE
fix(build): document and stabilize web build chain

### DIFF
--- a/docs/ops/vitalcv-build-chain.md
+++ b/docs/ops/vitalcv-build-chain.md
@@ -1,0 +1,82 @@
+# VitalCV Web Build Chain
+
+> **TL;DR**
+> Run `pnpm run build:web` (or `pnpm turbo run build --filter @vitalcv/web`) for any local web build. The bare `pnpm --filter @vitalcv/web build` fails in a fresh worktree because it skips the workspace prebuild step.
+
+## Canonical local web build command
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run build:web
+```
+
+Equivalent direct invocation:
+
+```bash
+pnpm turbo run build --filter @vitalcv/web
+```
+
+`turbo`'s `build` task in `turbo.json` declares `"dependsOn": ["^build"]`, so it walks the workspace dependency graph and prebuilds every workspace package that `@vitalcv/web` imports — most importantly `@vitalcv/trust-state` — before invoking `next build`.
+
+## Why the bare `pnpm --filter @vitalcv/web build` fails in a fresh worktree
+
+Several modules under `apps/web/lib/trust/*` import `@vitalcv/trust-state`, which is a workspace package whose `package.json` declares:
+
+```json
+{
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
+}
+```
+
+i.e. the resolver expects the **compiled** `dist/index.js` artifact, not the raw `src/`. The pnpm workspace symlink alone is not enough — `dist/` only exists after running:
+
+```bash
+pnpm --filter @vitalcv/trust-state build
+```
+
+`turbo run build` handles this automatically via its task-graph `dependsOn: ["^build"]`. A bare `pnpm --filter @vitalcv/web build` does not — it just runs `next build` against an empty `dist/` and fails with:
+
+```
+Module not found: Can't resolve '@vitalcv/trust-state'
+```
+
+at every import site.
+
+## Three supported local commands
+
+| Command | What it does | When to use |
+|---|---|---|
+| `pnpm run build:web` | Wraps `pnpm turbo run build --filter @vitalcv/web`. Prebuilds workspace deps via turbo's task graph, then runs `next build`. | **Default.** Use this for every local web build. |
+| `pnpm run build:web:direct` | Runs `pnpm --filter @vitalcv/trust-state build` then `pnpm --filter @vitalcv/web build`. No turbo. | Fallback when turbo's cache state is suspect or you want to inspect the trust-state build output independently. |
+| `pnpm run build:check-chain` | Runs `scripts/check-web-build-chain.sh`, which exercises the canonical command and prints guidance. | CI smoke / local pre-commit check that the build chain still works. |
+
+## CI behavior
+
+GitHub Actions's `Web Quality` workflow already invokes the turbo path. CI is not affected by the bare-pnpm failure mode — but local contributors hitting it spend ~5–10 min before discovering the workaround. This doc + the new root scripts surface the canonical command.
+
+## Known: `@vitalcv/shared` TS6059 rootDir issue (not fixed in this wave)
+
+Tracked in **issue #195** (BUILD-CHAIN-1). `pnpm --filter @vitalcv/shared build` fails with:
+
+```
+../crs/index.ts(10,8): error TS6059: File '.../packages/crs/CrsEngine.ts' is not under 'rootDir' '.../packages/shared'.
+crs/index.ts(1,75): error TS6059: File '.../packages/crs/index.ts' is not under 'rootDir' '.../packages/shared'.
+```
+
+This is a pre-existing package-boundary issue — `@vitalcv/shared`'s `tsconfig.json` declares `rootDir` as `packages/shared` but pulls source from a sibling `packages/crs` directory that lives outside that root. Candidate fixes are documented in #195 (broaden rootDir, separate package, or formalize project references). **Not fixed in this wave** because the correct fix touches the package boundary between `@vitalcv/shared` and `@vitalcv/crs` and warrants a separate, narrowly-scoped review. The web build does NOT depend on `@vitalcv/shared`'s tsc emit — it imports via the workspace symlink to the package's TypeScript source — so this bug does not block the web build chain.
+
+## Quick reference
+
+```bash
+# Default — what every contributor should run
+pnpm install --frozen-lockfile
+pnpm run build:web
+
+# If you suspect turbo cache, force a clean run
+pnpm install --frozen-lockfile
+pnpm run build:web:direct
+
+# Smoke-check the chain
+pnpm run build:check-chain
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "services/*"
   ],
   "scripts": {
-    "build:web": "pnpm --filter web build",
+    "build:web": "pnpm turbo run build --filter @vitalcv/web",
+    "build:web:direct": "pnpm --filter @vitalcv/trust-state build && pnpm --filter @vitalcv/web build",
+    "build:check-chain": "bash scripts/check-web-build-chain.sh",
     "typecheck": "turbo typecheck",
     "lint": "turbo lint",
     "test": "turbo test",

--- a/scripts/check-web-build-chain.sh
+++ b/scripts/check-web-build-chain.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# scripts/check-web-build-chain.sh
+#
+# BUILD-CHAIN-1 smoke check. Exercises the canonical local web build
+# command (`pnpm turbo run build --filter @vitalcv/web`) and prints
+# guidance on the supported alternatives.
+#
+# Behavior:
+#   - set -euo pipefail (any failure aborts and exits non-zero)
+#   - does NOT mutate source files
+#   - does NOT install dependencies (assumes `pnpm install` has run)
+#   - does NOT carry secrets or upstream payloads
+#
+# Exit code:
+#   - 0 if the canonical web build succeeds
+#   - non-zero if turbo or the underlying `next build` fails
+#
+# See docs/ops/vitalcv-build-chain.md for the full story.
+
+set -euo pipefail
+
+# Always run from the repo root regardless of caller cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[build-chain] Repo root: $REPO_ROOT"
+echo "[build-chain] Canonical command: pnpm turbo run build --filter @vitalcv/web"
+echo "[build-chain] Alternatives:"
+echo "  - pnpm run build:web         (wraps the canonical command)"
+echo "  - pnpm run build:web:direct  (prebuilds @vitalcv/trust-state, then runs next build directly)"
+echo
+
+# Verify pnpm is on PATH; do not silently install.
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[build-chain] ERROR: pnpm is not on PATH. Install pnpm and retry." >&2
+  exit 2
+fi
+
+echo "[build-chain] Running: pnpm turbo run build --filter @vitalcv/web"
+pnpm turbo run build --filter @vitalcv/web
+
+echo
+echo "[build-chain] Web build chain OK."


### PR DESCRIPTION
Fixes the broken root \`build:web\` script and documents the canonical local web build path. Closes / addresses **issue #195** (BUILD-CHAIN-1, partial — see "Out of scope" below).

## Root cause uncovered

`package.json` carried `\"build:web\": \"pnpm --filter web build\"`. **There is no workspace package called just \`web\`** — it's `@vitalcv/web`. The script silently failed for new contributors. CI never hit it because CI uses turbo directly.

The turbo task graph in `turbo.json` already declares `\"dependsOn\": [\"^build\"]` for the `build` task, so the workspace dep graph is correctly modeled. The only broken pieces were the root script + the absence of contributor-visible documentation.

## Files changed (3)

- **`package.json`** — fix `build:web`, add `build:web:direct` and `build:check-chain`:
  ```diff
  - \"build:web\": \"pnpm --filter web build\",
  + \"build:web\": \"pnpm turbo run build --filter @vitalcv/web\",
  + \"build:web:direct\": \"pnpm --filter @vitalcv/trust-state build && pnpm --filter @vitalcv/web build\",
  + \"build:check-chain\": \"bash scripts/check-web-build-chain.sh\",
  ```

- **`docs/ops/vitalcv-build-chain.md`** (new) — documents the canonical command, why bare `pnpm --filter @vitalcv/web build` fails in a fresh worktree (trust-state \`dist/\` not built; \`main\` field in `packages/trust-state/package.json` points at \`dist/index.js\`), and when to use each of the three supported commands.

- **`scripts/check-web-build-chain.sh`** (new, executable) — \`set -euo pipefail\` smoke check that runs the canonical command and prints guidance. Does not mutate source, carries no secrets.

## Truth rules
- No product feature code touched
- No UI route code touched
- No deploy config / CI workflow changes
- No secrets / env / migrations
- The `@vitalcv/shared` TS6059 issue is **not fixed in this wave** — see "Out of scope" below

## Validation
| Command | Result |
|---|---|
| `pnpm run build:web` | ✅ exit 0, turbo 13/13 tasks |
| `pnpm run build:web:direct` (with `.next/` + `trust-state/dist/` cleared) | ✅ exit 0, "Compiled successfully" |
| `pnpm run build:check-chain` (with `.next/` cleared) | ✅ exit 0, turbo 13/13 tasks, guidance printed |

## Out of scope (intentionally — #195 stays open)

The `@vitalcv/shared` TS6059 \`rootDir\` violation (sibling-package source pulled from `packages/crs`) is a separate package-boundary issue documented in #195 with three candidate fixes (broaden \`rootDir\` / move source / formalize project references). Not addressed in this wave because the correct fix touches the boundary between `@vitalcv/shared` and `@vitalcv/crs` and warrants its own narrowly-scoped review. The web build chain does NOT depend on `@vitalcv/shared`'s tsc emit, so this bug does not block the canonical web build path.

## #195 status
Partial close — Issue 1 (build chain) addressed; Issue 2 (`@vitalcv/shared` TS6059) remains open. Recommend keeping #195 open until Issue 2 ships its own PR.