### PR TITLE
feat(verifier): constraint tamper detection + cross-tenant reuse block

### DIFF
--- a/apps/web/__tests__/verifier-evidence-reuse.test.ts
+++ b/apps/web/__tests__/verifier-evidence-reuse.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { classifyConstraintViolation } from '@/lib/issuer-verification/receiptCandidate';
+import { checkCrossTenantReuseBlock } from '@/lib/issuer-verification/psvReceiptReuse';
+
+// ---------------------------------------------------------------------------
+// VERIFIER-EVIDENCE-1: classifyConstraintViolation
+// ---------------------------------------------------------------------------
+
+describe('classifyConstraintViolation', () => {
+  it('returns tamper_detected for Postgres 23514 (CHECK constraint violation)', () => {
+    const pgError = { code: '23514', message: 'new row violates check constraint' };
+    expect(classifyConstraintViolation(pgError)).toBe('tamper_detected');
+  });
+
+  it('returns unknown_error for non-database errors', () => {
+    expect(classifyConstraintViolation(new Error('network error'))).toBe('unknown_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VERIFIER-REUSE-1: checkCrossTenantReuseBlock
+// ---------------------------------------------------------------------------
+
+describe('checkCrossTenantReuseBlock', () => {
+  it('blocks reuse across tenants when no consent receipt is provided', () => {
+    const result = checkCrossTenantReuseBlock('tenant-org-b', 'tenant-org-a');
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toBe('cross_tenant_no_consent');
+    }
+  });
+
+  it('permits reuse across tenants only when explicit consent receipt is present', () => {
+    const result = checkCrossTenantReuseBlock(
+      'tenant-org-b',
+      'tenant-org-a',
+      'consent-receipt-xyz-789',
+    );
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/apps/web/lib/issuer-verification/psvReceiptReuse.ts
+++ b/apps/web/lib/issuer-verification/psvReceiptReuse.ts
@@ -514,3 +514,34 @@ export function markPsvReceiptSuperseded(input: {
     source: input.source ?? 'manual_entry',
   };
 }
+
+// ---------------------------------------------------------------------------
+// VERIFIER-REUSE-1 — Cross-tenant reuse block
+// ---------------------------------------------------------------------------
+
+export type CrossTenantReuseResult =
+  | { blocked: false }
+  | { blocked: true; reason: 'cross_tenant_no_consent' };
+
+/**
+ * Asserts that PSV receipt reuse is blocked across tenant boundaries
+ * unless an explicit cross-tenant consent receipt is provided.
+ *
+ * There is no auto-reuse path across tenants — even a fresh, in-scope receipt
+ * cannot be reused by a different tenant without an explicit consent receipt ID.
+ * This prevents a receipt issued for org-A's hiring workflow from being silently
+ * consumed by org-B without a documented consent handoff.
+ */
+export function checkCrossTenantReuseBlock(
+  requestingTenantId: string,
+  issuingTenantId: string,
+  crossTenantConsentReceiptId?: string,
+): CrossTenantReuseResult {
+  if (requestingTenantId === issuingTenantId) {
+    return { blocked: false };
+  }
+  if (crossTenantConsentReceiptId) {
+    return { blocked: false };
+  }
+  return { blocked: true, reason: 'cross_tenant_no_consent' };
+}

--- a/apps/web/lib/issuer-verification/receiptCandidate.ts
+++ b/apps/web/lib/issuer-verification/receiptCandidate.ts
@@ -180,3 +180,42 @@ export function buildReceiptCandidateFromIssuerResponse(
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// VERIFIER-EVIDENCE-1 — Constraint violation classifier
+// ---------------------------------------------------------------------------
+
+export type ConstraintViolationState =
+  | 'tamper_detected'
+  | 'constraint_violation'
+  | 'unknown_error';
+
+/**
+ * Classifies a database error into a verifier-surface state.
+ *
+ * Postgres error code 23514 is a CHECK constraint violation. In the context
+ * of a receipt candidate write, a 23514 means the row failed an invariant
+ * guard (e.g. decisionGrade must be false, proofTier must be 'receipt_candidate').
+ * This is treated as tamper_detected rather than an opaque error so the
+ * surface can surface a meaningful state to the operator.
+ */
+export function classifyConstraintViolation(error: unknown): ConstraintViolationState {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code: unknown }).code === '23514'
+  ) {
+    return 'tamper_detected';
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string' &&
+    (error as { code: string }).code.startsWith('23')
+  ) {
+    return 'constraint_violation';
+  }
+  return 'unknown_error';
+}


### PR DESCRIPTION
## Summary
**VERIFIER-EVIDENCE-1:**
- \`classifyConstraintViolation()\` in \`receiptCandidate.ts\`: maps Postgres error code 23514 (CHECK constraint) to \`'tamper_detected'\` — surfaces forged-candidate attempts instead of opaque DB error

**VERIFIER-REUSE-1:**
- \`checkCrossTenantReuseBlock()\` in \`psvReceiptReuse.ts\`: blocks receipt reuse across tenant IDs unless \`crossTenantConsentReceiptId\` is explicitly provided; no auto-reuse path exists across tenant boundaries

## Truth rules
- \`classifyConstraintViolation\` is a pure classify function — no DB writes, no fetches
- Cross-tenant block is absolute: different \`requestingTenantId\` / \`issuingTenantId\` without consent receipt always returns \`blocked: true\`
- \`checkCrossTenantReuseBlock\` does not widen the \`PSVReceiptReuseScope\` type

## Validation
- Tests: 4/4 passing (2 VERIFIER-EVIDENCE-1 + 2 VERIFIER-REUSE-1)
- Truth scan: CLEAN
- Diff scope: 2 lib files + 1 new test file; no type changes to existing exported interfaces