### PR TITLE
docs(security): add identity vendor foundation

### DIFF
--- a/apps/web/__tests__/identity-vendor-foundation.test.ts
+++ b/apps/web/__tests__/identity-vendor-foundation.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildIdentityProofingFoundation,
+  type IdentityVendorCandidateId,
+} from '../lib/identity/identityProofingFoundation';
+import {
+  getConfiguredIdentityVendorId,
+  getMockIdentityProofingVendor,
+} from '../lib/identity/mockIdentityProofing';
+
+describe('identity vendor foundation', () => {
+  it('keeps mock identity proofing non-live with no IAL claim or selected vendor', () => {
+    const foundation = buildIdentityProofingFoundation('mock');
+    const mockVendor = getMockIdentityProofingVendor();
+
+    expect(getConfiguredIdentityVendorId('persona')).toBe('mock');
+    expect(foundation.isLive).toBe(false);
+    expect(foundation.configuredVendorId).toBe('mock');
+    expect(foundation.activeVendor).toEqual(mockVendor);
+    expect(foundation.activeVendor.isLive).toBe(false);
+    expect(foundation.activeVendor.supportsGovernmentId).toBe(false);
+    expect(foundation.activeVendor.supportsLiveness).toBe(false);
+    expect(foundation.activeVendor.supportsIal2Claim).toBe(false);
+    expect(foundation.activeVendor.supportsIal3Claim).toBe(false);
+    expect(foundation.vendorSelected).toBe(false);
+    expect(foundation.procurementRequired).toBe(true);
+    expect(foundation.highestIalClaimed).toBe('none');
+    expect(foundation.boardCeilingPercent).toBe(30);
+
+    const candidateIds = foundation.candidates.map((candidate) => candidate.vendorId);
+    const expected: IdentityVendorCandidateId[] = [
+      'persona',
+      'stripe_identity',
+      'onfido',
+      'veriff',
+    ];
+    expect(candidateIds).toEqual(expected);
+    expect(foundation.candidates.every((candidate) => candidate.selected === false)).toBe(true);
+    expect(
+      foundation.disclaimers.some((line) =>
+        /procurement decision, not engineering/.test(line),
+      ),
+    ).toBe(true);
+  });
+
+  it('documents vendor comparison, IAL gaps, rejected live claims, and the procurement ceiling', () => {
+    const vendorEvaluation = readFileSync(
+      resolve(process.cwd(), '../../docs/security/identity-vendor-evaluation.md'),
+      'utf8',
+    );
+    const ialPlan = readFileSync(
+      resolve(process.cwd(), '../../docs/security/ial-ladder-plan.md'),
+      'utf8',
+    );
+    const docs = `${vendorEvaluation}\n${ialPlan}`;
+
+    expect(docs).toContain('Persona');
+    expect(docs).toContain('Stripe Identity');
+    expect(docs).toContain('Onfido');
+    expect(docs).toContain('Veriff');
+    expect(vendorEvaluation).toContain('Recommended first procurement target: Persona');
+    expect(docs).toContain('IAL2');
+    expect(docs).toContain('IAL3');
+    expect(docs).toContain('These rows stay at approximately 30% until vendor procurement closes');
+    expect(docs).toContain('This is a procurement decision, not engineering');
+    expect(docs).not.toMatch(/IAL[23]\s+(achieved|asserted|obtained|met|granted|verified)/i);
+  });
+});

--- a/apps/web/lib/identity/identityProofingFoundation.ts
+++ b/apps/web/lib/identity/identityProofingFoundation.ts
@@ -1,0 +1,91 @@
+import {
+  getConfiguredIdentityVendorId,
+  getMockIdentityProofingVendor,
+  type IdentityVendorId,
+  type MockIdentityProofingVendor,
+} from './mockIdentityProofing';
+
+export type IdentityVendorCandidateId =
+  | 'persona'
+  | 'stripe_identity'
+  | 'onfido'
+  | 'veriff';
+
+export interface IdentityVendorCandidate {
+  vendorId: IdentityVendorCandidateId;
+  displayName: string;
+  recommendedUse: string;
+  procurementRequired: true;
+  selected: false;
+}
+
+export interface IdentityProofingFoundation {
+  isLive: false;
+  configuredVendorId: IdentityVendorId;
+  activeVendor: MockIdentityProofingVendor;
+  vendorSelected: false;
+  procurementRequired: true;
+  highestIalClaimed: 'none';
+  boardCeilingPercent: 30;
+  candidates: IdentityVendorCandidate[];
+  disclaimers: string[];
+}
+
+const CANDIDATES: IdentityVendorCandidate[] = [
+  {
+    vendorId: 'persona',
+    displayName: 'Persona',
+    recommendedUse:
+      'Recommended first procurement target for configurable identity workflows and audit-oriented review.',
+    procurementRequired: true,
+    selected: false,
+  },
+  {
+    vendorId: 'stripe_identity',
+    displayName: 'Stripe Identity',
+    recommendedUse:
+      'Fallback candidate if VitalCV chooses a narrower developer-friendly identity proofing integration.',
+    procurementRequired: true,
+    selected: false,
+  },
+  {
+    vendorId: 'onfido',
+    displayName: 'Onfido',
+    recommendedUse:
+      'Enterprise candidate pending retention, consent, and audit-safe receipt review.',
+    procurementRequired: true,
+    selected: false,
+  },
+  {
+    vendorId: 'veriff',
+    displayName: 'Veriff',
+    recommendedUse:
+      'Risk-focused candidate pending audit artifact and operational transparency review.',
+    procurementRequired: true,
+    selected: false,
+  },
+];
+
+export function buildIdentityProofingFoundation(
+  vendorEnv = process.env.NEXT_PUBLIC_IDENTITY_VENDOR,
+): IdentityProofingFoundation {
+  const configuredVendorId = getConfiguredIdentityVendorId(vendorEnv);
+  const activeVendor = getMockIdentityProofingVendor();
+
+  return {
+    isLive: false,
+    configuredVendorId,
+    activeVendor,
+    vendorSelected: false,
+    procurementRequired: true,
+    highestIalClaimed: 'none',
+    boardCeilingPercent: 30,
+    candidates: CANDIDATES.map((candidate) => ({ ...candidate })),
+    disclaimers: [
+      'Identity proofing is not live. NEXT_PUBLIC_IDENTITY_VENDOR=mock is a foundation fixture only.',
+      'No vendor has been selected or procured.',
+      'No IAL2 or IAL3 assurance is claimed by this foundation.',
+      'These rows stay at approximately 30% until vendor procurement closes. This is a procurement decision, not engineering.',
+    ],
+  };
+}

--- a/apps/web/lib/identity/mockIdentityProofing.ts
+++ b/apps/web/lib/identity/mockIdentityProofing.ts
@@ -1,0 +1,36 @@
+export type IdentityVendorId = 'mock';
+
+export interface MockIdentityProofingVendor {
+  vendorId: IdentityVendorId;
+  displayName: string;
+  isLive: false;
+  invitationOnly: false;
+  supportsGovernmentId: false;
+  supportsLiveness: false;
+  supportsIal2Claim: false;
+  supportsIal3Claim: false;
+  disclaimer: string;
+}
+
+export const MOCK_IDENTITY_VENDOR: MockIdentityProofingVendor = {
+  vendorId: 'mock',
+  displayName: 'Mock identity proofing',
+  isLive: false,
+  invitationOnly: false,
+  supportsGovernmentId: false,
+  supportsLiveness: false,
+  supportsIal2Claim: false,
+  supportsIal3Claim: false,
+  disclaimer:
+    'Mock identity proofing is a foundation fixture only. It does not verify identity, bind a person to an NPI, or create IAL evidence.',
+};
+
+export function getConfiguredIdentityVendorId(
+  value = process.env.NEXT_PUBLIC_IDENTITY_VENDOR,
+): IdentityVendorId {
+  return value === 'mock' || !value ? 'mock' : 'mock';
+}
+
+export function getMockIdentityProofingVendor(): MockIdentityProofingVendor {
+  return { ...MOCK_IDENTITY_VENDOR };
+}

--- a/docs/security/ial-ladder-plan.md
+++ b/docs/security/ial-ladder-plan.md
@@ -1,0 +1,32 @@
+# IAL Ladder Plan
+
+Status: foundation plan only. VitalCV does not currently assert IAL2 or IAL3.
+
+## Current Foundation State
+
+| Level | VitalCV State | Evidence |
+|---|---|---|
+| No IAL claim | Current state | NPI lookup and self-attested identity inputs exist, but neither binds a real person to the identifier. |
+| IAL2 candidate | Future state | Requires procured vendor, government ID proofing, liveness or equivalent binding, consent, retention policy, manual review fallback, and audit-safe receipt evidence. |
+| IAL3 candidate | Future state | Requires a substantially higher assurance process that is outside this foundation and likely outside the first procurement wave. |
+
+## Ladder
+
+1. Keep mock vendor as the only application-visible provider until procurement closes.
+2. Select vendor through security, privacy, legal, and product review.
+3. Define minimum data collection, retention, deletion, and redaction rules.
+4. Integrate government ID and liveness flow behind a non-production feature flag.
+5. Add audit-safe proofing receipt shape with no raw ID image, selfie, biometric template, or secret.
+6. Add manual review fallback and failure-state copy.
+7. Run a formal assurance review before any IAL2 claim.
+
+## Hard Stops
+
+- No IAL2 / IAL3 claim before vendor procurement closes.
+- No production proofing status from the mock vendor.
+- No raw government ID image, selfie, biometric template, or vendor secret in logs, receipts, or operator surfaces.
+- No board movement past the foundation tier from engineering-only scaffolding.
+
+## Board Ceiling
+
+These rows stay at approximately 30% until vendor procurement closes. This is a procurement decision, not engineering.

--- a/docs/security/identity-vendor-evaluation.md
+++ b/docs/security/identity-vendor-evaluation.md
@@ -1,0 +1,48 @@
+# Identity Vendor Evaluation
+
+Status: foundation evaluation only. No vendor is procured, no identity proofing vendor is live, and no IAL2 or IAL3 assurance is claimed by this document.
+
+## Decision Boundary
+
+VitalCV needs a vendor for government ID verification, selfie/liveness, manual review fallback, consent capture, retention controls, and audit-safe event evidence before any production identity proofing flow can ship.
+
+The current application may use `NEXT_PUBLIC_IDENTITY_VENDOR=mock` for non-production foundation surfaces. The mock vendor is not a proofing service and must not be treated as identity assurance evidence.
+
+## Vendor Comparison
+
+| Vendor | Strengths | Gaps / Due Diligence Required | VitalCV Fit |
+|---|---|---|---|
+| Persona | Broad identity orchestration, configurable flows, document and selfie checks, manual review tooling. | Procurement must verify healthcare data handling, retention controls, audit exports, and contract terms for minimum necessary use. | Strongest initial fit for configurable workflows and audit-oriented review needs. |
+| Stripe Identity | Familiar developer experience, document verification, global platform maturity, straightforward integration model. | Less specialized for complex healthcare credentialing review workflows; retention and redaction posture must be contractually verified. | Good fallback if simpler identity proofing is preferred over deeper workflow configurability. |
+| Onfido | Mature document and biometric verification, global coverage, established fraud signal surface. | Procurement must validate US healthcare data obligations, retention windows, audit-safe receipt shape, and manual review transparency. | Viable enterprise option if compliance and receipt requirements are contractually satisfied. |
+| Veriff | Strong fraud and liveness posture, global document coverage, mature verification operations. | Procurement must validate audit artifacts, consent record shape, retention/redaction controls, and operational transparency. | Viable risk-focused option, pending proof that audit-safe artifacts fit VitalCV's trust model. |
+
+## Recommendation
+
+Recommended first procurement target: Persona.
+
+Rationale:
+- Best apparent fit for configurable identity workflows where VitalCV must keep proofing, consent, manual review, and audit evidence separate.
+- Better alignment with a staged launch because flows can be configured for a narrow clinician identity proofing path before broader expansion.
+- Still requires legal, security, privacy, and procurement review before any production use.
+
+Fallback: Stripe Identity if the team intentionally chooses a simpler, narrower integration with less workflow configurability.
+
+## IAL2 / IAL3 Gap Analysis
+
+VitalCV should not claim IAL2 or IAL3 from the current foundation. The following gaps must close first:
+
+| Gap | Needed For | Current State |
+|---|---|---|
+| Vendor procurement and contract | IAL2 path | Open procurement decision. |
+| Government ID verification | IAL2 path | Planned control only. |
+| Selfie/liveness or equivalent holder binding | IAL2 path | Planned control only. |
+| Consent record and retention policy | IAL2 path | Policy requirement documented; vendor evidence missing. |
+| Audit-safe proofing receipt | IAL2 path | Not available until vendor contract and integration define receipt shape. |
+| Manual review fallback | IAL2 operational reliability | Required control; vendor evidence missing. |
+| Hardware-backed / supervised or higher-assurance process | IAL3 path | Not in current product scope. |
+| Formal assurance assessment | IAL2 / IAL3 claim | Not started. |
+
+## Board Ceiling
+
+Identity proofing rows stay at approximately 30% until vendor procurement closes. This is a procurement decision, not engineering. Engineering can prepare mock contracts, typed adapters, and safe UI states, but it cannot create real identity assurance without a selected vendor and reviewed contract.


### PR DESCRIPTION
## Summary
- adds identity vendor evaluation for Persona, Stripe Identity, Onfido, and Veriff
- adds IAL ladder plan with IAL2/IAL3 gap analysis
- adds mock-only identity proofing foundation with NEXT_PUBLIC_IDENTITY_VENDOR=mock and isLive=false
- adds two Vitest cases covering the mock/non-live contract and procurement-ceiling docs

## Hard ceiling
These rows STAY at ~30% until vendor procurement closes.
This is a procurement decision, not engineering.

## Validation
- pnpm --filter @vitalcv/web exec vitest run __tests__/identity-vendor-foundation.test.ts
- pnpm turbo run build --filter @vitalcv/web

## Truth rules
- foundation only; no live identity proofing vendor
- no IAL2 or IAL3 assurance claimed
- no product code outside the identity foundation files