### PR TITLE
feat(employer): ROI Console v2 — per-pilot value dashboard at /employer/roi (Wave 44)

### DIFF
--- a/apps/web/__tests__/employer-roi-page.test.tsx
+++ b/apps/web/__tests__/employer-roi-page.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('/employer/roi page', () => {
+  it('renders the demo banner and pilot identity', async () => {
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+
+    // Demo banner mandatory until persistence Phase 2 lands.
+    expect(html).toContain('Demo cohort');
+
+    // Pilot identity surfaced in the header.
+    expect(html).toContain('PILOT-2026-Q2-014');
+    expect(html).toContain('Cedar Health Surgical Pavilion');
+
+    // The four headline cards.
+    expect(html).toContain('Decisions logged');
+    expect(html).toContain('Reviewer-hours saved');
+    expect(html).toContain('At your default wage');
+    expect(html).toContain('Time to first decision');
+
+    // Methodology panel header (collapsed by default but rendered).
+    expect(html).toContain('How this math works');
+
+    // Footer disclosure.
+    expect(html).toContain('not a comprehensive financial model');
+  });
+
+  it('frames every numeric estimate with an explicit qualifier', async () => {
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+
+    expect(html).toContain('Observed');
+    expect(html).toContain('Projected');
+    expect(html).toContain('Estimated');
+    expect(html).toContain('not an industry average');
+  });
+
+  it('sets data-pilot-id on the page wrapper for downstream selectors', async () => {
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+    expect(html).toContain('data-pilot-id="PILOT-2026-Q2-014"');
+    expect(html).toContain('data-testid="employer-roi-page"');
+  });
+
+  it('contains zero banned strings', async () => {
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement).toLowerCase();
+    for (const banned of BANNED) {
+      expect(html).not.toContain(banned.toLowerCase());
+    }
+  });
+
+  it('does not use bare "Verified" as a row-state label in the lane table', async () => {
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+
+    // Column header is "Confirmed", not "Verified".
+    expect(html).toContain('Confirmed');
+    // Searching for the Verified row-header pattern (column header text).
+    // The string "Verified" may appear inside CONFIDENCE_TIER_META copy if a
+    // ConfidenceBadge is rendered; on this surface no badge renders, so any
+    // "Verified" occurrence would be a row-state regression.
+    expect(html).not.toMatch(/<th[^>]*>Verified<\/th>/i);
+  });
+
+  it('does not render dollar values when wage is null (smoke check via toggle path)', async () => {
+    // The toggle is client-side; this asserts on the server-rendered default
+    // state where wage IS set. We separately test the hours-only path in
+    // roi-v2-headline-strip.test.tsx.
+    const { default: Page } = await import('../app/employer/roi/page');
+    const tree = await Page();
+    const html = renderToStaticMarkup(tree as React.ReactElement);
+    // Default snapshot has wage = $65/hr → dollar values must render.
+    expect(html).toMatch(/\$\d/);
+  });
+});

--- a/apps/web/__tests__/roi-v2-doctrine.test.ts
+++ b/apps/web/__tests__/roi-v2-doctrine.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { LABEL_QUALIFIER_V2 } from '../lib/roi-v2/label-qualifier';
+import {
+  getRoiV2DemoSnapshot,
+  withHoursOnlyMode,
+  ROI_V2_EXPORTS,
+} from '../lib/roi-v2/fixtures';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('LABEL_QUALIFIER_V2', () => {
+  it('locks the qualifier vocabulary to exactly six keys', () => {
+    expect(Object.keys(LABEL_QUALIFIER_V2).sort()).toEqual(
+      ['baseline', 'decisions', 'dollars', 'hours', 'rate', 'vsBaseline'].sort(),
+    );
+  });
+
+  it('every qualifier carries an explicit "Estimated" / "Projected" / "Observed" / "You entered" / "Comparison" qualifier', () => {
+    for (const key of Object.keys(LABEL_QUALIFIER_V2) as Array<
+      keyof typeof LABEL_QUALIFIER_V2
+    >) {
+      const text = LABEL_QUALIFIER_V2[key];
+      expect(text).toMatch(/Estimated|Projected|Observed|You entered|Comparison/);
+    }
+  });
+
+  it('comparison qualifier explicitly disclaims industry-average baselines', () => {
+    expect(LABEL_QUALIFIER_V2.vsBaseline).toContain('not an industry average');
+  });
+
+  it('contains zero banned strings across all qualifier copy', () => {
+    const haystack = Object.values(LABEL_QUALIFIER_V2).join(' ').toLowerCase();
+    for (const banned of BANNED) {
+      expect(haystack).not.toContain(banned.toLowerCase());
+    }
+  });
+});
+
+describe('getRoiV2DemoSnapshot', () => {
+  it('returns a stable seed across calls', () => {
+    const a = getRoiV2DemoSnapshot();
+    const b = getRoiV2DemoSnapshot();
+    expect(a.pilot.pilotId).toBe(b.pilot.pilotId);
+    expect(a.decisions.staged).toBe(b.decisions.staged);
+    expect(a.timeline).toHaveLength(b.timeline.length);
+  });
+
+  it('returns a fresh timeline so mutation does not bleed across calls', () => {
+    const a = getRoiV2DemoSnapshot();
+    a.timeline[0]!.observed = 999;
+    const b = getRoiV2DemoSnapshot();
+    expect(b.timeline[0]!.observed).not.toBe(999);
+  });
+
+  it('seeds the pilot with a non-null defaultWageUsd by default', () => {
+    const snapshot = getRoiV2DemoSnapshot();
+    expect(snapshot.pilot.defaultWageUsd).not.toBeNull();
+    expect(typeof snapshot.pilot.defaultWageUsd).toBe('number');
+  });
+
+  it('snapshot status is one of the four locked states', () => {
+    const snapshot = getRoiV2DemoSnapshot();
+    expect(['on-track', 'trailing', 'blocked', 'complete']).toContain(
+      snapshot.status.state,
+    );
+  });
+
+  it('lane breakdown column "confirmed" is the receipt-confirmation column (no "verified" row state)', () => {
+    const snapshot = getRoiV2DemoSnapshot();
+    for (const row of snapshot.laneBreakdown) {
+      expect(row).toHaveProperty('confirmed');
+      expect(row).not.toHaveProperty('verified');
+    }
+  });
+
+  it('exports list is exactly three options: csv, pdf, snapshot', () => {
+    const ids = ROI_V2_EXPORTS.map((e) => e.id).sort();
+    expect(ids).toEqual(['csv', 'pdf', 'snapshot']);
+  });
+
+  it('contains zero banned strings across all snapshot copy', () => {
+    const snapshot = getRoiV2DemoSnapshot();
+    const haystack = JSON.stringify(snapshot).toLowerCase();
+    for (const banned of BANNED) {
+      expect(haystack).not.toContain(banned.toLowerCase());
+    }
+  });
+
+  it('methodology panel discloses what is NOT included', () => {
+    const snapshot = getRoiV2DemoSnapshot();
+    const notIncludedRow = snapshot.methodology.find((r) =>
+      r.k.toLowerCase().includes('not include'),
+    );
+    expect(notIncludedRow).toBeDefined();
+    expect(notIncludedRow!.note.toLowerCase()).toContain(
+      'reviewer hours and decision throughput',
+    );
+  });
+});
+
+describe('withHoursOnlyMode', () => {
+  it('clears defaultWageUsd', () => {
+    const original = getRoiV2DemoSnapshot();
+    expect(original.pilot.defaultWageUsd).not.toBeNull();
+    const muted = withHoursOnlyMode(original);
+    expect(muted.pilot.defaultWageUsd).toBeNull();
+  });
+
+  it('does not mutate the original snapshot', () => {
+    const original = getRoiV2DemoSnapshot();
+    const originalWage = original.pilot.defaultWageUsd;
+    withHoursOnlyMode(original);
+    expect(original.pilot.defaultWageUsd).toBe(originalWage);
+  });
+});

--- a/apps/web/__tests__/roi-v2-headline-strip.test.tsx
+++ b/apps/web/__tests__/roi-v2-headline-strip.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RoiHeadlineStrip } from '../components/roi-v2';
+import { HoursOnlyBanner } from '../components/roi-v2/HoursOnlyBanner';
+import { getRoiV2DemoSnapshot, withHoursOnlyMode } from '../lib/roi-v2/fixtures';
+
+const BANNED = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+describe('RoiHeadlineStrip wage gating', () => {
+  it('renders the dollar card when defaultWageUsd is set', () => {
+    const snap = getRoiV2DemoSnapshot();
+    const html = renderToStaticMarkup(
+      <RoiHeadlineStrip
+        pilot={snap.pilot}
+        decisions={snap.decisions}
+        hours={snap.hours}
+        ttfd={snap.ttfd}
+      />,
+    );
+    expect(html).toContain('At your default wage');
+    expect(html).toMatch(/\$\d+(\.\d+)?K/);
+    expect(html).toContain('based on your default wage');
+  });
+
+  it('renders the hours-only CTA when defaultWageUsd is null', () => {
+    const snap = withHoursOnlyMode(getRoiV2DemoSnapshot());
+    const html = renderToStaticMarkup(
+      <RoiHeadlineStrip
+        pilot={snap.pilot}
+        decisions={snap.decisions}
+        hours={snap.hours}
+        ttfd={snap.ttfd}
+      />,
+    );
+    expect(html).toContain('Dollar equivalents');
+    expect(html).toContain('Activation Step');
+    // No dollar values rendered when wage is null.
+    expect(html).not.toMatch(/\$\d+(\.\d+)?K/);
+  });
+
+  it('always renders a qualifier on every metric card', () => {
+    const snap = getRoiV2DemoSnapshot();
+    const html = renderToStaticMarkup(
+      <RoiHeadlineStrip
+        pilot={snap.pilot}
+        decisions={snap.decisions}
+        hours={snap.hours}
+        ttfd={snap.ttfd}
+      />,
+    );
+    // Decisions card → "Observed · receipt-derived count for this pilot window"
+    expect(html).toContain('Observed');
+    // Hours card → "Projected · subject to volume"
+    expect(html).toContain('Projected');
+    // Dollars card → "Estimated · based on your default wage"
+    expect(html).toContain('Estimated');
+    // TTFD card → "Comparison vs. your baseline · not an industry average"
+    expect(html).toContain('not an industry average');
+  });
+
+  it('describes the speedup in terms of the entered baseline', () => {
+    const snap = getRoiV2DemoSnapshot();
+    const html = renderToStaticMarkup(
+      <RoiHeadlineStrip
+        pilot={snap.pilot}
+        decisions={snap.decisions}
+        hours={snap.hours}
+        ttfd={snap.ttfd}
+      />,
+    );
+    expect(html).toMatch(/faster vs\. your baseline of \d+d/);
+  });
+
+  it('contains zero banned strings in either render path', () => {
+    const both = [getRoiV2DemoSnapshot(), withHoursOnlyMode(getRoiV2DemoSnapshot())];
+    for (const snap of both) {
+      const html = renderToStaticMarkup(
+        <RoiHeadlineStrip
+          pilot={snap.pilot}
+          decisions={snap.decisions}
+          hours={snap.hours}
+          ttfd={snap.ttfd}
+        />,
+      ).toLowerCase();
+      for (const banned of BANNED) {
+        expect(html).not.toContain(banned.toLowerCase());
+      }
+    }
+  });
+});
+
+describe('HoursOnlyBanner', () => {
+  it('renders when defaultWageUsd is null', () => {
+    const snap = withHoursOnlyMode(getRoiV2DemoSnapshot());
+    const html = renderToStaticMarkup(<HoursOnlyBanner pilot={snap.pilot} />);
+    expect(html).toContain('Hours-only mode');
+  });
+
+  it('renders nothing when defaultWageUsd is set', () => {
+    const snap = getRoiV2DemoSnapshot();
+    const html = renderToStaticMarkup(<HoursOnlyBanner pilot={snap.pilot} />);
+    expect(html).toBe('');
+  });
+
+  it('renders the Add wage button when onAddWage is provided', () => {
+    const snap = withHoursOnlyMode(getRoiV2DemoSnapshot());
+    const html = renderToStaticMarkup(
+      <HoursOnlyBanner pilot={snap.pilot} onAddWage={() => {}} />,
+    );
+    expect(html).toContain('Add wage in Activation');
+  });
+
+  it('omits the Add wage button when onAddWage is missing', () => {
+    const snap = withHoursOnlyMode(getRoiV2DemoSnapshot());
+    const html = renderToStaticMarkup(<HoursOnlyBanner pilot={snap.pilot} />);
+    expect(html).not.toContain('Add wage in Activation');
+  });
+});

--- a/apps/web/app/employer/roi/RoiClient.tsx
+++ b/apps/web/app/employer/roi/RoiClient.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import * as React from 'react';
+import {
+  DecisionFlowFunnel,
+  HoursOnlyBanner,
+  LaneBreakdownTable,
+  MethodologyPanel,
+  PerDecisionCompare,
+  RoiConsoleHeader,
+  RoiHeadlineStrip,
+  RoiTimelineChart,
+  TtfdSparkline,
+} from '@/components/roi-v2';
+import type {
+  RoiV2ExportKind,
+  RoiV2Snapshot,
+} from '@/lib/roi-v2/types';
+
+export interface RoiClientProps {
+  /** Snapshot from the server component. Treat as immutable. */
+  snapshot: RoiV2Snapshot;
+}
+
+/**
+ * Client-side ROI Console v2. Owns:
+ *   - The hours-only demo toggle (showcase aid; not a runtime feature flag).
+ *   - The export click handler (logs `recordedBy: 'demo'` until the real
+ *     export pipeline lands in a follow-up wave).
+ *
+ * Does NOT mutate the snapshot itself. The toggle constructs a derived view
+ * by clearing `pilot.defaultWageUsd`; it does not alter the server's data.
+ */
+export function RoiClient({ snapshot }: RoiClientProps) {
+  const [hoursOnlyDemo, setHoursOnlyDemo] = React.useState(false);
+
+  const view = React.useMemo<RoiV2Snapshot>(() => {
+    if (!hoursOnlyDemo) return snapshot;
+    return {
+      ...snapshot,
+      pilot: { ...snapshot.pilot, defaultWageUsd: null },
+    };
+  }, [hoursOnlyDemo, snapshot]);
+
+  const handleExport = React.useCallback(
+    (kind: RoiV2ExportKind) => {
+      // No real export pipeline yet. Log with the demo marker so a
+      // production audit trail (post-TRUST-PERSIST-1 Phase 2) can claim
+      // these were never real exports.
+      // eslint-disable-next-line no-console
+      console.log('roi-v2-export', {
+        kind,
+        recordedBy: 'demo',
+        pilotId: view.pilot.pilotId,
+      });
+    },
+    [view.pilot.pilotId],
+  );
+
+  const handleAddWage = React.useCallback(() => {
+    // Hard navigation; the activation surface is not yet rendered as a
+    // route (Wave 43 ships it). Safe placeholder.
+    if (typeof window !== 'undefined') {
+      window.location.href = '/employer/activation';
+    }
+  }, []);
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-6 py-8 space-y-5">
+      <RoiConsoleHeader
+        pilot={view.pilot}
+        status={view.status}
+        onExport={handleExport}
+      />
+
+      <HoursOnlyBanner pilot={view.pilot} onAddWage={handleAddWage} />
+
+      <RoiHeadlineStrip
+        pilot={view.pilot}
+        decisions={view.decisions}
+        hours={view.hours}
+        ttfd={view.ttfd}
+      />
+
+      <div className="grid grid-cols-12 gap-5">
+        <div className="col-span-12 lg:col-span-8 space-y-5">
+          <RoiTimelineChart
+            timeline={view.timeline}
+            decisions={view.decisions}
+          />
+          <LaneBreakdownTable
+            lanes={view.laneBreakdown}
+            pilot={view.pilot}
+          />
+          <MethodologyPanel rows={view.methodology} />
+        </div>
+        <aside className="col-span-12 lg:col-span-4 space-y-5">
+          <DecisionFlowFunnel decisions={view.decisions} />
+          <PerDecisionCompare
+            pilot={view.pilot}
+            hours={view.hours}
+            cost={view.costDrilldown}
+          />
+          <TtfdSparkline ttfd={view.ttfd} />
+
+          <div className="border border-dashed border-slate-300 rounded-[3px] bg-slate-50/30 px-4 py-3 text-[11.5px] text-slate-600 leading-[1.55]">
+            <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500 mb-1">
+              Demo control · hours-only
+            </div>
+            <p className="mb-2">
+              Toggle to preview how the console renders for orgs that
+              haven&rsquo;t entered a default wage. Both paths are first-class
+              &mdash; neither is degraded.
+            </p>
+            <label className="inline-flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={hoursOnlyDemo}
+                onChange={(e) => setHoursOnlyDemo(e.target.checked)}
+                className="accent-slate-900"
+              />
+              <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-slate-700">
+                {hoursOnlyDemo ? 'hours-only · on' : 'wage-set · on'}
+              </span>
+            </label>
+          </div>
+        </aside>
+      </div>
+
+      <div className="border-t border-slate-200 pt-4 font-mono text-[10.5px] text-slate-500 leading-[1.55]">
+        Pilot {view.pilot.pilotId} · Owner {view.pilot.ownerContact} · Marketing
+        tier: {view.pilot.tier}. ROI on this surface is reviewer-hours and
+        decision throughput &mdash; not a comprehensive financial model.
+        Comparisons are vs. your entered baseline of {view.pilot.baselineDays}d,
+        not an industry average.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/employer/roi/page.tsx
+++ b/apps/web/app/employer/roi/page.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import { getRoiV2DemoSnapshot } from '@/lib/roi-v2/fixtures';
+import { RoiClient } from './RoiClient';
+
+export const metadata: Metadata = {
+  title: 'Pilot ROI Console · VitalCV',
+  description:
+    'Per-pilot ROI console. Reviewer-hours, decision throughput, and time-to-first-decision against your entered baseline. Demo data until persistence Phase 2.',
+};
+
+/**
+ * Per-pilot ROI Console v2.
+ *
+ * Sibling surface to the FY-aggregate executive ROI dashboard at
+ * `/roi` (Wave E). Both ship; they answer different questions:
+ *   - `/roi` answers "how is the credentialing program doing this fiscal year?"
+ *   - `/employer/roi` answers "is THIS pilot delivering on its activation
+ *     baseline halfway through the window?"
+ *
+ * Phase 1: snapshot is fixture-driven and the page is banner-disclosed as a
+ * demo. Phase 2 (post-TRUST-PERSIST-1) replaces the fetcher with a real
+ * receipt-log query against the org's pilot window.
+ */
+export default async function EmployerRoiPage() {
+  const snapshot = getRoiV2DemoSnapshot();
+
+  return (
+    <main
+      className="min-h-screen bg-slate-50/40"
+      data-testid="employer-roi-page"
+      data-pilot-id={snapshot.pilot.pilotId}
+    >
+      <div className="max-w-[1280px] mx-auto px-6 pt-6">
+        <p
+          className="inline-block rounded-[2px] bg-amber-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-amber-800 ring-1 ring-amber-600/20"
+          data-testid="roi-v2-demo-banner"
+        >
+          Demo cohort &mdash; illustrative only, not a real customer outcome
+        </p>
+      </div>
+      <RoiClient snapshot={snapshot} />
+    </main>
+  );
+}

--- a/apps/web/components/roi-v2/DecisionFlowFunnel.tsx
+++ b/apps/web/components/roi-v2/DecisionFlowFunnel.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Layers } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { RoiV2Decisions } from '@/lib/roi-v2/types';
+
+export interface DecisionFlowFunnelProps {
+  decisions: RoiV2Decisions;
+}
+
+/**
+ * Decision-flow funnel rendered from observed (receipt-derived) counters.
+ * Five rows in pipeline order: Staged → Decided → Accepted → Refreshed →
+ * Disputed. Bar widths are normalized to the largest row.
+ */
+export function DecisionFlowFunnel({ decisions }: DecisionFlowFunnelProps) {
+  const rows = [
+    { id: 'staged', label: 'Staged in Inbox', count: decisions.staged, cls: 'bg-slate-300' },
+    { id: 'decided', label: 'Decisions logged', count: decisions.decided, cls: 'bg-slate-700' },
+    { id: 'accepted', label: 'Accepted first-pass', count: decisions.acceptedFirstPass, cls: 'bg-emerald-600' },
+    { id: 'refreshed', label: 'Refreshed then accepted', count: decisions.refreshedAndAccepted, cls: 'bg-amber-500' },
+    { id: 'disputed', label: 'Disputed', count: decisions.disputed, cls: 'bg-rose-500' },
+  ];
+  const max = Math.max(...rows.map((r) => r.count), 1);
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white">
+      <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Layers className="h-3.5 w-3.5 text-slate-700" aria-hidden="true" />
+          <span className="text-[13px] font-semibold text-slate-900">
+            Decision flow this pilot
+          </span>
+        </div>
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+          observed · receipt-derived
+        </span>
+      </div>
+      <ul className="divide-y divide-slate-100">
+        {rows.map((r) => (
+          <li
+            key={r.id}
+            className="px-5 py-2.5 grid grid-cols-12 gap-3 items-center"
+          >
+            <div className="col-span-4 text-[12.5px] text-slate-700">
+              {r.label}
+            </div>
+            <div className="col-span-6">
+              <div className="h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                <div
+                  className={cn('h-full', r.cls)}
+                  style={{ width: `${(r.count / max) * 100}%` }}
+                />
+              </div>
+            </div>
+            <div className="col-span-2 text-right font-mono text-[12px] tabular-nums text-slate-900">
+              {r.count}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/HeadlineMetric.tsx
+++ b/apps/web/components/roi-v2/HeadlineMetric.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface HeadlineMetricProps {
+  label: string;
+  value: string;
+  unit?: string;
+  qualifier?: string;
+  sub?: string;
+  accent?: boolean;
+  className?: string;
+}
+
+/**
+ * Single metric card used in the ROI Console v2 headline strip.
+ *
+ * The `qualifier` prop is mandatory in practice — every projected number on
+ * this surface MUST render with a qualifier from `LABEL_QUALIFIER_V2`. The
+ * prop is optional in the type only because some callers split the qualifier
+ * into a footer instead of inlining it on the card.
+ */
+export function HeadlineMetric({
+  label,
+  value,
+  unit,
+  qualifier,
+  sub,
+  accent,
+  className,
+}: HeadlineMetricProps) {
+  return (
+    <div
+      className={cn(
+        'border rounded-[3px] bg-white px-5 py-4',
+        accent ? 'border-slate-900' : 'border-slate-200',
+        className,
+      )}
+    >
+      <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500 mb-1.5">
+        {label}
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-[28px] font-semibold tracking-[-0.018em] text-slate-900 leading-none tabular-nums">
+          {value}
+        </span>
+        {unit && <span className="text-[13px] text-slate-600">{unit}</span>}
+      </div>
+      {sub && <div className="mt-1.5 text-[12px] text-slate-700">{sub}</div>}
+      {qualifier && (
+        <div className="mt-1 font-mono text-[10.5px] text-slate-500">
+          {qualifier}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/HoursOnlyBanner.tsx
+++ b/apps/web/components/roi-v2/HoursOnlyBanner.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import type { RoiV2Pilot } from '@/lib/roi-v2/types';
+
+export interface HoursOnlyBannerProps {
+  pilot: RoiV2Pilot;
+  onAddWage?: () => void;
+}
+
+/**
+ * Renders a soft amber banner WHEN the org has not entered a default wage in
+ * Activation Step 1. The math is identical with or without wage; this banner
+ * exists solely to disclose that hours-only mode is active and to provide a
+ * one-click path back to set the wage.
+ *
+ * Returns `null` when wage is set (this component is "off by default").
+ */
+export function HoursOnlyBanner({ pilot, onAddWage }: HoursOnlyBannerProps) {
+  if (pilot.defaultWageUsd != null) return null;
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-amber-50/40 px-5 py-3 flex items-center justify-between gap-4 flex-wrap">
+      <div className="text-[12.5px] text-amber-900 leading-[1.55]">
+        <span className="font-mono uppercase tracking-[0.14em] text-[10.5px] mr-2 text-amber-800">
+          Hours-only mode
+        </span>
+        You haven&rsquo;t set a default wage. ROI is rendered in reviewer-hours
+        throughout this console &mdash; the math is identical, just no dollar
+        conversion.
+      </div>
+      {onAddWage && (
+        <button
+          type="button"
+          onClick={onAddWage}
+          className="font-mono text-[10.5px] uppercase tracking-[0.14em] px-3 py-1.5 rounded-[2px] border border-slate-300 bg-white text-slate-900 hover:bg-slate-50"
+        >
+          Add wage in Activation
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/LaneBreakdownTable.tsx
+++ b/apps/web/components/roi-v2/LaneBreakdownTable.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { Network } from 'lucide-react';
+import type { RoiV2LaneRow, RoiV2Pilot } from '@/lib/roi-v2/types';
+
+export interface LaneBreakdownTableProps {
+  lanes: RoiV2LaneRow[];
+  pilot: RoiV2Pilot;
+}
+
+/**
+ * Per-lane decision breakdown table. Counts come from receipts.
+ *
+ * Column header is "Confirmed" — the bare word "Verified" is reserved for
+ * the field-level confidence tier (Wave 41 doctrine), not pipeline state.
+ */
+export function LaneBreakdownTable({
+  lanes,
+  pilot,
+}: LaneBreakdownTableProps) {
+  const wage = pilot.defaultWageUsd;
+  const totals = lanes.reduce(
+    (acc, l) => ({
+      decided: acc.decided + l.decided,
+      confirmed: acc.confirmed + l.confirmed,
+      refreshed: acc.refreshed + l.refreshed,
+      contradicted: acc.contradicted + l.contradicted,
+      hoursSaved: acc.hoursSaved + l.hoursSaved,
+      dollars: acc.dollars + (wage != null ? Math.round(l.hoursSaved * wage) : 0),
+    }),
+    { decided: 0, confirmed: 0, refreshed: 0, contradicted: 0, hoursSaved: 0, dollars: 0 },
+  );
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white overflow-hidden">
+      <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-2">
+          <Network className="h-3.5 w-3.5 text-slate-700" aria-hidden="true" />
+          <span className="text-[13px] font-semibold text-slate-900">
+            Where value is coming from
+          </span>
+        </div>
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+          per-lane · receipt-derived
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-[12.5px]">
+          <thead>
+            <tr className="bg-slate-50/60 text-slate-500 font-mono text-[10.5px] uppercase tracking-[0.12em]">
+              <th scope="col" className="text-left px-5 py-2 font-medium">Lane</th>
+              <th scope="col" className="text-right px-3 py-2 font-medium">Decided</th>
+              <th scope="col" className="text-right px-3 py-2 font-medium">Confirmed</th>
+              <th scope="col" className="text-right px-3 py-2 font-medium">Refreshed</th>
+              <th scope="col" className="text-right px-3 py-2 font-medium">Contradicted</th>
+              <th scope="col" className="text-right px-3 py-2 font-medium">Hours saved</th>
+              {wage != null && (
+                <th scope="col" className="text-right px-5 py-2 font-medium">$ at wage</th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {lanes.map((l) => {
+              const dollars = wage != null ? Math.round(l.hoursSaved * wage) : null;
+              return (
+                <tr key={l.laneId} className="text-slate-800">
+                  <td className="px-5 py-2.5">
+                    <div className="font-medium text-slate-900">{l.laneName}</div>
+                    <div className="font-mono text-[10.5px] text-slate-500">
+                      {Math.round(l.pctOfTotal * 100)}% of pilot value
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5 text-right tabular-nums">{l.decided}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-emerald-700">{l.confirmed}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-amber-700">{l.refreshed}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums">{l.contradicted}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums">{l.hoursSaved.toFixed(1)}h</td>
+                  {wage != null && dollars != null && (
+                    <td className="px-5 py-2.5 text-right tabular-nums">${dollars.toLocaleString()}</td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="bg-slate-50/40 text-slate-700 font-mono text-[11px]">
+              <td className="px-5 py-2 uppercase tracking-[0.12em] text-slate-500">Total</td>
+              <td className="px-3 py-2 text-right tabular-nums">{totals.decided}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{totals.confirmed}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{totals.refreshed}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{totals.contradicted}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{totals.hoursSaved.toFixed(1)}h</td>
+              {wage != null && (
+                <td className="px-5 py-2 text-right tabular-nums">
+                  ${totals.dollars.toLocaleString()}
+                </td>
+              )}
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/MethodologyPanel.tsx
+++ b/apps/web/components/roi-v2/MethodologyPanel.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronRight, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { RoiV2MethodologyRow } from '@/lib/roi-v2/types';
+
+export interface MethodologyPanelProps {
+  rows: RoiV2MethodologyRow[];
+}
+
+/**
+ * Collapsible "How this math works" panel. Surfaces the methodology footnotes
+ * verbatim so a reader can audit how the math is computed on the surface.
+ *
+ * Required by the truth contract: ROI numbers must be transparently derived,
+ * not opaque marketing claims.
+ */
+export function MethodologyPanel({ rows }: MethodologyPanelProps) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-5 py-3 text-left hover:bg-slate-50/60"
+      >
+        <div className="flex items-center gap-2">
+          <Info className="h-3.5 w-3.5 text-slate-700" aria-hidden="true" />
+          <span className="text-[13px] font-semibold text-slate-900">
+            How this math works
+          </span>
+        </div>
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 text-slate-400 transition-transform',
+            open && 'rotate-90',
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      {open && (
+        <div className="border-t border-slate-100 divide-y divide-slate-100">
+          {rows.map((r) => (
+            <div key={r.k} className="px-5 py-3 grid grid-cols-12 gap-3">
+              <div className="col-span-12 md:col-span-3 font-mono text-[10.5px] uppercase tracking-[0.12em] text-slate-500 pt-0.5">
+                {r.k}
+              </div>
+              <div className="col-span-12 md:col-span-9">
+                <div className="font-mono text-[12px] text-slate-900">{r.v}</div>
+                <p className="mt-0.5 text-[12px] text-slate-600 leading-[1.55]">
+                  {r.note}
+                </p>
+              </div>
+            </div>
+          ))}
+          <div className="px-5 py-3 font-mono text-[10.5px] text-slate-500 leading-[1.55]">
+            We do not extrapolate beyond the pilot window. We do not benchmark
+            against industry averages &mdash; only against the baseline you
+            entered at activation.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/PerDecisionCompare.tsx
+++ b/apps/web/components/roi-v2/PerDecisionCompare.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { Clock } from 'lucide-react';
+import { LABEL_QUALIFIER_V2 } from '@/lib/roi-v2/label-qualifier';
+import type {
+  RoiV2CostDrilldown,
+  RoiV2Hours,
+  RoiV2Pilot,
+} from '@/lib/roi-v2/types';
+
+export interface PerDecisionCompareProps {
+  pilot: RoiV2Pilot;
+  hours: RoiV2Hours;
+  cost: RoiV2CostDrilldown;
+}
+
+/**
+ * Side-by-side compare card: employer's legacy per-decision time vs. observed
+ * pilot per-decision time. Right side renders a green wash to draw the eye to
+ * the pilot column. Dollar conversions appear only when a wage is set.
+ */
+export function PerDecisionCompare({
+  pilot,
+  hours: _hours,
+  cost,
+}: PerDecisionCompareProps) {
+  const wage = pilot.defaultWageUsd;
+  const baselineMin = cost.baselineMinutesPerDecision;
+  const pilotMin = cost.pilotMinutesPerDecision;
+  const ratio = baselineMin / Math.max(pilotMin, 1);
+  const baselineDollars =
+    wage != null ? Math.round((baselineMin / 60) * wage * 100) / 100 : null;
+  const pilotDollars =
+    wage != null ? Math.round((pilotMin / 60) * wage * 100) / 100 : null;
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white">
+      <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-2">
+          <Clock className="h-3.5 w-3.5 text-slate-700" aria-hidden="true" />
+          <span className="text-[13px] font-semibold text-slate-900">
+            Per-decision compare
+          </span>
+        </div>
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+          your legacy process vs. this pilot
+        </span>
+      </div>
+      <div className="grid grid-cols-2 divide-x divide-slate-100">
+        <div className="px-5 py-4">
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500 mb-1">
+            Your baseline
+          </div>
+          <div className="text-[24px] font-semibold tracking-[-0.015em] text-slate-900 tabular-nums leading-none">
+            {baselineMin}
+            <span className="text-[14px] text-slate-500 font-normal ml-1">min</span>
+          </div>
+          {baselineDollars != null && (
+            <div className="mt-1 text-[12px] text-slate-600">
+              &asymp; ${baselineDollars.toFixed(2)} / decision
+            </div>
+          )}
+          <div className="mt-2 font-mono text-[10.5px] text-slate-500">
+            {LABEL_QUALIFIER_V2.baseline}
+          </div>
+        </div>
+        <div className="px-5 py-4 bg-emerald-50/30">
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-emerald-800 mb-1">
+            This pilot
+          </div>
+          <div className="text-[24px] font-semibold tracking-[-0.015em] text-slate-900 tabular-nums leading-none">
+            {pilotMin}
+            <span className="text-[14px] text-slate-500 font-normal ml-1">min</span>
+          </div>
+          {pilotDollars != null && (
+            <div className="mt-1 text-[12px] text-slate-600">
+              &asymp; ${pilotDollars.toFixed(2)} / decision
+            </div>
+          )}
+          <div className="mt-2 font-mono text-[10.5px] text-emerald-800">
+            {ratio.toFixed(1)}× faster · {LABEL_QUALIFIER_V2.vsBaseline}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/RoiConsoleHeader.tsx
+++ b/apps/web/components/roi-v2/RoiConsoleHeader.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { ROI_V2_EXPORTS } from '@/lib/roi-v2/fixtures';
+import type {
+  RoiV2ExportKind,
+  RoiV2Pilot,
+  RoiV2StatusBlock,
+} from '@/lib/roi-v2/types';
+import { RoiStatusPip } from './RoiStatusPip';
+
+export interface RoiConsoleHeaderProps {
+  pilot: RoiV2Pilot;
+  status: RoiV2StatusBlock;
+  onExport?: (kind: RoiV2ExportKind) => void;
+}
+
+/**
+ * Top-of-page identity + window progress + export buttons for the ROI
+ * Console v2.
+ *
+ * Export buttons are placeholders — `onExport` is invoked with the export
+ * kind, and the caller is responsible for wiring the real handler. The
+ * default RoiClient implementation logs to console with `recordedBy: 'demo'`.
+ */
+export function RoiConsoleHeader({
+  pilot,
+  status,
+  onExport,
+}: RoiConsoleHeaderProps) {
+  const elapsedPct = Math.round(
+    (pilot.daysElapsed / pilot.pilotWindowDays) * 100,
+  );
+  const progressBarColor =
+    status.state === 'blocked'
+      ? 'bg-rose-500'
+      : status.state === 'trailing'
+        ? 'bg-amber-500'
+        : status.state === 'complete'
+          ? 'bg-slate-500'
+          : 'bg-emerald-600';
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white px-6 py-5">
+      <div className="flex items-start justify-between gap-6 flex-wrap">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+              ROI Console · {pilot.pilotId}
+            </span>
+            <RoiStatusPip state={status.state} />
+          </div>
+          <h1 className="text-[26px] font-semibold tracking-[-0.018em] text-slate-900 leading-tight">
+            {pilot.orgName}
+          </h1>
+          <p className="mt-1 text-[12.5px] text-slate-600 leading-[1.55] max-w-[68ch]">
+            {status.summary}
+          </p>
+          <div className="mt-2 font-mono text-[10.5px] text-slate-500">
+            Started {pilot.pilotStartedAt} · As of {status.asOf}
+          </div>
+        </div>
+        <div className="flex-shrink-0 min-w-[240px]">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+              Pilot window · {pilot.daysElapsed} of {pilot.pilotWindowDays}d
+            </span>
+            <span className="font-mono text-[11px] tabular-nums text-slate-700">
+              {elapsedPct}%
+            </span>
+          </div>
+          <div
+            role="progressbar"
+            aria-label="Pilot window progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={elapsedPct}
+            className="h-1.5 bg-slate-100 rounded-full overflow-hidden"
+          >
+            <div
+              className={cn('h-full', progressBarColor)}
+              style={{ width: `${elapsedPct}%` }}
+            />
+          </div>
+          {onExport && (
+            <div className="mt-3 flex items-center gap-2 justify-end flex-wrap">
+              {ROI_V2_EXPORTS.map((ex) => (
+                <button
+                  key={ex.id}
+                  type="button"
+                  onClick={() => onExport(ex.id)}
+                  title={ex.sub}
+                  className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-700 hover:text-slate-900 hover:underline"
+                >
+                  {ex.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/RoiHeadlineStrip.tsx
+++ b/apps/web/components/roi-v2/RoiHeadlineStrip.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { LABEL_QUALIFIER_V2 } from '@/lib/roi-v2/label-qualifier';
+import type {
+  RoiV2Decisions,
+  RoiV2Hours,
+  RoiV2Pilot,
+  RoiV2Ttfd,
+} from '@/lib/roi-v2/types';
+import { HeadlineMetric } from './HeadlineMetric';
+
+export interface RoiHeadlineStripProps {
+  pilot: RoiV2Pilot;
+  decisions: RoiV2Decisions;
+  hours: RoiV2Hours;
+  ttfd: RoiV2Ttfd;
+}
+
+/**
+ * Four-card headline strip for the ROI Console v2.
+ *
+ * Card 3 (`At your default wage`) is the wage-gated render path: when
+ * `pilot.defaultWageUsd` is null, it replaces the dollar metric with a CTA
+ * card pointing back to Activation Step 1. Hours-only is a first-class
+ * state, never a degraded one.
+ */
+export function RoiHeadlineStrip({
+  pilot,
+  decisions,
+  hours,
+  ttfd,
+}: RoiHeadlineStripProps) {
+  const wage = pilot.defaultWageUsd;
+  const dollarsK =
+    wage != null
+      ? Math.round((hours.observedSavedHours * wage) / 100) / 10
+      : null;
+  const projDollarsK =
+    wage != null
+      ? Math.round((hours.projectedTotalHoursAt30d * wage) / 100) / 10
+      : null;
+
+  return (
+    <div className="grid grid-cols-12 gap-3">
+      <div className="col-span-12 md:col-span-3">
+        <HeadlineMetric
+          label="Decisions logged"
+          value={decisions.decided.toLocaleString()}
+          unit={`of ${decisions.staged} staged`}
+          sub={`${decisions.acceptedFirstPass} accepted first-pass · ${decisions.disputed} disputed`}
+          qualifier={LABEL_QUALIFIER_V2.decisions}
+          accent
+        />
+      </div>
+      <div className="col-span-12 md:col-span-3">
+        <HeadlineMetric
+          label="Reviewer-hours saved"
+          value={`${hours.observedSavedHours}h`}
+          sub={`Projecting ~${hours.projectedTotalHoursAt30d}h at 30d`}
+          qualifier={LABEL_QUALIFIER_V2.hours}
+        />
+      </div>
+      <div className="col-span-12 md:col-span-3">
+        {wage != null && dollarsK != null && projDollarsK != null ? (
+          <HeadlineMetric
+            label="At your default wage"
+            value={`$${dollarsK}K`}
+            sub={`Projecting ~$${projDollarsK}K at 30d · $${wage}/hr`}
+            qualifier={LABEL_QUALIFIER_V2.dollars}
+          />
+        ) : (
+          <div className="border border-dashed border-slate-300 rounded-[3px] bg-slate-50/40 px-5 py-4 h-full">
+            <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500 mb-1.5">
+              Dollar equivalents
+            </div>
+            <p className="text-[12px] text-slate-600 leading-[1.55]">
+              Add a default wage in Activation Step&nbsp;1 to see dollar
+              equivalents. Hours-only is fine &mdash; the math doesn&rsquo;t
+              change.
+            </p>
+          </div>
+        )}
+      </div>
+      <div className="col-span-12 md:col-span-3">
+        <HeadlineMetric
+          label="Time to first decision"
+          value={`${ttfd.pilotMedianHours}h`}
+          unit="median"
+          sub={`${ttfd.speedupVsBaselineX}× faster vs. your baseline of ${ttfd.baselineDays}d`}
+          qualifier={LABEL_QUALIFIER_V2.vsBaseline}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/RoiStatusPip.tsx
+++ b/apps/web/components/roi-v2/RoiStatusPip.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { RoiV2Status } from '@/lib/roi-v2/types';
+
+const ROI_V2_STATUS_META: Record<
+  RoiV2Status,
+  { label: string; cls: string; dot: string }
+> = {
+  'on-track': {
+    label: 'On track',
+    cls: 'text-emerald-700 bg-emerald-50 ring-emerald-600/20',
+    dot: 'bg-emerald-600',
+  },
+  trailing: {
+    label: 'Trailing',
+    cls: 'text-amber-800 bg-amber-50 ring-amber-600/20',
+    dot: 'bg-amber-500',
+  },
+  blocked: {
+    label: 'Blocked',
+    cls: 'text-rose-700 bg-rose-50 ring-rose-600/20',
+    dot: 'bg-rose-500',
+  },
+  complete: {
+    label: 'Complete',
+    cls: 'text-slate-700 bg-slate-100 ring-slate-300',
+    dot: 'bg-slate-500',
+  },
+};
+
+export interface RoiStatusPipProps {
+  state: RoiV2Status;
+  className?: string;
+}
+
+/**
+ * Compact status pip for the ROI Console v2 header. Pipeline state vocabulary
+ * (`on-track | trailing | blocked | complete`) does not overlap with the lane
+ * state vocabulary or the confidence-tier vocabulary — it specifically
+ * describes pilot-window progress.
+ */
+export function RoiStatusPip({ state, className }: RoiStatusPipProps) {
+  const meta = ROI_V2_STATUS_META[state];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-[2px] ring-1 ring-inset',
+        'text-[10.5px] font-medium uppercase tracking-[0.06em]',
+        meta.cls,
+        className,
+      )}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', meta.dot)} />
+      {meta.label}
+    </span>
+  );
+}
+
+export { ROI_V2_STATUS_META };

--- a/apps/web/components/roi-v2/RoiTimelineChart.tsx
+++ b/apps/web/components/roi-v2/RoiTimelineChart.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { Activity } from 'lucide-react';
+import { LABEL_QUALIFIER_V2 } from '@/lib/roi-v2/label-qualifier';
+import type {
+  RoiV2Decisions,
+  RoiV2TimelineEntry,
+} from '@/lib/roi-v2/types';
+
+export interface RoiTimelineChartProps {
+  timeline: RoiV2TimelineEntry[];
+  decisions: RoiV2Decisions;
+}
+
+/**
+ * Decisions-per-day timeline. Pure SVG — no chart library. Observed series
+ * is solid; projected series is dashed. The "today" position is marked with
+ * a subtle vertical guide line.
+ */
+export function RoiTimelineChart({
+  timeline,
+  decisions,
+}: RoiTimelineChartProps) {
+  const W = 720;
+  const H = 200;
+  const padL = 36;
+  const padR = 16;
+  const padT = 16;
+  const padB = 28;
+  const innerW = W - padL - padR;
+  const innerH = H - padT - padB;
+
+  const max = Math.max(
+    ...timeline.map((d) => Math.max(d.observed ?? 0, d.projected ?? 0)),
+    12,
+  );
+  const xStep = innerW / Math.max(timeline.length - 1, 1);
+  const xy = (i: number, v: number): [number, number] => [
+    padL + i * xStep,
+    padT + innerH - (v / max) * innerH,
+  ];
+
+  const obsPts: Array<[number, number] | null> = timeline.map((d, i) =>
+    d.observed != null ? xy(i, d.observed) : null,
+  );
+  const projPts: Array<[number, number] | null> = timeline.map((d, i) =>
+    d.projected != null ? xy(i, d.projected) : null,
+  );
+
+  const obsPath = obsPts
+    .filter((p): p is [number, number] => p != null)
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0]},${p[1]}`)
+    .join(' ');
+  const projPath = projPts
+    .filter((p): p is [number, number] => p != null)
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0]},${p[1]}`)
+    .join(' ');
+
+  const todayIdx = timeline.findIndex((d) => d.isToday);
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white">
+      <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-2">
+          <Activity className="h-3.5 w-3.5 text-slate-700" aria-hidden="true" />
+          <span className="text-[13px] font-semibold text-slate-900">
+            Decisions per day
+          </span>
+        </div>
+        <div className="flex items-center gap-3 font-mono text-[10.5px] uppercase tracking-[0.14em]">
+          <span className="inline-flex items-center gap-1.5 text-slate-700">
+            <span className="h-0.5 w-4 bg-slate-900" /> observed
+          </span>
+          <span className="inline-flex items-center gap-1.5 text-slate-500">
+            <span className="h-0.5 w-4 border-t border-dashed border-slate-500" />{' '}
+            projected
+          </span>
+        </div>
+      </div>
+      <div className="px-2 py-3">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full h-auto block"
+          role="img"
+          aria-label={`Decisions per day. Running daily rate ${decisions.dailyDecisionRate.toFixed(1)} per day, last 3 days ${decisions.dailyRateLast3.toFixed(1)} per day.`}
+        >
+          {[0, 0.25, 0.5, 0.75, 1].map((t) => {
+            const y = padT + innerH - t * innerH;
+            const v = Math.round(max * t);
+            return (
+              <g key={t}>
+                <line
+                  x1={padL}
+                  y1={y}
+                  x2={W - padR}
+                  y2={y}
+                  stroke="#f1f5f9"
+                  strokeWidth="1"
+                />
+                <text
+                  x={padL - 6}
+                  y={y + 3}
+                  fontSize="9"
+                  textAnchor="end"
+                  fill="#94a3b8"
+                  fontFamily="JetBrains Mono, monospace"
+                >
+                  {v}
+                </text>
+              </g>
+            );
+          })}
+
+          {timeline
+            .filter((_, i) => i % 5 === 0 || i === timeline.length - 1)
+            .map((d) => {
+              const i = timeline.indexOf(d);
+              const [x] = xy(i, 0);
+              return (
+                <text
+                  key={d.day}
+                  x={x}
+                  y={H - 8}
+                  fontSize="9"
+                  textAnchor="middle"
+                  fill="#94a3b8"
+                  fontFamily="JetBrains Mono, monospace"
+                >
+                  d{d.day}
+                </text>
+              );
+            })}
+
+          {todayIdx >= 0 && (
+            <line
+              x1={padL + todayIdx * xStep}
+              y1={padT}
+              x2={padL + todayIdx * xStep}
+              y2={padT + innerH}
+              stroke="#cbd5e1"
+              strokeDasharray="3 2"
+              strokeWidth="1"
+            />
+          )}
+
+          {projPath && (
+            <path
+              d={projPath}
+              fill="none"
+              stroke="#94a3b8"
+              strokeWidth="1.5"
+              strokeDasharray="4 3"
+            />
+          )}
+          {obsPath && (
+            <path
+              d={obsPath}
+              fill="none"
+              stroke="#0f172a"
+              strokeWidth="1.75"
+            />
+          )}
+
+          {obsPts.map((p, i) =>
+            p ? <circle key={i} cx={p[0]} cy={p[1]} r="2.5" fill="#0f172a" /> : null,
+          )}
+        </svg>
+      </div>
+      <div className="px-5 py-2 border-t border-slate-100 font-mono text-[10.5px] text-slate-500 leading-[1.55]">
+        Running daily rate: {decisions.dailyDecisionRate.toFixed(1)} decisions/day
+        · last 3 days: {decisions.dailyRateLast3.toFixed(1)}/day. {LABEL_QUALIFIER_V2.rate}.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/TtfdSparkline.tsx
+++ b/apps/web/components/roi-v2/TtfdSparkline.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { LABEL_QUALIFIER_V2 } from '@/lib/roi-v2/label-qualifier';
+import type { RoiV2Ttfd } from '@/lib/roi-v2/types';
+
+export interface TtfdSparklineProps {
+  ttfd: RoiV2Ttfd;
+}
+
+/**
+ * Time-to-first-decision sparkline. Pure SVG. Compact secondary visual that
+ * sits in the right rail under the per-decision compare card.
+ */
+export function TtfdSparkline({ ttfd }: TtfdSparklineProps) {
+  const samples = ttfd.hourSamplesByDay;
+  const W = 320;
+  const H = 64;
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  const range = Math.max(max - min, 1);
+  const xStep = W / Math.max(samples.length - 1, 1);
+
+  const path = samples
+    .map((v, i) => {
+      const x = i * xStep;
+      const y = H - 6 - ((v - min) / range) * (H - 12);
+      return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="border border-slate-200 rounded-[3px] bg-white p-4">
+      <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+        <div className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-slate-500">
+          Time to first decision · daily median
+        </div>
+        <div className="font-mono text-[10.5px] tabular-nums text-slate-700">
+          p10 {ttfd.pilotP10Hours}h · p50 {ttfd.pilotMedianHours}h · p90{' '}
+          {ttfd.pilotP90Hours}h
+        </div>
+      </div>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="w-full h-auto block"
+        role="img"
+        aria-label={`Daily median time-to-first-decision sparkline. Median ${ttfd.pilotMedianHours} hours, p10 ${ttfd.pilotP10Hours}, p90 ${ttfd.pilotP90Hours}.`}
+      >
+        <path d={path} fill="none" stroke="#0f172a" strokeWidth="1.5" />
+        {samples.map((v, i) => {
+          const x = i * xStep;
+          const y = H - 6 - ((v - min) / range) * (H - 12);
+          return (
+            <circle key={i} cx={x} cy={y} r="1.6" fill="#0f172a" />
+          );
+        })}
+      </svg>
+      <div className="mt-1 font-mono text-[10.5px] text-slate-500">
+        Hours per decision · {ttfd.speedupVsBaselineX}× faster than your{' '}
+        {ttfd.baselineDays}d baseline · {LABEL_QUALIFIER_V2.vsBaseline}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/roi-v2/index.ts
+++ b/apps/web/components/roi-v2/index.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitalcv/web · components/roi-v2
+ *
+ * Per-pilot ROI Console v2 components. Sibling to the FY-aggregate executive
+ * ROI dashboard at apps/web/app/roi (Wave E) — both ship; they answer
+ * different questions.
+ */
+
+export { RoiStatusPip, ROI_V2_STATUS_META } from './RoiStatusPip';
+export type { RoiStatusPipProps } from './RoiStatusPip';
+
+export { RoiConsoleHeader } from './RoiConsoleHeader';
+export type { RoiConsoleHeaderProps } from './RoiConsoleHeader';
+
+export { HeadlineMetric } from './HeadlineMetric';
+export type { HeadlineMetricProps } from './HeadlineMetric';
+
+export { RoiHeadlineStrip } from './RoiHeadlineStrip';
+export type { RoiHeadlineStripProps } from './RoiHeadlineStrip';
+
+export { HoursOnlyBanner } from './HoursOnlyBanner';
+export type { HoursOnlyBannerProps } from './HoursOnlyBanner';
+
+export { DecisionFlowFunnel } from './DecisionFlowFunnel';
+export type { DecisionFlowFunnelProps } from './DecisionFlowFunnel';
+
+export { RoiTimelineChart } from './RoiTimelineChart';
+export type { RoiTimelineChartProps } from './RoiTimelineChart';
+
+export { LaneBreakdownTable } from './LaneBreakdownTable';
+export type { LaneBreakdownTableProps } from './LaneBreakdownTable';
+
+export { PerDecisionCompare } from './PerDecisionCompare';
+export type { PerDecisionCompareProps } from './PerDecisionCompare';
+
+export { TtfdSparkline } from './TtfdSparkline';
+export type { TtfdSparklineProps } from './TtfdSparkline';
+
+export { MethodologyPanel } from './MethodologyPanel';
+export type { MethodologyPanelProps } from './MethodologyPanel';

--- a/apps/web/lib/roi-v2/fixtures.ts
+++ b/apps/web/lib/roi-v2/fixtures.ts
@@ -1,0 +1,174 @@
+/**
+ * Demo fixtures for ROI Console v2.
+ *
+ * Phase 1: every value is fixture-driven. The page that consumes these is
+ * banner-disclosed as a demo until TRUST-PERSIST-1 Phase 2 lands the writer
+ * and a real receipt log is queryable.
+ *
+ * Replacement plan: when persistence Phase 2 ships, replace this module with
+ * a fetcher that queries the org's receipt log within the pilot window. The
+ * Snapshot shape is the contract; component code does not change.
+ */
+
+import type {
+  RoiV2CostDrilldown,
+  RoiV2Decisions,
+  RoiV2ExportOption,
+  RoiV2Hours,
+  RoiV2LaneRow,
+  RoiV2MethodologyRow,
+  RoiV2Pilot,
+  RoiV2Snapshot,
+  RoiV2StatusBlock,
+  RoiV2TimelineEntry,
+  RoiV2Ttfd,
+} from './types';
+
+const ROI_V2_PILOT_DEMO: RoiV2Pilot = {
+  orgId: 'org_demo_pilot_01',
+  orgName: 'Cedar Health Surgical Pavilion',
+  pilotId: 'PILOT-2026-Q2-014',
+  pilotStartedAt: '2026-04-22 09:12 UTC',
+  pilotWindowDays: 30,
+  daysElapsed: 14,
+  defaultWageUsd: 65,
+  baselineDays: 21,
+  ownerContact: 'Karen Patel · VP, Credentialing',
+  tier: 'Pilot',
+};
+
+const ROI_V2_STATUS_DEMO: RoiV2StatusBlock = {
+  state: 'on-track',
+  summary:
+    'Halfway through the pilot window. Decisions are accumulating at the rate we projected at activation.',
+  asOf: '2026-05-06 11:08 UTC',
+};
+
+const ROI_V2_DECISIONS_DEMO: RoiV2Decisions = {
+  staged: 142,
+  decided: 87,
+  acceptedFirstPass: 71,
+  disputed: 9,
+  refreshedAndAccepted: 7,
+  dailyDecisionRate: 6.2,
+  dailyRateLast3: 7.4,
+  windowStart: '2026-04-22',
+  windowEnd: '2026-05-22',
+};
+
+function buildTimelineDemo(): RoiV2TimelineEntry[] {
+  const observed = [0, 1, 2, 3, 5, 4, 6, 7, 8, 6, 9, 8, 11, 10];
+  const start = new Date(Date.UTC(2026, 3, 22));
+  const rows: RoiV2TimelineEntry[] = [];
+  for (let i = 0; i < 30; i++) {
+    const d = new Date(start);
+    d.setUTCDate(start.getUTCDate() + i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const isPast = i < observed.length;
+    const isToday = i === observed.length - 1;
+    rows.push({
+      day: i + 1,
+      date: dateStr,
+      observed: isPast ? observed[i] : null,
+      projected: isPast ? null : Math.round(7.4 * (1 + (i - 13) * 0.02)),
+      isToday,
+    });
+  }
+  return rows;
+}
+
+const ROI_V2_HOURS_DEMO: RoiV2Hours = {
+  observedSavedHours: 96,
+  projectedTotalHoursAt30d: 214,
+  hoursPerDecisionLegacy: 2.4,
+  hoursPerDecisionVitalcv: 0.4,
+  hoursSavedPerDecision: 2.0,
+};
+
+const ROI_V2_TTFD_DEMO: RoiV2Ttfd = {
+  baselineDays: 21,
+  pilotMedianHours: 18,
+  pilotP10Hours: 11,
+  pilotP90Hours: 36,
+  speedupVsBaselineX: 28,
+  hourSamplesByDay: [22, 24, 19, 21, 18, 17, 19, 16, 18, 15, 17, 16, 17, 18],
+};
+
+const ROI_V2_LANE_BREAKDOWN_DEMO: RoiV2LaneRow[] = [
+  { laneId: 'identity', laneName: 'Identity', decided: 84, confirmed: 81, contradicted: 1, refreshed: 2, hoursSaved: 28.0, pctOfTotal: 0.292 },
+  { laneId: 'licensure', laneName: 'Licensure', decided: 78, confirmed: 73, contradicted: 0, refreshed: 5, hoursSaved: 24.5, pctOfTotal: 0.255 },
+  { laneId: 'sanctions', laneName: 'Sanctions', decided: 87, confirmed: 86, contradicted: 1, refreshed: 0, hoursSaved: 22.0, pctOfTotal: 0.229 },
+  { laneId: 'dea', laneName: 'DEA registration', decided: 41, confirmed: 38, contradicted: 0, refreshed: 3, hoursSaved: 12.0, pctOfTotal: 0.125 },
+  { laneId: 'education', laneName: 'Education / GME', decided: 22, confirmed: 21, contradicted: 0, refreshed: 1, hoursSaved: 6.0, pctOfTotal: 0.063 },
+  { laneId: 'malprac', laneName: 'Malpractice hist.', decided: 14, confirmed: 13, contradicted: 0, refreshed: 1, hoursSaved: 3.5, pctOfTotal: 0.036 },
+];
+
+const ROI_V2_COST_DEMO: RoiV2CostDrilldown = {
+  baselineMinutesPerDecision: 144,
+  pilotMinutesPerDecision: 24,
+};
+
+const ROI_V2_METHODOLOGY_DEMO: RoiV2MethodologyRow[] = [
+  {
+    k: 'Decision count source',
+    v: 'Receipt log',
+    note: 'Every entry is an actual receipt object on disk. Pilot-window queries filter on receipt.recordedAt within the pilot window.',
+  },
+  {
+    k: 'Hours-saved math',
+    v: '(baselineMinutes − pilotMinutes) ÷ 60',
+    note: 'Per-decision delta multiplied by decided count. Baseline is employer-entered in Activation Step 3 (your own legacy process), not an industry average.',
+  },
+  {
+    k: 'Dollar conversion',
+    v: 'hours × defaultWageUsd',
+    note: 'Only computed when default wage is set in Activation Step 1. Otherwise hours-only.',
+  },
+  {
+    k: 'Projection model',
+    v: 'Linear from running daily rate',
+    note: 'Day-15 onward uses the running daily rate as the slope. We do not extrapolate beyond the 30-day pilot window.',
+  },
+  {
+    k: 'What we do NOT include',
+    v: 'Indirect costs, opportunity cost, locum offsets',
+    note: 'Pilot ROI is reviewer hours and decision throughput — not a comprehensive financial model.',
+  },
+];
+
+export const ROI_V2_EXPORTS: readonly RoiV2ExportOption[] = [
+  { id: 'csv', label: 'Download CSV', sub: 'Decision log + per-lane breakdown · 14d window' },
+  { id: 'pdf', label: 'Generate PDF', sub: 'Pilot ROI brief · branded for your CFO/board' },
+  { id: 'snapshot', label: 'Snapshot link', sub: 'Read-only URL · expires in 24h · revocable' },
+] as const;
+
+/**
+ * Returns a fresh demo snapshot. The timeline is recomputed each call (so
+ * tests that mutate it don't bleed across cases), but the seed values are
+ * stable.
+ */
+export function getRoiV2DemoSnapshot(): RoiV2Snapshot {
+  return {
+    pilot: { ...ROI_V2_PILOT_DEMO },
+    status: { ...ROI_V2_STATUS_DEMO },
+    decisions: { ...ROI_V2_DECISIONS_DEMO },
+    timeline: buildTimelineDemo(),
+    hours: { ...ROI_V2_HOURS_DEMO },
+    ttfd: { ...ROI_V2_TTFD_DEMO, hourSamplesByDay: [...ROI_V2_TTFD_DEMO.hourSamplesByDay] },
+    laneBreakdown: ROI_V2_LANE_BREAKDOWN_DEMO.map((row) => ({ ...row })),
+    costDrilldown: { ...ROI_V2_COST_DEMO },
+    methodology: ROI_V2_METHODOLOGY_DEMO.map((row) => ({ ...row })),
+    exports: ROI_V2_EXPORTS,
+  };
+}
+
+/**
+ * Mutates a snapshot to render the hours-only path (defaultWageUsd = null).
+ * Helper for tests + the showcase toggle in the client component.
+ */
+export function withHoursOnlyMode(snapshot: RoiV2Snapshot): RoiV2Snapshot {
+  return {
+    ...snapshot,
+    pilot: { ...snapshot.pilot, defaultWageUsd: null },
+  };
+}

--- a/apps/web/lib/roi-v2/label-qualifier.ts
+++ b/apps/web/lib/roi-v2/label-qualifier.ts
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for the inline qualifier copy that accompanies every
+ * numeric metric on the ROI Console v2 surface. Imported by every component
+ * that renders a number; the component MUST NOT render an inline qualifier
+ * outside this map.
+ *
+ * Why a single export: the wave brief's anti-contract requires every projected
+ * number to carry an "Estimated" / "Projected" / "Observed" qualifier. Drift
+ * is the failure mode — one component decides to omit it "to keep the layout
+ * clean," and suddenly the surface looks like a guarantee. By forcing every
+ * render through this map, drift becomes a typed `keyof` violation.
+ */
+
+export const LABEL_QUALIFIER_V2 = {
+  hours: 'Projected · subject to volume',
+  dollars: 'Estimated · based on your default wage',
+  baseline: 'You entered this · used as the comparison point for ROI',
+  decisions: 'Observed · receipt-derived count for this pilot window',
+  rate: 'Observed · running average over the pilot window',
+  vsBaseline: 'Comparison vs. your baseline · not an industry average',
+} as const;
+
+export type LabelQualifierKind = keyof typeof LABEL_QUALIFIER_V2;

--- a/apps/web/lib/roi-v2/types.ts
+++ b/apps/web/lib/roi-v2/types.ts
@@ -1,0 +1,130 @@
+/**
+ * ROI Console v2 — shared types.
+ *
+ * Per-pilot ROI surface, sibling to the FY-aggregate executive ROI dashboard
+ * at apps/web/app/roi (Wave E). Both ship; they answer different questions.
+ *
+ * Truth contract carry-overs:
+ *   - Every projected number must render with a qualifier from
+ *     LABEL_QUALIFIER_V2. Numbers that look like guarantees aren't.
+ *   - Dollar lines render only when defaultWageUsd is non-null. Hours-only
+ *     is a first-class state, not a degraded one.
+ *   - Comparisons are always "vs. your baseline of Nd" — the employer-entered
+ *     baseline from Activation Step 3 — never an industry average.
+ *   - "Confirmed" is the column label for receipt confirmations. The bare
+ *     word "Verified" is reserved for PSV claims and never used as a row state.
+ */
+
+/** Pilot status — drives header pill + progress-bar color + export availability. */
+export type RoiV2Status = 'on-track' | 'trailing' | 'blocked' | 'complete';
+
+export interface RoiV2Pilot {
+  orgId: string;
+  orgName: string;
+  pilotId: string;
+  /** ISO datetime string with " UTC" suffix to match the bundle convention. */
+  pilotStartedAt: string;
+  pilotWindowDays: number;
+  daysElapsed: number;
+  /**
+   * Default wage in USD/hr. When `null`, the surface renders in hours-only
+   * mode. Both render paths are first-class; null is not degraded.
+   */
+  defaultWageUsd: number | null;
+  /** Employer-entered baseline (days). Used as the comparison point — never industry. */
+  baselineDays: number;
+  /** Owner contact (informational). */
+  ownerContact: string;
+  /** Marketing tier (informational; comes from Wave 30 Plans + Billing once shipped). */
+  tier: 'Pilot' | 'Team' | 'Enterprise';
+}
+
+export interface RoiV2StatusBlock {
+  state: RoiV2Status;
+  summary: string;
+  asOf: string;
+}
+
+/** Decision-flow counters — observed from the receipt log, never projected. */
+export interface RoiV2Decisions {
+  staged: number;
+  decided: number;
+  acceptedFirstPass: number;
+  disputed: number;
+  refreshedAndAccepted: number;
+  dailyDecisionRate: number;
+  dailyRateLast3: number;
+  windowStart: string;
+  windowEnd: string;
+}
+
+export interface RoiV2TimelineEntry {
+  day: number;
+  date: string;
+  observed: number | null;
+  projected: number | null;
+  isToday: boolean;
+}
+
+export interface RoiV2Hours {
+  observedSavedHours: number;
+  projectedTotalHoursAt30d: number;
+  hoursPerDecisionLegacy: number;
+  hoursPerDecisionVitalcv: number;
+  hoursSavedPerDecision: number;
+}
+
+export interface RoiV2Ttfd {
+  baselineDays: number;
+  pilotMedianHours: number;
+  pilotP10Hours: number;
+  pilotP90Hours: number;
+  speedupVsBaselineX: number;
+  hourSamplesByDay: number[];
+}
+
+export interface RoiV2LaneRow {
+  laneId: string;
+  laneName: string;
+  decided: number;
+  /** Receipts where the lane fact was confirmed. Column header is "Confirmed",
+   *  not "Verified" — keeps tier vocabulary and pipeline state separate. */
+  confirmed: number;
+  contradicted: number;
+  refreshed: number;
+  hoursSaved: number;
+  /** Fraction of total pilot value attributable to this lane. */
+  pctOfTotal: number;
+}
+
+export interface RoiV2CostDrilldown {
+  baselineMinutesPerDecision: number;
+  pilotMinutesPerDecision: number;
+}
+
+export interface RoiV2MethodologyRow {
+  k: string;
+  v: string;
+  note: string;
+}
+
+export type RoiV2ExportKind = 'csv' | 'pdf' | 'snapshot';
+
+export interface RoiV2ExportOption {
+  id: RoiV2ExportKind;
+  label: string;
+  sub: string;
+}
+
+export interface RoiV2Snapshot {
+  pilot: RoiV2Pilot;
+  status: RoiV2StatusBlock;
+  decisions: RoiV2Decisions;
+  timeline: RoiV2TimelineEntry[];
+  hours: RoiV2Hours;
+  ttfd: RoiV2Ttfd;
+  laneBreakdown: RoiV2LaneRow[];
+  costDrilldown: RoiV2CostDrilldown;
+  methodology: RoiV2MethodologyRow[];
+  exports: readonly RoiV2ExportOption[];
+}


### PR DESCRIPTION
## Summary

Wave 44 of the integration roadmap: per-pilot ROI Console v2 ported from the v6 design bundle (`view-roi-v2.jsx` + `wave22-roi.jsx` + `data-roi-v2.jsx`) into apps/web at `/employer/roi`.

**Path A pilot-revenue critical surface.** This is the artifact an employer shows to their CFO/board to justify pilot renewal or expansion after Activation has them go-live.

Sibling to the existing FY-aggregate Executive ROI dashboard at `/roi` (Wave E #265). Both ship — they answer different questions:

| Route | Audience | Question |
|---|---|---|
| `/roi` | Credentialing leadership | How is the program doing this fiscal year? |
| `/employer/roi` | Employer ops + finance | Is THIS pilot delivering on its activation baseline halfway through the window? |

## What ships

- `app/employer/roi/page.tsx` (server) + `RoiClient.tsx` (client owns hours-only toggle + export handler)
- **11 components** in `components/roi-v2/`:
  - `RoiConsoleHeader` (pilot identity + window progress + export buttons)
  - `RoiStatusPip` (4-state pipeline status)
  - `HeadlineMetric` (one metric card with mandatory qualifier)
  - `RoiHeadlineStrip` (4-card strip with wage gating)
  - `HoursOnlyBanner` (renders only when wage is null)
  - `DecisionFlowFunnel` (5-row observed funnel)
  - `RoiTimelineChart` (pure-SVG decisions/day, observed solid + projected dashed)
  - `LaneBreakdownTable` (per-lane decisions, hours saved, dollar at wage)
  - `PerDecisionCompare` (baseline vs. pilot side-by-side)
  - `TtfdSparkline` (pure-SVG TTFD daily median)
  - `MethodologyPanel` (collapsible verbatim math disclosure)
- `lib/roi-v2/types.ts` — strict types for the snapshot, status, decisions, hours, ttfd, lane row, methodology, exports
- `lib/roi-v2/label-qualifier.ts` — `LABEL_QUALIFIER_V2` const, single source of truth for `Estimated` / `Projected` / `Observed` / `You entered` / `Comparison` qualifier copy
- `lib/roi-v2/fixtures.ts` — typed snapshot factory matching the bundle's data-roi-v2 fixture; `withHoursOnlyMode()` helper for the toggle path

## Truth contract held throughout

- **Every numeric metric** carries an explicit `Estimated · …` / `Projected · …` / `Observed · …` qualifier inline. The qualifier vocabulary is locked at six keys via `LABEL_QUALIFIER_V2` — drift becomes a typed `keyof` violation.
- **Dollar lines render only when** `defaultWageUsd` is non-null. Hours-only is a **first-class state**, not a degraded one — it has its own banner + CTA back to Activation Step 1.
- **Comparisons are always vs. the employer-entered baseline** from Activation Step 3, never an industry average. The qualifier copy explicitly disclaims this.
- **Lane breakdown column is "Confirmed"** (receipt confirmation), not "Verified". Bare "Verified" stays reserved for field-level confidence tier vocabulary (Wave 41 doctrine).
- **Demo banner** at the top of the page until TRUST-PERSIST-1 Phase 2 lands and the receipt-log query replaces the fixture.
- **Methodology panel** surfaces the math verbatim, including what is **NOT** included: indirect costs, opportunity cost, locum offsets.

## Test plan

- [x] `apps/web/__tests__/roi-v2-doctrine.test.ts` — 14 tests (qualifier vocabulary locked, every qualifier carries explicit framing, snapshot stability, lane breakdown column shape, banned-string sweep)
- [x] `apps/web/__tests__/roi-v2-headline-strip.test.tsx` — 9 tests (wage gating: dollar card vs. hours-only CTA; qualifier presence on every card; baseline phrasing; HoursOnlyBanner conditional rendering)
- [x] `apps/web/__tests__/employer-roi-page.test.tsx` — 6 tests (page renders, demo banner, qualifiers present, data attributes, banned-string scan, no bare "Verified" row state)
- [x] Full vitest suite: **1487 pass / 4 skip / 0 fail**
- [x] `pnpm turbo run build --filter @vitalcv/web` green
- [x] `pnpm --filter @vitalcv/web exec tsc --noEmit` green
- [x] `pnpm --filter @vitalcv/web lint` green

## Codex prompt seed

Run with `codex exec` (3 audits required for the merge gate):

````
Audit Integration Wave 44 — ROI Console v2 production port.

Worktree: /tmp/vitalcv-integration-wave-44-roi
Branch: feat/integration-wave-44-roi
PR: this PR

Three passes:

1. Implementation pass
   - Confirm app/employer/roi/page.tsx (server) + RoiClient.tsx (client) +
     11 components in components/roi-v2/ + lib/roi-v2/{types,label-qualifier,
     fixtures}.ts.
   - Confirm period selector toggles all four headline cards correctly (note:
     this build has a hours-only toggle, not the brief's period selector —
     period selector is deferred to a follow-up wave with real receipt-log
     data).
   - Confirm DollarEquivalentCard wage-gates correctly: null wage = hours-only
     CTA card; non-null wage = $XK with qualifier.
   - Confirm RoiTimelineChart renders observed (solid) + projected (dashed)
     paths with a today marker.
   - Confirm LaneBreakdownTable has column "Confirmed" (not "Verified") and
     conditionally renders the dollar column only when wage is set.
   - Confirm MethodologyPanel is collapsible and surfaces every methodology
     row plus the "NOT included" note.
   - Confirm export-mode strips chrome via existing print-mode CSS pattern
     (note: deferred — exports log recordedBy:'demo' for now).

2. Diff pass
   - Confirm /employer/roi is a NEW route — does not modify the existing
     /roi (Wave E #265 Executive ROI). Both ship.
   - Confirm types in lib/roi-v2/ are strict-typed (no `any`).
   - Confirm LABEL_QUALIFIER_V2 in lib/roi-v2/label-qualifier.ts is a single
     `as const` export and is imported (not duplicated) by every component
     that renders a number.
   - Confirm imports follow existing patterns (lucide-react icons, @/ alias,
     cn from @/lib/utils).

3. Copy pass
   - Grep all new files for the 11 banned strings (case-insensitive). Zero hits.
   - Confirm every metric has an Estimated / Projected / Observed / You
     entered / Comparison qualifier inline.
   - Confirm zero "audited" / "third-party validated" / "compliant" claims.
   - Confirm dollar values only render when wage is explicitly set — grep for
     '$' in conditional render paths.
   - Confirm zero "real-time" or "live" labels on timestamps.
   - Confirm column header is "Confirmed" not bare "Verified" in
     LaneBreakdownTable.
   - Confirm DEMO banner is rendered on page load.
   - Confirm methodology row "What we do NOT include" is present.

Output a single line:
Codex verdict: SAFE
or
Codex verdict: NOT-SAFE — <reason>
````

## Test plan (manual smoke)

- [ ] (post-Codex) Visit Vercel preview at `/employer/roi`; verify all 4 headline cards render with qualifiers
- [ ] (post-Codex) Toggle the hours-only demo control; verify dollar columns disappear and the HoursOnlyBanner appears
- [ ] (post-Codex) Click Methodology panel; verify it expands with all 5 rows
- [ ] (post-Codex) Click any export button; verify console logs `roi-v2-export` with `recordedBy: 'demo'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)