### PR TITLE
feat(oig): restore three-way confidence semantics — no_match / possible_match / exact (W1.2)

### DIFF
--- a/apps/web/__tests__/oig-adapter-confidence.test.ts
+++ b/apps/web/__tests__/oig-adapter-confidence.test.ts
@@ -1,0 +1,256 @@
+/**
+ * oig-adapter-confidence.test.ts
+ *
+ * W1.2 — restores semantic distinction between three OIG match outcomes
+ * that the adapter previously conflated under `confidence: 'exact'`:
+ *
+ *   no_match       — 0 records returned. ABSENCE of records, NOT a
+ *                    guarantee of clearance.
+ *   possible_match — records returned BUT none with an exact NPI match
+ *                    (e.g. legacy LEIE entries filed without NPI / by
+ *                    name only). Surfaces as REVIEW_REQUIRED — never
+ *                    auto-flips to BLOCKED_SIGNAL because false-positive
+ *                    name matches are a known LEIE limitation.
+ *   exact          — at least one returned record has e.npi === queriedNpi.
+ *                    Severity then depends on `reinstatedDate`.
+ *
+ * Tests run against the adapter directly with `globalThis.fetch` mocked
+ * — no network calls, no DB, no Clerk. Adapter under test is the live
+ * @vitalcv/source-adapters export imported via vitest's resolver.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The adapter's sha256Sync helper uses `globalThis.crypto.createHash`
+// (a known pre-existing bug — Node exposes that API on `node:crypto`,
+// not on the Web Crypto global). Stub it for test isolation; W1.2 is
+// about confidence semantics, not the hash util.
+vi.mock('../../../packages/source-adapters/src/utils/hash', () => ({
+  sha256Sync: (input: string) => `sha256:test-${input.length}`,
+}));
+
+import { OigLeieAdapter } from '../../../packages/source-adapters/src/adapters/oig';
+import { SourceStatus } from '../../../packages/source-adapters/src/types';
+
+const QUERIED_NPI = '1003000126';
+
+function mockOigResponse(body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => body,
+    }),
+  );
+}
+
+describe('OIG LEIE adapter — match confidence semantics (W1.2)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ── no_match ──────────────────────────────────────────────────────
+
+  it('0 records → confidence: no_match (NOT exact, NOT clearance)', async () => {
+    mockOigResponse({ exclusions: [], last_updated: '2026-05-01' });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('no_match');
+    // The check completed → status remains CHECKED, but the explanation
+    // must NOT imply guaranteed clearance.
+    expect(result.status).toBe(SourceStatus.CHECKED);
+    expect(result.matchBasis.explanation).toContain('0 records');
+    expect(result.matchBasis.explanation).toMatch(/not a guarantee/i);
+    // No exclusion claim should mark active exclusion present
+    const hasActive = result.claims.find((c) => c.key === 'has_active_exclusion');
+    expect(hasActive?.value).toBe(false);
+  });
+
+  it('no_match still surfaces oig_match_confidence as a claim', async () => {
+    mockOigResponse({ exclusions: [] });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    const confidenceClaim = result.claims.find((c) => c.key === 'oig_match_confidence');
+    expect(confidenceClaim).toBeDefined();
+    expect(confidenceClaim!.value).toBe('no_match');
+    expect(confidenceClaim!.present).toBe(true);
+  });
+
+  // ── exact ─────────────────────────────────────────────────────────
+
+  it('record with exact NPI match → confidence: exact + BLOCKED_SIGNAL', async () => {
+    mockOigResponse({
+      exclusions: [
+        {
+          npi: QUERIED_NPI,
+          firstname: 'Test',
+          lastname: 'Subject',
+          excltype: '1128(a)(1)',
+          excl_date: '2024-01-15',
+          reindate: null,
+          excl_reason: 'Conviction of program-related crime',
+        },
+      ],
+    });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('exact');
+    expect(result.status).toBe(SourceStatus.BLOCKED_SIGNAL);
+    expect(result.matchBasis.explanation).toContain('NPI-exact');
+    // Active exclusion limitation must be marked adverse
+    const adverse = result.limitations.find((l) => l.code === 'OIG_EXCLUSION_ACTIVE');
+    expect(adverse).toBeDefined();
+    expect(adverse!.adverse).toBe(true);
+  });
+
+  it('exact match all reinstated → confidence: exact + REVIEW_REQUIRED', async () => {
+    mockOigResponse({
+      exclusions: [
+        {
+          npi: QUERIED_NPI,
+          name: 'Reinstated Subject',
+          excltype: '1128(a)(1)',
+          excl_date: '2018-06-01',
+          reindate: '2022-12-01',
+          excl_reason: 'Reinstated after waiver',
+        },
+      ],
+    });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('exact');
+    expect(result.status).toBe(SourceStatus.REVIEW_REQUIRED);
+    const reinstated = result.limitations.find((l) => l.code === 'OIG_REINSTATED');
+    expect(reinstated).toBeDefined();
+    expect(reinstated!.adverse).toBe(false);
+  });
+
+  // ── possible_match ────────────────────────────────────────────────
+
+  it('records returned with NULL npi → confidence: possible_match + REVIEW_REQUIRED (not BLOCKED)', async () => {
+    // Legacy LEIE entry without NPI — could be a name-only false-positive.
+    mockOigResponse({
+      exclusions: [
+        {
+          npi: null,
+          firstname: 'Sarah',
+          lastname: 'Chen',
+          excltype: '1128(b)(7)',
+          excl_date: '2010-03-15',
+          reindate: null,
+          excl_reason: 'Healthcare-related fraud',
+        },
+      ],
+    });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('possible_match');
+    // CRITICAL: must NOT be BLOCKED_SIGNAL — false-positive risk.
+    expect(result.status).toBe(SourceStatus.REVIEW_REQUIRED);
+    expect(result.matchBasis.explanation).toMatch(/no.*exact NPI match/i);
+    expect(result.matchBasis.explanation).toMatch(/review required/i);
+
+    // Limitation must be marked non-adverse so downstream scoring
+    // doesn't treat name-only matches as confirmed exclusions.
+    const possible = result.limitations.find((l) => l.code === 'OIG_POSSIBLE_NAME_MATCH');
+    expect(possible).toBeDefined();
+    expect(possible!.adverse).toBe(false);
+  });
+
+  it('records with DIFFERENT npi than queried → confidence: possible_match', async () => {
+    // Adapter received records whose embedded NPI does not match the
+    // queried subject. This is unusual for the NPI-keyed endpoint but
+    // possible (cached / legacy / name-routed). Treat as possible_match.
+    mockOigResponse({
+      exclusions: [
+        {
+          npi: '9999999999',
+          firstname: 'Different',
+          lastname: 'Person',
+          excltype: '1128(a)(1)',
+          excl_date: '2020-01-01',
+          reindate: null,
+        },
+      ],
+    });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('possible_match');
+    expect(result.status).toBe(SourceStatus.REVIEW_REQUIRED);
+  });
+
+  // ── mixed ─────────────────────────────────────────────────────────
+
+  it('mix of exact + name-only records → confidence: exact (NPI-exact wins)', async () => {
+    mockOigResponse({
+      exclusions: [
+        {
+          npi: QUERIED_NPI,
+          name: 'Test Subject',
+          excltype: '1128(a)(1)',
+          excl_date: '2024-01-15',
+          reindate: null,
+        },
+        {
+          npi: null,
+          name: 'Different Name',
+          excltype: '1128(b)(7)',
+          excl_date: '2010-01-01',
+          reindate: null,
+        },
+      ],
+    });
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    // The NPI-exact match dominates; ambiguous record surfaces as a
+    // separate limitation but doesn't downgrade the confidence.
+    expect(result.matchBasis.confidence).toBe('exact');
+    expect(result.status).toBe(SourceStatus.BLOCKED_SIGNAL);
+    expect(result.matchBasis.explanation).toContain('1 NPI-exact record');
+    expect(result.matchBasis.explanation).toContain('1 additional');
+
+    // Both limitation codes should appear
+    const codes = result.limitations.map((l) => l.code);
+    expect(codes).toContain('OIG_EXCLUSION_ACTIVE');
+    expect(codes).toContain('OIG_POSSIBLE_NAME_MATCH');
+  });
+
+  // ── unresolved (regression — must remain unchanged) ───────────────
+
+  it('fetch error → confidence: unresolved + UNAVAILABLE (regression-guard)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      }),
+    );
+
+    const adapter = new OigLeieAdapter();
+    const result = await adapter.fetch(QUERIED_NPI);
+
+    expect(result.matchBasis.confidence).toBe('unresolved');
+    expect(result.status).toBe(SourceStatus.UNAVAILABLE);
+    expect(result.matchBasis.explanation).toMatch(/cannot confirm clearance/i);
+  });
+});

--- a/packages/source-adapters/src/adapters/oig.ts
+++ b/packages/source-adapters/src/adapters/oig.ts
@@ -1,7 +1,7 @@
 // ── OIG LEIE Source Adapter ───────────────────────────────────────
 // Exclusion lane. NEVER defaults to "clear". Unresolved ≠ Clear.
 
-import type { SourceAdapter, SourceCheckResult, SourceClaim, SourceLimitation, MatchResult, ErrorClass } from '../types';
+import type { SourceAdapter, SourceCheckResult, SourceClaim, SourceLimitation, MatchResult, MatchConfidence, ErrorClass } from '../types';
 import { SourceStatus } from '../types';
 import { sha256Sync } from '../utils/hash';
 
@@ -47,28 +47,10 @@ export class OigLeieAdapter implements SourceAdapter {
 
     const rawHash = this.hashRaw(raw);
     const normalized = this.normalize(raw);
-    const status = this.classify(normalized);
-    const claims = this.buildClaims(normalized);
-    const limitations = this.buildLimitations(normalized);
-
-    // CRITICAL: never default to "clear". Explicitly state match result.
-    const exclusionCount = (normalized.exclusions as any[])?.length || 0;
-    let matchConfidence: MatchResult['confidence'];
-    let explanation: string;
-
-    if (exclusionCount === 0) {
-      matchConfidence = 'exact';
-      explanation = `NPI ${npi} checked against OIG LEIE — 0 exclusion records found`;
-    } else {
-      matchConfidence = 'exact';
-      explanation = `NPI ${npi} has ${exclusionCount} exclusion record(s) in OIG LEIE`;
-    }
-
-    const matchBasis: MatchResult = {
-      mode: this.matchMode,
-      confidence: matchConfidence,
-      explanation,
-    };
+    const matchBasis = this.deriveMatchBasis(normalized, npi);
+    const status = this.classify(normalized, matchBasis.confidence);
+    const claims = this.buildClaims(normalized, matchBasis.confidence);
+    const limitations = this.buildLimitations(normalized, npi);
 
     return {
       sourceId: this.sourceId,
@@ -108,8 +90,80 @@ export class OigLeieAdapter implements SourceAdapter {
     };
   }
 
-  classify(normalized: Record<string, unknown>): SourceStatus {
+  /**
+   * W1.2 — derive a match-confidence value that distinguishes the three
+   * cases the audit found conflated:
+   *
+   *   no_match       — 0 records returned. ABSENCE of records — NOT a
+   *                    guarantee of clearance. Adverse data takes 30 days
+   *                    or more to land in LEIE; downstream copy must
+   *                    treat this as "no records on file at check time".
+   *
+   *   possible_match — records returned BUT none with an exact NPI match.
+   *                    The OIG endpoint is NPI-keyed, but legacy LEIE
+   *                    entries can land without an NPI (filed pre-NPI,
+   *                    or with name-only attribution). Returning records
+   *                    without NPI is signal — needs a human reviewer
+   *                    to reconcile whether the records describe the
+   *                    queried subject. Maps to REVIEW_REQUIRED.
+   *
+   *   exact          — at least one returned record has e.npi === npi.
+   *                    Severity then depends on `reinstatedDate` (handled
+   *                    in classify): active exclusion → BLOCKED_SIGNAL,
+   *                    fully reinstated → REVIEW_REQUIRED.
+   */
+  private deriveMatchBasis(normalized: Record<string, unknown>, queriedNpi: string): MatchResult {
+    const exclusions = (normalized.exclusions as any[]) ?? [];
+    const exclusionCount = exclusions.length;
+    const exactNpiMatches = exclusions.filter(
+      (e: any) => typeof e?.npi === 'string' && e.npi === queriedNpi,
+    ).length;
+    const ambiguousMatches = exclusionCount - exactNpiMatches;
+
+    if (exclusionCount === 0) {
+      return {
+        mode: this.matchMode,
+        confidence: 'no_match',
+        explanation:
+          `OIG LEIE returned 0 records for NPI ${queriedNpi}. ` +
+          `Absence of records on file at check time — not a guarantee of clearance.`,
+      };
+    }
+
+    if (exactNpiMatches > 0) {
+      return {
+        mode: this.matchMode,
+        confidence: 'exact',
+        explanation:
+          `OIG LEIE returned ${exactNpiMatches} NPI-exact record(s) for NPI ${queriedNpi}` +
+          (ambiguousMatches > 0
+            ? ` (plus ${ambiguousMatches} additional record(s) without an exact NPI match).`
+            : '.'),
+      };
+    }
+
+    return {
+      mode: this.matchMode,
+      confidence: 'possible_match',
+      explanation:
+        `OIG LEIE returned ${ambiguousMatches} record(s) for NPI ${queriedNpi} ` +
+        `but none with an exact NPI match. Possible name-only match — review required.`,
+    };
+  }
+
+  classify(
+    normalized: Record<string, unknown>,
+    matchConfidence: MatchConfidence = 'exact',
+  ): SourceStatus {
     const count = normalized.exclusionCount as number || 0;
+
+    // W1.2 — possible_match (records present but no exact NPI match) is a
+    // human-review signal, NOT a blocker. It must not flip to BLOCKED_SIGNAL
+    // because false-positive name matches in LEIE are a known limitation
+    // (see SOURCE_REGISTRY entry: 'Name variations may miss matches').
+    if (matchConfidence === 'possible_match') {
+      return SourceStatus.REVIEW_REQUIRED;
+    }
 
     if (count > 0) {
       // Check if all exclusions are reinstated
@@ -122,10 +176,17 @@ export class OigLeieAdapter implements SourceAdapter {
       return SourceStatus.BLOCKED_SIGNAL; // Active exclusion
     }
 
-    return SourceStatus.CHECKED; // 0 records = clear
+    // W1.2 — 0 records is `no_match` confidence (not `exact`). The
+    // SourceStatus stays CHECKED (the check completed) but the matchBasis
+    // confidence is what downstream surfaces should consult to render
+    // language. Never imply authoritative clearance from a `no_match`.
+    return SourceStatus.CHECKED;
   }
 
-  buildClaims(normalized: Record<string, unknown>): SourceClaim[] {
+  buildClaims(
+    normalized: Record<string, unknown>,
+    matchConfidence: MatchConfidence = 'exact',
+  ): SourceClaim[] {
     const exclusions = (normalized.exclusions as any[]) || [];
     const hasActiveExclusion = exclusions.some((e: any) => !e.reinstatedDate);
 
@@ -145,6 +206,13 @@ export class OigLeieAdapter implements SourceAdapter {
         value: hasActiveExclusion,
         present: true,
       },
+      // W1.2 — explicit match-confidence claim so downstream consumers
+      // can reason about it without re-deriving from the explanation.
+      {
+        key: 'oig_match_confidence',
+        value: matchConfidence,
+        present: true,
+      },
       {
         key: 'exclusions',
         value: exclusions,
@@ -153,11 +221,35 @@ export class OigLeieAdapter implements SourceAdapter {
     ];
   }
 
-  buildLimitations(normalized: Record<string, unknown>): SourceLimitation[] {
+  buildLimitations(
+    normalized: Record<string, unknown>,
+    queriedNpi?: string,
+  ): SourceLimitation[] {
     const exclusions = (normalized.exclusions as any[]) || [];
     const limitations: SourceLimitation[] = [];
 
     for (const exc of exclusions) {
+      // W1.2 — distinguish a name-only / no-NPI record from an NPI-exact
+      // exclusion. The former needs human reconciliation; the latter is
+      // an authoritative match (and may be active or reinstated).
+      const isNpiExact =
+        typeof queriedNpi === 'string' &&
+        typeof exc?.npi === 'string' &&
+        exc.npi === queriedNpi;
+
+      if (!isNpiExact) {
+        limitations.push({
+          code: 'OIG_POSSIBLE_NAME_MATCH',
+          description:
+            `Record returned without an exact NPI match` +
+            (exc.name ? ` (name: ${exc.name})` : '') +
+            `. Possible false-positive — review required before treating as adverse.`,
+          // Not adverse on its own — a human must reconcile.
+          adverse: false,
+        });
+        continue;
+      }
+
       if (exc.reinstatedDate) {
         limitations.push({
           code: 'OIG_REINSTATED',

--- a/packages/source-adapters/src/types.ts
+++ b/packages/source-adapters/src/types.ts
@@ -12,7 +12,28 @@ export type LaneType = 'identity' | 'exclusion' | 'enrollment' | 'licensure' | '
 
 export type AuthMode = 'none' | 'api_key' | 'oauth' | 'basic' | 'certificate' | 'manual';
 
-export type MatchConfidence = 'exact' | 'strong' | 'partial' | 'unresolved' | 'no_match';
+/**
+ * Match confidence semantics (W1.2).
+ *
+ *   exact          — deterministic identifier match (e.g. NPI-keyed return).
+ *   strong         — multiple corroborating identifiers; near-deterministic.
+ *   partial        — single non-identifier signal (e.g. name only) plus context.
+ *   possible_match — adapter received records BUT none with an exact identifier
+ *                    match — name-only match suspected. NOT a blocking signal
+ *                    on its own; surfaces as `REVIEW_REQUIRED` so a human
+ *                    reconciles whether the records describe the subject.
+ *   no_match       — adapter returned 0 records. ABSENCE of records — NOT a
+ *                    guarantee of clearance. Downstream surfaces must not
+ *                    render `no_match` as authoritative-safe certainty.
+ *   unresolved     — the check could not complete (timeout / network / parser).
+ */
+export type MatchConfidence =
+  | 'exact'
+  | 'strong'
+  | 'partial'
+  | 'possible_match'
+  | 'no_match'
+  | 'unresolved';
 
 export type MatchMode = 'npi_exact' | 'name_dob' | 'name_npi' | 'custom';
 


### PR DESCRIPTION
## Summary
W1.2 trust-restoration fix from the recursive audit. Closes the audit's **P0 finding**: \`packages/source-adapters/src/adapters/oig.ts\` emitted \`confidence: 'exact'\` for BOTH "0 records returned" and "N records returned" — a clean no-match was indistinguishable from a verified-safe clearance, and a name-only false-positive could slip through as if it were an authoritative NPI-exact exclusion.

## Three explicit cases

| Confidence | When | SourceStatus | Truth contract |
|---|---|---|---|
| \`no_match\` | 0 records returned | \`CHECKED\` | "Absence of records on file at check time — not a guarantee of clearance." |
| \`possible_match\` | Records returned BUT none with an exact NPI match | \`REVIEW_REQUIRED\` | Never auto-flips to BLOCKED_SIGNAL. False-positive name matches are a known LEIE limitation. Limitation marked **non-adverse** so downstream scoring doesn't treat name-only matches as confirmed exclusions. |
| \`exact\` | ≥ 1 record with \`e.npi === queriedNpi\` | \`BLOCKED_SIGNAL\` (active) or \`REVIEW_REQUIRED\` (all reinstated) | Mixed exact + name-only preserves exact verdict; ambiguous record surfaces as separate non-adverse limitation. |

## Files changed (3)

- **\`packages/source-adapters/src/types.ts\`** — \`MatchConfidence\` union extended with \`'possible_match'\`. Docstring per value. Order rearranged for narrative flow.
- **\`packages/source-adapters/src/adapters/oig.ts\`** — \`deriveMatchBasis()\` extracted; \`classify()\` / \`buildClaims()\` / \`buildLimitations()\` now match-confidence aware. New claim \`oig_match_confidence\`. New limitation code \`OIG_POSSIBLE_NAME_MATCH\` (non-adverse).
- **\`apps/web/__tests__/oig-adapter-confidence.test.ts\`** (new) — 8 vitest cases.

## Backward compatibility
- Sibling adapters (NPPES, PECOS, ca-pa-board) untouched. None emit \`possible_match\` today; no \`switch\` case is silently broken.
- \`classify(normalized)\` still works when called without the new parameter (defaults to \`'exact'\`).
- Web-side \`passport.standing.exclusionStatus\` enum already supports \`'POSSIBLE_MATCH'\` (\`passport-contract.ts:159\`) and renders "Review required" in \`PassportWallet:346\` + \`passportProofSections:283-309\`. **No UI changes needed**. The backend identity bridge that maps adapter confidence → \`standing.exclusionStatus\` is the next-wave wiring (out of W1.2 scope).

## Truth-language guarantees
- \`no_match\` explanation reads "not a guarantee of clearance" — UI consumers cannot accidentally render it as authoritative-safe certainty
- \`possible_match\` explanation reads "review required" — visibly degrades trust posture
- \`exact + active\` produces \`BLOCKED_SIGNAL\` and an adverse limitation, unchanged from baseline
- No fuzzy AI scoring, no probabilistic ML, no autonomous matching. Evidence-based classification only (NPI string equality).

## Test plan
- [x] 8 vitest cases pass — no_match (with explanation + claim), exact + active, exact + reinstated, possible_match (NULL npi), possible_match (mismatched npi), mixed records, unresolved regression guard
- [ ] Manual: hit a real OIG_LEIE_ENABLED flow with a known excluded NPI and confirm \`exclusionStatus === 'EXCLUDED'\` once the backend bridge wires \`oig_match_confidence\` through

## Pre-existing bug surfaced (NOT in scope)
\`packages/source-adapters/src/utils/hash.ts\` uses \`globalThis.crypto.createHash\` — only exists on Node's \`node:crypto\`, not the Web Crypto global. The test mocks the helper to bypass. **Production fix is a separate one-line PR**: change to \`import { createHash } from 'node:crypto'\`.

## Remaining exclusion semantics still NOT governed by W1.2
- **Backend identity bridge**: \`apps/api/backend/src/services/identity/leieCache.ts\` (and \`identityIngestionPipeline.ts\`) — needs to read \`oig_match_confidence\` claim and map to \`standing.exclusionStatus = 'POSSIBLE_MATCH'\` so the UI's existing "Review required" treatment fires. **Next-wave**.
- **\`apps/api/backend/src/services/identity/ofacAdapter.ts\`** — separate exclusion source (OFAC), not OIG. Different adapter; same pattern of confidence semantics may need follow-up.
- **CRS \`exclusion_clear\` boolean**: any backend readiness path that reads \`hasActiveExclusion\` should also degrade to "review required" when \`possible_match\` is the verdict — verify in the next-wave bridge.
- **Fuzzy/Levenshtein name matching**: not introduced by this PR. The adapter still relies on the API endpoint's NPI keying. If LEIE name-fuzziness becomes a future capability, the matchMode will need extension; out of W1.2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)