### PR TITLE
feat(crypto): add ES256 receipt issuer and JWKS endpoint

### DIFF
--- a/apps/web/__tests__/crypto-receipt.test.ts
+++ b/apps/web/__tests__/crypto-receipt.test.ts
@@ -1,0 +1,127 @@
+/**
+ * crypto-receipt.test.ts
+ *
+ * Validates the ES256 receipt issuer, JWKS key-safety contract, and that the
+ * employer-facing review surface contains no overreaching copy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKeyPair, SignJWT, decodeProtectedHeader, exportJWK } from 'jose';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// ---------------------------------------------------------------------------
+// 1. ES256 JWT signing
+// ---------------------------------------------------------------------------
+
+describe('ES256 JWT signing', () => {
+  it('produces a three-part JWT with correct alg and kid in the protected header', async () => {
+    const { privateKey } = await generateKeyPair('ES256', { extractable: true });
+
+    const jwt = await new SignJWT({ receiptId: 'r-001', orchestrator: 'vitalcv' })
+      .setProtectedHeader({ alg: 'ES256', kid: 'vitalcv-trust-key-1' })
+      .setIssuer('https://vitalcv.com')
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(privateKey);
+
+    // Must be a three-segment compact serialization.
+    expect(jwt.split('.').length).toBe(3);
+
+    const header = decodeProtectedHeader(jwt);
+    expect(header.alg).toBe('ES256');
+    expect(header.kid).toBe('vitalcv-trust-key-1');
+  });
+
+  it('produces distinct signatures for distinct payloads (non-deterministic signing)', async () => {
+    const { privateKey } = await generateKeyPair('ES256', { extractable: true });
+    const base = { alg: 'ES256' as const, kid: 'k1' };
+
+    const [j1, j2] = await Promise.all([
+      new SignJWT({ n: 1 }).setProtectedHeader(base).setIssuer('https://vitalcv.com').setIssuedAt().sign(privateKey),
+      new SignJWT({ n: 2 }).setProtectedHeader(base).setIssuer('https://vitalcv.com').setIssuedAt().sign(privateKey),
+    ]);
+
+    expect(j1).not.toBe(j2);
+  });
+
+  it('exports a public JWK without private key material (no d field)', async () => {
+    const { publicKey } = await generateKeyPair('ES256', { extractable: true });
+    const jwk = await exportJWK(publicKey);
+
+    expect(jwk).not.toHaveProperty('d');
+    expect(jwk.kty).toBe('EC');
+    expect(jwk.crv).toBe('P-256');
+    expect(jwk.x).toBeTruthy();
+    expect(jwk.y).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. JWKS endpoint key-safety contract
+// ---------------------------------------------------------------------------
+
+describe('JWKS public key contract', () => {
+  it('getPublicKeyJwk returns only public EC key fields — no private d parameter', async () => {
+    // Import from the canonical ES256 receipt issuer module.
+    const { getPublicKeyJwk } = await import('@/lib/crypto/receiptIssuer');
+    const jwk = await getPublicKeyJwk();
+
+    // Private key component — must never be present in JWKS response.
+    expect(jwk).not.toHaveProperty('d');
+
+    // Required public-key fields for ES256 / P-256.
+    expect(jwk.kty).toBe('EC');
+    expect(jwk.crv).toBe('P-256');
+    expect(jwk.use).toBe('sig');
+    expect(jwk.alg).toBe('ES256');
+    expect(jwk.kid).toBeTruthy();
+    expect(jwk.x).toBeTruthy();
+    expect(jwk.y).toBeTruthy();
+  });
+
+  it('JWKS response shape wraps public key in a keys array', async () => {
+    const { getPublicKeyJwk } = await import('@/lib/crypto/receiptIssuer');
+    const jwk = await getPublicKeyJwk();
+
+    // Simulate what the GET handler returns.
+    const jwks = { keys: [jwk] };
+
+    expect(Array.isArray(jwks.keys)).toBe(true);
+    expect(jwks.keys.length).toBeGreaterThan(0);
+    for (const key of jwks.keys) {
+      expect(key).not.toHaveProperty('d');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Employer UI copy contract — no blockchain overclaiming
+// ---------------------------------------------------------------------------
+
+describe('Employer review UI copy', () => {
+  const reviewClientSrc = readFileSync(
+    resolve(__dirname, '../components/review/ReviewClient.tsx'),
+    'utf8',
+  );
+
+  // The word "blockchain" is banned from credentialing copy — VitalCV uses
+  // cryptographic signatures, not distributed ledger claims.
+  it('does not contain the word "blockchain" in ReviewClient source', () => {
+    expect(reviewClientSrc.toLowerCase()).not.toMatch(/\bblockchain\b/);
+  });
+
+  it('uses the correct VitalCV orchestration agent copy', () => {
+    expect(reviewClientSrc).toContain(
+      'cryptographically signed by VitalCV as the orchestration agent',
+    );
+  });
+
+  it('labels the panel as "Cryptographic Receipt Available" — not "blockchain"', () => {
+    expect(reviewClientSrc).toContain('Cryptographic Receipt Available');
+  });
+
+  it('links to the JWKS endpoint for independent verification', () => {
+    expect(reviewClientSrc).toContain('/.well-known/jwks.json');
+  });
+});

--- a/apps/web/__tests__/es256-receipt-engine.test.ts
+++ b/apps/web/__tests__/es256-receipt-engine.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ES256 receipt engine — unit tests.
+ *
+ * Covers:
+ *   - generateReceiptKeypair produces extractable ES256 keys
+ *   - signIssuerReceipt returns a valid JWT with correct payload shape
+ *   - getPublicKeyJwk returns a JWKS-safe object (no private key material)
+ *   - buildAndSignReceiptCandidate attaches JWT only for 'confirmed' status
+ */
+
+import { describe, it, expect } from 'vitest';
+import { jwtVerify, importJWK } from 'jose';
+import {
+  generateReceiptKeypair,
+  signIssuerReceipt,
+  getPublicKeyJwk,
+} from '../lib/crypto/receiptIssuer';
+import { buildAndSignReceiptCandidate } from '../lib/crypto/receiptCandidateSigner';
+import type { IssuerVerificationRequest, IssuerResponse } from '../lib/issuer-verification/types';
+
+// Minimal fixture helpers
+function makeResponse(status: IssuerResponse['status'] = 'confirmed'): IssuerResponse {
+  return {
+    responseId: 'resp-001',
+    status,
+    respondedAt: '2026-01-15T10:00:00Z',
+    responderName: 'Registrar Office',
+    reviewRequired: false,
+  };
+}
+
+function makeRequest(): IssuerVerificationRequest {
+  return {
+    requestId: 'req-001',
+    claimType: 'education_degree',
+    claimSummary: 'MD — State University School of Medicine',
+    issuerCandidate: {
+      candidateId: 'ic-001',
+      organizationName: 'State University',
+      source: 'clinician_provided',
+    },
+    route: {
+      route: 'clearinghouse_or_registrar',
+      partnerCategory: 'student_clearinghouse_degreeverify_category',
+      rationale: 'Degree verification via clearinghouse',
+      accessLevel: 'available',
+    },
+    consent: {
+      consentId: 'consent-001',
+      scope: 'education_degree',
+      status: 'granted',
+      consentedAt: '2026-01-10T08:00:00Z',
+    },
+    status: 'confirmed',
+    createdAt: '2026-01-10T08:00:00Z',
+    updatedAt: '2026-01-15T10:00:00Z',
+    history: [],
+  };
+}
+
+describe('generateReceiptKeypair', () => {
+  it('returns a keypair with a kid', async () => {
+    const kp = await generateReceiptKeypair();
+    expect(kp.kid).toMatch(/^vcv-es256-/);
+    expect(kp.privateKey).toBeDefined();
+    expect(kp.publicKey).toBeDefined();
+  });
+
+  it('produces distinct key material on each call', async () => {
+    const kp1 = await generateReceiptKeypair();
+    const kp2 = await generateReceiptKeypair();
+    // Export both public keys and compare x/y coordinates.
+    const { exportJWK } = await import('jose');
+    const jwk1 = await exportJWK(kp1.publicKey);
+    const jwk2 = await exportJWK(kp2.publicKey);
+    // EC P-256 x coordinates are astronomically unlikely to collide.
+    expect(jwk1.x).not.toBe(jwk2.x);
+  });
+});
+
+describe('getPublicKeyJwk', () => {
+  it('returns a JWK without the private key component (no d field)', async () => {
+    const jwk = await getPublicKeyJwk();
+    expect(jwk.kty).toBe('EC');
+    expect(jwk.crv).toBe('P-256');
+    expect(jwk.alg).toBe('ES256');
+    expect(jwk.use).toBe('sig');
+    expect(jwk.x).toBeDefined();
+    expect(jwk.y).toBeDefined();
+    // The 'd' field is the private key component — must be absent
+    expect(jwk.d).toBeUndefined();
+  });
+});
+
+describe('signIssuerReceipt', () => {
+  it('produces a verifiable ES256 JWT with correct payload structure', async () => {
+    const kp = await generateReceiptKeypair();
+    const response = makeResponse();
+
+    // Sign with the ephemeral keypair's private key by temporarily
+    // replacing the module singleton via env — use signIssuerReceipt directly
+    // and verify with the matching public key.
+    const { jwt, jti } = await signIssuerReceipt(response, {
+      providerId: 'npi-1234567890',
+      claimId: 'claim-001',
+      source: 'State University',
+      rawHash: 'abc123',
+    });
+
+    expect(typeof jwt).toBe('string');
+    expect(jti).toMatch(/^rcpt_resp-001_/);
+
+    // Verify the JWT with the public key from getPublicKeyJwk
+    const publicJwk = await getPublicKeyJwk();
+    const publicKey = await importJWK(publicJwk, 'ES256');
+    const { payload } = await jwtVerify(jwt, publicKey, { algorithms: ['ES256'] });
+
+    expect(payload.sub).toBe('npi-1234567890');
+    expect(payload.jti).toBe(jti);
+    expect(typeof payload.iat).toBe('number');
+    expect(typeof payload.exp).toBe('number');
+
+    const vcv = payload.vcv as Record<string, unknown>;
+    expect(vcv.claimId).toBe('claim-001');
+    expect(vcv.source).toBe('State University');
+    expect(vcv.status).toBe('confirmed');
+    expect(vcv.observed_at).toBe('2026-01-15T10:00:00Z');
+    expect(vcv.raw_hash).toBe('abc123');
+  });
+
+  it('sets exp roughly 90 days after iat', async () => {
+    const response = makeResponse();
+    const { jwt } = await signIssuerReceipt(response, {
+      providerId: 'npi-111',
+      claimId: 'claim-002',
+      source: 'Test Org',
+      rawHash: 'deadbeef',
+    });
+
+    const publicJwk = await getPublicKeyJwk();
+    const publicKey = await importJWK(publicJwk, 'ES256');
+    const { payload } = await jwtVerify(jwt, publicKey, { algorithms: ['ES256'] });
+
+    const durationDays = ((payload.exp ?? 0) - (payload.iat ?? 0)) / 86400;
+    expect(durationDays).toBeCloseTo(90, 0);
+  });
+});
+
+describe('buildAndSignReceiptCandidate', () => {
+  it('attaches signedReceiptJwt only when status is confirmed', async () => {
+    const request = makeRequest();
+    const confirmedResponse = makeResponse('confirmed');
+
+    const candidate = await buildAndSignReceiptCandidate(request, confirmedResponse, {
+      receiptCandidateId: 'rc-001',
+      claimId: 'claim-001',
+      providerId: 'npi-1234567890',
+      source: 'State University',
+      rawHash: 'sha256-abc',
+    });
+
+    expect(candidate.signedReceiptJwt).toBeDefined();
+    expect(typeof candidate.signedReceiptJwt).toBe('string');
+    // JWT must have 3 parts
+    expect(candidate.signedReceiptJwt!.split('.').length).toBe(3);
+    // Truth contract invariants must hold
+    expect(candidate.decisionGrade).toBe(false);
+    expect(candidate.proofTier).toBe('receipt_candidate');
+  });
+
+  it('does NOT attach signedReceiptJwt for non-confirmed statuses', async () => {
+    const request = makeRequest();
+
+    for (const status of ['unable_to_verify', 'wrong_office', 'legally_only', 'requires_release'] as const) {
+      const response = makeResponse(status);
+      const candidate = await buildAndSignReceiptCandidate(request, response, {
+        receiptCandidateId: `rc-${status}`,
+        claimId: 'claim-001',
+        providerId: 'npi-111',
+        source: 'Test Org',
+        rawHash: 'no-hash',
+      });
+      expect(candidate.signedReceiptJwt).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/app/api/.well-known/jwks.json/route.ts
+++ b/apps/web/app/api/.well-known/jwks.json/route.ts
@@ -1,6 +1,30 @@
+/**
+ * GET /.well-known/jwks.json
+ *
+ * Publishes the ES256 public key so any verifier can validate
+ * signed issuer receipts without calling back to VitalCV.
+ *
+ * The private key is NEVER included here — only the public JWK.
+ * Cache-Control allows CDN caching for 1 hour with a 24h stale window,
+ * accommodating key rotation without breaking in-flight verifications.
+ */
+
 import { NextResponse } from 'next/server';
-import { getPublicJWKS } from '../../../../../../apps/api/backend/src/services/trust/cryptoService';
+import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
+
+export const runtime = 'nodejs';
+
+export const revalidate = 3600;
 
 export async function GET() {
-  return NextResponse.json(getPublicJWKS());
+  const publicKeyJwk = await getPublicKeyJwk();
+
+  return NextResponse.json(
+    { keys: [publicKeyJwk] },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    },
+  );
 }

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -586,6 +586,7 @@ interface ReviewClientLoadedProps {
   bundleId?:  string;
   sharedBy?:  string;
   acceptanceHistory?: EmployerAcceptanceHistoryResponse;
+  receiptJwts?: string[];
 }
 
 interface ReviewClientLoadingProps {
@@ -867,6 +868,83 @@ function AcceptanceHistoryPanel({
   );
 }
 
+// ── Cryptographic receipt available panel ────────────────────────────────
+
+function extractKidFromJwt(jwt: string): string | null {
+  try {
+    const raw = jwt.split('.')[0] ?? '';
+    const padded = raw + '='.repeat((4 - (raw.length % 4)) % 4);
+    const decoded = JSON.parse(atob(padded.replace(/-/g, '+').replace(/_/g, '/'))) as Record<string, unknown>;
+    return typeof decoded.kid === 'string' ? decoded.kid : null;
+  } catch {
+    return null;
+  }
+}
+
+function CryptoReceiptAvailablePanel({ receiptJwts }: { receiptJwts: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (receiptJwts.length === 0) return null;
+
+  const firstJwt = receiptJwts[0]!;
+  const kid = extractKidFromJwt(firstJwt);
+  const truncatedJwt = firstJwt.length > 100 ? `${firstJwt.slice(0, 100)}…` : firstJwt;
+
+  return (
+    <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/[0.04] px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <span className="text-indigo-400 text-sm" aria-label="Cryptographic Receipt">🔐</span>
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-indigo-400/80">
+              Cryptographic Receipt Available
+            </p>
+            <p className="mt-0.5 text-[10px] leading-relaxed text-muted-foreground/50">
+              This evidence is cryptographically signed by VitalCV as the orchestration agent.
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="shrink-0 h-7 px-2 text-[10px] text-indigo-400/70 hover:text-indigo-300 hover:bg-indigo-500/10"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Hide' : 'View proof'}
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 space-y-2.5 border-t border-white/8 pt-3">
+          {kid && (
+            <div className="flex items-center justify-between gap-2 text-[10px]">
+              <span className="text-muted-foreground/60 shrink-0">Key ID (kid)</span>
+              <span className="font-mono text-foreground/80 truncate">{kid}</span>
+            </div>
+          )}
+          <div className="rounded-lg border border-white/8 bg-black/20 px-2.5 py-2">
+            <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/40 break-all">
+              {receiptJwts.length === 1 ? truncatedJwt : `${truncatedJwt} (+${receiptJwts.length - 1} more)`}
+            </p>
+          </div>
+          <div className="flex items-center justify-between gap-2 text-[10px]">
+            <span className="text-muted-foreground/50">Verify public keys independently</span>
+            <Link
+              href="/.well-known/jwks.json"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-400/70 hover:text-indigo-300 underline underline-offset-2 shrink-0"
+            >
+              /.well-known/jwks.json ↗
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ReviewClientLoadingShell({ entityId }: { entityId?: string }) {
   return (
     <main className="min-h-screen bg-vt-surface-ops-base flex flex-col items-center px-4 pt-10 sm:pt-16 pb-28">
@@ -930,6 +1008,7 @@ function ReviewClientLoaded({
   bundleId,
   sharedBy,
   acceptanceHistory,
+  receiptJwts,
 }: ReviewClientLoadedProps) {
   const [actionState, setActionState] = useState<ActionState>({ phase: 'idle' });
   const [persistedActionState, setPersistedActionState] = useState<EmployerReviewActionState | null>(null);
@@ -1283,6 +1362,11 @@ function ReviewClientLoaded({
           <span className="text-muted-foreground/50 text-xs tracking-widest uppercase">VitalCV</span>
           <span className="text-muted-foreground/50 text-xs">Employer review</span>
         </div>
+
+        {/* ── Cryptographic receipt available panel ───────────────────────── */}
+        {receiptJwts && receiptJwts.length > 0 && (
+          <CryptoReceiptAvailablePanel receiptJwts={receiptJwts} />
+        )}
 
         {/* ══════════════════════════════════════════════════════════════════
             BINARY DECISION CARD — Above the fold. Employer decides here.

--- a/apps/web/lib/crypto/receiptCandidateSigner.ts
+++ b/apps/web/lib/crypto/receiptCandidateSigner.ts
@@ -1,0 +1,69 @@
+/**
+ * Receipt candidate signing orchestration.
+ *
+ * Wraps the pure `buildReceiptCandidateFromIssuerResponse` transform and
+ * conditionally mints an ES256 JWT for confirmed responses. The builder
+ * remains a pure transform; this module is the async boundary.
+ *
+ * Rule: only `confirmed` responses receive a signed JWT. All other statuses
+ * produce an unsigned candidate because they require further review before
+ * proof can be derived.
+ */
+
+import { buildReceiptCandidateFromIssuerResponse } from '@/lib/issuer-verification/receiptCandidate';
+import { signIssuerReceipt } from './receiptIssuer';
+import type {
+  IssuerResponse,
+  IssuerVerificationRequest,
+  ReceiptCandidate,
+} from '@/lib/issuer-verification/types';
+
+interface BuildAndSignOptions {
+  receiptCandidateId: string;
+  claimId: string;
+  /** NPI or system provider identifier for the JWT `sub` claim. */
+  providerId: string;
+  /** Human-readable source name (organization / clearinghouse). */
+  source: string;
+  /**
+   * Deterministic hash of the raw response payload for audit
+   * non-repudiation. Callers should use SHA-256 of the serialized
+   * issuer response before passing it here.
+   */
+  rawHash: string;
+  auditChannel?: 'issuer_response_form' | 'partner_response' | 'manual_entry';
+  recordedBy?: 'demo' | 'review_surface' | 'system';
+}
+
+/**
+ * Build a ReceiptCandidate and — if the response is 'confirmed' —
+ * attach a signed ES256 JWT to `candidate.signedReceiptJwt`.
+ *
+ * Non-confirmed responses return an unsigned candidate; calling code
+ * must not treat the absence of `signedReceiptJwt` as an error.
+ */
+export async function buildAndSignReceiptCandidate(
+  request: IssuerVerificationRequest,
+  response: IssuerResponse,
+  options: BuildAndSignOptions,
+): Promise<ReceiptCandidate> {
+  const candidate = buildReceiptCandidateFromIssuerResponse(request, response, {
+    receiptCandidateId: options.receiptCandidateId,
+    claimId: options.claimId,
+    auditChannel: options.auditChannel,
+    recordedBy: options.recordedBy,
+  });
+
+  if (response.status !== 'confirmed') {
+    return candidate;
+  }
+
+  const { jwt } = await signIssuerReceipt(response, {
+    providerId: options.providerId,
+    claimId: options.claimId,
+    source: options.source,
+    rawHash: options.rawHash,
+  });
+
+  return { ...candidate, signedReceiptJwt: jwt };
+}

--- a/apps/web/lib/crypto/receiptIssuer.ts
+++ b/apps/web/lib/crypto/receiptIssuer.ts
@@ -1,0 +1,133 @@
+/**
+ * ES256 Receipt Issuer — asymmetric signing for issuer receipts.
+ *
+ * Production: set RECEIPT_PRIVATE_KEY_JWK (JSON-encoded JWK of the private
+ * EC key) via env. The matching public key must be published at /.well-known/jwks.json.
+ *
+ * Development/test: if RECEIPT_PRIVATE_KEY_JWK is absent, a fresh ephemeral
+ * keypair is generated at module load time. The keypair is NOT persisted across
+ * restarts — dev only.
+ *
+ * This module is pure signing. It never touches the network or DB.
+ */
+
+import { generateKeyPair, importJWK, exportJWK, SignJWT } from 'jose';
+import type { JWTPayload } from 'jose';
+import type { IssuerResponse } from '@/lib/issuer-verification/types';
+
+export interface ReceiptKeypair {
+  /** ES256 private key — kept in process memory only. */
+  privateKey: CryptoKey;
+  /** ES256 public key — safe to publish in JWKS. */
+  publicKey: CryptoKey;
+  /** Stable identifier so clients can find the right key in JWKS. */
+  kid: string;
+}
+
+export interface SignedIssuerReceipt {
+  jwt: string;
+  kid: string;
+  jti: string;
+}
+
+// Module-level keypair. Lazy-initialized on first call.
+let _keypairPromise: Promise<ReceiptKeypair> | null = null;
+
+export async function generateReceiptKeypair(): Promise<ReceiptKeypair> {
+  const { privateKey, publicKey } = await generateKeyPair('ES256', {
+    extractable: true,
+  });
+  const kid = `vcv-es256-${Date.now()}`;
+  return { privateKey, publicKey, kid };
+}
+
+/**
+ * Returns the singleton keypair for this process.
+ * In production, imports from RECEIPT_PRIVATE_KEY_JWK + RECEIPT_KID env vars.
+ * In dev/test, generates a fresh ephemeral keypair once.
+ */
+export async function getOrInitKeypair(): Promise<ReceiptKeypair> {
+  if (_keypairPromise) return _keypairPromise;
+
+  _keypairPromise = (async () => {
+    const privateJwkEnv = process.env.RECEIPT_PRIVATE_KEY_JWK;
+    const kid = process.env.RECEIPT_KID ?? `vcv-es256-dev-${Date.now()}`;
+
+    if (privateJwkEnv) {
+      const jwk = JSON.parse(privateJwkEnv) as object;
+      const privateKey = await importJWK(jwk, 'ES256');
+
+      // Derive public key from the JWK by removing private components.
+      const { d: _d, ...publicJwk } = jwk as Record<string, unknown>;
+      const publicKey = await importJWK(publicJwk, 'ES256');
+
+      return { privateKey: privateKey as CryptoKey, publicKey: publicKey as CryptoKey, kid };
+    }
+
+    // Dev: ephemeral keypair.
+    return generateReceiptKeypair();
+  })();
+
+  return _keypairPromise;
+}
+
+/**
+ * Returns the public key JWK — safe to publish. Used by the JWKS route.
+ */
+export async function getPublicKeyJwk(): Promise<Record<string, unknown>> {
+  const { publicKey, kid } = await getOrInitKeypair();
+  const jwk = await exportJWK(publicKey);
+  return { ...jwk, alg: 'ES256', use: 'sig', kid };
+}
+
+/**
+ * Signs an issuer receipt as an ES256 JWT.
+ *
+ * Payload contract:
+ *   iss  — VitalCV canonical issuer URL
+ *   sub  — providerId or NPI from the response's request context
+ *   jti  — unique receipt identifier
+ *   iat  — issued-at (seconds)
+ *   exp  — expires in 90 days
+ *   vcv  — VitalCV claim block (claimId, source, status, observed_at, raw_hash)
+ */
+export async function signIssuerReceipt(
+  response: IssuerResponse,
+  context: {
+    providerId: string;
+    claimId: string;
+    source: string;
+    rawHash: string;
+  },
+): Promise<SignedIssuerReceipt> {
+  const { privateKey, kid } = await getOrInitKeypair();
+
+  const issuerUrl =
+    process.env.VITACV_ISSUER_URL ??
+    (process.env.NEXT_PUBLIC_APP_URL
+      ? process.env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '')
+      : 'https://vitalcv.com');
+
+  const jti = `rcpt_${response.responseId}_${Date.now()}`;
+
+  const payload: JWTPayload & { vcv: object } = {
+    iss: issuerUrl,
+    sub: context.providerId,
+    jti,
+    vcv: {
+      claimId: context.claimId,
+      source: context.source,
+      status: 'confirmed',
+      observed_at: response.respondedAt,
+      raw_hash: context.rawHash,
+    },
+  };
+
+  const jwt = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'ES256', kid })
+    .setIssuedAt()
+    .setExpirationTime('90d')
+    .sign(privateKey);
+
+  return { jwt, kid, jti };
+}

--- a/apps/web/lib/issuer-verification/types.ts
+++ b/apps/web/lib/issuer-verification/types.ts
@@ -216,6 +216,15 @@ export interface ReceiptCandidate {
   /** Literal — type-level guarantee that the candidate is never marked source-backed. */
   proofTier?: 'receipt_candidate';
   auditMetadata?: ReceiptCandidateAuditMetadata;
+
+  // ---- ISSUER-ES256 — signed receipt extension ----
+  /**
+   * ES256-signed JWT minted by signIssuerReceipt when the response
+   * status is 'confirmed'. Present only on confirmed candidates.
+   * The JWT payload carries claimId, source, status, observed_at,
+   * and raw_hash. Absent on non-confirmed candidates.
+   */
+  signedReceiptJwt?: string;
 }
 
 export interface IssuerResponse {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.34.3",
+    "jose": "^6.2.3",
     "lucide-react": "^0.454.0",
     "next": "15.2.8",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,9 @@ importers:
       framer-motion:
         specifier: ^12.34.3
         version: 12.34.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.2.3)
@@ -2064,6 +2067,7 @@ packages:
   '@clerk/clerk-react@5.60.0':
     resolution: {integrity: sha512-P88FncsJpq/3WZJhhlj+md8mYb35BIXpr462C/figwsBGHsinr8VuBQUMcMZZ/6M34C8ABfLTPa6PHVp6+3D5Q==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -2091,6 +2095,7 @@ packages:
   '@clerk/types@4.101.14':
     resolution: {integrity: sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2731,7 +2736,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -5663,11 +5668,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8629,6 +8635,9 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -11644,14 +11653,17 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -22043,6 +22055,8 @@ snapshots:
   jose@5.10.0: {}
 
   jose@6.1.3: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- **`receiptIssuer.ts`** — async ES256 signer via `jose`; singleton keypair per process with `RECEIPT_PRIVATE_KEY_JWK` env override for production KMS integration
- **`GET /.well-known/jwks.json`** — publishes only the public JWK (no private `d` field); 1h CDN cache with 24h stale-while-revalidate for graceful key rotation
- **`ReviewClient.tsx`** — adds `CryptoReceiptAvailablePanel`: shows Key ID (`kid`), truncated JWT, and link to JWKS so employers can independently verify. Required copy: _"This evidence is cryptographically signed by VitalCV as the orchestration agent."_
- **`crypto-receipt.test.ts`** — 9 tests: ES256 signing correctness, JWKS key-safety contract (no `d` field), employer UI copy contract (no "blockchain" overclaiming, required VitalCV orchestration agent copy)

## Test plan

- [x] `pnpm exec vitest run __tests__/crypto-receipt.test.ts` → 9/9 pass
- [x] `pnpm turbo run build --filter @vitalcv/web` → 13/13 tasks successful, 0 type errors
- [ ] Codex SAFE audit: implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)