### PR TITLE
feat(rbac): verifier org RBAC enforcement — rbacEnforced true, /api/verifier/* gated

### DIFF
--- a/apps/web/__tests__/verifier-rbac-enforcement.test.ts
+++ b/apps/web/__tests__/verifier-rbac-enforcement.test.ts
@@ -1,0 +1,185 @@
+/**
+ * verifier-rbac-enforcement.test.ts
+ *
+ * Tests the pure RBAC logic in lib/auth/orgInvitations.ts.
+ * No Clerk, no DB, no network — all cases are deterministic.
+ *
+ * Truth contracts verified:
+ *   1. readonly role cannot POST/PUT/DELETE on /api/verifier/* → 403
+ *   2. Cross-org request → 404 (not 403; no info leak)
+ *   3. Timing-safe: all byte positions processed regardless of length
+ *   4. org_id absent from JWT → no implicit grant → 403 no_org_context
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  checkVerifierPermission,
+  rbacEnforced,
+  timingSafeEqualStrings,
+  parseTeamRole,
+} from '../lib/auth/orgInvitations';
+import { VERIFIER_TEAM_ROLES } from '../lib/auth/roles';
+
+const ORG_A = 'org_abc123';
+const ORG_B = 'org_xyz789';
+
+// ── Case 1 — readonly role blocks mutating methods; allows reads ───────────
+describe('readonly role enforcement on /api/verifier/*', () => {
+  const ctx = {
+    requestingOrgId: ORG_A,
+    teamRole: 'readonly' as const,
+    resourceOrgId: ORG_A,
+  };
+
+  it('blocks POST with 403', () => {
+    const d = checkVerifierPermission({ ...ctx, method: 'POST' });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) {
+      expect(d.statusCode).toBe(403);
+      expect(d.reason).toBe('readonly_blocks_mutation');
+    }
+  });
+
+  it('blocks PUT with 403', () => {
+    const d = checkVerifierPermission({ ...ctx, method: 'PUT' });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) expect(d.statusCode).toBe(403);
+  });
+
+  it('blocks DELETE with 403', () => {
+    const d = checkVerifierPermission({ ...ctx, method: 'DELETE' });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) expect(d.statusCode).toBe(403);
+  });
+
+  it('permits GET for readonly', () => {
+    const d = checkVerifierPermission({ ...ctx, method: 'GET' });
+    expect(d.permitted).toBe(true);
+  });
+
+  it('member and admin roles may POST on same org', () => {
+    for (const role of ['member', 'admin', 'owner'] as const) {
+      const d = checkVerifierPermission({ ...ctx, teamRole: role, method: 'POST' });
+      expect(d.permitted).toBe(true);
+    }
+  });
+});
+
+// ── Case 2 — cross-org request returns 404, not 403 ──────────────────────
+describe('cross-org access returns 404', () => {
+  it('returns 404 when requesting org differs from resource org', () => {
+    const d = checkVerifierPermission({
+      requestingOrgId: ORG_A,
+      teamRole: 'admin',
+      resourceOrgId: ORG_B,
+      method: 'GET',
+    });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) {
+      expect(d.statusCode).toBe(404);
+      expect(d.reason).toBe('cross_org');
+    }
+  });
+
+  it('returns 404 even for owner role on a different org', () => {
+    const d = checkVerifierPermission({
+      requestingOrgId: ORG_A,
+      teamRole: 'owner',
+      resourceOrgId: ORG_B,
+      method: 'DELETE',
+    });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) expect(d.statusCode).toBe(404);
+  });
+});
+
+// ── Case 3 — timing-safe org_id comparison ───────────────────────────────
+describe('timingSafeEqualStrings — constant-time comparison', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqualStrings(ORG_A, ORG_A)).toBe(true);
+    expect(timingSafeEqualStrings('', '')).toBe(true);
+  });
+
+  it('returns false for different strings of same length', () => {
+    expect(timingSafeEqualStrings('org_aaa', 'org_bbb')).toBe(false);
+  });
+
+  it('returns false for different-length strings without short-circuiting', () => {
+    // Short string vs long — must not early-return on length mismatch alone
+    expect(timingSafeEqualStrings('org_a', 'org_a_extra')).toBe(false);
+    expect(timingSafeEqualStrings('org_a_extra', 'org_a')).toBe(false);
+  });
+
+  it('returns false for empty vs non-empty', () => {
+    expect(timingSafeEqualStrings('', ORG_A)).toBe(false);
+    expect(timingSafeEqualStrings(ORG_A, '')).toBe(false);
+  });
+});
+
+// ── Case 4 — org_id absence → no implicit grant ──────────────────────────
+describe('org_id absent from JWT → no implicit grant', () => {
+  it('returns 403 no_org_context when requestingOrgId is null', () => {
+    const d = checkVerifierPermission({
+      requestingOrgId: null,
+      teamRole: 'admin',
+      resourceOrgId: ORG_A,
+      method: 'GET',
+    });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) {
+      expect(d.statusCode).toBe(403);
+      expect(d.reason).toBe('no_org_context');
+    }
+  });
+
+  it('returns 403 no_org_context when teamRole is null (even with valid org_id)', () => {
+    const d = checkVerifierPermission({
+      requestingOrgId: ORG_A,
+      teamRole: null,
+      resourceOrgId: ORG_A,
+      method: 'GET',
+    });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) {
+      expect(d.statusCode).toBe(403);
+      expect(d.reason).toBe('no_org_context');
+    }
+  });
+
+  it('returns 403 no_org_context when both are null', () => {
+    const d = checkVerifierPermission({
+      requestingOrgId: null,
+      teamRole: null,
+      resourceOrgId: ORG_A,
+      method: 'POST',
+    });
+    expect(d.permitted).toBe(false);
+    if (!d.permitted) expect(d.statusCode).toBe(403);
+  });
+});
+
+// ── Structural invariants ─────────────────────────────────────────────────
+describe('structural invariants', () => {
+  it('rbacEnforced is the literal true', () => {
+    expect(rbacEnforced).toBe(true);
+    // Type-level: this would be a TS error if someone widened to boolean
+    const enforced: true = rbacEnforced;
+    expect(enforced).toBe(true);
+  });
+
+  it('VERIFIER_TEAM_ROLES contains exactly four roles', () => {
+    expect(VERIFIER_TEAM_ROLES).toEqual(['owner', 'admin', 'member', 'readonly']);
+  });
+
+  it('parseTeamRole returns null for unknown values', () => {
+    expect(parseTeamRole('superadmin')).toBeNull();
+    expect(parseTeamRole(42)).toBeNull();
+    expect(parseTeamRole(undefined)).toBeNull();
+    expect(parseTeamRole('')).toBeNull();
+  });
+
+  it('parseTeamRole maps all known roles correctly', () => {
+    for (const role of VERIFIER_TEAM_ROLES) {
+      expect(parseTeamRole(role)).toBe(role);
+    }
+  });
+});

--- a/apps/web/lib/auth/orgInvitations.ts
+++ b/apps/web/lib/auth/orgInvitations.ts
@@ -1,0 +1,109 @@
+/**
+ * apps/web/lib/auth/orgInvitations.ts
+ *
+ * Verifier org RBAC enforcement. rbacEnforced is the literal `true`.
+ *
+ * Truth contracts:
+ *   - readonly role cannot POST/PUT/DELETE/PATCH on /api/verifier/*.
+ *     Returns statusCode 403.
+ *   - Cross-org request (requesting org ≠ resource org) returns statusCode 404.
+ *     404 is deliberate: no information leaks about whether the resource org
+ *     exists, who owns it, or what roles it has.
+ *   - Absent org context (org_id or team_role missing from JWT) → no implicit
+ *     grant → statusCode 403 with reason 'no_org_context'.
+ *   - org_id comparison is timing-safe: all bytes processed regardless of
+ *     length to prevent oracle-based timing attacks on org IDs.
+ *
+ * This module is a pure transform — no DB reads, no Clerk API calls, no fetch.
+ */
+
+import type { VerifierTeamRole } from './roles';
+
+// Seal the enforcement flag as a literal so callers cannot accidentally
+// widen it to `boolean` and bypass the guard.
+export const rbacEnforced = true as const;
+
+/** HTTP methods that modify state — blocked for readonly members. */
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
+
+export type RbacFailureReason =
+  | 'no_org_context'
+  | 'readonly_blocks_mutation'
+  | 'cross_org';
+
+export type RbacDecision =
+  | { permitted: true }
+  | { permitted: false; statusCode: 403 | 404; reason: RbacFailureReason };
+
+export interface MembershipContext {
+  /** org_id from the Clerk JWT vitalcv claim; null when absent. */
+  requestingOrgId: string | null;
+  /** team_role from the Clerk JWT vitalcv claim; null when absent. */
+  teamRole: VerifierTeamRole | null;
+  /** The org that owns the verifier resource being accessed. */
+  resourceOrgId: string;
+  /** HTTP method of the incoming request. */
+  method: string;
+}
+
+/**
+ * Evaluate whether the requesting member may access a verifier resource.
+ *
+ * Gate order (must not be reordered — each gate is load-bearing):
+ *   1. No org context  → 403 no_org_context
+ *   2. Cross-org check → 404 cross_org  (timing-safe compare)
+ *   3. Readonly + mutating method → 403 readonly_blocks_mutation
+ *   4. Permitted
+ */
+export function checkVerifierPermission(ctx: MembershipContext): RbacDecision {
+  // Gate 1 — no org context in JWT → no implicit grant
+  if (!ctx.requestingOrgId || !ctx.teamRole) {
+    return { permitted: false, statusCode: 403, reason: 'no_org_context' };
+  }
+
+  // Gate 2 — cross-org access → 404 (no info leak)
+  if (!timingSafeEqualStrings(ctx.requestingOrgId, ctx.resourceOrgId)) {
+    return { permitted: false, statusCode: 404, reason: 'cross_org' };
+  }
+
+  // Gate 3 — readonly role cannot mutate
+  if (ctx.teamRole === 'readonly' && MUTATING_METHODS.has(ctx.method.toUpperCase())) {
+    return { permitted: false, statusCode: 403, reason: 'readonly_blocks_mutation' };
+  }
+
+  return { permitted: true };
+}
+
+/**
+ * Timing-safe string equality for org IDs.
+ *
+ * Processes every byte of both strings before returning, preventing
+ * timing oracles that could enumerate valid org IDs by measuring
+ * how quickly an early-exit comparison returns.
+ *
+ * Edge-runtime safe: uses TextEncoder (Web API), not Node crypto.
+ */
+export function timingSafeEqualStrings(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const aBytes = enc.encode(a);
+  const bBytes = enc.encode(b);
+  // Length difference is a mismatch but we do NOT early-return here —
+  // we continue processing all bytes so timing stays constant.
+  let mismatch = aBytes.length ^ bBytes.length;
+  const len = Math.max(aBytes.length, bBytes.length);
+  for (let i = 0; i < len; i++) {
+    mismatch |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0);
+  }
+  return mismatch === 0;
+}
+
+/**
+ * Extract and validate the team role from a raw JWT claim string.
+ * Returns null when the value is absent or not a known VerifierTeamRole.
+ * Does not throw — invalid values are treated as no role.
+ */
+export function parseTeamRole(raw: unknown): VerifierTeamRole | null {
+  if (typeof raw !== 'string') return null;
+  const known: ReadonlyArray<string> = ['owner', 'admin', 'member', 'readonly'];
+  return known.includes(raw) ? (raw as VerifierTeamRole) : null;
+}

--- a/apps/web/lib/auth/roles.ts
+++ b/apps/web/lib/auth/roles.ts
@@ -3,6 +3,14 @@
 // Canonical role definitions, route-role mappings, and post-login redirects.
 // Used by middleware, components, and tests.
 
+/**
+ * Clerk org-membership roles for verifier team access.
+ * Maps to the `team_role` claim in the Clerk JWT.
+ * Order is privilege-ascending: readonly < member < admin < owner.
+ */
+export const VERIFIER_TEAM_ROLES = ['owner', 'admin', 'member', 'readonly'] as const;
+export type VerifierTeamRole = (typeof VERIFIER_TEAM_ROLES)[number];
+
 export const UserRole = {
   CLINICIAN: 'CLINICIAN',
   VERIFIER: 'VERIFIER',

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -8,6 +8,10 @@ import {
   ROLE_LANDING,
   type UserRoleType,
 } from '@/lib/auth/roles';
+import {
+  checkVerifierPermission,
+  parseTeamRole,
+} from '@/lib/auth/orgInvitations';
 
 /**
  * Role-based middleware for VitalCV.
@@ -31,10 +35,38 @@ const isSignInPage = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
  * failures are caught and the request passes through to route handlers.
  */
 const INTELLIGENCE_API = /^\/api\/(intelligence|investigation)(\/.*)?$/;
+/** Verifier API routes — require Clerk auth + org-level RBAC before the
+ *  normal /api/* public-route pass-through would fire. */
+const VERIFIER_API = /^\/api\/verifier(\/.*)?$/;
 const CLERK_MIDDLEWARE_ENABLED = Boolean(process.env.CLERK_SECRET_KEY);
 
 const clerkHandler = clerkMiddleware(async (auth, req) => {
   const { pathname } = req.nextUrl;
+
+  // 0. Verifier API RBAC — checked before the /api/* public-route pass-through.
+  //    Reads org_id and team_role from the JWT vitalcv claim. The resource
+  //    org_id is supplied by the client via the x-verifier-org header so the
+  //    middleware can enforce cross-org isolation without a DB read.
+  if (VERIFIER_API.test(pathname)) {
+    const session = await auth();
+    if (!session.userId) {
+      return new NextResponse(null, { status: 403 });
+    }
+    const claims = session.sessionClaims?.vitalcv as Record<string, unknown> | undefined;
+    const requestingOrgId = (claims?.org_id as string | undefined) ?? null;
+    const teamRole = parseTeamRole(claims?.team_role);
+    const resourceOrgId = req.headers.get('x-verifier-org') ?? '';
+    const decision = checkVerifierPermission({
+      requestingOrgId,
+      teamRole,
+      resourceOrgId,
+      method: req.method,
+    });
+    if (!decision.permitted) {
+      return new NextResponse(null, { status: decision.statusCode });
+    }
+    return NextResponse.next();
+  }
 
   // 1. Public routes pass through
   if (isPublicRoute(pathname)) {


### PR DESCRIPTION
## Summary

- **`lib/auth/roles.ts`** — adds `VERIFIER_TEAM_ROLES = ['owner','admin','member','readonly'] as const` and `VerifierTeamRole` type.
- **`lib/auth/orgInvitations.ts`** (new) — pure RBAC logic. `rbacEnforced` is the literal `true`. `checkVerifierPermission(ctx)` evaluates three gates in order: (1) no org context → 403, (2) cross-org (timing-safe) → 404, (3) readonly + mutating method → 403. `timingSafeEqualStrings()` uses `TextEncoder` XOR over all bytes with no early-exit — Edge-runtime safe. `parseTeamRole()` maps raw JWT claim strings to `VerifierTeamRole | null`; unknown values return null (no silent grants).
- **`middleware.ts`** — adds `VERIFIER_API = /^\/api\/verifier(\/.*)?$/` intercept **before** the `/api/*` public-route pass-through. Reads `org_id` + `team_role` from `sessionClaims.vitalcv`; reads resource org from `x-verifier-org` request header; calls `checkVerifierPermission`; returns 403/404 as appropriate.

## Truth contract

| Case | Result | Status |
|------|--------|--------|
| `readonly` + POST/PUT/DELETE | Blocked | 403 `readonly_blocks_mutation` |
| `readonly` + GET | Permitted | — |
| `member`/`admin`/`owner` + POST, same org | Permitted | — |
| Requesting org ≠ resource org | Blocked | **404** `cross_org` (no info leak) |
| `org_id` absent from JWT | Blocked | 403 `no_org_context` |
| `team_role` absent from JWT | Blocked | 403 `no_org_context` |

`timingSafeEqualStrings` processes every byte position regardless of string length, preventing timing oracles that could probe whether a given org ID is valid by measuring comparison latency.

## Test plan

- [x] 18/18 tests passing: `pnpm --filter @vitalcv/web exec vitest run __tests__/verifier-rbac-enforcement.test.ts`
- [ ] Codex SAFE verdict (three-pass: implementation / diff / copy) before merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)