### PR TITLE
feat(security): CORS allowlist + API key foundation (SEC-CORS-1)

### DIFF
--- a/apps/web/__tests__/security-api-hardening.test.ts
+++ b/apps/web/__tests__/security-api-hardening.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowlist';
+import { getApiKeyFoundationState } from '@/lib/security/apiKeyFoundation';
+
+describe('CORS allowlist — default config (ALLOWED_CORS_ORIGINS unset)', () => {
+  it('blocks an API request when allowlist is empty', () => {
+    // No env var set — allowlist is empty by default
+    const result = checkCorsAllowlist('https://evil.example.com', []);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows a request whose origin is in the allowlist', () => {
+    const result = checkCorsAllowlist(
+      'https://app.vitalcv.com',
+      ['https://app.vitalcv.com', 'https://staging.vitalcv.com'],
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks a request whose origin is not in the allowlist', () => {
+    const result = checkCorsAllowlist(
+      'https://attacker.example.com',
+      ['https://app.vitalcv.com'],
+    );
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBe('origin_not_in_allowlist');
+    }
+  });
+});
+
+describe('API key foundation — keysInProduction invariant', () => {
+  it('keysInProduction is false at foundation tier', () => {
+    const state = getApiKeyFoundationState();
+    expect(state.keysInProduction).toBe(false);
+  });
+});
+
+describe('getAllowedOrigins — env parsing', () => {
+  it('returns empty array when ALLOWED_CORS_ORIGINS is unset', () => {
+    // process.env.ALLOWED_CORS_ORIGINS is not set in test environment
+    expect(getAllowedOrigins()).toEqual([]);
+  });
+});

--- a/apps/web/lib/security/apiKeyFoundation.ts
+++ b/apps/web/lib/security/apiKeyFoundation.ts
@@ -1,0 +1,10 @@
+// Foundation tier: API key infrastructure is scaffolded but no keys are active in production.
+// keysInProduction must remain false until the key rotation + vault integration wave ships.
+export type ApiKeyFoundationState = {
+  keysInProduction: false;
+  reason: 'foundation_only';
+};
+
+export function getApiKeyFoundationState(): ApiKeyFoundationState {
+  return { keysInProduction: false, reason: 'foundation_only' };
+}

--- a/apps/web/lib/security/corsAllowlist.ts
+++ b/apps/web/lib/security/corsAllowlist.ts
@@ -1,0 +1,25 @@
+// ALLOWED_CORS_ORIGINS: comma-separated list of allowed origins for /api/* routes.
+// Defaults to an empty list — nothing is allowed unless explicitly set.
+// Example: https://app.vitalcv.com,https://staging.vitalcv.com
+export function getAllowedOrigins(): readonly string[] {
+  const raw = process.env.ALLOWED_CORS_ORIGINS ?? '';
+  if (!raw.trim()) return [];
+  return raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+}
+
+export type CorsCheckResult =
+  | { allowed: true }
+  | { allowed: false; reason: 'origin_not_in_allowlist' | 'no_origin_header' | 'allowlist_empty' };
+
+export function checkCorsAllowlist(
+  origin: string | null,
+  allowedOrigins: readonly string[],
+): CorsCheckResult {
+  if (!origin) return { allowed: false, reason: 'no_origin_header' };
+  if (allowedOrigins.length === 0) return { allowed: false, reason: 'allowlist_empty' };
+  if (allowedOrigins.includes(origin)) return { allowed: true };
+  return { allowed: false, reason: 'origin_not_in_allowlist' };
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -8,6 +8,7 @@ import {
   ROLE_LANDING,
   type UserRoleType,
 } from '@/lib/auth/roles';
+import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowlist';
 
 /**
  * Role-based middleware for VitalCV.
@@ -105,6 +106,23 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
 });
 
 export default async function middleware(req: NextRequest, event: NextFetchEvent) {
+  // CORS gate: /api/* routes require the Origin to be in the allowlist.
+  // An absent ALLOWED_CORS_ORIGINS env var means the allowlist is empty and
+  // all cross-origin API requests are blocked. Same-origin requests (no Origin
+  // header) pass through — browsers omit Origin on same-origin fetches.
+  if (req.nextUrl.pathname.startsWith('/api/')) {
+    const origin = req.headers.get('origin');
+    if (origin !== null) {
+      const cors = checkCorsAllowlist(origin, getAllowedOrigins());
+      if (!cors.allowed) {
+        return new NextResponse(null, {
+          status: 403,
+          headers: { 'x-cors-blocked': '1' },
+        });
+      }
+    }
+  }
+
   if (!CLERK_MIDDLEWARE_ENABLED) {
     if (isPublicRoute(req.nextUrl.pathname)) {
       return NextResponse.next();


### PR DESCRIPTION
## Summary
- \`corsAllowlist.ts\`: \`checkCorsAllowlist()\` + \`getAllowedOrigins()\` reading \`ALLOWED_CORS_ORIGINS\` env var; empty list = all cross-origin API blocked by default
- \`apiKeyFoundation.ts\`: \`keysInProduction: false\` at foundation tier
- \`middleware.ts\`: CORS gate runs on \`/api/*\` before Clerk handler — non-allowlisted Origin returns 403 with \`x-cors-blocked: 1\`; same-origin requests (no Origin header) pass through; does not interfere with Clerk role middleware or intelligence API graceful-degradation path

## Truth rules
- Default config: \`ALLOWED_CORS_ORIGINS\` unset → allowlist empty → all cross-origin API calls blocked
- \`keysInProduction: false\` is a literal type at foundation tier — no widening
- No compliance certification copy

## Validation
- Tests: 5/5 passing
- Truth scan: CLEAN
- Middleware modification: CORS check is additive (prepended before Clerk); existing middleware test suite untouched