### PR TITLE
feat(persist): wire writer into /issuer/psv-receipt (TRUST-PERSIST-1 Phase 3c)

### DIFF
--- a/apps/web/__tests__/issuer-psv-receipt-page-persist.test.ts
+++ b/apps/web/__tests__/issuer-psv-receipt-page-persist.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('server-only', () => ({}));
+
+const writeMock = vi.fn();
+vi.mock('@/lib/issuer-verification/issuerPersistenceWriter', () => ({
+  writeReceiptCandidateRow: (...args: unknown[]) => writeMock(...args),
+  isIssuerPersistenceEnabled: () => false,
+}));
+
+import PsvReceiptPromotionPage from '../app/issuer/psv-receipt/[requestId]/page';
+
+const REQUEST_ID = 'req-test-psv';
+
+beforeEach(() => {
+  writeMock.mockReset();
+});
+
+afterEach(() => {
+  writeMock.mockReset();
+});
+
+async function renderPage(): Promise<string> {
+  const element = await PsvReceiptPromotionPage({ params: Promise.resolve({ requestId: REQUEST_ID }) });
+  return renderToStaticMarkup(element as React.ReactElement);
+}
+
+describe('issuer psv-receipt page — persistence wiring', () => {
+  it('renders disabled banner and recordedBy=demo when writer reports disabled', async () => {
+    writeMock.mockResolvedValueOnce({ status: 'disabled', recordedBy: 'demo' });
+    const html = await renderPage();
+    expect(html).toContain('data-testid="persistence-banner"');
+    expect(html).toContain('data-banner-state="disabled"');
+    expect(html).toContain('data-recorded-by="demo"');
+    expect(html).toContain('data-persistence-status="disabled"');
+    expect(html).toContain('Persistence disabled');
+    expect(writeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders persisted banner and recordedBy=system when writer reports persisted', async () => {
+    writeMock.mockResolvedValueOnce({ status: 'persisted', recordedBy: 'system' });
+    const html = await renderPage();
+    expect(html).toContain('data-banner-state="persisted"');
+    expect(html).toContain('data-recorded-by="system"');
+    expect(html).toContain('data-persistence-status="persisted"');
+    expect(html).toContain('Candidate row recorded');
+  });
+
+  it('renders tamper_detected banner and recordedBy=demo on DB CHECK violation', async () => {
+    writeMock.mockResolvedValueOnce({ status: 'tamper_detected', recordedBy: 'demo' });
+    const html = await renderPage();
+    expect(html).toContain('data-banner-state="tamper_detected"');
+    expect(html).toContain('data-recorded-by="demo"');
+    expect(html).toContain('Candidate row CHECK violation');
+  });
+
+  it('renders transient_error banner and recordedBy=demo on connection failure', async () => {
+    writeMock.mockResolvedValueOnce({ status: 'transient_error', recordedBy: 'demo' });
+    const html = await renderPage();
+    expect(html).toContain('data-banner-state="transient_error"');
+    expect(html).toContain('data-recorded-by="demo"');
+    expect(html).toContain('Persistence unavailable');
+  });
+
+  it('degrades to transient_error when the writer itself throws (unexpected error)', async () => {
+    writeMock.mockImplementationOnce(() => {
+      throw new Error('writer module crashed unexpectedly');
+    });
+    const html = await renderPage();
+    expect(html).toContain('data-banner-state="transient_error"');
+    expect(html).toContain('data-recorded-by="demo"');
+    expect(html).toContain('Persistence unavailable');
+  });
+
+  it('preserves the truth-contract literals on the rendered page in every persistence state', async () => {
+    for (const outcome of [
+      { status: 'disabled', recordedBy: 'demo' },
+      { status: 'persisted', recordedBy: 'system' },
+      { status: 'tamper_detected', recordedBy: 'demo' },
+      { status: 'transient_error', recordedBy: 'demo' },
+    ] as const) {
+      writeMock.mockResolvedValueOnce(outcome);
+      const html = await renderPage();
+      // PSVReceipt promotion succeeds in the demo path, so proof-tier
+      // becomes the literal 'psv_receipt'. decision-grade can be true
+      // for the promoted PSVReceipt — that is the contract for a
+      // promoted receipt and is unchanged by this PR. Persisting the
+      // underlying ReceiptCandidate must not alter those PSVReceipt
+      // literals.
+      expect(html).toContain('data-promoted="true"');
+    }
+  });
+});

--- a/apps/web/app/issuer/psv-receipt/[requestId]/page.tsx
+++ b/apps/web/app/issuer/psv-receipt/[requestId]/page.tsx
@@ -84,6 +84,29 @@ export default async function PsvReceiptPromotionPage({ params }: PageProps) {
     },
   );
 
+  // Attempt to persist the underlying ReceiptCandidate (same as
+  // /issuer/review and /issuer/policy-review). The page itself is a
+  // dry-run for promotion to a PSVReceipt; PSVReceipt persistence
+  // and PolicyReviewDecision persistence are separate writers and
+  // separate phases. Strict no-crash via dynamic import + try/catch
+  // with a default outcome of transient_error/demo.
+  type WriteOutcome =
+    | { status: 'persisted'; recordedBy: 'system' }
+    | { status: 'disabled'; recordedBy: 'demo' }
+    | { status: 'tamper_detected'; recordedBy: 'demo' }
+    | { status: 'transient_error'; recordedBy: 'demo' };
+  let writeOutcome: WriteOutcome = { status: 'transient_error', recordedBy: 'demo' };
+  try {
+    const mod = await import('@/lib/issuer-verification/issuerPersistenceWriter');
+    writeOutcome = await mod.writeReceiptCandidateRow({
+      candidate: receiptCandidate,
+      surface: 'review_surface',
+    });
+  } catch {
+    // already initialized to transient_error/demo above
+  }
+  const persistedRecordedBy = writeOutcome.recordedBy;
+
   const policyApplied = applyPolicyReviewDecision(
     receiptCandidate,
     'accept_candidate',
@@ -139,6 +162,8 @@ export default async function PsvReceiptPromotionPage({ params }: PageProps) {
       data-audit-event-state={
         promotion?.psvReceipt?.auditMetadata.eventState ?? 'pending_not_written'
       }
+      data-persistence-status={writeOutcome.status}
+      data-recorded-by={persistedRecordedBy}
     >
       <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
         <header className="space-y-1">
@@ -156,6 +181,42 @@ export default async function PsvReceiptPromotionPage({ params }: PageProps) {
             credentialing review and remains subject to policy, freshness, and
             source limitations.
           </p>
+          {writeOutcome.status === 'persisted' && (
+            <p
+              className="mt-2 inline-block rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-emerald-700"
+              data-testid="persistence-banner"
+              data-banner-state="persisted"
+            >
+              Candidate row recorded (recordedBy: system)
+            </p>
+          )}
+          {writeOutcome.status === 'tamper_detected' && (
+            <p
+              className="mt-2 inline-block rounded-md bg-amber-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-amber-700"
+              data-testid="persistence-banner"
+              data-banner-state="tamper_detected"
+            >
+              Candidate row CHECK violation — render only (recordedBy: demo)
+            </p>
+          )}
+          {writeOutcome.status === 'transient_error' && (
+            <p
+              className="mt-2 inline-block rounded-md bg-slate-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-700"
+              data-testid="persistence-banner"
+              data-banner-state="transient_error"
+            >
+              Persistence unavailable — render only (recordedBy: demo)
+            </p>
+          )}
+          {writeOutcome.status === 'disabled' && (
+            <p
+              className="mt-2 inline-block rounded-md bg-slate-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600"
+              data-testid="persistence-banner"
+              data-banner-state="disabled"
+            >
+              Persistence disabled — render only (recordedBy: demo)
+            </p>
+          )}
         </header>
 
         <section


### PR DESCRIPTION
Wires PR #255's writer into /issuer/psv-receipt using the same pattern as Phases 3a/3b (PRs #256/#257). Default behavior unchanged. /issuer/psv-reuse defers to a future phase (operates on PSVReceipt + ReuseDecision, needs different writers). 6 tests pass. Codex SAFE.