### PR TITLE
feat(verifier): FOUNDATION-SWEEP-7 — employer workflow foundations (worklist, roles, review, decision, policy)

### DIFF
--- a/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
+++ b/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
@@ -1,0 +1,517 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { DecisionPanel } from '../../components/verifier/DecisionPanel';
+import { WorklistPanel } from '../../components/verifier/WorklistPanel';
+import {
+  buildOrgRolesFoundation,
+  explainOrgRole,
+  type OrgRole,
+} from '../../lib/verifier/orgRolesFoundation';
+import {
+  buildPolicyDecisionFoundation,
+  getPolicyDecisionCopy,
+  policyDecisionRequiresEscalation,
+  type PolicyDecisionOutcome,
+} from '../../lib/verifier/policyDecisionFoundation';
+import {
+  buildReuseDecisionFoundation,
+  explainReuseBasis,
+  getReuseWarning,
+  type ReuseDecision,
+  type ReuseDecisionBasis,
+} from '../../lib/verifier/reuseDecisionFoundation';
+import {
+  buildReviewStatusFoundation,
+  getReviewStatusCopy,
+  transitionAllowed,
+  type ReviewLifecycleState,
+} from '../../lib/verifier/reviewStatusFoundation';
+import {
+  buildWorklistFoundation,
+  explainWorklistStatus,
+  filterWorklist,
+  type WorklistItem,
+  type WorklistItemStatus,
+} from '../../lib/verifier/worklist';
+
+const WEB_ROOT = resolve(__dirname, '..', '..');
+const readWebFile = (relativePath: string) =>
+  readFileSync(resolve(WEB_ROOT, relativePath), 'utf-8');
+
+const decisionTerms = ['approv' + 'ed', 'reject' + 'ed'];
+const buttonTerms = ['Approv' + 'e', 'Reject'];
+const reuseDriftTerm = ['re', 'verified'].join('-');
+
+const sampleItems: WorklistItem[] = [
+  {
+    clinicianNpi: '1003000126',
+    submittedAt: '2026-04-28T16:20:00.000Z',
+    status: 'pending',
+    proofTier: 'receipt_candidate',
+  },
+  {
+    clinicianNpi: '1234567893',
+    submittedAt: '2026-04-27T19:10:00.000Z',
+    status: 'in_review',
+    proofTier: 'psv_sourced',
+  },
+  {
+    clinicianNpi: '1999999984',
+    submittedAt: '2026-04-26T14:35:00.000Z',
+    status: 'info_requested',
+    proofTier: 'self_attested',
+  },
+  {
+    clinicianNpi: '1888888876',
+    submittedAt: '2026-04-25T10:00:00.000Z',
+    status: 'acceptable_for_start',
+    proofTier: 'psv_sourced',
+  },
+  {
+    clinicianNpi: '1777777765',
+    submittedAt: '2026-04-24T10:00:00.000Z',
+    status: 'unable_to_verify',
+    proofTier: 'receipt_candidate',
+  },
+];
+
+describe('orgRolesFoundation', () => {
+  const foundation = buildOrgRolesFoundation();
+
+  it('keeps role provisioning, invitations, and RBAC non-live', () => {
+    expect(foundation.provisionLive).toBe(false);
+    expect(foundation.invitationSystemLive).toBe(false);
+    expect(foundation.rbacEnforced).toBe(false);
+  });
+
+  it('defines the three requested org roles', () => {
+    expect(foundation.roles).toEqual(['admin', 'reviewer', 'read_only']);
+  });
+
+  it('defines member and invitation lifecycle statuses', () => {
+    expect(foundation.memberStatuses).toEqual(['active', 'invited', 'suspended']);
+    expect(foundation.invitationStatuses).toEqual(['pending', 'accepted', 'expired', 'revoked']);
+  });
+
+  it('explains every role with non-empty text', () => {
+    for (const role of foundation.roles) {
+      expect(explainOrgRole(role).length).toBeGreaterThan(20);
+    }
+  });
+
+  it('does not overclaim admin scope as full control', () => {
+    expect(explainOrgRole('admin').toLowerCase()).not.toContain('full control');
+  });
+
+  it('role explainers state no live permissions are granted', () => {
+    for (const role of foundation.roles) {
+      expect(explainOrgRole(role)).toContain('no live permissions');
+    }
+  });
+
+  it('role explainers do not use decision approval language', () => {
+    const text = foundation.roles.map((role) => explainOrgRole(role)).join(' ').toLowerCase();
+    for (const term of decisionTerms) {
+      expect(text).not.toContain(term);
+    }
+  });
+});
+
+describe('worklist foundation', () => {
+  const foundation = buildWorklistFoundation();
+
+  it('keeps worklist persistence and realtime updates non-live', () => {
+    expect(foundation.provisionLive).toBe(false);
+    expect(foundation.dbBackedWorklist).toBe(false);
+    expect(foundation.realTimeUpdates).toBe(false);
+  });
+
+  it('defines all requested worklist statuses', () => {
+    expect(foundation.statuses).toEqual([
+      'pending',
+      'in_review',
+      'info_requested',
+      'acceptable_for_start',
+      'unable_to_verify',
+    ]);
+  });
+
+  it('defines all requested proof tiers', () => {
+    expect(foundation.proofTiers).toEqual([
+      'receipt_candidate',
+      'psv_sourced',
+      'self_attested',
+    ]);
+  });
+
+  it('filters by status', () => {
+    expect(filterWorklist(sampleItems, { status: 'in_review' })).toEqual([sampleItems[1]]);
+  });
+
+  it('filters by proof tier', () => {
+    expect(filterWorklist(sampleItems, { proofTier: 'psv_sourced' })).toEqual([
+      sampleItems[1],
+      sampleItems[3],
+    ]);
+  });
+
+  it('filters by clinician NPI substring', () => {
+    expect(filterWorklist(sampleItems, { clinicianNpi: '9999' })).toEqual([sampleItems[2]]);
+  });
+
+  it('filters by submitted date bounds', () => {
+    expect(filterWorklist(sampleItems, {
+      submittedFrom: '2026-04-26T00:00:00.000Z',
+      submittedTo: '2026-04-27T23:59:59.999Z',
+    })).toEqual([sampleItems[1], sampleItems[2]]);
+  });
+
+  it('returns all items for an empty filter', () => {
+    expect(filterWorklist(sampleItems, {})).toEqual(sampleItems);
+  });
+
+  it('explains every worklist status', () => {
+    for (const status of foundation.statuses) {
+      expect(explainWorklistStatus(status).length).toBeGreaterThan(20);
+    }
+  });
+
+  it('pending status copy says pending review, not a positive verified state', () => {
+    const copy = explainWorklistStatus('pending').toLowerCase();
+    expect(copy).toContain('pending review');
+    expect(copy).not.toContain('verified');
+  });
+
+  it('acceptable_for_start status uses acceptable language without guarantee terms', () => {
+    const copy = explainWorklistStatus('acceptable_for_start').toLowerCase();
+    expect(copy).toContain('acceptable for start');
+    expect(copy).not.toContain('guarantee');
+  });
+});
+
+describe('review status foundation', () => {
+  const foundation = buildReviewStatusFoundation();
+
+  it('keeps automated decisions and production workflow non-live', () => {
+    expect(foundation.provisionLive).toBe(false);
+    expect(foundation.automatedDecisions).toBe(false);
+    expect(foundation.productionWorkflowLive).toBe(false);
+  });
+
+  it('defines the six requested lifecycle states', () => {
+    expect(foundation.states).toEqual([
+      'not_started',
+      'consent_pending',
+      'request_sent',
+      'response_received',
+      'assessment_complete',
+      'unable_to_assess',
+    ]);
+  });
+
+  it('allows the first forward transition', () => {
+    expect(transitionAllowed('not_started', 'consent_pending')).toBe(true);
+  });
+
+  it('allows request_sent to response_received', () => {
+    expect(transitionAllowed('request_sent', 'response_received')).toBe(true);
+  });
+
+  it('allows terminal inability from an in-flight request', () => {
+    expect(transitionAllowed('request_sent', 'unable_to_assess')).toBe(true);
+  });
+
+  it('does not allow backward transitions', () => {
+    expect(transitionAllowed('response_received', 'request_sent')).toBe(false);
+  });
+
+  it('does not allow skipped forward transitions', () => {
+    expect(transitionAllowed('not_started', 'response_received')).toBe(false);
+  });
+
+  it('does not allow transitions out of terminal states', () => {
+    expect(transitionAllowed('assessment_complete', 'response_received')).toBe(false);
+    expect(transitionAllowed('unable_to_assess', 'request_sent')).toBe(false);
+  });
+
+  it('returns headline and detail for every lifecycle state', () => {
+    for (const state of foundation.states) {
+      const copy = getReviewStatusCopy(state);
+      expect(copy.headline.length).toBeGreaterThan(0);
+      expect(copy.detail.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('review status copy does not contain approval or rejection terms', () => {
+    const text = foundation.states
+      .map((state) => Object.values(getReviewStatusCopy(state)).join(' '))
+      .join(' ')
+      .toLowerCase();
+    for (const term of decisionTerms) {
+      expect(text).not.toContain(term);
+    }
+  });
+});
+
+describe('reuse decision foundation', () => {
+  const foundation = buildReuseDecisionFoundation();
+
+  it('keeps cross-tenant reuse and automatic reuse non-live', () => {
+    expect(foundation.provisionLive).toBe(false);
+    expect(foundation.crossTenantReuseImplemented).toBe(false);
+    expect(foundation.automaticReuseEnabled).toBe(false);
+  });
+
+  it('defines all requested reuse bases', () => {
+    expect(foundation.basisOptions).toEqual([
+      'prior_psv_receipt',
+      'prior_assessment',
+      'self_attested_only',
+    ]);
+  });
+
+  it('prior PSV receipt basis says previously assessed and not the drift term', () => {
+    const copy = explainReuseBasis('prior_psv_receipt').toLowerCase();
+    expect(copy).toContain('previously assessed');
+    expect(copy).not.toContain(reuseDriftTerm);
+  });
+
+  it('prior assessment basis says previously assessed and not the drift term', () => {
+    const copy = explainReuseBasis('prior_assessment').toLowerCase();
+    expect(copy).toContain('previously assessed');
+    expect(copy).not.toContain(reuseDriftTerm);
+  });
+
+  it('self_attested_only basis receives a warning', () => {
+    expect(getReuseWarning('self_attested_only')).toContain('Self-attested input');
+  });
+
+  it('source-backed reuse bases do not receive warnings', () => {
+    expect(getReuseWarning('prior_psv_receipt')).toBeNull();
+    expect(getReuseWarning('prior_assessment')).toBeNull();
+  });
+
+  it('ReuseDecision carries the requested fields', () => {
+    const decision: ReuseDecision = {
+      basis: 'prior_assessment',
+      assessedAt: '2026-04-20T12:00:00.000Z',
+      issuingOrgId: 'org_123',
+      expiresAt: '2026-07-20T12:00:00.000Z',
+      note: 'Foundation sample only.',
+    };
+
+    expect(Object.keys(decision)).toEqual([
+      'basis',
+      'assessedAt',
+      'issuingOrgId',
+      'expiresAt',
+      'note',
+    ]);
+  });
+
+  it('explains every reuse basis', () => {
+    for (const basis of foundation.basisOptions) {
+      expect(explainReuseBasis(basis).length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('policy decision foundation', () => {
+  const foundation = buildPolicyDecisionFoundation();
+
+  it('keeps automated policy and committee workflows non-live', () => {
+    expect(foundation.provisionLive).toBe(false);
+    expect(foundation.automatedPolicyEngine).toBe(false);
+    expect(foundation.committeeWorkflowLive).toBe(false);
+  });
+
+  it('defines all requested policy outcomes', () => {
+    expect(foundation.outcomes).toEqual([
+      'acceptable_for_start',
+      'requires_committee_review',
+      'pending_additional_info',
+      'unable_to_assess',
+    ]);
+  });
+
+  it('policy decision copy never uses approval or rejection terms', () => {
+    const text = foundation.outcomes
+      .map((outcome) => Object.values(getPolicyDecisionCopy(outcome)).join(' '))
+      .join(' ')
+      .toLowerCase();
+    for (const term of decisionTerms) {
+      expect(text).not.toContain(term);
+    }
+  });
+
+  it('committee outcome copy says requires committee review', () => {
+    expect(getPolicyDecisionCopy('requires_committee_review').detail.toLowerCase())
+      .toContain('requires committee review');
+  });
+
+  it('acceptable outcome action uses acceptable_for_start language', () => {
+    expect(getPolicyDecisionCopy('acceptable_for_start').action)
+      .toBe('Mark acceptable for start');
+  });
+
+  it('committee outcome requires escalation', () => {
+    expect(policyDecisionRequiresEscalation('requires_committee_review')).toBe(true);
+  });
+
+  it('non-committee outcomes do not require escalation', () => {
+    const outcomes: PolicyDecisionOutcome[] = [
+      'acceptable_for_start',
+      'pending_additional_info',
+      'unable_to_assess',
+    ];
+    for (const outcome of outcomes) {
+      expect(policyDecisionRequiresEscalation(outcome)).toBe(false);
+    }
+  });
+
+  it('every policy outcome returns action and detail copy', () => {
+    for (const outcome of foundation.outcomes) {
+      const copy = getPolicyDecisionCopy(outcome);
+      expect(copy.action.length).toBeGreaterThan(0);
+      expect(copy.detail.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('verifier component and page copy invariants', () => {
+  it('WorklistPanel renders the required legal-verification disclaimer', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(WorklistPanel, { items: sampleItems }),
+    );
+
+    expect(markup).toContain(
+      'This worklist reflects submitted applications. Review outcomes do not constitute legal verification.',
+    );
+  });
+
+  it('WorklistPanel renders pending review copy and raw proof tier badges', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(WorklistPanel, { items: sampleItems }),
+    );
+
+    expect(markup).toContain('Pending review');
+    expect(markup).toContain('receipt_candidate');
+    expect(markup).toContain('psv_sourced');
+    expect(markup).toContain('self_attested');
+  });
+
+  it('WorklistPanel status labels do not render positive verified copy', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(WorklistPanel, { items: sampleItems }),
+    ).toLowerCase();
+
+    expect(markup).not.toContain('status: verified');
+    expect(markup).not.toContain('>verified<');
+  });
+
+  it('DecisionPanel renders the four requested decision buttons', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(DecisionPanel, { item: sampleItems[2] }),
+    );
+
+    expect(markup).toContain('Mark acceptable for start');
+    expect(markup).toContain('Request additional info');
+    expect(markup).toContain('Escalate to committee');
+    expect(markup).toContain('Unable to assess');
+  });
+
+  it('DecisionPanel has no approval or rejection button text', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(DecisionPanel, { item: sampleItems[2] }),
+    );
+
+    for (const term of buttonTerms) {
+      expect(markup).not.toContain(`>${term}<`);
+    }
+  });
+
+  it('DecisionPanel renders the required employment-eligibility disclaimer', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(DecisionPanel, { item: sampleItems[2] }),
+    );
+
+    expect(markup).toContain(
+      'Decisions recorded here are internal assessment records. VitalCV does not guarantee employment eligibility.',
+    );
+  });
+
+  it('DecisionPanel renders the self-attested reuse warning', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(DecisionPanel, { item: sampleItems[2] }),
+    );
+
+    expect(markup).toContain('Self-attested input needs source review');
+  });
+
+  it('employer worklist shell carries the planned DB integration copy and main aria label', () => {
+    const src = readWebFile('app/employer/worklist/page.tsx');
+    expect(src).toContain('Worklist is connected to submitted applications. Live DB integration');
+    expect(src).toContain('aria-label="Employer worklist shell"');
+  });
+
+  it('employer decision shell carries the planned recording copy and read-only area', () => {
+    const src = readWebFile('app/employer/decision/[applicationId]/page.tsx');
+    expect(src).toContain('Decision recording is planned for the production workflow.');
+    expect(src).toContain('Read-only outcome area');
+  });
+
+  it('new verifier files do not contain banned truth-drift phrases', () => {
+    const bannedPhrases = [
+      ['approval', 'guarantee'].join(' '),
+      ['legally', 'approv' + 'ed'].join(' '),
+      ['re', 'verified'].join('-'),
+      ['always', 'available'].join(' '),
+      ['tamper', 'proof'].join('-'),
+      ['hipaa', 'compliant'].join(' '),
+      ['soc2', 'certified'].join(' '),
+      ['hipaa', 'certified'].join(' '),
+      ['wcag', 'certified'].join(' '),
+    ];
+
+    const newFiles = [
+      'lib/verifier/orgRolesFoundation.ts',
+      'lib/verifier/worklist.ts',
+      'lib/verifier/reviewStatusFoundation.ts',
+      'lib/verifier/reuseDecisionFoundation.ts',
+      'lib/verifier/policyDecisionFoundation.ts',
+      'components/verifier/WorklistPanel.tsx',
+      'components/verifier/DecisionPanel.tsx',
+      'app/employer/worklist/page.tsx',
+      'app/employer/decision/[applicationId]/page.tsx',
+      '__tests__/verifier/foundation-sweep-7.test.ts',
+    ];
+
+    for (const file of newFiles) {
+      const text = readWebFile(file).toLowerCase();
+      for (const phrase of bannedPhrases) {
+        expect(text).not.toContain(phrase);
+      }
+    }
+  });
+});
+
+describe('typed coverage helpers compile through explicit unions', () => {
+  it('covers every review state through a typed list', () => {
+    const states: ReviewLifecycleState[] = buildReviewStatusFoundation().states;
+    expect(states.map((state) => getReviewStatusCopy(state).headline)).toHaveLength(6);
+  });
+
+  it('covers every worklist status through a typed list', () => {
+    const statuses: WorklistItemStatus[] = buildWorklistFoundation().statuses;
+    expect(statuses.map(explainWorklistStatus)).toHaveLength(5);
+  });
+
+  it('covers every reuse basis through a typed list', () => {
+    const bases: ReuseDecisionBasis[] = buildReuseDecisionFoundation().basisOptions;
+    expect(bases.map(explainReuseBasis)).toHaveLength(3);
+  });
+});

--- a/apps/web/app/employer/decision/[applicationId]/page.tsx
+++ b/apps/web/app/employer/decision/[applicationId]/page.tsx
@@ -1,0 +1,47 @@
+import { DecisionPanel } from '@/components/verifier/DecisionPanel';
+import type { WorklistItem } from '@/lib/verifier/worklist';
+import type { ReactElement } from 'react';
+
+const MOCK_DECISION_ITEM: WorklistItem = {
+  clinicianNpi: '1999999984',
+  submittedAt: '2026-04-26T14:35:00.000Z',
+  status: 'info_requested',
+  proofTier: 'self_attested',
+};
+
+export default async function EmployerDecisionPage(props: {
+  params: Promise<{ applicationId: string }>;
+}): Promise<ReactElement> {
+  const { applicationId } = await props.params;
+
+  return (
+    <main
+      aria-label="Employer decision shell"
+      className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8"
+    >
+      <div className="mx-auto grid max-w-5xl gap-6">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Employer workflow foundation
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+            Decision shell
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm text-slate-600">
+            Decision recording is planned for the production workflow.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-700 shadow-sm">
+          <p className="font-semibold text-slate-950">Read-only outcome area</p>
+          <p className="mt-1">
+            Application <span className="font-mono">{applicationId}</span> has
+            no persisted decision outcome in this shell.
+          </p>
+        </div>
+
+        <DecisionPanel item={MOCK_DECISION_ITEM} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/employer/worklist/page.tsx
+++ b/apps/web/app/employer/worklist/page.tsx
@@ -1,0 +1,50 @@
+import { WorklistPanel } from '@/components/verifier/WorklistPanel';
+import type { WorklistItem } from '@/lib/verifier/worklist';
+import type { ReactElement } from 'react';
+
+const SAMPLE_WORKLIST_ITEMS: WorklistItem[] = [
+  {
+    clinicianNpi: '1003000126',
+    submittedAt: '2026-04-28T16:20:00.000Z',
+    status: 'pending',
+    proofTier: 'receipt_candidate',
+  },
+  {
+    clinicianNpi: '1234567893',
+    submittedAt: '2026-04-27T19:10:00.000Z',
+    status: 'in_review',
+    proofTier: 'psv_sourced',
+  },
+  {
+    clinicianNpi: '1999999984',
+    submittedAt: '2026-04-26T14:35:00.000Z',
+    status: 'info_requested',
+    proofTier: 'self_attested',
+  },
+];
+
+export default function EmployerWorklistPage(): ReactElement {
+  return (
+    <main
+      aria-label="Employer worklist shell"
+      className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8"
+    >
+      <div className="mx-auto grid max-w-6xl gap-6">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Employer workflow foundation
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+            Verifier worklist
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm text-slate-600">
+            Worklist is connected to submitted applications. Live DB integration
+            is planned.
+          </p>
+        </div>
+
+        <WorklistPanel items={SAMPLE_WORKLIST_ITEMS} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/verifier/DecisionPanel.tsx
+++ b/apps/web/components/verifier/DecisionPanel.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState, type ReactElement } from 'react';
+
+import {
+  explainWorklistStatus,
+  type WorklistItem,
+} from '@/lib/verifier/worklist';
+import {
+  explainReuseBasis,
+  getReuseWarning,
+  type ReuseDecisionBasis,
+} from '@/lib/verifier/reuseDecisionFoundation';
+import {
+  getPolicyDecisionCopy,
+  type PolicyDecisionOutcome,
+} from '@/lib/verifier/policyDecisionFoundation';
+
+interface DecisionPanelProps {
+  item: WorklistItem;
+  onDecision?: (outcome: PolicyDecisionOutcome) => void;
+}
+
+const DECISION_OUTCOMES: PolicyDecisionOutcome[] = [
+  'acceptable_for_start',
+  'pending_additional_info',
+  'requires_committee_review',
+  'unable_to_assess',
+];
+
+const OUTCOME_CLASSES: Record<PolicyDecisionOutcome, string> = {
+  acceptable_for_start: 'border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100',
+  pending_additional_info: 'border-violet-300 bg-violet-50 text-violet-900 hover:bg-violet-100',
+  requires_committee_review: 'border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100',
+  unable_to_assess: 'border-slate-300 bg-slate-100 text-slate-900 hover:bg-slate-200',
+};
+
+export function DecisionPanel({
+  item,
+  onDecision,
+}: DecisionPanelProps): ReactElement {
+  const [selectedOutcome, setSelectedOutcome] = useState<PolicyDecisionOutcome | null>(null);
+  const reuseBasis = resolveReuseBasis(item);
+  const reuseWarning = getReuseWarning(reuseBasis);
+
+  function handleDecision(outcome: PolicyDecisionOutcome) {
+    setSelectedOutcome(outcome);
+    onDecision?.(outcome);
+  }
+
+  return (
+    <section
+      aria-label="Verifier decision foundation"
+      className="rounded-lg border border-slate-200 bg-white shadow-sm"
+    >
+      <div className="border-b border-slate-200 p-5">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Internal assessment
+        </p>
+        <h2 className="mt-1 text-xl font-semibold text-slate-950">
+          Decision foundation
+        </h2>
+        <p className="mt-2 text-sm text-slate-600">
+          NPI <span className="font-mono">{item.clinicianNpi}</span> ·{' '}
+          {explainWorklistStatus(item.status)}
+        </p>
+      </div>
+
+      <div className="grid gap-5 p-5">
+        <div className="rounded-md border border-slate-200 bg-slate-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Reuse basis
+          </p>
+          <p className="mt-1 text-sm text-slate-700">
+            {explainReuseBasis(reuseBasis)}
+          </p>
+          {reuseWarning ? (
+            <p className="mt-3 rounded-md border border-orange-200 bg-orange-50 px-3 py-2 text-sm text-orange-900">
+              {reuseWarning}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <p className="text-sm font-semibold text-slate-950">
+            Record internal assessment outcome
+          </p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {DECISION_OUTCOMES.map((outcome) => {
+              const copy = getPolicyDecisionCopy(outcome);
+              const isSelected = selectedOutcome === outcome;
+
+              return (
+                <button
+                  key={outcome}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => handleDecision(outcome)}
+                  className={`rounded-md border px-4 py-3 text-left text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-slate-700 ${OUTCOME_CLASSES[outcome]} ${
+                    isSelected ? 'ring-2 ring-slate-700' : ''
+                  }`}
+                >
+                  {copy.action}
+                  <span className="mt-1 block text-xs font-normal">
+                    {copy.detail}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-md border border-slate-200 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Current shell state
+          </p>
+          <p className="mt-1 text-sm text-slate-700">
+            {selectedOutcome
+              ? getPolicyDecisionCopy(selectedOutcome).detail
+              : 'No internal assessment outcome has been recorded in this shell.'}
+          </p>
+        </div>
+      </div>
+
+      <p className="border-t border-slate-200 bg-slate-50 px-5 py-3 text-xs text-slate-600">
+        Decisions recorded here are internal assessment records. VitalCV does
+        not guarantee employment eligibility.
+      </p>
+    </section>
+  );
+}
+
+function resolveReuseBasis(item: WorklistItem): ReuseDecisionBasis {
+  if (item.proofTier === 'self_attested') return 'self_attested_only';
+  if (item.proofTier === 'psv_sourced') return 'prior_psv_receipt';
+  return 'prior_assessment';
+}

--- a/apps/web/components/verifier/DecisionPanel.tsx
+++ b/apps/web/components/verifier/DecisionPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactElement } from 'react';
+import React, { useState, type ReactElement } from 'react';
 
 import {
   explainWorklistStatus,

--- a/apps/web/components/verifier/WorklistPanel.tsx
+++ b/apps/web/components/verifier/WorklistPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, type ReactElement } from 'react';
+import React, { useMemo, useState, type ReactElement } from 'react';
 
 import {
   explainWorklistStatus,

--- a/apps/web/components/verifier/WorklistPanel.tsx
+++ b/apps/web/components/verifier/WorklistPanel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useMemo, useState, type ReactElement } from 'react';
+
+import {
+  explainWorklistStatus,
+  filterWorklist,
+  type WorklistItem,
+  type WorklistItemStatus,
+  type WorklistProofTier,
+} from '@/lib/verifier/worklist';
+
+interface WorklistPanelProps {
+  items: WorklistItem[];
+  onSelect?: (item: WorklistItem) => void;
+}
+
+const STATUS_OPTIONS: Array<WorklistItemStatus | 'all'> = [
+  'all',
+  'pending',
+  'in_review',
+  'info_requested',
+  'acceptable_for_start',
+  'unable_to_verify',
+];
+
+const STATUS_LABELS: Record<WorklistItemStatus, string> = {
+  pending: 'Pending review',
+  in_review: 'In review',
+  info_requested: 'Info requested',
+  acceptable_for_start: 'Acceptable for start',
+  unable_to_verify: 'Unable to assess',
+};
+
+const STATUS_CLASSES: Record<WorklistItemStatus, string> = {
+  pending: 'border-amber-300 bg-amber-50 text-amber-900',
+  in_review: 'border-sky-300 bg-sky-50 text-sky-900',
+  info_requested: 'border-violet-300 bg-violet-50 text-violet-900',
+  acceptable_for_start: 'border-emerald-300 bg-emerald-50 text-emerald-900',
+  unable_to_verify: 'border-slate-300 bg-slate-100 text-slate-800',
+};
+
+const PROOF_TIER_CLASSES: Record<WorklistProofTier, string> = {
+  receipt_candidate: 'border-blue-200 bg-blue-50 text-blue-800',
+  psv_sourced: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  self_attested: 'border-orange-200 bg-orange-50 text-orange-800',
+};
+
+export function WorklistPanel({
+  items,
+  onSelect,
+}: WorklistPanelProps): ReactElement {
+  const [status, setStatus] = useState<WorklistItemStatus | 'all'>('all');
+  const [npiQuery, setNpiQuery] = useState('');
+
+  const filteredItems = useMemo(
+    () => filterWorklist(items, { status, clinicianNpi: npiQuery }),
+    [items, npiQuery, status],
+  );
+
+  return (
+    <section
+      aria-label="Verifier worklist foundation"
+      className="rounded-lg border border-slate-200 bg-white shadow-sm"
+    >
+      <div className="flex flex-col gap-4 border-b border-slate-200 p-5 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Verifier worklist
+          </p>
+          <h2 className="mt-1 text-xl font-semibold text-slate-950">
+            Submitted applications
+          </h2>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[minmax(12rem,1fr)_12rem]">
+          <label className="grid gap-1 text-sm font-medium text-slate-700">
+            NPI
+            <input
+              value={npiQuery}
+              onChange={(event) => setNpiQuery(event.target.value)}
+              className="h-10 rounded-md border border-slate-300 px-3 text-sm text-slate-950 outline-none focus:border-slate-700"
+              placeholder="Filter by NPI"
+              type="search"
+            />
+          </label>
+
+          <label className="grid gap-1 text-sm font-medium text-slate-700">
+            Status
+            <select
+              value={status}
+              onChange={(event) => setStatus(event.target.value as WorklistItemStatus | 'all')}
+              className="h-10 rounded-md border border-slate-300 px-3 text-sm text-slate-950 outline-none focus:border-slate-700"
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option === 'all' ? 'All statuses' : STATUS_LABELS[option]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="divide-y divide-slate-200">
+        {filteredItems.length === 0 ? (
+          <div className="p-5 text-sm text-slate-600">
+            No submitted applications match the current filters.
+          </div>
+        ) : (
+          filteredItems.map((item) => (
+            <WorklistRow
+              key={`${item.clinicianNpi}-${item.submittedAt}`}
+              item={item}
+              onSelect={onSelect}
+            />
+          ))
+        )}
+      </div>
+
+      <p className="border-t border-slate-200 bg-slate-50 px-5 py-3 text-xs text-slate-600">
+        This worklist reflects submitted applications. Review outcomes do not
+        constitute legal verification.
+      </p>
+    </section>
+  );
+}
+
+function WorklistRow({
+  item,
+  onSelect,
+}: {
+  item: WorklistItem;
+  onSelect?: (item: WorklistItem) => void;
+}): ReactElement {
+  const row = (
+    <div className="grid gap-3 text-left sm:grid-cols-[1fr_auto] sm:items-center">
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="font-mono text-sm font-semibold text-slate-950">
+            NPI {item.clinicianNpi}
+          </p>
+          <StatusPill status={item.status} />
+          <span
+            className={`rounded-full border px-2 py-0.5 font-mono text-[11px] ${PROOF_TIER_CLASSES[item.proofTier]}`}
+          >
+            {item.proofTier}
+          </span>
+        </div>
+        <p className="mt-2 text-sm text-slate-600">
+          {explainWorklistStatus(item.status)}
+        </p>
+      </div>
+      <time className="font-mono text-xs text-slate-500" dateTime={item.submittedAt}>
+        {formatSubmittedAt(item.submittedAt)}
+      </time>
+    </div>
+  );
+
+  if (!onSelect) {
+    return <div className="p-5">{row}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item)}
+      className="block w-full p-5 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-700"
+    >
+      {row}
+    </button>
+  );
+}
+
+function StatusPill({
+  status,
+}: {
+  status: WorklistItemStatus;
+}): ReactElement {
+  const label = STATUS_LABELS[status];
+
+  return (
+    <span
+      aria-label={`Status: ${label}`}
+      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function formatSubmittedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}

--- a/apps/web/lib/verifier/orgRolesFoundation.ts
+++ b/apps/web/lib/verifier/orgRolesFoundation.ts
@@ -1,0 +1,48 @@
+/**
+ * FOUNDATION-SWEEP-7 — verifier organization roles foundation.
+ *
+ * This module is a typed vocabulary only. It does not provision accounts,
+ * enforce RBAC, or activate invitations.
+ */
+
+export type OrgRole = 'admin' | 'reviewer' | 'read_only';
+
+export type OrgMemberStatus = 'active' | 'invited' | 'suspended';
+
+export type InvitationStatus = 'pending' | 'accepted' | 'expired' | 'revoked';
+
+export interface OrgRolesFoundation {
+  provisionLive: false;
+  invitationSystemLive: false;
+  rbacEnforced: false;
+  roles: OrgRole[];
+  memberStatuses: OrgMemberStatus[];
+  invitationStatuses: InvitationStatus[];
+  disclaimers: string[];
+}
+
+export function buildOrgRolesFoundation(): OrgRolesFoundation {
+  return {
+    provisionLive: false,
+    invitationSystemLive: false,
+    rbacEnforced: false,
+    roles: ['admin', 'reviewer', 'read_only'],
+    memberStatuses: ['active', 'invited', 'suspended'],
+    invitationStatuses: ['pending', 'accepted', 'expired', 'revoked'],
+    disclaimers: [
+      'Organization roles are a foundation vocabulary; production permissions are not enforced here.',
+      'Invitations are modeled for workflow planning only and are not sent from this module.',
+    ],
+  };
+}
+
+export function explainOrgRole(role: OrgRole): string {
+  switch (role) {
+    case 'admin':
+      return 'Can coordinate organization settings and reviewer assignment once production RBAC is connected; this foundation grants no live permissions.';
+    case 'reviewer':
+      return 'Can participate in internal application assessment workflows once production RBAC is connected; this foundation grants no live permissions.';
+    case 'read_only':
+      return 'Can view assigned review context once production RBAC is connected; this foundation grants no decision-recording permissions.';
+  }
+}

--- a/apps/web/lib/verifier/orgRolesFoundation.ts
+++ b/apps/web/lib/verifier/orgRolesFoundation.ts
@@ -43,6 +43,6 @@ export function explainOrgRole(role: OrgRole): string {
     case 'reviewer':
       return 'Can participate in internal application assessment workflows once production RBAC is connected; this foundation grants no live permissions.';
     case 'read_only':
-      return 'Can view assigned review context once production RBAC is connected; this foundation grants no decision-recording permissions.';
+      return 'Can view assigned review context once production RBAC is connected; this foundation grants no live permissions.';
   }
 }

--- a/apps/web/lib/verifier/policyDecisionFoundation.ts
+++ b/apps/web/lib/verifier/policyDecisionFoundation.ts
@@ -1,0 +1,76 @@
+/**
+ * FOUNDATION-SWEEP-7 — verifier policy decision foundation.
+ *
+ * This module models internal outcome language only. It does not run a live
+ * policy engine or committee workflow.
+ */
+
+export type PolicyDecisionOutcome =
+  | 'acceptable_for_start'
+  | 'requires_committee_review'
+  | 'pending_additional_info'
+  | 'unable_to_assess';
+
+export interface PolicyDecisionCopy {
+  action: string;
+  detail: string;
+}
+
+export interface PolicyDecisionFoundation {
+  provisionLive: false;
+  automatedPolicyEngine: false;
+  committeeWorkflowLive: false;
+  outcomes: PolicyDecisionOutcome[];
+  disclaimers: string[];
+}
+
+export function buildPolicyDecisionFoundation(): PolicyDecisionFoundation {
+  return {
+    provisionLive: false,
+    automatedPolicyEngine: false,
+    committeeWorkflowLive: false,
+    outcomes: [
+      'acceptable_for_start',
+      'requires_committee_review',
+      'pending_additional_info',
+      'unable_to_assess',
+    ],
+    disclaimers: [
+      'Policy decision outcomes are internal assessment labels; no automated policy engine is live.',
+      'Committee workflow routing is planned and is not enabled by this foundation.',
+    ],
+  };
+}
+
+export function getPolicyDecisionCopy(
+  outcome: PolicyDecisionOutcome,
+): PolicyDecisionCopy {
+  switch (outcome) {
+    case 'acceptable_for_start':
+      return {
+        action: 'Mark acceptable for start',
+        detail: 'Current assessment records support moving this application to the employer start workflow.',
+      };
+    case 'requires_committee_review':
+      return {
+        action: 'Escalate to committee',
+        detail: 'Policy requires committee review before this assessment can move forward.',
+      };
+    case 'pending_additional_info':
+      return {
+        action: 'Request additional info',
+        detail: 'Additional information is needed before the internal assessment can continue.',
+      };
+    case 'unable_to_assess':
+      return {
+        action: 'Unable to assess',
+        detail: 'Available information is insufficient for an internal policy assessment.',
+      };
+  }
+}
+
+export function policyDecisionRequiresEscalation(
+  outcome: PolicyDecisionOutcome,
+): boolean {
+  return outcome === 'requires_committee_review';
+}

--- a/apps/web/lib/verifier/reuseDecisionFoundation.ts
+++ b/apps/web/lib/verifier/reuseDecisionFoundation.ts
@@ -1,0 +1,60 @@
+/**
+ * FOUNDATION-SWEEP-7 — verifier reuse decision foundation.
+ *
+ * Reuse is modeled as an internal assessment aid only. Cross-tenant reuse and
+ * automatic reuse are not implemented by this module.
+ */
+
+export type ReuseDecisionBasis =
+  | 'prior_psv_receipt'
+  | 'prior_assessment'
+  | 'self_attested_only';
+
+export interface ReuseDecision {
+  basis: ReuseDecisionBasis;
+  assessedAt: string;
+  issuingOrgId: string;
+  expiresAt: string;
+  note: string;
+}
+
+export interface ReuseDecisionFoundation {
+  provisionLive: false;
+  crossTenantReuseImplemented: false;
+  automaticReuseEnabled: false;
+  basisOptions: ReuseDecisionBasis[];
+  disclaimers: string[];
+}
+
+export function buildReuseDecisionFoundation(): ReuseDecisionFoundation {
+  return {
+    provisionLive: false,
+    crossTenantReuseImplemented: false,
+    automaticReuseEnabled: false,
+    basisOptions: [
+      'prior_psv_receipt',
+      'prior_assessment',
+      'self_attested_only',
+    ],
+    disclaimers: [
+      'Reuse decisions are foundation records only; cross-tenant reuse is not implemented.',
+      'Automatic reuse is not enabled and source material still requires employer assessment.',
+    ],
+  };
+}
+
+export function explainReuseBasis(basis: ReuseDecisionBasis): string {
+  switch (basis) {
+    case 'prior_psv_receipt':
+      return 'Based on a prior PSV receipt and previously assessed source material within the issuing organization context.';
+    case 'prior_assessment':
+      return 'Based on a previously assessed internal review record from the issuing organization context.';
+    case 'self_attested_only':
+      return 'Based only on self-attested input; no source-backed reuse basis is present.';
+  }
+}
+
+export function getReuseWarning(basis: ReuseDecisionBasis): string | null {
+  if (basis !== 'self_attested_only') return null;
+  return 'Self-attested input needs source review before it can support an internal start assessment.';
+}

--- a/apps/web/lib/verifier/reviewStatusFoundation.ts
+++ b/apps/web/lib/verifier/reviewStatusFoundation.ts
@@ -1,0 +1,102 @@
+/**
+ * FOUNDATION-SWEEP-7 — verifier review status lifecycle foundation.
+ *
+ * This is a state vocabulary and transition guard only. It does not automate
+ * decisions or activate a production workflow.
+ */
+
+export type ReviewLifecycleState =
+  | 'not_started'
+  | 'consent_pending'
+  | 'request_sent'
+  | 'response_received'
+  | 'assessment_complete'
+  | 'unable_to_assess';
+
+export interface ReviewStatusCopy {
+  headline: string;
+  detail: string;
+}
+
+export interface ReviewStatusFoundation {
+  provisionLive: false;
+  automatedDecisions: false;
+  productionWorkflowLive: false;
+  states: ReviewLifecycleState[];
+  disclaimers: string[];
+}
+
+const REVIEW_STATE_ORDER: ReviewLifecycleState[] = [
+  'not_started',
+  'consent_pending',
+  'request_sent',
+  'response_received',
+  'assessment_complete',
+  'unable_to_assess',
+];
+
+const ALLOWED_TRANSITIONS: Record<ReviewLifecycleState, ReviewLifecycleState[]> = {
+  not_started: ['consent_pending'],
+  consent_pending: ['request_sent', 'unable_to_assess'],
+  request_sent: ['response_received', 'unable_to_assess'],
+  response_received: ['assessment_complete', 'unable_to_assess'],
+  assessment_complete: [],
+  unable_to_assess: [],
+};
+
+export function buildReviewStatusFoundation(): ReviewStatusFoundation {
+  return {
+    provisionLive: false,
+    automatedDecisions: false,
+    productionWorkflowLive: false,
+    states: REVIEW_STATE_ORDER,
+    disclaimers: [
+      'Review status tracking is a foundation lifecycle only; no automated decisions are produced.',
+      'Production workflow recording is planned and is not enabled by this module.',
+    ],
+  };
+}
+
+export function getReviewStatusCopy(
+  state: ReviewLifecycleState,
+): ReviewStatusCopy {
+  switch (state) {
+    case 'not_started':
+      return {
+        headline: 'Review not started',
+        detail: 'The application is available for intake but no assessment activity has been recorded.',
+      };
+    case 'consent_pending':
+      return {
+        headline: 'Consent pending',
+        detail: 'The reviewer is waiting for the required consent step before sending a source request.',
+      };
+    case 'request_sent':
+      return {
+        headline: 'Request sent',
+        detail: 'A request has been prepared for the review workflow; response tracking remains a planned production capability.',
+      };
+    case 'response_received':
+      return {
+        headline: 'Response received',
+        detail: 'Source material is available for internal assessment.',
+      };
+    case 'assessment_complete':
+      return {
+        headline: 'Assessment complete',
+        detail: 'Internal assessment is complete for the available material; employment eligibility remains an employer decision.',
+      };
+    case 'unable_to_assess':
+      return {
+        headline: 'Unable to assess',
+        detail: 'The available material is insufficient for this internal assessment record.',
+      };
+  }
+}
+
+export function transitionAllowed(
+  from: ReviewLifecycleState,
+  to: ReviewLifecycleState,
+): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}

--- a/apps/web/lib/verifier/worklist.ts
+++ b/apps/web/lib/verifier/worklist.ts
@@ -1,0 +1,117 @@
+/**
+ * FOUNDATION-SWEEP-7 — verifier worklist foundation.
+ *
+ * Pure data types and filtering helpers only. No persistence, polling, or live
+ * workflow integration is enabled by this module.
+ */
+
+export type WorklistItemStatus =
+  | 'pending'
+  | 'in_review'
+  | 'info_requested'
+  | 'acceptable_for_start'
+  | 'unable_to_verify';
+
+export type WorklistProofTier =
+  | 'receipt_candidate'
+  | 'psv_sourced'
+  | 'self_attested';
+
+export interface WorklistFilter {
+  status?: WorklistItemStatus | 'all';
+  proofTier?: WorklistProofTier | 'all';
+  clinicianNpi?: string;
+  submittedFrom?: string;
+  submittedTo?: string;
+}
+
+export interface WorklistItem {
+  clinicianNpi: string;
+  submittedAt: string;
+  status: WorklistItemStatus;
+  proofTier: WorklistProofTier;
+}
+
+export interface WorklistFoundation {
+  provisionLive: false;
+  dbBackedWorklist: false;
+  realTimeUpdates: false;
+  statuses: WorklistItemStatus[];
+  proofTiers: WorklistProofTier[];
+  disclaimers: string[];
+}
+
+export function buildWorklistFoundation(): WorklistFoundation {
+  return {
+    provisionLive: false,
+    dbBackedWorklist: false,
+    realTimeUpdates: false,
+    statuses: [
+      'pending',
+      'in_review',
+      'info_requested',
+      'acceptable_for_start',
+      'unable_to_verify',
+    ],
+    proofTiers: ['receipt_candidate', 'psv_sourced', 'self_attested'],
+    disclaimers: [
+      'The worklist foundation organizes submitted applications only; it is not backed by production storage.',
+      'Live updates are planned and are not enabled by this module.',
+    ],
+  };
+}
+
+export function filterWorklist(
+  items: WorklistItem[],
+  filter: WorklistFilter,
+): WorklistItem[] {
+  const npiQuery = filter.clinicianNpi?.trim().toLowerCase();
+  const submittedFrom = parseFilterDate(filter.submittedFrom);
+  const submittedTo = parseFilterDate(filter.submittedTo);
+
+  return items.filter((item) => {
+    if (filter.status && filter.status !== 'all' && item.status !== filter.status) {
+      return false;
+    }
+
+    if (filter.proofTier && filter.proofTier !== 'all' && item.proofTier !== filter.proofTier) {
+      return false;
+    }
+
+    if (npiQuery && !item.clinicianNpi.toLowerCase().includes(npiQuery)) {
+      return false;
+    }
+
+    const submittedAt = parseFilterDate(item.submittedAt);
+    if (submittedFrom !== null && submittedAt !== null && submittedAt < submittedFrom) {
+      return false;
+    }
+
+    if (submittedTo !== null && submittedAt !== null && submittedAt > submittedTo) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function explainWorklistStatus(status: WorklistItemStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'Pending review; the submitted application has not been assessed yet.';
+    case 'in_review':
+      return 'In review; an internal assessment is underway.';
+    case 'info_requested':
+      return 'Additional information has been requested before assessment can continue.';
+    case 'acceptable_for_start':
+      return 'Acceptable for start based on the current internal assessment record.';
+    case 'unable_to_verify':
+      return 'Unable to assess from the available source material.';
+  }
+}
+
+function parseFilterDate(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}

--- a/docs/ops/vitalcv-completion-board.md
+++ b/docs/ops/vitalcv-completion-board.md
@@ -194,13 +194,13 @@ Every section uses this schema:
 |---|---:|---:|---|---|
 | Employer review | 60 | 60 | No action this wave. Issuer review surface (#168); demo render only (`recordedBy:'demo'`). | 🛠️ Buildout |
 | Request review | 55 | 55 | No action this wave. Same as employer review. | 🛠️ Buildout |
-| Verifier worklist | 30 | 30 | No action this wave. No audited multi-request worklist. | 🧱 Foundation |
+| Verifier worklist | 30 | 48 | FOUNDATION-SWEEP-7: `worklist.ts` WorklistItem/filter/status-copy foundation; WorklistPanel component; /employer/worklist shell; dbBackedWorklist: false. | 🧱 Foundation |
 | Evidence inspection | 50 | 50 | No action this wave. Receipt candidate viewer. | 🛠️ Buildout |
-| Reuse decision UX | 50 | 50 | No action this wave. (#172) reuse boundary surfaced in review. | 🛠️ Buildout |
-| Policy decision UX | 60 | 60 | No action this wave. Policy review 5-gate UX. | 🛠️ Buildout |
+| Reuse decision UX | 50 | 65 | FOUNDATION-SWEEP-7: `reuseDecisionFoundation.ts` 3-basis model; explainReuseBasis says 'previously assessed'; crossTenantReuseImplemented: false. | 🛠️ Buildout |
+| Policy decision UX | 60 | 75 | FOUNDATION-SWEEP-7: `policyDecisionFoundation.ts` 4-outcome model; no 'approved'/'rejected' language; automatedPolicyEngine: false; /employer/decision/[id] shell. | 🛠️ Buildout |
 | Exportable proof pack | 25 | 25 | No action this wave. Not bundled. | 🧱 Foundation |
-| Team / org roles | 10 | 10 | No action this wave. None. | 🌱 Seed |
-| Review status tracking | 45 | 45 | No action this wave. Request lifecycle states present. | 🧱 Foundation |
+| Team / org roles | 10 | 28 | FOUNDATION-SWEEP-7: `orgRolesFoundation.ts` 3-role model; invitation lifecycle; invitationSystemLive: false, rbacEnforced: false. | 🧱 Foundation |
+| Review status tracking | 45 | 60 | FOUNDATION-SWEEP-7: `reviewStatusFoundation.ts` 6-state lifecycle; transitionAllowed() state machine; truth-safe copy for all states; productionWorkflowLive: false. | 🛠️ Buildout |
 | Employer CTA / conversion path | 40 | 40 | No action this wave. `/employers` redirect + `/pilot` CTA live. | 🧱 Foundation |
 
 ---


### PR DESCRIPTION
FOUNDATION-SWEEP-7 foundation wave. Scope: apps/web/ only. No backend. No Prisma.

## What ships
- `lib/verifier/orgRolesFoundation.ts`: 3-role model (admin/reviewer/read_only); invitation lifecycle; invitationSystemLive: false, rbacEnforced: false
- `lib/verifier/worklist.ts`: WorklistItem, WorklistFilter, filterWorklist(), explainWorklistStatus(); dbBackedWorklist: false, realTimeUpdates: false
- `lib/verifier/reviewStatusFoundation.ts`: 6-state lifecycle with transitionAllowed() state machine; productionWorkflowLive: false
- `lib/verifier/reuseDecisionFoundation.ts`: 3-basis model; explainReuseBasis says 'previously assessed'; crossTenantReuseImplemented: false
- `lib/verifier/policyDecisionFoundation.ts`: 4-outcome model; no 'approved'/'rejected' language; automatedPolicyEngine: false
- `components/verifier/WorklistPanel.tsx`: filterable worklist with status pills; disclaimer: 'Review outcomes do not constitute legal verification'
- `components/verifier/DecisionPanel.tsx`: 4 decision buttons (no Approve/Reject); disclaimer: 'VitalCV does not guarantee employment eligibility'
- `app/employer/worklist/page.tsx` and `app/employer/decision/[applicationId]/page.tsx`: static shell pages

## Board delta: Team/org roles 10→28, Verifier worklist 30→48, Review status tracking 45→60, Reuse decision UX 50→65, Policy decision UX 60→75