### PR TITLE
feat(worklist): replace foundation array with DB-backed ReceiptCandidate reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ node_modules/
 dist/
 .cache/
 
+apps/web/lib/generated/

--- a/apps/web/__tests__/verifier-worklist-db.test.ts
+++ b/apps/web/__tests__/verifier-worklist-db.test.ts
@@ -1,0 +1,138 @@
+/**
+ * verifier-worklist-db.test.ts
+ *
+ * Real-Postgres tests for worklistRepo.getWorklist().
+ * Skipped automatically when DATABASE_URL is not set (no mock/fake-fill).
+ *
+ * Truth contract asserted:
+ *   - Empty table → []  (no fake-fill)
+ *   - decisionGrade: false preserved through query → result round-trip
+ *   - Only ReceiptCandidate rows returned; no PSVReceipt path exists here
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const DB_URL = process.env.DATABASE_URL;
+const SKIP = !DB_URL;
+
+// We import PrismaClient directly (not via lib/db) so the test can
+// manage its own connection lifecycle and perform cleanup.
+import { PrismaClient } from '../lib/generated/prisma';
+
+const prismaTest = new PrismaClient({ datasources: { db: { url: DB_URL ?? '' } } });
+
+// Candidate IDs seeded by this test — cleaned up in afterAll.
+const SEEDED_IDS: string[] = [];
+
+async function seedCandidate(overrides: {
+  candidateId: string;
+  reviewState?: string;
+  proofTier?: string;
+}) {
+  SEEDED_IDS.push(overrides.candidateId);
+  return prismaTest.receiptCandidate.create({
+    data: {
+      candidateId: overrides.candidateId,
+      basis: 'test-basis',
+      sourceOrganizationName: 'Test GME Office',
+      attributionStatus: 'test',
+      decisionGrade: false,
+      proofTier: overrides.proofTier ?? 'receipt_candidate',
+      reviewState: overrides.reviewState ?? null,
+      recordedBy: 'demo',
+    },
+  });
+}
+
+beforeAll(async () => {
+  if (SKIP) return;
+  await prismaTest.$connect();
+});
+
+afterAll(async () => {
+  if (SKIP) return;
+  if (SEEDED_IDS.length > 0) {
+    await prismaTest.receiptCandidate.deleteMany({
+      where: { candidateId: { in: SEEDED_IDS } },
+    });
+  }
+  await prismaTest.$disconnect();
+});
+
+// Dynamically import the repo inside tests to avoid 'server-only'
+// guard failing in the test runner (vitest runs in node environment
+// where server-only is a no-op).
+async function getWorklist(filter = {}) {
+  const mod = await import('../lib/verifier/worklistRepo');
+  return mod.getWorklist(filter);
+}
+
+// Case 1 — empty table returns [] (no fake-fill)
+describe('getWorklist — empty table', () => {
+  it.skipIf(SKIP)('returns an empty array when no rows match; never fake-fills', async () => {
+    // Use a filter that is guaranteed to return no rows (unique state
+    // that no seed uses) so we can assert the empty-result branch
+    // without deleting production data.
+    const result = await getWorklist({ reviewState: 'unable_to_verify' });
+    // Cannot assert result.length === 0 if other suites seeded rows,
+    // but we CAN assert it is an array and no row has a fabricated
+    // candidateId (the fake-fill guard).
+    expect(Array.isArray(result)).toBe(true);
+    for (const row of result) {
+      expect(typeof row.candidateId).toBe('string');
+      // decisionGrade must be the literal false on every row
+      expect(row.decisionGrade).toBe(false);
+    }
+  });
+});
+
+// Case 2 — seeded row appears in results; decisionGrade: false preserved
+describe('getWorklist — seeded row round-trip', () => {
+  it.skipIf(SKIP)(
+    'returns seeded ReceiptCandidate and preserves decisionGrade: false literal',
+    async () => {
+      const id = `wl-test-${Date.now()}-1`;
+      await seedCandidate({
+        candidateId: id,
+        reviewState: 'pending_policy_review',
+        proofTier: 'receipt_candidate',
+      });
+
+      const result = await getWorklist({ reviewState: 'pending' });
+      const found = result.find((r) => r.candidateId === id);
+      expect(found).toBeDefined();
+      // Truth contract: decisionGrade is the literal false through the round-trip
+      expect(found!.decisionGrade).toBe(false);
+      expect(found!.proofTier).toBe('receipt_candidate');
+      expect(found!.reviewState).toBe('pending');
+    },
+  );
+});
+
+// Case 3 — filter excludes non-matching reviewState rows
+describe('getWorklist — reviewState filter', () => {
+  it.skipIf(SKIP)(
+    'excludes rows whose reviewState does not match the filter',
+    async () => {
+      const matchId = `wl-test-${Date.now()}-match`;
+      const noMatchId = `wl-test-${Date.now()}-nomatch`;
+
+      await Promise.all([
+        seedCandidate({ candidateId: matchId, reviewState: 'in_review' }),
+        seedCandidate({ candidateId: noMatchId, reviewState: 'pending_policy_review' }),
+      ]);
+
+      const result = await getWorklist({ reviewState: 'in_review' });
+      const matchFound = result.some((r) => r.candidateId === matchId);
+      const noMatchFound = result.some((r) => r.candidateId === noMatchId);
+
+      expect(matchFound).toBe(true);
+      expect(noMatchFound).toBe(false);
+
+      // PSVReceipt safety: no row in result should have decisionGrade !== false
+      // (PSVReceipt rows have decisionGrade: true; they must not leak into this query)
+      for (const row of result) {
+        expect(row.decisionGrade).toBe(false);
+      }
+    },
+  );
+});

--- a/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
+++ b/apps/web/__tests__/verifier/foundation-sweep-7.test.ts
@@ -452,10 +452,16 @@ describe('verifier component and page copy invariants', () => {
     expect(markup).toContain('Self-attested input needs source review');
   });
 
-  it('employer worklist shell carries the planned DB integration copy and main aria label', () => {
+  it('employer worklist shell is wired to the live DB-backed worklist repo', () => {
     const src = readWebFile('app/employer/worklist/page.tsx');
-    expect(src).toContain('Worklist is connected to submitted applications. Live DB integration');
-    expect(src).toContain('aria-label="Employer worklist shell"');
+    // DB integration is now live (PR superseding #241): the page imports
+    // getWorklist from the verifier worklistRepo and renders rows via
+    // WorklistPanel. The earlier placeholder copy "Worklist is connected
+    // to submitted applications. Live DB integration" was replaced when
+    // the live read landed.
+    expect(src).toContain("from '@/lib/verifier/worklistRepo'");
+    expect(src).toContain('getWorklist');
+    expect(src).toContain('WorklistPanel');
   });
 
   it('employer decision shell carries the planned recording copy and read-only area', () => {

--- a/apps/web/app/employer/worklist/page.tsx
+++ b/apps/web/app/employer/worklist/page.tsx
@@ -1,49 +1,62 @@
+import type { ReactElement } from 'react';
+import { getWorklist } from '@/lib/verifier/worklistRepo';
+import type { WorklistDbRow } from '@/lib/verifier/worklistRepo';
 import { WorklistPanel } from '@/components/verifier/WorklistPanel';
 import type { WorklistItem } from '@/lib/verifier/worklist';
-import type { ReactElement } from 'react';
 
-const SAMPLE_WORKLIST_ITEMS: WorklistItem[] = [
-  {
-    clinicianNpi: '1003000126',
-    submittedAt: '2026-04-28T16:20:00.000Z',
-    status: 'pending',
+// NPI is not stored on ReceiptCandidate (a future wave adds that lookup).
+// candidateId is used as the identifier in the panel until then.
+function toWorklistItem(row: WorklistDbRow): WorklistItem {
+  return {
+    clinicianNpi: row.candidateId,
+    submittedAt: row.createdAt.toISOString(),
+    status: row.reviewState,
     proofTier: 'receipt_candidate',
-  },
-  {
-    clinicianNpi: '1234567893',
-    submittedAt: '2026-04-27T19:10:00.000Z',
-    status: 'in_review',
-    proofTier: 'psv_sourced',
-  },
-  {
-    clinicianNpi: '1999999984',
-    submittedAt: '2026-04-26T14:35:00.000Z',
-    status: 'info_requested',
-    proofTier: 'self_attested',
-  },
-];
+  };
+}
 
-export default function EmployerWorklistPage(): ReactElement {
+export default async function EmployerWorklistPage(): Promise<ReactElement> {
+  // DB-backed read. Returns [] when the table is empty — no fake-fill.
+  // Org-scope and RBAC gating are deferred to a later wave.
+  let items: WorklistItem[] = [];
+  let dbError = false;
+
+  try {
+    const rows = await getWorklist({ limit: 100 });
+    items = rows.map(toWorklistItem);
+  } catch {
+    dbError = true;
+  }
+
   return (
     <main
-      aria-label="Employer worklist shell"
+      aria-label="Employer worklist"
       className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8"
     >
       <div className="mx-auto grid max-w-6xl gap-6">
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Employer workflow foundation
+            Employer workflow
           </p>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight">
             Verifier worklist
           </h1>
           <p className="mt-3 max-w-2xl text-sm text-slate-600">
-            Worklist is connected to submitted applications. Live DB integration
-            is planned.
+            Showing receipt candidates from the database. Org-scoping and role
+            gating are in progress.
           </p>
         </div>
 
-        <WorklistPanel items={SAMPLE_WORKLIST_ITEMS} />
+        {dbError && (
+          <p
+            role="alert"
+            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          >
+            Database unavailable. The worklist cannot be displayed at this time.
+          </p>
+        )}
+
+        <WorklistPanel items={items} />
       </div>
     </main>
   );

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,18 @@
+import 'server-only';
+import { PrismaClient } from './generated/prisma';
+
+declare global {
+  // Prevent multiple instances of PrismaClient in dev hot-reload.
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
+}
+
+export const prisma =
+  globalThis.__prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['warn', 'error'] : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__prisma = prisma;
+}

--- a/apps/web/lib/verifier/worklistRepo.ts
+++ b/apps/web/lib/verifier/worklistRepo.ts
@@ -1,0 +1,106 @@
+import 'server-only';
+import { prisma } from '@/lib/db';
+
+// ReceiptCandidate reviewState values that map to worklist status.
+// Rows with a NULL reviewState are included as 'pending'.
+const REVIEW_STATE_MAP: Record<string, WorklistReviewState> = {
+  pending_policy_review: 'pending',
+  in_review: 'in_review',
+  info_requested: 'info_requested',
+  accepted: 'acceptable_for_start',
+  unable_to_verify: 'unable_to_verify',
+};
+
+export type WorklistReviewState =
+  | 'pending'
+  | 'in_review'
+  | 'info_requested'
+  | 'acceptable_for_start'
+  | 'unable_to_verify';
+
+// Shape returned by the repo. Does NOT include clinician NPI
+// (not stored on ReceiptCandidate; a future NPI-lookup wave adds it).
+// decisionGrade is the literal false — preserved from the DB CHECK
+// constraint through the query round-trip.
+export interface WorklistDbRow {
+  candidateId: string;
+  sourceOrganizationName: string;
+  reviewState: WorklistReviewState;
+  /** Literal false — the DB CHECK constraint enforces this. */
+  decisionGrade: false;
+  /** Literal 'receipt_candidate' when set; null otherwise. */
+  proofTier: 'receipt_candidate' | null;
+  createdAt: Date;
+}
+
+export interface WorklistRepoFilter {
+  reviewState?: WorklistReviewState | 'all';
+  limit?: number;
+}
+
+/**
+ * Query ReceiptCandidate rows filtered by reviewState.
+ *
+ * Truth contract:
+ *   - Returns ONLY ReceiptCandidate rows. PSVReceipt is a distinct
+ *     table and is never queried or returned here.
+ *   - decisionGrade is always the literal false (enforced by DB CHECK;
+ *     mapped to the narrowed `false` type in the return shape).
+ *   - When the table is empty, returns []. No fake-fill.
+ *   - org scope and RBAC are deferred; this reads all rows in the
+ *     table (scoped to org = a later wave).
+ */
+export async function getWorklist(
+  filter: WorklistRepoFilter = {},
+): Promise<WorklistDbRow[]> {
+  const { reviewState, limit = 100 } = filter;
+
+  const where =
+    reviewState && reviewState !== 'all'
+      ? { reviewState: dbStateForFilter(reviewState) }
+      : {};
+
+  const rows = await prisma.receiptCandidate.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    select: {
+      candidateId: true,
+      sourceOrganizationName: true,
+      reviewState: true,
+      decisionGrade: true,
+      proofTier: true,
+      createdAt: true,
+    },
+  });
+
+  return rows.map(mapRow);
+}
+
+function dbStateForFilter(state: WorklistReviewState): string {
+  const inverse = Object.entries(REVIEW_STATE_MAP).find(([, v]) => v === state);
+  return inverse ? inverse[0] : state;
+}
+
+function mapRow(row: {
+  candidateId: string;
+  sourceOrganizationName: string;
+  reviewState: string | null;
+  decisionGrade: boolean;
+  proofTier: string | null;
+  createdAt: Date;
+}): WorklistDbRow {
+  return {
+    candidateId: row.candidateId,
+    sourceOrganizationName: row.sourceOrganizationName,
+    reviewState: toWorklistState(row.reviewState),
+    decisionGrade: false, // DB CHECK enforces this; we narrow the type
+    proofTier: row.proofTier === 'receipt_candidate' ? 'receipt_candidate' : null,
+    createdAt: row.createdAt,
+  };
+}
+
+function toWorklistState(raw: string | null): WorklistReviewState {
+  if (!raw) return 'pending';
+  return REVIEW_STATE_MAP[raw] ?? 'pending';
+}

--- a/apps/web/lib/verifier/worklistRepo.ts
+++ b/apps/web/lib/verifier/worklistRepo.ts
@@ -1,14 +1,23 @@
 import 'server-only';
 import { prisma } from '@/lib/db';
+import type { ReceiptCandidateReviewState } from '@/lib/issuer-verification/types';
 
-// ReceiptCandidate reviewState values that map to worklist status.
-// Rows with a NULL reviewState are included as 'pending'.
-const REVIEW_STATE_MAP: Record<string, WorklistReviewState> = {
-  pending_policy_review: 'pending',
-  in_review: 'in_review',
-  info_requested: 'info_requested',
-  accepted: 'acceptable_for_start',
+// WorklistReviewState is a UI-facing label space, not a parallel
+// truth-contract enum. Each label maps from one or more canonical
+// ReceiptCandidateReviewState values from
+// apps/web/lib/issuer-verification/types.ts. The mapping is explicit
+// here so the canonical type remains the single source of truth.
+//
+// Rows with a NULL reviewState are surfaced as 'pending'.
+const REVIEW_STATE_MAP: Record<ReceiptCandidateReviewState, WorklistReviewState> = {
+  review_required: 'pending',
+  ready_for_policy_review: 'in_review',
+  conflict_review_required: 'in_review',
+  release_required: 'info_requested',
+  reroute_required: 'info_requested',
   unable_to_verify: 'unable_to_verify',
+  expired: 'pending',
+  canceled: 'pending',
 };
 
 export type WorklistReviewState =
@@ -57,7 +66,7 @@ export async function getWorklist(
 
   const where =
     reviewState && reviewState !== 'all'
-      ? { reviewState: dbStateForFilter(reviewState) }
+      ? { reviewState: { in: dbStateForFilter(reviewState) } }
       : {};
 
   const rows = await prisma.receiptCandidate.findMany({
@@ -77,9 +86,10 @@ export async function getWorklist(
   return rows.map(mapRow);
 }
 
-function dbStateForFilter(state: WorklistReviewState): string {
-  const inverse = Object.entries(REVIEW_STATE_MAP).find(([, v]) => v === state);
-  return inverse ? inverse[0] : state;
+function dbStateForFilter(state: WorklistReviewState): string[] {
+  return (Object.entries(REVIEW_STATE_MAP) as [ReceiptCandidateReviewState, WorklistReviewState][])
+    .filter(([, label]) => label === state)
+    .map(([canonical]) => canonical);
 }
 
 function mapRow(row: {
@@ -102,5 +112,5 @@ function mapRow(row: {
 
 function toWorklistState(raw: string | null): WorklistReviewState {
   if (!raw) return 'pending';
-  return REVIEW_STATE_MAP[raw] ?? 'pending';
+  return REVIEW_STATE_MAP[raw as ReceiptCandidateReviewState] ?? 'pending';
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build"
   },
   "dependencies": {
+    "@prisma/client": "^6.19.2",
     "@blueprintjs/core": "^6.10.0",
     "@blueprintjs/icons": "^6.7.0",
     "@blueprintjs/table": "^6.0.19",
@@ -71,6 +72,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "prisma": "^6.19.2",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.9",
     "@types/node": "^22",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "prisma generate && next build",
+    "postinstall": "prisma generate",
     "build-storybook": "storybook build",
     "dev": "next dev",
     "dev:e2e": "next dev -H 127.0.0.1 -p 3000",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -5,6 +5,15 @@
 // definitions must stay in sync with that schema. The tables are
 // shared — there is one database.
 //
+// Truth-contract CHECK constraints live in the apps/api/backend
+// migrations and are NOT duplicated here:
+//   * ReceiptCandidate.decisionGrade = FALSE
+//   * ReceiptCandidate.proofTier IS NULL OR = 'receipt_candidate'
+//   * ReceiptCandidate.recordedBy IN ('demo','review_surface','system')
+// See apps/api/backend/prisma/migrations/20260504000000_issuer_persistence_scaffold/migration.sql
+// (landed in PR #221). The web schema is read-only for type generation;
+// it cannot weaken those database-level invariants.
+//
 // Run `pnpm --filter @vitalcv/web exec prisma generate` after
 // any model change here to regenerate the typed client.
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1,0 +1,73 @@
+// apps/web Prisma schema — web-app-facing subset only.
+//
+// This schema mirrors the models that the web app reads directly.
+// Migrations are managed by apps/api/backend/prisma; these model
+// definitions must stay in sync with that schema. The tables are
+// shared — there is one database.
+//
+// Run `pnpm --filter @vitalcv/web exec prisma generate` after
+// any model change here to regenerate the typed client.
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model IssuerRequest {
+  id              String    @id @default(uuid()) @db.Uuid
+  requestId       String    @unique
+  claimType       String
+  claimSummary    String
+  issuerCandidate Json
+  route           Json
+  consent         Json
+  status          String
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  expiresAt       DateTime?
+
+  receiptCandidates ReceiptCandidate[]
+
+  @@index([requestId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+model ReceiptCandidate {
+  id          String         @id @default(uuid()) @db.Uuid
+  candidateId String         @unique
+  requestId   String?
+  request     IssuerRequest? @relation(fields: [requestId], references: [requestId])
+
+  basis                  String
+  agentName              String?
+  sourceOrganizationName String
+
+  attributionStatus String
+
+  decisionGrade Boolean @default(false)
+  proofTier     String?
+
+  notes              String?
+  limitationNote     String?
+  responseStatus     String?
+  responseSummary    String?
+  responseReceivedAt DateTime?
+  reviewState        String?
+
+  recordedBy String @default("demo")
+
+  signedReceiptJwt String?
+
+  createdAt DateTime @default(now())
+
+  @@index([candidateId])
+  @@index([requestId])
+  @@index([reviewState])
+  @@index([createdAt])
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       '@clerk/nextjs':
         specifier: ^6.37.3
         version: 6.37.3(next@15.2.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@prisma/client':
+        specifier: ^6.19.2
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -867,6 +870,9 @@ importers:
       postcss:
         specifier: ^8.5
         version: 8.5.6
+      prisma:
+        specifier: ^6.19.2
+        version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.9
         version: 4.1.18
@@ -2736,7 +2742,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}


### PR DESCRIPTION
Supersedes #241 (auto-closed when its base branch feat/trust-persist-1-scaffold was deleted by the merge of #221 to main). Codex verdict: SAFE.