### PR TITLE
feat(crs): cap CRS at L1 (45) when licensure cannot be sourced (W1.1)

### DIFF
--- a/packages/crs/CrsEngine.ts
+++ b/packages/crs/CrsEngine.ts
@@ -3,6 +3,26 @@ import { validateReceiptSet, type TrustStateReceiptRecord } from '@vitalcv/psv';
 
 export const CRS_START_THRESHOLD = 80;
 
+/**
+ * Maximum CRS score allowed when licensure verification cannot be sourced.
+ *
+ * Rationale: NPPES (the foundational identity source the engine sees most
+ * often) enumerates NPI registrations — presence in NPPES does NOT verify
+ * that the clinician holds a current, unrevoked medical license. Live
+ * licensure sources are Nursys / FSMB / state-board adapters, which today
+ * are gated, unsupported, or unintegrated for most jurisdictions.
+ *
+ * Without verified licensure evidence, the CRS cannot imply PSV-grade
+ * trust. The cap forces such records into the L1 (Provisional) band,
+ * signaling "manual review required before proceeding" rather than
+ * "ready to start."
+ *
+ * Aligned numerically with the existing missing-acceptance band (45) so
+ * the cap composes deterministically with other gates without inventing
+ * a new tier.
+ */
+export const CRS_LICENSURE_UNVERIFIED_CEILING = 45;
+
 export type CrsBand = 'GREEN' | 'YELLOW' | 'RED';
 
 export type CrsBlockingReason =
@@ -10,7 +30,40 @@ export type CrsBlockingReason =
   | 'EXPIRED_PSV'
   | 'REVOKED_PSV'
   | 'MISSING_ACCEPTANCE'
+  | 'LICENSURE_UNVERIFIED'
   | 'ACTIVE_DIVERGENCE';
+
+/**
+ * State a licensure-verification source can be in for a given clinician.
+ *
+ * Only `verified` lifts the licensure cap. Every other state — including
+ * `unchecked`, `unavailable`, `access_required` (Nursys/FSMB onboarding
+ * pending), `unsupported` (no integration), and `missing` (no source for
+ * the jurisdiction) — leaves the cap engaged.
+ */
+export type CrsLicensureSourceState =
+  | 'verified'
+  | 'unverified'
+  | 'unavailable'
+  | 'unchecked'
+  | 'access_required'
+  | 'unsupported'
+  | 'missing';
+
+export type CrsLicensureCheck = Readonly<{
+  /**
+   * True ONLY when at least one licensure source returned a `verified`
+   * state for this clinician. Identity-only sources (NPPES) do NOT
+   * satisfy this — they enumerate NPIs, they do not verify licensure.
+   */
+  hasVerifiedLicensure: boolean;
+  /**
+   * Per-source states observed during the licensure check. Engine reads
+   * only `hasVerifiedLicensure`; this field is preserved so the audit
+   * trail shows why the cap was engaged.
+   */
+  source_states: readonly CrsLicensureSourceState[];
+}>;
 
 export type CrsOutput = Readonly<{
   clinician_id: string;
@@ -35,6 +88,24 @@ export type CrsEngineDependencies = Readonly<{
       as_of: string,
     ): { penalty: number; hasBlocking: boolean } | Promise<{ penalty: number; hasBlocking: boolean }>;
   };
+  /**
+   * Optional licensure-verification check.
+   *
+   * When supplied AND `hasVerifiedLicensure === false`, the engine caps
+   * the score at `CRS_LICENSURE_UNVERIFIED_CEILING` (45) and surfaces
+   * `LICENSURE_UNVERIFIED` in `blocking_reasons`. The cap is a HARD
+   * CEILING — it strictly clamps the score, never raises it, and is
+   * applied AFTER all other gates so it cannot be undone by a later
+   * positive signal.
+   *
+   * When NOT supplied, behavior is unchanged from the YC-MVP frozen
+   * baseline — callers that have not yet integrated licensure-source
+   * state see no change. The cap is opt-in for callers; once integrated,
+   * it is a hard invariant.
+   */
+  licensure?: {
+    getForClinician(clinician_id: string): CrsLicensureCheck | Promise<CrsLicensureCheck>;
+  };
   now?: () => Date;
   missing_acceptance_band?: 'YELLOW' | 'RED';
 }>;
@@ -44,6 +115,7 @@ const BLOCKING_REASON_ORDER: readonly CrsBlockingReason[] = [
   'EXPIRED_PSV',
   'REVOKED_PSV',
   'MISSING_ACCEPTANCE',
+  'LICENSURE_UNVERIFIED',
 ] as const;
 
 function assertClinicianId(value: unknown): asserts value is string {
@@ -84,6 +156,10 @@ export class CrsEngine {
     const divergence = this.deps.divergence
       ? await this.deps.divergence.getForClinician(input.clinician_id, asOf)
       : { penalty: 0, hasBlocking: false };
+    const licensure = this.deps.licensure
+      ? await this.deps.licensure.getForClinician(input.clinician_id)
+      : null;
+    const licensureUnverified = licensure !== null && !licensure.hasVerifiedLicensure;
 
     const receiptSummary = validateReceiptSet(receipts, asOf);
 
@@ -92,6 +168,7 @@ export class CrsEngine {
     if (receiptSummary.has_expired) reasons.add('EXPIRED_PSV');
     if (receiptSummary.has_revoked) reasons.add('REVOKED_PSV');
     if (!hasAcceptance) reasons.add('MISSING_ACCEPTANCE');
+    if (licensureUnverified) reasons.add('LICENSURE_UNVERIFIED');
     if (divergence.hasBlocking) reasons.add('ACTIVE_DIVERGENCE');
 
     const orderedReasons = sortReasons(reasons);
@@ -122,6 +199,19 @@ export class CrsEngine {
     if (divergence.hasBlocking && band !== 'RED') {
       score = Math.min(score, 79);
       band = 'YELLOW';
+    }
+
+    // Licensure cap — final invariant.
+    //
+    // Applied AFTER every other gate so a later positive signal cannot
+    // lift a record above the L1 ceiling once licensure is unverified.
+    // The cap strictly clamps; it never raises. RED records stay RED;
+    // YELLOW stays YELLOW; GREEN drops to YELLOW.
+    if (licensureUnverified) {
+      score = Math.min(score, CRS_LICENSURE_UNVERIFIED_CEILING);
+      if (band !== 'RED') {
+        band = 'YELLOW';
+      }
     }
 
     return Object.freeze({

--- a/packages/crs/__tests__/CrsEngine.test.ts
+++ b/packages/crs/__tests__/CrsEngine.test.ts
@@ -1,6 +1,11 @@
 /** YC MVP — behavior frozen. Do not modify without scope approval. */
 import { describe, expect, it } from 'vitest';
-import { CrsEngine } from '../CrsEngine';
+import {
+  CRS_LICENSURE_UNVERIFIED_CEILING,
+  CrsEngine,
+  type CrsLicensureCheck,
+  type CrsLicensureSourceState,
+} from '../CrsEngine';
 
 describe('CrsEngine', () => {
   it('returns RED when any PSV receipt is expired', async () => {
@@ -86,6 +91,163 @@ describe('CrsEngine', () => {
     });
     expect(afterExpiry.band).toBe('RED');
     expect(afterExpiry.blocking_reasons).toContain('EXPIRED_PSV');
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Licensure cap (W1.1) — opt-in dependency. When supplied AND
+  // hasVerifiedLicensure is false, the score is capped at
+  // CRS_LICENSURE_UNVERIFIED_CEILING (45) and LICENSURE_UNVERIFIED is
+  // surfaced. When NOT supplied, behavior is unchanged from the YC-MVP
+  // frozen baseline (the four tests above cover the unchanged paths).
+  // ───────────────────────────────────────────────────────────────────────
+
+  function freshHappyReceipt() {
+    return {
+      receipt_id: 'rcpt-fresh',
+      fetched_at: '2026-02-06T10:00:00.000Z',
+      ttl_seconds: 7200,
+      revoked: false,
+    };
+  }
+
+  function buildLicensureDep(check: CrsLicensureCheck) {
+    return {
+      getForClinician: async () => check,
+    };
+  }
+
+  it('caps score at L1 ceiling for an NPPES-only provider (no verified licensure)', async () => {
+    // Simulates: NPPES says identity exists; no licensure source returned verified.
+    const engine = new CrsEngine({
+      receipts: { listByClinician: async () => [freshHappyReceipt()] },
+      acceptances: { existsForClinician: async () => true },
+      licensure: buildLicensureDep({
+        hasVerifiedLicensure: false,
+        source_states: ['unchecked'] satisfies readonly CrsLicensureSourceState[],
+      }),
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-nppes-only',
+      as_of: '2026-02-06T10:30:00.000Z',
+    });
+
+    // Without the cap this would be 95/GREEN. With the cap it's 45/YELLOW.
+    expect(result.score).toBe(CRS_LICENSURE_UNVERIFIED_CEILING);
+    expect(result.score).toBe(45);
+    expect(result.band).toBe('YELLOW');
+    expect(result.blocking_reasons).toContain('LICENSURE_UNVERIFIED');
+  });
+
+  it('caps score when every licensure source is missing for the jurisdiction', async () => {
+    const engine = new CrsEngine({
+      receipts: { listByClinician: async () => [freshHappyReceipt()] },
+      acceptances: { existsForClinician: async () => true },
+      licensure: buildLicensureDep({
+        hasVerifiedLicensure: false,
+        source_states: ['missing'] satisfies readonly CrsLicensureSourceState[],
+      }),
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-no-jurisdiction',
+      as_of: '2026-02-06T10:30:00.000Z',
+    });
+
+    expect(result.score).toBeLessThanOrEqual(CRS_LICENSURE_UNVERIFIED_CEILING);
+    expect(result.band).not.toBe('GREEN');
+    expect(result.blocking_reasons).toContain('LICENSURE_UNVERIFIED');
+  });
+
+  it('caps score when licensure source is access_required (Nursys / FSMB onboarding pending)', async () => {
+    const engine = new CrsEngine({
+      receipts: { listByClinician: async () => [freshHappyReceipt()] },
+      acceptances: { existsForClinician: async () => true },
+      licensure: buildLicensureDep({
+        hasVerifiedLicensure: false,
+        source_states: ['access_required'] satisfies readonly CrsLicensureSourceState[],
+      }),
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-gated',
+      as_of: '2026-02-06T10:30:00.000Z',
+    });
+
+    expect(result.score).toBeLessThanOrEqual(CRS_LICENSURE_UNVERIFIED_CEILING);
+    expect(result.band).toBe('YELLOW');
+    expect(result.blocking_reasons).toContain('LICENSURE_UNVERIFIED');
+  });
+
+  it('does not cap when at least one licensure source returns verified', async () => {
+    const engine = new CrsEngine({
+      receipts: { listByClinician: async () => [freshHappyReceipt()] },
+      acceptances: { existsForClinician: async () => true },
+      licensure: buildLicensureDep({
+        hasVerifiedLicensure: true,
+        source_states: ['verified', 'access_required'] satisfies readonly CrsLicensureSourceState[],
+      }),
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-verified',
+      as_of: '2026-02-06T10:30:00.000Z',
+    });
+
+    // Cap does not fire — the unmodified happy path stands.
+    expect(result.score).toBeGreaterThan(CRS_LICENSURE_UNVERIFIED_CEILING);
+    expect(result.band).toBe('GREEN');
+    expect(result.blocking_reasons).not.toContain('LICENSURE_UNVERIFIED');
+  });
+
+  it('preserves legacy behavior when licensure dependency is not supplied (frozen-baseline opt-out)', async () => {
+    // Backward-compatibility guard — existing callers that have not yet
+    // integrated licensure-source state see the original scoring.
+    const engine = new CrsEngine({
+      receipts: { listByClinician: async () => [freshHappyReceipt()] },
+      acceptances: { existsForClinician: async () => true },
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-legacy',
+      as_of: '2026-02-06T10:30:00.000Z',
+    });
+
+    expect(result.score).toBe(95);
+    expect(result.band).toBe('GREEN');
+    expect(result.blocking_reasons).not.toContain('LICENSURE_UNVERIFIED');
+  });
+
+  it('cap never raises a record — RED records stay RED even with licensure unverified', async () => {
+    // Compose with another red gate: ensure cap clamps, never lifts.
+    const engine = new CrsEngine({
+      receipts: {
+        listByClinician: async () => [
+          {
+            receipt_id: 'rcpt-revoked',
+            fetched_at: '2026-02-06T09:00:00.000Z',
+            ttl_seconds: 7200,
+            revoked: true,
+          },
+        ],
+      },
+      acceptances: { existsForClinician: async () => true },
+      licensure: buildLicensureDep({
+        hasVerifiedLicensure: false,
+        source_states: ['unsupported'] satisfies readonly CrsLicensureSourceState[],
+      }),
+    });
+
+    const result = await engine.computeForClinician({
+      clinician_id: 'clin-revoked-and-unverified',
+      as_of: '2026-02-06T09:30:00.000Z',
+    });
+
+    // RED from REVOKED_PSV must persist; cap does not soften RED to YELLOW.
+    expect(result.band).toBe('RED');
+    expect(result.score).toBeLessThanOrEqual(CRS_LICENSURE_UNVERIFIED_CEILING);
+    expect(result.blocking_reasons).toContain('REVOKED_PSV');
+    expect(result.blocking_reasons).toContain('LICENSURE_UNVERIFIED');
   });
 
   it('applies divergence penalties and blocks GREEN when a high-severity divergence is active', async () => {

--- a/packages/crs/index.ts
+++ b/packages/crs/index.ts
@@ -3,8 +3,11 @@
 export {
   CrsEngine,
   CRS_START_THRESHOLD,
+  CRS_LICENSURE_UNVERIFIED_CEILING,
   type CrsBand,
   type CrsBlockingReason,
+  type CrsLicensureCheck,
+  type CrsLicensureSourceState,
   type CrsOutput,
   type CrsEngineDependencies,
 } from './CrsEngine';


### PR DESCRIPTION
## Summary
Wave 1.1 trust-restoration fix from the recursive audit. Closes the audit's **P0 finding**: the CRS engine initialized score at 95 and could surface a clinician with only NPPES (identity-only) + clear-OIG as L2/L3-ready, with state-board licensure still gated/unintegrated.

## Approach
**Strictly preserves the YC-MVP frozen baseline** — the cap is wired through an OPT-IN \`licensure\` dependency on \`CrsEngineDependencies\`. Existing callers (none in apps/web today; the only reference is \`next.config.mjs\` transpilePackages) see no behavior change.

When a caller supplies \`licensure\` AND it returns \`hasVerifiedLicensure: false\`, the engine:
- clamps the score at \`CRS_LICENSURE_UNVERIFIED_CEILING\` (45 — aligned with the existing missing-acceptance band)
- surfaces \`'LICENSURE_UNVERIFIED'\` in \`blocking_reasons\`
- forces band \`YELLOW\` (RED records stay RED — cap never raises)

The cap is applied AFTER all other gates so a later positive signal cannot lift a record above L1 once licensure is unverified.

## Truth contracts
- Every other state — \`unchecked\`, \`unavailable\`, \`access_required\` (Nursys/FSMB pending), \`unsupported\`, \`missing\` — leaves the cap engaged. **Only \`verified\` lifts it.**
- NPPES is identity enumeration, not licensure verification — explicit comment in CRS_LICENSURE_UNVERIFIED_CEILING docblock
- Cap strictly clamps; never raises score or band
- Backward-compatible default (no \`licensure\` dep → frozen behavior)

## Test plan
- [x] 6 new tests cover: NPPES-only, missing source, access_required (gated), verified (cap off), no-dep legacy compat, RED-stays-RED composability
- [x] All 6 new tests pass; 3/4 pre-existing tests pass
- [x] \`pnpm --filter @vitalcv/crs typecheck\` green

## Pre-existing latent bug surfaced (NOT in scope for this PR)
The 4th pre-existing test \`'applies divergence penalties and blocks GREEN…'\` fails on this branch AND on origin/main: \`BLOCKING_REASON_ORDER\` (CrsEngine.ts:47 origin) omits \`'ACTIVE_DIVERGENCE'\`, so \`sortReasons\` drops it. The package has no \`test\` script — it's typecheck-only — so this never surfaced in CI. **One-line follow-up**, deferred to keep this PR surgical.

## Caveat for the rim layer
The web app's user-facing readiness scores today come from \`passport.readiness.score\` (backend-computed), not this engine. This PR fixes the cap **at the engine** — a parallel cap on the backend's readiness path is required before the audit's P0 finding actually disappears from production demos. Recommend follow-up: \`feat(api): mirror CRS licensure cap in apps/api/backend/src/.../readiness/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)