### PR TITLE
feat(inbox): AI Knowledge Inbox surface foundation (Wave D Phase 2)

### DIFF
--- a/apps/web/__tests__/inbox-data.test.ts
+++ b/apps/web/__tests__/inbox-data.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DOC_CLASS_META,
+  INBOX_PROVENANCE_META,
+  computeInboxStats,
+  demoInbox,
+  formatBytes,
+} from '@/lib/inbox/inboxData';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('INBOX_PROVENANCE_META', () => {
+  it('has 5 provenance states', () => {
+    expect(Object.keys(INBOX_PROVENANCE_META)).toEqual([
+      'source_confirmed',
+      'inferred',
+      'user_entered',
+      'unknown',
+      'contradicted',
+    ]);
+  });
+
+  it('does NOT use the bare label "Verified" for any provenance', () => {
+    // CLAUDE.md bans bare "Verified" as a status label. The strongest
+    // provenance is mapped to "Source-confirmed" instead.
+    for (const meta of Object.values(INBOX_PROVENANCE_META)) {
+      expect(meta.label).not.toBe('Verified');
+    }
+    expect(INBOX_PROVENANCE_META.source_confirmed.label).toBe('Source-confirmed');
+  });
+});
+
+describe('DOC_CLASS_META', () => {
+  it('has 8 document classifications', () => {
+    expect(Object.keys(DOC_CLASS_META)).toEqual([
+      'cv',
+      'state_license',
+      'board_cert',
+      'dea',
+      'malpractice',
+      'diploma',
+      'attestation',
+      'unknown',
+    ]);
+  });
+
+  it('uses a vendor-neutral label for the controlled-substance authority class', () => {
+    // CR-3 Element D is named "DEA" by NCQA but the user-facing
+    // label intentionally avoids naming a specific upstream vendor
+    // because no real DEA integration is wired today.
+    expect(DOC_CLASS_META.dea.label).not.toContain('DEA');
+    expect(DOC_CLASS_META.dea.label).toBe('Controlled-Substance Authority');
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders bytes under 1 kB as B', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('renders kB when 1 kB ≤ b < 1 MB', () => {
+    expect(formatBytes(1024)).toBe('1.0 kB');
+    expect(formatBytes(184_392)).toBe('180.1 kB');
+  });
+
+  it('renders MB when b ≥ 1 MB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(2_840_122)).toBe('2.7 MB');
+  });
+});
+
+describe('demoInbox', () => {
+  it('returns an InboxState with isDemo === literal true', () => {
+    const s = demoInbox();
+    expect(s.isDemo).toBe(true);
+  });
+
+  it('has 5 demo documents covering processed / classifying / unclassified', () => {
+    const s = demoInbox();
+    expect(s.documents.length).toBe(5);
+    const states = s.documents.map((d) => d.state);
+    expect(states.filter((x) => x === 'processed').length).toBe(3);
+    expect(states.filter((x) => x === 'classifying').length).toBe(1);
+    expect(states.filter((x) => x === 'unclassified').length).toBe(1);
+  });
+
+  it('classifying document carries null classification + null confidence', () => {
+    const s = demoInbox();
+    const c = s.documents.find((d) => d.state === 'classifying');
+    expect(c?.classification).toBeNull();
+    expect(c?.classificationConfidence).toBeNull();
+    expect(c?.extractedCount).toBe(0);
+  });
+
+  it('every extracted field uses a non-banned provenance', () => {
+    const s = demoInbox();
+    const valid = new Set(Object.keys(INBOX_PROVENANCE_META));
+    for (const list of Object.values(s.extractions)) {
+      for (const f of list) {
+        expect(valid.has(f.provenance)).toBe(true);
+      }
+    }
+  });
+
+  it('renders no banned overclaim copy in any string field', () => {
+    const s = demoInbox();
+    const blob = JSON.stringify({ s, INBOX_PROVENANCE_META, DOC_CLASS_META }).toLowerCase();
+    for (const phrase of BANNED) {
+      expect(blob).not.toContain(phrase.toLowerCase());
+    }
+  });
+});
+
+describe('computeInboxStats', () => {
+  it('matches the demoInbox composition', () => {
+    const s = demoInbox();
+    const stats = computeInboxStats(s);
+    expect(stats.docCount).toBe(5);
+    expect(stats.processed).toBe(3);
+    expect(stats.classifying).toBe(1);
+    expect(stats.unclassified).toBe(1);
+    // demoInbox has 4+4+3 = 11 extractions across 3 processed docs.
+    expect(stats.extractedFields).toBe(11);
+    expect(stats.suggestionCount).toBe(3);
+  });
+
+  it('returns all zeros for an empty inbox', () => {
+    const stats = computeInboxStats({
+      isDemo: true,
+      documents: [],
+      extractions: {},
+      suggestions: [],
+    });
+    expect(stats).toEqual({
+      docCount: 0,
+      processed: 0,
+      classifying: 0,
+      unclassified: 0,
+      extractedFields: 0,
+      suggestionCount: 0,
+    });
+  });
+});

--- a/apps/web/__tests__/inbox-page-render.test.tsx
+++ b/apps/web/__tests__/inbox-page-render.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import InboxPage from '../app/inbox/page';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+function renderInbox(): string {
+  const element = InboxPage();
+  return renderToStaticMarkup(element as React.ReactElement);
+}
+
+describe('inbox page — render', () => {
+  it('renders the demo banner', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-demo-banner"');
+    expect(html).toContain('Demo intake');
+    expect(html).toContain('data-is-demo="true"');
+    expect(html).toContain('data-doc-count="5"');
+  });
+
+  it('renders the stats strip with all 6 cells', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-stats-strip"');
+    for (const id of [
+      'stat-docs',
+      'stat-processed',
+      'stat-classifying',
+      'stat-unclassified',
+      'stat-extracted',
+      'stat-suggestions',
+    ]) {
+      expect(html).toContain(`data-testid="${id}"`);
+    }
+  });
+
+  it('renders the dropzone placeholder explicitly disabled for Phase 1', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-dropzone-placeholder"');
+    expect(html).toContain('Phase 2');
+  });
+
+  it('renders the document list with all 5 demo docs and their states', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-document-list"');
+    for (const id of ['doc-001', 'doc-002', 'doc-003', 'doc-004', 'doc-005']) {
+      expect(html).toContain(`data-doc-id="${id}"`);
+    }
+    expect(html).toContain('data-doc-state="processed"');
+    expect(html).toContain('data-doc-state="classifying"');
+    expect(html).toContain('data-doc-state="unclassified"');
+  });
+
+  it('renders document detail panels for processed docs only', () => {
+    const html = renderInbox();
+    // 3 processed docs => 3 detail panels.
+    const matches = html.match(/data-testid="inbox-document-detail"/g) ?? [];
+    expect(matches.length).toBe(3);
+  });
+
+  it('renders provenance badges using the project-safe label "Source-confirmed", not bare "Verified"', () => {
+    const html = renderInbox();
+    // Legend renders all 5 provenance badges, including source-confirmed.
+    expect(html).toContain('Source-confirmed');
+    expect(html).toContain('data-provenance-label="Source-confirmed"');
+    // Bare "Verified" must not appear as a status label anywhere on the
+    // page — neither as a badge label nor as an inline tag.
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+    expect(html).not.toContain('data-provenance-label="Verified"');
+  });
+
+  it('renders suggestions with disabled accept buttons in Phase 1', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-suggestions-section"');
+    const acceptButtons = html.match(/data-testid="suggestion-accept-button"/g) ?? [];
+    expect(acceptButtons.length).toBe(3);
+    expect(html).toContain('data-disabled-reason="phase-2-pending"');
+  });
+
+  it('renders the provenance legend with all 5 keys', () => {
+    const html = renderInbox();
+    expect(html).toContain('data-testid="inbox-provenance-legend"');
+    for (const key of ['source_confirmed', 'inferred', 'user_entered', 'unknown', 'contradicted']) {
+      expect(html).toContain(`data-provenance-key="${key}"`);
+    }
+  });
+
+  it('introduces no banned overclaim copy', () => {
+    const html = renderInbox();
+    const lower = html.toLowerCase();
+    for (const phrase of BANNED) {
+      expect(lower).not.toContain(phrase.toLowerCase());
+    }
+  });
+});

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -1,0 +1,367 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import {
+  DOC_CLASS_META,
+  INBOX_PROVENANCE_META,
+  computeInboxStats,
+  demoInbox,
+  formatBytes,
+  type InboxDocument,
+  type InboxExtractedField,
+  type InboxProvenance,
+  type InboxState,
+  type InboxSuggestion,
+} from '@/lib/inbox/inboxData';
+
+export const metadata: Metadata = {
+  title: 'AI Knowledge Inbox · Demo · VitalCV',
+  description:
+    'Demo render of the document intake surface. Classification organizes information; primary-source checks decide what becomes confirmed.',
+};
+
+const TONE_BADGE: Record<string, string> = {
+  emerald: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700',
+  amber: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
+  slate: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+  purple: 'border-purple-500/30 bg-purple-500/10 text-purple-700',
+};
+
+export default function InboxPage() {
+  const state = demoInbox();
+  const stats = computeInboxStats(state);
+
+  return (
+    <main
+      className="mx-auto max-w-[1200px] px-4 py-6 sm:px-6 sm:py-8"
+      data-testid="inbox-page"
+      data-is-demo={String(state.isDemo)}
+      data-doc-count={String(stats.docCount)}
+    >
+      <header className="border-b border-border pb-3" data-testid="inbox-header">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          AI Knowledge Inbox
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-foreground sm:text-3xl">
+          Document intake
+        </h1>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Classification organizes information. Primary-source checks decide
+          what becomes source-confirmed. Inferred fields are not verification
+          claims.
+        </p>
+      </header>
+
+      <p
+        className="mt-4 inline-block rounded-md bg-amber-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-amber-800"
+        data-testid="inbox-demo-banner"
+      >
+        Demo intake — illustrative only, not a real clinician&rsquo;s documents
+      </p>
+
+      <StatsStrip state={state} />
+
+      <DropzonePlaceholder />
+
+      <div className="mt-6 grid grid-cols-12 gap-6">
+        <aside
+          className="col-span-12 lg:col-span-5 lg:sticky lg:top-[72px] lg:self-start"
+          aria-label="Document list"
+        >
+          <DocumentList documents={state.documents} />
+        </aside>
+        <div className="col-span-12 lg:col-span-7 space-y-6">
+          {state.documents
+            .filter((d) => d.state === 'processed')
+            .map((doc) => (
+              <DocumentDetail
+                key={doc.id}
+                doc={doc}
+                fields={state.extractions[doc.id] ?? []}
+              />
+            ))}
+        </div>
+      </div>
+
+      <SuggestionsSection suggestions={state.suggestions} />
+
+      <ProvenanceLegend />
+    </main>
+  );
+}
+
+function StatsStrip({ state }: { state: InboxState }) {
+  const stats = computeInboxStats(state);
+  const cells = [
+    { label: 'Documents',         value: stats.docCount,         testId: 'stat-docs' },
+    { label: 'Processed',         value: stats.processed,        testId: 'stat-processed' },
+    { label: 'Classifying',       value: stats.classifying,      testId: 'stat-classifying' },
+    { label: 'Unclassified',      value: stats.unclassified,     testId: 'stat-unclassified' },
+    { label: 'Extracted fields',  value: stats.extractedFields,  testId: 'stat-extracted' },
+    { label: 'Suggestions',       value: stats.suggestionCount,  testId: 'stat-suggestions' },
+  ];
+  return (
+    <section
+      aria-labelledby="stats-heading"
+      className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6"
+      data-testid="inbox-stats-strip"
+    >
+      <h2 id="stats-heading" className="sr-only">
+        Inbox stats
+      </h2>
+      {cells.map((c) => (
+        <div
+          key={c.testId}
+          className="rounded-md border border-border bg-card p-3"
+          data-testid={c.testId}
+        >
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+            {c.label}
+          </p>
+          <p className="mt-1 text-xl font-semibold text-foreground tabular-nums">
+            {c.value}
+          </p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function DropzonePlaceholder() {
+  // Phase 1 renders a placeholder dropzone — interactive upload is
+  // Phase 2 work (needs auth + chunked upload + virus scan + the
+  // real classifier). The page surfaces the affordance so a viewer
+  // sees where uploads will live.
+  return (
+    <section
+      aria-labelledby="dropzone-heading"
+      className="mt-6 rounded-md border border-dashed border-border bg-muted/10 p-6 text-center"
+      data-testid="inbox-dropzone-placeholder"
+    >
+      <h2 id="dropzone-heading" className="text-sm font-semibold text-foreground">
+        Drop documents here (Phase 2)
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Upload, classification, and OCR run in a queued worker. The current
+        view renders the demo inbox state; live upload is wired in a later
+        phase.
+      </p>
+    </section>
+  );
+}
+
+function DocumentList({ documents }: { documents: ReadonlyArray<InboxDocument> }) {
+  return (
+    <ol
+      className="rounded-md border border-border bg-card overflow-hidden"
+      data-testid="inbox-document-list"
+    >
+      {documents.map((doc, i) => {
+        const cls = doc.classification ? DOC_CLASS_META[doc.classification] : null;
+        return (
+          <li
+            key={doc.id}
+            className={`flex items-start gap-3 p-3 ${i < documents.length - 1 ? 'border-b border-border/50' : ''}`}
+            data-doc-id={doc.id}
+            data-doc-state={doc.state}
+            data-classification={doc.classification ?? 'none'}
+          >
+            <div
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-border bg-muted/30 text-[9.5px] font-mono uppercase tracking-wider text-muted-foreground"
+              aria-hidden="true"
+            >
+              {cls?.glyph ?? '·'}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-foreground">
+                {doc.name}
+              </p>
+              <p className="text-[10px] text-muted-foreground">
+                {formatBytes(doc.bytes)} · {doc.pages} pp · {doc.receivedRel}
+              </p>
+              <p className="mt-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+                {cls?.label ?? 'pending'} ·{' '}
+                <span data-doc-state-label={doc.state}>{doc.state}</span>
+                {doc.classificationConfidence !== null && (
+                  <>
+                    {' '}
+                    · {(doc.classificationConfidence * 100).toFixed(0)}%
+                  </>
+                )}
+              </p>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function DocumentDetail({
+  doc,
+  fields,
+}: {
+  doc: InboxDocument;
+  fields: ReadonlyArray<InboxExtractedField>;
+}) {
+  return (
+    <section
+      className="rounded-md border border-border bg-card p-5"
+      aria-labelledby={`doc-${doc.id}-heading`}
+      data-testid="inbox-document-detail"
+      data-doc-id={doc.id}
+    >
+      <header className="mb-3 border-b border-border/50 pb-2">
+        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+          {DOC_CLASS_META[doc.classification ?? 'unknown'].label}
+        </p>
+        <h2
+          id={`doc-${doc.id}-heading`}
+          className="text-base font-semibold text-foreground"
+        >
+          {doc.name}
+        </h2>
+        {doc.classificationReason && (
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {doc.classificationReason}
+          </p>
+        )}
+      </header>
+      {fields.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No extractions yet for this document.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {fields.map((f) => (
+            <li
+              key={f.fieldKey}
+              className="rounded border border-border/60 bg-background/40 p-2.5"
+              data-field-key={f.fieldKey}
+              data-provenance={f.provenance}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+                  {f.label}
+                </p>
+                <ProvenanceBadge provenance={f.provenance} />
+              </div>
+              <p className="mt-1 text-sm text-foreground">{f.value}</p>
+              {f.confidence !== null && (
+                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                  AI confidence {(f.confidence * 100).toFixed(0)}%
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ProvenanceBadge({ provenance }: { provenance: InboxProvenance }) {
+  const meta = INBOX_PROVENANCE_META[provenance];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${TONE_BADGE[meta.tone]}`}
+      title={meta.description}
+      data-provenance-label={meta.label}
+    >
+      <span aria-hidden="true">{meta.glyph}</span>
+      {meta.label}
+    </span>
+  );
+}
+
+function SuggestionsSection({
+  suggestions,
+}: {
+  suggestions: ReadonlyArray<InboxSuggestion>;
+}) {
+  return (
+    <section
+      aria-labelledby="suggestions-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="inbox-suggestions-section"
+    >
+      <h2 id="suggestions-heading" className="text-base font-semibold sm:text-lg">
+        Suggested profile updates
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Inferred from the documents above. Accepting a suggestion writes a
+        user-entered field to your profile — it does NOT mark the field as
+        source-confirmed. A primary-source check is required for that.
+      </p>
+      {suggestions.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground">No suggestions.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {suggestions.map((s) => (
+            <li
+              key={s.id}
+              className="rounded border border-border/60 bg-background/40 p-3"
+              data-testid="inbox-suggestion"
+              data-suggestion-id={s.id}
+              data-source-doc={s.sourceDocId}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-sm font-medium text-foreground">{s.label}</p>
+                <p className="text-[10px] font-mono text-muted-foreground">
+                  AI {(s.confidence * 100).toFixed(0)}%
+                </p>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Field <code className="font-mono">{s.fieldKey}</code>:
+                proposed <span className="font-mono">{s.suggestedValue}</span>
+                {s.currentValue !== null && (
+                  <>
+                    {' '}
+                    · current <span className="font-mono">{s.currentValue}</span>
+                  </>
+                )}
+              </p>
+              <button
+                type="button"
+                disabled
+                title="Accept-into-profile is a Phase 2 feature"
+                className="mt-3 inline-flex items-center justify-center rounded border border-border px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider opacity-50 cursor-not-allowed"
+                data-testid="suggestion-accept-button"
+                data-disabled-reason="phase-2-pending"
+              >
+                Accept (Phase 2)
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ProvenanceLegend() {
+  return (
+    <section
+      aria-labelledby="provenance-legend-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="inbox-provenance-legend"
+    >
+      <h2
+        id="provenance-legend-heading"
+        className="text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+      >
+        Provenance vocabulary
+      </h2>
+      <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+        {Object.entries(INBOX_PROVENANCE_META).map(([key, meta]) => (
+          <div key={key} className="rounded border border-border/60 p-3" data-provenance-key={key}>
+            <dt className="flex items-center gap-2 text-xs font-semibold text-foreground">
+              <ProvenanceBadge provenance={key as InboxProvenance} />
+            </dt>
+            <dd className="mt-2 text-[11px] text-muted-foreground">{meta.description}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/lib/inbox/inboxData.ts
+++ b/apps/web/lib/inbox/inboxData.ts
@@ -1,0 +1,318 @@
+/**
+ * Wave D Phase 2 — AI Knowledge Inbox data shape + demo fixture.
+ *
+ * Pure types + a single demoInbox() fixture. No fetch, no DB, no DOM.
+ *
+ * PRINCIPLE (from data-inbox.jsx):
+ *   Classification organizes information.
+ *   Source checks decide what becomes verified.
+ *
+ * Truth contract:
+ *   - The provenance vocabulary distinguishes AI extractions from
+ *     primary-source confirmations. The "source_confirmed" provenance
+ *     is the strongest possible state and means a primary-source
+ *     authority confirmed the field during ingest. We do NOT use the
+ *     bare label "Verified" anywhere — CLAUDE.md bans bare "Verified"
+ *     status labels — so the design's `verified` provenance maps to
+ *     `source_confirmed` here, with a label "Source-confirmed".
+ *   - The page that renders this data always carries a
+ *     "Demo intake — illustrative only" banner. data-is-demo is the
+ *     literal `true`.
+ *   - This module does NOT introduce a real OCR pipeline, classifier,
+ *     or PSV check. The demo data describes the *shape* of intake,
+ *     not active intelligence.
+ */
+
+export type InboxProvenance =
+  | 'source_confirmed'
+  | 'inferred'
+  | 'user_entered'
+  | 'unknown'
+  | 'contradicted';
+
+export interface InboxProvenanceMeta {
+  /** Visible label. We intentionally do not use the bare word
+   *  "Verified" anywhere — see CLAUDE.md banned-status-labels. */
+  label: string;
+  description: string;
+  glyph: string;
+  /** Subtle styling token. Resolved to actual classes in the page. */
+  tone: 'emerald' | 'amber' | 'slate' | 'purple';
+}
+
+export const INBOX_PROVENANCE_META: Record<InboxProvenance, InboxProvenanceMeta> = {
+  source_confirmed: {
+    label: 'Source-confirmed',
+    description:
+      'Confirmed against a primary-source authority during ingest.',
+    glyph: '✔',
+    tone: 'emerald',
+  },
+  inferred: {
+    label: 'Inferred',
+    description:
+      'AI-extracted from this document. Not primary-source confirmed.',
+    glyph: '≈',
+    tone: 'amber',
+  },
+  user_entered: {
+    label: 'User-entered',
+    description:
+      'Typed by the clinician. Owned but not source-checked.',
+    glyph: '✎',
+    tone: 'slate',
+  },
+  unknown: {
+    label: 'Unknown',
+    description:
+      'Not found in this document. Not a negative signal.',
+    glyph: '?',
+    tone: 'amber',
+  },
+  contradicted: {
+    label: 'Contradicted',
+    description:
+      'Two extractions disagree. Requires reconciliation.',
+    glyph: '⑂',
+    tone: 'purple',
+  },
+};
+
+export type DocClassification =
+  | 'cv'
+  | 'state_license'
+  | 'board_cert'
+  | 'dea'
+  | 'malpractice'
+  | 'diploma'
+  | 'attestation'
+  | 'unknown';
+
+export interface DocClassMeta {
+  label: string;
+  glyph: string;
+}
+
+export const DOC_CLASS_META: Record<DocClassification, DocClassMeta> = {
+  cv:            { label: 'Curriculum Vitae',       glyph: 'CV'  },
+  state_license: { label: 'State License',          glyph: 'SL'  },
+  board_cert:    { label: 'Board Certification',    glyph: 'BC'  },
+  dea:           { label: 'Controlled-Substance Authority', glyph: 'CSA' },
+  malpractice:   { label: 'Malpractice COI',        glyph: 'COI' },
+  diploma:       { label: 'Diploma / Transcript',   glyph: 'EDU' },
+  attestation:   { label: 'Self-Attestation',       glyph: 'ATT' },
+  unknown:       { label: 'Unclassified',           glyph: '?'   },
+};
+
+export type DocState = 'queued' | 'classifying' | 'processed' | 'unclassified';
+
+export interface InboxDocument {
+  id: string;
+  name: string;
+  bytes: number;
+  pages: number;
+  receivedAt: string;
+  receivedRel: string;
+  state: DocState;
+  classification: DocClassification | null;
+  /** 0..1 confidence the classifier assigned. Null while classifying. */
+  classificationConfidence: number | null;
+  classificationReason?: string;
+  extractedCount: number;
+}
+
+export interface InboxExtractedField {
+  /** Profile field this maps into, e.g. "name.full" or "license.state". */
+  fieldKey: string;
+  label: string;
+  value: string;
+  provenance: InboxProvenance;
+  /** Confidence for AI extractions; null for non-inferred provenance. */
+  confidence: number | null;
+}
+
+export interface InboxSuggestion {
+  id: string;
+  fieldKey: string;
+  label: string;
+  /** What the inbox proposes to write into the profile. */
+  suggestedValue: string;
+  /** What the profile currently holds (may be null on a new field). */
+  currentValue: string | null;
+  /** AI confidence at suggestion time. */
+  confidence: number;
+  /** Document this suggestion was extracted from. */
+  sourceDocId: string;
+}
+
+export interface InboxStats {
+  docCount: number;
+  processed: number;
+  classifying: number;
+  unclassified: number;
+  extractedFields: number;
+  suggestionCount: number;
+}
+
+export interface InboxState {
+  isDemo: true;
+  documents: ReadonlyArray<InboxDocument>;
+  /** Per-document extracted fields. */
+  extractions: Readonly<Record<string, ReadonlyArray<InboxExtractedField>>>;
+  suggestions: ReadonlyArray<InboxSuggestion>;
+}
+
+export function computeInboxStats(state: InboxState): InboxStats {
+  let processed = 0;
+  let classifying = 0;
+  let unclassified = 0;
+  let extractedFields = 0;
+  for (const doc of state.documents) {
+    if (doc.state === 'processed') processed++;
+    else if (doc.state === 'classifying') classifying++;
+    else if (doc.state === 'unclassified') unclassified++;
+  }
+  for (const list of Object.values(state.extractions)) {
+    extractedFields += list.length;
+  }
+  return {
+    docCount: state.documents.length,
+    processed,
+    classifying,
+    unclassified,
+    extractedFields,
+    suggestionCount: state.suggestions.length,
+  };
+}
+
+/** Pretty bytes — kB / MB. Pure helper, testable. */
+export function formatBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} kB`;
+  return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function demoInbox(): InboxState {
+  const documents: ReadonlyArray<InboxDocument> = [
+    {
+      id: 'doc-001',
+      name: 'demo-cv-2026-04.pdf',
+      bytes: 184_392,
+      pages: 3,
+      receivedAt: '2026-04-18T14:18:00Z',
+      receivedRel: '14 min ago',
+      state: 'processed',
+      classification: 'cv',
+      classificationConfidence: 0.94,
+      classificationReason:
+        'Header parsed as a clinician name with credential suffix. Section structure matches the CV pattern (Education → Experience → Certifications). 7 employment entries detected.',
+      extractedCount: 11,
+    },
+    {
+      id: 'doc-002',
+      name: 'demo-state-license-renewal.pdf',
+      bytes: 612_104,
+      pages: 1,
+      receivedAt: '2026-04-18T14:09:00Z',
+      receivedRel: '23 min ago',
+      state: 'processed',
+      classification: 'state_license',
+      classificationConfidence: 0.99,
+      classificationReason:
+        'State professional-licensure board letterhead detected. Wallet-card layout. License number format matches state pattern.',
+      extractedCount: 7,
+    },
+    {
+      id: 'doc-003',
+      name: 'demo-board-certification-2025.pdf',
+      bytes: 248_712,
+      pages: 2,
+      receivedAt: '2026-04-18T14:02:00Z',
+      receivedRel: '30 min ago',
+      state: 'processed',
+      classification: 'board_cert',
+      classificationConfidence: 0.97,
+      classificationReason:
+        'Issuing-board seal recognized. Certification ID format matches pattern.',
+      extractedCount: 6,
+    },
+    {
+      id: 'doc-004',
+      name: 'demo-photo.heic',
+      bytes: 2_840_122,
+      pages: 1,
+      receivedAt: '2026-04-18T14:31:00Z',
+      receivedRel: '1 min ago',
+      state: 'classifying',
+      classification: null,
+      classificationConfidence: null,
+      extractedCount: 0,
+    },
+    {
+      id: 'doc-005',
+      name: 'demo-unknown-form.pdf',
+      bytes: 96_433,
+      pages: 1,
+      receivedAt: '2026-04-17T22:51:00Z',
+      receivedRel: 'yesterday',
+      state: 'unclassified',
+      classification: 'unknown',
+      classificationConfidence: 0.31,
+      classificationReason:
+        'No recognized issuer letterhead. Text density low. Best three guesses: continuing-education certificate (0.31), insurance card (0.18), training receipt (0.11).',
+      extractedCount: 0,
+    },
+  ];
+
+  const extractions: Record<string, ReadonlyArray<InboxExtractedField>> = {
+    'doc-001': [
+      { fieldKey: 'name.full',         label: 'Full name',       value: 'Macie Miller, PA-C',                                provenance: 'inferred',     confidence: 0.93 },
+      { fieldKey: 'credential.suffix', label: 'Credential',      value: 'PA-C',                                              provenance: 'inferred',     confidence: 0.95 },
+      { fieldKey: 'employer.recent',   label: 'Most recent employer', value: 'Demo Surgical Pavilion · 2024–present',         provenance: 'inferred',     confidence: 0.81 },
+      { fieldKey: 'training.school',   label: 'PA training program',  value: 'Demo State University PA Program',              provenance: 'inferred',     confidence: 0.74 },
+    ],
+    'doc-002': [
+      { fieldKey: 'license.state',     label: 'License state',   value: 'CA',                                                provenance: 'inferred',     confidence: 0.99 },
+      { fieldKey: 'license.number',    label: 'License number',  value: 'PA-58129',                                          provenance: 'inferred',     confidence: 0.97 },
+      { fieldKey: 'license.expires',   label: 'Expires',         value: '2027-06-30',                                        provenance: 'inferred',     confidence: 0.95 },
+      { fieldKey: 'license.holder',    label: 'License holder',  value: 'Macie Miller',                                      provenance: 'inferred',     confidence: 0.96 },
+    ],
+    'doc-003': [
+      { fieldKey: 'cert.body',         label: 'Issuing body',    value: 'Demo Board (PA)',                                   provenance: 'inferred',     confidence: 0.96 },
+      { fieldKey: 'cert.id',           label: 'Certificate ID',  value: 'BC-DEMO-9931',                                      provenance: 'inferred',     confidence: 0.93 },
+      { fieldKey: 'cert.expires',      label: 'Expires',         value: '2031-12-31',                                        provenance: 'inferred',     confidence: 0.94 },
+    ],
+  };
+
+  const suggestions: ReadonlyArray<InboxSuggestion> = [
+    {
+      id: 'sug-1',
+      fieldKey: 'license.state',
+      label: 'Set primary licensure state to CA',
+      suggestedValue: 'CA',
+      currentValue: null,
+      confidence: 0.99,
+      sourceDocId: 'doc-002',
+    },
+    {
+      id: 'sug-2',
+      fieldKey: 'license.number',
+      label: 'Set primary license number to PA-58129',
+      suggestedValue: 'PA-58129',
+      currentValue: null,
+      confidence: 0.97,
+      sourceDocId: 'doc-002',
+    },
+    {
+      id: 'sug-3',
+      fieldKey: 'cert.body',
+      label: 'Set certifying body to Demo Board',
+      suggestedValue: 'Demo Board (PA)',
+      currentValue: null,
+      confidence: 0.96,
+      sourceDocId: 'doc-003',
+    },
+  ];
+
+  return { isDemo: true, documents, extractions, suggestions };
+}


### PR DESCRIPTION
Third of six missing design surfaces. New /inbox route with stats strip, document list, per-doc extractions with provenance badges, suggestions, and provenance legend. The design's bare 'Verified' provenance is renamed to 'Source-confirmed' to comply with CLAUDE.md banned-status-labels. 23 tests pass. Verified end-to-end. Codex SAFE.