### PR TITLE
docs(ops): record PR-B crypto verifier supersession

### DIFF
--- a/docs/ops/pr-b-crypto-superseded-note.md
+++ b/docs/ops/pr-b-crypto-superseded-note.md
@@ -1,0 +1,12 @@
+# PR-B Crypto Receipt Verifier Superseded Note
+
+Status: PR-B not rescued.
+
+Reason: PR-B is superseded by merged PR #203 and PR #204. VitalCV now uses the ES256 asymmetric issuer/JWKS path plus the ES256 verifier flow on `origin/main`.
+
+Rejected paths:
+- HS256/shared-secret receipt verification is weaker than the merged ES256 asymmetric path and should not be rescued.
+- Stub JWKS implementations are not production verifier evidence and should not be used to move completion-board scores.
+
+Score impact: no board score movement.
+


### PR DESCRIPTION
## Summary

- Adds `docs/ops/pr-b-crypto-superseded-note.md`, recording that the PR-B crypto receipt verifier work (closed PR #205, HS256/shared-secret path) is **superseded** by the merged ES256 issuer/JWKS stack: PR #203 (ES256 receipt issuer + JWKS endpoint) and PR #204 (ES256 verifier path).
- Captures the rejected paths for the record:
  - HS256/shared-secret receipt verification is weaker than the merged ES256 asymmetric path and should not be rescued.
  - Stub JWKS implementations are not production verifier evidence and should not be used to move completion-board scores.
- States explicitly: **no board score movement** from this PR.

## What this PR is NOT

- Not a re-attempt at the HS256 verifier closed in #205.
- Not a code change, not a crypto/JWT/JWKS change, not a config change.
- Not a board-score delta.

## Diff scope

- `docs/ops/pr-b-crypto-superseded-note.md` (new, 12 lines).
- `git diff --numstat origin/main..HEAD` → exactly one file added; no source, test, config, package, or schema files touched.

## Test plan

- [x] `git diff --stat origin/main..HEAD` shows only `docs/ops/pr-b-crypto-superseded-note.md`
- [ ] CI passes (docs-only — no build/test impact expected)
- [ ] Codex SAFE verdict (mandatory pre-merge per repo merge-protection hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)