### PR TITLE
feat(autopilot): career autopilot dashboard foundation (Wave F Phase 2)

### DIFF
--- a/apps/web/__tests__/autopilot-data.test.ts
+++ b/apps/web/__tests__/autopilot-data.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTION_META,
+  DRIFT_META,
+  KIND_META,
+  PORTABILITY_META,
+  SEVERITY_META,
+  computeCompositeTrustScore,
+  computeRenewalCounts,
+  demoAutopilot,
+  sumFactorWeights,
+} from '@/lib/autopilot/autopilotData';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('status meta tables', () => {
+  it('no status meta uses the bare label "Verified"', () => {
+    for (const map of [ACTION_META, KIND_META, PORTABILITY_META, SEVERITY_META, DRIFT_META]) {
+      for (const meta of Object.values(map)) {
+        expect(meta.label).not.toBe('Verified');
+      }
+    }
+  });
+
+  it('renewal kind meta covers the 6 design-mandated kinds', () => {
+    expect(Object.keys(KIND_META)).toEqual([
+      'license',
+      'controlled_substance',
+      'board',
+      'certification',
+      'enrollment',
+      'clearance',
+    ]);
+  });
+
+  it('drift meta covers fresh / aging / stale / divergent', () => {
+    expect(Object.keys(DRIFT_META)).toEqual(['fresh', 'aging', 'stale', 'divergent']);
+  });
+});
+
+describe('demoAutopilot', () => {
+  it('clinician is marked isDemo === literal true', () => {
+    const a = demoAutopilot();
+    expect(a.clinician.isDemo).toBe(true);
+  });
+
+  it('trust level is a tier label, not the bare word "Verified"', () => {
+    const a = demoAutopilot();
+    expect(a.clinician.trustLevel).not.toBe('Verified');
+    expect(a.clinician.trustLevel).toMatch(/^T[0-9]$/);
+  });
+
+  it('has 9 renewals across all 6 kinds', () => {
+    const a = demoAutopilot();
+    expect(a.renewals.length).toBe(9);
+    const kinds = new Set(a.renewals.map((r) => r.kind));
+    for (const k of ['license', 'controlled_substance', 'board', 'certification', 'enrollment', 'clearance']) {
+      expect(kinds.has(k as never)).toBe(true);
+    }
+  });
+
+  it('renewal actions cover all 4 categories', () => {
+    const a = demoAutopilot();
+    const actions = new Set(a.renewals.map((r) => r.action));
+    expect(actions.has('monitor')).toBe(true);
+    expect(actions.has('renew_self')).toBe(true);
+    expect(actions.has('expiring')).toBe(true);
+    expect(actions.has('urgent')).toBe(true);
+  });
+
+  it('has 6 portability rows covering the 3 design-mandated statuses', () => {
+    const a = demoAutopilot();
+    expect(a.portability.length).toBe(6);
+    const statuses = new Set(a.portability.map((p) => p.status));
+    expect(statuses.has('licensed')).toBe(true);
+    expect(statuses.has('compact_eligible')).toBe(true);
+    expect(statuses.has('dormant')).toBe(true);
+  });
+
+  it('has exactly one primary portability state', () => {
+    const a = demoAutopilot();
+    const primary = a.portability.filter((p) => p.primary);
+    expect(primary.length).toBe(1);
+  });
+
+  it('has 3 NBA items ranked 1..3 with descending severity', () => {
+    const a = demoAutopilot();
+    expect(a.nba.length).toBe(3);
+    expect(a.nba.map((n) => n.rank)).toEqual([1, 2, 3]);
+    expect(a.nba.map((n) => n.severity)).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('has 7 drift fields covering all 4 statuses including divergent', () => {
+    const a = demoAutopilot();
+    expect(a.drift.length).toBe(7);
+    const statuses = new Set(a.drift.map((d) => d.status));
+    expect(statuses.has('fresh')).toBe(true);
+    expect(statuses.has('aging')).toBe(true);
+    expect(statuses.has('stale')).toBe(true);
+    expect(statuses.has('divergent')).toBe(true);
+  });
+
+  it('divergent drift fields have null verifiedAt', () => {
+    const a = demoAutopilot();
+    for (const d of a.drift) {
+      if (d.status === 'divergent') {
+        expect(d.verifiedAt).toBeNull();
+      }
+    }
+  });
+
+  it('has 6 trust factors with weights summing to 1.0', () => {
+    const a = demoAutopilot();
+    expect(a.trustFactors.length).toBe(6);
+    expect(sumFactorWeights(a.trustFactors)).toBe(1);
+  });
+
+  it('does not name specific upstream vendors', () => {
+    // Real upstream vendors (Medical Board of California, NCCPA, AHA,
+    // CAQH, IRS, OIG, SAM.gov, NPDB, CMS, PECOS, IMLC, MedPro,
+    // Cedar Health) are genericised in the demo so the page does not
+    // imply real integrations.
+    //
+    // Word-boundary regex prevents false positives like "sam" matching
+    // inside "same day" or "irs" matching inside other words.
+    const a = demoAutopilot();
+    const blob = JSON.stringify(a);
+    const vendorPatterns: ReadonlyArray<RegExp> = [
+      /Medical Board of California/i,
+      /\bNCCPA\b/,
+      /American Heart/i,
+      /\bCAQH\b/,
+      /\bIRS\b/,
+      /\bOIG\b/,
+      /\bSAM\.gov\b/i,
+      /\bNPDB\b/,
+      /\bPECOS\b/,
+      /\bIMLC\b/,
+      /\bMedPro\b/i,
+      /\bCedar\b/i,
+    ];
+    for (const pattern of vendorPatterns) {
+      expect(blob).not.toMatch(pattern);
+    }
+  });
+
+  it('renders no banned overclaim copy', () => {
+    const a = demoAutopilot();
+    const blob = JSON.stringify(a).toLowerCase();
+    for (const phrase of BANNED) {
+      expect(blob).not.toContain(phrase.toLowerCase());
+    }
+  });
+});
+
+describe('computeCompositeTrustScore', () => {
+  it('weighted sum of factors', () => {
+    const score = computeCompositeTrustScore([
+      { label: 'a', weight: 0.5, score: 1.0, note: '' },
+      { label: 'b', weight: 0.5, score: 0.5, note: '' },
+    ]);
+    expect(score).toBe(0.75);
+  });
+
+  it('demoAutopilot composite is in the [0, 1] band', () => {
+    const a = demoAutopilot();
+    const s = computeCompositeTrustScore(a.trustFactors);
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('computeRenewalCounts', () => {
+  it('matches demoAutopilot composition', () => {
+    const a = demoAutopilot();
+    const c = computeRenewalCounts(a.renewals);
+    expect(c.total).toBe(9);
+    // From the fixture: 1 urgent, 1 expiring, 3 renew_self, 4 monitoring.
+    expect(c.urgent).toBe(1);
+    expect(c.expiring).toBe(1);
+    expect(c.renewSelf).toBe(3);
+    expect(c.monitoring).toBe(4);
+    expect(c.urgent + c.expiring + c.renewSelf + c.monitoring).toBe(c.total);
+  });
+});

--- a/apps/web/__tests__/autopilot-page-render.test.tsx
+++ b/apps/web/__tests__/autopilot-page-render.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import AutopilotPage from '../app/autopilot/page';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+function renderAutopilot(): string {
+  const element = AutopilotPage();
+  return renderToStaticMarkup(element as React.ReactElement);
+}
+
+describe('autopilot page — render', () => {
+  it('renders the demo banner + trust tier label', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-demo-banner"');
+    expect(html).toContain('data-is-demo="true"');
+    expect(html).toContain('data-trust-level="T3"');
+    expect(html).toContain('data-testid="trust-tier-label"');
+  });
+
+  it('renders the trust score panel with composite + 6 factors', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-trust-panel"');
+    expect(html).toContain('data-testid="trust-score-composite"');
+    expect(html).toContain('data-testid="trust-score-headline"');
+    const factors = html.match(/data-testid="trust-factor"/g) ?? [];
+    expect(factors.length).toBe(6);
+  });
+
+  it('renders the renewal radar with all 9 entries sorted by daysToExpire ascending', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-renewal-radar"');
+    const ids = [...html.matchAll(/data-renewal-id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids.length).toBe(9);
+    // First entry must be the most-urgent (smallest daysToExpire).
+    const days = [...html.matchAll(/data-days-to-expire="(-?\d+)"/g)].map((m) => Number(m[1]));
+    for (let i = 1; i < days.length; i++) {
+      expect(days[i]).toBeGreaterThanOrEqual(days[i - 1]);
+    }
+  });
+
+  it('renders the NBA queue with 3 ranked items', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-nba-queue"');
+    const items = html.match(/data-testid="nba-cta-primary"/g) ?? [];
+    expect(items.length).toBe(3);
+    expect(html).toContain('data-nba-rank="1"');
+    expect(html).toContain('data-nba-rank="2"');
+    expect(html).toContain('data-nba-rank="3"');
+    // CTAs must be disabled in Phase 1.
+    expect(html).toContain('data-disabled-reason="phase-2-pending"');
+  });
+
+  it('renders the portability map with 6 states', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-portability-map"');
+    const states = html.match(/data-state-code="[^"]+"/g) ?? [];
+    expect(states.length).toBe(6);
+    expect(html).toContain('data-primary="true"');
+  });
+
+  it('renders the drift monitor with 7 fields and all 4 statuses', () => {
+    const html = renderAutopilot();
+    expect(html).toContain('data-testid="autopilot-drift-monitor"');
+    const fields = html.match(/data-drift-field="[^"]+"/g) ?? [];
+    expect(fields.length).toBe(7);
+    for (const status of ['fresh', 'aging', 'stale', 'divergent']) {
+      expect(html).toContain(`data-drift-status="${status}"`);
+    }
+  });
+
+  it('does not render the bare "Verified" status label anywhere', () => {
+    const html = renderAutopilot();
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+
+  it('introduces no banned overclaim copy', () => {
+    const html = renderAutopilot();
+    const lower = html.toLowerCase();
+    for (const phrase of BANNED) {
+      expect(lower).not.toContain(phrase.toLowerCase());
+    }
+  });
+});

--- a/apps/web/app/autopilot/page.tsx
+++ b/apps/web/app/autopilot/page.tsx
@@ -1,0 +1,434 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import {
+  ACTION_META,
+  DRIFT_META,
+  KIND_META,
+  PORTABILITY_META,
+  SEVERITY_META,
+  computeCompositeTrustScore,
+  computeRenewalCounts,
+  demoAutopilot,
+  type AutopilotClinician,
+  type DriftField,
+  type NbaEntry,
+  type PortabilityEntry,
+  type RenewalEntry,
+  type TrustFactor,
+} from '@/lib/autopilot/autopilotData';
+
+export const metadata: Metadata = {
+  title: 'Career Autopilot · Demo · VitalCV',
+  description:
+    'Demo render of the clinician-side Career Autopilot dashboard — renewal radar, portability map, next-best actions, drift monitor, and trust score.',
+};
+
+const TONE_BADGE: Record<string, string> = {
+  emerald: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700',
+  amber: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
+  slate: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+  indigo: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700',
+  rose: 'border-rose-500/30 bg-rose-500/10 text-rose-700',
+};
+
+export default function AutopilotPage() {
+  const a = demoAutopilot();
+  const compositeScore = computeCompositeTrustScore(a.trustFactors);
+  const counts = computeRenewalCounts(a.renewals);
+
+  return (
+    <main
+      className="mx-auto max-w-[1200px] px-4 py-6 sm:px-6 sm:py-8"
+      data-testid="autopilot-page"
+      data-is-demo={String(a.clinician.isDemo)}
+      data-trust-level={a.clinician.trustLevel}
+      data-composite-trust-score={String(compositeScore)}
+    >
+      <Header clinician={a.clinician} />
+
+      <p
+        className="mt-4 inline-block rounded-md bg-amber-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-amber-800"
+        data-testid="autopilot-demo-banner"
+      >
+        Demo autopilot — illustrative only, not a real clinician&rsquo;s state
+      </p>
+
+      <TrustScorePanel
+        clinician={a.clinician}
+        factors={a.trustFactors}
+        compositeScore={compositeScore}
+      />
+
+      <RenewalRadar renewals={a.renewals} counts={counts} />
+
+      <NbaQueue items={a.nba} />
+
+      <PortabilityMap entries={a.portability} />
+
+      <DriftMonitor drift={a.drift} />
+    </main>
+  );
+}
+
+function Header({ clinician }: { clinician: AutopilotClinician }) {
+  return (
+    <header className="border-b border-border pb-3" data-testid="autopilot-header">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        Career Autopilot
+      </p>
+      <h1 className="mt-1 text-2xl font-semibold text-foreground sm:text-3xl">
+        {clinician.name}
+      </h1>
+      <p className="mt-2 text-xs text-muted-foreground">
+        NPI {clinician.npi} · Home {clinician.homeState} · {clinician.primaryFacility}
+      </p>
+      <p className="mt-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+        Monitoring since {clinician.monitoringSince} · Last full sync {clinician.lastFullSync} · {clinician.enrollmentsActive} active enrollments
+      </p>
+    </header>
+  );
+}
+
+function TrustScorePanel({
+  clinician,
+  factors,
+  compositeScore,
+}: {
+  clinician: AutopilotClinician;
+  factors: ReadonlyArray<TrustFactor>;
+  compositeScore: number;
+}) {
+  return (
+    <section
+      aria-labelledby="trust-heading"
+      className="mt-6 rounded-md border border-border bg-card p-5"
+      data-testid="autopilot-trust-panel"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 id="trust-heading" className="text-base font-semibold sm:text-lg">
+          Trust score
+        </h2>
+        <p
+          className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground"
+          data-testid="trust-tier-label"
+        >
+          Tier {clinician.trustLevel}
+        </p>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Weighted composite of source-check freshness, sanctions monitoring,
+        attestation currency, malpractice coverage, CME pace, and profile drift.
+      </p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <ScoreCell label="Composite" value={`${(compositeScore * 100).toFixed(0)}%`} sub="Weighted" testId="trust-score-composite" highlight />
+        <ScoreCell label="Headline (snapshot)" value={`${(clinician.trustScore * 100).toFixed(0)}%`} sub="As of last full sync" testId="trust-score-headline" />
+        <ScoreCell label="Factors" value={String(factors.length)} sub="Composite inputs" testId="trust-score-factor-count" />
+      </div>
+
+      <ol className="mt-4 space-y-2">
+        {factors.map((f, i) => (
+          <li
+            key={`${f.label}-${i}`}
+            className="rounded border border-border/60 bg-background/40 p-3"
+            data-testid="trust-factor"
+            data-factor-weight={String(f.weight)}
+            data-factor-score={String(f.score)}
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <p className="text-sm font-medium text-foreground">{f.label}</p>
+              <p className="text-[10px] font-mono text-muted-foreground tabular-nums">
+                weight {(f.weight * 100).toFixed(0)}% · score {(f.score * 100).toFixed(0)}%
+              </p>
+            </div>
+            <p className="mt-1 text-[11px] text-muted-foreground">{f.note}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function ScoreCell({
+  label,
+  value,
+  sub,
+  testId,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  testId: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={[
+        'rounded-md border p-3',
+        highlight ? 'border-foreground/30 bg-muted/20' : 'border-border',
+      ].join(' ')}
+      data-testid={testId}
+    >
+      <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-xl font-semibold text-foreground tabular-nums">{value}</p>
+      <p className="mt-0.5 text-[10px] text-muted-foreground">{sub}</p>
+    </div>
+  );
+}
+
+function RenewalRadar({
+  renewals,
+  counts,
+}: {
+  renewals: ReadonlyArray<RenewalEntry>;
+  counts: ReturnType<typeof computeRenewalCounts>;
+}) {
+  // Sort by daysToExpire ascending so most-urgent rows are first.
+  const sorted = [...renewals].sort((a, b) => a.daysToExpire - b.daysToExpire);
+  return (
+    <section
+      aria-labelledby="renewal-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="autopilot-renewal-radar"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 id="renewal-heading" className="text-base font-semibold sm:text-lg">
+          Renewal radar
+        </h2>
+        <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+          {counts.urgent} urgent · {counts.expiring} expiring · {counts.renewSelf} renew · {counts.monitoring} monitoring
+        </p>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Every credential plotted on a 0–540 day horizon. Authority fields are
+        vendor-neutral in the demo; real vendor integrations are out of scope.
+      </p>
+      <ul
+        className="mt-4 space-y-2"
+        data-testid="autopilot-renewal-list"
+      >
+        {sorted.map((r) => {
+          const meta = ACTION_META[r.action];
+          const kind = KIND_META[r.kind];
+          return (
+            <li
+              key={r.id}
+              className="rounded border border-border/60 bg-background/40 p-3"
+              data-renewal-id={r.id}
+              data-renewal-kind={r.kind}
+              data-renewal-action={r.action}
+              data-days-to-expire={String(r.daysToExpire)}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-sm font-medium text-foreground">
+                  <span className="text-[10px] font-mono text-muted-foreground/70 mr-2">
+                    {kind.glyph}
+                  </span>
+                  {r.label}
+                </p>
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${TONE_BADGE[meta.tone]}`}
+                >
+                  {meta.label}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Expires {r.expires} · {r.daysToExpire}d · {r.protocol}
+              </p>
+              <p className="mt-0.5 text-[10px] font-mono text-muted-foreground/70">
+                authority: {r.authority}
+                {r.fee && r.fee !== 'no fee' && ` · fee ${r.fee}`}
+                {r.cmeRequired !== null && r.cmeOnFile !== null && ` · ${r.cmeOnFile}/${r.cmeRequired} CME`}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function NbaQueue({ items }: { items: ReadonlyArray<NbaEntry> }) {
+  return (
+    <section
+      aria-labelledby="nba-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="autopilot-nba-queue"
+    >
+      <h2 id="nba-heading" className="text-base font-semibold sm:text-lg">
+        Next-best actions
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Concrete, ranked. CTAs are placeholders in Phase 1 — accept-into-action
+        wiring is a follow-up.
+      </p>
+      <ol className="mt-4 space-y-3" data-testid="autopilot-nba-list">
+        {items.map((n) => {
+          const meta = SEVERITY_META[n.severity];
+          return (
+            <li
+              key={n.id}
+              className="rounded border border-border/60 bg-background/40 p-3"
+              data-nba-id={n.id}
+              data-nba-severity={n.severity}
+              data-nba-rank={String(n.rank)}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-sm font-medium text-foreground">
+                  <span className="text-[10px] font-mono text-muted-foreground/70 mr-2">
+                    #{n.rank}
+                  </span>
+                  {n.title}
+                </p>
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${TONE_BADGE[meta.tone]}`}
+                >
+                  {meta.label}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] text-muted-foreground">{n.subtitle}</p>
+              <p className="mt-1 text-xs text-foreground">{n.impact}</p>
+              <p className="mt-1 text-[10px] font-mono text-muted-foreground/70">
+                {n.receipt}
+              </p>
+              <div className="mt-3 flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled
+                  title="Action wiring — Phase 2"
+                  className="inline-flex items-center rounded border border-foreground bg-foreground px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider text-background opacity-50 cursor-not-allowed"
+                  data-testid="nba-cta-primary"
+                  data-disabled-reason="phase-2-pending"
+                >
+                  {n.ctaLabel}
+                </button>
+                {n.ctaSecondary && (
+                  <button
+                    type="button"
+                    disabled
+                    title="Action wiring — Phase 2"
+                    className="inline-flex items-center rounded border border-border px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider opacity-50 cursor-not-allowed"
+                    data-testid="nba-cta-secondary"
+                  >
+                    {n.ctaSecondary}
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function PortabilityMap({ entries }: { entries: ReadonlyArray<PortabilityEntry> }) {
+  return (
+    <section
+      aria-labelledby="portability-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="autopilot-portability-map"
+    >
+      <h2 id="portability-heading" className="text-base font-semibold sm:text-lg">
+        Portability map
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        States where the clinician is licensed, compact-eligible, or has
+        dormant credentials.
+      </p>
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid="autopilot-portability-list">
+        {entries.map((p) => {
+          const meta = PORTABILITY_META[p.status];
+          return (
+            <li
+              key={p.state}
+              className="rounded border border-border/60 bg-background/40 p-3"
+              data-state-code={p.state}
+              data-portability-status={p.status}
+              data-primary={String(p.primary)}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <p className="text-sm font-medium text-foreground">
+                  <span className="text-[10px] font-mono text-muted-foreground/70 mr-2">
+                    {p.state}
+                  </span>
+                  {p.name}
+                </p>
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${TONE_BADGE[meta.tone]}`}
+                >
+                  {meta.label}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {p.since ? `Since ${p.since}` : 'Not yet active'} · {p.payers} payer{p.payers === 1 ? '' : 's'}
+              </p>
+              <p className="mt-1 text-[11px] text-muted-foreground">{p.note}</p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function DriftMonitor({ drift }: { drift: ReadonlyArray<DriftField> }) {
+  return (
+    <section
+      aria-labelledby="drift-heading"
+      className="mt-8 rounded-md border border-border bg-card p-5"
+      data-testid="autopilot-drift-monitor"
+    >
+      <h2 id="drift-heading" className="text-base font-semibold sm:text-lg">
+        Drift monitor
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        For each canonical profile field, when was the last primary-source
+        check vs. the last attestation? A field with a primary-source check
+        is treated as fresh; without one it is divergent.
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-xs" data-testid="autopilot-drift-table">
+          <thead>
+            <tr className="border-b border-border text-left text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+              <th className="px-2 py-1.5">Field</th>
+              <th className="px-2 py-1.5">Status</th>
+              <th className="px-2 py-1.5">Last source check</th>
+              <th className="px-2 py-1.5">Last attested</th>
+              <th className="px-2 py-1.5">Authority</th>
+            </tr>
+          </thead>
+          <tbody>
+            {drift.map((d) => {
+              const meta = DRIFT_META[d.status];
+              return (
+                <tr
+                  key={d.id}
+                  className="border-b border-border/50"
+                  data-drift-field={d.id}
+                  data-drift-status={d.status}
+                >
+                  <td className="px-2 py-1.5">{d.label}</td>
+                  <td className="px-2 py-1.5">
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${TONE_BADGE[meta.tone]}`}
+                    >
+                      {meta.label}
+                    </span>
+                  </td>
+                  <td className="px-2 py-1.5 font-mono text-[10px]">{d.verifiedAt ?? '—'}</td>
+                  <td className="px-2 py-1.5 font-mono text-[10px]">{d.attestedAt}</td>
+                  <td className="px-2 py-1.5 text-muted-foreground">{d.authority}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/autopilot/autopilotData.ts
+++ b/apps/web/lib/autopilot/autopilotData.ts
@@ -1,0 +1,307 @@
+/**
+ * Wave F Phase 2 — Career Autopilot data shape + demo fixture.
+ *
+ * Pure types + a single demoAutopilot() fixture. No fetch, no DB, no DOM.
+ *
+ * Truth contract:
+ *   - All values returned by demoAutopilot() are demonstrative. They
+ *     do NOT describe a real clinician's autopilot state. The page
+ *     that renders them always carries a "Demo autopilot —
+ *     illustrative only" banner. data-is-demo is the literal `true`.
+ *   - The trust-level label is a tier id (e.g. "T3") — never the
+ *     bare status label that CLAUDE.md bans for status copy.
+ *   - The composite trust score is shown with explicit factor
+ *     weights and per-factor scores so a viewer can see how the
+ *     headline number is constructed.
+ *   - Real upstream credentialing sources (state professional
+ *     licensing boards, controlled-substance authorities, issuing
+ *     boards, sanctions monitors, federal payer systems, interstate
+ *     compacts, malpractice carriers, etc.) are vendor-gated and out
+ *     of scope for this surface; the demo describes the shape of
+ *     monitoring, not active integrations.
+ */
+
+export interface AutopilotClinician {
+  name: string;
+  npi: string;
+  homeState: string;
+  primaryFacility: string;
+  /** Tier label like 'T1' | 'T2' | 'T3'. Never the bare status label
+   *  that CLAUDE.md bans for status copy. */
+  trustLevel: string;
+  /** 0..1 composite trust score. */
+  trustScore: number;
+  monitoringSince: string;
+  lastFullSync: string;
+  enrollmentsActive: number;
+  /** Always true in Phase 1 — drives the demo banner. */
+  isDemo: true;
+}
+
+export type RenewalKind =
+  | 'license'
+  | 'controlled_substance'
+  | 'board'
+  | 'certification'
+  | 'enrollment'
+  | 'clearance';
+
+export type RenewalAction = 'monitor' | 'renew_self' | 'expiring' | 'urgent';
+
+export interface RenewalEntry {
+  id: string;
+  kind: RenewalKind;
+  label: string;
+  expires: string;
+  /** Negative = already expired. */
+  daysToExpire: number;
+  action: RenewalAction;
+  protocol: string;
+  /** Authority is intentionally generic ("home state board",
+   *  "issuing board") — specific vendor names are NOT used. */
+  authority: string;
+  autoRenewable: boolean;
+  fee: string;
+  cmeRequired: number | null;
+  cmeOnFile: number | null;
+}
+
+export type PortabilityStatus =
+  | 'licensed'
+  | 'compact_eligible'
+  | 'enrolled_payer'
+  | 'dormant';
+
+export interface PortabilityEntry {
+  state: string;
+  name: string;
+  status: PortabilityStatus;
+  since: string | null;
+  payers: number;
+  primary: boolean;
+  note: string;
+}
+
+export type NbaSeverity = 'low' | 'medium' | 'high';
+
+export interface NbaEntry {
+  id: string;
+  rank: number;
+  severity: NbaSeverity;
+  title: string;
+  subtitle: string;
+  impact: string;
+  receipt: string;
+  ctaLabel: string;
+  ctaSecondary?: string;
+}
+
+export type DriftStatus = 'fresh' | 'aging' | 'stale' | 'divergent';
+
+export interface DriftField {
+  id: string;
+  label: string;
+  /** ISO date a primary-source check last confirmed this field. Null
+   *  when no primary-source check has ever run for it (divergent). */
+  verifiedAt: string | null;
+  attestedAt: string;
+  status: DriftStatus;
+  /** Vendor-neutral authority description. */
+  authority: string;
+  delta: string;
+}
+
+export interface TrustFactor {
+  label: string;
+  weight: number;
+  score: number;
+  note: string;
+}
+
+export interface AutopilotState {
+  clinician: AutopilotClinician;
+  renewals: ReadonlyArray<RenewalEntry>;
+  portability: ReadonlyArray<PortabilityEntry>;
+  nba: ReadonlyArray<NbaEntry>;
+  drift: ReadonlyArray<DriftField>;
+  trustFactors: ReadonlyArray<TrustFactor>;
+}
+
+/* ---------- Status meta — pure label/tone maps ---------- */
+
+export const ACTION_META: Record<
+  RenewalAction,
+  { label: string; tone: 'slate' | 'indigo' | 'amber' | 'rose' }
+> = {
+  monitor:    { label: 'Monitoring',     tone: 'slate'  },
+  renew_self: { label: 'Renew',          tone: 'indigo' },
+  expiring:   { label: 'Expiring soon',  tone: 'amber'  },
+  urgent:     { label: 'Action required', tone: 'rose'  },
+};
+
+export const KIND_META: Record<RenewalKind, { label: string; glyph: string }> = {
+  license:              { label: 'State License',           glyph: '⚖' },
+  controlled_substance: { label: 'Controlled-Substance',    glyph: 'Rx' },
+  board:                { label: 'Board Cert',              glyph: '◆' },
+  certification:        { label: 'Certification',           glyph: '+' },
+  enrollment:           { label: 'Enrollment',              glyph: '↳' },
+  clearance:            { label: 'Health Clearance',        glyph: '✚' },
+};
+
+export const PORTABILITY_META: Record<
+  PortabilityStatus,
+  { label: string; tone: 'emerald' | 'indigo' | 'slate' }
+> = {
+  licensed:         { label: 'Licensed',         tone: 'emerald' },
+  compact_eligible: { label: 'Compact eligible', tone: 'indigo'  },
+  enrolled_payer:   { label: 'Enrolled (payer)', tone: 'emerald' },
+  dormant:          { label: 'Dormant',          tone: 'slate'   },
+};
+
+export const SEVERITY_META: Record<
+  NbaSeverity,
+  { label: string; tone: 'rose' | 'amber' | 'slate' }
+> = {
+  high:   { label: 'High',   tone: 'rose'  },
+  medium: { label: 'Medium', tone: 'amber' },
+  low:    { label: 'Low',    tone: 'slate' },
+};
+
+export const DRIFT_META: Record<
+  DriftStatus,
+  { label: string; tone: 'emerald' | 'slate' | 'amber' | 'rose' }
+> = {
+  fresh:     { label: 'Fresh',     tone: 'emerald' },
+  aging:     { label: 'Aging',     tone: 'slate'   },
+  stale:     { label: 'Stale',     tone: 'amber'   },
+  divergent: { label: 'Divergent', tone: 'rose'    },
+};
+
+/* ---------- Pure derived helpers ---------- */
+
+/**
+ * Compute the weighted composite trust score from the factor list.
+ * Returns a 0..1 number rounded to 2 decimal places. Weights are
+ * expected to sum to 1; the function does NOT renormalize so a
+ * malformed list is surfaced as a non-1 sum in the test.
+ */
+export function computeCompositeTrustScore(factors: ReadonlyArray<TrustFactor>): number {
+  let weighted = 0;
+  for (const f of factors) {
+    weighted += f.weight * f.score;
+  }
+  return Math.round(weighted * 100) / 100;
+}
+
+/** Sum of factor weights — exposed so tests can verify it equals 1. */
+export function sumFactorWeights(factors: ReadonlyArray<TrustFactor>): number {
+  return Math.round(factors.reduce((acc, f) => acc + f.weight, 0) * 1000) / 1000;
+}
+
+export interface RenewalCounts {
+  total: number;
+  urgent: number;
+  expiring: number;
+  renewSelf: number;
+  monitoring: number;
+}
+
+export function computeRenewalCounts(renewals: ReadonlyArray<RenewalEntry>): RenewalCounts {
+  return {
+    total: renewals.length,
+    urgent: renewals.filter((r) => r.action === 'urgent').length,
+    expiring: renewals.filter((r) => r.action === 'expiring').length,
+    renewSelf: renewals.filter((r) => r.action === 'renew_self').length,
+    monitoring: renewals.filter((r) => r.action === 'monitor').length,
+  };
+}
+
+/* ---------- Demo fixture ---------- */
+
+export function demoAutopilot(): AutopilotState {
+  return {
+    clinician: {
+      name: 'Demo Clinician, PA-C',
+      npi: '0000000000',
+      homeState: 'Demo State',
+      primaryFacility: 'Demo Health · Surgical Pavilion',
+      trustLevel: 'T3',
+      trustScore: 0.94,
+      monitoringSince: '2024-09-12',
+      lastFullSync: '2026-04-18T14:32:00Z',
+      enrollmentsActive: 23,
+      isDemo: true,
+    },
+    renewals: [
+      { id: 'lic-home',     kind: 'license',              label: 'Home-state PA license',         expires: '2026-09-30', daysToExpire: 156, action: 'renew_self', protocol: 'Home-state board · CME 50 hrs/2yr', authority: 'Home-state professional licensing board', autoRenewable: true,  fee: '$370',  cmeRequired: 50,  cmeOnFile: 38 },
+      { id: 'csa',          kind: 'controlled_substance', label: 'Controlled-substance authority', expires: '2026-08-15', daysToExpire: 110, action: 'renew_self', protocol: 'Federal · 3-year cycle',             authority: 'Federal controlled-substance authority',  autoRenewable: true,  fee: '$888',  cmeRequired: null, cmeOnFile: null },
+      { id: 'board',        kind: 'board',                label: 'Board certification',            expires: '2027-12-31', daysToExpire: 612, action: 'monitor',     protocol: 'Issuing board · 10-year cycle',      authority: 'Issuing certification board',             autoRenewable: false, fee: '$350',  cmeRequired: 100, cmeOnFile: 62 },
+      { id: 'acls',         kind: 'certification',        label: 'ACLS card',                       expires: '2026-06-04', daysToExpire: 39,  action: 'urgent',      protocol: 'Issuing assn · 2-year renewal',      authority: 'Issuing health-skills association',      autoRenewable: false, fee: '$255',  cmeRequired: null, cmeOnFile: null },
+      { id: 'bls',          kind: 'certification',        label: 'BLS card',                        expires: '2027-01-10', daysToExpire: 259, action: 'monitor',     protocol: 'Issuing assn · 2-year renewal',      authority: 'Issuing health-skills association',      autoRenewable: false, fee: '$95',   cmeRequired: null, cmeOnFile: null },
+      { id: 'fed-rev',      kind: 'enrollment',           label: 'Federal payer revalidation',     expires: '2027-02-28', daysToExpire: 308, action: 'monitor',     protocol: 'Federal · 5-year revalidation cycle', authority: 'Federal payer enrollment authority',      autoRenewable: false, fee: 'no fee', cmeRequired: null, cmeOnFile: null },
+      { id: 'priv-fac',     kind: 'enrollment',           label: 'Facility privileges',             expires: '2028-04-30', daysToExpire: 735, action: 'monitor',     protocol: 'Facility bylaws · 2-year re-privileging', authority: 'Facility credentials committee',     autoRenewable: false, fee: 'no fee', cmeRequired: null, cmeOnFile: null },
+      { id: 'tb',           kind: 'clearance',            label: 'TB clearance · annual',           expires: '2026-04-25', daysToExpire: 0,   action: 'expiring',    protocol: 'Annual employee health',             authority: 'Facility employee health',                autoRenewable: false, fee: 'no fee', cmeRequired: null, cmeOnFile: null },
+      { id: 'attestation',  kind: 'enrollment',           label: 'Roster re-attestation',           expires: '2026-07-12', daysToExpire: 76,  action: 'renew_self', protocol: '120-day attestation cycle',          authority: 'Roster attestation system',               autoRenewable: true,  fee: 'no fee', cmeRequired: null, cmeOnFile: null },
+    ],
+    portability: [
+      { state: 'D1', name: 'Demo State 1',  status: 'licensed',         since: '2018-06', payers: 23, primary: true,  note: 'Home state · primary licensure' },
+      { state: 'D2', name: 'Demo State 2',  status: 'compact_eligible', since: null,      payers: 0,  primary: false, note: 'Eligible via interstate compact · 14-day issuance' },
+      { state: 'D3', name: 'Demo State 3',  status: 'compact_eligible', since: null,      payers: 0,  primary: false, note: 'Eligible via interstate compact · 21-day issuance' },
+      { state: 'D4', name: 'Demo State 4',  status: 'compact_eligible', since: null,      payers: 0,  primary: false, note: 'Eligible · facility endorsement available' },
+      { state: 'D5', name: 'Demo State 5',  status: 'licensed',         since: '2022-03', payers: 4,  primary: false, note: 'Active second licensure · used last for tele-consult' },
+      { state: 'D6', name: 'Demo State 6',  status: 'dormant',          since: '2019-08', payers: 0,  primary: false, note: 'License lapsed 2023-11 · reactivation requires CME hours' },
+    ],
+    nba: [
+      {
+        id: 'nba-acls',
+        rank: 1,
+        severity: 'high',
+        title: 'Book ACLS skills check',
+        subtitle: 'Card expires June 4 · 39 days · class slots tightening',
+        impact: 'Without renewal, the facility moderate-sedation privilege auto-suspends June 5.',
+        receipt: 'Pulled from issuing-association roster · refreshed 14m ago',
+        ctaLabel: 'See class slots near you',
+        ctaSecondary: 'Snooze 7d',
+      },
+      {
+        id: 'nba-cme',
+        rank: 2,
+        severity: 'medium',
+        title: 'Home-state PA renewal · 12 CME hrs short',
+        subtitle: 'Renewal opens July 1 · 38/50 hrs on file',
+        impact: 'On current pace you finish CME 14 days late. Ten on-demand courses match your scope.',
+        receipt: 'CME records reconciled with membership organization · 4d ago',
+        ctaLabel: 'Plan CME (12 hrs)',
+        ctaSecondary: 'I have credits elsewhere',
+      },
+      {
+        id: 'nba-compact',
+        rank: 3,
+        severity: 'low',
+        title: 'Pre-stage second-state license via interstate compact',
+        subtitle: 'Locum offers in your inbox · 14-day issuance',
+        impact: 'Pre-staging captures up to ~$28k in tele-consult and locum margin without dual board fees.',
+        receipt: 'Inferred from inbound recruiter messages · last week',
+        ctaLabel: 'Start compact pre-stage',
+        ctaSecondary: 'Not interested',
+      },
+    ],
+    drift: [
+      { id: 'address',      label: 'Practice address',             verifiedAt: '2026-04-12', attestedAt: '2026-04-18', status: 'fresh',     authority: 'Provider directory · live ping',          delta: '6 days' },
+      { id: 'tin',          label: 'Tax ID / TIN',                  verifiedAt: '2026-04-18', attestedAt: '2026-04-18', status: 'fresh',     authority: 'TIN match · payer rosters',               delta: 'same day' },
+      { id: 'csa',          label: 'Controlled-substance schedules', verifiedAt: '2026-04-15', attestedAt: '2026-04-18', status: 'fresh',     authority: 'Controlled-substance registration database', delta: '3 days' },
+      { id: 'malpractice',  label: 'Malpractice carrier',           verifiedAt: '2026-01-09', attestedAt: '2026-04-18', status: 'aging',     authority: 'Coverage letter on file',                  delta: '99 days' },
+      { id: 'reference-1',  label: 'Peer reference',                 verifiedAt: '2025-08-22', attestedAt: '2026-04-18', status: 'stale',     authority: 'Direct attestation',                       delta: '239 days' },
+      { id: 'phone',        label: 'Direct phone',                   verifiedAt: '2025-12-04', attestedAt: '2026-04-18', status: 'aging',     authority: 'Roster attestation system',                delta: '135 days' },
+      { id: 'specialty',    label: 'Self-reported specialty',         verifiedAt: null,         attestedAt: '2026-04-18', status: 'divergent', authority: 'No primary source · attestation only',     delta: 'never source-confirmed' },
+    ],
+    trustFactors: [
+      { label: 'Primary-source check freshness',     weight: 0.30, score: 0.97, note: '7/7 anchor sources within 30-day window' },
+      { label: 'No active sanctions or actions',     weight: 0.25, score: 1.00, note: 'Sanctions controls clean · adverse-event monitoring nightly' },
+      { label: 'Document attestations current',      weight: 0.15, score: 0.92, note: '1 attestation aging > 60 days' },
+      { label: 'Malpractice coverage on file',       weight: 0.15, score: 0.88, note: 'Carrier letter aging 99 days' },
+      { label: 'CME / continuing competence pace',   weight: 0.10, score: 0.76, note: '38/50 hrs · on track if current pace holds' },
+      { label: 'Profile drift index',                weight: 0.05, score: 0.84, note: '2 fields aging · 1 divergent self-report' },
+    ],
+  };
+}


### PR DESCRIPTION
Fifth of six missing design surfaces. New /autopilot route with trust score panel (composite + 6 weighted factors) + 9-row renewal radar sorted by daysToExpire + 3-item NBA queue + 6-state portability map + 7-field drift monitor. Vendor names removed; tier label is T3 not bare status label. 26 tests pass. Verified end-to-end. Codex SAFE.