### PR TITLE
fix(app-shell): remove NPDB from T3 tier example — show only live sources

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -73,7 +73,7 @@ interface TierRow {
 const TIER_LADDER: TierRow[] = [
   { tier: 'T1', blurb: 'Self-asserted by the clinician.', example: 'Manually entered employment history.' },
   { tier: 'T2', blurb: 'Inferred by AI from clinician artifacts.', example: 'Residency dates parsed from a CV.' },
-  { tier: 'T3', blurb: 'Source-checked against a federal/state registry.', example: 'NPPES · OIG/LEIE · PECOS · NPDB.' },
+  { tier: 'T3', blurb: 'Source-checked against a federal/state registry.', example: 'NPPES · OIG/LEIE · PECOS.' },
   { tier: 'T4', blurb: 'Cryptographically signed by the issuing authority.', example: 'Board-issued VC 2.0 receipt.' },
 ];
 


### PR DESCRIPTION
## Problem
`HomePageClient.tsx:76` T3 tier-ladder example listed `NPPES · OIG/LEIE · PECOS · NPDB`, implying VitalCV checks NPDB. NPDB requires institutional subscription and is explicitly forbidden as a public-copy live-source claim per:
- `docs/specs/vitalcv-source-coverage-matrix.md` — Cannot claim: "NPDB checked", "NPDB cleared"
- `docs/ops/vitalcv-public-claims-matrix.md` — NPDB not in the Live/Partial rows

## Fix
T3 example updated to: `NPPES · OIG/LEIE · PECOS.`

Only the three federal sources actually checked by the current wedge appear.

## Evidence
- 1-line change, no functional impact
- Codex SAFE (3 rounds on companion board/prf-delta branch)
- CI will gate