### PR TITLE
feat(verifier): cross-tenant PSV reuse block — blocked_cross_tenant, consent-gate in main flow

### DIFF
--- a/apps/web/__tests__/verifier-reuse-cross-tenant.test.ts
+++ b/apps/web/__tests__/verifier-reuse-cross-tenant.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPsvReceiptReuseDecision,
+  checkCrossTenantReuseBlock,
+} from '../lib/issuer-verification/psvReceiptReuse';
+import type {
+  PSVReceiptReuseRequest,
+  PSVReceiptReuseScope,
+} from '../lib/issuer-verification/psvReceiptReuse';
+import type { PSVReceipt, PSVReceiptScope } from '../lib/issuer-verification/types';
+
+const SCOPE: PSVReceiptScope = {
+  claimType: 'residency',
+  covers: 'Confirms completion of the residency program.',
+  doesNotCover: 'Does not confirm board certification or license status.',
+  sourceOrganizationName: 'Demo GME Office',
+};
+
+function makeReceipt(overrides: Partial<PSVReceipt> = {}): PSVReceipt {
+  return {
+    psvReceiptId: 'psv-cross-1',
+    psvCandidateId: 'psv-1',
+    receiptCandidateId: 'rc-1',
+    requestId: 'req-1',
+    claimId: 'claim-1',
+    claimType: 'residency',
+    promotedAt: '2026-04-01T00:00:00.000Z',
+    promotedBy: { actorId: 'actor-1', displayName: 'Pat Reviewer', role: 'policy_reviewer' },
+    sourceBasis: {
+      sourceOrganizationName: 'Demo GME Office',
+      isContractedAgent: false,
+      basisNote: 'Direct from source.',
+    },
+    attributedResponder: {
+      name: 'J. Doe',
+      role: 'Program Coordinator',
+      attributedAt: '2026-04-01T01:00:00.000Z',
+      attributionMethod: 'self_attested',
+    },
+    scope: SCOPE,
+    limitations: [],
+    freshness: {
+      ttlDays: 365,
+      issuedAt: '2026-04-01T00:00:00.000Z',
+      staleAfter: '2027-04-01T00:00:00.000Z',
+    },
+    proofTier: 'psv_receipt',
+    decisionGrade: true,
+    globalCredentialTruth: false,
+    auditMetadata: {
+      recordedAt: '2026-04-01T00:00:00.000Z',
+      recordedBy: 'review_surface',
+      eventState: 'pending_not_written',
+      notes: 'Demo audit metadata; no real audit-event row written.',
+    },
+    notes: 'PSV receipt. Scoped evidence subject to limitations and freshness; not global credential truth.',
+    ...overrides,
+  };
+}
+
+const REUSE_SCOPE: PSVReceiptReuseScope = {
+  claimType: 'residency',
+  sourceOrganizationName: 'Demo GME Office',
+  purpose: 'Reuse for a new pilot enrollment.',
+};
+
+function decisionOptions(id = 'reuse-cross-1') {
+  return { decisionId: id, decidedAt: '2026-05-01T00:00:00.000Z', recordedBy: 'demo' as const };
+}
+
+// Case 1 — cross-tenant reuse without consent is blocked
+describe('cross-tenant reuse without consent receipt', () => {
+  it('returns reuseStatus blocked_cross_tenant when tenants differ and no consent id', () => {
+    const request: PSVReceiptReuseRequest = {
+      receipt: makeReceipt(),
+      reuseScope: REUSE_SCOPE,
+      nowIso: '2026-05-01T00:00:00.000Z',
+      requestingTenantId: 'tenant-employer-abc',
+      issuingTenantId: 'tenant-hospital-xyz',
+    };
+    const decision = buildPsvReceiptReuseDecision(request, decisionOptions());
+    expect(decision.status).toBe('blocked_cross_tenant');
+    expect(decision.reusable).toBe(false);
+    expect(decision.failureReason).toBe('cross_tenant_no_consent');
+    // Truth contract: reuse never returns a PSVReceipt or upgrades truth tier
+    expect(decision.globalCredentialTruth).toBe(false);
+  });
+
+  it('standalone guard also returns blocked=true without consent', () => {
+    const result = checkCrossTenantReuseBlock('tenant-employer-abc', 'tenant-hospital-xyz');
+    expect(result.blocked).toBe(true);
+    if (result.blocked) expect(result.reason).toBe('cross_tenant_no_consent');
+  });
+});
+
+// Case 2 — cross-tenant reuse with explicit consent receipt is permitted
+describe('cross-tenant reuse with explicit consent receipt', () => {
+  it('permits reuse when crossTenantConsentReceiptId is present', () => {
+    const request: PSVReceiptReuseRequest = {
+      receipt: makeReceipt(),
+      reuseScope: REUSE_SCOPE,
+      nowIso: '2026-05-01T00:00:00.000Z',
+      requestingTenantId: 'tenant-employer-abc',
+      issuingTenantId: 'tenant-hospital-xyz',
+      crossTenantConsentReceiptId: 'consent-receipt-99',
+    };
+    const decision = buildPsvReceiptReuseDecision(request, decisionOptions('reuse-cross-2'));
+    expect(decision.status).toBe('reusable');
+    expect(decision.reusable).toBe(true);
+    expect(decision.failureReason).toBeUndefined();
+    // Truth contract: reuse never returns PSVReceipt or promotes truth tier
+    expect(decision.globalCredentialTruth).toBe(false);
+  });
+
+  it('standalone guard returns blocked=false when consent id is present', () => {
+    const result = checkCrossTenantReuseBlock(
+      'tenant-employer-abc',
+      'tenant-hospital-xyz',
+      'consent-receipt-99',
+    );
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/apps/web/lib/issuer-verification/psvReceiptReuse.ts
+++ b/apps/web/lib/issuer-verification/psvReceiptReuse.ts
@@ -44,7 +44,8 @@ export type PSVReceiptReuseStatus =
   | 'scope_mismatch'
   | 'limitation_blocks_reuse'
   | 'policy_review_required'
-  | 'source_recheck_required';
+  | 'source_recheck_required'
+  | 'blocked_cross_tenant';
 
 export type PSVReceiptReuseFailureReason =
   | 'receipt_expired'
@@ -58,7 +59,8 @@ export type PSVReceiptReuseFailureReason =
   | 'responder_attribution_missing'
   | 'policy_review_required'
   | 'audit_metadata_missing'
-  | 'unsupported_receipt_type';
+  | 'unsupported_receipt_type'
+  | 'cross_tenant_no_consent';
 
 export type PSVReceiptFreshnessState = 'fresh' | 'needs_refresh' | 'expired';
 
@@ -129,6 +131,15 @@ export interface PSVReceiptReuseRequest {
    * `reusable`. Caller-controlled.
    */
   refreshSoftThresholdDays?: number;
+  /**
+   * Cross-tenant guard. When both are supplied and they differ, reuse
+   * is blocked unless `crossTenantConsentReceiptId` is also present.
+   * Omitting either field skips the tenant check (single-tenant path).
+   */
+  requestingTenantId?: string;
+  issuingTenantId?: string;
+  /** Explicit consent receipt that authorises cross-tenant reuse. */
+  crossTenantConsentReceiptId?: string;
 }
 
 /**
@@ -206,6 +217,8 @@ export function getPsvReceiptFreshnessState(
 }
 
 const FAILURE_EXPLANATIONS: Record<PSVReceiptReuseFailureReason, string> = {
+  cross_tenant_no_consent:
+    'Reuse is blocked: the requesting tenant differs from the issuing tenant and no cross-tenant consent receipt is present. An explicit consent receipt is required before cross-tenant reuse is permitted.',
   receipt_expired:
     'The PSV receipt is past its freshness window. Reuse is blocked; a source recheck or refresh is required.',
   receipt_revoked:
@@ -233,6 +246,7 @@ const FAILURE_EXPLANATIONS: Record<PSVReceiptReuseFailureReason, string> = {
 };
 
 const STATUS_BY_FAILURE: Record<PSVReceiptReuseFailureReason, PSVReceiptReuseStatus> = {
+  cross_tenant_no_consent: 'blocked_cross_tenant',
   receipt_expired: 'expired',
   receipt_revoked: 'revoked',
   receipt_superseded: 'superseded',
@@ -313,6 +327,15 @@ export function getPsvReceiptReuseFailureReason(
   if (revocation.state === 'revoked') return 'receipt_revoked';
   if (supersession.state === 'superseded') return 'receipt_superseded';
   if (freshness.state === 'expired') return 'receipt_expired';
+
+  if (
+    request.requestingTenantId &&
+    request.issuingTenantId &&
+    request.requestingTenantId !== request.issuingTenantId &&
+    !request.crossTenantConsentReceiptId
+  ) {
+    return 'cross_tenant_no_consent';
+  }
 
   if (!scopesMatch(receipt.scope, reuseScope)) return 'scope_mismatch';
 
@@ -513,4 +536,20 @@ export function markPsvReceiptSuperseded(input: {
     supersededAt: input.supersededAt,
     source: input.source ?? 'manual_entry',
   };
+}
+
+// Cross-tenant reuse guard — standalone predicate used when the full
+// buildPsvReceiptReuseDecision pipeline is not needed.
+export type CrossTenantReuseResult =
+  | { blocked: false }
+  | { blocked: true; reason: 'cross_tenant_no_consent' };
+
+export function checkCrossTenantReuseBlock(
+  requestingTenantId: string,
+  issuingTenantId: string,
+  crossTenantConsentReceiptId?: string,
+): CrossTenantReuseResult {
+  if (requestingTenantId === issuingTenantId) return { blocked: false };
+  if (crossTenantConsentReceiptId) return { blocked: false };
+  return { blocked: true, reason: 'cross_tenant_no_consent' };
 }


### PR DESCRIPTION
## Summary

- **`PSVReceiptReuseStatus`** — adds `'blocked_cross_tenant'` variant
- **`PSVReceiptReuseFailureReason`** — adds `'cross_tenant_no_consent'` reason
- **`PSVReceiptReuseRequest`** — adds optional `requestingTenantId`, `issuingTenantId`, `crossTenantConsentReceiptId` (backward-compatible; single-tenant callers omit all three and the check is bypassed)
- **`getPsvReceiptReuseFailureReason`** — cross-tenant check integrated into main gate sequence: fires after freshness-expiry, before scope-mismatch; returns `'cross_tenant_no_consent'` when tenants differ and no `crossTenantConsentReceiptId` is present
- **`checkCrossTenantReuseBlock`** — standalone predicate for callers that don't need the full `buildPsvReceiptReuseDecision` pipeline; exported as `CrossTenantReuseResult` discriminated union

## Truth contract

`globalCredentialTruth` stays the literal `false` on every code path, including the new `blocked_cross_tenant` branch. The decision object is `PSVReceiptReuseDecision`, never a `PSVReceipt` — there is no auto-promote path. Reuse with an explicit `crossTenantConsentReceiptId` permits the decision but still emits `globalCredentialTruth: false`.

## Test plan

- [x] 4/4 tests passing: `pnpm --filter @vitalcv/web exec vitest run __tests__/verifier-reuse-cross-tenant.test.ts`
  - Cross-tenant without consent → `status: 'blocked_cross_tenant'`, `failureReason: 'cross_tenant_no_consent'`
  - Standalone guard without consent → `blocked: true`
  - Cross-tenant with `crossTenantConsentReceiptId` → `status: 'reusable'`, no `failureReason`
  - Standalone guard with consent id → `blocked: false`
- [ ] Codex SAFE verdict (three-pass: implementation / diff / copy) before merge
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)