### PR TITLE
feat(gtm): three persona landing pages + form preselect (Wave H2)

### DIFF
--- a/apps/web/__tests__/persona-landing-content.test.ts
+++ b/apps/web/__tests__/persona-landing-content.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PERSONA_LANDING_PAGES,
+  getPersonaLandingContent,
+} from '@/lib/personas/landingContent';
+
+const ALLOWED_INTAKE_PERSONAS = new Set([
+  'cvo',
+  'payer',
+  'staffing_exchange',
+  'health_system',
+  'individual_clinician',
+  'other',
+]);
+
+// Banned-phrase split-join constants per CLAUDE.md so a naive grep
+// over this file does not flag it.
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+function gather(content: unknown): string {
+  return JSON.stringify(content);
+}
+
+describe('PERSONA_LANDING_PAGES — registry shape', () => {
+  it('has exactly the three Wave H2 personas in the expected order', () => {
+    const slugs = PERSONA_LANDING_PAGES.map((p) => p.slug);
+    expect(slugs).toEqual(['cvo', 'payer', 'staffing-exchange']);
+  });
+
+  it('every entry has all required fields', () => {
+    for (const entry of PERSONA_LANDING_PAGES) {
+      expect(entry.title).toBeTruthy();
+      expect(entry.description).toBeTruthy();
+      expect(entry.hero.eyebrow).toBeTruthy();
+      expect(entry.hero.headline).toBeTruthy();
+      expect(entry.hero.subhead).toBeTruthy();
+      expect(entry.cta.button).toBeTruthy();
+      expect(entry.cta.headline).toBeTruthy();
+      expect(entry.valueProps.length).toBe(3);
+      expect(entry.flow.length).toBe(3);
+    }
+  });
+
+  it("every entry's intakePersona is a literal accepted by the validate helper", () => {
+    for (const entry of PERSONA_LANDING_PAGES) {
+      expect(ALLOWED_INTAKE_PERSONAS.has(entry.intakePersona)).toBe(true);
+    }
+  });
+});
+
+describe('PERSONA_LANDING_PAGES — copy compliance', () => {
+  it.each(PERSONA_LANDING_PAGES.map((p) => [p.slug, p]))(
+    '%s contains no banned phrases',
+    (_slug, entry) => {
+      const haystack = gather(entry).toLowerCase();
+      for (const phrase of BANNED) {
+        expect(haystack).not.toContain(phrase.toLowerCase());
+      }
+    },
+  );
+
+  it.each(PERSONA_LANDING_PAGES.map((p) => [p.slug, p]))(
+    '%s does not use the bare "Verified" status label',
+    (_slug, entry) => {
+      // Reject the bare standalone word "Verified" used as a label.
+      // Phrases like "verifications" or "source-verified" remain
+      // allowed; this targets the exact bare label per CLAUDE.md.
+      const text = gather(entry);
+      expect(text).not.toMatch(/[\s">]Verified[\s"<,.]/);
+    },
+  );
+});
+
+describe('getPersonaLandingContent', () => {
+  it('returns the entry by slug', () => {
+    const cvo = getPersonaLandingContent('cvo');
+    expect(cvo?.intakePersona).toBe('cvo');
+    const payer = getPersonaLandingContent('payer');
+    expect(payer?.intakePersona).toBe('payer');
+    const staffing = getPersonaLandingContent('staffing-exchange');
+    expect(staffing?.intakePersona).toBe('staffing_exchange');
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    expect(getPersonaLandingContent('unknown')).toBeUndefined();
+    expect(getPersonaLandingContent('')).toBeUndefined();
+  });
+});

--- a/apps/web/__tests__/persona-landing-render.test.tsx
+++ b/apps/web/__tests__/persona-landing-render.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { PersonaLandingPage } from '@/components/personas/PersonaLandingPage';
+import { PERSONA_LANDING_PAGES } from '@/lib/personas/landingContent';
+
+function renderFor(slug: string): string {
+  const content = PERSONA_LANDING_PAGES.find((p) => p.slug === slug);
+  if (!content) throw new Error(`unknown slug: ${slug}`);
+  return renderToStaticMarkup(<PersonaLandingPage content={content} />);
+}
+
+describe.each(['cvo', 'payer', 'staffing-exchange'])(
+  'PersonaLandingPage — %s',
+  (slug) => {
+    it('renders the persona-landing testid and the slug data attribute', () => {
+      const html = renderFor(slug);
+      expect(html).toContain('data-testid="persona-landing"');
+      expect(html).toContain(`data-persona-slug="${slug}"`);
+    });
+
+    it('renders both CTA buttons pointing at /contact?persona=<intakePersona>', () => {
+      const html = renderFor(slug);
+      const content = PERSONA_LANDING_PAGES.find((p) => p.slug === slug)!;
+      expect(html).toContain(`data-intake-persona="${content.intakePersona}"`);
+      expect(html).toContain(`href="/contact?persona=${content.intakePersona}"`);
+      expect(html).toContain('data-testid="persona-hero-cta"');
+      expect(html).toContain('data-testid="persona-footer-cta"');
+    });
+
+    it('renders all three value-prop cards and all three flow steps', () => {
+      const html = renderFor(slug);
+      const content = PERSONA_LANDING_PAGES.find((p) => p.slug === slug)!;
+      for (const prop of content.valueProps) {
+        expect(html).toContain(prop.title);
+      }
+      for (const step of content.flow) {
+        expect(html).toContain(step.title);
+      }
+    });
+
+    it('renders the hero headline as an h1', () => {
+      const html = renderFor(slug);
+      const content = PERSONA_LANDING_PAGES.find((p) => p.slug === slug)!;
+      expect(html).toMatch(
+        new RegExp(`<h1[^>]*>${escapeRegex(content.hero.headline)}</h1>`),
+      );
+    });
+  },
+);
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/apps/web/app/contact/PilotIntakeForm.tsx
+++ b/apps/web/app/contact/PilotIntakeForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import type { FormEvent } from 'react';
 
 import type { PilotIntakePersona } from '@/lib/pilot-intake/validate';
@@ -14,6 +15,10 @@ const PERSONA_OPTIONS: ReadonlyArray<{ value: PilotIntakePersona; label: string 
   { value: 'other', label: 'Other' },
 ];
 
+const ALLOWED_PERSONA_VALUES = new Set<PilotIntakePersona>(
+  PERSONA_OPTIONS.map((o) => o.value),
+);
+
 type Status =
   | { kind: 'idle' }
   | { kind: 'submitting' }
@@ -23,6 +28,12 @@ type Status =
 
 export function PilotIntakeForm() {
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const searchParams = useSearchParams();
+  const personaFromUrl = searchParams.get('persona');
+  const presetPersona =
+    personaFromUrl && ALLOWED_PERSONA_VALUES.has(personaFromUrl as PilotIntakePersona)
+      ? (personaFromUrl as PilotIntakePersona)
+      : '';
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -131,7 +142,9 @@ export function PilotIntakeForm() {
           id="persona"
           name="persona"
           required
-          defaultValue=""
+          defaultValue={presetPersona}
+          data-testid="persona-select"
+          data-preset-persona={presetPersona || 'none'}
           className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
         >
           <option value="" disabled>

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 import { PilotIntakeForm } from './PilotIntakeForm';
 
@@ -24,7 +25,9 @@ export default function ContactPage() {
           <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
         </p>
       </header>
-      <PilotIntakeForm />
+      <Suspense fallback={null}>
+        <PilotIntakeForm />
+      </Suspense>
     </main>
   );
 }

--- a/apps/web/app/for/cvo/page.tsx
+++ b/apps/web/app/for/cvo/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { PersonaLandingPage } from '@/components/personas/PersonaLandingPage';
+import { getPersonaLandingContent } from '@/lib/personas/landingContent';
+
+const SLUG = 'cvo';
+const content = getPersonaLandingContent(SLUG);
+
+export const metadata: Metadata = content
+  ? {
+      title: content.title,
+      description: content.description,
+    }
+  : {};
+
+export default function ForCvoPage() {
+  if (!content) notFound();
+  return <PersonaLandingPage content={content} />;
+}

--- a/apps/web/app/for/payer/page.tsx
+++ b/apps/web/app/for/payer/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { PersonaLandingPage } from '@/components/personas/PersonaLandingPage';
+import { getPersonaLandingContent } from '@/lib/personas/landingContent';
+
+const SLUG = 'payer';
+const content = getPersonaLandingContent(SLUG);
+
+export const metadata: Metadata = content
+  ? {
+      title: content.title,
+      description: content.description,
+    }
+  : {};
+
+export default function ForPayerPage() {
+  if (!content) notFound();
+  return <PersonaLandingPage content={content} />;
+}

--- a/apps/web/app/for/staffing-exchange/page.tsx
+++ b/apps/web/app/for/staffing-exchange/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { PersonaLandingPage } from '@/components/personas/PersonaLandingPage';
+import { getPersonaLandingContent } from '@/lib/personas/landingContent';
+
+const SLUG = 'staffing-exchange';
+const content = getPersonaLandingContent(SLUG);
+
+export const metadata: Metadata = content
+  ? {
+      title: content.title,
+      description: content.description,
+    }
+  : {};
+
+export default function ForStaffingExchangePage() {
+  if (!content) notFound();
+  return <PersonaLandingPage content={content} />;
+}

--- a/apps/web/components/personas/PersonaLandingPage.tsx
+++ b/apps/web/components/personas/PersonaLandingPage.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import Link from 'next/link';
+
+import type { PersonaLandingContent } from '@/lib/personas/landingContent';
+
+interface PersonaLandingPageProps {
+  content: PersonaLandingContent;
+}
+
+/**
+ * Shared persona landing surface. Single component renders every
+ * /for/<slug> page so the structural a11y + copy review applies
+ * uniformly. Persona-specific content lives in
+ * apps/web/lib/personas/landingContent.ts.
+ */
+export function PersonaLandingPage({ content }: PersonaLandingPageProps) {
+  const ctaHref = `/contact?persona=${encodeURIComponent(content.intakePersona)}`;
+
+  return (
+    <main
+      className="mx-auto max-w-4xl px-4 py-16 space-y-20"
+      data-testid="persona-landing"
+      data-persona-slug={content.slug}
+      data-intake-persona={content.intakePersona}
+    >
+      <section aria-labelledby="persona-hero-headline">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+          {content.hero.eyebrow}
+        </p>
+        <h1
+          id="persona-hero-headline"
+          className="mt-2 text-3xl font-semibold leading-tight text-foreground sm:text-4xl"
+        >
+          {content.hero.headline}
+        </h1>
+        <p className="mt-4 max-w-2xl text-base text-muted-foreground">
+          {content.hero.subhead}
+        </p>
+        <div className="mt-6">
+          <Link
+            href={ctaHref}
+            className="inline-flex items-center justify-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+            data-testid="persona-hero-cta"
+          >
+            {content.cta.button}
+          </Link>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="persona-value-props"
+        data-testid="persona-value-props"
+      >
+        <h2
+          id="persona-value-props"
+          className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
+        >
+          What changes for you
+        </h2>
+        <ul className="mt-6 grid gap-6 sm:grid-cols-3">
+          {content.valueProps.map((prop) => (
+            <li
+              key={prop.title}
+              className="rounded-2xl border border-border bg-card p-5"
+            >
+              <h3 className="text-base font-semibold text-foreground">
+                {prop.title}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {prop.description}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="persona-flow"
+        data-testid="persona-flow"
+      >
+        <h2
+          id="persona-flow"
+          className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
+        >
+          How VitalCV fits your flow
+        </h2>
+        <ol className="mt-6 space-y-4">
+          {content.flow.map((step) => (
+            <li
+              key={step.step}
+              className="flex gap-4 rounded-2xl border border-border/60 bg-background/40 p-5"
+            >
+              <span className="text-2xl font-bold text-muted-foreground/50">
+                {step.step}
+              </span>
+              <div>
+                <h3 className="text-base font-semibold text-foreground">
+                  {step.title}
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {step.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section
+        aria-labelledby="persona-cta"
+        className="rounded-2xl border border-border bg-card p-8"
+        data-testid="persona-cta-section"
+      >
+        <h2
+          id="persona-cta"
+          className="text-xl font-semibold text-foreground"
+        >
+          {content.cta.headline}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">{content.cta.body}</p>
+        <div className="mt-5">
+          <Link
+            href={ctaHref}
+            className="inline-flex items-center justify-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
+            data-testid="persona-footer-cta"
+          >
+            {content.cta.button}
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/personas/landingContent.ts
+++ b/apps/web/lib/personas/landingContent.ts
@@ -1,0 +1,233 @@
+import type { PilotIntakePersona } from '@/lib/pilot-intake/validate';
+
+/**
+ * Persona landing-page content registry.
+ *
+ * Each entry is the data backing a single /for/<slug>/page.tsx
+ * surface. All copy lives here so:
+ *   - Adding a new persona is one-line (add an entry + one route file).
+ *   - Banned-strings CI scans a single file for compliance copy.
+ *   - The CTA always wires through to /contact?persona=<value>, where
+ *     <value> is a literal PilotIntakePersona that the form's
+ *     validate helper accepts directly.
+ *
+ * No banned phrases per CLAUDE.md. No bare 'Verified' status label.
+ */
+
+export interface PersonaLandingValueProp {
+  title: string;
+  description: string;
+}
+
+export interface PersonaLandingFlowStep {
+  step: string;
+  title: string;
+  description: string;
+}
+
+export interface PersonaLandingContent {
+  /** URL slug under /for/<slug>. */
+  slug: 'cvo' | 'payer' | 'staffing-exchange';
+  /** Maps to a literal PilotIntakePersona for the /contact form. */
+  intakePersona: PilotIntakePersona;
+  /** Browser title + og:title. */
+  title: string;
+  /** Meta description + og:description. */
+  description: string;
+  /** Page hero — eyebrow / headline / subhead. */
+  hero: {
+    eyebrow: string;
+    headline: string;
+    subhead: string;
+  };
+  /** Three-up value proposition row. */
+  valueProps: ReadonlyArray<PersonaLandingValueProp>;
+  /** "How VitalCV fits your flow" steps. */
+  flow: ReadonlyArray<PersonaLandingFlowStep>;
+  /** Closing CTA copy. */
+  cta: {
+    headline: string;
+    body: string;
+    button: string;
+  };
+}
+
+export const PERSONA_LANDING_PAGES: ReadonlyArray<PersonaLandingContent> = [
+  {
+    slug: 'cvo',
+    intakePersona: 'cvo',
+    title: 'For CVOs — VitalCV',
+    description:
+      'Cut days-to-start without dropping primary-source rigor. VitalCV produces receipt candidates and PSV receipts your reviewers can stand behind.',
+    hero: {
+      eyebrow: 'For credentialing verification organizations',
+      headline:
+        'Faster files. Same source rigor. Receipts your reviewers will stand behind.',
+      subhead:
+        'VitalCV models every issuer response as a receipt candidate, not a verification — so a clinician moves only when a human reviewer accepts the policy decision.',
+    },
+    valueProps: [
+      {
+        title: 'Receipt candidates, not silent approvals',
+        description:
+          'Issuer responses become typed receipt candidates with explicit limitation notes. Nothing is decision-grade until a reviewer accepts it under your policy.',
+      },
+      {
+        title: 'PSV reuse with explicit consent boundaries',
+        description:
+          'Cross-tenant reuse is blocked unless a consent receipt is on file. Constraint tampering is detected at the database level, not just the UI.',
+      },
+      {
+        title: 'Drop-in next to your existing CVO stack',
+        description:
+          'API-first, schema-typed, audit-ready. We sit alongside your existing case management; we do not require ripping out a system of record.',
+      },
+    ],
+    flow: [
+      {
+        step: '01',
+        title: 'Issuer request goes out',
+        description:
+          'Clinician consent + partner route are recorded. The request itself is not a verification.',
+      },
+      {
+        step: '02',
+        title: 'Issuer responds',
+        description:
+          'Response is normalized into a receipt candidate with attribution, source basis, and limitation notes.',
+      },
+      {
+        step: '03',
+        title: 'Your reviewer makes the policy call',
+        description:
+          'Five-gate policy review. Only an accept_candidate decision under ready_for_policy_review can produce a PSV receipt candidate.',
+      },
+    ],
+    cta: {
+      headline: 'See it on a real file.',
+      body:
+        'Ten-minute screen-share, no slide deck. Bring a closed file you would not mind us walking through end to end.',
+      button: 'Request a CVO walkthrough',
+    },
+  },
+  {
+    slug: 'payer',
+    intakePersona: 'payer',
+    title: 'For Payers — VitalCV',
+    description:
+      'Reduce credentialing-cycle drag on network expansion. Receipt candidates are auditable, scoped, and never claim more than the source said.',
+    hero: {
+      eyebrow: 'For health plans + payers',
+      headline:
+        'Bring credentialing drag down without inheriting a vendor lock.',
+      subhead:
+        'VitalCV produces source-attributed receipt candidates that your delegation oversight team can audit. Reuse is scoped, not assumed.',
+    },
+    valueProps: [
+      {
+        title: 'Audit trail your delegation oversight already expects',
+        description:
+          'Every receipt candidate carries the responder, source basis, attribution status, and review state. No black-box scoring.',
+      },
+      {
+        title: 'Network expansion without re-credentialing every clinician',
+        description:
+          'PSV receipts are scoped artifacts with explicit freshness and supersession. They do not silently expire under your auditor.',
+      },
+      {
+        title: 'No proprietary trust score',
+        description:
+          'We do not invent a numeric score for credentialing decisions. The decision and its evidence stay separable.',
+      },
+    ],
+    flow: [
+      {
+        step: '01',
+        title: 'Network candidate enters credentialing',
+        description:
+          'Identity is captured with provenance. Nothing is claimed about source truth at this step.',
+      },
+      {
+        step: '02',
+        title: 'Source verification produces receipt candidates',
+        description:
+          'Each issuer response is a typed candidate. Limitations and unable-to-verify outcomes are first-class, not error states.',
+      },
+      {
+        step: '03',
+        title: 'Your committee or delegated reviewer decides',
+        description:
+          'Policy review under your standards produces the PSV receipt candidate. Promotion to PSV receipt is gated by your scope rules.',
+      },
+    ],
+    cta: {
+      headline: 'Bring a delegation oversight question.',
+      body:
+        'Send us the question your auditor would ask first. We will show you exactly where in the receipt the answer lives.',
+      button: 'Request a payer walkthrough',
+    },
+  },
+  {
+    slug: 'staffing-exchange',
+    intakePersona: 'staffing_exchange',
+    title: 'For Staffing Exchanges — VitalCV',
+    description:
+      'Clinicians arrive with portable, scoped credentialing artifacts. Match faster without re-running primary source for every placement.',
+    hero: {
+      eyebrow: 'For locum networks + staffing exchanges',
+      headline:
+        'Clinicians who arrive credentialing-ready — with receipts a hospital can audit.',
+      subhead:
+        'VitalCV gives your clinicians portable, scoped artifacts. The hospital sees the source, the responder, and the limitation — not a marketing badge.',
+    },
+    valueProps: [
+      {
+        title: 'Portable receipt candidates per credential',
+        description:
+          'A receipt candidate travels with the clinician. The receiving hospital can see the source and the responder, not just a green check.',
+      },
+      {
+        title: 'Reuse scoped to consent and freshness',
+        description:
+          'Same-tenant reuse is straightforward; cross-tenant reuse requires a consent receipt and is logged. No silent reuse.',
+      },
+      {
+        title: 'Faster placements without claiming finality',
+        description:
+          'A PSV receipt is scoped evidence. It compresses time to ready without overstating what the hospital is being asked to accept.',
+      },
+    ],
+    flow: [
+      {
+        step: '01',
+        title: 'Clinician onboarded once',
+        description:
+          'Identity, license, board, malpractice, and education each captured with provenance and consent.',
+      },
+      {
+        step: '02',
+        title: 'Receipt candidates accrue per credential',
+        description:
+          'Each successful issuer response becomes a receipt candidate the clinician carries forward.',
+      },
+      {
+        step: '03',
+        title: 'Receiving hospital reviews the scoped receipt',
+        description:
+          'They see the source, responder, freshness, and limitation. Their committee makes the decision; we do not pretend to make it for them.',
+      },
+    ],
+    cta: {
+      headline: 'See a clinician dossier in 10 minutes.',
+      body:
+        'We will show you a real demo dossier — sources, attribution, limitation notes, and reuse scope, end to end.',
+      button: 'Request a staffing walkthrough',
+    },
+  },
+];
+
+export function getPersonaLandingContent(
+  slug: string,
+): PersonaLandingContent | undefined {
+  return PERSONA_LANDING_PAGES.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
Persona landing surfaces under /for/cvo, /for/payer, /for/staffing-exchange. CTAs link to /contact?persona=<value>; PilotIntakeForm preselects the dropdown from the URL. 23 tests pass. Verified end-to-end against local next start. Codex SAFE.