### PR TITLE
feat(passport): mount LaneHealthMount on /passport/[id] — TRUST-HEALTH-UX-1

### DIFF
--- a/apps/web/__tests__/passport-entity-lane-health.test.tsx
+++ b/apps/web/__tests__/passport-entity-lane-health.test.tsx
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { LaneHealthSection } from '@/components/source-health/LaneHealthSection';
+import { getLaneSnapshots } from '@/lib/source-health/getLaneSnapshots';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const passportEntityClientPath = resolve(
+  __dirname,
+  '../app/passport/[id]/PassportEntityClient.tsx',
+);
+
+describe('/passport/[id] mounts LaneHealth surface', () => {
+  it('imports LaneHealthMount and renders it as a labeled section', () => {
+    const source = readFileSync(passportEntityClientPath, 'utf8');
+
+    expect(source).toContain(
+      "import { LaneHealthMount } from '@/components/source-health/LaneHealthMount'",
+    );
+    expect(source).toContain('data-testid="passport-lane-health-mount"');
+    expect(source).toContain('aria-label="Source health"');
+    expect(source).toContain('<LaneHealthMount heading="Source health" />');
+  });
+
+  it('renders cold-start UNKNOWN lanes — never fakes LIVE', () => {
+    const snapshots = getLaneSnapshots();
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snap of snapshots) {
+      expect(snap.state).toBe('UNKNOWN');
+    }
+
+    const markup = renderToStaticMarkup(
+      <LaneHealthSection snapshots={snapshots} heading="Source health" />,
+    );
+
+    expect(markup).toContain('Source health');
+    expect(markup).not.toMatch(/\bLIVE\b/);
+  });
+});

--- a/apps/web/app/passport/[id]/PassportEntityClient.tsx
+++ b/apps/web/app/passport/[id]/PassportEntityClient.tsx
@@ -9,6 +9,7 @@ import { fetchPassportEntity } from '@/lib/api';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { KnowledgeInboxPanel } from '@/components/knowledge-inbox/KnowledgeInboxPanel';
 import type { KnowledgeInboxItem } from '@/lib/knowledge-inbox/types';
+import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
 
 interface PassportEntityClientProps {
   entityId: string;
@@ -77,6 +78,12 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
     <div className="flex flex-col gap-8 pb-16">
       <PassportWallet passport={passport} />
       <div className="mx-auto max-w-[480px] sm:max-w-[640px] md:max-w-3xl lg:max-w-4xl px-4 w-full space-y-8">
+        <section
+          aria-label="Source health"
+          data-testid="passport-lane-health-mount"
+        >
+          <LaneHealthMount heading="Source health" />
+        </section>
         <section
           className="rounded-2xl border border-border bg-background/60 p-5 sm:p-6"
           aria-label="Knowledge Inbox"


### PR DESCRIPTION
## Summary
- Mounts the existing source-health UX surface (`LaneHealthMount`) on the per-clinician passport view (`/passport/[id]`)
- Pure UX surface PR — the 88-test source-health foundation has been on origin/main since RELIABILITY-2 (#187); this is the clinician-facing mount point the 100% Action Map calls out
- 5-line addition to `PassportEntityClient.tsx` plus a structural integration test

## Why this row, this PR
Per the unmerged 100% Action Map ([PR #212](https://github.com/ctol3r/vitalcv/pull/212)), the **Source health classifier** row has a target of 65 → 80 with a single PR — and the action map specifies the exact fastest evidence: "Add `LaneHealthBadge` to `/passport/[id]`; mobile + a11y check." That's this PR.

## Truth invariants preserved
- `getLaneSnapshots()` placeholder seed remains 4×UNKNOWN at cold start; LIVE only originates from a confirmed 2xx probe (asserted by `noFakeLive.test.ts` on main and re-asserted in the new integration test)
- New section uses `aria-label="Source health"` and `data-testid="passport-lane-health-mount"` for stable a11y + test queries
- No banned strings introduced

## Test plan
- [x] 99/99 source-health + new integration suite green
  - `pnpm --filter @vitalcv/web exec vitest run __tests__/source-health __tests__/source-health-panel.test.tsx __tests__/passport-entity-lane-health.test.tsx __tests__/passport-page.test.tsx __tests__/passport-trust-posture.test.tsx`
- [x] Turbo build green (13/13 tasks, fresh worktree)
- [x] `/passport/[id]` empty-state path verified in dev preview (HTTP 200, no client errors related to LaneHealth)
- [ ] Visual confirmation against a real backend-served passport (deferred — needs a running backend)
- [ ] Mobile + a11y axe pass (deferred to A11Y-AXE-1 wave; this PR matches the action map's "today" scope)

## Files changed
- `apps/web/app/passport/[id]/PassportEntityClient.tsx` — adds import + labeled section
- `apps/web/__tests__/passport-entity-lane-health.test.tsx` — new test (2 cases: structural import assertion + cold-start UNKNOWN render assertion)

## Out of scope
- Mobile/a11y hardening — A11Y-AXE-1 covers this in a separate PR
- LaneHealth on the passport empty state — the empty state intentionally renders the centered "Passport not available" card layout; mounting LaneHealth there would compete visually for no real benefit
- Real-data success-path screenshot — backend not available in this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)