### PR TITLE
fix(a11y): wrap homepage in <main id="main-content"> landmark

### DIFF
--- a/apps/web/__tests__/homepage-main-landmark.test.tsx
+++ b/apps/web/__tests__/homepage-main-landmark.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * homepage-main-landmark.test.tsx
+ *
+ * Closes the Browser-discovered a11y bug: the homepage rendered no
+ * <main> landmark, so the chrome's "Skip to content" link landed on a
+ * <div> with id="main-content" instead of a real landmark element.
+ *
+ * Truth contract:
+ *   - HomePageClient must render a <main id="main-content"> wrapping
+ *     the primary content.
+ *   - The skip-link target ("#main-content") in RootChrome must match
+ *     the id rendered by the homepage. (Pure source-grep — no DOM render
+ *     needed; HomePageClient is a 'use client' component with hooks
+ *     that are awkward to render in vitest's node environment.)
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const HOMEPAGE_PATH = resolve(__dirname, '../app/HomePageClient.tsx');
+const ROOT_CHROME_PATH = resolve(__dirname, '../components/layout/RootChrome.tsx');
+
+describe('homepage <main> landmark', () => {
+  it('HomePageClient renders <main id="main-content"> and skip link target matches', () => {
+    const homepage = readFileSync(HOMEPAGE_PATH, 'utf-8');
+    const chrome = readFileSync(ROOT_CHROME_PATH, 'utf-8');
+
+    // The fix: top-level wrapper is <main id="main-content"> not <div>
+    expect(homepage).toMatch(/<main\s+id="main-content"/);
+    // And it must close as </main> at the end (no orphan <main> tag)
+    expect(homepage).toMatch(/<\/main>\s*\)?\s*;?\s*\}?\s*$/m);
+
+    // The chrome's skip link must point at #main-content — the id the
+    // homepage now exposes on a real landmark.
+    const skipLinkMatch = chrome.match(/href="(#[a-z0-9_-]+)"[^>]*>\s*Skip to content/i);
+    expect(skipLinkMatch, 'RootChrome must contain a "Skip to content" link with an href').not.toBeNull();
+    expect(skipLinkMatch![1]).toBe('#main-content');
+  });
+});

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -108,7 +108,7 @@ export default function HomePageClient() {
   }, []);
 
   return (
-    <div className="bg-[var(--vt-bg)] text-[var(--vt-text-primary)]">
+    <main id="main-content" className="bg-[var(--vt-bg)] text-[var(--vt-text-primary)]">
       {CLERK_PROVIDER_ENABLED && (
         <SignedIn>
           <div className="border-b border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-state-verified)_10%,transparent)] py-2.5 px-4 text-center">
@@ -420,6 +420,6 @@ export default function HomePageClient() {
           <div className="font-mono">© 2026 VitalCV, Inc. · Trust Registry Node 202 · ed25519</div>
         </footer>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
Closes the Browser-discovered a11y bug: \`/\` rendered no \`<main>\` landmark, so the chrome's "Skip to content" link landed on a generic \`<div>\`.

## Changes
- \`apps/web/app/HomePageClient.tsx\` — root \`<div>\` → \`<main id="main-content">\`
- New test \`apps/web/__tests__/homepage-main-landmark.test.tsx\` asserts the \`<main>\` is present AND the chrome's skip link \`href\` matches the rendered id

## Truth contracts
- **No copy changes** — structural a11y only; classes carried over verbatim
- **Skip link target matches** — RootChrome's \`Skip to content\` link \`href="#main-content"\` is verified to match the homepage's \`<main id="main-content">\`

## Test plan
- [ ] Vitest: 1 case passes
- [ ] Manual: tab once on \`/\`, hit Enter on Skip link, focus lands inside the \`<main>\`
- [ ] Manual: axe-core scan of \`/\` no longer reports the "missing landmark" violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)