### PR TITLE
feat(gtm): public source-health panel on /status (Wave H5)

### DIFF
--- a/apps/web/__tests__/source-health-public-panel.test.tsx
+++ b/apps/web/__tests__/source-health-public-panel.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { SourceHealthPublicPanel } from '../components/status/SourceHealthPublicPanel';
+import type { SourceHealthSnapshot } from '../lib/source-health/sourceHealthTypes';
+
+function snap(over: Partial<SourceHealthSnapshot> & Pick<SourceHealthSnapshot, 'sourceId' | 'state'>): SourceHealthSnapshot {
+  return {
+    sourceId: over.sourceId,
+    state: over.state,
+    reason: over.reason ?? `state=${over.state}`,
+    lastSuccessAt: over.lastSuccessAt ?? null,
+    lastErrorAt: over.lastErrorAt ?? null,
+    lastLatencyMs: over.lastLatencyMs ?? null,
+    observedAt: over.observedAt ?? '2026-05-06T12:00:00.000Z',
+  };
+}
+
+const BANNED_PHRASES = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('SourceHealthPublicPanel — empty snapshot store', () => {
+  it('renders the empty-state message and does not invent state', () => {
+    const html = renderToStaticMarkup(<SourceHealthPublicPanel snapshots={[]} />);
+    expect(html).toContain('data-testid="source-health-public-panel"');
+    expect(html).toContain('data-snapshot-count="0"');
+    expect(html).toContain('data-testid="source-health-empty-state"');
+    expect(html).toContain('data-testid="source-health-as-of-empty"');
+    // No source rows when empty
+    expect(html).not.toContain('data-testid="source-health-list"');
+  });
+});
+
+describe('SourceHealthPublicPanel — populated snapshots', () => {
+  it('renders all four canonical sources in canonical order', () => {
+    const html = renderToStaticMarkup(
+      <SourceHealthPublicPanel
+        snapshots={[
+          snap({ sourceId: 'STATE_BOARD', state: 'LIVE' }),
+          snap({ sourceId: 'OIG_LEIE', state: 'DEGRADED' }),
+          snap({ sourceId: 'NPPES', state: 'LIVE' }),
+          snap({ sourceId: 'PECOS', state: 'UNAVAILABLE' }),
+        ]}
+      />,
+    );
+    expect(html).toContain('data-snapshot-count="4"');
+    // Canonical order: NPPES, OIG_LEIE, PECOS, STATE_BOARD
+    const nppesIdx = html.indexOf('data-source-id="NPPES"');
+    const oigIdx = html.indexOf('data-source-id="OIG_LEIE"');
+    const pecosIdx = html.indexOf('data-source-id="PECOS"');
+    const stateBoardIdx = html.indexOf('data-source-id="STATE_BOARD"');
+    expect(nppesIdx).toBeGreaterThan(0);
+    expect(oigIdx).toBeGreaterThan(nppesIdx);
+    expect(pecosIdx).toBeGreaterThan(oigIdx);
+    expect(stateBoardIdx).toBeGreaterThan(pecosIdx);
+  });
+
+  it('renders the state badge for each row using the snapshot state', () => {
+    const html = renderToStaticMarkup(
+      <SourceHealthPublicPanel
+        snapshots={[
+          snap({ sourceId: 'NPPES', state: 'LIVE' }),
+          snap({ sourceId: 'OIG_LEIE', state: 'DEGRADED' }),
+          snap({ sourceId: 'PECOS', state: 'RATE_LIMITED' }),
+          snap({ sourceId: 'STATE_BOARD', state: 'UNAVAILABLE' }),
+        ]}
+      />,
+    );
+    expect(html).toContain('data-state="LIVE"');
+    expect(html).toContain('data-state="DEGRADED"');
+    expect(html).toContain('data-state="RATE_LIMITED"');
+    expect(html).toContain('data-state="UNAVAILABLE"');
+    expect(html).toContain('Live');
+    expect(html).toContain('Degraded');
+    expect(html).toContain('Rate limited');
+    expect(html).toContain('Unavailable');
+  });
+
+  it('marks sources with no snapshot as MISSING when only some are recorded', () => {
+    const html = renderToStaticMarkup(
+      <SourceHealthPublicPanel
+        snapshots={[snap({ sourceId: 'NPPES', state: 'LIVE' })]}
+      />,
+    );
+    expect(html).toContain('data-source-id="NPPES"');
+    expect(html).toContain('data-state="LIVE"');
+    expect(html).toContain('data-state="MISSING"');
+    expect(html).toContain('No snapshot recorded.');
+  });
+
+  it('renders newestObservedAt as the as-of timestamp', () => {
+    const html = renderToStaticMarkup(
+      <SourceHealthPublicPanel
+        snapshots={[
+          snap({ sourceId: 'NPPES', state: 'LIVE', observedAt: '2026-05-06T11:00:00.000Z' }),
+          snap({ sourceId: 'OIG_LEIE', state: 'LIVE', observedAt: '2026-05-06T13:00:00.000Z' }),
+          snap({ sourceId: 'PECOS', state: 'LIVE', observedAt: '2026-05-06T12:00:00.000Z' }),
+        ]}
+      />,
+    );
+    expect(html).toContain('As of 2026-05-06T13:00:00.000Z');
+  });
+
+  it('renders lastSuccessAt and lastErrorAt as plain text data attrs without raw payload', () => {
+    const html = renderToStaticMarkup(
+      <SourceHealthPublicPanel
+        snapshots={[
+          snap({
+            sourceId: 'NPPES',
+            state: 'LIVE',
+            lastSuccessAt: '2026-05-06T12:00:00.000Z',
+            lastErrorAt: '2026-05-04T09:00:00.000Z',
+            lastLatencyMs: 234,
+          }),
+        ]}
+      />,
+    );
+    expect(html).toContain('data-last-success-at="2026-05-06T12:00:00.000Z"');
+    expect(html).toContain('data-last-error-at="2026-05-04T09:00:00.000Z"');
+    expect(html).toContain('234 ms');
+  });
+});
+
+describe('SourceHealthPublicPanel — banned strings', () => {
+  it('renders no banned overclaim copy in any state', () => {
+    const allStates = ['LIVE', 'DEGRADED', 'UNAVAILABLE', 'RATE_LIMITED', 'UNKNOWN'] as const;
+    for (const state of allStates) {
+      const html = renderToStaticMarkup(
+        <SourceHealthPublicPanel
+          snapshots={[snap({ sourceId: 'NPPES', state })]}
+        />,
+      );
+      const lower = html.toLowerCase();
+      for (const phrase of BANNED_PHRASES) {
+        expect(lower).not.toContain(phrase.toLowerCase());
+      }
+      // No bare "Verified" status label; we use "Live" instead.
+      expect(html).not.toMatch(/>Verified</);
+    }
+  });
+});

--- a/apps/web/app/status/page.tsx
+++ b/apps/web/app/status/page.tsx
@@ -5,6 +5,8 @@ import {
   buildStatusFoundationPlan,
   explainStatusSurfaceStatus,
 } from '@/lib/commercial/statusFoundation';
+import { SourceHealthPublicPanel } from '@/components/status/SourceHealthPublicPanel';
+import { getAllSnapshots } from '@/lib/source-health/store/snapshotStore';
 
 export const metadata: Metadata = {
   title: 'Status · VitalCV',
@@ -12,8 +14,24 @@ export const metadata: Metadata = {
     'Status surfaces are foundation previews. No uptime guarantee is implied.',
 };
 
+// The snapshot store is module-scope and ephemeral (cold-start resets);
+// the page always renders fresh state on each request rather than cache.
+export const dynamic = 'force-dynamic';
+
 export default function StatusPage() {
   const plan = buildStatusFoundationPlan();
+  // Read-only access to the in-memory snapshot store. Snapshots already
+  // contain only safe metadata (sourceId, state, reason, observedAt,
+  // lastSuccessAt, lastErrorAt, lastLatencyMs); no raw upstream payloads
+  // or PII are stored. If the probe has not run yet (cold-start case),
+  // snapshots is [] — the panel renders an honest empty state rather
+  // than fabricating green checks.
+  let snapshots: ReturnType<typeof getAllSnapshots> = [];
+  try {
+    snapshots = getAllSnapshots();
+  } catch {
+    snapshots = [];
+  }
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
@@ -29,6 +47,8 @@ export default function StatusPage() {
           {' '}Incident notices and public changelogs are planned surfaces. Neither is wired today.
         </p>
       </header>
+
+      <SourceHealthPublicPanel snapshots={snapshots} />
 
       <section
         aria-labelledby="invariants-heading"

--- a/apps/web/components/status/SourceHealthPublicPanel.tsx
+++ b/apps/web/components/status/SourceHealthPublicPanel.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+
+import {
+  ALL_SOURCE_IDS,
+  type SourceHealthSnapshot,
+  type SourceHealthState,
+  type SourceId,
+} from '@/lib/source-health/sourceHealthTypes';
+
+interface SourceHealthPublicPanelProps {
+  snapshots: ReadonlyArray<SourceHealthSnapshot>;
+  /** Optional override for the rendered "as of" timestamp. Defaults to the
+   *  newest observedAt in `snapshots`. */
+  observedAt?: string | null;
+}
+
+const SOURCE_LABEL: Record<SourceId, string> = {
+  NPPES: 'NPPES (NPI registry)',
+  OIG_LEIE: 'OIG LEIE (exclusion list)',
+  PECOS: 'PECOS (Medicare enrollment)',
+  STATE_BOARD: 'State medical boards',
+};
+
+const STATE_BADGE: Record<
+  SourceHealthState,
+  { label: string; className: string; description: string }
+> = {
+  LIVE: {
+    label: 'Live',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700',
+    description:
+      'The source responded within the latest probe window. Evidence may be upgraded against this source.',
+  },
+  DEGRADED: {
+    label: 'Degraded',
+    className: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
+    description:
+      'The source is responding but slow or partially failing. Evidence is not upgraded while degraded.',
+  },
+  UNAVAILABLE: {
+    label: 'Unavailable',
+    className: 'border-red-500/30 bg-red-500/10 text-red-700',
+    description:
+      'The source is not responding. Evidence is not upgraded while unavailable.',
+  },
+  RATE_LIMITED: {
+    label: 'Rate limited',
+    className: 'border-orange-500/30 bg-orange-500/10 text-orange-700',
+    description:
+      'Source is throttling our requests. Evidence is not upgraded while rate limited.',
+  },
+  UNKNOWN: {
+    label: 'Unknown',
+    className: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+    description:
+      'No probe result yet. Evidence is not upgraded while state is unknown.',
+  },
+};
+
+function newestObservedAt(snaps: ReadonlyArray<SourceHealthSnapshot>): string | null {
+  if (snaps.length === 0) return null;
+  let newest = snaps[0].observedAt;
+  for (const s of snaps) {
+    if (s.observedAt > newest) newest = s.observedAt;
+  }
+  return newest;
+}
+
+export function SourceHealthPublicPanel({
+  snapshots,
+  observedAt,
+}: SourceHealthPublicPanelProps) {
+  const asOf = observedAt ?? newestObservedAt(snapshots);
+  const bySource = new Map<SourceId, SourceHealthSnapshot>();
+  for (const s of snapshots) bySource.set(s.sourceId, s);
+
+  return (
+    <section
+      aria-labelledby="source-health-heading"
+      className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      data-testid="source-health-public-panel"
+      data-snapshot-count={String(snapshots.length)}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h2
+          id="source-health-heading"
+          className="text-base font-semibold sm:text-lg"
+        >
+          Source operational health
+        </h2>
+        {asOf ? (
+          <p
+            className="text-[10px] uppercase tracking-wider text-muted-foreground"
+            data-testid="source-health-as-of"
+          >
+            As of {asOf}
+          </p>
+        ) : (
+          <p
+            className="text-[10px] uppercase tracking-wider text-muted-foreground"
+            data-testid="source-health-as-of-empty"
+          >
+            No probe yet
+          </p>
+        )}
+      </div>
+
+      <p className="mt-2 text-xs text-muted-foreground">
+        Operational state of upstream credentialing sources. This reports
+        availability of the source itself — it does not certify any clinician
+        record.
+      </p>
+
+      {snapshots.length === 0 ? (
+        <p
+          className="mt-4 rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-xs text-slate-600"
+          data-testid="source-health-empty-state"
+        >
+          The source-health probe has not run since the last deploy. Per the
+          probe&rsquo;s design, no snapshot is shown until a real result is
+          recorded — we do not invent state.
+        </p>
+      ) : (
+        <ul className="mt-4 grid gap-3 sm:grid-cols-2" data-testid="source-health-list">
+          {ALL_SOURCE_IDS.map((sourceId) => {
+            const snap = bySource.get(sourceId);
+            if (!snap) {
+              return (
+                <li
+                  key={sourceId}
+                  className="rounded-md border border-dashed border-slate-300 p-3 text-xs"
+                  data-source-id={sourceId}
+                  data-state="MISSING"
+                >
+                  <p className="font-medium text-foreground">
+                    {SOURCE_LABEL[sourceId]}
+                  </p>
+                  <p className="mt-1 text-muted-foreground">
+                    No snapshot recorded.
+                  </p>
+                </li>
+              );
+            }
+            const badge = STATE_BADGE[snap.state];
+            return (
+              <li
+                key={sourceId}
+                className="rounded-md border border-border p-3 text-xs"
+                data-source-id={sourceId}
+                data-state={snap.state}
+                data-last-success-at={snap.lastSuccessAt ?? ''}
+                data-last-error-at={snap.lastErrorAt ?? ''}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="font-medium text-foreground">
+                    {SOURCE_LABEL[sourceId]}
+                  </p>
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${badge.className}`}
+                    aria-label={`State: ${badge.label}`}
+                    title={badge.description}
+                  >
+                    {badge.label}
+                  </span>
+                </div>
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  {snap.reason}
+                </p>
+                <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
+                  <div>
+                    <dt className="uppercase tracking-wider">Last success</dt>
+                    <dd className="mt-0.5 font-mono text-foreground/80">
+                      {snap.lastSuccessAt ?? '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="uppercase tracking-wider">Last error</dt>
+                    <dd className="mt-0.5 font-mono text-foreground/80">
+                      {snap.lastErrorAt ?? '—'}
+                    </dd>
+                  </div>
+                  {snap.lastLatencyMs !== null && (
+                    <div className="col-span-2">
+                      <dt className="uppercase tracking-wider">Last latency</dt>
+                      <dd className="mt-0.5 font-mono text-foreground/80">
+                        {snap.lastLatencyMs} ms
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Wires the in-memory snapshot store (#187/#252) to /status as a public read-only panel. Honest empty state when store is empty (no probe yet); shows Live/Degraded/Unavailable/Rate limited/Unknown badges per source. Only safe metadata. 7 tests pass. Verified end-to-end. Codex SAFE.