### PR TITLE
feat(verifier): live verifier-invitation lifecycle (W6C invitationSystemLive flip)

### DIFF
--- a/apps/web/__tests__/verifier-invitation-lifecycle.test.ts
+++ b/apps/web/__tests__/verifier-invitation-lifecycle.test.ts
@@ -1,0 +1,215 @@
+/**
+ * verifier-invitation-lifecycle.test.ts
+ *
+ * Tests the verifier invitation lifecycle (create + accept) with
+ * Prisma and the Clerk sender mocked.
+ *
+ * Truth contracts verified:
+ *   1. POST creates invitation row + returns shareableUrl + invitationSystemLive: true
+ *   2. acceptInvitation: pending non-expired → success; row transitions to accepted
+ *   3. acceptInvitation: expired (expiresAt < now) → 410 Gone
+ *   4. acceptInvitation: already-accepted → 409 Conflict (idempotent — original row preserved)
+ *   5. invitationSystemLive is the literal true (foundation flip)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const authMock = vi.fn();
+const sendInvitationViaClerkMock = vi.fn();
+
+const prismaCreate = vi.fn();
+const prismaFindUnique = vi.fn();
+const prismaUpdate = vi.fn();
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: authMock,
+}));
+
+vi.mock('../lib/db', () => ({
+  prisma: {
+    verifierInvitation: {
+      create: prismaCreate,
+      findUnique: prismaFindUnique,
+      update: prismaUpdate,
+    },
+  },
+}));
+
+vi.mock('../lib/auth/clerkInvitationSender', () => ({
+  sendInvitationViaClerk: sendInvitationViaClerkMock,
+}));
+
+vi.mock('server-only', () => ({}));
+
+interface RawRow {
+  id: string;
+  invitationCode: string;
+  email: string;
+  role: string;
+  orgId: string;
+  invitedByUserId: string;
+  status: string;
+  expiresAt: Date;
+  acceptedAt: Date | null;
+  acceptedByUserId: string | null;
+  emailSendChannel: string;
+  createdAt: Date;
+}
+
+function buildRawRow(overrides: Partial<RawRow> = {}): RawRow {
+  return {
+    id: 'cuid-001',
+    invitationCode: 'inv-code-abc',
+    email: 'teammate@example.com',
+    role: 'reviewer',
+    orgId: 'org_test',
+    invitedByUserId: 'user_inviter',
+    status: 'pending',
+    expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+    acceptedAt: null,
+    acceptedByUserId: null,
+    emailSendChannel: 'shareable_url_only',
+    createdAt: new Date('2026-05-04T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('verifier invitation lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    authMock.mockReset();
+    sendInvitationViaClerkMock.mockReset();
+    prismaCreate.mockReset();
+    prismaFindUnique.mockReset();
+    prismaUpdate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('case 1: POST /api/verifier/invite creates a row and returns shareableUrl + invitationSystemLive: true', async () => {
+    authMock.mockResolvedValue({
+      userId: 'user_inviter',
+      sessionClaims: { vitalcv: { org_id: 'org_test' } },
+    });
+    sendInvitationViaClerkMock.mockResolvedValue('clerk_magic_link');
+    prismaCreate.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+      Promise.resolve(buildRawRow({
+        invitationCode: data.invitationCode as string,
+        email: data.email as string,
+        role: data.role as string,
+        emailSendChannel: data.emailSendChannel as string,
+      })),
+    );
+
+    const { POST } = await import('../app/api/verifier/invite/route');
+    const req = new NextRequest('http://localhost/api/verifier/invite', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'teammate@example.com', role: 'reviewer' }),
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      invitation: { invitationCode: string; status: string };
+      shareableUrl: string;
+      emailSendChannel: string;
+      invitationSystemLive: boolean;
+    };
+
+    expect(body.invitationSystemLive).toBe(true);
+    expect(body.shareableUrl).toMatch(/\/verifier\/invite\/[a-f0-9]+\/accept$/);
+    expect(body.emailSendChannel).toBe('clerk_magic_link');
+    expect(body.invitation.status).toBe('pending');
+    expect(prismaCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          email: 'teammate@example.com',
+          role: 'reviewer',
+          orgId: 'org_test',
+          status: 'pending',
+        }),
+      }),
+    );
+  });
+
+  it('case 2: acceptInvitation on pending non-expired invitation transitions to accepted', async () => {
+    const future = new Date('2027-01-01T00:00:00.000Z');
+    prismaFindUnique.mockResolvedValue(buildRawRow({ status: 'pending', expiresAt: future }));
+    prismaUpdate.mockResolvedValue(
+      buildRawRow({
+        status: 'accepted',
+        acceptedAt: new Date('2026-05-04T12:00:00.000Z'),
+        acceptedByUserId: 'user_acceptor',
+        expiresAt: future,
+      }),
+    );
+
+    const { acceptInvitation } = await import('../lib/auth/invitationRepo');
+    const result = await acceptInvitation('inv-code-abc', 'user_acceptor', new Date('2026-05-04T12:00:00.000Z'));
+
+    expect(result.decision.ok).toBe(true);
+    expect(result.invitation?.status).toBe('accepted');
+    expect(result.invitation?.acceptedByUserId).toBe('user_acceptor');
+    expect(prismaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { invitationCode: 'inv-code-abc' },
+        data: expect.objectContaining({ status: 'accepted', acceptedByUserId: 'user_acceptor' }),
+      }),
+    );
+  });
+
+  it('case 3: expired invitation returns 410 Gone — no DB write', async () => {
+    const past = new Date('2026-04-01T00:00:00.000Z');
+    prismaFindUnique.mockResolvedValue(buildRawRow({ status: 'pending', expiresAt: past }));
+
+    const { acceptInvitation } = await import('../lib/auth/invitationRepo');
+    const result = await acceptInvitation('inv-code-abc', 'user_acceptor', new Date('2026-05-04T00:00:00.000Z'));
+
+    expect(result.decision.ok).toBe(false);
+    if (!result.decision.ok) {
+      expect(result.decision.statusCode).toBe(410);
+      expect(result.decision.reason).toBe('invitation_expired');
+    }
+    expect(prismaUpdate).not.toHaveBeenCalled();
+  });
+
+  it('case 4: already-accepted invitation returns 409 Conflict — idempotent (original acceptedAt preserved, no DB write)', async () => {
+    const originalAcceptedAt = new Date('2026-04-15T08:00:00.000Z');
+    prismaFindUnique.mockResolvedValue(
+      buildRawRow({
+        status: 'accepted',
+        acceptedAt: originalAcceptedAt,
+        acceptedByUserId: 'user_first_acceptor',
+      }),
+    );
+
+    const { acceptInvitation } = await import('../lib/auth/invitationRepo');
+    const result = await acceptInvitation('inv-code-abc', 'user_second_acceptor', new Date('2026-05-04T00:00:00.000Z'));
+
+    expect(result.decision.ok).toBe(false);
+    if (!result.decision.ok) {
+      expect(result.decision.statusCode).toBe(409);
+      expect(result.decision.reason).toBe('invitation_already_accepted');
+    }
+    // Idempotency: returned invitation preserves the original acceptedAt + acceptor
+    expect(result.invitation?.acceptedAt?.toISOString()).toBe(originalAcceptedAt.toISOString());
+    expect(result.invitation?.acceptedByUserId).toBe('user_first_acceptor');
+    // No DB update was attempted
+    expect(prismaUpdate).not.toHaveBeenCalled();
+  });
+
+  it('case 5: invitationSystemLive is the literal true (W6C foundation flip)', async () => {
+    const { invitationSystemLive } = await import('../lib/auth/invitationLifecycle');
+    const { buildOrgRolesFoundation } = await import('../lib/verifier/orgRolesFoundation');
+
+    expect(invitationSystemLive).toBe(true);
+    // Type-level: this would not compile if invitationSystemLive widened to boolean
+    const literalCheck: true = invitationSystemLive;
+    expect(literalCheck).toBe(true);
+
+    expect(buildOrgRolesFoundation().invitationSystemLive).toBe(true);
+  });
+});

--- a/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
+++ b/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
@@ -82,9 +82,9 @@ const sampleItems: WorklistItem[] = [
 describe('orgRolesFoundation', () => {
   const foundation = buildOrgRolesFoundation();
 
-  it('keeps role provisioning, invitations, and RBAC non-live', () => {
+  it('keeps role provisioning and RBAC non-live; invitation system is now live (W6C foundation flip)', () => {
     expect(foundation.provisionLive).toBe(false);
-    expect(foundation.invitationSystemLive).toBe(false);
+    expect(foundation.invitationSystemLive).toBe(true);
     expect(foundation.rbacEnforced).toBe(false);
   });
 

--- a/apps/web/app/api/verifier/invite/route.ts
+++ b/apps/web/app/api/verifier/invite/route.ts
@@ -1,0 +1,85 @@
+/**
+ * /api/verifier/invite — POST creates a verifier team invitation.
+ *
+ * Auth: requires Clerk user + org_id claim (read by middleware RBAC).
+ *
+ * Body: { email: string; role: 'admin' | 'reviewer' | 'read_only' }
+ *
+ * Response: 201 with { invitation, shareableUrl, emailSendChannel, invitationSystemLive: true }
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { createInvitation } from '@/lib/auth/invitationRepo';
+import { validateCreateInput } from '@/lib/auth/invitationLifecycle';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { userId, sessionClaims } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'unauthorized', message: 'Sign in to send invitations.' },
+      { status: 401 },
+    );
+  }
+
+  const claims = sessionClaims?.vitalcv as Record<string, unknown> | undefined;
+  const orgId = typeof claims?.org_id === 'string' ? claims.org_id : null;
+  if (!orgId) {
+    return NextResponse.json(
+      { error: 'no_org_context', message: 'Active org membership required to invite.' },
+      { status: 403 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Expected JSON body.' },
+      { status: 400 },
+    );
+  }
+  const { email, role } = (body ?? {}) as { email?: unknown; role?: unknown };
+
+  const validation = validateCreateInput({
+    email,
+    role,
+    orgId,
+    invitedByUserId: userId,
+  });
+  if (!validation.ok) {
+    return NextResponse.json(
+      { error: validation.reason, message: 'Email and role are required; role must be admin, reviewer, or read_only.' },
+      { status: 400 },
+    );
+  }
+
+  const baseUrl = req.nextUrl.origin;
+  const result = await createInvitation({
+    email: email as string,
+    role: role as 'admin' | 'reviewer' | 'read_only',
+    orgId,
+    invitedByUserId: userId,
+    baseUrl,
+  });
+
+  return NextResponse.json(
+    {
+      invitation: {
+        invitationCode: result.invitation.invitationCode,
+        email: result.invitation.email,
+        role: result.invitation.role,
+        orgId: result.invitation.orgId,
+        status: result.invitation.status,
+        expiresAt: result.invitation.expiresAt.toISOString(),
+        createdAt: result.invitation.createdAt.toISOString(),
+      },
+      shareableUrl: result.shareableUrl,
+      emailSendChannel: result.emailSendChannel,
+      invitationSystemLive: result.invitationSystemLive,
+    },
+    { status: 201 },
+  );
+}

--- a/apps/web/app/verifier/invite/[code]/accept/page.tsx
+++ b/apps/web/app/verifier/invite/[code]/accept/page.tsx
@@ -1,0 +1,127 @@
+/**
+ * /verifier/invite/[code]/accept — invitation accept surface.
+ *
+ * Server component: reads the invitation row, runs the pure
+ * decideAccept gate, and renders one of:
+ *   - 200 success render (decision.ok)
+ *   - 410 Gone copy (expired or revoked)
+ *   - 409 Conflict copy (already accepted)
+ *   - 404 Not found copy (unknown code)
+ *
+ * The actual write (status → 'accepted') is performed by acceptInvitation
+ * once the user is signed in — for the demo render we display gates only.
+ */
+import { auth } from '@clerk/nextjs/server';
+import * as React from 'react';
+import { acceptInvitation, getInvitationByCode } from '@/lib/auth/invitationRepo';
+import { decideAccept } from '@/lib/auth/invitationLifecycle';
+
+interface PageProps {
+  params: Promise<{ code: string }>;
+}
+
+const REASON_COPY: Record<string, { headline: string; detail: string }> = {
+  invitation_not_found: {
+    headline: 'Invitation not found',
+    detail: 'This invitation link is not valid. Ask the inviter to send a new one.',
+  },
+  invitation_expired: {
+    headline: 'Invitation expired',
+    detail: 'This invitation passed its expiry window. Ask the inviter to send a new one.',
+  },
+  invitation_revoked: {
+    headline: 'Invitation revoked',
+    detail: 'This invitation was revoked by the inviting team and is no longer valid.',
+  },
+  invitation_already_accepted: {
+    headline: 'Already accepted',
+    detail: 'This invitation has already been accepted. If that was not you, contact the inviting team.',
+  },
+};
+
+export default async function AcceptInvitationPage({ params }: PageProps) {
+  const { code } = await params;
+  const { userId } = await auth();
+
+  // Pre-flight: read the row and run the pure gate so we render the
+  // correct status without writing anything until the user is signed in.
+  const existing = await getInvitationByCode(code).catch(() => null);
+  const preflight = decideAccept(existing, new Date());
+
+  let outcome:
+    | { kind: 'sign_in_required' }
+    | { kind: 'accepted'; email: string; role: string }
+    | { kind: 'refused'; statusCode: 404 | 409 | 410; reason: string };
+
+  if (!preflight.ok) {
+    outcome = {
+      kind: 'refused',
+      statusCode: preflight.statusCode,
+      reason: preflight.reason,
+    };
+  } else if (!userId) {
+    outcome = { kind: 'sign_in_required' };
+  } else {
+    const result = await acceptInvitation(code, userId).catch(() => null);
+    if (!result || !result.decision.ok) {
+      outcome = {
+        kind: 'refused',
+        statusCode: result?.decision.ok === false ? result.decision.statusCode : 404,
+        reason: result?.decision.ok === false ? result.decision.reason : 'invitation_not_found',
+      };
+    } else {
+      outcome = {
+        kind: 'accepted',
+        email: result.invitation?.email ?? '',
+        role: result.invitation?.role ?? '',
+      };
+    }
+  }
+
+  return (
+    <main
+      className="mx-auto w-full max-w-xl px-4 py-12"
+      data-testid="verifier-invite-accept"
+      data-invitation-code={code}
+      data-outcome-kind={outcome.kind}
+    >
+      <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+        Verifier team invitation
+      </p>
+
+      {outcome.kind === 'sign_in_required' && (
+        <section className="mt-4 space-y-3">
+          <h1 className="text-2xl font-semibold">Sign in to accept</h1>
+          <p className="text-sm text-muted-foreground">
+            This invitation is valid. Sign in or create an account to accept it.
+          </p>
+        </section>
+      )}
+
+      {outcome.kind === 'accepted' && (
+        <section className="mt-4 space-y-3" role="status" data-status-code="200">
+          <h1 className="text-2xl font-semibold">Invitation accepted</h1>
+          <p className="text-sm text-muted-foreground">
+            You&apos;ve joined the verifier team as <strong>{outcome.role}</strong>.
+          </p>
+        </section>
+      )}
+
+      {outcome.kind === 'refused' && (
+        <section
+          className="mt-4 space-y-3"
+          role="alert"
+          data-status-code={String(outcome.statusCode)}
+          data-refusal-reason={outcome.reason}
+        >
+          <h1 className="text-2xl font-semibold">
+            {REASON_COPY[outcome.reason]?.headline ?? 'Invitation unavailable'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {REASON_COPY[outcome.reason]?.detail ?? 'This invitation is not available.'}
+          </p>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/verifier/team/invite/page.tsx
+++ b/apps/web/app/verifier/team/invite/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import * as React from 'react';
+
+type FormState =
+  | { phase: 'idle' }
+  | { phase: 'sending' }
+  | { phase: 'sent'; shareableUrl: string; emailSendChannel: 'clerk_magic_link' | 'shareable_url_only' }
+  | { phase: 'error'; message: string };
+
+const ROLES = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'reviewer', label: 'Reviewer' },
+  { value: 'read_only', label: 'Read-only' },
+] as const;
+
+export default function VerifierTeamInvitePage() {
+  const [email, setEmail] = React.useState('');
+  const [role, setRole] = React.useState<'admin' | 'reviewer' | 'read_only'>('reviewer');
+  const [state, setState] = React.useState<FormState>({ phase: 'idle' });
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setState({ phase: 'sending' });
+    try {
+      const res = await fetch('/api/verifier/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, role }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
+        setState({ phase: 'error', message: body.message ?? `Invitation failed (${res.status}).` });
+        return;
+      }
+      const data = (await res.json()) as {
+        shareableUrl: string;
+        emailSendChannel: 'clerk_magic_link' | 'shareable_url_only';
+      };
+      setState({
+        phase: 'sent',
+        shareableUrl: data.shareableUrl,
+        emailSendChannel: data.emailSendChannel,
+      });
+    } catch {
+      setState({ phase: 'error', message: 'Network error. Try again.' });
+    }
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-xl px-4 py-10">
+      <header className="mb-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Verifier team
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold">Invite a teammate</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Invitations are sent through Clerk hosted email. If email delivery is
+          unavailable, a copyable invitation URL is returned instead.
+        </p>
+      </header>
+
+      <form onSubmit={onSubmit} className="space-y-4" aria-label="Invite teammate form">
+        <div className="space-y-1">
+          <label htmlFor="invite-email" className="text-xs font-medium">
+            Teammate email
+          </label>
+          <input
+            id="invite-email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-zinc-700 bg-transparent px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="invite-role" className="text-xs font-medium">
+            Role
+          </label>
+          <select
+            id="invite-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as 'admin' | 'reviewer' | 'read_only')}
+            className="w-full rounded-md border border-zinc-700 bg-transparent px-3 py-2 text-sm"
+          >
+            {ROLES.map((r) => (
+              <option key={r.value} value={r.value}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          type="submit"
+          disabled={state.phase === 'sending' || !email}
+          className="rounded-md border border-emerald-600/50 bg-emerald-600/10 px-4 py-2 text-sm font-medium text-emerald-300 disabled:opacity-50"
+        >
+          {state.phase === 'sending' ? 'Sending…' : 'Send invitation'}
+        </button>
+      </form>
+
+      {state.phase === 'sent' && (
+        <section className="mt-6 rounded-md border border-emerald-600/40 bg-emerald-600/10 p-4 text-sm" role="status">
+          <p className="font-medium text-emerald-300">Invitation created.</p>
+          <p className="mt-1 text-xs text-emerald-200/80">
+            {state.emailSendChannel === 'clerk_magic_link'
+              ? 'A magic-link email has been queued via Clerk.'
+              : 'Email delivery was unavailable; share the URL below directly.'}
+          </p>
+          <p className="mt-2 break-all font-mono text-xs">{state.shareableUrl}</p>
+        </section>
+      )}
+
+      {state.phase === 'error' && (
+        <p className="mt-4 text-sm text-red-400" role="alert">
+          {state.message}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/lib/auth/clerkInvitationSender.ts
+++ b/apps/web/lib/auth/clerkInvitationSender.ts
@@ -1,0 +1,41 @@
+/**
+ * clerkInvitationSender.ts
+ *
+ * Wraps Clerk's invitations API for sending verifier invitations as
+ * magic-link emails. Best-effort — if CLERK_SECRET_KEY is absent or
+ * the Clerk call fails, returns 'shareable_url_only' so the caller
+ * can still hand the user a copyable URL.
+ *
+ * Truth contracts:
+ *   - This codebase NEVER sends email via SMTP, nodemailer, or any
+ *     other direct mailer. Clerk's hosted invitation email is the only
+ *     transport. Keep this file the single mention of email send paths.
+ */
+import 'server-only';
+import type { EmailSendChannel } from './invitationLifecycle';
+
+export interface ClerkSendInput {
+  email: string;
+  redirectUrl: string;
+  invitationCode: string;
+}
+
+export async function sendInvitationViaClerk(
+  input: ClerkSendInput,
+): Promise<EmailSendChannel> {
+  if (!process.env.CLERK_SECRET_KEY) {
+    return 'shareable_url_only';
+  }
+  try {
+    const { clerkClient } = await import('@clerk/nextjs/server');
+    const client = await clerkClient();
+    await client.invitations.createInvitation({
+      emailAddress: input.email,
+      redirectUrl: input.redirectUrl,
+      publicMetadata: { vitalcv_invitation_code: input.invitationCode },
+    });
+    return 'clerk_magic_link';
+  } catch {
+    return 'shareable_url_only';
+  }
+}

--- a/apps/web/lib/auth/invitationLifecycle.ts
+++ b/apps/web/lib/auth/invitationLifecycle.ts
@@ -1,0 +1,136 @@
+/**
+ * invitationLifecycle.ts
+ *
+ * Pure lifecycle logic for verifier invitations. No DB, no Clerk, no I/O.
+ * The repo layer wraps these helpers around real Prisma reads/writes.
+ *
+ * Truth contracts:
+ *   - invitationSystemLive: true (literal) — system is no longer foundation-only.
+ *   - Status transitions are one-way: pending → {accepted, expired, revoked}.
+ *     Once terminal, the row is never re-opened.
+ *   - Accept-acceptance idempotency: a second accept attempt on an
+ *     already-accepted invitation returns 409 with the original acceptedAt
+ *     preserved — it does NOT update acceptedAt.
+ *   - Email transport is Clerk magic-link only. No SMTP, no nodemailer.
+ */
+
+import type { OrgRole } from '@/lib/verifier/orgRolesFoundation';
+
+export const invitationSystemLive = true as const;
+
+export type InvitationStatus = 'pending' | 'accepted' | 'expired' | 'revoked';
+
+export type EmailSendChannel = 'clerk_magic_link' | 'shareable_url_only';
+
+export const ALLOWED_EMAIL_CHANNELS: ReadonlyArray<EmailSendChannel> = [
+  'clerk_magic_link',
+  'shareable_url_only',
+] as const;
+
+export interface VerifierInvitationRow {
+  id: string;
+  invitationCode: string;
+  email: string;
+  role: OrgRole;
+  orgId: string;
+  invitedByUserId: string;
+  status: InvitationStatus;
+  expiresAt: Date;
+  acceptedAt: Date | null;
+  acceptedByUserId: string | null;
+  emailSendChannel: EmailSendChannel;
+  createdAt: Date;
+}
+
+export type AcceptDecision =
+  | { ok: true; transitionTo: 'accepted' }
+  | { ok: false; statusCode: 404 | 409 | 410; reason: AcceptRefusalReason };
+
+export type AcceptRefusalReason =
+  | 'invitation_not_found'
+  | 'invitation_expired'
+  | 'invitation_already_accepted'
+  | 'invitation_revoked';
+
+/**
+ * Pure decision: should this invitation be accepted now?
+ *
+ * Returns a structured outcome. Repo callers map ok=false statusCode
+ * directly to the HTTP response status (404 / 409 / 410).
+ *
+ * Order of gates:
+ *   1. Row missing      → 404
+ *   2. Already accepted → 409 (idempotent — original acceptedAt is kept)
+ *   3. Revoked          → 410 (treat as gone)
+ *   4. Expired by time  → 410
+ *   5. Permitted        → ok
+ */
+export function decideAccept(
+  row: VerifierInvitationRow | null,
+  now: Date,
+): AcceptDecision {
+  if (!row) {
+    return { ok: false, statusCode: 404, reason: 'invitation_not_found' };
+  }
+  if (row.status === 'accepted') {
+    return { ok: false, statusCode: 409, reason: 'invitation_already_accepted' };
+  }
+  if (row.status === 'revoked') {
+    return { ok: false, statusCode: 410, reason: 'invitation_revoked' };
+  }
+  if (row.status === 'expired' || row.expiresAt.getTime() <= now.getTime()) {
+    return { ok: false, statusCode: 410, reason: 'invitation_expired' };
+  }
+  return { ok: true, transitionTo: 'accepted' };
+}
+
+const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type CreateValidation =
+  | { ok: true }
+  | { ok: false; statusCode: 400; reason: 'invalid_email' | 'invalid_role' | 'missing_field' };
+
+export function validateCreateInput(input: {
+  email?: unknown;
+  role?: unknown;
+  orgId?: unknown;
+  invitedByUserId?: unknown;
+}): CreateValidation {
+  if (
+    typeof input.email !== 'string' ||
+    typeof input.role !== 'string' ||
+    typeof input.orgId !== 'string' ||
+    typeof input.invitedByUserId !== 'string'
+  ) {
+    return { ok: false, statusCode: 400, reason: 'missing_field' };
+  }
+  if (!EMAIL_RX.test(input.email)) {
+    return { ok: false, statusCode: 400, reason: 'invalid_email' };
+  }
+  if (!['admin', 'reviewer', 'read_only'].includes(input.role)) {
+    return { ok: false, statusCode: 400, reason: 'invalid_role' };
+  }
+  return { ok: true };
+}
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function defaultInvitationExpiry(now: Date): Date {
+  return new Date(now.getTime() + SEVEN_DAYS_MS);
+}
+
+/** Build a URL-safe random invitation code. Uses Web Crypto only. */
+export function generateInvitationCode(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  let s = '';
+  for (const b of bytes) {
+    s += b.toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+export function shareableInvitationUrl(baseUrl: string, code: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return `${trimmed}/verifier/invite/${code}/accept`;
+}

--- a/apps/web/lib/auth/invitationRepo.ts
+++ b/apps/web/lib/auth/invitationRepo.ts
@@ -1,0 +1,153 @@
+/**
+ * invitationRepo.ts
+ *
+ * Server-only Prisma repo for VerifierInvitation rows.
+ * Composes invitationLifecycle.ts (pure decisions) + clerkInvitationSender.ts
+ * (Clerk magic-link transport).
+ */
+import 'server-only';
+import { prisma } from '@/lib/db';
+import { sendInvitationViaClerk } from './clerkInvitationSender';
+import {
+  decideAccept,
+  defaultInvitationExpiry,
+  generateInvitationCode,
+  shareableInvitationUrl,
+  invitationSystemLive,
+  type AcceptDecision,
+  type EmailSendChannel,
+  type InvitationStatus,
+  type VerifierInvitationRow,
+} from './invitationLifecycle';
+import type { OrgRole } from '@/lib/verifier/orgRolesFoundation';
+
+export { invitationSystemLive } from './invitationLifecycle';
+
+export interface CreateInvitationInput {
+  email: string;
+  role: OrgRole;
+  orgId: string;
+  invitedByUserId: string;
+  baseUrl: string;
+  now?: Date;
+}
+
+export interface CreateInvitationResult {
+  invitation: VerifierInvitationRow;
+  shareableUrl: string;
+  emailSendChannel: EmailSendChannel;
+  invitationSystemLive: true;
+}
+
+function rowToDomain(row: {
+  id: string;
+  invitationCode: string;
+  email: string;
+  role: string;
+  orgId: string;
+  invitedByUserId: string;
+  status: string;
+  expiresAt: Date;
+  acceptedAt: Date | null;
+  acceptedByUserId: string | null;
+  emailSendChannel: string;
+  createdAt: Date;
+}): VerifierInvitationRow {
+  return {
+    id: row.id,
+    invitationCode: row.invitationCode,
+    email: row.email,
+    role: row.role as OrgRole,
+    orgId: row.orgId,
+    invitedByUserId: row.invitedByUserId,
+    status: row.status as InvitationStatus,
+    expiresAt: row.expiresAt,
+    acceptedAt: row.acceptedAt,
+    acceptedByUserId: row.acceptedByUserId,
+    emailSendChannel: row.emailSendChannel as EmailSendChannel,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function createInvitation(
+  input: CreateInvitationInput,
+): Promise<CreateInvitationResult> {
+  const now = input.now ?? new Date();
+  const code = generateInvitationCode();
+  const expiresAt = defaultInvitationExpiry(now);
+  const shareableUrl = shareableInvitationUrl(input.baseUrl, code);
+
+  const channel = await sendInvitationViaClerk({
+    email: input.email,
+    redirectUrl: shareableUrl,
+    invitationCode: code,
+  });
+
+  const created = await prisma.verifierInvitation.create({
+    data: {
+      invitationCode: code,
+      email: input.email,
+      role: input.role,
+      orgId: input.orgId,
+      invitedByUserId: input.invitedByUserId,
+      status: 'pending',
+      expiresAt,
+      emailSendChannel: channel,
+    },
+  });
+
+  return {
+    invitation: rowToDomain(created),
+    shareableUrl,
+    emailSendChannel: channel,
+    invitationSystemLive,
+  };
+}
+
+export interface AcceptInvitationResult {
+  decision: AcceptDecision;
+  invitation: VerifierInvitationRow | null;
+}
+
+/**
+ * Accept an invitation by code.
+ *
+ * Idempotency contract: when the row is already accepted, the decision
+ * is 409 and the original row is returned unchanged — acceptedAt and
+ * acceptedByUserId are NOT overwritten.
+ */
+export async function acceptInvitation(
+  invitationCode: string,
+  acceptingUserId: string,
+  now: Date = new Date(),
+): Promise<AcceptInvitationResult> {
+  const row = await prisma.verifierInvitation.findUnique({
+    where: { invitationCode },
+  });
+  const domain = row ? rowToDomain(row) : null;
+  const decision = decideAccept(domain, now);
+
+  if (!decision.ok) {
+    return { decision, invitation: domain };
+  }
+
+  const updated = await prisma.verifierInvitation.update({
+    where: { invitationCode },
+    data: {
+      status: 'accepted',
+      acceptedAt: now,
+      acceptedByUserId: acceptingUserId,
+    },
+  });
+
+  return { decision, invitation: rowToDomain(updated) };
+}
+
+export async function getInvitationByCode(
+  invitationCode: string,
+): Promise<VerifierInvitationRow | null> {
+  const row = await prisma.verifierInvitation.findUnique({
+    where: { invitationCode },
+  });
+  return row ? rowToDomain(row) : null;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+import { PrismaClient } from './generated/prisma';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
+}
+
+export const prisma =
+  globalThis.__prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['warn', 'error'] : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__prisma = prisma;
+}

--- a/apps/web/lib/verifier/orgRolesFoundation.ts
+++ b/apps/web/lib/verifier/orgRolesFoundation.ts
@@ -13,7 +13,8 @@ export type InvitationStatus = 'pending' | 'accepted' | 'expired' | 'revoked';
 
 export interface OrgRolesFoundation {
   provisionLive: false;
-  invitationSystemLive: false;
+  /** Flipped to literal true once the live invitation route + accept flow shipped. */
+  invitationSystemLive: true;
   rbacEnforced: false;
   roles: OrgRole[];
   memberStatuses: OrgMemberStatus[];
@@ -24,14 +25,14 @@ export interface OrgRolesFoundation {
 export function buildOrgRolesFoundation(): OrgRolesFoundation {
   return {
     provisionLive: false,
-    invitationSystemLive: false,
+    invitationSystemLive: true,
     rbacEnforced: false,
     roles: ['admin', 'reviewer', 'read_only'],
     memberStatuses: ['active', 'invited', 'suspended'],
     invitationStatuses: ['pending', 'accepted', 'expired', 'revoked'],
     disclaimers: [
       'Organization roles are a foundation vocabulary; production permissions are not enforced here.',
-      'Invitations are modeled for workflow planning only and are not sent from this module.',
+      'Invitations are sent through Clerk hosted email; this module does not perform direct SMTP delivery.',
     ],
   };
 }

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1,0 +1,54 @@
+// apps/web Prisma schema — web-app-facing subset only.
+//
+// This schema mirrors the models that the web app reads directly.
+// Migrations are managed by apps/api/backend/prisma; these model
+// definitions must stay in sync with that schema.
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+// VerifierInvitation — verifier team invitation lifecycle.
+//
+// Truth contracts:
+//   - status transitions are forward-only:
+//       pending -> accepted | expired | revoked
+//     accepted, expired, and revoked are terminal.
+//   - acceptedAt and acceptedByUserId are immutable once set; a second
+//     accept attempt returns 409 Conflict and does NOT mutate the row.
+//   - emailSendChannel is 'clerk_magic_link' or 'shareable_url_only';
+//     no row may be created with a 'smtp' channel — Clerk is the only
+//     transport this codebase wires.
+model VerifierInvitation {
+  id String @id @default(cuid())
+
+  invitationCode String @unique
+
+  email String
+  role  String
+
+  orgId           String
+  invitedByUserId String
+
+  status String @default("pending")
+
+  expiresAt        DateTime
+  acceptedAt       DateTime?
+  acceptedByUserId String?
+
+  emailSendChannel String @default("shareable_url_only")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([orgId])
+  @@index([email])
+  @@index([status])
+  @@index([expiresAt])
+}


### PR DESCRIPTION
## Summary
- POST \`/api/verifier/invite\` creates a \`VerifierInvitation\` row + sends a Clerk hosted magic-link; falls back to a copyable shareable URL when \`CLERK_SECRET_KEY\` is absent or the Clerk call fails
- Accept flow at \`/verifier/invite/[code]/accept\` reads the row, runs the pure \`decideAccept\` gate, renders 200 / 404 / 409 / 410
- W6C \`invitationSystemLive\` flipped from \`false\` → literal \`true\`; foundation test assertion updated

## Truth contracts
- **No SMTP path** — \`clerkInvitationSender.ts\` is the single email transport file (Clerk hosted email only)
- **Expired invitation** (status='expired' OR expiresAt <= now) → \`410 Gone\`; no DB write attempted
- **Already-accepted invitation** → \`409 Conflict\` (idempotent — original \`acceptedAt\` and \`acceptedByUserId\` preserved; no DB update attempted)
- **invitationSystemLive: true** literal — type-checked + runtime-asserted

## Test plan
- [ ] 5 lifecycle tests (Prisma + Clerk mocked): POST happy path, accept pending, accept expired (410), accept already-accepted (409 idempotent), invitationSystemLive flip
- [ ] 57 foundation-sweep-7 tests still pass (only the invitationSystemLive assertion flipped)
- [ ] Manual: \`/verifier/team/invite\` form submit returns shareable URL section
- [ ] Manual: \`/verifier/invite/<code>/accept\` shows 410 page when expiry passed

## Dependencies
- Schema overlaps with #241 / #247 (introduces apps/web Prisma generator + datasource boilerplate). Resolve at merge by keeping the existing generator block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)