### PR TITLE
feat(persist): add feature-flagged ReceiptCandidate writer (TRUST-PERSIST-1 Phase 2)

### DIFF
--- a/apps/web/__tests__/issuer-persistence-writer.test.ts
+++ b/apps/web/__tests__/issuer-persistence-writer.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReceiptCandidate } from '@/lib/issuer-verification/types';
+
+vi.mock('server-only', () => ({}));
+
+const baseCandidate: ReceiptCandidate = {
+  candidateId: 'cand-123',
+  createdAt: new Date('2026-05-05T12:00:00Z').toISOString(),
+  basis: 'issuer_direct',
+  sourceOrganizationName: 'Test GME Office',
+  attributionStatus: 'unattributed',
+  decisionGrade: false,
+  requestId: 'req-456',
+  proofTier: 'receipt_candidate',
+  reviewState: 'review_required',
+};
+
+const createMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    receiptCandidate: {
+      create: (...args: unknown[]) => createMock(...args),
+    },
+  },
+}));
+
+const ORIGINAL_FLAG = process.env.ISSUER_PERSISTENCE_ENABLED;
+
+beforeEach(() => {
+  createMock.mockReset();
+});
+
+afterEach(() => {
+  if (ORIGINAL_FLAG === undefined) delete process.env.ISSUER_PERSISTENCE_ENABLED;
+  else process.env.ISSUER_PERSISTENCE_ENABLED = ORIGINAL_FLAG;
+});
+
+describe('issuerPersistenceWriter — disabled (default)', () => {
+  it('returns recordedBy: demo and never calls prisma when the flag is unset', async () => {
+    delete process.env.ISSUER_PERSISTENCE_ENABLED;
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('disabled');
+    expect(out.recordedBy).toBe('demo');
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('returns recordedBy: demo when the flag is anything other than the literal "true"', async () => {
+    process.env.ISSUER_PERSISTENCE_ENABLED = '1';
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('disabled');
+    expect(out.recordedBy).toBe('demo');
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('issuerPersistenceWriter — enabled, happy path', () => {
+  it('persists with recordedBy: system and decisionGrade: false on success', async () => {
+    process.env.ISSUER_PERSISTENCE_ENABLED = 'true';
+    createMock.mockResolvedValueOnce({ id: 'row-1' });
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('persisted');
+    expect(out.recordedBy).toBe('system');
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const arg = createMock.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(arg.data.decisionGrade).toBe(false);
+    expect(arg.data.proofTier).toBe('receipt_candidate');
+    expect(arg.data.recordedBy).toBe('system');
+    expect(arg.data.candidateId).toBe('cand-123');
+  });
+});
+
+describe('issuerPersistenceWriter — enabled, DB CHECK constraint violation', () => {
+  it('classifies SQLSTATE 23514 as tamper_detected and falls back to demo', async () => {
+    process.env.ISSUER_PERSISTENCE_ENABLED = 'true';
+    createMock.mockRejectedValueOnce({ code: '23514', message: 'check constraint violation' });
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('tamper_detected');
+    expect(out.recordedBy).toBe('demo');
+  });
+
+  it('classifies Prisma-wrapped 23514 as tamper_detected', async () => {
+    process.env.ISSUER_PERSISTENCE_ENABLED = 'true';
+    createMock.mockRejectedValueOnce({ code: 'P2010', meta: { code: '23514' } });
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('tamper_detected');
+    expect(out.recordedBy).toBe('demo');
+  });
+});
+
+describe('issuerPersistenceWriter — enabled, transient error', () => {
+  it('falls back to demo on a generic write failure', async () => {
+    process.env.ISSUER_PERSISTENCE_ENABLED = 'true';
+    createMock.mockRejectedValueOnce(new Error('connection reset'));
+    const { writeReceiptCandidateRow } = await import('../lib/issuer-verification/issuerPersistenceWriter');
+    const out = await writeReceiptCandidateRow({ candidate: baseCandidate, surface: 'review_surface' });
+    expect(out.status).toBe('transient_error');
+    expect(out.recordedBy).toBe('demo');
+  });
+});

--- a/apps/web/lib/issuer-verification/issuerPersistenceWriter.ts
+++ b/apps/web/lib/issuer-verification/issuerPersistenceWriter.ts
@@ -1,0 +1,119 @@
+import 'server-only';
+
+import { prisma } from '@/lib/db';
+import type { ReceiptCandidate } from '@/lib/issuer-verification/types';
+
+/**
+ * TRUST-PERSIST-1 Phase 2 — feature-flagged ReceiptCandidate writer.
+ *
+ * Design contract:
+ *   - Off by default. Off => writer is a no-op and the caller continues
+ *     with `recordedBy: 'demo'`. Existing demo render paths are not
+ *     disturbed.
+ *   - On => writes a ReceiptCandidate row to the same Postgres table
+ *     that `apps/api/backend/prisma/migrations/20260504000000_issuer_persistence_scaffold/migration.sql`
+ *     (PR #221) created. The DB-level CHECK constraints enforce the
+ *     truth contract:
+ *       * decisionGrade = FALSE
+ *       * proofTier IS NULL OR = 'receipt_candidate'
+ *       * recordedBy IN ('demo','review_surface','system')
+ *   - The writer never widens those literals at the TS level. It
+ *     accepts a `ReceiptCandidate` and only persists fields whose
+ *     types already encode the contract.
+ *   - Database-level violations (Postgres SQLSTATE 23514) surface as a
+ *     `tamper_detected` outcome via the helper landed in #235; this
+ *     writer treats them as a fatal write error and returns an error
+ *     status rather than swallowing.
+ *   - Connection or other transient errors degrade to a no-op so the
+ *     review surface never crashes; the caller falls back to
+ *     `recordedBy: 'demo'`.
+ *
+ * No callsite is changed by this PR. A subsequent PR wires the four
+ * issuer/policy-review pages to call this writer.
+ */
+
+/** Whether the writer is enabled in the current environment. */
+export function isIssuerPersistenceEnabled(): boolean {
+  return process.env.ISSUER_PERSISTENCE_ENABLED === 'true';
+}
+
+export type WriteReceiptCandidateOutcome =
+  | { status: 'persisted'; recordedBy: 'system' }
+  | { status: 'disabled'; recordedBy: 'demo' }
+  | { status: 'tamper_detected'; recordedBy: 'demo' }
+  | { status: 'transient_error'; recordedBy: 'demo' };
+
+interface WriteReceiptCandidateInput {
+  candidate: ReceiptCandidate;
+  /**
+   * The actor surface that triggered the write. Maps directly to the
+   * DB CHECK enum on `recordedBy`. The writer always persists
+   * `recordedBy: 'system'` — passing `surface` is metadata for the
+   * caller, not something the DB column carries.
+   */
+  surface: 'review_surface' | 'system';
+}
+
+/**
+ * Persist a ReceiptCandidate row when the persistence flag is on.
+ *
+ * Returns one of four outcomes, all of which include the
+ * `recordedBy` literal the caller should use in its render. The DB
+ * row itself is always written with `recordedBy: 'system'` when
+ * persisted; the demo fallback uses `recordedBy: 'demo'`.
+ */
+export async function writeReceiptCandidateRow(
+  input: WriteReceiptCandidateInput,
+): Promise<WriteReceiptCandidateOutcome> {
+  if (!isIssuerPersistenceEnabled()) {
+    return { status: 'disabled', recordedBy: 'demo' };
+  }
+
+  const { candidate } = input;
+
+  try {
+    await prisma.receiptCandidate.create({
+      data: {
+        candidateId: candidate.candidateId,
+        requestId: candidate.requestId ?? null,
+        basis: candidate.basis,
+        agentName: candidate.agentName ?? null,
+        sourceOrganizationName: candidate.sourceOrganizationName,
+        attributionStatus: candidate.attributionStatus,
+        decisionGrade: false,
+        proofTier: candidate.proofTier ?? null,
+        notes: candidate.notes ?? null,
+        limitationNote: candidate.limitationNote ?? null,
+        responseStatus: candidate.responseStatus ?? null,
+        responseSummary: candidate.responseSummary ?? null,
+        responseReceivedAt: candidate.responseReceivedAt
+          ? new Date(candidate.responseReceivedAt)
+          : null,
+        reviewState: candidate.reviewState ?? null,
+        recordedBy: 'system',
+        signedReceiptJwt: candidate.signedReceiptJwt ?? null,
+      },
+    });
+    return { status: 'persisted', recordedBy: 'system' };
+  } catch (err) {
+    if (isCheckConstraintViolation(err)) {
+      return { status: 'tamper_detected', recordedBy: 'demo' };
+    }
+    return { status: 'transient_error', recordedBy: 'demo' };
+  }
+}
+
+/**
+ * Postgres SQLSTATE 23514 = check_violation. Prisma surfaces this as
+ * a PrismaClientKnownRequestError with `code === 'P2010'` and the
+ * underlying meta.code set to '23514' (or similar). We accept both
+ * the Prisma envelope and a raw pg error in case the writer is
+ * exercised via a different driver in tests.
+ */
+function isCheckConstraintViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: unknown; meta?: { code?: unknown } };
+  if (e.code === '23514') return true;
+  if (typeof e.meta?.code === 'string' && e.meta.code === '23514') return true;
+  return false;
+}


### PR DESCRIPTION
Adds the writer that fills the ReceiptCandidate table from PR #221. Feature-flagged via ISSUER_PERSISTENCE_ENABLED. Off by default (no callsite changed). 6 tests pass. Codex SAFE.