### PR TITLE
feat(vds): Confidence Doctrine v2 — categorical primitives + doctrine module (Wave 41)

### DIFF
--- a/apps/web/__tests__/confidence-components.test.tsx
+++ b/apps/web/__tests__/confidence-components.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  ConfidenceLegend,
+  type ConfidenceTier,
+} from '../components/vds/confidence';
+import { ConfidenceFieldHelp } from '../components/vds/confidence/ConfidenceFieldHelp';
+import { UnknownFieldExplainer } from '../components/vds/confidence/UnknownFieldExplainer';
+
+// Banned phrases split + joined so a naive grep over this test file does not
+// flag the file itself.
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+const TIERS: readonly ConfidenceTier[] = [
+  'verified',
+  'inferred',
+  'unknown',
+  'contradicted',
+];
+
+describe('ConfidenceLegend', () => {
+  it('renders all four tiers in row layout by default', () => {
+    const html = renderToStaticMarkup(<ConfidenceLegend />);
+    expect(html).toContain('Verified');
+    expect(html).toContain('Inferred');
+    expect(html).toContain('Unknown');
+    expect(html).toContain('Contradicted');
+  });
+
+  it('renders the canonical aria-label', () => {
+    const html = renderToStaticMarkup(<ConfidenceLegend />);
+    expect(html).toContain('aria-label="Confidence tiers"');
+  });
+
+  it('renders descriptions when layout is stack (default behavior)', () => {
+    const html = renderToStaticMarkup(<ConfidenceLegend layout="stack" />);
+    expect(html).toContain('Primary-source registry');
+    expect(html).toContain('AI-derived');
+    expect(html).toContain('Data not on file');
+    expect(html).toContain('disagree');
+  });
+
+  it('omits descriptions when layout is row by default', () => {
+    const html = renderToStaticMarkup(<ConfidenceLegend layout="row" />);
+    expect(html).not.toContain('Primary-source registry');
+    expect(html).not.toContain('AI-derived');
+  });
+
+  it('honors explicit showDescriptions=false override on stack', () => {
+    const html = renderToStaticMarkup(
+      <ConfidenceLegend layout="stack" showDescriptions={false} />,
+    );
+    expect(html).not.toContain('Primary-source registry');
+  });
+
+  it('honors explicit showDescriptions=true override on row', () => {
+    const html = renderToStaticMarkup(
+      <ConfidenceLegend layout="row" showDescriptions />,
+    );
+    expect(html).toContain('Primary-source registry');
+  });
+
+  it('contains zero banned strings', () => {
+    const html = renderToStaticMarkup(
+      <ConfidenceLegend layout="stack" />,
+    ).toLowerCase();
+    for (const banned of BANNED) {
+      expect(html).not.toContain(banned.toLowerCase());
+    }
+  });
+});
+
+describe('ConfidenceFieldHelp', () => {
+  it.each(TIERS)('renders accessible trigger button for tier %s', (tier) => {
+    const html = renderToStaticMarkup(<ConfidenceFieldHelp tier={tier} />);
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('Why is this');
+  });
+
+  it('does not render the popover content on initial server render', () => {
+    const html = renderToStaticMarkup(<ConfidenceFieldHelp tier="inferred" />);
+    expect(html).not.toContain('Press');
+    expect(html).not.toContain('confidence tier explanation');
+  });
+
+  it('contains zero banned strings in any tier render', () => {
+    for (const tier of TIERS) {
+      const html = renderToStaticMarkup(
+        <ConfidenceFieldHelp
+          tier={tier}
+          source="NPPES (CMS)"
+          label="NPI"
+        />,
+      ).toLowerCase();
+      for (const banned of BANNED) {
+        expect(html).not.toContain(banned.toLowerCase());
+      }
+    }
+  });
+});
+
+describe('UnknownFieldExplainer', () => {
+  it('renders the neutral-signal copy', () => {
+    const html = renderToStaticMarkup(<UnknownFieldExplainer />).toLowerCase();
+    expect(html).toContain('not on file');
+    expect(html).toContain('not a negative signal');
+  });
+
+  it('includes the field label when provided', () => {
+    const html = renderToStaticMarkup(
+      <UnknownFieldExplainer fieldLabel="Med school" />,
+    );
+    expect(html).toContain('Med school');
+  });
+
+  it('renders a CTA when both ctaLabel and onRequestUpload are set', () => {
+    const html = renderToStaticMarkup(
+      <UnknownFieldExplainer
+        ctaLabel="Request clinician upload"
+        onRequestUpload={vi.fn()}
+      />,
+    );
+    expect(html).toContain('Request clinician upload');
+  });
+
+  it('omits the CTA when onRequestUpload is missing', () => {
+    const html = renderToStaticMarkup(
+      <UnknownFieldExplainer ctaLabel="Request clinician upload" />,
+    );
+    expect(html).not.toContain('Request clinician upload');
+  });
+
+  it('contains zero banned strings', () => {
+    const html = renderToStaticMarkup(
+      <UnknownFieldExplainer
+        fieldLabel="Subspecialty"
+        ctaLabel="Request clinician upload"
+        onRequestUpload={vi.fn()}
+      />,
+    ).toLowerCase();
+    for (const banned of BANNED) {
+      expect(html).not.toContain(banned.toLowerCase());
+    }
+  });
+});

--- a/apps/web/__tests__/confidence-doctrine.test.ts
+++ b/apps/web/__tests__/confidence-doctrine.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONFIDENCE_TIER_META,
+  CONFIDENCE_TIER_ORDER,
+  CONFIDENCE_TIER_SHORT,
+  confidenceDoctrineNarrative,
+  isConfidenceTier,
+  type ConfidenceTier,
+} from '../components/vds/confidence/doctrine';
+
+// Banned phrases are split + joined so a naive grep over this test file does
+// not flag the file itself; runtime assertions still prove they are absent
+// from real output.
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('Confidence Doctrine v2', () => {
+  it('locks the canonical tier order to exactly four tiers', () => {
+    expect(CONFIDENCE_TIER_ORDER).toEqual([
+      'verified',
+      'inferred',
+      'unknown',
+      'contradicted',
+    ]);
+    expect(CONFIDENCE_TIER_ORDER).toHaveLength(4);
+  });
+
+  it('exposes meta + short copy for every canonical tier', () => {
+    for (const tier of CONFIDENCE_TIER_ORDER) {
+      expect(CONFIDENCE_TIER_META[tier]).toBeDefined();
+      expect(CONFIDENCE_TIER_META[tier].label).toBeTruthy();
+      expect(CONFIDENCE_TIER_META[tier].glyph).toBeTruthy();
+      expect(CONFIDENCE_TIER_META[tier].description).toBeTruthy();
+      expect(CONFIDENCE_TIER_SHORT[tier]).toBeTruthy();
+    }
+  });
+
+  it('describes unknown as a neutral signal, not a negative one', () => {
+    const desc = CONFIDENCE_TIER_META.unknown.description.toLowerCase();
+    expect(desc).toContain('not on file');
+    // The canonical phrasing is "Not a negative signal" (existing meta) or
+    // "neutral signal, not a negative one" (narrative). Either is acceptable
+    // — we just need the disclaimer that absence ≠ deficiency.
+    expect(desc).toMatch(/not a negative|neutral/);
+    // Must not frame absence of data as a deficiency.
+    expect(desc).not.toContain('missing');
+    expect(desc).not.toContain('failure');
+  });
+
+  it('describes unknown in the narrative as explicitly neutral', () => {
+    expect(confidenceDoctrineNarrative.toLowerCase()).toContain('neutral');
+    expect(confidenceDoctrineNarrative.toLowerCase()).toContain(
+      'not a negative',
+    );
+  });
+
+  it('describes contradicted as requiring human reconciliation', () => {
+    const desc = CONFIDENCE_TIER_META.contradicted.description.toLowerCase();
+    expect(desc).toContain('disagree');
+    expect(desc).toMatch(/human|reconciliation/);
+  });
+
+  it('exports a narrative that mentions all four tiers in decision-tree order', () => {
+    expect(confidenceDoctrineNarrative).toContain('verified');
+    expect(confidenceDoctrineNarrative).toContain('inferred');
+    expect(confidenceDoctrineNarrative).toContain('unknown');
+    expect(confidenceDoctrineNarrative).toContain('contradicted');
+    // Decision-tree ordering: verified appears before inferred, which appears
+    // before unknown, which appears before contradicted.
+    const idxVerified = confidenceDoctrineNarrative.indexOf('verified');
+    const idxInferred = confidenceDoctrineNarrative.indexOf('inferred');
+    const idxUnknown = confidenceDoctrineNarrative.indexOf('unknown');
+    const idxContradicted = confidenceDoctrineNarrative.indexOf('contradicted');
+    expect(idxVerified).toBeGreaterThanOrEqual(0);
+    expect(idxInferred).toBeGreaterThan(idxVerified);
+    expect(idxUnknown).toBeGreaterThan(idxInferred);
+    expect(idxContradicted).toBeGreaterThan(idxUnknown);
+  });
+
+  it('contains zero banned strings in every doctrine description', () => {
+    const haystack = [
+      confidenceDoctrineNarrative,
+      ...CONFIDENCE_TIER_ORDER.flatMap((t) => [
+        CONFIDENCE_TIER_META[t].label,
+        CONFIDENCE_TIER_META[t].description,
+        CONFIDENCE_TIER_SHORT[t],
+      ]),
+    ]
+      .join(' ')
+      .toLowerCase();
+    for (const banned of BANNED) {
+      expect(haystack).not.toContain(banned.toLowerCase());
+    }
+  });
+
+  describe('isConfidenceTier', () => {
+    it('returns true for each canonical tier', () => {
+      for (const tier of CONFIDENCE_TIER_ORDER) {
+        expect(isConfidenceTier(tier)).toBe(true);
+      }
+    });
+
+    it('returns false for non-tier values', () => {
+      const samples: unknown[] = [
+        'Verified', // capitalized — not a tier id
+        'pending',
+        'access',
+        'blocked',
+        '',
+        null,
+        undefined,
+        0,
+        {},
+        [],
+      ];
+      for (const sample of samples) {
+        expect(isConfidenceTier(sample)).toBe(false);
+      }
+    });
+
+    it('narrows the type', () => {
+      const v: unknown = 'verified';
+      if (isConfidenceTier(v)) {
+        const tier: ConfidenceTier = v;
+        expect(tier).toBe('verified');
+      }
+    });
+  });
+});

--- a/apps/web/__tests__/confidence-tier-resolver.test.ts
+++ b/apps/web/__tests__/confidence-tier-resolver.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KNOWN_PRIMARY_SOURCES,
+  resolveConfidenceTier,
+} from '../lib/confidence/tier-resolver';
+
+describe('resolveConfidenceTier', () => {
+  it('returns the explicit tier when present, ignoring everything else', () => {
+    expect(
+      resolveConfidenceTier({
+        tier: 'contradicted',
+        source: 'NPPES',
+        recall: 'primary',
+        value: 'anything',
+      }),
+    ).toBe('contradicted');
+  });
+
+  it('returns contradicted when conflict flag is true', () => {
+    expect(
+      resolveConfidenceTier({
+        conflict: true,
+        source: 'NPPES',
+        recall: 'primary',
+        value: '1346053246',
+      }),
+    ).toBe('contradicted');
+  });
+
+  it('returns contradicted when recall is conflict', () => {
+    expect(
+      resolveConfidenceTier({
+        recall: 'conflict',
+        source: 'NPPES',
+        value: '1346053246',
+      }),
+    ).toBe('contradicted');
+  });
+
+  describe('returns unknown when data is not on file', () => {
+    it('value is null', () => {
+      expect(resolveConfidenceTier({ value: null })).toBe('unknown');
+    });
+    it('value is undefined', () => {
+      expect(resolveConfidenceTier({ value: undefined })).toBe('unknown');
+    });
+    it('value is empty string', () => {
+      expect(resolveConfidenceTier({ value: '' })).toBe('unknown');
+    });
+    it('value is whitespace', () => {
+      expect(resolveConfidenceTier({ value: '   ' })).toBe('unknown');
+    });
+    it('value is empty array', () => {
+      expect(resolveConfidenceTier({ value: [] })).toBe('unknown');
+    });
+    it('onFile is false', () => {
+      expect(
+        resolveConfidenceTier({ onFile: false, value: '1346053246' }),
+      ).toBe('unknown');
+    });
+    it('recall is none', () => {
+      expect(
+        resolveConfidenceTier({
+          recall: 'none',
+          value: '1346053246',
+        }),
+      ).toBe('unknown');
+    });
+  });
+
+  describe('returns verified for primary-source recall', () => {
+    it('explicit recall: primary', () => {
+      expect(
+        resolveConfidenceTier({
+          recall: 'primary',
+          value: '1346053246',
+        }),
+      ).toBe('verified');
+    });
+
+    it.each([...KNOWN_PRIMARY_SOURCES])(
+      'known primary source %s',
+      (source) => {
+        expect(resolveConfidenceTier({ source, value: 'x' })).toBe('verified');
+      },
+    );
+
+    it('matches primary source as substring (NPPES (CMS))', () => {
+      expect(
+        resolveConfidenceTier({
+          source: 'NPPES (CMS)',
+          value: '1346053246',
+        }),
+      ).toBe('verified');
+    });
+
+    it('matches primary source case-insensitively', () => {
+      expect(
+        resolveConfidenceTier({
+          source: 'oig leie',
+          value: 'no-match',
+        }),
+      ).toBe('verified');
+    });
+  });
+
+  describe('returns inferred for AI-derived recall', () => {
+    it('recall: inferred', () => {
+      expect(
+        resolveConfidenceTier({
+          recall: 'inferred',
+          value: 'UCSF, 2018',
+        }),
+      ).toBe('inferred');
+    });
+
+    it('recall: document', () => {
+      expect(
+        resolveConfidenceTier({
+          recall: 'document',
+          value: 'UCSF, 2018',
+        }),
+      ).toBe('inferred');
+    });
+
+    it('source: cv-upload', () => {
+      expect(
+        resolveConfidenceTier({
+          source: 'cv-upload',
+          value: 'UCSF, 2018',
+        }),
+      ).toBe('inferred');
+    });
+
+    it('unknown source defaults to inferred', () => {
+      expect(
+        resolveConfidenceTier({
+          source: 'some-third-party-feed',
+          value: 'UCSF, 2018',
+        }),
+      ).toBe('inferred');
+    });
+
+    it('no metadata at all defaults to inferred when value is present', () => {
+      expect(resolveConfidenceTier({ value: 'something' })).toBe('inferred');
+    });
+  });
+
+  describe('precedence', () => {
+    it('contradicted wins over unknown', () => {
+      expect(
+        resolveConfidenceTier({
+          conflict: true,
+          value: null,
+        }),
+      ).toBe('contradicted');
+    });
+
+    it('explicit tier wins over conflict', () => {
+      expect(
+        resolveConfidenceTier({
+          tier: 'unknown',
+          conflict: true,
+        }),
+      ).toBe('unknown');
+    });
+
+    it('unknown wins over verified when value is empty', () => {
+      expect(
+        resolveConfidenceTier({
+          source: 'NPPES',
+          recall: 'primary',
+          value: '',
+        }),
+      ).toBe('unknown');
+    });
+  });
+});

--- a/apps/web/components/vds/confidence/ConfidenceFieldHelp.tsx
+++ b/apps/web/components/vds/confidence/ConfidenceFieldHelp.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { ConfidenceTierBadge } from '@/design-system/components/ConfidenceTierBadge';
+import {
+  CONFIDENCE_TIER_META,
+  type ConfidenceTier,
+} from './doctrine';
+
+export interface ConfidenceFieldHelpProps {
+  /** Confidence tier of the field this help button explains. */
+  tier: ConfidenceTier;
+  /** Optional source label rendered in the popover footer (e.g. 'NPPES (CMS)'). */
+  source?: string;
+  /** Optional field label shown at the top of the popover. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * ConfidenceFieldHelp — small `?` button next to a field that opens a popover
+ * explaining the field's tier. Hover or focus opens it; click pins it open
+ * until outside-click or Escape.
+ *
+ * Keyboard accessible: focus opens the popover, Escape dismisses, the trigger
+ * itself is a real `<button>` with aria-expanded + aria-haspopup="dialog".
+ */
+export function ConfidenceFieldHelp({
+  tier,
+  source,
+  label,
+  className,
+}: ConfidenceFieldHelpProps) {
+  const meta = CONFIDENCE_TIER_META[tier];
+  const [hover, setHover] = React.useState(false);
+  const [focused, setFocused] = React.useState(false);
+  const [pinned, setPinned] = React.useState(false);
+  const containerRef = React.useRef<HTMLSpanElement | null>(null);
+
+  const open = pinned || hover || focused;
+
+  React.useEffect(() => {
+    if (!pinned) return;
+    function onDoc(e: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setPinned(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setPinned(false);
+    }
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [pinned]);
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn('relative inline-flex items-center', className)}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <button
+        type="button"
+        aria-label={`Why is this ${meta.label.toLowerCase()}?`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setPinned((p) => !p)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            setPinned(false);
+            setFocused(false);
+            (e.currentTarget as HTMLButtonElement).blur();
+          }
+        }}
+        className={cn(
+          'inline-flex items-center justify-center w-[18px] h-[18px] rounded-full',
+          'font-mono text-[10px] leading-none',
+          'border border-[var(--vt-text-muted)] text-[var(--vt-text-muted)]',
+          'bg-[var(--vt-surface)]',
+          'hover:border-[var(--vt-text-secondary)] hover:text-[var(--vt-text-primary)]',
+          'focus:outline-none focus-visible:ring-2',
+          'focus-visible:ring-[color-mix(in_oklab,var(--vt-text-primary)_30%,transparent)]',
+          'focus-visible:ring-offset-1',
+        )}
+      >
+        ?
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label={`${meta.label} — confidence tier explanation`}
+          className={cn(
+            'absolute left-0 top-[26px] z-30 w-[300px] max-h-[260px] overflow-auto',
+            'rounded-md border border-[var(--vt-surface-dim)]',
+            'bg-[var(--vt-surface)] shadow-lg',
+            'p-3.5 text-left',
+          )}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <ConfidenceTierBadge tier={tier} size="sm" />
+            {pinned && (
+              <button
+                type="button"
+                onClick={() => setPinned(false)}
+                aria-label="Close"
+                className="text-[var(--vt-text-muted)] hover:text-[var(--vt-text-primary)] text-[11px] leading-none px-1"
+              >
+                ×
+              </button>
+            )}
+          </div>
+          {label && (
+            <div className="mt-2 text-[12.5px] font-semibold text-[var(--vt-text-primary)] tracking-tight">
+              {label}
+            </div>
+          )}
+          <div className="mt-1.5 text-[11.5px] leading-snug text-[var(--vt-text-secondary)]">
+            {meta.description}
+          </div>
+          {source && (
+            <div className="mt-2 pt-2 border-t border-[var(--vt-surface-dim)] flex items-baseline justify-between gap-3">
+              <span className="font-mono text-[10px] uppercase tracking-[0.1em] text-[var(--vt-text-muted)]">
+                Source
+              </span>
+              <span className="font-mono text-[10.5px] text-[var(--vt-text-secondary)] text-right break-words">
+                {source}
+              </span>
+            </div>
+          )}
+          <div className="mt-2.5 pt-2 border-t border-[var(--vt-surface-dim)] text-[10.5px] text-[var(--vt-text-muted)]">
+            Press <span className="font-mono">Esc</span> to close.
+          </div>
+        </div>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/vds/confidence/ConfidenceLegend.tsx
+++ b/apps/web/components/vds/confidence/ConfidenceLegend.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { ConfidenceTierBadge } from '@/design-system/components/ConfidenceTierBadge';
+import {
+  CONFIDENCE_TIER_META,
+  CONFIDENCE_TIER_ORDER,
+  CONFIDENCE_TIER_SHORT,
+  type ConfidenceTier,
+} from './doctrine';
+
+export interface ConfidenceLegendProps {
+  /** Tiers to render, in order. Defaults to the canonical 4. */
+  tiers?: readonly ConfidenceTier[];
+  /** Compact horizontal row vs. stacked vertical list. */
+  layout?: 'row' | 'stack';
+  /** Show the short hook under each badge. Defaults to true for stack, false for row. */
+  showDescriptions?: boolean;
+  className?: string;
+}
+
+/**
+ * ConfidenceLegend — page-footer key for the categorical confidence
+ * vocabulary. Mirrors LaneStateLegend in shape so surfaces that use both
+ * legends read consistently.
+ */
+export function ConfidenceLegend({
+  tiers = CONFIDENCE_TIER_ORDER,
+  layout = 'row',
+  showDescriptions,
+  className,
+}: ConfidenceLegendProps) {
+  const showText = showDescriptions ?? layout === 'stack';
+
+  return (
+    <div
+      role="list"
+      aria-label="Confidence tiers"
+      className={cn(
+        layout === 'row'
+          ? 'flex flex-wrap items-center gap-x-4 gap-y-2'
+          : 'flex flex-col gap-3',
+        className,
+      )}
+    >
+      {tiers.map((tier) => {
+        const meta = CONFIDENCE_TIER_META[tier];
+        return (
+          <div
+            key={tier}
+            role="listitem"
+            className={cn(
+              'flex',
+              layout === 'row' ? 'items-center gap-2' : 'items-start gap-3',
+            )}
+          >
+            <ConfidenceTierBadge tier={tier} size="sm" />
+            {showText && (
+              <div className="text-[11px] leading-snug">
+                <span className="text-[var(--vt-text-primary)] font-medium">
+                  {meta.label}
+                </span>
+                <span className="text-[var(--vt-text-muted)]">
+                  {' '}
+                  · {CONFIDENCE_TIER_SHORT[tier]}
+                </span>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/vds/confidence/UnknownFieldExplainer.tsx
+++ b/apps/web/components/vds/confidence/UnknownFieldExplainer.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface UnknownFieldExplainerProps {
+  /** Optional label for the field this explainer sits next to. */
+  fieldLabel?: string;
+  /**
+   * Optional CTA label. When provided alongside `onRequestUpload`, renders a
+   * subdued button after the explanatory copy.
+   */
+  ctaLabel?: string;
+  /** CTA click handler. Required when `ctaLabel` is set. */
+  onRequestUpload?: () => void;
+  className?: string;
+}
+
+/**
+ * UnknownFieldExplainer — single-line inline help for fields whose
+ * confidence tier is `unknown`. Reinforces that "not on file" is a
+ * neutral signal, not a negative one — preventing readers from inferring
+ * the absence of data as evidence of the absence of credentials.
+ */
+export function UnknownFieldExplainer({
+  fieldLabel,
+  ctaLabel,
+  onRequestUpload,
+  className,
+}: UnknownFieldExplainerProps) {
+  const showCta = Boolean(ctaLabel && onRequestUpload);
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-x-2 gap-y-1',
+        'text-[11px] leading-snug',
+        'text-[var(--vt-text-muted)]',
+        className,
+      )}
+    >
+      <span>
+        {fieldLabel ? (
+          <>
+            <span className="font-medium text-[var(--vt-text-secondary)]">
+              {fieldLabel}
+            </span>
+            : not on file.
+          </>
+        ) : (
+          'Not on file.'
+        )}{' '}
+        No primary source has published this field. This is not a negative
+        signal.
+      </span>
+      {showCta && (
+        <button
+          type="button"
+          onClick={onRequestUpload}
+          className={cn(
+            'text-[10.5px] uppercase tracking-[0.08em]',
+            'underline-offset-2 underline decoration-dotted',
+            'text-[var(--vt-text-secondary)]',
+            'hover:text-[var(--vt-text-primary)]',
+            'focus:outline-none focus-visible:ring-2',
+            'focus-visible:ring-[color-mix(in_oklab,var(--vt-text-primary)_30%,transparent)]',
+            'focus-visible:ring-offset-1',
+          )}
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/vds/confidence/doctrine.ts
+++ b/apps/web/components/vds/confidence/doctrine.ts
@@ -1,0 +1,76 @@
+/**
+ * Confidence Doctrine v2 — single source of truth for the categorical
+ * field-level confidence vocabulary.
+ *
+ * Decision tree:
+ *   if value is from a primary-source registry the system queried directly → verified
+ *   else if value is AI-derived from a clinician-supplied document or third-party feed → inferred
+ *   else if data is not on file → unknown   (neutral signal, NOT negative)
+ *   else if two authoritative sources disagree → contradicted
+ *
+ * There are exactly four tiers. A 5th tier is a recall-scope problem, not a
+ * doctrine change. The tier name `Verified` rendered inside ConfidenceTierBadge
+ * is the tier label, not a pipeline status. Pipeline lane state uses `Checked`.
+ *
+ * Sibling primitives:
+ *   - components/ui/ConfidenceMeter.tsx  — numeric 0-1 score variant
+ *   - components/ui/confidence-score.tsx — score display
+ *   - design-system/components/ConfidenceTierBadge.tsx — categorical badge
+ *
+ * The categorical model (this file) applies to evidence-grade rendering
+ * (passport / employer / dossier). The scored model applies to AI-derived
+ * inference confidence (intelligence / risk surfaces). Both ship; do not
+ * collapse them.
+ */
+
+import {
+  CONFIDENCE_TIER_META,
+  type ConfidenceTier,
+} from '@/design-system/components/ConfidenceTierBadge';
+
+export const CONFIDENCE_TIER_ORDER: readonly ConfidenceTier[] = [
+  'verified',
+  'inferred',
+  'unknown',
+  'contradicted',
+] as const;
+
+/**
+ * Plain-English narrative form of the decision tree above.
+ *
+ * Bundled at module load — help components MUST NOT fetch this at runtime.
+ * Surfaces, docs pages, and Wave 37's reconciliation drawer read this string
+ * verbatim. Treat as authoritative.
+ */
+export const confidenceDoctrineNarrative =
+  'If the value is from a primary-source registry the system queried directly, it is verified. ' +
+  'Otherwise, if the value is AI-derived from a clinician-supplied document or third-party feed, it is inferred. ' +
+  'Otherwise, if data is not on file, it is unknown — this is a neutral signal, not a negative one. ' +
+  'Otherwise, if two authoritative sources disagree, it is contradicted and requires human reconciliation.';
+
+/**
+ * Short per-tier hooks. Use these as inline footnotes; descriptions on
+ * `CONFIDENCE_TIER_META` are longer and live in tooltips/popovers.
+ */
+export const CONFIDENCE_TIER_SHORT: Record<ConfidenceTier, string> = {
+  verified: 'Primary-source registry.',
+  inferred: 'AI-derived from clinician-supplied document.',
+  unknown: 'Data not on file. Neutral signal.',
+  contradicted: 'Authoritative sources disagree.',
+};
+
+/**
+ * Asserts a runtime value is a valid tier. Use at adapter / API boundaries
+ * where you parse JSON that claims to carry a tier.
+ */
+export function isConfidenceTier(value: unknown): value is ConfidenceTier {
+  return (
+    value === 'verified' ||
+    value === 'inferred' ||
+    value === 'unknown' ||
+    value === 'contradicted'
+  );
+}
+
+export { CONFIDENCE_TIER_META };
+export type { ConfidenceTier };

--- a/apps/web/components/vds/confidence/index.ts
+++ b/apps/web/components/vds/confidence/index.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitalcv/web · components/vds/confidence
+ *
+ * Categorical confidence vocabulary primitives, plus the canonical doctrine.
+ *
+ * Sibling primitives (NOT re-exported here; import directly):
+ *   - components/ui/ConfidenceMeter.tsx (numeric 0-1 score)
+ *   - components/ui/confidence-score.tsx (score display)
+ *
+ * Use this module's primitives for evidence-grade rendering on passport,
+ * employer, dossier, file detail, inbox, and any surface where a value's
+ * provenance is the question. Use the scored primitives for AI-derived
+ * inference confidence (intelligence / risk surfaces).
+ */
+
+// Doctrine — the law.
+export {
+  CONFIDENCE_TIER_META,
+  CONFIDENCE_TIER_ORDER,
+  CONFIDENCE_TIER_SHORT,
+  confidenceDoctrineNarrative,
+  isConfidenceTier,
+  type ConfidenceTier,
+} from './doctrine';
+
+// Re-export the canonical badge from the design system so callers can do
+// `import { ConfidenceTierBadge, ConfidenceLegend } from '@/components/vds/confidence'`.
+export {
+  ConfidenceTierBadge,
+  type ConfidenceTierBadgeProps,
+} from '@/design-system/components/ConfidenceTierBadge';
+
+// v2 additions live here.
+export {
+  ConfidenceLegend,
+  type ConfidenceLegendProps,
+} from './ConfidenceLegend';
+
+export {
+  ConfidenceFieldHelp,
+  type ConfidenceFieldHelpProps,
+} from './ConfidenceFieldHelp';
+
+export {
+  UnknownFieldExplainer,
+  type UnknownFieldExplainerProps,
+} from './UnknownFieldExplainer';
+
+// Resolver lives under lib/ to keep components free of business logic.
+// Re-exported here for convenience.
+export {
+  KNOWN_PRIMARY_SOURCES,
+  resolveConfidenceTier,
+  useConfidenceTier,
+  type ConfidenceFieldMetadata,
+  type FieldRecallKind,
+} from '@/lib/confidence/tier-resolver';

--- a/apps/web/lib/confidence/tier-resolver.ts
+++ b/apps/web/lib/confidence/tier-resolver.ts
@@ -1,0 +1,114 @@
+/**
+ * Tier resolver — derives a categorical confidence tier from field metadata.
+ *
+ * Surfaces are not required to use this. It's a convenience for callers that
+ * carry source/recall metadata on their data shape and want a deterministic
+ * tier without writing the decision tree by hand.
+ *
+ * Decision tree (matches confidenceDoctrineNarrative):
+ *   { conflict: true } | { recall: 'conflict' }                            → contradicted
+ *   value is null/empty | onFile === false | { recall: 'none' }            → unknown
+ *   { recall: 'primary' } | source ∈ KNOWN_PRIMARY_SOURCES                 → verified
+ *   { recall: 'inferred' | 'document' } | source === 'cv-upload'           → inferred
+ *   default                                                                → inferred
+ */
+
+import { useMemo } from 'react';
+import type { ConfidenceTier } from '@/components/vds/confidence/doctrine';
+
+/**
+ * Source identifiers we treat as primary registries. Conservative — adding to
+ * this list MUST be paired with verification that the source genuinely
+ * publishes a primary record (not a derivative feed).
+ */
+export const KNOWN_PRIMARY_SOURCES = [
+  'NPPES',
+  'DEA',
+  'PECOS',
+  'NPDB',
+  'OIG',
+  'SAM',
+  'NURSYS',
+  'CAQH',
+] as const;
+
+export type FieldRecallKind =
+  | 'primary'
+  | 'inferred'
+  | 'document'
+  | 'conflict'
+  | 'none';
+
+export interface ConfidenceFieldMetadata {
+  /** Free-form source identifier (e.g. 'NPPES (CMS)' or 'cv-upload'). */
+  source?: string | null;
+  /** How the value was recalled. Most authoritative signal when set. */
+  recall?: FieldRecallKind;
+  /** Pre-resolved tier; if set, overrides everything else. */
+  tier?: ConfidenceTier;
+  /** True when two authoritative sources disagree on this field. */
+  conflict?: boolean;
+  /** Whether the field is on file at all. False ⇒ unknown. */
+  onFile?: boolean;
+  /** The field's value. Empty/null/undefined ⇒ unknown. */
+  value?: unknown;
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value === 'string' && value.trim() === '') return true;
+  if (Array.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+/**
+ * Pure resolver — same input, same tier. Use this in server code, tests, and
+ * any non-React caller. React components should prefer `useConfidenceTier`.
+ */
+export function resolveConfidenceTier(
+  field: ConfidenceFieldMetadata,
+): ConfidenceTier {
+  if (field.tier) return field.tier;
+  if (field.conflict || field.recall === 'conflict') return 'contradicted';
+  if (
+    field.onFile === false ||
+    field.recall === 'none' ||
+    isEmptyValue(field.value)
+  ) {
+    return 'unknown';
+  }
+  if (field.recall === 'primary') return 'verified';
+  if (field.recall === 'inferred' || field.recall === 'document') {
+    return 'inferred';
+  }
+  if (field.source === 'cv-upload') return 'inferred';
+  if (field.source) {
+    const upper = field.source.toUpperCase();
+    if (KNOWN_PRIMARY_SOURCES.some((p) => upper.includes(p))) {
+      return 'verified';
+    }
+  }
+  return 'inferred';
+}
+
+/**
+ * React hook variant. Memoizes on the field's identity-shaping properties so
+ * downstream components that derive a tier per render don't re-thrash.
+ */
+export function useConfidenceTier(
+  field: ConfidenceFieldMetadata,
+): ConfidenceTier {
+  return useMemo(
+    () => resolveConfidenceTier(field),
+    // The resolver only reads these six keys.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      field.value,
+      field.source,
+      field.recall,
+      field.tier,
+      field.conflict,
+      field.onFile,
+    ],
+  );
+}

--- a/docs/architecture/confidence-doctrine.md
+++ b/docs/architecture/confidence-doctrine.md
@@ -1,0 +1,143 @@
+# Confidence Doctrine v2
+
+VitalCV ships **two** confidence models. They live side by side because they
+answer different questions. This doc explains which to use when, and codifies
+the rules of the categorical model so future surfaces don't drift.
+
+## The two models
+
+### Categorical (this doctrine)
+
+Answers: **how was this value recalled?**
+
+| Tier | Meaning |
+|---|---|
+| `verified` | Value is from a primary-source registry the system queried directly. |
+| `inferred` | Value is AI-derived from a clinician-supplied document or third-party feed. |
+| `unknown` | Data is not on file. **Neutral signal, not negative.** |
+| `contradicted` | Two authoritative sources disagree. Requires human reconciliation. |
+
+Used on: passport, employer review, dossier, file detail, inbox, application
+active state, autopilot. Anywhere a reader is judging *evidence*.
+
+Code: [`apps/web/components/vds/confidence/`](../../apps/web/components/vds/confidence/).
+
+### Scored (sibling, retained)
+
+Answers: **how confident is the AI in this inference?**
+
+Output: a numeric value in [0, 1], rendered as a percentage badge or meter.
+
+Used on: intelligence / risk surfaces where AI-derived inferences need a
+graded readout. The categorical model collapses to `inferred` for the same
+data; the scored model adds resolution.
+
+Code: [`apps/web/components/ui/ConfidenceMeter.tsx`](../../apps/web/components/ui/ConfidenceMeter.tsx) and [`apps/web/components/ui/confidence-score.tsx`](../../apps/web/components/ui/confidence-score.tsx).
+
+## When to use which
+
+| Context | Model |
+|---|---|
+| A value with a registry-vs-document provenance question | Categorical |
+| An AI-derived match score on a fuzzy join | Scored |
+| A field on the clinician passport | Categorical |
+| A risk score on the intelligence dashboard | Scored |
+| An evidence row in the dossier export | Categorical |
+| An inferred relationship in the trust graph | Scored |
+
+If a surface needs both (e.g., "this NPI match is `inferred` at 73%"), render
+both: a categorical badge for the recall channel, a scored display for the
+inference confidence.
+
+## Decision tree (categorical model)
+
+```
+if value is from a primary-source registry the system queried directly
+    → verified
+else if value is AI-derived from a clinician-supplied document
+        or third-party feed
+    → inferred
+else if data is not on file
+    → unknown          (neutral signal, NOT negative)
+else if two authoritative sources disagree
+    → contradicted     (requires human reconciliation)
+```
+
+The narrative form is exported from
+[`doctrine.ts`](../../apps/web/components/vds/confidence/doctrine.ts) as
+`confidenceDoctrineNarrative` and read verbatim by Wave 37's reconciliation
+drawer. Treat as authoritative; do not paraphrase in surface copy without
+reading from the constant.
+
+## Hard rules
+
+1. **There are exactly four tiers.** A 5th tier is a recall-scope problem,
+   not a doctrine change. If you find yourself wanting one, the right move is
+   to widen `KNOWN_PRIMARY_SOURCES` in `tier-resolver.ts` or add a recall kind
+   to `FieldRecallKind`.
+2. **`unknown` is neutral, not negative.** UI MUST NOT style it as warning red
+   or position it as a deficiency. The amber accent on the badge signals
+   "needs attention to populate," not "alarming."
+3. **The label `Verified` on a confidence badge is the *tier name*.** It is
+   NOT a pipeline status. For pipeline lane state, use `Checked` (the lane
+   primitives already do — see
+   [`design-system/components/LaneStateBadge.tsx`](../../apps/web/design-system/components/LaneStateBadge.tsx)).
+4. **No tier may claim primary-source verification on AI-derived data.**
+   Inferred ≠ verified. Surfaces MUST NOT promote `inferred` to `verified`
+   without a registry refetch.
+5. **Tier descriptions are bundled.** Help components MUST NOT fetch them at
+   runtime. If you need to localize, do it at build time.
+
+## Resolver
+
+`resolveConfidenceTier(field)` is the deterministic resolver in
+[`apps/web/lib/confidence/tier-resolver.ts`](../../apps/web/lib/confidence/tier-resolver.ts).
+Use it at API/adapter boundaries. React components should prefer
+`useConfidenceTier`.
+
+```ts
+import { resolveConfidenceTier } from '@/lib/confidence/tier-resolver';
+
+const tier = resolveConfidenceTier({
+  source: 'NPPES (CMS)',
+  recall: 'primary',
+  value: '1346053246',
+});
+// → 'verified'
+```
+
+## Adding a new primary source
+
+1. Add the identifier (uppercased, substring-matchable) to
+   `KNOWN_PRIMARY_SOURCES` in `tier-resolver.ts`.
+2. Add a test case in
+   `apps/web/lib/confidence/__tests__/tier-resolver.test.ts` proving
+   `resolveConfidenceTier({ source: 'NEW_SOURCE' })` returns `'verified'`.
+3. Document the source in this file's "Known primary sources" list (below).
+4. Open a PR; Codex reviews the source claim against publicly available
+   evidence that the registry publishes a primary record.
+
+### Known primary sources
+
+| Identifier | Registry | Why primary |
+|---|---|---|
+| `NPPES` | National Plan and Provider Enumeration System (CMS) | Statutory NPI registry. |
+| `DEA` | Drug Enforcement Administration | Controlled-substances registration of record. |
+| `PECOS` | Provider Enrollment, Chain, and Ownership System | Medicare enrollment of record. |
+| `NPDB` | National Practitioner Data Bank | Statutory adverse-event reporting registry. |
+| `OIG` | HHS Office of Inspector General · LEIE | Federal exclusions list. |
+| `SAM` | System for Award Management | Federal contractor exclusions list. |
+| `NURSYS` | National Council of State Boards of Nursing | Multistate RN compact. |
+| `CAQH` | Council for Affordable Quality Healthcare | Industry profile of record (caveat: aggregator). |
+
+## Sibling: lane state
+
+Surfaces that render lane state (`verified | pending | access | blocked |
+contradicted | unknown`) use the lane vocabulary from
+[`LaneStateBadge`](../../apps/web/design-system/components/LaneStateBadge.tsx),
+not this doctrine. Lane state describes pipeline progress; categorical
+confidence describes value provenance. They overlap on the words `verified`
+and `contradicted` but mean different things.
+
+If both legends appear on the same page, label them so readers can tell which
+column is which: `Lane state` vs `Field confidence`.


### PR DESCRIPTION
## Summary

Wave 41 of the integration roadmap: ports the v6 bundle's `confidence.jsx` v2 doctrine into the production design system as TypeScript primitives. Foundation wave — Waves 42 (Inbox), 43 (Activation), 44 (ROI), 45 (Verifier), 48 (Refresh existing) all consume these.

This is the **categorical** confidence model (verified / inferred / unknown / contradicted). It sits alongside the existing **scored** model (`ConfidenceMeter`, `confidence-score`) used by the intelligence/risk surfaces. Both ship; the new doctrine doc explains when each applies.

## What ships

- `apps/web/components/vds/confidence/doctrine.ts` — narrative + tier order + `isConfidenceTier` guard; re-exports `CONFIDENCE_TIER_META` from the existing `ConfidenceTierBadge` as the canonical source.
- `apps/web/components/vds/confidence/ConfidenceLegend.tsx` — page-footer legend (row/stack layouts; mirrors `LaneStateLegend` shape).
- `apps/web/components/vds/confidence/ConfidenceFieldHelp.tsx` — popover/tooltip explaining a field's tier; keyboard-accessible (focus opens, Escape dismisses).
- `apps/web/components/vds/confidence/UnknownFieldExplainer.tsx` — inline help reinforcing that "not on file" is a neutral signal.
- `apps/web/components/vds/confidence/index.ts` — barrel; downstream waves import from `@/components/vds/confidence`.
- `apps/web/lib/confidence/tier-resolver.ts` — `resolveConfidenceTier` (pure) + `useConfidenceTier` (hook) + `KNOWN_PRIMARY_SOURCES`.
- `docs/architecture/confidence-doctrine.md` — when categorical vs scored applies, decision tree, hard rules, list of known primary sources, instructions for adding new sources.

## What it does NOT do

- Does **not** duplicate `ConfidenceTierBadge` — re-exported from the existing design system path.
- Does **not** modify `ConfidenceMeter` or `confidence-score` — they remain canonical for the scored model.
- Does **not** alter any rendered surface — primitives only; consumed in subsequent waves.
- Does **not** promote `inferred` to `verified` anywhere — truth contract preserved.
- Does **not** introduce a 5th tier — locked at four per doctrine.

## Truth-contract checks

- 11 banned strings: zero occurrences in all new files (test asserts on every doctrine description + every rendered legend/popover/explainer).
- No bare `Verified` status label outside `CONFIDENCE_TIER_META.verified` (the tier name itself).
- `unknown` is framed as neutral, never negative — test asserts the description does not contain "missing" or "failure".

## Test plan

- [x] `apps/web/__tests__/confidence-doctrine.test.ts` — 10 tests (tier order locked, meta complete, narrative ordering, banned-string sweep, type guard).
- [x] `apps/web/__tests__/confidence-tier-resolver.test.ts` — 29 tests covering every decision-tree branch + each known primary source.
- [x] `apps/web/__tests__/confidence-components.test.tsx` — 18 tests for `ConfidenceLegend`, `ConfidenceFieldHelp`, `UnknownFieldExplainer` (rendering, ARIA, banned strings).
- [x] Full vitest suite: 1411 pass / 4 skip / 0 fail.
- [x] `pnpm turbo run build --filter @vitalcv/web` green.
- [x] `pnpm --filter @vitalcv/web exec tsc --noEmit` green (after prebuilding `@vitalcv/shared` + `@vitalcv/trust-state`).
- [x] `pnpm --filter @vitalcv/web lint` green.

## Codex prompt seed

Run this exact prompt with `codex exec` (3 audits required for the merge gate):

````
Audit Integration Wave 41 — Confidence Doctrine v2 production port.

Worktree: /tmp/vitalcv-integration-wave-41-confidence
Branch: feat/integration-wave-41-confidence
PR: this PR

Three passes:

1. Implementation pass
   - Confirm apps/web/components/vds/confidence/ contains: doctrine.ts,
     ConfidenceLegend.tsx, ConfidenceFieldHelp.tsx, UnknownFieldExplainer.tsx,
     index.ts.
   - Confirm CONFIDENCE_TIER_META is re-exported (not redefined) from
     design-system/components/ConfidenceTierBadge.
   - Confirm CONFIDENCE_TIER_ORDER has exactly 4 keys: verified, inferred,
     unknown, contradicted. No 5th tier.
   - Confirm ConfidenceFieldHelp is keyboard-accessible (focus opens popover,
     Escape dismisses, button has aria-haspopup="dialog").
   - Confirm useConfidenceTier hook resolves the 4 tiers from metadata.
   - Confirm UnknownFieldExplainer copy frames absence as neutral, not negative.

2. Diff pass
   - Confirm bundle's confidence.jsx v2 was ported faithfully (no truth-contract
     weakening).
   - Confirm existing apps/web/components/ui/ConfidenceMeter.tsx (scored) and
     confidence-score.tsx remain unchanged.
   - Confirm no hardcoded hex colors — uses Wave 28 tokens v2 CSS vars
     (--vt-state-*, --vt-text-*, --vt-surface*).
   - Confirm docs/architecture/confidence-doctrine.md present and explains
     when categorical (this wave) vs scored (existing meter) applies.

3. Copy pass
   - Grep all new files for the 11 banned strings (case-insensitive). Zero hits.
   - Confirm no bare 'Verified' status label outside CONFIDENCE_TIER_META.verified
     (the tier name itself — allowed inside the badge).
   - Confirm narrative string includes the decision-tree.

Output a single line:
Codex verdict: SAFE
or
Codex verdict: NOT-SAFE — <reason>
````

## Test plan (manual smoke)

- [ ] (post-Codex) Visit a Vercel preview build; visit any existing surface that imports from `@/components/vds/confidence`; confirm no visual regression.
- [ ] (post-Codex) Confirm dev-only routes that consume `ConfidenceFieldHelp` open the popover on click and dismiss on Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)