### PR TITLE
feat(upload): add CV upload route and CvUploadZone (UPLOAD-CV-1)

### DIFF
--- a/apps/web/__tests__/upload-cv.test.ts
+++ b/apps/web/__tests__/upload-cv.test.ts
@@ -1,0 +1,86 @@
+/**
+ * upload-cv.test.ts
+ *
+ * Tests the /api/upload/cv route handler in isolation.
+ * No Clerk, no DB, no network.
+ *
+ * Truth contracts verified:
+ *   1. Non-PDF/DOCX MIME type → 415
+ *   2. PDF upload → 200; ocrLive: false, parseLive: false, parsedEntries: []
+ *   3. DOCX upload → 200; ocrLive: false, parseLive: false, parsedEntries: []
+ *   4. File > 5 MB → 413
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const CV_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+function buildMultipartRequest(
+  mimeType: string,
+  content: string | Uint8Array,
+  filename = 'test.pdf',
+): NextRequest {
+  const file = new File([content], filename, { type: mimeType });
+  const form = new FormData();
+  form.append('file', file);
+  return new NextRequest('http://localhost/api/upload/cv', {
+    method: 'POST',
+    body: form,
+  });
+}
+
+describe('/api/upload/cv', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns 415 for non-PDF/DOCX MIME type', async () => {
+    const { POST } = await import('../app/api/upload/cv/route');
+    const req = buildMultipartRequest('image/jpeg', 'fake-image-data', 'photo.jpg');
+    const res = await POST(req);
+    expect(res.status).toBe(415);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('mime_not_allowed');
+  });
+
+  it('accepts PDF and returns ocrLive: false, parseLive: false, parsedEntries: []', async () => {
+    const { POST } = await import('../app/api/upload/cv/route');
+    const req = buildMultipartRequest('application/pdf', '%PDF-1.4 stub', 'cv.pdf');
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      ocrLive: boolean;
+      parseLive: boolean;
+      parsedEntries: unknown[];
+      provenance: string;
+    };
+    expect(body.ocrLive).toBe(false);
+    expect(body.parseLive).toBe(false);
+    expect(body.parsedEntries).toEqual([]);
+    expect(body.provenance).toBe('USER_ENTERED');
+  });
+
+  it('accepts DOCX and returns ocrLive: false, parseLive: false', async () => {
+    const { POST } = await import('../app/api/upload/cv/route');
+    const req = buildMultipartRequest(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'PK stub docx bytes',
+      'cv.docx',
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ocrLive: boolean; parseLive: boolean };
+    expect(body.ocrLive).toBe(false);
+    expect(body.parseLive).toBe(false);
+  });
+
+  it('returns 413 for files exceeding the 5 MB limit', async () => {
+    const { POST } = await import('../app/api/upload/cv/route');
+    const oversized = new Uint8Array(CV_MAX_FILE_SIZE_BYTES + 1);
+    const req = buildMultipartRequest('application/pdf', oversized, 'big.pdf');
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('file_too_large');
+  });
+});

--- a/apps/web/app/api/upload/cv/route.ts
+++ b/apps/web/app/api/upload/cv/route.ts
@@ -1,0 +1,71 @@
+/**
+ * /api/upload/cv — multipart CV upload (foundation tier)
+ *
+ * POST multipart/form-data { file: File }
+ *
+ * Truth contract:
+ *   - All uploads land as USER_ENTERED provenance. No OCR, no parsing.
+ *   - MIME allowlist: application/pdf and DOCX only.
+ *   - Files > 5 MB return 413.
+ *   - parsedEntries is always [] (parseLive: false).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  checkCvUploadConstraints,
+  getCvFoundationState,
+  CV_MAX_FILE_SIZE_BYTES,
+} from '@/lib/upload/cvFoundation';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const foundation = getCvFoundationState();
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Expected multipart/form-data body.' },
+      { status: 400 },
+    );
+  }
+
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Missing file field.' },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > CV_MAX_FILE_SIZE_BYTES) {
+    return NextResponse.json(
+      { error: 'file_too_large', message: 'File exceeds the 5 MB limit.' },
+      { status: 413 },
+    );
+  }
+
+  const check = checkCvUploadConstraints(file.type, file.size);
+  if (!check.allowed) {
+    return NextResponse.json(
+      { error: 'mime_not_allowed', message: 'Only PDF and DOCX files are accepted.' },
+      { status: 415 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      accepted: true,
+      provenance: foundation.provenance,
+      ocrLive: foundation.ocrLive,
+      parseLive: foundation.parseLive,
+      mimeType: check.mimeType,
+      sizeBytes: file.size,
+      parsedEntries: [],
+      message:
+        'CV received. It has been recorded as user-entered. Structured parsing is not active on this entry point.',
+    },
+    { status: 200 },
+  );
+}

--- a/apps/web/app/clinician/import/page.tsx
+++ b/apps/web/app/clinician/import/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import { CvUploadZone } from '@/components/upload/CvUploadZone';
 
 export const metadata: Metadata = {
   title: 'Clinician Import · VitalCV',
@@ -137,6 +138,14 @@ export default function ClinicianImportPage() {
 
       <div className="space-y-10">
         <CardGrid heading="Import" items={IMPORTS} headingId="import-section-heading" />
+
+        <section aria-labelledby="cv-upload-zone-heading" className="space-y-4">
+          <h2 id="cv-upload-zone-heading" className="text-lg font-semibold sm:text-xl">
+            Upload CV
+          </h2>
+          <CvUploadZone />
+        </section>
+
         <CardGrid heading="Export" items={EXPORTS} headingId="export-section-heading" />
       </div>
     </main>

--- a/apps/web/components/upload/CvUploadZone.tsx
+++ b/apps/web/components/upload/CvUploadZone.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import * as React from 'react';
+import { CV_ALLOWED_MIME_TYPES, CV_MAX_FILE_SIZE_BYTES } from '@/lib/upload/cvFoundation';
+
+const CV_ACCEPT = CV_ALLOWED_MIME_TYPES.join(',');
+const CV_MAX_MB = CV_MAX_FILE_SIZE_BYTES / (1024 * 1024);
+
+type UploadState =
+  | { phase: 'idle' }
+  | { phase: 'dragging' }
+  | { phase: 'uploading' }
+  | { phase: 'success'; mimeType: string; sizeBytes: number }
+  | { phase: 'error'; message: string };
+
+function validateCvFile(file: File): string | null {
+  if (file.size > CV_MAX_FILE_SIZE_BYTES) {
+    return `File exceeds the ${CV_MAX_MB} MB limit.`;
+  }
+  if (!(CV_ALLOWED_MIME_TYPES as readonly string[]).includes(file.type)) {
+    return 'Only PDF and DOCX files are accepted.';
+  }
+  return null;
+}
+
+export function CvUploadZone() {
+  const [state, setState] = React.useState<UploadState>({ phase: 'idle' });
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFile = React.useCallback(async (file: File) => {
+    const clientError = validateCvFile(file);
+    if (clientError) {
+      setState({ phase: 'error', message: clientError });
+      return;
+    }
+
+    setState({ phase: 'uploading' });
+    try {
+      const body = new FormData();
+      body.append('file', file);
+      const res = await fetch('/api/upload/cv', { method: 'POST', body });
+      if (res.status === 413) {
+        setState({ phase: 'error', message: `File exceeds the ${CV_MAX_MB} MB limit.` });
+        return;
+      }
+      if (res.status === 415) {
+        setState({ phase: 'error', message: 'Only PDF and DOCX files are accepted.' });
+        return;
+      }
+      if (!res.ok) {
+        setState({ phase: 'error', message: 'Upload failed. Please try again.' });
+        return;
+      }
+      const data = await res.json() as { mimeType: string; sizeBytes: number };
+      setState({ phase: 'success', mimeType: data.mimeType, sizeBytes: data.sizeBytes });
+    } catch {
+      setState({ phase: 'error', message: 'Upload failed. Please try again.' });
+    }
+  }, []);
+
+  const handleFiles = React.useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      void handleFile(files[0]);
+    },
+    [handleFile],
+  );
+
+  const onDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (state.phase !== 'uploading') setState({ phase: 'dragging' });
+  };
+
+  const onDragLeave = () => {
+    if (state.phase === 'dragging') setState({ phase: 'idle' });
+  };
+
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (state.phase !== 'uploading') {
+      setState({ phase: 'idle' });
+      handleFiles(e.dataTransfer.files);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      inputRef.current?.click();
+    }
+  };
+
+  const disabled = state.phase === 'uploading';
+  const isDragging = state.phase === 'dragging';
+
+  return (
+    <div className="space-y-3">
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label="Upload a CV or resume. Click or drag and drop a PDF or DOCX file."
+        aria-disabled={disabled}
+        aria-describedby="cv-dropzone-hint cv-dropzone-status"
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        onClick={() => !disabled && inputRef.current?.click()}
+        onKeyDown={onKeyDown}
+        className={[
+          'flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 text-center transition-colors cursor-pointer select-none',
+          isDragging
+            ? 'border-emerald-500 bg-emerald-950/20'
+            : 'border-zinc-700 hover:border-zinc-500',
+          disabled ? 'cursor-not-allowed opacity-50' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <svg
+          aria-hidden
+          className="h-8 w-8 text-zinc-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        <p className="text-sm font-medium text-zinc-300">
+          {isDragging ? 'Drop to upload' : 'Click or drag a CV here'}
+        </p>
+        <p id="cv-dropzone-hint" className="text-xs text-zinc-500">
+          PDF or DOCX · max {CV_MAX_MB} MB
+        </p>
+      </div>
+
+      <div id="cv-dropzone-status">
+        {state.phase === 'uploading' && (
+          <p className="text-xs text-zinc-400" role="status">Uploading…</p>
+        )}
+        {state.phase === 'success' && (
+          <p className="text-xs text-emerald-400" role="status">
+            CV received. Recorded as user-entered — structured parsing is a separate step.
+          </p>
+        )}
+        {state.phase === 'error' && (
+          <p className="text-xs text-red-400" role="alert">{state.message}</p>
+        )}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={CV_ACCEPT}
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+    </div>
+  );
+}

--- a/apps/web/lib/upload/cvFoundation.ts
+++ b/apps/web/lib/upload/cvFoundation.ts
@@ -1,0 +1,41 @@
+// CV upload foundation — parsing and OCR are not live.
+// All uploaded CVs land as USER_ENTERED provenance; they never
+// acquire VERIFIED provenance through this path.
+export type CvProvenance = 'USER_ENTERED';
+
+export type CvFoundationState = {
+  ocrLive: false;
+  parseLive: false;
+  provenance: CvProvenance;
+};
+
+export function getCvFoundationState(): CvFoundationState {
+  return { ocrLive: false, parseLive: false, provenance: 'USER_ENTERED' };
+}
+
+// MIME types allowed for CV upload: PDF and DOCX only.
+export const CV_ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+] as const;
+
+export type CvAllowedMimeType = (typeof CV_ALLOWED_MIME_TYPES)[number];
+
+export const CV_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export type CvMimeCheckResult =
+  | { allowed: true; mimeType: CvAllowedMimeType }
+  | { allowed: false; reason: 'mime_not_allowed' | 'file_too_large' };
+
+export function checkCvUploadConstraints(
+  mimeType: string,
+  sizeBytes: number,
+): CvMimeCheckResult {
+  if (sizeBytes > CV_MAX_FILE_SIZE_BYTES) {
+    return { allowed: false, reason: 'file_too_large' };
+  }
+  if ((CV_ALLOWED_MIME_TYPES as readonly string[]).includes(mimeType)) {
+    return { allowed: true, mimeType: mimeType as CvAllowedMimeType };
+  }
+  return { allowed: false, reason: 'mime_not_allowed' };
+}


### PR DESCRIPTION
## Summary
- POST `/api/upload/cv` accepts PDF and DOCX ≤ 5 MB; returns `ocrLive: false`, `parseLive: false`, `parsedEntries: []`
- All uploads land as `USER_ENTERED` provenance with no automatic parsing or OCR
- `CvUploadZone` client component (self-contained drag-and-drop, PDF/DOCX only) mounted on `/clinician/import`
- `cvFoundation.ts` exports literal types for all truth-contract fields

## Test plan
- [ ] 4 unit tests: non-PDF/DOCX → 415, PDF → 200 + correct literals, DOCX → 200, >5 MB → 413
- [ ] Verify CvUploadZone renders between Import cards and Export cards on `/clinician/import`
- [ ] Confirm drag-and-drop accepts PDF and DOCX, rejects other types client-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)