### PR TITLE
feat(issuer): add policy decision persistence with ISSUER_PERSISTENCE_ENABLED gate

### DIFF
--- a/apps/web/__tests__/policy-decision-persisted.test.ts
+++ b/apps/web/__tests__/policy-decision-persisted.test.ts
@@ -1,0 +1,188 @@
+/**
+ * policy-decision-persisted.test.ts
+ *
+ * Tests policyDecisionRepo.ts with Prisma mocked.
+ * No real database, no Clerk, no network.
+ *
+ * Truth contracts verified:
+ *   1. accepted_as_psv_candidate — persists with decisionGrade: false,
+ *      automatedPolicyEngine: false, createdPsvReceiptCandidate: true
+ *   2. rejected — persists with createdPsvReceiptCandidate: false
+ *   3. request_more_info — persists with status 'request_more_info'
+ *   4. conflict_review_required — persists with status 'conflict_review_required'
+ *   5. (structural) missing reviewerActorId → throws; no auto-approve path
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PersistedPolicyDecision } from '../lib/issuer-verification/policyDecisionRepo';
+import type { PolicyReviewDecision } from '../lib/issuer-verification/types';
+
+const mockCreate = vi.fn();
+
+vi.mock('../lib/db', () => ({
+  prisma: {
+    policyReviewDecision: {
+      create: mockCreate,
+    },
+  },
+}));
+
+// server-only guard will throw in vitest without this stub
+vi.mock('server-only', () => ({}));
+
+function buildDecision(
+  overrides: Partial<PolicyReviewDecision> = {},
+): PolicyReviewDecision {
+  return {
+    decisionId: 'dec-test-001',
+    receiptCandidateId: 'rc-test-001',
+    requestId: 'req-test-001',
+    action: 'accept_candidate',
+    status: 'accepted_as_psv_candidate',
+    decidedAt: '2026-05-04T00:00:00.000Z',
+    actor: {
+      actorId: 'actor-001',
+      displayName: 'Test Reviewer',
+      role: 'policy_reviewer',
+    },
+    rationale: 'Confirmed residency via GME office.',
+    createdPsvReceiptCandidate: true,
+    outcome: { createdPsvReceiptCandidate: true, reason: 'Candidate accepted under policy review.' },
+    auditMetadata: {
+      recordedAt: '2026-05-04T00:00:00.000Z',
+      recordedBy: 'review_surface',
+      notes: 'test',
+    },
+    ...overrides,
+  };
+}
+
+function mockRow(
+  overrides: Partial<PersistedPolicyDecision> = {},
+): PersistedPolicyDecision {
+  return {
+    id: 'cuid-001',
+    decisionId: 'dec-test-001',
+    receiptCandidateId: 'rc-test-001',
+    requestId: 'req-test-001',
+    action: 'accept_candidate',
+    status: 'accepted_as_psv_candidate',
+    decidedAt: '2026-05-04T00:00:00.000Z',
+    reviewerActorId: 'actor-001',
+    decisionGrade: false,
+    automatedPolicyEngine: false,
+    createdPsvReceiptCandidate: true,
+    createdAt: new Date('2026-05-04T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('policyDecisionRepo — persistPolicyDecision', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockCreate.mockReset();
+  });
+
+  it('case 1: accepted_as_psv_candidate — decisionGrade: false, automatedPolicyEngine: false, createdPsvReceiptCandidate: true', async () => {
+    mockCreate.mockResolvedValue(mockRow());
+    const { persistPolicyDecision } = await import('../lib/issuer-verification/policyDecisionRepo');
+
+    const result = await persistPolicyDecision({
+      decision: buildDecision(),
+      reviewerActorId: 'actor-001',
+    });
+
+    expect(result.status).toBe('accepted_as_psv_candidate');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.automatedPolicyEngine).toBe(false);
+    expect(result.createdPsvReceiptCandidate).toBe(true);
+    expect(result.reviewerActorId).toBe('actor-001');
+
+    // Verify the DB write carries the literal false values
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          decisionGrade: false,
+          automatedPolicyEngine: false,
+          createdPsvReceiptCandidate: true,
+          reviewerActorId: 'actor-001',
+          status: 'accepted_as_psv_candidate',
+        }),
+      }),
+    );
+  });
+
+  it('case 2: rejected — createdPsvReceiptCandidate: false; underlying evidence preserved (no auto-delete)', async () => {
+    mockCreate.mockResolvedValue(
+      mockRow({ action: 'reject_candidate', status: 'rejected', createdPsvReceiptCandidate: false }),
+    );
+    const { persistPolicyDecision } = await import('../lib/issuer-verification/policyDecisionRepo');
+
+    const result = await persistPolicyDecision({
+      decision: buildDecision({
+        action: 'reject_candidate',
+        status: 'rejected',
+        createdPsvReceiptCandidate: false,
+        outcome: { createdPsvReceiptCandidate: false, reason: 'Candidate rejected.' },
+      }),
+      reviewerActorId: 'actor-001',
+    });
+
+    expect(result.status).toBe('rejected');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.createdPsvReceiptCandidate).toBe(false);
+  });
+
+  it('case 3: request_more_info — persists without creating a PSV candidate', async () => {
+    mockCreate.mockResolvedValue(
+      mockRow({ action: 'request_more_info', status: 'request_more_info', createdPsvReceiptCandidate: false }),
+    );
+    const { persistPolicyDecision } = await import('../lib/issuer-verification/policyDecisionRepo');
+
+    const result = await persistPolicyDecision({
+      decision: buildDecision({
+        action: 'request_more_info',
+        status: 'request_more_info',
+        createdPsvReceiptCandidate: false,
+        outcome: { createdPsvReceiptCandidate: false, reason: 'More information requested.' },
+      }),
+      reviewerActorId: 'actor-001',
+    });
+
+    expect(result.status).toBe('request_more_info');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.createdPsvReceiptCandidate).toBe(false);
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it('case 4: conflict_review_required — persists; no PSV candidate produced', async () => {
+    mockCreate.mockResolvedValue(
+      mockRow({ action: 'mark_conflict_review', status: 'conflict_review_required', createdPsvReceiptCandidate: false }),
+    );
+    const { persistPolicyDecision } = await import('../lib/issuer-verification/policyDecisionRepo');
+
+    const result = await persistPolicyDecision({
+      decision: buildDecision({
+        action: 'mark_conflict_review',
+        status: 'conflict_review_required',
+        createdPsvReceiptCandidate: false,
+        outcome: { createdPsvReceiptCandidate: false, reason: 'Conflict review required.' },
+      }),
+      reviewerActorId: 'actor-001',
+    });
+
+    expect(result.status).toBe('conflict_review_required');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.createdPsvReceiptCandidate).toBe(false);
+  });
+
+  it('structural: missing reviewerActorId throws — no auto-approve path exists', async () => {
+    const { persistPolicyDecision } = await import('../lib/issuer-verification/policyDecisionRepo');
+
+    await expect(
+      persistPolicyDecision({ decision: buildDecision(), reviewerActorId: '' }),
+    ).rejects.toThrow('reviewerActorId is required');
+
+    // Prisma must not have been called — the throw is pre-DB
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/issuer/policy-review/[requestId]/page.tsx
+++ b/apps/web/app/issuer/policy-review/[requestId]/page.tsx
@@ -9,6 +9,7 @@ import {
   buildPolicyReviewDecision,
   canCreatePsvReceiptCandidate,
 } from '@/lib/issuer-verification/policyReview';
+import { POLICY_PERSISTENCE_STATE } from '@/lib/issuer-verification/policyDecisionRepo';
 import {
   POLICY_REVIEW_COPY,
   policyReviewCopy,
@@ -78,6 +79,7 @@ interface PageProps {
 
 export default async function PolicyReviewPage({ params }: PageProps) {
   const { requestId } = await params;
+  const isPersistenceEnabled = Boolean(process.env.ISSUER_PERSISTENCE_ENABLED);
 
   const claimType: VerificationClaimType = 'residency';
   const request: IssuerVerificationRequest = {
@@ -324,6 +326,31 @@ export default async function PolicyReviewPage({ params }: PageProps) {
             >
               PSV receipt candidate {dryRunAccept.psvReceiptCandidate.psvCandidateId}.
               Not final credentialing proof.
+            </p>
+          )}
+        </section>
+
+        <section
+          className="rounded-xl border border-border/50 bg-background/30 px-4 py-3 space-y-1"
+          aria-label="Persistence status"
+          data-testid="persistence-status"
+          data-persistence-enabled={String(isPersistenceEnabled)}
+          data-automated-policy-engine={String(POLICY_PERSISTENCE_STATE.automatedPolicyEngine)}
+        >
+          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Decision persistence
+          </p>
+          {isPersistenceEnabled ? (
+            <p className="text-xs text-muted-foreground">
+              Persistence active — submitted decisions will be written to the
+              database via policyDecisionRepo. Every write requires an explicit
+              reviewer action; <strong>automatedPolicyEngine: {String(POLICY_PERSISTENCE_STATE.automatedPolicyEngine)}</strong>.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Persistence inactive (ISSUER_PERSISTENCE_ENABLED not set). This
+              surface is a demo render; decisions are not written to the database.
+              Set ISSUER_PERSISTENCE_ENABLED to enable policyDecisionRepo writes.
             </p>
           )}
         </section>

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,18 @@
+import 'server-only';
+import { PrismaClient } from './generated/prisma';
+
+declare global {
+  // Prevent multiple instances of PrismaClient in dev hot-reload.
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
+}
+
+export const prisma =
+  globalThis.__prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['warn', 'error'] : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__prisma = prisma;
+}

--- a/apps/web/lib/issuer-verification/policyDecisionRepo.ts
+++ b/apps/web/lib/issuer-verification/policyDecisionRepo.ts
@@ -1,0 +1,103 @@
+/**
+ * policyDecisionRepo.ts
+ *
+ * Persists PolicyReviewDecision rows to the database.
+ *
+ * Truth contracts (enforced at runtime, not just types):
+ *   - automatedPolicyEngine: false — there is no automated approval path.
+ *     Every persisted row must have a non-empty reviewerActorId supplied
+ *     by an explicit human reviewer action.
+ *   - decisionGrade: false literal — a policy review decision produces
+ *     only a candidate; it is never decision-grade on its own.
+ *   - Missing reviewerActorId throws unconditionally; it does not fall
+ *     back to a system actor or an empty string.
+ *
+ * This module is server-only and performs real DB writes when called.
+ * It is intentionally separate from the pure-transform policyReview.ts.
+ */
+import 'server-only';
+import { prisma } from '@/lib/db';
+import type { PolicyReviewDecision } from '@/lib/issuer-verification/types';
+
+export type PolicyPersistenceState = {
+  automatedPolicyEngine: false;
+};
+
+export const POLICY_PERSISTENCE_STATE: PolicyPersistenceState = {
+  automatedPolicyEngine: false,
+};
+
+export interface PersistPolicyDecisionInput {
+  decision: PolicyReviewDecision;
+  /** Required. No auto-approve path exists — this must identify the human reviewer. */
+  reviewerActorId: string;
+}
+
+export interface PersistedPolicyDecision {
+  id: string;
+  decisionId: string;
+  receiptCandidateId: string;
+  requestId: string;
+  action: string;
+  status: string;
+  decidedAt: string;
+  reviewerActorId: string;
+  /** Literal false — preserved through the DB round-trip. */
+  decisionGrade: false;
+  /** Literal false — no automated policy engine exists. */
+  automatedPolicyEngine: false;
+  createdPsvReceiptCandidate: boolean;
+  createdAt: Date;
+}
+
+/**
+ * Persist a PolicyReviewDecision row.
+ *
+ * Throws if `reviewerActorId` is absent or empty — this is the runtime
+ * guard for the "no auto-approve path" contract. The type alone is not
+ * sufficient because callers could pass an empty string.
+ */
+export async function persistPolicyDecision(
+  input: PersistPolicyDecisionInput,
+): Promise<PersistedPolicyDecision> {
+  if (!input.reviewerActorId || input.reviewerActorId.trim() === '') {
+    throw new Error(
+      'persistPolicyDecision: reviewerActorId is required — no auto-approve path exists.',
+    );
+  }
+
+  const { decision } = input;
+
+  const row = await prisma.policyReviewDecision.create({
+    data: {
+      decisionId: decision.decisionId,
+      receiptCandidateId: decision.receiptCandidateId,
+      requestId: decision.requestId,
+      action: decision.action,
+      status: decision.status,
+      decidedAt: decision.decidedAt,
+      reviewerActorId: input.reviewerActorId,
+      reviewerDisplayName: decision.actor.displayName,
+      reviewerRole: decision.actor.role,
+      rationale: decision.rationale ?? null,
+      decisionGrade: false,
+      automatedPolicyEngine: false,
+      createdPsvReceiptCandidate: decision.createdPsvReceiptCandidate,
+    },
+  });
+
+  return {
+    id: row.id,
+    decisionId: row.decisionId,
+    receiptCandidateId: row.receiptCandidateId,
+    requestId: row.requestId,
+    action: row.action,
+    status: row.status,
+    decidedAt: row.decidedAt,
+    reviewerActorId: row.reviewerActorId,
+    decisionGrade: false,
+    automatedPolicyEngine: false,
+    createdPsvReceiptCandidate: row.createdPsvReceiptCandidate,
+    createdAt: row.createdAt,
+  };
+}

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1,0 +1,110 @@
+// apps/web Prisma schema — web-app-facing subset only.
+//
+// This schema mirrors the models that the web app reads directly.
+// Migrations are managed by apps/api/backend/prisma; these model
+// definitions must stay in sync with that schema. The tables are
+// shared — there is one database.
+//
+// Run `pnpm --filter @vitalcv/web exec prisma generate` after
+// any model change here to regenerate the typed client.
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model IssuerRequest {
+  id              String    @id @default(uuid()) @db.Uuid
+  requestId       String    @unique
+  claimType       String
+  claimSummary    String
+  issuerCandidate Json
+  route           Json
+  consent         Json
+  status          String
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  expiresAt       DateTime?
+
+  receiptCandidates ReceiptCandidate[]
+
+  @@index([requestId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+model ReceiptCandidate {
+  id          String         @id @default(uuid()) @db.Uuid
+  candidateId String         @unique
+  requestId   String?
+  request     IssuerRequest? @relation(fields: [requestId], references: [requestId])
+
+  basis                  String
+  agentName              String?
+  sourceOrganizationName String
+
+  attributionStatus String
+
+  decisionGrade Boolean @default(false)
+  proofTier     String?
+
+  notes              String?
+  limitationNote     String?
+  responseStatus     String?
+  responseSummary    String?
+  responseReceivedAt DateTime?
+  reviewState        String?
+
+  recordedBy String @default("demo")
+
+  signedReceiptJwt String?
+
+  createdAt DateTime @default(now())
+
+  @@index([candidateId])
+  @@index([requestId])
+  @@index([reviewState])
+  @@index([createdAt])
+}
+
+// Truth contract:
+//   - decisionGrade is always false — no issuer policy review is
+//     decision-grade on its own; it produces only a candidate.
+//   - automatedPolicyEngine is always false — every row requires
+//     an explicit human reviewer action (reviewerActorId is required).
+//   - No row may be written without reviewerActorId.
+model PolicyReviewDecision {
+  id String @id @default(cuid())
+
+  decisionId         String @unique
+  receiptCandidateId String
+  requestId          String
+
+  action String
+  status String
+
+  decidedAt String
+
+  reviewerActorId     String
+  reviewerDisplayName String
+  reviewerRole        String
+  rationale           String?
+
+  // Literal false — a policy review decision is never decision-grade by itself.
+  decisionGrade Boolean @default(false)
+  // Literal false — no automated engine; every decision is human-initiated.
+  automatedPolicyEngine Boolean @default(false)
+
+  createdPsvReceiptCandidate Boolean @default(false)
+
+  createdAt DateTime @default(now())
+
+  @@index([receiptCandidateId])
+  @@index([status])
+  @@index([createdAt])
+}


### PR DESCRIPTION
## Summary
- `policyDecisionRepo.ts` — server-only Prisma writer for `PolicyReviewDecision` rows
- `PolicyReviewDecision` model added to `apps/web/prisma/schema.prisma` (alongside `IssuerRequest` + `ReceiptCandidate` from #241)
- Policy-review page shows a persistence-status section; active when `ISSUER_PERSISTENCE_ENABLED` is set

## Truth contracts enforced at runtime (not just types)
- `automatedPolicyEngine: false` — field is hard-coded `false` in every DB write; no path sets it true
- `decisionGrade: false` literal — narrowed in the return type and written as `false` unconditionally
- `reviewerActorId` required — `persistPolicyDecision` throws before any DB call when absent or empty; `mockCreate` is never reached in the negative test

## Test plan
- [ ] 5 unit tests (Prisma mocked): `accepted_as_psv_candidate`, `rejected`, `request_more_info`, `conflict_review_required` round-trips + structural no-auto-approve guard
- [ ] `data-automated-policy-engine="false"` visible in page HTML when `ISSUER_PERSISTENCE_ENABLED` is set
- [ ] `data-persistence-enabled="false"` when env var absent; `"true"` when present

## Dependencies
- Schema overlaps with #241 (worklist-db). If #241 merges first, this PR's schema adds only the `PolicyReviewDecision` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)