### PR TITLE
feat(demo): seed Macie Miller PA-C demo passport on /passport/[DEMO_NPI]

### DIFF
--- a/apps/web/__tests__/demo-passport-seed.test.ts
+++ b/apps/web/__tests__/demo-passport-seed.test.ts
@@ -1,0 +1,102 @@
+/**
+ * demo-passport-seed.test.ts
+ *
+ * Verifies the seeded demo passport for /passport/[DEMO_NPI].
+ * Closes the Browser-QA "20 of 28 boundaries not testable" finding.
+ *
+ * Truth contracts:
+ *   1. getDemoPassport(DEMO_NPI) returns the fixture; getDemoPassport(other) returns null
+ *   2. Fixture passes assertPassportData() — every panel mounts without throwing
+ *   3. Every audit-metadata field carries recordedBy: 'demo'
+ *   4. Sample PSV receipt has globalCredentialTruth: false (literal)
+ *   5. Banner copy matches the page render path AND fixture contains no real PHI
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { DEMO_NPI, isDemoNpi } from '../lib/env';
+import { getDemoPassport } from '../lib/demo/seedDemoPassport';
+import {
+  MACIE_MILLER_DEMO_PASSPORT,
+  MACIE_MILLER_LANE_SNAPSHOTS,
+  MACIE_MILLER_PSV_RECEIPT_SAMPLE,
+  DEMO_PASSPORT_BANNER_COPY,
+} from '../lib/demo/demoPassportFixture';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+describe('demo passport seed', () => {
+  it('case 1: getDemoPassport returns the fixture for DEMO_NPI and null otherwise', () => {
+    expect(DEMO_NPI).toBe('1346053246');
+    expect(isDemoNpi('1346053246')).toBe(true);
+    expect(isDemoNpi('1003000126')).toBe(false);
+    expect(isDemoNpi(null)).toBe(false);
+
+    const hit = getDemoPassport('1346053246');
+    expect(hit).not.toBeNull();
+    expect(hit!.isDemo).toBe(true);
+    expect(hit!.passport.npi).toBe('1346053246');
+
+    expect(getDemoPassport('1003000126')).toBeNull();
+    expect(getDemoPassport('')).toBeNull();
+    expect(getDemoPassport(null)).toBeNull();
+
+    // Also resolves by entityId so /passport/<entityId> works
+    expect(getDemoPassport(MACIE_MILLER_DEMO_PASSPORT.entityId)).not.toBeNull();
+  });
+
+  it('case 2: fixture passes assertPassportData — every panel can mount without throwing', () => {
+    expect(() => assertPassportData(MACIE_MILLER_DEMO_PASSPORT, 'demo passport')).not.toThrow();
+
+    // All 4 lane states populated so LaneHealthMount renders every branch
+    const states = MACIE_MILLER_LANE_SNAPSHOTS.map((s) => s.state).sort();
+    expect(states).toEqual(['limitation_required', 'missing_evidence', 'ready_for_review', 'verified']);
+  });
+
+  it('case 3: every audit-metadata field carries recordedBy: demo (no production attribution leaks)', () => {
+    for (const lane of MACIE_MILLER_LANE_SNAPSHOTS) {
+      expect(lane.recordedBy).toBe('demo');
+    }
+    expect(MACIE_MILLER_PSV_RECEIPT_SAMPLE.recordedBy).toBe('demo');
+  });
+
+  it('case 4: sample PSV receipt carries globalCredentialTruth: false literal', () => {
+    expect(MACIE_MILLER_PSV_RECEIPT_SAMPLE.globalCredentialTruth).toBe(false);
+    // Type-level: would not compile if widened from `false` to `boolean`
+    const literalCheck: false = MACIE_MILLER_PSV_RECEIPT_SAMPLE.globalCredentialTruth;
+    expect(literalCheck).toBe(false);
+    expect(MACIE_MILLER_PSV_RECEIPT_SAMPLE.proofTier).toBe('psv_receipt');
+  });
+
+  it('case 5: banner copy matches page render path AND fixture contains no real PHI/NPI from production data', () => {
+    // Banner constant matches what the page passes to the client component
+    const pagePath = resolve(__dirname, '../app/passport/[id]/page.tsx');
+    const pageSource = readFileSync(pagePath, 'utf-8');
+    expect(pageSource).toContain('DEMO_PASSPORT_BANNER_COPY');
+    expect(DEMO_PASSPORT_BANNER_COPY).toContain('synthetic data');
+    expect(DEMO_PASSPORT_BANNER_COPY).toContain('not a real clinician record');
+
+    // Page must invoke getDemoPassport on the route id
+    expect(pageSource).toContain('getDemoPassport(id)');
+    // Client component must render the banner via demo prop pass-through
+    const clientPath = resolve(__dirname, '../app/passport/[id]/PassportEntityClient.tsx');
+    const clientSource = readFileSync(clientPath, 'utf-8');
+    expect(clientSource).toContain('demoBanner');
+    expect(clientSource).toContain('data-testid="demo-passport-banner"');
+
+    // Synthetic data marker: institution name is explicitly tagged synthetic
+    expect(MACIE_MILLER_DEMO_PASSPORT.training.records[0].institutionName).toContain('synthetic demo institution');
+
+    // No real production PHI markers — the only NPI in the fixture is the
+    // demo NPI itself; no real names, no real DEA, no real email
+    const fixtureJson = JSON.stringify(MACIE_MILLER_DEMO_PASSPORT);
+    // Sweep for credential numbers that look like real DEA registrations (BB#######)
+    expect(fixtureJson).not.toMatch(/\b[A-Z]{2}\d{7}\b/);
+    // No SSN-like patterns
+    expect(fixtureJson).not.toMatch(/\b\d{3}-\d{2}-\d{4}\b/);
+    // No NPIs other than the demo one
+    const npiMatches = fixtureJson.match(/\b\d{10}\b/g) ?? [];
+    for (const npi of npiMatches) {
+      expect(npi).toBe(DEMO_NPI);
+    }
+  });
+});

--- a/apps/web/app/passport/[id]/PassportEntityClient.tsx
+++ b/apps/web/app/passport/[id]/PassportEntityClient.tsx
@@ -13,13 +13,26 @@ import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
 
 interface PassportEntityClientProps {
   entityId: string;
+  /** When provided, the demo seeder hydrates the passport in place of the fetch. */
+  initialPassport?: PassportData;
+  /** Banner copy rendered above PassportWallet when the demo fixture is in use. */
+  demoBanner?: string;
 }
 
-export default function PassportEntityClient({ entityId }: PassportEntityClientProps) {
-  const [passport, setPassport] = useState<PassportData | null>(null);
-  const [loading, setLoading] = useState(true);
+export default function PassportEntityClient({
+  entityId,
+  initialPassport,
+  demoBanner,
+}: PassportEntityClientProps) {
+  const [passport, setPassport] = useState<PassportData | null>(initialPassport ?? null);
+  const [loading, setLoading] = useState(!initialPassport);
 
   useEffect(() => {
+    if (initialPassport) {
+      // Demo path — fixture is already seeded, no fetch.
+      return;
+    }
+
     let cancelled = false;
 
     void (async () => {
@@ -36,7 +49,7 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
     return () => {
       cancelled = true;
     };
-  }, [entityId]);
+  }, [entityId, initialPassport]);
 
   if (loading) {
     return <PassportWallet loading />;
@@ -75,7 +88,17 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
   const inboxItems: KnowledgeInboxItem[] = [];
 
   return (
-    <div className="flex flex-col gap-8 pb-16">
+    <div className="flex flex-col gap-8 pb-16" data-demo-passport={demoBanner ? 'true' : 'false'}>
+      {demoBanner && (
+        <div
+          role="note"
+          aria-label="Demo passport banner"
+          data-testid="demo-passport-banner"
+          className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-2.5 text-center text-xs text-amber-200"
+        >
+          {demoBanner}
+        </div>
+      )}
       <PassportWallet passport={passport} />
       <div className="mx-auto max-w-[480px] sm:max-w-[640px] md:max-w-3xl lg:max-w-4xl px-4 w-full space-y-8">
         <section

--- a/apps/web/app/passport/[id]/page.tsx
+++ b/apps/web/app/passport/[id]/page.tsx
@@ -1,4 +1,6 @@
 import PassportEntityClient from './PassportEntityClient';
+import { getDemoPassport } from '@/lib/demo/seedDemoPassport';
+import { DEMO_PASSPORT_BANNER_COPY } from '@/lib/demo/demoPassportFixture';
 
 export const dynamic = 'force-dynamic';
 
@@ -8,5 +10,17 @@ export default async function PassportEntityPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const demo = getDemoPassport(id);
+
+  if (demo) {
+    return (
+      <PassportEntityClient
+        entityId={id}
+        initialPassport={demo.passport}
+        demoBanner={DEMO_PASSPORT_BANNER_COPY}
+      />
+    );
+  }
+
   return <PassportEntityClient entityId={id} />;
 }

--- a/apps/web/lib/demo/demoPassportFixture.ts
+++ b/apps/web/lib/demo/demoPassportFixture.ts
@@ -1,0 +1,195 @@
+/**
+ * demoPassportFixture.ts
+ *
+ * Canonical Macie Miller, PA-C demo passport. Synthetic data only —
+ * no PHI or NPI from real production records appears here.
+ *
+ * Truth contracts (verified by demo-passport-seed.test):
+ *   - Every audit-metadata field carries recordedBy: 'demo'
+ *   - The PSV receipt sample carries globalCredentialTruth: false literal
+ *   - All 4 lane states are populated (verified, ready_for_review,
+ *     limitation_required, missing_evidence) so the LaneHealthMount
+ *     panel exercises every branch
+ *   - The fixture renders cleanly through assertPassportData()
+ */
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+const NPI = '1346053246';
+const ENTITY_ID = 'demo-entity-macie-miller';
+const NOW_ISO = '2026-05-04T00:00:00.000Z';
+
+export interface DemoPsvReceiptSample {
+  psvReceiptId: string;
+  recordedBy: 'demo';
+  /** Literal — distinct from real PSV receipts written by the platform. */
+  globalCredentialTruth: false;
+  proofTier: 'psv_receipt';
+  scope: { covers: string; doesNotCover: string };
+}
+
+export const MACIE_MILLER_PSV_RECEIPT_SAMPLE: DemoPsvReceiptSample = {
+  psvReceiptId: 'demo-psv-receipt-001',
+  recordedBy: 'demo',
+  globalCredentialTruth: false,
+  proofTier: 'psv_receipt',
+  scope: {
+    covers: 'PA license issuance and current standing in California',
+    doesNotCover: 'Out-of-state license endorsements; subspecialty board status',
+  },
+};
+
+export interface DemoLaneSnapshot {
+  laneId: string;
+  state: 'verified' | 'ready_for_review' | 'limitation_required' | 'missing_evidence';
+  observedAt: string;
+  recordedBy: 'demo';
+}
+
+/** All four lane states populated so the LaneHealthMount renders every branch. */
+export const MACIE_MILLER_LANE_SNAPSHOTS: DemoLaneSnapshot[] = [
+  { laneId: 'identity', state: 'verified', observedAt: NOW_ISO, recordedBy: 'demo' },
+  { laneId: 'authority', state: 'ready_for_review', observedAt: NOW_ISO, recordedBy: 'demo' },
+  { laneId: 'training', state: 'limitation_required', observedAt: NOW_ISO, recordedBy: 'demo' },
+  { laneId: 'standing', state: 'missing_evidence', observedAt: NOW_ISO, recordedBy: 'demo' },
+];
+
+export const MACIE_MILLER_DEMO_PASSPORT: PassportData = {
+  entityId: ENTITY_ID,
+  npi: NPI,
+  identity: {
+    displayName: 'Macie Miller, PA-C',
+    specialty: 'Primary Care (Physician Assistant)',
+    entityType: 'PERSON',
+    status: 'ACTIVE',
+    npi: NPI,
+  },
+  authority: {
+    credentials: [
+      {
+        id: 'demo-cred-pa-license-ca',
+        domain: 'professional_license',
+        type: 'physician_assistant_license',
+        status: 'active',
+        verificationLevel: 'source_backed',
+        issuerName: 'California Physician Assistant Board',
+        sourceId: 'CA_PA_BOARD',
+        jurisdiction: 'CA',
+        issuedAt: '2022-08-15T00:00:00.000Z',
+        expiresAt: '2027-08-15T00:00:00.000Z',
+        verifiedAt: NOW_ISO,
+        observedAt: NOW_ISO,
+        stale: false,
+        confidenceLabel: 'HIGH',
+        claimConfidenceLabel: 'HIGH',
+        dataFreshness: 'current',
+        dataFreshnessLabel: 'Current source coverage',
+        reviewRequired: false,
+      },
+    ],
+    summary: { active: 1, expired: 0, stale: 0, missing: ['DEA_registration_pending'] },
+  },
+  training: {
+    records: [
+      {
+        id: 'demo-training-pa-master',
+        recordType: 'graduate_degree',
+        degreeOrTitle: 'Master of Physician Assistant Studies',
+        specialty: 'Primary Care',
+        institutionName: 'University of California, Davis (synthetic demo institution)',
+        endYear: 2022,
+        completed: true,
+        verificationLevel: 'self_attested',
+      },
+    ],
+    hasDegree: true,
+    degreeVerified: false,
+    hasResidency: false,
+    fellowshipCount: 0,
+  },
+  standing: {
+    exclusionClear: true,
+    exclusionStatus: 'CLEAR',
+    exclusionCheckedAt: NOW_ISO,
+    exclusionConfidenceLabel: 'HIGH',
+    licensureStatus: 'verified',
+    deaStatus: 'unknown',
+    pecosStatus: 'enrolled',
+    pecosEnrollmentStatus: 'ENROLLED',
+    enrollmentSourceLabel: 'CMS PECOS',
+    enrollmentDataFreshness: 'Quarterly',
+    enrollmentSourceLatency: 'Quarterly snapshot',
+    enrollmentNote: 'PECOS enrollment found; refreshes quarterly.',
+    enrollmentObservedAt: '2026-04-01T00:00:00.000Z',
+    enrollmentDataVersion: '2026-Q1',
+    enrollmentStatusLabel: 'Enrolled',
+    enrollmentFreshnessLabel: 'Quarterly',
+    enrollmentConfidenceLabel: 'Quarterly release',
+    negativeFindings: [],
+  },
+  readiness: {
+    status: 'PARTIAL',
+    score: 78,
+    level: 'L2',
+    blockers: [],
+    gaps: ['DEA registration pending', 'NPI directory phone update needed'],
+    estimatedStartDays: 14,
+    nextActions: [
+      {
+        id: 'demo-action-dea',
+        title: 'Submit DEA registration application',
+        detail: 'PA prescribing authority is jurisdiction-specific; current status is unregistered.',
+        priority: 'HIGH',
+      },
+    ],
+  },
+  sources: {
+    checked: ['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC', 'CA_PA_BOARD'],
+    lastFetch: {
+      NPPES_API: NOW_ISO,
+      OIG_LEIE: NOW_ISO,
+      PECOS_PUBLIC: '2026-04-01T00:00:00.000Z',
+      CA_PA_BOARD: NOW_ISO,
+    },
+  },
+  sourceCoverage: {
+    checks: [
+      { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity confirmed for demo NPI.', checkedAt: NOW_ISO },
+      { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE exclusion list clear for demo identity.', checkedAt: NOW_ISO },
+      { sourceId: 'PECOS_PUBLIC', state: 'checked', reason: 'PECOS quarterly enrollment confirmed.', checkedAt: '2026-04-01T00:00:00.000Z' },
+      { sourceId: 'CA_PA_BOARD', state: 'checked', reason: 'California PA Board license active.', checkedAt: NOW_ISO },
+    ],
+  },
+  trustPosture: {
+    band: 'L2',
+    bandLabel: 'Moderate trust',
+    score: 78,
+    dimensions: [
+      { id: 'identity', label: 'Identity', state: 'current', detail: 'Confirmed via NPPES.', checkedAt: NOW_ISO },
+      { id: 'authority', label: 'Authority', state: 'current', detail: 'CA PA Board license active.', checkedAt: NOW_ISO },
+      { id: 'training', label: 'Training', state: 'review_required', detail: 'Graduate degree self-attested; verification pending.', checkedAt: NOW_ISO },
+      { id: 'standing', label: 'Standing', state: 'review_required', detail: 'DEA registration absent.', checkedAt: NOW_ISO },
+    ],
+    freshness: {
+      state: 'current',
+      label: 'Current source coverage',
+      items: [
+        { id: 'identity', label: 'NPPES', source: 'NPPES_API', state: 'current', checkedAt: NOW_ISO, note: 'Demo NPPES snapshot.' },
+        { id: 'authority', label: 'CA PA Board', source: 'CA_PA_BOARD', state: 'current', checkedAt: NOW_ISO, note: 'Demo CA board snapshot.' },
+      ],
+    },
+    safeToRelyOnNow: ['Identity confirmed', 'Federal exclusion clear'],
+    missingItems: ['DEA registration'],
+    gatedItems: [],
+    reviewRequiredItems: ['Graduate degree verification'],
+    staleItems: [],
+    blockers: [],
+  },
+  lastCheckedAt: NOW_ISO,
+};
+
+/**
+ * The banner copy that must render when this fixture is the source for
+ * /passport/[id]. Asserted by the demo-passport-seed test.
+ */
+export const DEMO_PASSPORT_BANNER_COPY =
+  'Demo passport — synthetic data, not a real clinician record';

--- a/apps/web/lib/demo/seedDemoPassport.ts
+++ b/apps/web/lib/demo/seedDemoPassport.ts
@@ -1,0 +1,35 @@
+/**
+ * seedDemoPassport.ts
+ *
+ * Idempotent request-time seeder for the demo passport.
+ *
+ * The seeder is pure — it returns the fixture object when the id (NPI
+ * or entityId) matches DEMO_NPI, otherwise null. No DB writes, no
+ * fetches, no caching layer (the fixture is a frozen module-scope
+ * constant; calling getDemoPassport() repeatedly is free).
+ */
+import { DEMO_NPI } from '@/lib/env';
+import { MACIE_MILLER_DEMO_PASSPORT } from './demoPassportFixture';
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+export interface DemoPassportLookup {
+  passport: PassportData;
+  isDemo: true;
+}
+
+/**
+ * Returns the demo passport when `id` matches DEMO_NPI, otherwise null.
+ *
+ * Accepts either a raw NPI ('1346053246') or the demo entityId
+ * ('demo-entity-macie-miller') so both `/passport/<NPI>` and
+ * `/passport/<entityId>` URLs hydrate from the fixture.
+ */
+export function getDemoPassport(id: string | null | undefined): DemoPassportLookup | null {
+  if (typeof id !== 'string') return null;
+  const trimmed = id.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed === DEMO_NPI || trimmed === MACIE_MILLER_DEMO_PASSPORT.entityId) {
+    return { passport: MACIE_MILLER_DEMO_PASSPORT, isDemo: true };
+  }
+  return null;
+}

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,0 +1,22 @@
+/**
+ * lib/env.ts — minimal env accessor for runtime-time env reads.
+ *
+ * Centralizes env-var reads that are referenced from multiple modules
+ * so defaults and shape are documented in one place.
+ */
+
+/**
+ * The synthetic NPI used by the seeded demo passport. Defaults to
+ * Macie Miller PA-C (1346053246) — the prototype's walking scenario
+ * that the marketing pages already advertise.
+ *
+ * Override with the DEMO_NPI env var if a different demo identity is
+ * needed. The value is read at request time so a deployment can flip
+ * the demo without rebuilding.
+ */
+export const DEMO_NPI: string = process.env.DEMO_NPI?.trim() || '1346053246';
+
+export function isDemoNpi(value: string | null | undefined): boolean {
+  if (typeof value !== 'string') return false;
+  return value.trim() === DEMO_NPI;
+}


### PR DESCRIPTION
## Summary
**Closes the Browser-QA "20 of 28 boundaries not testable on the live demo" P0 finding.**

The marketing pages advertise NPI \`1346053246\` (Macie Miller, PA-C) as the walking scenario, but \`/passport/1346053246\` returned the "Passport not available" placeholder — TrustGraph panel + LaneHealthMount + KnowledgeInboxPanel were all unreachable on the live demo.

## Changes
- \`lib/env.ts\` — exports \`DEMO_NPI\` (defaults \`1346053246\`, override via env)
- \`lib/demo/demoPassportFixture.ts\` — Macie Miller synthetic passport satisfying \`assertPassportData()\`; 4 lane snapshots covering every state; sample PSV receipt with literal \`globalCredentialTruth: false\`; \`recordedBy: 'demo'\` on every audit field
- \`lib/demo/seedDemoPassport.ts\` — pure request-time seeder; resolves by NPI or entityId
- \`app/passport/[id]/page.tsx\` — hydrates from fixture when id matches DEMO_NPI; passes demo banner copy
- \`app/passport/[id]/PassportEntityClient.tsx\` — accepts \`initialPassport\` + \`demoBanner\` props; skips fetch when seeded; renders banner with \`role="note"\` and \`data-testid="demo-passport-banner"\`

## Truth contracts (asserted)
- **No real PHI/NPI** — fixture sweep blocks DEA-shaped (\`[A-Z]{2}\d{7}\`), SSN-shaped, and any non-DEMO 10-digit NPIs
- **recordedBy: 'demo'** on every audit field — synthetic-data marker is structural
- **globalCredentialTruth: false** literal on the sample PSV receipt — distinct from real platform-issued receipts
- **Banner renders** the synthetic-data disclaimer above PassportWallet with \`role="note"\`

## Test plan
- [ ] 5 unit tests pass (seeder behavior, fixture validates, audit tagging, literal types, banner + PHI sweep)
- [ ] Manual: \`/passport/1346053246\` shows the demo banner above the wallet
- [ ] Manual: TrustGraph + LaneHealthMount + KnowledgeInboxPanel all render
- [ ] Manual: \`/passport/1003000126\` (other NPI) still shows the not-available placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)