### PR TITLE
feat(gtm): pricing page CTAs + Cal.com booking embed (Wave H4)

### DIFF
--- a/apps/web/__tests__/calendar-booking-embed.test.tsx
+++ b/apps/web/__tests__/calendar-booking-embed.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  CalendarBookingEmbed,
+  isAllowedBookingUrl,
+} from '../components/pricing/CalendarBookingEmbed';
+
+const ORIGINAL = process.env.NEXT_PUBLIC_CALENDLY_URL;
+
+beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_CALENDLY_URL;
+});
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_CALENDLY_URL;
+  else process.env.NEXT_PUBLIC_CALENDLY_URL = ORIGINAL;
+});
+
+describe('isAllowedBookingUrl — host allow list', () => {
+  it('accepts cal.com and subdomains', () => {
+    expect(isAllowedBookingUrl('https://cal.com/team/vitalcv/pilot')).toBe(true);
+    expect(isAllowedBookingUrl('https://app.cal.com/x')).toBe(true);
+  });
+
+  it('accepts calendly.com and subdomains', () => {
+    expect(isAllowedBookingUrl('https://calendly.com/vitalcv/pilot')).toBe(true);
+    expect(isAllowedBookingUrl('https://app.calendly.com/x')).toBe(true);
+  });
+
+  it('rejects http schemes', () => {
+    expect(isAllowedBookingUrl('http://cal.com/x')).toBe(false);
+  });
+
+  it('rejects unknown hostnames', () => {
+    expect(isAllowedBookingUrl('https://evil.com/cal.com/x')).toBe(false);
+    expect(isAllowedBookingUrl('https://attacker.example/cal')).toBe(false);
+  });
+
+  it('rejects empty / undefined / unparseable', () => {
+    expect(isAllowedBookingUrl(undefined)).toBe(false);
+    expect(isAllowedBookingUrl('')).toBe(false);
+    expect(isAllowedBookingUrl('not a url')).toBe(false);
+  });
+});
+
+describe('CalendarBookingEmbed — render gating', () => {
+  it('returns null when env is unset and no override is given', () => {
+    const html = renderToStaticMarkup(<CalendarBookingEmbed />);
+    expect(html).toBe('');
+  });
+
+  it('returns null when env is set to a disallowed host', () => {
+    process.env.NEXT_PUBLIC_CALENDLY_URL = 'https://evil.example/embed';
+    const html = renderToStaticMarkup(<CalendarBookingEmbed />);
+    expect(html).toBe('');
+  });
+
+  it('renders the iframe when the env var points at calendly.com', () => {
+    process.env.NEXT_PUBLIC_CALENDLY_URL = 'https://calendly.com/vitalcv/pilot';
+    const html = renderToStaticMarkup(<CalendarBookingEmbed />);
+    expect(html).toContain('data-testid="calendar-booking-embed"');
+    expect(html).toContain('data-booking-host="calendly.com"');
+    expect(html).toContain('src="https://calendly.com/vitalcv/pilot"');
+    expect(html).toContain('Book a pilot scoping call');
+    expect(html).toContain('Booking does not create a paid');
+  });
+
+  it('renders the iframe when the env var points at cal.com', () => {
+    process.env.NEXT_PUBLIC_CALENDLY_URL = 'https://cal.com/team/vitalcv/pilot';
+    const html = renderToStaticMarkup(<CalendarBookingEmbed />);
+    expect(html).toContain('data-booking-host="cal.com"');
+    expect(html).toContain('src="https://cal.com/team/vitalcv/pilot"');
+  });
+
+  it('uses a sandbox attribute that omits allow-top-navigation', () => {
+    process.env.NEXT_PUBLIC_CALENDLY_URL = 'https://calendly.com/x';
+    const html = renderToStaticMarkup(<CalendarBookingEmbed />);
+    // The sandbox should not include allow-top-navigation (the embed
+    // must not be able to navigate the parent away from VitalCV).
+    expect(html).toMatch(/sandbox="[^"]*"/);
+    expect(html).not.toContain('allow-top-navigation');
+  });
+});

--- a/apps/web/__tests__/pricing-cta.test.ts
+++ b/apps/web/__tests__/pricing-cta.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { ctaForKind, ctaForPricingPlan } from '@/lib/commercial/pricingCta';
+import {
+  buildPricingFoundationPlan,
+  type PricingPlanKind,
+} from '@/lib/commercial/pricingFoundation';
+
+const ALL_KINDS: ReadonlyArray<PricingPlanKind> = [
+  'clinician_free',
+  'clinician_plus_planned',
+  'verifier_pilot',
+  'verifier_team_planned',
+  'enterprise_planned',
+];
+
+describe('ctaForPricingPlan — truth contract', () => {
+  it('every plan returns opensPaidCheckout: false', () => {
+    for (const kind of ALL_KINDS) {
+      const cta = ctaForKind(kind);
+      // Literal-typed false — covered by TS too, but assert at runtime
+      // so a future change that flips the literal fails this test.
+      expect(cta.opensPaidCheckout).toBe(false);
+    }
+  });
+
+  it('clinician plans have null href (no contact CTA)', () => {
+    expect(ctaForKind('clinician_free').href).toBeNull();
+    expect(ctaForKind('clinician_plus_planned').href).toBeNull();
+  });
+
+  it('verifier and enterprise plans route to /contact with persona', () => {
+    expect(ctaForKind('verifier_pilot').href).toBe('/contact?persona=cvo');
+    expect(ctaForKind('verifier_team_planned').href).toBe('/contact?persona=cvo');
+    expect(ctaForKind('enterprise_planned').href).toBe('/contact?persona=health_system');
+  });
+
+  it('builds a CTA for every plan returned by buildPricingFoundationPlan', () => {
+    const plans = buildPricingFoundationPlan();
+    for (const plan of plans) {
+      const cta = ctaForPricingPlan(plan);
+      expect(cta).toBeDefined();
+      expect(cta.opensPaidCheckout).toBe(false);
+    }
+  });
+
+  it('rationale on contact CTAs explicitly disclaims payment', () => {
+    const verifier = ctaForKind('verifier_pilot');
+    expect(verifier.rationale.toLowerCase()).toContain('no payment');
+    const enterprise = ctaForKind('enterprise_planned');
+    expect(enterprise.rationale.toLowerCase()).toMatch(
+      /conversation|scoping|talk|fit/i,
+    );
+  });
+});

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Link from 'next/link';
 import type { Metadata } from 'next';
 
 import {
@@ -6,6 +7,8 @@ import {
   explainPricingPlanStatus,
   type PricingPlanStatus,
 } from '@/lib/commercial/pricingFoundation';
+import { ctaForPricingPlan } from '@/lib/commercial/pricingCta';
+import { CalendarBookingEmbed } from '@/components/pricing/CalendarBookingEmbed';
 
 export const metadata: Metadata = {
   title: 'Pricing Foundation | VitalCV',
@@ -66,10 +69,54 @@ export default function PricingFoundationPage() {
                 {String(plan.checkoutIntegrationLive)}. Subscription active:{' '}
                 {String(plan.subscriptionActive)}.
               </p>
+              <PlanCta planKind={plan.kind} />
             </li>
           ))}
         </ul>
       </section>
+
+      <CalendarBookingEmbed />
     </main>
+  );
+}
+
+function PlanCta({
+  planKind,
+}: {
+  planKind: ReturnType<typeof buildPricingFoundationPlan>[number]['kind'];
+}) {
+  // Resolve the CTA from the canonical helper so the page never
+  // hardcodes a checkout/payment claim.
+  const cta = ctaForPricingPlan({ kind: planKind } as Parameters<typeof ctaForPricingPlan>[0]);
+
+  if (cta.href === null) {
+    return (
+      <p
+        className="mt-4 text-xs text-muted-foreground"
+        data-testid="plan-cta"
+        data-cta-kind={cta.kind}
+        data-opens-paid-checkout={String(cta.opensPaidCheckout)}
+      >
+        {cta.label}. {cta.rationale}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="mt-4"
+      data-testid="plan-cta"
+      data-cta-kind={cta.kind}
+      data-cta-href={cta.href}
+      data-opens-paid-checkout={String(cta.opensPaidCheckout)}
+    >
+      <Link
+        href={cta.href}
+        className="inline-flex items-center justify-center rounded-md border border-foreground bg-foreground px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90"
+      >
+        {cta.label} →
+      </Link>
+      <p className="mt-2 text-[11px] text-muted-foreground">{cta.rationale}</p>
+    </div>
   );
 }

--- a/apps/web/components/pricing/CalendarBookingEmbed.tsx
+++ b/apps/web/components/pricing/CalendarBookingEmbed.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+/**
+ * Cal.com / Calendly booking embed.
+ *
+ * Behavior:
+ *   - When NEXT_PUBLIC_CALENDLY_URL is unset, returns null. The page
+ *     falls through to the per-plan /contact CTAs.
+ *   - When set, renders a sandboxed iframe pointing at the URL. We
+ *     intentionally don't load Calendly's or Cal.com's JS widget
+ *     (which would inject third-party scripts into the marketing
+ *     bundle); the iframe is enough for booking and stays inside
+ *     our CSP.
+ *   - Only `https://` URLs from cal.com or calendly.com hostnames
+ *     are accepted. Any other value renders the same null fallback,
+ *     so a misconfigured env can't smuggle a third-party iframe in.
+ */
+
+const ALLOWED_HOSTS: ReadonlyArray<RegExp> = [
+  /^([a-z0-9-]+\.)?cal\.com$/i,
+  /^([a-z0-9-]+\.)?calendly\.com$/i,
+];
+
+export function isAllowedBookingUrl(url: string | undefined): url is string {
+  if (!url) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  return ALLOWED_HOSTS.some((re) => re.test(parsed.hostname));
+}
+
+export function CalendarBookingEmbed() {
+  // Single source of truth: the env var. There is no prop override.
+  // Tests stub `process.env.NEXT_PUBLIC_CALENDLY_URL` directly so
+  // there is exactly one render path — both for tests and prod —
+  // gated by isAllowedBookingUrl.
+  const resolved = process.env.NEXT_PUBLIC_CALENDLY_URL;
+  if (!isAllowedBookingUrl(resolved)) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="booking-heading"
+      className="mt-8 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      data-testid="calendar-booking-embed"
+      data-booking-host={new URL(resolved).hostname}
+    >
+      <h2 id="booking-heading" className="text-base font-semibold sm:text-lg">
+        Or book a 20-minute call
+      </h2>
+      <p className="mt-2 text-xs text-muted-foreground">
+        For pilot scoping conversations. Booking does not create a paid
+        subscription.
+      </p>
+      <div className="mt-4 overflow-hidden rounded-lg border border-border">
+        <iframe
+          src={resolved}
+          title="Book a pilot scoping call"
+          className="h-[640px] w-full"
+          // Explicit allow list — keep this minimal; the embed only
+          // needs basic scheduling primitives.
+          allow="camera; microphone; clipboard-write"
+          // Don't grant top-level navigation to a third party.
+          sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+          loading="lazy"
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/commercial/pricingCta.ts
+++ b/apps/web/lib/commercial/pricingCta.ts
@@ -1,0 +1,101 @@
+import type {
+  PricingFoundationPlan,
+  PricingPlanKind,
+} from './pricingFoundation';
+
+/**
+ * Maps a pricing plan to a buyer-facing call-to-action.
+ *
+ * Truth contract:
+ *   - This module never claims a plan collects payment, has a live
+ *     subscription, or has live checkout. Those literals stay
+ *     `false` on PricingFoundationPlan and are surfaced verbatim in
+ *     the page.
+ *   - The CTA's only effect is to route the buyer into a real
+ *     conversation via /contact?persona=<derived>. No ledger write,
+ *     no Stripe checkout, no payment capture.
+ */
+
+export type PricingPlanCtaKind =
+  | 'contact_pilot'
+  | 'contact_team'
+  | 'contact_enterprise'
+  | 'self_serve_no_action';
+
+export interface PricingPlanCta {
+  kind: PricingPlanCtaKind;
+  /** Visible button label. */
+  label: string;
+  /**
+   * Internal href. Always a relative URL into /contact when the CTA
+   * is conversational; null when no CTA action is appropriate.
+   */
+  href: string | null;
+  /** Whether the CTA opens a paid checkout. Always false in this
+   *  PR — kept here as a typed literal so a future PR that wires
+   *  Stripe must update both the literal and the truth tests. */
+  opensPaidCheckout: false;
+  /**
+   * Short rationale shown beneath the CTA button. Defensive copy
+   * that reinforces the truth contract.
+   */
+  rationale: string;
+}
+
+/**
+ * Pure helper. No fetch, no env access, no DOM. Safe to import in
+ * any environment.
+ */
+export function ctaForPricingPlan(plan: PricingFoundationPlan): PricingPlanCta {
+  return ctaForKind(plan.kind);
+}
+
+export function ctaForKind(kind: PricingPlanKind): PricingPlanCta {
+  switch (kind) {
+    case 'clinician_free':
+      return {
+        kind: 'self_serve_no_action',
+        label: 'No action needed',
+        href: null,
+        opensPaidCheckout: false,
+        rationale:
+          'The clinician baseline is free to view. No checkout flow exists for this plan.',
+      };
+    case 'clinician_plus_planned':
+      return {
+        kind: 'self_serve_no_action',
+        label: 'Roadmap only',
+        href: null,
+        opensPaidCheckout: false,
+        rationale:
+          'Clinician Plus is a future plan shape. No checkout or pilot conversation is wired for it today.',
+      };
+    case 'verifier_pilot':
+      return {
+        kind: 'contact_pilot',
+        label: 'Start a pilot conversation',
+        href: '/contact?persona=cvo',
+        opensPaidCheckout: false,
+        rationale:
+          'Routes you to the pilot intake form. We typically reply within one business day. No payment is collected from this button.',
+      };
+    case 'verifier_team_planned':
+      return {
+        kind: 'contact_team',
+        label: 'Talk to us about a team plan',
+        href: '/contact?persona=cvo',
+        opensPaidCheckout: false,
+        rationale:
+          'Verifier Team pricing is planned, not live. The CTA opens the same pilot intake form so we can scope a fit.',
+      };
+    case 'enterprise_planned':
+      return {
+        kind: 'contact_enterprise',
+        label: 'Talk to us about enterprise',
+        href: '/contact?persona=health_system',
+        opensPaidCheckout: false,
+        rationale:
+          'Enterprise scoping is conversation-led. The CTA opens the pilot intake form so we can route to the right contact.',
+      };
+  }
+}


### PR DESCRIPTION
Per-plan CTAs route buyers to /contact?persona=. Optional Cal.com/Calendly embed gated on NEXT_PUBLIC_CALENDLY_URL (residual manual #9). Truth contract preserved: opensPaidCheckout:false literal on every CTA; no Stripe wiring. 15 tests pass. Verified end-to-end. Codex SAFE.