### PR TITLE
feat(ops): post-deploy source-health probe (workflow + script + test)

### DIFF
--- a/.github/workflows/deploy-health-probe.yml
+++ b/.github/workflows/deploy-health-probe.yml
@@ -1,0 +1,34 @@
+name: Deploy health probe
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # Don't run two probes against prod simultaneously
+  group: deploy-health-probe
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Source-health snapshot probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait 60s for deploy to settle
+        run: sleep 60
+
+      - name: Probe source-health snapshots
+        env:
+          # Token is passed via env, NEVER as a shell argument; never echoed.
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET secret is not configured for this workflow."
+            exit 1
+          fi
+          bash scripts/deploy-health-probe.sh https://vitalcv.com

--- a/apps/web/__tests__/deploy-health-probe-script.test.ts
+++ b/apps/web/__tests__/deploy-health-probe-script.test.ts
@@ -1,0 +1,54 @@
+/**
+ * deploy-health-probe-script.test.ts
+ *
+ * Structural test for scripts/deploy-health-probe.sh and the
+ * accompanying GitHub Actions workflow.
+ *
+ * Truth contracts:
+ *   - Script asserts ≥ 4 snapshots returned
+ *   - Script reads CRON_SECRET via env, never as a CLI argument; the
+ *     secret is never written to stdout (no `echo $CRON_SECRET`)
+ *   - Workflow runs on push to main + workflow_dispatch
+ *   - Workflow passes CRON_SECRET via env, not as a shell argument
+ *   - Failure surfaces as workflow status (no auto-rollback step)
+ */
+import { describe, expect, it } from 'vitest';
+import { accessSync, constants, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SCRIPT_PATH = resolve(__dirname, '../../../scripts/deploy-health-probe.sh');
+const WORKFLOW_PATH = resolve(__dirname, '../../../.github/workflows/deploy-health-probe.yml');
+
+describe('deploy-health-probe', () => {
+  it('script exists, is executable, and meets truth contracts', () => {
+    accessSync(SCRIPT_PATH, constants.X_OK);
+    const script = readFileSync(SCRIPT_PATH, 'utf-8');
+
+    // Asserts ≥ 4 snapshots
+    expect(script).toMatch(/lt\s+4/);
+    expect(script).toContain('NPPES');
+    expect(script).toContain('OIG');
+    expect(script).toContain('PECOS');
+    expect(script).toContain('state-board');
+
+    // Reads CRON_SECRET from env (not as CLI arg)
+    expect(script).toMatch(/\$\{?CRON_SECRET\b/);
+    // Authorization header uses Bearer scheme
+    expect(script).toContain('Authorization: Bearer');
+    // Never echo the secret to stdout
+    expect(script).not.toMatch(/echo\s+["'$]?\$\{?CRON_SECRET\b/);
+    // No SMTP / mailer / notifier wired in (failure surfaces as workflow status only)
+    expect(script).not.toMatch(/sendmail|nodemailer|curl.*slack/i);
+
+    // Workflow file
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf-8');
+    // Runs on push to main + workflow_dispatch
+    expect(workflow).toMatch(/branches:\s*\[main\]/);
+    expect(workflow).toContain('workflow_dispatch');
+    // CRON_SECRET passed via env, not as CLI argument
+    expect(workflow).toMatch(/CRON_SECRET:\s*\$\{\{\s*secrets\.CRON_SECRET\s*\}\}/);
+    expect(workflow).not.toMatch(/deploy-health-probe\.sh\s+\S+\s+\$\{\{\s*secrets\.CRON_SECRET/);
+    // No auto-rollback (probe surfaces failure; cutover is operator-driven)
+    expect(workflow).not.toMatch(/rollback|revert/i);
+  });
+});

--- a/scripts/deploy-health-probe.sh
+++ b/scripts/deploy-health-probe.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# deploy-health-probe.sh
+#
+# Post-deploy probe: hits /api/internal/source-health/snapshots on the
+# given base URL with the CRON_SECRET bearer and asserts that at least
+# 4 source snapshots are returned (NPPES / OIG / PECOS / state-board).
+#
+# Usage:
+#   CRON_SECRET=... ./scripts/deploy-health-probe.sh https://vitalcv.com
+#
+# Exit codes:
+#   0 = >= 4 snapshots returned
+#   1 = config error (missing BASE_URL or CRON_SECRET)
+#   2 = endpoint returned non-200
+#   3 = endpoint returned < 4 snapshots
+set -uo pipefail
+
+BASE_URL="${1:-}"
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "ERROR: base URL required as first argument." >&2
+  echo "       Example: ./scripts/deploy-health-probe.sh https://vitalcv.com" >&2
+  exit 1
+fi
+
+if [[ -z "${CRON_SECRET:-}" ]]; then
+  echo "ERROR: CRON_SECRET env var is required." >&2
+  exit 1
+fi
+
+BASE_URL="${BASE_URL%/}"
+URL="${BASE_URL}/api/internal/source-health/snapshots"
+
+echo "Probing ${URL}..."
+
+# -s silent, -S show errors, -o body, -w status
+# Use Authorization header (Bearer); never echo the secret to stdout.
+HTTP_STATUS=$(curl -sS -o /tmp/deploy_health_probe_body \
+  -w '%{http_code}' \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  -H 'Accept: application/json' \
+  --max-time 15 \
+  "$URL" 2>/dev/null || echo "000")
+
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "FAIL: endpoint returned HTTP ${HTTP_STATUS}" >&2
+  # Body is generic shape only — safe to print.
+  head -c 500 /tmp/deploy_health_probe_body 2>/dev/null >&2 || true
+  echo "" >&2
+  exit 2
+fi
+
+# Count snapshots without leaking payload contents.
+# The snapshots endpoint returns { snapshots: [ { sourceId, ... }, ... ] }.
+SNAPSHOT_COUNT=$(python3 -c '
+import json, sys
+try:
+  data = json.load(open("/tmp/deploy_health_probe_body"))
+  arr = data.get("snapshots", []) if isinstance(data, dict) else []
+  print(len(arr) if isinstance(arr, list) else 0)
+except Exception:
+  print(0)
+')
+
+echo "Snapshots returned: ${SNAPSHOT_COUNT}"
+
+if [[ "$SNAPSHOT_COUNT" -lt 4 ]]; then
+  echo "FAIL: expected >= 4 snapshots (NPPES / OIG / PECOS / state-board), got ${SNAPSHOT_COUNT}" >&2
+  exit 3
+fi
+
+echo "OK: deploy health probe passed."


### PR DESCRIPTION
## Summary
Post-deploy probe that polls \`vitalcv.com\` after a push-to-main and asserts the source-health snapshots endpoint returns at least 4 entries.

## Changes
- **\`scripts/deploy-health-probe.sh\`** — POSTs \`Authorization: Bearer \$CRON_SECRET\` to \`/api/internal/source-health/snapshots\`; counts snapshots via Python (no jq dependency); exits 0 / 1 / 2 / 3 with structured error codes
- **\`.github/workflows/deploy-health-probe.yml\`** — \`on: push (main) + workflow_dispatch\`; 60s settle delay; concurrency group prevents racing probes
- **\`apps/web/__tests__/deploy-health-probe-script.test.ts\`** — 1 structural test asserting all four truth contracts

## Truth contracts (asserted)
- **Workflow runs on push to main + workflow_dispatch** — both triggers explicit
- **Asserts ≥ 4 snapshots returned** (NPPES / OIG / PECOS / state-board) — script exits 3 if fewer
- **Token via CRON_SECRET secret; never logged** — passed via env in workflow; \`Authorization: Bearer\` header in script; no \`echo \$CRON_SECRET\`; no Slack/SMTP notifier
- **Failure surfaces as workflow status; does not auto-rollback** — workflow has no rollback/revert steps; operator follows the cutover runbook on red

## Test plan
- [ ] Vitest: 1 structural test passes
- [ ] Manual dispatch: \`gh workflow run deploy-health-probe.yml\` against current prod, expect green
- [ ] Manual: \`CRON_SECRET=… ./scripts/deploy-health-probe.sh https://vitalcv.com\` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)