### PR TITLE
feat(readiness): propagate CRS licensure cap to backend + web rim layers (W1.1b)

### DIFF
--- a/apps/api/backend/src/services/entity/__tests__/passportService-licensure-cap.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/passportService-licensure-cap.test.ts
@@ -1,0 +1,63 @@
+/**
+ * passportService-licensure-cap.test.ts
+ *
+ * Focused unit tests for the W1.1b licensure cap helper exported from
+ * passportService.ts. Tests the pure helper directly — no jest.mock
+ * fixtures needed because the helper has no dependencies.
+ *
+ * Truth contracts:
+ *   - When licensureStatus === 'verified', the score is returned unchanged.
+ *   - When licensureStatus is anything else (pending / expired / unknown),
+ *     the score is clamped at READINESS_LICENSURE_UNVERIFIED_CEILING (45).
+ *   - The cap is a hard ceiling: Math.min only — it never raises a lower
+ *     score.
+ */
+import {
+  applyReadinessLicensureCap,
+  READINESS_LICENSURE_UNVERIFIED_CEILING,
+} from '../readinessLicensureCap';
+
+describe('applyReadinessLicensureCap (W1.1b)', () => {
+  it('ceiling constant is 45 (aligned with engine-level CRS_LICENSURE_UNVERIFIED_CEILING)', () => {
+    expect(READINESS_LICENSURE_UNVERIFIED_CEILING).toBe(45);
+  });
+
+  it("returns score unchanged when licensureStatus === 'verified'", () => {
+    expect(applyReadinessLicensureCap(100, 'verified')).toBe(100);
+    expect(applyReadinessLicensureCap(95, 'verified')).toBe(95);
+    expect(applyReadinessLicensureCap(80, 'verified')).toBe(80);
+    expect(applyReadinessLicensureCap(45, 'verified')).toBe(45);
+    expect(applyReadinessLicensureCap(0, 'verified')).toBe(0);
+  });
+
+  it("caps score at 45 when licensureStatus === 'pending'", () => {
+    expect(applyReadinessLicensureCap(100, 'pending')).toBe(45);
+    expect(applyReadinessLicensureCap(95, 'pending')).toBe(45);
+    expect(applyReadinessLicensureCap(80, 'pending')).toBe(45);
+    expect(applyReadinessLicensureCap(60, 'pending')).toBe(45);
+  });
+
+  it("caps score at 45 when licensureStatus === 'expired'", () => {
+    expect(applyReadinessLicensureCap(100, 'expired')).toBe(45);
+    expect(applyReadinessLicensureCap(80, 'expired')).toBe(45);
+  });
+
+  it("caps score at 45 when licensureStatus === 'unknown'", () => {
+    expect(applyReadinessLicensureCap(100, 'unknown')).toBe(45);
+    expect(applyReadinessLicensureCap(80, 'unknown')).toBe(45);
+  });
+
+  it('cap never raises a lower score (Math.min, not Math.max)', () => {
+    // A score already below the ceiling stays below — the cap clamps,
+    // it does not normalize upward.
+    expect(applyReadinessLicensureCap(20, 'pending')).toBe(20);
+    expect(applyReadinessLicensureCap(0, 'pending')).toBe(0);
+    expect(applyReadinessLicensureCap(45, 'pending')).toBe(45);
+    expect(applyReadinessLicensureCap(44, 'pending')).toBe(44);
+  });
+
+  it('cap is exact: a score of 46 with unverified licensure becomes 45', () => {
+    expect(applyReadinessLicensureCap(46, 'pending')).toBe(45);
+    expect(applyReadinessLicensureCap(45, 'pending')).toBe(45);
+  });
+});

--- a/apps/api/backend/src/services/entity/passportService.ts
+++ b/apps/api/backend/src/services/entity/passportService.ts
@@ -41,6 +41,7 @@ import {
 } from './evidenceIntegrity';
 import { buildReadinessNextActions, type ReadinessNextAction } from './readinessActions';
 import { syncBlockerEvents } from '../seal/sealEventCapture';
+import { applyReadinessLicensureCap } from './readinessLicensureCap';
 import {
   coverageSatisfiesDecisionGradeTruth,
   createCanonicalTruth,
@@ -348,6 +349,16 @@ function derivePassportReadinessLevel(
   }
   return 'L0';
 }
+
+/**
+ * W1.1b — readiness licensure cap. Helper lives in its own module so it
+ * can be tested in isolation. Re-exported here for callers that already
+ * import from passportService.
+ */
+export {
+  applyReadinessLicensureCap,
+  READINESS_LICENSURE_UNVERIFIED_CEILING,
+} from './readinessLicensureCap';
 
 function dedupeStrings(values: readonly string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
@@ -2224,7 +2235,18 @@ export async function buildPassport(entityId: string): Promise<TrustPassport | n
       normalizedBlockers.length > 0 ? Math.min(baseScore, 20)
       : normalizedGaps.length > 0 ? Math.min(baseScore, 75)
       : baseScore;
-    return Math.max(0, cappedScore - (divergence?.totalPenalty ?? 0));
+    let finalScore = Math.max(0, cappedScore - (divergence?.totalPenalty ?? 0));
+    // W1.1b — licensure cap. Mirror of the engine-level invariant from
+    // packages/crs/CrsEngine.ts (CRS_LICENSURE_UNVERIFIED_CEILING = 45).
+    //
+    // NPPES presence enumerates an NPI registration; it does NOT verify
+    // that a clinician holds a current, unrevoked medical license. Live
+    // licensure sources (Nursys / FSMB / state-board) are gated or
+    // unintegrated for most jurisdictions today. Without verified
+    // licensure, readiness cannot exceed L1 (Provisional). The cap is a
+    // hard ceiling: Math.min only — never raises a lower score.
+    finalScore = applyReadinessLicensureCap(finalScore, standing.licensureStatus);
+    return finalScore;
   })();
   // KPI: sync blocker lifecycle events (fire-and-forget — never blocks passport build).
   // This populates blocker_resolution_events so /pilot-ops blocker metrics are live.

--- a/apps/api/backend/src/services/entity/readinessLicensureCap.ts
+++ b/apps/api/backend/src/services/entity/readinessLicensureCap.ts
@@ -1,0 +1,37 @@
+/**
+ * readinessLicensureCap.ts
+ *
+ * Hard ceiling on `readinessScore` when licensure has not been verified.
+ * Mirrors the engine-level invariant from
+ * `packages/crs/CrsEngine.ts` (`CRS_LICENSURE_UNVERIFIED_CEILING = 45`)
+ * and the web-side defense-in-depth helper at
+ * `apps/web/lib/readiness/licensureCap.ts`.
+ *
+ * Numerically aligned with the existing missing-acceptance band so cap
+ * composition stays deterministic without inventing a new tier.
+ *
+ * Truth contracts:
+ *   - When `licensureStatus === 'verified'`, the score is returned unchanged.
+ *   - When `licensureStatus` is anything else (`'pending'`, `'expired'`,
+ *     `'unknown'`), the score is clamped at READINESS_LICENSURE_UNVERIFIED_CEILING.
+ *   - The cap is a hard ceiling: Math.min only — it never raises a lower score.
+ *
+ * Lives in its own module so test files can import the helper without
+ * pulling in the rest of passportService.ts (which has unrelated
+ * pre-existing TS errors that block the test runner — see
+ * apps/api/backend/src/services/entity/passportService.ts:2168, :2209).
+ */
+
+export type LicensureStatus = 'verified' | 'pending' | 'expired' | 'unknown';
+
+export const READINESS_LICENSURE_UNVERIFIED_CEILING = 45;
+
+export function applyReadinessLicensureCap(
+  score: number,
+  licensureStatus: LicensureStatus,
+): number {
+  if (licensureStatus === 'verified') {
+    return score;
+  }
+  return Math.min(score, READINESS_LICENSURE_UNVERIFIED_CEILING);
+}

--- a/apps/web/__tests__/readiness-licensure-cap.test.ts
+++ b/apps/web/__tests__/readiness-licensure-cap.test.ts
@@ -1,0 +1,240 @@
+/**
+ * readiness-licensure-cap.test.ts
+ *
+ * Tests the web-side defense-in-depth helper at lib/readiness/licensureCap.ts.
+ * Mirrors the backend `applyReadinessLicensureCap` (passportService.ts) and
+ * the engine-level `CRS_LICENSURE_UNVERIFIED_CEILING` (CrsEngine.ts).
+ *
+ * Truth contracts verified:
+ *   - Ceiling = 45, identical to the backend constant.
+ *   - When licensureStatus === 'verified', passport is returned unchanged.
+ *   - When licensureStatus !== 'verified', score is clamped, level
+ *     deterministically resolves to L1, readiness_score mirror updated.
+ *   - Cap never raises a lower score.
+ *   - Source-state distinction is preserved — only readiness fields are
+ *     clamped, never sourceCoverage or trustPosture.
+ *   - readLicensureUiState surfaces capEngaged + raw + ui-tier strings
+ *     for use as data-licensure-state attributes.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PassportData } from '../lib/trust/passport-contract';
+import {
+  READINESS_LICENSURE_UNVERIFIED_CEILING,
+  applyLicensureCapToPassport,
+  clampReadinessScore,
+  deriveLevelFromScore,
+  readLicensureUiState,
+} from '../lib/readiness/licensureCap';
+
+function buildPassport(overrides: {
+  licensureStatus: PassportData['standing']['licensureStatus'];
+  score: number;
+  level?: string;
+  status?: PassportData['readiness']['status'];
+}): PassportData {
+  return {
+    entityId: 'demo-entity',
+    npi: '1003000126',
+    identity: {
+      displayName: 'Test Clinician',
+      specialty: 'Internal Medicine',
+      entityType: 'PERSON',
+      status: 'ACTIVE',
+      npi: '1003000126',
+    },
+    authority: {
+      credentials: [],
+      summary: { active: 0, expired: 0, stale: 0, missing: [] },
+    },
+    training: {
+      records: [],
+      hasDegree: true,
+      degreeVerified: true,
+      hasResidency: true,
+      fellowshipCount: 0,
+    },
+    standing: {
+      exclusionClear: true,
+      exclusionStatus: 'CLEAR',
+      licensureStatus: overrides.licensureStatus,
+      deaStatus: 'unknown',
+      pecosStatus: 'enrolled',
+      pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS',
+      enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: null,
+      negativeFindings: [],
+    },
+    readiness: {
+      status: overrides.status ?? 'PARTIAL',
+      score: overrides.score,
+      level: overrides.level ?? 'L2',
+      blockers: [],
+      gaps: [],
+      estimatedStartDays: 14,
+      nextActions: [],
+    },
+    sources: { checked: [], lastFetch: {} },
+    sourceCoverage: { checks: [] },
+    trustPosture: {
+      band: 'L2',
+      bandLabel: 'Moderate trust',
+      score: overrides.score,
+      dimensions: [],
+      freshness: { state: 'current', label: 'Current', items: [] },
+      safeToRelyOnNow: [],
+      missingItems: [],
+      gatedItems: [],
+      reviewRequiredItems: [],
+      staleItems: [],
+      blockers: [],
+    },
+    lastCheckedAt: '2026-05-04T00:00:00.000Z',
+  };
+}
+
+describe('readiness licensure cap (web-side, W1.1b defense-in-depth)', () => {
+  it('ceiling constant matches backend (45)', () => {
+    expect(READINESS_LICENSURE_UNVERIFIED_CEILING).toBe(45);
+  });
+
+  describe('clampReadinessScore', () => {
+    it("returns score unchanged for 'verified'", () => {
+      expect(clampReadinessScore(100, 'verified')).toBe(100);
+      expect(clampReadinessScore(45, 'verified')).toBe(45);
+      expect(clampReadinessScore(0, 'verified')).toBe(0);
+    });
+
+    it("caps score at 45 for 'pending' / 'expired' / 'unknown'", () => {
+      expect(clampReadinessScore(100, 'pending')).toBe(45);
+      expect(clampReadinessScore(80, 'expired')).toBe(45);
+      expect(clampReadinessScore(60, 'unknown')).toBe(45);
+    });
+
+    it('never raises a lower score', () => {
+      expect(clampReadinessScore(20, 'pending')).toBe(20);
+      expect(clampReadinessScore(0, 'pending')).toBe(0);
+    });
+  });
+
+  describe('deriveLevelFromScore', () => {
+    it('returns L0 for BLOCKED status regardless of score', () => {
+      expect(deriveLevelFromScore(100, 'BLOCKED')).toBe('L0');
+    });
+
+    it('returns L1 for capped score (45) with non-BLOCKED status', () => {
+      expect(deriveLevelFromScore(45, 'PARTIAL')).toBe('L1');
+      expect(deriveLevelFromScore(45, 'CHECKING')).toBe('L1');
+    });
+
+    it('returns L3 only for score >= 80 AND DECISION_GRADE', () => {
+      expect(deriveLevelFromScore(80, 'DECISION_GRADE')).toBe('L3');
+      expect(deriveLevelFromScore(95, 'DECISION_GRADE')).toBe('L3');
+      // 80 + non-DECISION_GRADE → L2 (still source-backed, not decision-grade)
+      expect(deriveLevelFromScore(80, 'PARTIAL')).toBe('L2');
+    });
+
+    it('returns L2 for score in [60, 80) regardless of status', () => {
+      expect(deriveLevelFromScore(60, 'PARTIAL')).toBe('L2');
+      expect(deriveLevelFromScore(79, 'CHECKING')).toBe('L2');
+    });
+  });
+
+  describe('readLicensureUiState', () => {
+    it("returns capEngaged: false + uiState 'verified' for verified", () => {
+      const passport = buildPassport({ licensureStatus: 'verified', score: 87 });
+      const ui = readLicensureUiState(passport);
+      expect(ui.capEngaged).toBe(false);
+      expect(ui.uiState).toBe('verified');
+      expect(ui.rawStatus).toBe('verified');
+    });
+
+    it("returns capEngaged: true + uiState 'unverified' for pending and expired", () => {
+      for (const status of ['pending', 'expired'] as const) {
+        const passport = buildPassport({ licensureStatus: status, score: 87 });
+        const ui = readLicensureUiState(passport);
+        expect(ui.capEngaged).toBe(true);
+        expect(ui.uiState).toBe('unverified');
+        expect(ui.rawStatus).toBe(status);
+      }
+    });
+
+    it("returns capEngaged: true + uiState 'unknown' for unknown", () => {
+      const passport = buildPassport({ licensureStatus: 'unknown', score: 87 });
+      const ui = readLicensureUiState(passport);
+      expect(ui.capEngaged).toBe(true);
+      expect(ui.uiState).toBe('unknown');
+    });
+  });
+
+  describe('applyLicensureCapToPassport', () => {
+    it('returns the same passport object when cap not engaged (verified)', () => {
+      const passport = buildPassport({ licensureStatus: 'verified', score: 87 });
+      const result = applyLicensureCapToPassport(passport);
+      // Identity-equal — no copy needed when cap is a no-op
+      expect(result).toBe(passport);
+    });
+
+    it('returns the same passport object when cap engaged but score already below ceiling', () => {
+      const passport = buildPassport({ licensureStatus: 'pending', score: 30 });
+      const result = applyLicensureCapToPassport(passport);
+      expect(result).toBe(passport);
+      expect(result.readiness.score).toBe(30);
+    });
+
+    it('clamps score and re-derives level when cap fires', () => {
+      const passport = buildPassport({
+        licensureStatus: 'pending',
+        score: 87,
+        level: 'L3',
+        status: 'DECISION_GRADE',
+      });
+      const result = applyLicensureCapToPassport(passport);
+      expect(result.readiness.score).toBe(45);
+      expect(result.readiness.readiness_score).toBe(45);
+      expect(result.readiness.level).toBe('L1');
+      // DECISION_GRADE label survives — only score/level change. The
+      // backend may re-derive ReadinessState elsewhere; this rim helper
+      // only guarantees no L2+ is rendered.
+      expect(result.readiness.status).toBe('DECISION_GRADE');
+    });
+
+    it('does NOT mutate the input passport', () => {
+      const passport = buildPassport({
+        licensureStatus: 'pending',
+        score: 87,
+        level: 'L3',
+      });
+      const result = applyLicensureCapToPassport(passport);
+      expect(passport.readiness.score).toBe(87);
+      expect(passport.readiness.level).toBe('L3');
+      expect(result).not.toBe(passport);
+    });
+
+    it('preserves source-state distinction — only readiness fields are touched', () => {
+      const passport = buildPassport({
+        licensureStatus: 'pending',
+        score: 87,
+        level: 'L3',
+      });
+      const result = applyLicensureCapToPassport(passport);
+      expect(result.standing).toBe(passport.standing);
+      expect(result.sourceCoverage).toBe(passport.sourceCoverage);
+      expect(result.trustPosture).toBe(passport.trustPosture);
+      expect(result.identity).toBe(passport.identity);
+    });
+
+    it('cap composes with BLOCKED — BLOCKED stays BLOCKED, level stays L0', () => {
+      const passport = buildPassport({
+        licensureStatus: 'pending',
+        score: 12,
+        status: 'BLOCKED',
+        level: 'L0',
+      });
+      const result = applyLicensureCapToPassport(passport);
+      // Score already below ceiling → no-op
+      expect(result).toBe(passport);
+      expect(result.readiness.level).toBe('L0');
+    });
+  });
+});

--- a/apps/web/app/passport/[id]/PassportEntityClient.tsx
+++ b/apps/web/app/passport/[id]/PassportEntityClient.tsx
@@ -10,6 +10,10 @@ import type { PassportData } from '@/lib/trust/passport-contract';
 import { KnowledgeInboxPanel } from '@/components/knowledge-inbox/KnowledgeInboxPanel';
 import type { KnowledgeInboxItem } from '@/lib/knowledge-inbox/types';
 import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
+import {
+  applyLicensureCapToPassport,
+  readLicensureUiState,
+} from '@/lib/readiness/licensureCap';
 
 interface PassportEntityClientProps {
   entityId: string;
@@ -74,9 +78,26 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
   // in classification — see lib/knowledge-inbox/classifyInboxItem.ts.
   const inboxItems: KnowledgeInboxItem[] = [];
 
+  // W1.1b — defense-in-depth licensure cap. The backend's
+  // applyReadinessLicensureCap (passportService.ts) is authoritative;
+  // this rim clamp is a no-op when the backend already capped, and a
+  // safety net when the surface is fed cached or demo data that bypassed
+  // the backend cap. Source-state distinction is preserved on the
+  // original passport object — only score / readiness_score / level are
+  // clamped.
+  const cappedPassport = applyLicensureCapToPassport(passport);
+  const licensureUi = readLicensureUiState(cappedPassport);
+
   return (
-    <div className="flex flex-col gap-8 pb-16">
-      <PassportWallet passport={passport} />
+    <div
+      className="flex flex-col gap-8 pb-16"
+      data-licensure-state={licensureUi.uiState}
+      data-licensure-raw={licensureUi.rawStatus}
+      data-licensure-cap-engaged={String(licensureUi.capEngaged)}
+      data-readiness-score={String(cappedPassport.readiness.score)}
+      data-readiness-level={cappedPassport.readiness.level}
+    >
+      <PassportWallet passport={cappedPassport} />
       <div className="mx-auto max-w-[480px] sm:max-w-[640px] md:max-w-3xl lg:max-w-4xl px-4 w-full space-y-8">
         <section
           aria-label="Source health"

--- a/apps/web/lib/demo/demoProfiles.ts
+++ b/apps/web/lib/demo/demoProfiles.ts
@@ -35,16 +35,21 @@ export interface DemoProfile {
 
 export const DEMO_PROFILES: Record<string, DemoProfile> = {
   '1003000126': {
+    // W1.1b — Sarah Chen previously rendered as DECISION_GRADE / score 87
+    // while Nursys + FSMB licensure sources were `access-required`. NPPES +
+    // OIG + PECOS by themselves do NOT verify state licensure, so a
+    // DECISION_GRADE label was a W1.1 violation. Capped to PARTIAL / 45 to
+    // honor the engine-level invariant: no L2+ without verified licensure.
     npi: '1003000126',
     name: 'Sarah Chen, MD',
     specialty: 'Internal Medicine',
-    readiness: 'DECISION_GRADE',
-    readinessScore: 87,
+    readiness: 'PARTIAL',
+    readinessScore: 45,
     verifiedItems: ['NPI identity checked', 'OIG / LEIE checked', 'Medicare enrolled'],
     missingItems: [],
     gatedItems: ['State license - Nursys (access required)', 'FSMB board history (access required)'],
     blockers: [],
-    estimatedStart: '7-14 days',
+    estimatedStart: '14-21 days (pending state license verification)',
     sources: {
       nppes: { status: 'checked', npiVerified: true },
       oigLeie: { status: 'checked', exclusionClear: true },
@@ -54,11 +59,14 @@ export const DEMO_PROFILES: Record<string, DemoProfile> = {
     },
   },
   '1942788324': {
+    // W1.1b — score lowered from 54 → 45 (L1 ceiling) to honor the
+    // licensure cap. Marcus's PECOS enrollment is missing AND Nursys/FSMB
+    // are access-required; either gap alone holds the cap engaged.
     npi: '1942788324',
     name: 'Marcus Williams, DO',
     specialty: 'Emergency Medicine',
     readiness: 'PARTIAL',
-    readinessScore: 54,
+    readinessScore: 45,
     verifiedItems: ['NPI identity checked', 'OIG / LEIE checked'],
     missingItems: ['Medicare enrollment not found - submit PECOS enrollment (45-60 days)'],
     gatedItems: ['State license - Nursys (access required)', 'FSMB board history (access required)'],

--- a/apps/web/lib/readiness/licensureCap.ts
+++ b/apps/web/lib/readiness/licensureCap.ts
@@ -1,0 +1,113 @@
+/**
+ * lib/readiness/licensureCap.ts
+ *
+ * Web-side defense-in-depth mirror of the W1.1 engine cap and the W1.1b
+ * backend cap. The authoritative source is the backend (passportService);
+ * this module exists for surfaces that consume passport data WITHOUT
+ * going through the backend (cached payloads, demo fixtures, server-
+ * less cold starts that hand a stale snapshot to the client).
+ *
+ * Truth contracts mirrored here:
+ *   - When `standing.licensureStatus !== 'verified'`, the readiness score
+ *     cannot exceed `READINESS_LICENSURE_UNVERIFIED_CEILING` (45).
+ *   - The cap is a hard ceiling — `Math.min` only, never raises a lower
+ *     score.
+ *   - The displayed `level` is derived from the capped score, so a
+ *     45 cap deterministically becomes L1 (Provisional).
+ *   - Source-state distinction (`access_required` vs `unsupported` vs
+ *     `missing` etc.) is preserved on the original object — the cap
+ *     only modifies score/level, never the underlying coverage shape.
+ *
+ * Aligned numerically with `CRS_LICENSURE_UNVERIFIED_CEILING` in
+ * packages/crs/CrsEngine.ts and `READINESS_LICENSURE_UNVERIFIED_CEILING`
+ * in apps/api/backend/src/services/entity/passportService.ts. If any
+ * one of these three constants changes, all three must change together.
+ */
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+export const READINESS_LICENSURE_UNVERIFIED_CEILING = 45;
+
+export type LicensureUiState =
+  | 'verified'
+  | 'unverified'
+  | 'unknown';
+
+/**
+ * Reduces the four-state `standing.licensureStatus` to the boolean cap
+ * decision (verified ↔ uncapped). Other fields (`'pending'`, `'expired'`,
+ * `'unknown'`) all leave the cap engaged.
+ *
+ * Returns the original string for use as a `data-licensure-state`
+ * attribute when the surface wants a richer audit trail.
+ */
+export function readLicensureUiState(
+  passport: Pick<PassportData, 'standing'>,
+): { capEngaged: boolean; rawStatus: PassportData['standing']['licensureStatus']; uiState: LicensureUiState } {
+  const rawStatus = passport.standing.licensureStatus;
+  const verified = rawStatus === 'verified';
+  return {
+    capEngaged: !verified,
+    rawStatus,
+    uiState: verified ? 'verified' : rawStatus === 'unknown' ? 'unknown' : 'unverified',
+  };
+}
+
+/**
+ * Clamp a score by the licensure cap. Pure — never raises.
+ */
+export function clampReadinessScore(
+  score: number,
+  licensureStatus: PassportData['standing']['licensureStatus'],
+): number {
+  if (licensureStatus === 'verified') {
+    return score;
+  }
+  return Math.min(score, READINESS_LICENSURE_UNVERIFIED_CEILING);
+}
+
+/**
+ * Derive the readiness level from a (post-cap) score. Mirrors the
+ * backend `derivePassportReadinessLevel` so a capped score deterministically
+ * resolves to L1, never L2+.
+ *
+ * Note: backend returns level as a free-form string. This helper returns
+ * only the levels actually emitted today (L0–L3) so callers can switch on
+ * a finite set when rendering.
+ */
+export function deriveLevelFromScore(score: number, status: PassportData['readiness']['status']): 'L0' | 'L1' | 'L2' | 'L3' {
+  if (status === 'BLOCKED') return 'L0';
+  if (score >= 80 && status === 'DECISION_GRADE') return 'L3';
+  if (score >= 60) return 'L2';
+  if (score > 0) return 'L1';
+  return 'L0';
+}
+
+/**
+ * Apply the licensure cap to a PassportData copy. Does NOT mutate the
+ * input. Returns a fresh object with `readiness.score`, `readiness.readiness_score`,
+ * and `readiness.level` clamped when `standing.licensureStatus !== 'verified'`.
+ *
+ * Surfaces that already trust a backend-capped passport are free to
+ * skip this — it's a no-op when the input is already capped. Surfaces
+ * that handle demo/cached/legacy payloads should call this before render.
+ */
+export function applyLicensureCapToPassport(passport: PassportData): PassportData {
+  const { capEngaged } = readLicensureUiState(passport);
+  if (!capEngaged) {
+    return passport;
+  }
+  const cappedScore = clampReadinessScore(passport.readiness.score, passport.standing.licensureStatus);
+  if (cappedScore === passport.readiness.score) {
+    return passport;
+  }
+  const cappedLevel = deriveLevelFromScore(cappedScore, passport.readiness.status);
+  return {
+    ...passport,
+    readiness: {
+      ...passport.readiness,
+      score: cappedScore,
+      readiness_score: cappedScore,
+      level: cappedLevel,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Mirrors the W1.1 engine-level licensure invariant (#266) at every readiness-producing layer. After this PR no production or demo surface can render >45 / GREEN / L2+ when licensure is unverified.

Independent of #266 — does not import \`@vitalcv/crs\`, defines its own ceiling constants with cross-references in docblocks.

## Three-tier propagation

### Tier 1 — Backend cap (single root)
- **\`apps/api/backend/src/services/entity/readinessLicensureCap.ts\`** (new): pure helper \`applyReadinessLicensureCap(score, licensureStatus)\`. Lives in its own module so the test compiles in isolation around pre-existing TS errors elsewhere in \`passportService.ts\` (lines 2184, 2209 — unrelated work).
- **\`apps/api/backend/src/services/entity/passportService.ts\`**: imports the helper and applies it inside the \`readinessScore\` IIFE (~line 2262). Since the capped score feeds \`derivePassportReadinessLevel\`, a 45 cap deterministically resolves to L1 — no separate level cap needed.

### Tier 2 — Demo fixture alignment (production demo bypass)
- **\`apps/web/lib/demo/demoProfiles.ts\`**:
  - Sarah Chen (NPI 1003000126) previously rendered as \`DECISION_GRADE\` / score 87 while Nursys + FSMB were \`access-required\` — **direct W1.1 violation in production demo**. Capped to \`PARTIAL\` / 45.
  - Marcus Williams (NPI 1942788324) lowered 54 → 45 (PECOS missing + Nursys/FSMB access-required).

### Tier 3 — Web defense-in-depth
- **\`apps/web/lib/readiness/licensureCap.ts\`** (new): pure helpers \`applyLicensureCapToPassport\`, \`clampReadinessScore\`, \`deriveLevelFromScore\`, \`readLicensureUiState\`. Safety net for surfaces that consume passport data WITHOUT going through the backend (cached payloads, demo fixtures, serverless cold starts).
- **\`apps/web/app/passport/[id]/PassportEntityClient.tsx\`**: applies the cap before render and emits data attributes on root div:
  - \`data-licensure-state\` (\`verified\` / \`unverified\` / \`unknown\`)
  - \`data-licensure-raw\` (the original \`'verified' | 'pending' | 'expired' | 'unknown'\`)
  - \`data-licensure-cap-engaged\` (\`true\` / \`false\`)
  - \`data-readiness-score\` (post-cap)
  - \`data-readiness-level\` (post-cap)

Source-state distinction (\`access_required\` vs \`unsupported\` vs \`missing\` etc.) is **preserved on the \`standing\` object** — only \`readiness.{score, readiness_score, level}\` clamps.

## Out of scope (documented for follow-ups)
- **\`apps/web/components/marketing/ReadinessDemo.tsx\`** claims DEA + ABMS + state-license verified for hardcoded profiles. The profiles claim \`verified\`, so the cap doesn't fire. The deeper drift (catalog claims integrations VitalCV doesn't have) is W1.3's catalog-cleanup job.
- **\`apps/web/components/employers/ClinicianReadinessCheck.tsx\`** consumes \`/api/trust-state/:npi\` — inherits the backend cap once that route's payload includes \`standing.licensureStatus\`. No web-side clamp needed there.
- **\`apps/web/components/mobile/ClinicianReadinessSurface.tsx\`** consumes \`useClinicianMobile()\` hook output — inherits the backend cap.

## Constant alignment
Three constants share the value 45:
- \`packages/crs/CrsEngine.ts\` → \`CRS_LICENSURE_UNVERIFIED_CEILING\` (engine, PR #266)
- \`apps/api/backend/.../readinessLicensureCap.ts\` → \`READINESS_LICENSURE_UNVERIFIED_CEILING\` (this PR)
- \`apps/web/lib/readiness/licensureCap.ts\` → \`READINESS_LICENSURE_UNVERIFIED_CEILING\` (this PR)

If any change, all three must change together. Each docblock cross-references the others.

## Test plan
- [x] **Backend**: 7 jest tests pass (\`pnpm --filter chai-vc-platform-backend test -- passportService-licensure-cap\`)
- [x] **Web**: 17 vitest tests pass (\`pnpm --filter @vitalcv/web exec vitest run __tests__/readiness-licensure-cap.test.ts\`)
- [x] Pre-existing \`passportService.test.ts\` failure on origin/main is unrelated (independently confirmed via git stash) — same TS errors at lines 2184, 2209
- [ ] Manual: load \`/passport/<NPI>\` for an unverified-licensure record, inspect DOM for \`data-licensure-state="unverified"\`, score ≤ 45, level "L1"

## Remaining surfaces still NOT governed by CRS invariants (documented)
- \`apps/web/components/marketing/ReadinessDemo.tsx\` — hardcoded marketing scores 84/71/96 with claimed verified state licenses; deeper drift (W1.3 catalog)
- \`apps/web/components/hero/ReadinessPreview.tsx\` — consumes \`ClinicianTrustState\` not \`PassportData\`; backend cap covers it once trust-state endpoint includes \`licensureStatus\`
- \`apps/web/app/p/[slug]/page.tsx\` — public proof page uses \`proofTier\` (no score render); not affected
- \`apps/web/app/holder/readiness/ReadinessSurface.tsx\` — demo-snapshot only, hardcoded score 25 (already L1); production wiring TBD

🤖 Generated with [Claude Code](https://claude.com/claude-code)