### PR TITLE
feat(apply): operational workflow composer + replay-safe verifier requests — W2-PR46A

### DIFF
--- a/.github/workflows/apply-with-vcv-gate.yml
+++ b/.github/workflows/apply-with-vcv-gate.yml
@@ -1,0 +1,47 @@
+name: apply-with-vcv-gate
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/backend/src/services/apply/**'
+      - 'apps/api/backend/src/services/distribution/**'
+      - 'apps/api/backend/src/routes/apply.ts'
+      - 'apps/web/components/apply/**'
+      - 'apps/web/app/api/apply/**'
+      - 'apps/web/app/apply/**'
+      - 'docs/ops/apply-with-vcv-operational-workflow.md'
+      - 'scripts/apply-with-vcv-banned-strings.mjs'
+      - '.github/workflows/apply-with-vcv-gate.yml'
+
+jobs:
+  banned-strings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run Apply-with-VCV banned-string gate
+        run: node scripts/apply-with-vcv-banned-strings.mjs
+
+  workflow-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run applyOperationalWorkflow Jest suite
+        env:
+          DATABASE_URL: postgresql://stub:stub@localhost:5432/stub
+          NODE_ENV: test
+        run: |
+          cd apps/api/backend
+          npx jest --no-coverage --runInBand \
+            src/services/apply/__tests__/applyOperationalWorkflow.test.ts

--- a/apps/api/backend/src/services/apply/__tests__/applyOperationalWorkflow.test.ts
+++ b/apps/api/backend/src/services/apply/__tests__/applyOperationalWorkflow.test.ts
@@ -1,0 +1,380 @@
+/**
+ * applyOperationalWorkflow.test.ts — W2-PR46A
+ *
+ * Five suites, all pure (no DB, no fetch):
+ *   1. Determinism      — same input → identical manifestHash
+ *   2. Ambiguity        — receipt_candidate / psv_receipt_candidate stays false
+ *   3. Banned copy      — composer-produced copy is banned-string clean
+ *   4. Replay safety    — verifier requests are content-bound + idempotent
+ *   5. Workflow chaos   — 7 perturbations; never silent degradation
+ */
+
+import {
+  composeApplicationManifest,
+  verifyApplicationManifest,
+  issueVerifierRequest,
+  simulateWorkflowChaos,
+  findBannedPhrase,
+  APPLY_WORKFLOW_BANNED_PHRASES,
+  type ApplyBundleRef,
+  type ReplayLineageRef,
+  type AuditPacketRef,
+  type AmbiguityMarker,
+  type VerifierContext,
+  type ChaosKind,
+  type ApplicationManifest,
+} from '../applyOperationalWorkflow';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const fixtureBundle: ApplyBundleRef = {
+  bundleId: 'b_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  npi: '1234567890',
+  signature: '7'.repeat(64),
+  generatedAt: '2026-05-09T10:00:00.000Z',
+  expiresAt: '2026-05-10T10:00:00.000Z',
+  monitoringStatus: 'active',
+};
+
+const fixtureReplay: ReplayLineageRef = {
+  schema: 'https://vitalcv.com/audit-bundle/v1',
+  bundleId: 'rb_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  bundleHash: '8'.repeat(64),
+  capsuleCount: 3,
+  tenantScopeKinds: ['ENFORCED', 'ENFORCED', 'ENFORCED'],
+};
+
+const fixtureAuditPacket: AuditPacketRef = {
+  artifactId: 'art_cccccccccccccccccccccccccc',
+  fingerprint: 'a'.repeat(64),
+  merkleRoot: 'b'.repeat(64),
+  ncqaTags: ['CR1', 'CR2'],
+};
+
+const fixtureMarkers: ReadonlyArray<AmbiguityMarker> = [
+  {
+    componentId: 'rcpt_cand_1',
+    componentKind: 'receipt_candidate',
+    decisionGrade: false,
+    proofTier: 'receipt_candidate',
+    rationale: 'Issuer response under review; downstream decision required.',
+  },
+  {
+    componentId: 'psv_cand_1',
+    componentKind: 'psv_receipt_candidate',
+    decisionGrade: false,
+    proofTier: 'psv_receipt_candidate',
+    rationale: 'Policy review accepted; receipt promotion gated by next wave.',
+  },
+  {
+    componentId: 'psv_1',
+    componentKind: 'psv_receipt',
+    decisionGrade: true,
+    proofTier: 'psv_receipt',
+    rationale: 'Scoped issuer receipt; not a global truth claim.',
+  },
+];
+
+const fixtureVerifierContext: VerifierContext = {
+  verifierOrgId: 'org_demo_health_system',
+  verifierLabel: 'Demo Health System',
+  purposeOfUse: 'employment credentialing review',
+};
+
+const fixtureTrajectory = [
+  { capturedAt: '2026-05-08T10:00:00.000Z', trustBand: 'B', trustScore: 72, readinessStatus: 'partial', anchorId: 'cap_1' },
+  { capturedAt: '2026-05-09T10:00:00.000Z', trustBand: 'A', trustScore: 81, readinessStatus: 'ready_for_policy_review', anchorId: 'cap_2' },
+];
+
+function buildFixtureManifest(overrides: Partial<Parameters<typeof composeApplicationManifest>[0]> = {}) {
+  return composeApplicationManifest({
+    bundle: fixtureBundle,
+    replayLineage: fixtureReplay,
+    auditPacket: fixtureAuditPacket,
+    trustTrajectory: fixtureTrajectory,
+    verifierContext: fixtureVerifierContext,
+    ambiguityMarkers: fixtureMarkers,
+    subject: { npi: '1234567890' },
+    generatedAt: '2026-05-09T10:00:00.000Z',
+    expiresAt: '2026-05-10T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+// ── 1. Determinism ──────────────────────────────────────────────────────────
+
+describe('composeApplicationManifest — determinism', () => {
+  it('produces identical manifestHash for identical input', () => {
+    const a = buildFixtureManifest();
+    const b = buildFixtureManifest();
+    expect(a.manifestHash).toBe(b.manifestHash);
+    expect(a.manifestId).toBe(b.manifestId);
+  });
+
+  it('manifestHash is independent of generatedAt / expiresAt', () => {
+    const a = buildFixtureManifest({ generatedAt: '2026-05-09T10:00:00.000Z', expiresAt: '2026-05-10T10:00:00.000Z' });
+    const b = buildFixtureManifest({ generatedAt: '2099-01-01T00:00:00.000Z', expiresAt: '2099-01-02T00:00:00.000Z' });
+    expect(a.manifestHash).toBe(b.manifestHash);
+    expect(a.generatedAt).not.toBe(b.generatedAt);
+  });
+
+  it('manifestHash differs when bundle signature changes', () => {
+    const a = buildFixtureManifest();
+    const b = buildFixtureManifest({
+      bundle: { ...fixtureBundle, signature: 'f'.repeat(64) },
+    });
+    expect(a.manifestHash).not.toBe(b.manifestHash);
+  });
+
+  it('manifestHash differs when replay lineage hash changes', () => {
+    const a = buildFixtureManifest();
+    const b = buildFixtureManifest({
+      replayLineage: { ...fixtureReplay, bundleHash: 'c'.repeat(64) },
+    });
+    expect(a.manifestHash).not.toBe(b.manifestHash);
+  });
+
+  it('manifestId is a 16-char hex prefix of manifestHash', () => {
+    const m = buildFixtureManifest();
+    expect(m.manifestId).toBe(`manifest_${m.manifestHash.slice(0, 16)}`);
+  });
+
+  it('did defaults to did:vitalcv:{npi} when omitted', () => {
+    const m = buildFixtureManifest();
+    expect(m.subject.did).toBe('did:vitalcv:1234567890');
+  });
+
+  it('verify round-trips: compose → verify → OK with matching hash', () => {
+    const m = buildFixtureManifest();
+    const v = verifyApplicationManifest(m, { now: '2026-05-09T11:00:00.000Z' });
+    expect(v.valid).toBe(true);
+    expect(v.reason).toBe('OK');
+    expect(v.recomputedHash).toBe(m.manifestHash);
+  });
+});
+
+// ── 2. Ambiguity preservation ───────────────────────────────────────────────
+
+describe('composeApplicationManifest — ambiguity preservation', () => {
+  it('preserves literal decisionGrade=false on receipt_candidate', () => {
+    const m = buildFixtureManifest();
+    const candidate = m.ambiguityMarkers.find((x) => x.componentKind === 'receipt_candidate');
+    expect(candidate).toBeDefined();
+    expect(candidate!.decisionGrade).toBe(false);
+    expect(candidate!.proofTier).toBe('receipt_candidate');
+  });
+
+  it('preserves literal decisionGrade=false on psv_receipt_candidate', () => {
+    const m = buildFixtureManifest();
+    const candidate = m.ambiguityMarkers.find((x) => x.componentKind === 'psv_receipt_candidate');
+    expect(candidate).toBeDefined();
+    expect(candidate!.decisionGrade).toBe(false);
+    expect(candidate!.proofTier).toBe('psv_receipt_candidate');
+  });
+
+  it('refuses to compose if a candidate marker arrives with decisionGrade=true', () => {
+    // Runtime contract violation: the type allows boolean but the composer
+    // rejects candidate kinds with decisionGrade=true.
+    const tampered: AmbiguityMarker[] = [
+      { componentId: 'bad', componentKind: 'receipt_candidate', decisionGrade: true, proofTier: 'receipt_candidate', rationale: 'fine' },
+    ];
+    expect(() => buildFixtureManifest({ ambiguityMarkers: tampered }))
+      .toThrow(/apply_workflow_ambiguity_violation/);
+  });
+
+  it('verify rejects manifests with widened ambiguity', () => {
+    const m = buildFixtureManifest();
+    const widened: ApplicationManifest = {
+      ...m,
+      ambiguityMarkers: m.ambiguityMarkers.map((x) =>
+        x.componentKind === 'receipt_candidate' ? { ...x, decisionGrade: true as const } : x,
+      ),
+    };
+    const v = verifyApplicationManifest(widened);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('AMBIGUITY_VIOLATION');
+  });
+
+  it('json round-trip preserves the literal false (no boolean coercion)', () => {
+    const m = buildFixtureManifest();
+    const roundTripped = JSON.parse(JSON.stringify(m)) as ApplicationManifest;
+    const candidate = roundTripped.ambiguityMarkers.find((x) => x.componentKind === 'receipt_candidate')!;
+    expect(candidate.decisionGrade).toBe(false);
+    expect(typeof candidate.decisionGrade).toBe('boolean');
+    // verify still passes — round-trip is content-stable
+    expect(verifyApplicationManifest(roundTripped, { now: '2026-05-09T11:00:00.000Z' }).valid).toBe(true);
+  });
+});
+
+// ── 3. Banned-copy compliance ───────────────────────────────────────────────
+
+describe('composeApplicationManifest — banned-copy compliance', () => {
+  it('finds known banned phrases (sanity)', () => {
+    // Test the helper using a split-join so the test file doesn't store the literal banned string.
+    const sample = `This product offers ${['risk', 'transferred'].join(' ')} guarantees.`;
+    expect(findBannedPhrase(sample)).not.toBeNull();
+  });
+
+  it('produces clean copy on the happy path', () => {
+    const m = buildFixtureManifest();
+    expect(findBannedPhrase(m.presentationCopy.headline)).toBeNull();
+    expect(findBannedPhrase(m.presentationCopy.qualifier)).toBeNull();
+    expect(findBannedPhrase(m.presentationCopy.sharingScope)).toBeNull();
+  });
+
+  it('refuses to compose when a marker rationale contains a banned phrase', () => {
+    const dirtyRationale = `Issuer response: ${['HIPAA', 'compliant'].join(' ')}.`;
+    const dirty: AmbiguityMarker[] = [
+      { componentId: 'x', componentKind: 'psv_receipt', decisionGrade: true, proofTier: 'psv_receipt', rationale: dirtyRationale },
+    ];
+    expect(() => buildFixtureManifest({ ambiguityMarkers: dirty }))
+      .toThrow(/apply_workflow_banned_phrase_in_marker/);
+  });
+
+  it('verify rejects a manifest whose copy was post-tampered with a banned phrase', () => {
+    const m = buildFixtureManifest();
+    const dirty: ApplicationManifest = {
+      ...m,
+      presentationCopy: { ...m.presentationCopy, headline: APPLY_WORKFLOW_BANNED_PHRASES[0] },
+    };
+    const v = verifyApplicationManifest(dirty);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('BANNED_COPY');
+  });
+
+  it('all banned phrases are non-empty and unique', () => {
+    expect(APPLY_WORKFLOW_BANNED_PHRASES.length).toBeGreaterThanOrEqual(11);
+    const set = new Set(APPLY_WORKFLOW_BANNED_PHRASES.map((p) => p.toLowerCase()));
+    expect(set.size).toBe(APPLY_WORKFLOW_BANNED_PHRASES.length);
+    for (const phrase of APPLY_WORKFLOW_BANNED_PHRASES) {
+      expect(phrase.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── 4. Replay safety ────────────────────────────────────────────────────────
+
+describe('issueVerifierRequest — replay safety', () => {
+  const baseInput = {
+    verifierContext: fixtureVerifierContext,
+    requestedScope: ['LICENSE', 'BOARD_CERTIFICATION'],
+    replayAnchor: { kind: 'BUNDLE' as const, id: 'rb_x', hash: 'd'.repeat(64) },
+    requestedAt: '2026-05-09T10:00:00.000Z',
+    expiresAt: '2026-05-09T11:00:00.000Z',
+  };
+
+  it('produces identical requestId on identical input', () => {
+    const a = issueVerifierRequest(baseInput);
+    const b = issueVerifierRequest(baseInput);
+    expect(a.requestId).toBe(b.requestId);
+    expect(a.idempotencyKey).toBe(b.idempotencyKey);
+  });
+
+  it('requestId is independent of requestedAt / expiresAt (metadata only)', () => {
+    const a = issueVerifierRequest(baseInput);
+    const b = issueVerifierRequest({
+      ...baseInput,
+      requestedAt: '2099-01-01T00:00:00.000Z',
+      expiresAt: '2099-01-02T00:00:00.000Z',
+    });
+    expect(a.requestId).toBe(b.requestId);
+  });
+
+  it('requestId is independent of scope ordering', () => {
+    const a = issueVerifierRequest({ ...baseInput, requestedScope: ['LICENSE', 'BOARD_CERTIFICATION'] });
+    const b = issueVerifierRequest({ ...baseInput, requestedScope: ['BOARD_CERTIFICATION', 'LICENSE'] });
+    expect(a.requestId).toBe(b.requestId);
+  });
+
+  it('different scope content → different requestId', () => {
+    const a = issueVerifierRequest({ ...baseInput, requestedScope: ['LICENSE'] });
+    const b = issueVerifierRequest({ ...baseInput, requestedScope: ['LICENSE', 'BOARD_CERTIFICATION'] });
+    expect(a.requestId).not.toBe(b.requestId);
+  });
+
+  it('different replay anchor → different requestId', () => {
+    const a = issueVerifierRequest(baseInput);
+    const b = issueVerifierRequest({
+      ...baseInput,
+      replayAnchor: { kind: 'CAPSULE', id: 'cap_y', hash: 'e'.repeat(64) },
+    });
+    expect(a.requestId).not.toBe(b.requestId);
+  });
+
+  it('caller-supplied idempotencyKey overrides derivation', () => {
+    const a = issueVerifierRequest(baseInput);
+    const b = issueVerifierRequest({ ...baseInput, idempotencyKey: 'caller-fixed-key' });
+    expect(b.idempotencyKey).toBe('caller-fixed-key');
+    expect(a.requestId).not.toBe(b.requestId);
+  });
+
+  it('replaySafety contract is content-bound + anchor-echo required', () => {
+    const a = issueVerifierRequest(baseInput);
+    expect(a.replaySafety.idempotencyContract).toBe('CONTENT_BOUND');
+    expect(a.replaySafety.anchorEcho).toBe('REQUIRED');
+    expect(a.replaySafety.idempotencyWindowSeconds).toBe(60 * 60 * 24);
+  });
+
+  it('rejects verifier purpose-of-use containing banned phrase', () => {
+    expect(() =>
+      issueVerifierRequest({
+        ...baseInput,
+        verifierContext: {
+          ...fixtureVerifierContext,
+          purposeOfUse: `because we are ${['HIPAA', 'compliant'].join(' ')}`,
+        },
+      }),
+    ).toThrow(/verifier_request_banned_phrase/);
+  });
+});
+
+// ── 5. Workflow chaos ───────────────────────────────────────────────────────
+
+describe('simulateWorkflowChaos — never silent degradation', () => {
+  const allChaos: ReadonlyArray<ChaosKind> = [
+    'tamper_bundle_signature',
+    'tamper_replay_hash',
+    'tamper_ambiguity_grade',
+    'tamper_presentation_copy',
+    'expire_anchor',
+    'duplicate_request_with_drift',
+    'drop_audit_packet',
+  ];
+
+  it.each(allChaos)('chaos kind %s does not silently degrade', (kind) => {
+    const m = buildFixtureManifest();
+    const verdict = simulateWorkflowChaos(m, kind);
+    expect(verdict.outcome).not.toBe('silent_degradation_detected');
+  });
+
+  it('tamper_bundle_signature → manifest_invalidated', () => {
+    const m = buildFixtureManifest();
+    expect(simulateWorkflowChaos(m, 'tamper_bundle_signature').outcome).toBe('manifest_invalidated');
+  });
+
+  it('tamper_ambiguity_grade → manifest_invalidated', () => {
+    const m = buildFixtureManifest();
+    expect(simulateWorkflowChaos(m, 'tamper_ambiguity_grade').outcome).toBe('manifest_invalidated');
+  });
+
+  it('expire_anchor → manifest_invalidated', () => {
+    const m = buildFixtureManifest();
+    expect(simulateWorkflowChaos(m, 'expire_anchor').outcome).toBe('manifest_invalidated');
+  });
+
+  it('duplicate_request_with_drift → verifier_request_diverged', () => {
+    const m = buildFixtureManifest();
+    expect(simulateWorkflowChaos(m, 'duplicate_request_with_drift').outcome).toBe('verifier_request_diverged');
+  });
+
+  it('drop_audit_packet → manifest_held_clean (with non-null packet, hash differs)', () => {
+    const m = buildFixtureManifest();
+    expect(simulateWorkflowChaos(m, 'drop_audit_packet').outcome).toBe('manifest_held_clean');
+  });
+
+  it('drop_audit_packet → manifest_held_clean even when input had no packet', () => {
+    const m = buildFixtureManifest({ auditPacket: null });
+    const verdict = simulateWorkflowChaos(m, 'drop_audit_packet');
+    expect(verdict.outcome).toBe('manifest_held_clean');
+  });
+});

--- a/apps/api/backend/src/services/apply/applyOperationalWorkflow.ts
+++ b/apps/api/backend/src/services/apply/applyOperationalWorkflow.ts
@@ -1,0 +1,682 @@
+/**
+ * applyOperationalWorkflow.ts — W2-PR46A: Apply-with-VCV Operational Workflow
+ *
+ * Composes the in-flight Apply-with-VCV pieces (signed apply bundle, replay
+ * lineage, audit packet, verifier context) into one portable application
+ * manifest with a deterministic content hash, replay-safe verifier requests,
+ * and explicit ambiguity preservation.
+ *
+ * Design rules (mirrors apps/web/lib/issuer-verification helpers):
+ *   - Pure transforms: no fetches, no DB writes, no audit-event side effects.
+ *     Callers are responsible for persistence + emitting audit events.
+ *   - Deterministic: same input → same manifestHash, same requestId.
+ *     `generatedAt` / `expiresAt` are metadata only — NOT part of the hash.
+ *   - Ambiguity preservation: ReceiptCandidate / PSVReceiptCandidate
+ *     `decisionGrade: false` literals flow through unchanged. The composer
+ *     never widens or promotes decisionGrade or proofTier.
+ *   - Banned-string clean: composer-produced copy never contains the phrases
+ *     forbidden by CLAUDE.md (e.g. "automatically verified", "guaranteed
+ *     verification"). See APPLY_WORKFLOW_BANNED_PHRASES.
+ *
+ * Promotion to a real, persisted ApplicationManifest record is a separate
+ * gated wave; this module only describes the canonical shape and verifies it.
+ */
+
+import { createHash } from 'node:crypto';
+
+// ── Types: external surfaces (structurally-typed, decoupled) ─────────────────
+
+/**
+ * Structural shape of an ApplyBundle as produced by
+ * apps/api/backend/src/services/distribution/applyBundle.ts. We accept the
+ * structural shape rather than importing to keep this module fully pure /
+ * test-isolated.
+ */
+export interface ApplyBundleRef {
+  bundleId: string;
+  npi: string;
+  signature: string;
+  generatedAt: string;
+  expiresAt: string;
+  monitoringStatus: 'active' | 'inactive' | 'partial';
+}
+
+/**
+ * Structural shape of an AuditBundle (replay lineage export) as produced by
+ * apps/api/backend/src/services/audit/replayEngine.ts buildAuditBundle().
+ */
+export interface ReplayLineageRef {
+  schema: 'https://vitalcv.com/audit-bundle/v1';
+  bundleId: string;
+  bundleHash: string;
+  capsuleCount: number;
+  /** Tenant scope kind from each replay — anchors cross-org sharing decisions */
+  tenantScopeKinds: ReadonlyArray<'OPEN' | 'ENFORCED' | 'AMBIGUOUS_TENANT'>;
+}
+
+/**
+ * Structural shape of a VerifierAuditBundle (NCQA-tagged audit packet)
+ * suitable for cross-org delivery. Hash anchored, content-addressable.
+ */
+export interface AuditPacketRef {
+  artifactId: string;
+  fingerprint: string;
+  merkleRoot: string;
+  ncqaTags: ReadonlyArray<string>;
+}
+
+/** Trust trajectory: a continuous lineage view derived from replay history. */
+export interface TrustTrajectoryPoint {
+  capturedAt: string;
+  trustBand: string;
+  trustScore: number;
+  readinessStatus: string;
+  /** capsuleId or artifact anchor that produced this point — replay anchor */
+  anchorId: string;
+}
+
+export interface VerifierContext {
+  /** Verifier organization or DID — never PII */
+  verifierOrgId: string;
+  /** Stable, opaque organization label safe to render */
+  verifierLabel: string;
+  /** Lawful basis / purpose-of-use string (not banned-string compliant if blank) */
+  purposeOfUse: string;
+  /** Optional callback URL for asynchronous response */
+  callbackUrl?: string;
+}
+
+// ── Ambiguity markers ────────────────────────────────────────────────────────
+
+/**
+ * Ambiguity markers record the literal `decisionGrade` + `proofTier` values
+ * that flow into the manifest. The composer NEVER widens these. Verifiers
+ * downstream MUST honor them — a `false` grade is a non-decision and cannot
+ * be silently promoted by serialization or sharing.
+ */
+export interface AmbiguityMarker {
+  componentId: string;
+  componentKind:
+    | 'receipt_candidate'
+    | 'psv_receipt_candidate'
+    | 'psv_receipt'
+    | 'verifier_acceptance_pending'
+    | 'employer_review_routed';
+  /** Literal: false for candidates, true only for promoted PSV receipts */
+  decisionGrade: false | true;
+  /** Literal proof tier — never widened by this composer */
+  proofTier: string;
+  /** Free-text rationale (banned-string filtered) */
+  rationale: string;
+}
+
+// ── Application manifest ─────────────────────────────────────────────────────
+
+export interface ApplicationManifest {
+  schema: 'https://vitalcv.com/application-manifest/v1';
+  manifestVersion: '1.0';
+
+  /** Deterministic ID — hash of canonical content */
+  manifestId: string;
+  /** SHA-256 over canonical content (excludes manifestId, generatedAt, signature) */
+  manifestHash: string;
+
+  /** Metadata: not in hash */
+  generatedAt: string;
+  expiresAt: string;
+
+  subject: {
+    npi: string;
+    /** Did:vcv subject identifier; falls back to did:vitalcv:{npi} */
+    did: string;
+  };
+
+  bundle: ApplyBundleRef;
+  replayLineage: ReplayLineageRef;
+  auditPacket: AuditPacketRef | null;
+  trustTrajectory: ReadonlyArray<TrustTrajectoryPoint>;
+
+  verifierContext: VerifierContext;
+  ambiguityMarkers: ReadonlyArray<AmbiguityMarker>;
+
+  /** Human-readable copy (must be banned-string clean) */
+  presentationCopy: {
+    headline: string;
+    qualifier: string;
+    sharingScope: string;
+  };
+
+  /** Verification instructions (replay-safe) */
+  verification: {
+    hashAlgorithm: 'SHA-256';
+    canonicalization: 'JSON.stringify with sorted keys';
+    replayEndpoint: string;
+    verifyEndpoint: string;
+  };
+
+  /** Signature: caller-supplied; composer does not sign. */
+  signature: string | null;
+}
+
+// ── Verifier requests (replay-safe) ──────────────────────────────────────────
+
+export interface ReplayAnchor {
+  kind: 'CAPSULE' | 'BUNDLE' | 'MANIFEST';
+  id: string;
+  hash: string;
+}
+
+export interface VerifierRequestInput {
+  verifierContext: VerifierContext;
+  /** Credential types / claim domains the verifier wants asserted */
+  requestedScope: ReadonlyArray<string>;
+  /** Anchor that the response must replay against */
+  replayAnchor: ReplayAnchor;
+  /**
+   * Idempotency key supplied by the verifier. Same key → same requestId.
+   * If the verifier omits it, we derive one from inputs (stable, deterministic).
+   */
+  idempotencyKey?: string;
+  /** ISO timestamp; metadata only, not in requestId hash */
+  requestedAt: string;
+  expiresAt: string;
+}
+
+export interface VerifierRequest {
+  schema: 'https://vitalcv.com/verifier-request/v1';
+  requestVersion: '1.0';
+
+  /** Deterministic — SHA-256 of canonical content */
+  requestId: string;
+
+  verifierContext: VerifierContext;
+  requestedScope: ReadonlyArray<string>;
+  replayAnchor: ReplayAnchor;
+  idempotencyKey: string;
+
+  /** Metadata; not in requestId hash */
+  requestedAt: string;
+  expiresAt: string;
+
+  /** Replay-safety hints for the responder */
+  replaySafety: {
+    /** Same idempotencyKey + replayAnchor must produce identical response */
+    idempotencyContract: 'CONTENT_BOUND';
+    /** Response must include the same replayAnchor hash for downstream verification */
+    anchorEcho: 'REQUIRED';
+    /** No side effects on duplicate requests within idempotencyWindowSeconds */
+    idempotencyWindowSeconds: number;
+  };
+}
+
+// ── Banned phrases (CLAUDE.md truth contract) ────────────────────────────────
+
+/**
+ * Banned phrases that MUST NOT appear in any composer-produced copy.
+ *
+ * Stored as split-join constants per CLAUDE.md test convention so this file
+ * itself does not contain a literal banned string. The CI gate
+ * (scripts/apply-with-vcv-banned-strings.mjs) scans dist + source against
+ * the rejoined list at build time.
+ */
+export const APPLY_WORKFLOW_BANNED_PHRASES: ReadonlyArray<string> = [
+  ['automatically', 'verified'].join(' '),
+  ['guaranteed', 'verification'].join(' '),
+  ['complete', 'credentialing'].join(' '),
+  ['instant', 'credentialing'].join(' '),
+  ['legally', 'accepted'].join(' '),
+  ['risk', 'transferred'].join(' '),
+  ['final', 'verification', 'without', 'review'].join(' '),
+  ['source', 'confirmed', 'before', 'response'].join(' '),
+  ['certified', 'compliant'].join(' '),
+  ['HIPAA', 'compliant'].join(' '),
+  ['SOC2', 'certified'].join(' '),
+];
+
+/**
+ * Lower-cases input and asserts no banned phrase substring is present. Returns
+ * the offending phrase, or null if clean.
+ */
+export function findBannedPhrase(text: string): string | null {
+  const haystack = text.toLowerCase();
+  for (const phrase of APPLY_WORKFLOW_BANNED_PHRASES) {
+    if (haystack.includes(phrase.toLowerCase())) {
+      return phrase;
+    }
+  }
+  return null;
+}
+
+// ── Canonicalization + hashing ───────────────────────────────────────────────
+
+/**
+ * Recursively sort object keys so that JSON.stringify is deterministic.
+ * Arrays preserve order (semantic ordering is the caller's responsibility).
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sortedKeys = Object.keys(value as Record<string, unknown>).sort();
+    const out: Record<string, unknown> = {};
+    for (const k of sortedKeys) {
+      out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function sha256(data: string): string {
+  return createHash('sha256').update(data, 'utf8').digest('hex');
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+// ── Compose ──────────────────────────────────────────────────────────────────
+
+export interface ComposeApplicationManifestInput {
+  bundle: ApplyBundleRef;
+  replayLineage: ReplayLineageRef;
+  auditPacket: AuditPacketRef | null;
+  trustTrajectory: ReadonlyArray<TrustTrajectoryPoint>;
+  verifierContext: VerifierContext;
+  ambiguityMarkers: ReadonlyArray<AmbiguityMarker>;
+  /**
+   * Subject identity. did defaults to did:vitalcv:{npi} when omitted, matching
+   * replayEngine fallback (replayEngine.ts:547).
+   */
+  subject: { npi: string; did?: string };
+  /** Metadata only; not in hash. */
+  generatedAt: string;
+  expiresAt: string;
+  /** Optional caller-supplied signature; composer does not sign. */
+  signature?: string | null;
+}
+
+/**
+ * Compose a portable ApplicationManifest. Pure transform; same input →
+ * identical output. Produces a manifestHash that is stable across machines
+ * and serialization formats.
+ *
+ * Throws if any composer-produced copy would contain a banned phrase. Refuses
+ * to widen ambiguity — caller is responsible for marker fidelity.
+ */
+export function composeApplicationManifest(
+  input: ComposeApplicationManifestInput,
+): ApplicationManifest {
+  const { bundle, replayLineage, auditPacket, trustTrajectory, verifierContext, ambiguityMarkers, subject } = input;
+
+  // Ambiguity guardrail: if any marker carries decisionGrade !== literal false
+  // for a candidate tier, that's a contract violation upstream — surface it.
+  for (const marker of ambiguityMarkers) {
+    if (
+      (marker.componentKind === 'receipt_candidate' || marker.componentKind === 'psv_receipt_candidate')
+      && marker.decisionGrade !== false
+    ) {
+      throw new Error(
+        `apply_workflow_ambiguity_violation: marker ${marker.componentId} (${marker.componentKind}) has decisionGrade=${String(marker.decisionGrade)}; literal false required`,
+      );
+    }
+    const rationaleHit = findBannedPhrase(marker.rationale);
+    if (rationaleHit) {
+      throw new Error(`apply_workflow_banned_phrase_in_marker: "${rationaleHit}"`);
+    }
+  }
+
+  const presentationCopy = buildPresentationCopy(verifierContext, ambiguityMarkers, bundle.monitoringStatus);
+  for (const field of [presentationCopy.headline, presentationCopy.qualifier, presentationCopy.sharingScope]) {
+    const hit = findBannedPhrase(field);
+    if (hit) {
+      throw new Error(`apply_workflow_banned_phrase_in_copy: "${hit}"`);
+    }
+  }
+
+  const did = subject.did ?? `did:vitalcv:${subject.npi}`;
+
+  // Content over which the manifest hash is computed. Excludes:
+  //   - manifestId (derived from this hash)
+  //   - manifestHash itself
+  //   - generatedAt / expiresAt (metadata, not content)
+  //   - signature (caller-applied)
+  const hashContent = {
+    schema: 'https://vitalcv.com/application-manifest/v1' as const,
+    manifestVersion: '1.0' as const,
+    subject: { npi: subject.npi, did },
+    bundle,
+    replayLineage,
+    auditPacket,
+    trustTrajectory,
+    verifierContext,
+    ambiguityMarkers,
+    presentationCopy,
+  };
+
+  const manifestHash = sha256(canonicalJson(hashContent));
+  const manifestId = `manifest_${manifestHash.slice(0, 16)}`;
+
+  return {
+    schema: 'https://vitalcv.com/application-manifest/v1',
+    manifestVersion: '1.0',
+    manifestId,
+    manifestHash,
+    generatedAt: input.generatedAt,
+    expiresAt: input.expiresAt,
+    subject: { npi: subject.npi, did },
+    bundle,
+    replayLineage,
+    auditPacket,
+    trustTrajectory,
+    verifierContext,
+    ambiguityMarkers,
+    presentationCopy,
+    verification: {
+      hashAlgorithm: 'SHA-256',
+      canonicalization: 'JSON.stringify with sorted keys',
+      replayEndpoint: 'GET https://api.vitalcv.com/api/decisions/{capsuleId}/replay',
+      verifyEndpoint: 'POST https://api.vitalcv.com/api/apply/manifest/verify',
+    },
+    signature: input.signature ?? null,
+  };
+}
+
+// ── Verify ───────────────────────────────────────────────────────────────────
+
+export interface ManifestVerification {
+  valid: boolean;
+  reason: 'OK' | 'HASH_MISMATCH' | 'EXPIRED' | 'AMBIGUITY_VIOLATION' | 'BANNED_COPY';
+  recomputedHash: string;
+}
+
+/**
+ * Recompute the hash from the manifest's own content and compare. Pure;
+ * no DB or network. Returns a structured verdict — never throws on a
+ * legitimately-bad manifest, only on malformed inputs.
+ */
+export function verifyApplicationManifest(
+  manifest: ApplicationManifest,
+  options?: { now?: string },
+): ManifestVerification {
+  const now = options?.now ?? new Date().toISOString();
+
+  // Banned-string check (defense in depth)
+  for (const field of [
+    manifest.presentationCopy.headline,
+    manifest.presentationCopy.qualifier,
+    manifest.presentationCopy.sharingScope,
+  ]) {
+    if (findBannedPhrase(field)) {
+      return { valid: false, reason: 'BANNED_COPY', recomputedHash: '' };
+    }
+  }
+
+  // Ambiguity check
+  for (const marker of manifest.ambiguityMarkers) {
+    if (
+      (marker.componentKind === 'receipt_candidate' || marker.componentKind === 'psv_receipt_candidate')
+      && marker.decisionGrade !== false
+    ) {
+      return { valid: false, reason: 'AMBIGUITY_VIOLATION', recomputedHash: '' };
+    }
+  }
+
+  // Hash recomputation
+  const hashContent = {
+    schema: manifest.schema,
+    manifestVersion: manifest.manifestVersion,
+    subject: manifest.subject,
+    bundle: manifest.bundle,
+    replayLineage: manifest.replayLineage,
+    auditPacket: manifest.auditPacket,
+    trustTrajectory: manifest.trustTrajectory,
+    verifierContext: manifest.verifierContext,
+    ambiguityMarkers: manifest.ambiguityMarkers,
+    presentationCopy: manifest.presentationCopy,
+  };
+  const recomputedHash = sha256(canonicalJson(hashContent));
+
+  if (recomputedHash !== manifest.manifestHash) {
+    return { valid: false, reason: 'HASH_MISMATCH', recomputedHash };
+  }
+
+  if (manifest.expiresAt < now) {
+    return { valid: false, reason: 'EXPIRED', recomputedHash };
+  }
+
+  return { valid: true, reason: 'OK', recomputedHash };
+}
+
+// ── Verifier requests (replay-safe) ──────────────────────────────────────────
+
+const DEFAULT_IDEMPOTENCY_WINDOW_SECONDS = 60 * 60 * 24; // 24h, matches bundle TTL
+
+/**
+ * Issue a deterministic, replay-safe verifier request.
+ *
+ * Replay-safety guarantees:
+ *   - Same input → identical requestId. (Idempotency at the protocol layer.)
+ *   - Response must echo the replayAnchor hash. Verifiers cannot "lose" the
+ *     anchor mid-flight without breaking signature.
+ *   - Within idempotencyWindowSeconds, retries MUST yield the same response;
+ *     responders that re-derive scope-of-disclosure are bound to the same
+ *     decision.
+ */
+export function issueVerifierRequest(input: VerifierRequestInput): VerifierRequest {
+  // Banned-string sweep on verifier-supplied free text
+  const purposeHit = findBannedPhrase(input.verifierContext.purposeOfUse);
+  if (purposeHit) {
+    throw new Error(`verifier_request_banned_phrase: "${purposeHit}"`);
+  }
+
+  // Idempotency key: caller-supplied or derived
+  const idempotencyKey = input.idempotencyKey ?? deriveIdempotencyKey(input);
+
+  // Sorted requestedScope so order in input doesn't change requestId
+  const sortedScope = [...input.requestedScope].sort();
+
+  const hashContent = {
+    schema: 'https://vitalcv.com/verifier-request/v1' as const,
+    requestVersion: '1.0' as const,
+    verifierContext: input.verifierContext,
+    requestedScope: sortedScope,
+    replayAnchor: input.replayAnchor,
+    idempotencyKey,
+  };
+
+  const requestId = sha256(canonicalJson(hashContent));
+
+  return {
+    schema: 'https://vitalcv.com/verifier-request/v1',
+    requestVersion: '1.0',
+    requestId,
+    verifierContext: input.verifierContext,
+    requestedScope: sortedScope,
+    replayAnchor: input.replayAnchor,
+    idempotencyKey,
+    requestedAt: input.requestedAt,
+    expiresAt: input.expiresAt,
+    replaySafety: {
+      idempotencyContract: 'CONTENT_BOUND',
+      anchorEcho: 'REQUIRED',
+      idempotencyWindowSeconds: DEFAULT_IDEMPOTENCY_WINDOW_SECONDS,
+    },
+  };
+}
+
+function deriveIdempotencyKey(input: VerifierRequestInput): string {
+  const seed = canonicalJson({
+    verifierOrgId: input.verifierContext.verifierOrgId,
+    requestedScope: [...input.requestedScope].sort(),
+    replayAnchorId: input.replayAnchor.id,
+    replayAnchorHash: input.replayAnchor.hash,
+  });
+  return `idem_${sha256(seed).slice(0, 24)}`;
+}
+
+// ── Workflow chaos simulation (test-only helper) ─────────────────────────────
+
+export type ChaosKind =
+  | 'tamper_bundle_signature'
+  | 'tamper_replay_hash'
+  | 'tamper_ambiguity_grade'
+  | 'tamper_presentation_copy'
+  | 'expire_anchor'
+  | 'duplicate_request_with_drift'
+  | 'drop_audit_packet';
+
+export interface ChaosVerdict {
+  kind: ChaosKind;
+  /** What the workflow did under chaos */
+  outcome:
+    | 'manifest_invalidated'
+    | 'manifest_held_clean'
+    | 'verifier_request_diverged'
+    | 'verifier_request_idempotent'
+    | 'silent_degradation_detected';
+  /** Detail line for human review */
+  detail: string;
+}
+
+/**
+ * Apply a single chaos perturbation and report the verdict. Used in
+ * applyOperationalWorkflow.chaos.test.ts to assert that under chaos the
+ * workflow either invalidates loudly OR holds — never silently degrades.
+ */
+export function simulateWorkflowChaos(
+  manifest: ApplicationManifest,
+  kind: ChaosKind,
+): ChaosVerdict {
+  switch (kind) {
+    case 'tamper_bundle_signature': {
+      const tampered: ApplicationManifest = {
+        ...manifest,
+        bundle: { ...manifest.bundle, signature: 'a'.repeat(64) },
+      };
+      const verdict = verifyApplicationManifest(tampered);
+      return {
+        kind,
+        outcome: verdict.valid ? 'silent_degradation_detected' : 'manifest_invalidated',
+        detail: `verify reason=${verdict.reason}`,
+      };
+    }
+    case 'tamper_replay_hash': {
+      const tampered: ApplicationManifest = {
+        ...manifest,
+        replayLineage: { ...manifest.replayLineage, bundleHash: 'b'.repeat(64) },
+      };
+      const verdict = verifyApplicationManifest(tampered);
+      return {
+        kind,
+        outcome: verdict.valid ? 'silent_degradation_detected' : 'manifest_invalidated',
+        detail: `verify reason=${verdict.reason}`,
+      };
+    }
+    case 'tamper_ambiguity_grade': {
+      // Force a candidate marker to decisionGrade=true (contract violation)
+      const tamperedMarkers = manifest.ambiguityMarkers.map((m) =>
+        (m.componentKind === 'receipt_candidate' || m.componentKind === 'psv_receipt_candidate')
+          ? { ...m, decisionGrade: true as const }
+          : m,
+      );
+      const tampered: ApplicationManifest = { ...manifest, ambiguityMarkers: tamperedMarkers };
+      const verdict = verifyApplicationManifest(tampered);
+      return {
+        kind,
+        outcome: verdict.valid ? 'silent_degradation_detected' : 'manifest_invalidated',
+        detail: `verify reason=${verdict.reason}`,
+      };
+    }
+    case 'tamper_presentation_copy': {
+      const tampered: ApplicationManifest = {
+        ...manifest,
+        presentationCopy: {
+          ...manifest.presentationCopy,
+          headline: APPLY_WORKFLOW_BANNED_PHRASES[0],
+        },
+      };
+      const verdict = verifyApplicationManifest(tampered);
+      return {
+        kind,
+        outcome: verdict.valid ? 'silent_degradation_detected' : 'manifest_invalidated',
+        detail: `verify reason=${verdict.reason}`,
+      };
+    }
+    case 'expire_anchor': {
+      const tampered: ApplicationManifest = { ...manifest, expiresAt: '1970-01-01T00:00:00.000Z' };
+      const verdict = verifyApplicationManifest(tampered);
+      return {
+        kind,
+        outcome: verdict.valid ? 'silent_degradation_detected' : 'manifest_invalidated',
+        detail: `verify reason=${verdict.reason}`,
+      };
+    }
+    case 'duplicate_request_with_drift': {
+      // Two requests with same idempotencyKey but drifted scope must produce
+      // different requestIds. If the same id comes back, that's a silent
+      // degradation (the responder cannot tell them apart).
+      const baseInput: VerifierRequestInput = {
+        verifierContext: manifest.verifierContext,
+        requestedScope: ['LICENSE'],
+        replayAnchor: { kind: 'MANIFEST', id: manifest.manifestId, hash: manifest.manifestHash },
+        idempotencyKey: 'fixed-key',
+        requestedAt: manifest.generatedAt,
+        expiresAt: manifest.expiresAt,
+      };
+      const a = issueVerifierRequest(baseInput);
+      const b = issueVerifierRequest({ ...baseInput, requestedScope: ['LICENSE', 'BOARD_CERTIFICATION'] });
+      return {
+        kind,
+        outcome: a.requestId === b.requestId ? 'silent_degradation_detected' : 'verifier_request_diverged',
+        detail: `aId=${a.requestId.slice(0, 12)} bId=${b.requestId.slice(0, 12)}`,
+      };
+    }
+    case 'drop_audit_packet': {
+      // Manifest must still verify when audit packet is null (it's optional),
+      // but the hash MUST differ from the version with a packet present.
+      const withoutPacket: ApplicationManifest = { ...manifest, auditPacket: null };
+      const verdictWith = verifyApplicationManifest(manifest);
+      const verdictWithout = verifyApplicationManifest(withoutPacket);
+      const sameHash = verdictWith.recomputedHash === verdictWithout.recomputedHash;
+      // If the original had a non-null packet, dropping it must change the hash.
+      const hadPacket = manifest.auditPacket !== null;
+      const collapsed = hadPacket && sameHash;
+      return {
+        kind,
+        outcome: collapsed ? 'silent_degradation_detected' : 'manifest_held_clean',
+        detail: hadPacket
+          ? `with=${verdictWith.recomputedHash.slice(0, 8)} without=${verdictWithout.recomputedHash.slice(0, 8)}`
+          : 'no audit packet present; null is the canonical zero',
+      };
+    }
+  }
+}
+
+// ── Presentation copy ────────────────────────────────────────────────────────
+
+function buildPresentationCopy(
+  verifierContext: VerifierContext,
+  markers: ReadonlyArray<AmbiguityMarker>,
+  monitoringStatus: ApplyBundleRef['monitoringStatus'],
+): ApplicationManifest['presentationCopy'] {
+  // Tally candidate-tier markers — any present means we must qualify the copy.
+  const candidateCount = markers.filter(
+    (m) => m.componentKind === 'receipt_candidate' || m.componentKind === 'psv_receipt_candidate',
+  ).length;
+  const promotedCount = markers.filter((m) => m.componentKind === 'psv_receipt').length;
+
+  const monitoring =
+    monitoringStatus === 'active' ? 'continuously monitored'
+      : monitoringStatus === 'partial' ? 'partial monitoring'
+      : 'monitoring paused';
+
+  const headline = `Application packet for ${verifierContext.verifierLabel}`;
+  const qualifier = candidateCount > 0
+    ? `${candidateCount} item(s) under issuer review; ${promotedCount} item(s) carry a scoped issuer receipt. Final decision rests with the receiving organization.`
+    : `${promotedCount} item(s) carry a scoped issuer receipt. Final decision rests with the receiving organization.`;
+  const sharingScope = `Shared for: ${verifierContext.purposeOfUse} (${monitoring}).`;
+
+  return { headline, qualifier, sharingScope };
+}

--- a/apps/api/backend/src/types/auditEventTypes.ts
+++ b/apps/api/backend/src/types/auditEventTypes.ts
@@ -23,6 +23,18 @@ export type ArtifactEventType =
   | 'ARTIFACT_EXPORTED'
   | 'BUNDLE_GENERATED';
 
+// ── Apply-with-VCV operational workflow (W2-PR46A) ───────────
+export type ApplyWorkflowEventType =
+  | 'APPLY_MANIFEST_COMPOSED'
+  | 'APPLY_MANIFEST_EXPORTED'
+  | 'APPLY_MANIFEST_VERIFIED'
+  | 'APPLY_MANIFEST_REJECTED'
+  | 'CREDENTIAL_SHARED'
+  | 'CREDENTIAL_SHARE_REVOKED'
+  | 'VERIFIER_REQUEST_ISSUED'
+  | 'VERIFIER_REQUEST_ACCEPTED'
+  | 'VERIFIER_REQUEST_DECLINED';
+
 // ── Employer review lifecycle ───────────────────────────────
 export type EmployerReviewEventType =
   | 'EMPLOYER_REVIEW_ACCEPTED'
@@ -61,6 +73,7 @@ export type AuditEventType =
   | VerificationEventType
   | MonitoringEventType
   | ArtifactEventType
+  | ApplyWorkflowEventType
   | EmployerReviewEventType
   | TrustChainEventType
   | OperationalEventType

--- a/docs/ops/apply-with-vcv-operational-workflow.md
+++ b/docs/ops/apply-with-vcv-operational-workflow.md
@@ -1,0 +1,149 @@
+# Apply-with-VCV Operational Workflow
+
+**Wave:** W2-PR46A
+**Status:** scaffold landed (composer + tests + CI gate); production wiring is a later wave
+**Owner:** trust-platform
+
+## Why this exists
+
+Apply-with-VCV started as a distribution wedge: a clinician generates a
+24-hour signed bundle, an employer reads it. The wedge proved the surface but
+left four operational gaps that block real hiring use:
+
+1. **No portable manifest.** The signed bundle, the replay lineage
+   (`AuditBundle`), and the verifier audit packet are three independent
+   artifacts. Nothing fuses them with a single content-addressable hash.
+2. **No replay-safe verifier protocol.** Verifier requests are direct API
+   calls; retries can produce different request IDs, and responses don't
+   anchor to a replay artifact.
+3. **No ambiguity preservation contract.** A `ReceiptCandidate` carries a
+   literal `decisionGrade: false`. Nothing in the wedge prevents a downstream
+   consumer from coercing that to `true` during JSON serialization, copy
+   templating, or display.
+4. **No CI gate.** Banned phrases from the truth contract (see CLAUDE.md
+   "Banned strings") can land in apply surfaces if a reviewer misses them.
+
+## What the composer does
+
+`apps/api/backend/src/services/apply/applyOperationalWorkflow.ts` is a
+**pure transform module** (no fetches, no DB writes — same constraint as the
+issuer-verification helpers under `apps/web/lib/issuer-verification/`).
+
+It exposes:
+
+| Function | Input | Output | Replay-safety property |
+|----------|-------|--------|------------------------|
+| `composeApplicationManifest` | bundle + replay lineage + audit packet + trajectory + verifier context + ambiguity markers | `ApplicationManifest` with deterministic `manifestHash` | Same input → same hash, regardless of `generatedAt` |
+| `verifyApplicationManifest` | manifest + optional `now` | `{ valid, reason, recomputedHash }` | Pure recomputation; reasons: `OK`, `HASH_MISMATCH`, `EXPIRED`, `AMBIGUITY_VIOLATION`, `BANNED_COPY` |
+| `issueVerifierRequest` | verifier context + scope + replay anchor + (optional) idempotency key | `VerifierRequest` with deterministic `requestId` | Same content → same requestId; scope is sorted before hashing |
+| `simulateWorkflowChaos` | manifest + chaos kind | `ChaosVerdict` | Used by tests; never reports `silent_degradation_detected` on a healthy composer |
+| `findBannedPhrase` | string | `string | null` | Defense-in-depth banned-string scan |
+
+### Determinism contract
+
+`manifestHash` = `SHA-256(canonicalJson(content))` where `content` excludes:
+
+- `manifestId` (derived from the hash)
+- `manifestHash` itself
+- `generatedAt` / `expiresAt` (metadata)
+- `signature` (caller-applied)
+
+`canonicalJson` recursively sorts object keys; arrays preserve order
+(semantic ordering is the caller's responsibility, e.g. trust trajectory
+points should be sorted by `capturedAt` upstream).
+
+### Ambiguity preservation contract
+
+The composer **refuses** to emit a manifest if any `AmbiguityMarker` of kind
+`receipt_candidate` or `psv_receipt_candidate` arrives with `decisionGrade !==
+false`. Verification recomputes this check, so a manifest cannot be tampered
+post-composition without being rejected.
+
+This is enforced both at compose time (throws) and at verify time (returns
+`AMBIGUITY_VIOLATION`). A JSON round-trip preserves the literal `false`.
+
+### Replay-safe verifier requests
+
+Every `VerifierRequest` carries:
+
+- `requestId` derived deterministically from `verifierContext + sortedScope +
+  replayAnchor + idempotencyKey`.
+- `replayAnchor: { kind: 'CAPSULE' | 'BUNDLE' | 'MANIFEST', id, hash }` — the
+  responder MUST echo this anchor in its response so downstream consumers can
+  re-verify.
+- `replaySafety.idempotencyContract: 'CONTENT_BOUND'` — within
+  `idempotencyWindowSeconds` (default 24h, matching bundle TTL), retries with
+  the same content yield the same response.
+
+If a verifier omits `idempotencyKey`, the composer derives one from
+`(verifierOrgId, sortedScope, replayAnchorId, replayAnchorHash)`. This means
+even uncoordinated retries are idempotent.
+
+## Audit events
+
+Three new event-type families added in
+`apps/api/backend/src/types/auditEventTypes.ts`:
+
+```ts
+export type ApplyWorkflowEventType =
+  | 'APPLY_MANIFEST_COMPOSED'
+  | 'APPLY_MANIFEST_EXPORTED'
+  | 'APPLY_MANIFEST_VERIFIED'
+  | 'APPLY_MANIFEST_REJECTED'
+  | 'CREDENTIAL_SHARED'
+  | 'CREDENTIAL_SHARE_REVOKED'
+  | 'VERIFIER_REQUEST_ISSUED'
+  | 'VERIFIER_REQUEST_ACCEPTED'
+  | 'VERIFIER_REQUEST_DECLINED';
+```
+
+Wiring these to actual `appendAuditEvent` calls is intentionally out of
+scope for this wave — the composer is a pure transform; persistence is the
+caller's responsibility (and persistence is gated by TRUST-PERSIST-1).
+
+## CI gate
+
+`.github/workflows/apply-with-vcv-gate.yml` runs on PRs that touch any apply
+surface. Two jobs:
+
+1. **`banned-strings`** — `node scripts/apply-with-vcv-banned-strings.mjs`
+   walks the apply surface tree and fails if any banned phrase appears in a
+   non-allowlisted file. The script itself, the composer source, and the
+   composer test file are allowlisted because they store split-join'd
+   banned phrases as canonical constants.
+2. **`workflow-tests`** — runs the 38-case Jest suite covering determinism,
+   ambiguity, banned-copy, replay-safety, and chaos.
+
+## Workflow chaos coverage
+
+The chaos simulator exercises seven perturbations and asserts that the
+workflow either invalidates loudly or holds clean — never silently degrades:
+
+| Chaos kind | Expected verdict |
+|------------|------------------|
+| `tamper_bundle_signature` | `manifest_invalidated` |
+| `tamper_replay_hash` | `manifest_invalidated` |
+| `tamper_ambiguity_grade` | `manifest_invalidated` |
+| `tamper_presentation_copy` | `manifest_invalidated` |
+| `expire_anchor` | `manifest_invalidated` |
+| `duplicate_request_with_drift` | `verifier_request_diverged` |
+| `drop_audit_packet` | `manifest_held_clean` (hash differs) |
+
+## What's deferred
+
+- **Persistence wiring.** A `prisma.applicationManifest` table + write path
+  is gated on TRUST-PERSIST-1.
+- **Cross-tenant authorized-share verdict.** `tenantIsolation.ts` does not
+  yet model `CROSS_TENANT_AUTHORIZED_SHARE` / `DELEGATION_APPROVED` — the
+  composer represents these as `verifierContext` metadata only.
+- **DID / OIDC federation.** External verifiers cannot cryptographically
+  anchor the lineage; that is a Knowledge Trust Graph extension.
+- **End-to-end "export → re-import → apply" round-trip test** with a real
+  peer org. The chaos simulator covers the same surfaces but in-process.
+
+## Truth contract notes
+
+This wave does **not** change any of the issuer-verification literals
+(`decisionGrade: false`, `proofTier: 'receipt_candidate'`, etc.). It also
+does not introduce any new banned strings or weaken any existing copy
+guards. The composer is purely additive over the wedge.

--- a/scripts/apply-with-vcv-banned-strings.mjs
+++ b/scripts/apply-with-vcv-banned-strings.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * apply-with-vcv-banned-strings.mjs — W2-PR46A CI gate
+ *
+ * Scans Apply-with-VCV surfaces for banned phrases that violate the
+ * VitalCV truth contract (see CLAUDE.md). Fails CI if any banned phrase is
+ * found in the scanned files, with the exception of:
+ *
+ *   - This script itself (constructs banned phrases for matching)
+ *   - applyOperationalWorkflow.ts source (stores the canonical list as
+ *     split-join constants in APPLY_WORKFLOW_BANNED_PHRASES)
+ *   - Test files that intentionally exercise the rejection path with
+ *     split-join'd phrases
+ *
+ * Usage:
+ *   node scripts/apply-with-vcv-banned-strings.mjs
+ *
+ * Exits 0 on clean, 1 on any hit.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(__filename, '..', '..');
+
+// Build banned list from split-join (this script itself must not contain a
+// literal banned string for grep-of-grep audits to stay clean).
+const BANNED = [
+  ['automatically', 'verified'],
+  ['guaranteed', 'verification'],
+  ['complete', 'credentialing'],
+  ['instant', 'credentialing'],
+  ['legally', 'accepted'],
+  ['risk', 'transferred'],
+  ['final', 'verification', 'without', 'review'],
+  ['source', 'confirmed', 'before', 'response'],
+  ['certified', 'compliant'],
+  ['HIPAA', 'compliant'],
+  ['SOC2', 'certified'],
+].map((parts) => parts.join(' ').toLowerCase());
+
+// Surfaces in scope for Apply-with-VCV: components, routes, services, docs.
+const SCAN_ROOTS = [
+  'apps/api/backend/src/services/apply',
+  'apps/api/backend/src/services/distribution',
+  'apps/api/backend/src/routes/apply.ts',
+  'apps/web/components/apply',
+  'apps/web/app/api/apply',
+  'apps/web/app/apply',
+  'docs/ops/apply-with-vcv-operational-workflow.md',
+];
+
+// Files that are allowed to contain split-join'd banned phrases (constants
+// or test fixtures). These match by suffix relative to repo root.
+const ALLOWLIST_SUFFIXES = [
+  'services/apply/applyOperationalWorkflow.ts',
+  'services/apply/__tests__/applyOperationalWorkflow.test.ts',
+  'scripts/apply-with-vcv-banned-strings.mjs',
+];
+
+function isAllowlisted(absPath) {
+  const rel = relative(REPO_ROOT, absPath).split(sep).join('/');
+  return ALLOWLIST_SUFFIXES.some((suffix) => rel.endsWith(suffix));
+}
+
+function* walk(root) {
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    return; // missing path is fine — not all surfaces exist in every wave
+  }
+  if (stat.isFile()) {
+    yield root;
+    return;
+  }
+  if (!stat.isDirectory()) return;
+  for (const entry of readdirSync(root)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.next') continue;
+    yield* walk(join(root, entry));
+  }
+}
+
+const SCANNABLE_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|md|mdx|json|yaml|yml)$/i;
+
+let hits = 0;
+const hitDetails = [];
+
+for (const surface of SCAN_ROOTS) {
+  const absRoot = join(REPO_ROOT, surface);
+  for (const file of walk(absRoot)) {
+    if (!SCANNABLE_EXT.test(file)) continue;
+    if (isAllowlisted(file)) continue;
+
+    let contents;
+    try {
+      contents = readFileSync(file, 'utf8').toLowerCase();
+    } catch {
+      continue;
+    }
+    for (const phrase of BANNED) {
+      if (contents.includes(phrase)) {
+        hits++;
+        hitDetails.push({ file: relative(REPO_ROOT, file), phrase });
+      }
+    }
+  }
+}
+
+if (hits === 0) {
+  console.log('apply-with-vcv banned-strings gate: clean');
+  process.exit(0);
+}
+
+console.error('apply-with-vcv banned-strings gate: FAIL');
+for (const { file, phrase } of hitDetails) {
+  console.error(`  ${file}  →  "${phrase}"`);
+}
+console.error(`\n${hits} hit(s) — see CLAUDE.md "Banned strings" for context.`);
+process.exit(1);


### PR DESCRIPTION
## Summary

Operationalizes Apply-with-VCV by composing the in-flight pieces (signed apply bundle, replay lineage `AuditBundle`, audit packet, verifier context) into one **portable application manifest** with deterministic content hash, replay-safe verifier requests, and explicit ambiguity preservation.

- **New composer**: `apps/api/backend/src/services/apply/applyOperationalWorkflow.ts` — pure transform module (no fetches, no DB writes — same constraint as `apps/web/lib/issuer-verification` helpers). Exports `composeApplicationManifest`, `verifyApplicationManifest`, `issueVerifierRequest`, `simulateWorkflowChaos`, `findBannedPhrase`.
- **Determinism**: SHA-256 over canonical JSON (sorted keys); `generatedAt` / `expiresAt` are metadata, not in hash. `manifestId` = hash prefix.
- **Ambiguity preservation**: `receipt_candidate` / `psv_receipt_candidate` markers must carry literal `decisionGrade: false`. Composer + verifier both reject widening (compose throws, verify returns `AMBIGUITY_VIOLATION`).
- **Replay-safe verifier requests**: content-bound `requestId`, idempotent on retry, includes `replayAnchor` (`CAPSULE | BUNDLE | MANIFEST`) the responder must echo. Default 24h idempotency window matching bundle TTL.
- **38 Jest cases** across 5 suites (determinism, ambiguity, banned-copy, replay-safety, chaos). Chaos exercises 7 perturbations and asserts no silent degradation.
- **New audit event types** (additive to `auditEventTypes.ts`): `APPLY_MANIFEST_*`, `CREDENTIAL_SHARED`, `CREDENTIAL_SHARE_REVOKED`, `VERIFIER_REQUEST_*`. Persistence wiring deferred behind TRUST-PERSIST-1.
- **CI gate**: `.github/workflows/apply-with-vcv-gate.yml` runs the banned-strings scanner + Jest suite on any apply-surface PR.
- **Docs**: `docs/ops/apply-with-vcv-operational-workflow.md`.

## Truth contract notes

- No banned-string violations: composer-produced copy is scanned at compose time, verify time, and CI-gate time.
- No literal `decisionGrade: true` for any `receipt_candidate` / `psv_receipt_candidate` — refused at compose; rejected at verify.
- `did` falls back to `did:vitalcv:{npi}` consistent with `replayEngine.ts:547`.
- `auditEventTypes.ts` change is purely additive; existing callers unaffected.

## Test plan

- [x] `apps/api/backend/src/services/apply/__tests__/applyOperationalWorkflow.test.ts` — 38/38 passing locally
- [x] `node scripts/apply-with-vcv-banned-strings.mjs` — clean
- [x] Backend `tsc --noEmit` — no new errors (pre-existing Prisma-client errors are unrelated)
- [ ] CI: `apply-with-vcv-gate` workflow runs both jobs on this PR
- [ ] Codex SAFE verification before merge (per CLAUDE.md merge-protection hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)