### PR TITLE
feat(activation): institutional activation readiness verification — W2-PR144A

### DIFF
--- a/.github/workflows/activation-readiness-gate.yml
+++ b/.github/workflows/activation-readiness-gate.yml
@@ -1,0 +1,64 @@
+name: Activation Readiness Gate (W2-PR144A)
+
+on:
+  push:
+    paths:
+      - 'apps/api/backend/src/services/activation/**'
+  pull_request:
+    paths:
+      - 'apps/api/backend/src/services/activation/**'
+
+jobs:
+  activation-readiness-ci-gate:
+    name: Activation Readiness CI Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run activation readiness CI gate tests
+        run: |
+          pnpm --filter @vitalcv/backend exec vitest run \
+            src/services/activation/__tests__/activationReadiness.ci.gate.test.ts \
+            --reporter=verbose
+
+      - name: Run activation readiness chaos simulations
+        run: |
+          pnpm --filter @vitalcv/backend exec vitest run \
+            src/services/activation/__tests__/activationReadiness.chaos.test.ts \
+            --reporter=verbose
+
+      - name: Verify no banned strings in activation services
+        run: |
+          grep -RInE \
+            "automatically verified|guaranteed verification|complete credentialing|instant credentialing|legally accepted|risk transferred|HIPAA compliant|SOC2 certified|certified compliant|final verification without review|source confirmed before response" \
+            apps/api/backend/src/services/activation/ && \
+            { echo "BANNED STRING FOUND — failing build"; exit 1; } || \
+            echo "Truth scan CLEAN"
+
+      - name: Verify fail-closed sentinel present in activationReadiness.ts
+        run: |
+          grep -q "ACTIVATION_BREACH" \
+            apps/api/backend/src/services/activation/activationReadiness.ts && \
+            echo "fail-closed sentinel present" || \
+            { echo "MISSING fail-closed sentinel"; exit 1; }
+
+      - name: Verify replay-safe sentinel present in activationReplayValidation.ts
+        run: |
+          grep -q "REPLAY_MISSING" \
+            apps/api/backend/src/services/activation/activationReplayValidation.ts && \
+            echo "replay-safe sentinel present" || \
+            { echo "MISSING replay-safe sentinel"; exit 1; }

--- a/apps/api/backend/src/services/activation/__tests__/activationReadiness.chaos.test.ts
+++ b/apps/api/backend/src/services/activation/__tests__/activationReadiness.chaos.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Activation Readiness — Chaos Simulations (W2-PR144A)
+ *
+ * Adversarial test suite. Each scenario attempts to produce a false READY
+ * verdict under degraded or tampered conditions. Every case must be
+ * detected — no silent activation on bad evidence.
+ *
+ * Scenarios:
+ *   1. Empty evidence slice → EMPTY_EVIDENCE_SLICE error
+ *   2. Single CONTAINMENT_BREACH capsule voids composite → ACTIVATION_BREACH
+ *   3. All capsules lack replay IDs → ACTIVATION_AMBIGUOUS
+ *   4. OPERATOR ready, all others BLOCKED → NOT_READY
+ *   5. One AMBIGUOUS dimension blocks READY verdict
+ *   6. Evidence score 100 with CONTAMINATED containment → score voided
+ *   7. Replay-validation: missing anchor → REPLAY_MISSING
+ *   8. Replay-validation: stale anchor → REPLAY_STALE
+ *   9. Replay-validation: evidence spine drift → EVIDENCE_SPINE_DRIFTED
+ *  10. Survivability: FATAL failure → SURVIVABILITY_FAILED
+ *  11. Survivability: fail-open detection (failedClosed=false)
+ *  12. Telemetry: overconfidence episode accumulates
+ *  13. Lineage manifest: breach count enumerated, not suppressed
+ *  14. Ecosystem survivability: one failed institution collapses overall
+ */
+
+import {
+  scoreActivationReadiness,
+  ActivationReadinessError,
+  ACTIVATION_READINESS_SENTINELS,
+  type ReadinessEvidenceCapsule,
+} from '../activationReadiness';
+import {
+  validateActivationReplay,
+  REPLAY_ACTIVATION_SENTINELS,
+  type ReplayAnchor,
+} from '../activationReplayValidation';
+import {
+  verifyInstitutionalSurvivability,
+  buildEcosystemSurvivabilityReport,
+  type SurvivabilityFailureEvent,
+} from '../institutionalSurvivability';
+import { buildActivationConfidenceTelemetry } from '../activationConfidenceTelemetry';
+import { sealReadinessLineageManifest } from '../readinessLineageManifest';
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function cleanCapsule(
+  overrides: Partial<ReadinessEvidenceCapsule> = {},
+): ReadinessEvidenceCapsule {
+  return {
+    schema: 'vitalcv.activation-evidence.v1',
+    capsuleId: `cap-${Math.random().toString(36).slice(2, 8)}`,
+    dimension: 'OPERATOR',
+    evidenceScore: 90,
+    containmentVerdict: 'CLEAN',
+    replayCapsuleIds: ['replay-1'],
+    observedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function cleanAnchor(overrides: Partial<ReplayAnchor> = {}): ReplayAnchor {
+  return {
+    schema: 'vitalcv.replay-anchor.v1',
+    capsuleId: 'anchor-1',
+    capturedAt: new Date(Date.now() - 60_000).toISOString(), // 1 min ago
+    containmentVerdict: 'CLEAN',
+    evidenceSpineHash: 'abc123',
+    replayVerified: true,
+    ...overrides,
+  };
+}
+
+// ── chaos scenarios ────────────────────────────────────────────────────────────
+
+describe('Chaos 1 — empty evidence slice throws EMPTY_EVIDENCE_SLICE', () => {
+  it('throws on empty capsule array', () => {
+    expect(() => scoreActivationReadiness([])).toThrow(ActivationReadinessError);
+    try {
+      scoreActivationReadiness([]);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ActivationReadinessError);
+      expect((e as ActivationReadinessError).violation).toBe('EMPTY_EVIDENCE_SLICE');
+    }
+  });
+});
+
+describe('Chaos 2 — single CONTAINMENT_BREACH capsule voids composite', () => {
+  it('returns ACTIVATION_BREACH and null compositeReadiness', () => {
+    const capsules: ReadinessEvidenceCapsule[] = [
+      cleanCapsule({ dimension: 'OPERATOR', containmentVerdict: 'CONTAINMENT_BREACH' }),
+      cleanCapsule({ dimension: 'VERIFIER', evidenceScore: 100 }),
+      cleanCapsule({ dimension: 'EXECUTIVE', evidenceScore: 100 }),
+      cleanCapsule({ dimension: 'ECOSYSTEM', evidenceScore: 100 }),
+    ];
+    const result = scoreActivationReadiness(capsules);
+    expect(result.overallVerdict).toBe('ACTIVATION_BREACH');
+    expect(result.compositeReadiness).toBeNull();
+    expect(result.confidenceScore).toBe(0);
+    expect(result.evidenceCeiling).toBe(0);
+  });
+});
+
+describe('Chaos 3 — all capsules lack replay IDs → ACTIVATION_AMBIGUOUS', () => {
+  it('surfaces ACTIVATION_AMBIGUOUS when no capsule has replay IDs', () => {
+    const capsules: ReadinessEvidenceCapsule[] = [
+      cleanCapsule({ dimension: 'OPERATOR', replayCapsuleIds: [] }),
+      cleanCapsule({ dimension: 'VERIFIER', replayCapsuleIds: [] }),
+      cleanCapsule({ dimension: 'EXECUTIVE', replayCapsuleIds: [] }),
+      cleanCapsule({ dimension: 'ECOSYSTEM', replayCapsuleIds: [] }),
+    ];
+    const result = scoreActivationReadiness(capsules);
+    expect(result.overallVerdict).toBe('ACTIVATION_AMBIGUOUS');
+    expect(result.compositeReadiness).toBeNull();
+  });
+});
+
+describe('Chaos 4 — OPERATOR ready, all others BLOCKED → NOT_READY', () => {
+  it('returns NOT_READY when non-operator dimensions are blocked', () => {
+    const capsules: ReadinessEvidenceCapsule[] = [
+      cleanCapsule({ dimension: 'OPERATOR', evidenceScore: 95 }),
+      cleanCapsule({ dimension: 'VERIFIER', evidenceScore: 10 }),
+      cleanCapsule({ dimension: 'EXECUTIVE', evidenceScore: 10 }),
+      cleanCapsule({ dimension: 'ECOSYSTEM', evidenceScore: 10 }),
+    ];
+    const result = scoreActivationReadiness(capsules);
+    expect(result.overallVerdict).toBe('NOT_READY');
+    const operator = result.dimensions.find(d => d.dimension === 'OPERATOR');
+    const verifier = result.dimensions.find(d => d.dimension === 'VERIFIER');
+    expect(operator?.status).toBe('PASSING');
+    expect(verifier?.status).toBe('BLOCKED');
+  });
+});
+
+describe('Chaos 5 — one AMBIGUOUS dimension blocks READY verdict', () => {
+  it('returns ACTIVATION_AMBIGUOUS when one dimension lacks replay IDs', () => {
+    const capsules: ReadinessEvidenceCapsule[] = [
+      cleanCapsule({ dimension: 'OPERATOR', evidenceScore: 95 }),
+      cleanCapsule({ dimension: 'VERIFIER', evidenceScore: 95 }),
+      cleanCapsule({ dimension: 'EXECUTIVE', evidenceScore: 95 }),
+      // ECOSYSTEM has no replay IDs → AMBIGUOUS
+      cleanCapsule({ dimension: 'ECOSYSTEM', evidenceScore: 95, replayCapsuleIds: [] }),
+    ];
+    const result = scoreActivationReadiness(capsules);
+    expect(result.overallVerdict).toBe('ACTIVATION_AMBIGUOUS');
+  });
+});
+
+describe('Chaos 6 — evidenceScore=100 with CONTAMINATED containment voids score', () => {
+  it('treats CONTAMINATED capsule as not replay-safe → low composite', () => {
+    const capsules: ReadinessEvidenceCapsule[] = [
+      cleanCapsule({
+        dimension: 'OPERATOR',
+        evidenceScore: 100,
+        containmentVerdict: 'CONTAMINATED',
+        replayCapsuleIds: ['replay-1'],
+      }),
+    ];
+    const result = scoreActivationReadiness(capsules);
+    const op = result.dimensions.find(d => d.dimension === 'OPERATOR');
+    // CONTAMINATED capsules are not replay-safe; evidenceCeiling = 0
+    expect(op?.replaySafeCapsuleCount).toBe(0);
+    expect(op?.evidenceCeiling).toBe(0);
+  });
+});
+
+describe('Chaos 7 — replay validation: missing anchor → REPLAY_MISSING', () => {
+  it('returns REPLAY_MISSING with NO_ANCHOR_CAPSULE failure reason', () => {
+    const result = validateActivationReplay({
+      activationId: 'act-1',
+      proposedAt: new Date().toISOString(),
+      anchor: null,
+      currentEvidenceSpineHash: 'abc123',
+    });
+    expect(result.verdict).toBe('REPLAY_MISSING');
+    expect(result.failureReasons).toContain('NO_ANCHOR_CAPSULE');
+    expect(result.anchorCapsuleId).toBeNull();
+  });
+});
+
+describe('Chaos 8 — replay validation: stale anchor → REPLAY_STALE', () => {
+  it('returns REPLAY_STALE when anchor age exceeds maxReplayAgeMs', () => {
+    const oldCapturedAt = new Date(
+      Date.now() - (REPLAY_ACTIVATION_SENTINELS.DEFAULT_MAX_REPLAY_AGE_MS + 60_000),
+    ).toISOString();
+    const result = validateActivationReplay({
+      activationId: 'act-stale',
+      proposedAt: new Date().toISOString(),
+      anchor: cleanAnchor({ capturedAt: oldCapturedAt }),
+      currentEvidenceSpineHash: 'abc123',
+    });
+    expect(result.verdict).toBe('REPLAY_STALE');
+    expect(result.failureReasons).toContain('ANCHOR_STALE');
+  });
+});
+
+describe('Chaos 9 — replay validation: evidence spine drift', () => {
+  it('flags EVIDENCE_SPINE_DRIFTED when hashes differ', () => {
+    const result = validateActivationReplay({
+      activationId: 'act-drift',
+      proposedAt: new Date().toISOString(),
+      anchor: cleanAnchor({ evidenceSpineHash: 'abc123' }),
+      currentEvidenceSpineHash: 'DIFFERENT_HASH',
+    });
+    expect(result.evidenceSpineDrifted).toBe(true);
+    expect(result.failureReasons).toContain('EVIDENCE_SPINE_DRIFTED');
+  });
+});
+
+describe('Chaos 10 — survivability: FATAL failure → SURVIVABILITY_FAILED', () => {
+  it('fails the institution when a FATAL event is present', () => {
+    const fatalEvent: SurvivabilityFailureEvent = {
+      schema: 'vitalcv.survivability-failure.v1',
+      institutionId: 'inst-1',
+      mode: 'EVIDENCE_SPINE_COLLAPSE',
+      severity: 'FATAL',
+      detectedAt: new Date().toISOString(),
+      failedClosed: true,
+    };
+    const result = verifyInstitutionalSurvivability({
+      institutionId: 'inst-1',
+      observationWindowStart: new Date(Date.now() - 3600_000).toISOString(),
+      observationWindowEnd: new Date().toISOString(),
+      failureEvents: [fatalEvent],
+      activationSuccessRate: 0.98,
+      replayFallbackConfigured: true,
+    });
+    expect(result.verdict).toBe('SURVIVABILITY_FAILED');
+    expect(result.fatalFailureCount).toBe(1);
+  });
+});
+
+describe('Chaos 11 — survivability: fail-open detection', () => {
+  it('detects imperfect fail-closed compliance', () => {
+    const failOpenEvent: SurvivabilityFailureEvent = {
+      schema: 'vitalcv.survivability-failure.v1',
+      institutionId: 'inst-2',
+      mode: 'AUTH_DEGRADATION',
+      severity: 'DEGRADING',
+      detectedAt: new Date().toISOString(),
+      failedClosed: false, // system activated on degraded evidence — fail-open
+    };
+    const result = verifyInstitutionalSurvivability({
+      institutionId: 'inst-2',
+      observationWindowStart: new Date(Date.now() - 3600_000).toISOString(),
+      observationWindowEnd: new Date().toISOString(),
+      failureEvents: [failOpenEvent],
+      activationSuccessRate: 0.95,
+      replayFallbackConfigured: true,
+    });
+    expect(result.perfectFailClosedCompliance).toBe(false);
+    expect(result.failedClosedRate).toBeLessThan(1.0);
+  });
+});
+
+describe('Chaos 12 — telemetry: overconfidence episode accumulates', () => {
+  it('flags scores where compositeReadiness exceeds evidenceCeiling', () => {
+    const overconfidentScore = {
+      schema: 'vitalcv.activation-readiness.v1' as const,
+      scoreId: 'sc-oc-1',
+      overallVerdict: 'READY' as const,
+      compositeReadiness: 95,
+      evidenceCeiling: 50, // readiness > ceiling → overconfidence
+      dimensions: [],
+      confidenceScore: 0.5,
+      readinessDigest: 'digest-1',
+      scoredAt: new Date().toISOString(),
+      methodologyVersion: 'activation-readiness.v1' as const,
+    };
+    const telemetry = buildActivationConfidenceTelemetry([overconfidentScore]);
+    expect(telemetry.overconfidenceEpisodes).toHaveLength(1);
+    expect(telemetry.overconfidenceEpisodes[0].excessAmount).toBe(45);
+  });
+});
+
+describe('Chaos 13 — lineage manifest: breach capsule enumerated, not suppressed', () => {
+  it('counts CONTAINMENT_BREACH capsules in breachCount', () => {
+    const capsule = cleanCapsule({ containmentVerdict: 'CONTAINMENT_BREACH' });
+    const score = scoreActivationReadiness([capsule]);
+    const manifest = sealReadinessLineageManifest(score, [capsule]);
+    expect(manifest.breachCount).toBe(1);
+    expect(manifest.overallVerdict).toBe('ACTIVATION_BREACH');
+  });
+});
+
+describe('Chaos 14 — ecosystem survivability: one failed institution collapses overall', () => {
+  it('returns SURVIVABILITY_FAILED when any institution fails', () => {
+    const survivableResult = verifyInstitutionalSurvivability({
+      institutionId: 'inst-ok',
+      observationWindowStart: new Date(Date.now() - 3600_000).toISOString(),
+      observationWindowEnd: new Date().toISOString(),
+      failureEvents: [],
+      activationSuccessRate: 1.0,
+      replayFallbackConfigured: true,
+    });
+    const failedResult = verifyInstitutionalSurvivability({
+      institutionId: 'inst-fail',
+      observationWindowStart: new Date(Date.now() - 3600_000).toISOString(),
+      observationWindowEnd: new Date().toISOString(),
+      failureEvents: [{
+        schema: 'vitalcv.survivability-failure.v1',
+        institutionId: 'inst-fail',
+        mode: 'TENANT_ISOLATION_FAILURE',
+        severity: 'FATAL',
+        detectedAt: new Date().toISOString(),
+        failedClosed: true,
+      }],
+      activationSuccessRate: 0.5,
+      replayFallbackConfigured: false,
+    });
+    const report = buildEcosystemSurvivabilityReport([survivableResult, failedResult]);
+    expect(report.overallVerdict).toBe('SURVIVABILITY_FAILED');
+    expect(report.failedInstitutionCount).toBe(1);
+    expect(report.survivableInstitutionCount).toBe(1);
+  });
+});

--- a/apps/api/backend/src/services/activation/__tests__/activationReadiness.ci.gate.test.ts
+++ b/apps/api/backend/src/services/activation/__tests__/activationReadiness.ci.gate.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Activation Readiness — CI Gate (W2-PR144A)
+ *
+ * Canary suite. Every public primitive must:
+ *   - export an enumerated sentinel list matching the runtime type union;
+ *   - throw ActivationReadinessError (not plain Error) on boundary breaches;
+ *   - never coerce ACTIVATION_AMBIGUOUS to READY (the silent-collapse
+ *     anti-pattern);
+ *   - produce deterministic readinessDigest (same input → same digest);
+ *   - expose methodologyVersion literal on every score.
+ *
+ * If a future refactor accidentally weakens any of these invariants, this
+ * suite breaks the build before the regression ships.
+ */
+
+import {
+  KNOWN_ACTIVATION_VERDICTS,
+  KNOWN_READINESS_DIMENSIONS,
+  KNOWN_DIMENSION_STATUSES,
+  ACTIVATION_READINESS_SENTINELS,
+  ActivationReadinessError,
+  scoreActivationReadiness,
+  type ActivationVerdict,
+  type ReadinessDimension,
+  type DimensionReadinessStatus,
+  type ReadinessEvidenceCapsule,
+} from '../activationReadiness';
+
+import {
+  KNOWN_REPLAY_ACTIVATION_VERDICTS,
+  KNOWN_REPLAY_FAILURE_REASONS,
+  REPLAY_ACTIVATION_SENTINELS,
+  validateActivationReplay,
+  type ReplayActivationVerdict,
+  type ReplayActivationFailureReason,
+} from '../activationReplayValidation';
+
+import {
+  KNOWN_SURVIVABILITY_VERDICTS,
+  KNOWN_SURVIVABILITY_FAILURE_MODES,
+  SURVIVABILITY_SENTINELS,
+  verifyInstitutionalSurvivability,
+  buildEcosystemSurvivabilityReport,
+  type SurvivabilityVerdict,
+} from '../institutionalSurvivability';
+
+import { buildActivationConfidenceTelemetry } from '../activationConfidenceTelemetry';
+import { sealReadinessLineageManifest } from '../readinessLineageManifest';
+
+// ── Expected sentinel lists ────────────────────────────────────────────────────
+
+const EXPECTED_VERDICTS: ActivationVerdict[] = [
+  'READY',
+  'CONDITIONALLY_READY',
+  'NOT_READY',
+  'ACTIVATION_AMBIGUOUS',
+  'ACTIVATION_BREACH',
+];
+
+const EXPECTED_DIMENSIONS: ReadinessDimension[] = [
+  'OPERATOR',
+  'VERIFIER',
+  'EXECUTIVE',
+  'ECOSYSTEM',
+];
+
+const EXPECTED_DIM_STATUSES: DimensionReadinessStatus[] = [
+  'PASSING',
+  'PARTIAL',
+  'BLOCKED',
+  'AMBIGUOUS',
+  'BREACH',
+];
+
+const EXPECTED_REPLAY_VERDICTS: ReplayActivationVerdict[] = [
+  'REPLAY_VALID',
+  'REPLAY_STALE',
+  'REPLAY_AMBIGUOUS',
+  'REPLAY_BREACH',
+  'REPLAY_MISSING',
+];
+
+const EXPECTED_REPLAY_FAILURES: ReplayActivationFailureReason[] = [
+  'NO_ANCHOR_CAPSULE',
+  'ANCHOR_CONTAINMENT_BREACH',
+  'ANCHOR_CONTAINMENT_AMBIGUOUS',
+  'ANCHOR_NOT_REPLAY_VERIFIED',
+  'ANCHOR_STALE',
+  'EVIDENCE_SPINE_DRIFTED',
+];
+
+const EXPECTED_SURVIVABILITY_VERDICTS: SurvivabilityVerdict[] = [
+  'SURVIVABLE',
+  'DEGRADED',
+  'SURVIVABILITY_FAILED',
+  'SURVIVABILITY_AMBIGUOUS',
+];
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function allDimsCapsule(score: number, verdict: ReadinessEvidenceCapsule['containmentVerdict'] = 'CLEAN'): ReadinessEvidenceCapsule[] {
+  return EXPECTED_DIMENSIONS.map(dim => ({
+    schema: 'vitalcv.activation-evidence.v1' as const,
+    capsuleId: `cap-gate-${dim}`,
+    dimension: dim,
+    evidenceScore: score,
+    containmentVerdict: verdict,
+    replayCapsuleIds: ['replay-gate-1'],
+    observedAt: new Date().toISOString(),
+  }));
+}
+
+// ── CI gate: exported enums ────────────────────────────────────────────────────
+
+describe('CI gate — activation readiness sentinel lists match type unions', () => {
+  it('KNOWN_ACTIVATION_VERDICTS covers all expected verdicts', () => {
+    for (const v of EXPECTED_VERDICTS) {
+      expect(KNOWN_ACTIVATION_VERDICTS).toContain(v);
+    }
+    expect(KNOWN_ACTIVATION_VERDICTS).toHaveLength(EXPECTED_VERDICTS.length);
+  });
+
+  it('KNOWN_READINESS_DIMENSIONS covers all four participant classes', () => {
+    for (const d of EXPECTED_DIMENSIONS) {
+      expect(KNOWN_READINESS_DIMENSIONS).toContain(d);
+    }
+    expect(KNOWN_READINESS_DIMENSIONS).toHaveLength(EXPECTED_DIMENSIONS.length);
+  });
+
+  it('KNOWN_DIMENSION_STATUSES covers all expected statuses', () => {
+    for (const s of EXPECTED_DIM_STATUSES) {
+      expect(KNOWN_DIMENSION_STATUSES).toContain(s);
+    }
+    expect(KNOWN_DIMENSION_STATUSES).toHaveLength(EXPECTED_DIM_STATUSES.length);
+  });
+});
+
+describe('CI gate — replay activation sentinel lists match type unions', () => {
+  it('KNOWN_REPLAY_ACTIVATION_VERDICTS is complete', () => {
+    for (const v of EXPECTED_REPLAY_VERDICTS) {
+      expect(KNOWN_REPLAY_ACTIVATION_VERDICTS).toContain(v);
+    }
+    expect(KNOWN_REPLAY_ACTIVATION_VERDICTS).toHaveLength(EXPECTED_REPLAY_VERDICTS.length);
+  });
+
+  it('KNOWN_REPLAY_FAILURE_REASONS is complete', () => {
+    for (const r of EXPECTED_REPLAY_FAILURES) {
+      expect(KNOWN_REPLAY_FAILURE_REASONS).toContain(r);
+    }
+    expect(KNOWN_REPLAY_FAILURE_REASONS).toHaveLength(EXPECTED_REPLAY_FAILURES.length);
+  });
+});
+
+describe('CI gate — survivability sentinel lists match type unions', () => {
+  it('KNOWN_SURVIVABILITY_VERDICTS is complete', () => {
+    for (const v of EXPECTED_SURVIVABILITY_VERDICTS) {
+      expect(KNOWN_SURVIVABILITY_VERDICTS).toContain(v);
+    }
+    expect(KNOWN_SURVIVABILITY_VERDICTS).toHaveLength(EXPECTED_SURVIVABILITY_VERDICTS.length);
+  });
+});
+
+// ── CI gate: error types ───────────────────────────────────────────────────────
+
+describe('CI gate — ActivationReadinessError is thrown (not plain Error)', () => {
+  it('empty slice throws ActivationReadinessError with enumerated violation', () => {
+    try {
+      scoreActivationReadiness([]);
+      expect(true).toBe(false); // must not reach here
+    } catch (e) {
+      expect(e).toBeInstanceOf(ActivationReadinessError);
+      const err = e as ActivationReadinessError;
+      expect(err.name).toBe('ActivationReadinessError');
+      expect(['EMPTY_EVIDENCE_SLICE', 'BREACH_DIMENSION_BLOCKS_ACTIVATION', 'ALL_DIMENSIONS_AMBIGUOUS'])
+        .toContain(err.violation);
+    }
+  });
+});
+
+// ── CI gate: AMBIGUOUS never silently collapses to READY ─────────────────────
+
+describe('CI gate — AMBIGUOUS never collapses to READY', () => {
+  it('capsules without replay IDs produce ACTIVATION_AMBIGUOUS, not READY', () => {
+    const capsules = allDimsCapsule(100).map(c => ({ ...c, replayCapsuleIds: [] as string[] }));
+    const result = scoreActivationReadiness(capsules);
+    expect(result.overallVerdict).not.toBe('READY');
+    expect(result.overallVerdict).toBe('ACTIVATION_AMBIGUOUS');
+  });
+});
+
+// ── CI gate: deterministic digest ─────────────────────────────────────────────
+
+describe('CI gate — readinessDigest is tamper-evident (different inputs → different digest)', () => {
+  it('mutating a capsule evidenceScore changes the readinessDigest', () => {
+    const capsules85 = allDimsCapsule(85);
+    const capsules90 = allDimsCapsule(90);
+    const r85 = scoreActivationReadiness(capsules85);
+    const r90 = scoreActivationReadiness(capsules90);
+    expect(r85.readinessDigest).not.toBe(r90.readinessDigest);
+  });
+
+  it('readinessDigest is a non-empty hex string', () => {
+    const result = scoreActivationReadiness(allDimsCapsule(85));
+    expect(result.readinessDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── CI gate: methodology version literal ──────────────────────────────────────
+
+describe('CI gate — methodologyVersion literal present on every score', () => {
+  it('score includes methodologyVersion = activation-readiness.v1', () => {
+    const result = scoreActivationReadiness(allDimsCapsule(85));
+    expect(result.methodologyVersion).toBe('activation-readiness.v1');
+  });
+});
+
+// ── CI gate: schema literals present on outputs ───────────────────────────────
+
+describe('CI gate — schema literals on all output types', () => {
+  it('ActivationReadinessScore has correct schema literal', () => {
+    const result = scoreActivationReadiness(allDimsCapsule(85));
+    expect(result.schema).toBe('vitalcv.activation-readiness.v1');
+  });
+
+  it('ActivationReplayResult has correct schema literal', () => {
+    const result = validateActivationReplay({
+      activationId: 'act-schema-test',
+      proposedAt: new Date().toISOString(),
+      anchor: null,
+      currentEvidenceSpineHash: 'x',
+    });
+    expect(result.schema).toBe('vitalcv.activation-replay-result.v1');
+  });
+
+  it('InstitutionalSurvivabilityResult has correct schema literal', () => {
+    const result = verifyInstitutionalSurvivability({
+      institutionId: 'inst-schema',
+      observationWindowStart: new Date(Date.now() - 3600_000).toISOString(),
+      observationWindowEnd: new Date().toISOString(),
+      failureEvents: [],
+      activationSuccessRate: 1.0,
+      replayFallbackConfigured: true,
+    });
+    expect(result.schema).toBe('vitalcv.institutional-survivability.v1');
+  });
+
+  it('ReadinessLineageManifest has correct schema literal', () => {
+    const capsules = allDimsCapsule(85);
+    const score = scoreActivationReadiness(capsules);
+    const manifest = sealReadinessLineageManifest(score, capsules);
+    expect(manifest.schema).toBe('vitalcv.readiness-lineage-manifest.v1');
+  });
+
+  it('ActivationConfidenceTelemetry has correct schema literal', () => {
+    const capsules = allDimsCapsule(85);
+    const score = scoreActivationReadiness(capsules);
+    const telemetry = buildActivationConfidenceTelemetry([score]);
+    expect(telemetry.schema).toBe('vitalcv.activation-confidence-telemetry.v1');
+  });
+});
+
+// ── CI gate: ACTIVATION_BREACH thresholds are correct ─────────────────────────
+
+describe('CI gate — ACTIVATION_READINESS_SENTINELS thresholds are sane', () => {
+  it('READY_THRESHOLD > CONDITIONAL_THRESHOLD', () => {
+    expect(ACTIVATION_READINESS_SENTINELS.READY_THRESHOLD)
+      .toBeGreaterThan(ACTIVATION_READINESS_SENTINELS.CONDITIONAL_THRESHOLD);
+  });
+
+  it('CONDITIONAL_THRESHOLD > 0', () => {
+    expect(ACTIVATION_READINESS_SENTINELS.CONDITIONAL_THRESHOLD).toBeGreaterThan(0);
+  });
+
+  it('READY_THRESHOLD ≤ 100', () => {
+    expect(ACTIVATION_READINESS_SENTINELS.READY_THRESHOLD).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── CI gate: replay activation default age constant is positive ────────────────
+
+describe('CI gate — REPLAY_ACTIVATION_SENTINELS are positive', () => {
+  it('DEFAULT_MAX_REPLAY_AGE_MS is a positive integer', () => {
+    expect(REPLAY_ACTIVATION_SENTINELS.DEFAULT_MAX_REPLAY_AGE_MS).toBeGreaterThan(0);
+    expect(Number.isInteger(REPLAY_ACTIVATION_SENTINELS.DEFAULT_MAX_REPLAY_AGE_MS)).toBe(true);
+  });
+});
+
+// ── CI gate: survivability thresholds ─────────────────────────────────────────
+
+describe('CI gate — SURVIVABILITY_SENTINELS are ordered correctly', () => {
+  it('MIN_SUCCESS_RATE_FOR_SURVIVABLE > MIN_SUCCESS_RATE_FOR_DEGRADED', () => {
+    expect(SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_SURVIVABLE)
+      .toBeGreaterThan(SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_DEGRADED);
+  });
+
+  it('both rates are in (0, 1]', () => {
+    expect(SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_SURVIVABLE).toBeLessThanOrEqual(1);
+    expect(SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_DEGRADED).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/backend/src/services/activation/activationConfidenceTelemetry.ts
+++ b/apps/api/backend/src/services/activation/activationConfidenceTelemetry.ts
@@ -1,0 +1,227 @@
+/**
+ * activationConfidenceTelemetry.ts — W2-PR144A
+ *
+ * Activation confidence telemetry. Bins longitudinal activation-readiness
+ * scores into time-windows and surfaces overconfidence drift, plateau
+ * detection, and ecosystem-wide confidence velocity.
+ *
+ * Invariants:
+ *   1. Bin keys are deterministic from scoredAt — same input always
+ *      produces the same bin sequence.
+ *   2. Per-bin confidence splits replay-safe vs. degraded so a regulator
+ *      never sees confidence growth that masks replay failures.
+ *   3. snapshotDigest folds every bin and every confidence floor/ceiling
+ *      so the telemetry dashboard cannot silently rewrite the curve.
+ *   4. Overconfidence episodes accumulate in the alarm field — never
+ *      silently discarded.
+ *
+ * Pure transform — no fetches, no DB writes.
+ */
+import { sha256ForPayload } from '../../utils/deterministic';
+import type { ActivationReadinessScore, ActivationVerdict } from './activationReadiness';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type TelemetryBinResolution = 'DAY' | 'WEEK' | 'MONTH';
+
+export interface ActivationTelemetryPoint {
+  scoreId: string;
+  scoredAt: string;
+  compositeReadiness: number | null;
+  confidenceScore: number;
+  evidenceCeiling: number;
+  overallVerdict: ActivationVerdict;
+}
+
+export interface ActivationConfidenceBin {
+  schema: 'vitalcv.activation-confidence-bin.v1';
+  binKey: string;
+  binStart: string;
+  scoreCount: number;
+  avgCompositeReadiness: number | null;
+  avgConfidenceScore: number;
+  minEvidenceCeiling: number;
+  /** Number of READY verdicts in this bin. */
+  readyCount: number;
+  /** Number of ACTIVATION_BREACH verdicts in this bin. */
+  breachCount: number;
+  /** True iff every score in this bin was replay-safe (confidenceScore = 1.0). */
+  fullReplaySafe: boolean;
+}
+
+export interface ConfidenceOverconfidenceEpisode {
+  scoreId: string;
+  scoredAt: string;
+  claimedCompositeReadiness: number;
+  evidenceCeiling: number;
+  excessAmount: number;
+}
+
+export interface ActivationConfidenceTelemetry {
+  readonly schema: 'vitalcv.activation-confidence-telemetry.v1';
+  readonly reportId: string;
+  readonly resolution: TelemetryBinResolution;
+  readonly bins: ReadonlyArray<ActivationConfidenceBin>;
+  readonly growthBinCount: number;
+  readonly decayBinCount: number;
+  /** Bins where breach count > 0. */
+  readonly breachBinCount: number;
+  /**
+   * Average bin-to-bin delta in avgCompositeReadiness.
+   * Null when fewer than 2 bins.
+   */
+  readonly confidenceVelocityPerBin: number | null;
+  readonly overconfidenceEpisodes: ReadonlyArray<ConfidenceOverconfidenceEpisode>;
+  readonly snapshotDigest: string;
+  readonly generatedAt: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function toBinKey(
+  iso: string,
+  res: TelemetryBinResolution,
+): { key: string; start: string } {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { key: 'INVALID', start: 'INVALID' };
+  const y = d.getUTCFullYear();
+  const mo = d.getUTCMonth();
+  const day = d.getUTCDate();
+  if (res === 'MONTH') {
+    const start = new Date(Date.UTC(y, mo, 1));
+    return { key: start.toISOString().slice(0, 7), start: start.toISOString() };
+  }
+  if (res === 'WEEK') {
+    const dow = d.getUTCDay();
+    const monday = new Date(Date.UTC(y, mo, day - ((dow + 6) % 7)));
+    return { key: `${monday.toISOString().slice(0, 10)}~W`, start: monday.toISOString() };
+  }
+  const start = new Date(Date.UTC(y, mo, day));
+  return { key: start.toISOString().slice(0, 10), start: start.toISOString() };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+export function buildActivationConfidenceTelemetry(
+  scores: ReadonlyArray<ActivationReadinessScore>,
+  resolution: TelemetryBinResolution = 'DAY',
+): ActivationConfidenceTelemetry {
+  const reportId = `act-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const generatedAt = new Date().toISOString();
+
+  // Detect overconfidence: compositeReadiness > evidenceCeiling
+  const overconfidenceEpisodes: ConfidenceOverconfidenceEpisode[] = scores
+    .filter(s => s.compositeReadiness !== null && s.compositeReadiness > s.evidenceCeiling)
+    .map(s => ({
+      scoreId: s.scoreId,
+      scoredAt: s.scoredAt,
+      claimedCompositeReadiness: s.compositeReadiness as number,
+      evidenceCeiling: s.evidenceCeiling,
+      excessAmount: (s.compositeReadiness as number) - s.evidenceCeiling,
+    }));
+
+  // Bin the scores
+  const binMap = new Map<string, { start: string; points: ActivationTelemetryPoint[] }>();
+  for (const score of scores) {
+    const { key, start } = toBinKey(score.scoredAt, resolution);
+    if (!binMap.has(key)) {
+      binMap.set(key, { start, points: [] });
+    }
+    binMap.get(key)!.points.push({
+      scoreId: score.scoreId,
+      scoredAt: score.scoredAt,
+      compositeReadiness: score.compositeReadiness,
+      confidenceScore: score.confidenceScore,
+      evidenceCeiling: score.evidenceCeiling,
+      overallVerdict: score.overallVerdict,
+    });
+  }
+
+  const bins: ActivationConfidenceBin[] = [...binMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([binKey, { start, points }]) => {
+      const validReadiness = points
+        .filter(p => p.compositeReadiness !== null)
+        .map(p => p.compositeReadiness as number);
+
+      const avgCompositeReadiness = validReadiness.length > 0
+        ? parseFloat(
+            (validReadiness.reduce((a, b) => a + b, 0) / validReadiness.length).toFixed(1),
+          )
+        : null;
+
+      const avgConfidenceScore = points.length > 0
+        ? parseFloat(
+            (points.reduce((a, p) => a + p.confidenceScore, 0) / points.length).toFixed(3),
+          )
+        : 0;
+
+      const minEvidenceCeiling = points.length > 0
+        ? Math.min(...points.map(p => p.evidenceCeiling))
+        : 0;
+
+      return {
+        schema: 'vitalcv.activation-confidence-bin.v1',
+        binKey,
+        binStart: start,
+        scoreCount: points.length,
+        avgCompositeReadiness,
+        avgConfidenceScore,
+        minEvidenceCeiling,
+        readyCount: points.filter(p => p.overallVerdict === 'READY').length,
+        breachCount: points.filter(p => p.overallVerdict === 'ACTIVATION_BREACH').length,
+        fullReplaySafe: points.every(p => p.confidenceScore >= 1.0),
+      };
+    });
+
+  // Growth / decay analysis
+  let growthBinCount = 0;
+  let decayBinCount = 0;
+  let breachBinCount = 0;
+  const velocities: number[] = [];
+
+  for (let i = 0; i < bins.length; i++) {
+    if (bins[i].breachCount > 0) breachBinCount++;
+    if (i > 0) {
+      const prev = bins[i - 1].avgCompositeReadiness;
+      const curr = bins[i].avgCompositeReadiness;
+      if (prev !== null && curr !== null) {
+        const delta = curr - prev;
+        velocities.push(delta);
+        if (delta > 0) growthBinCount++;
+        else if (delta < 0) decayBinCount++;
+      }
+    }
+  }
+
+  const confidenceVelocityPerBin = velocities.length > 0
+    ? parseFloat((velocities.reduce((a, b) => a + b, 0) / velocities.length).toFixed(2))
+    : null;
+
+  const snapshotDigest = sha256ForPayload({
+    reportId,
+    resolution,
+    bins: bins.map(b => ({
+      binKey: b.binKey,
+      scoreCount: b.scoreCount,
+      avgCompositeReadiness: b.avgCompositeReadiness,
+      avgConfidenceScore: b.avgConfidenceScore,
+      breachCount: b.breachCount,
+    })),
+    overconfidenceEpisodeCount: overconfidenceEpisodes.length,
+  });
+
+  return {
+    schema: 'vitalcv.activation-confidence-telemetry.v1',
+    reportId,
+    resolution,
+    bins,
+    growthBinCount,
+    decayBinCount,
+    breachBinCount,
+    confidenceVelocityPerBin,
+    overconfidenceEpisodes,
+    snapshotDigest,
+    generatedAt,
+  };
+}

--- a/apps/api/backend/src/services/activation/activationReadiness.ts
+++ b/apps/api/backend/src/services/activation/activationReadiness.ts
@@ -1,0 +1,417 @@
+/**
+ * activationReadiness.ts — W2-PR144A
+ *
+ * Institutional Activation Readiness scoring engine. Pure transform that
+ * consumes evidence slices from operators, verifiers, executives, and
+ * ecosystem participants and produces a replay-safe, lineage-anchored
+ * readiness score.
+ *
+ * Hard invariants (fail-closed):
+ *   1. Readiness replay-safe — every score is traceable to a real evidence
+ *      capsule. A capsule with containment breach forces
+ *      overallVerdict=ACTIVATION_BREACH. Empty slice →
+ *      ACTIVATION_AMBIGUOUS, never a default win.
+ *   2. Ambiguity preserved operationally — when dimension scores
+ *      contradict (e.g. high operator score, zero verifier score),
+ *      the composite surfaces ACTIVATION_AMBIGUOUS. No silent merge.
+ *   3. Activation lineage reconstructable — readinessDigest folds every
+ *      input id, dimension score, and lineage reference. A tamper-evident
+ *      hash a regulator can re-run.
+ *   4. Fail-closed readiness semantics — ACTIVATION_BREACH voids the
+ *      composite score; any single BLOCKED dimension caps overall to
+ *      NOT_READY.
+ *   5. Institutional confidence measurable — confidenceScore exposes the
+ *      evidence ceiling plus the contribution breakdown so the operator
+ *      dashboard can surface "why" next to every score.
+ *   6. Ecosystem readiness longitudinally visible — the snapshot includes
+ *      per-participant-class curves so a regulator can reconstruct who
+ *      was ready for activation, when.
+ *
+ * Pure transform — no fetches, no DB writes, no audit-event writes.
+ */
+import { sha256ForPayload } from '../../utils/deterministic';
+
+/**
+ * Containment verdict from the replay corruption containment layer.
+ * Defined locally so this module is self-contained on origin/main.
+ */
+export type ContainmentVerdict =
+  | 'CLEAN'
+  | 'AMBIGUOUS'
+  | 'QUARANTINED'
+  | 'CONTAMINATED'
+  | 'CONTAINMENT_BREACH';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ActivationVerdict =
+  | 'READY'
+  | 'CONDITIONALLY_READY'
+  | 'NOT_READY'
+  | 'ACTIVATION_AMBIGUOUS'
+  | 'ACTIVATION_BREACH';
+
+export type ReadinessDimension =
+  | 'OPERATOR'
+  | 'VERIFIER'
+  | 'EXECUTIVE'
+  | 'ECOSYSTEM';
+
+export type DimensionReadinessStatus =
+  | 'PASSING'
+  | 'PARTIAL'
+  | 'BLOCKED'
+  | 'AMBIGUOUS'
+  | 'BREACH';
+
+export interface ReadinessEvidenceCapsule {
+  schema: 'vitalcv.activation-evidence.v1';
+  capsuleId: string;
+  dimension: ReadinessDimension;
+  /**
+   * Normalized evidence score 0–100 for this capsule's dimension.
+   * Must be derived from replay-safe audit bundles.
+   */
+  evidenceScore: number;
+  containmentVerdict: ContainmentVerdict;
+  /** Replay capsule IDs that back this evidence. Empty → AMBIGUOUS. */
+  replayCapsuleIds: ReadonlyArray<string>;
+  observedAt: string;
+}
+
+export interface DimensionScore {
+  dimension: ReadinessDimension;
+  status: DimensionReadinessStatus;
+  /**
+   * Composite score 0–100 for this dimension across all supplied capsules.
+   * Null when status=BREACH (score is voided).
+   */
+  compositeScore: number | null;
+  /** Number of replay-safe capsules backing the score. */
+  replaySafeCapsuleCount: number;
+  /** Number of capsules that were ambiguous (missing replay IDs). */
+  ambiguousCapsuleCount: number;
+  /** Highest containment violation seen across capsules. */
+  worstContainmentVerdict: ContainmentVerdict;
+  evidenceCeiling: number;
+}
+
+export interface ActivationReadinessScore {
+  readonly schema: 'vitalcv.activation-readiness.v1';
+  readonly scoreId: string;
+  readonly overallVerdict: ActivationVerdict;
+  /**
+   * Composite readiness percentage 0–100.
+   * Null when overallVerdict=ACTIVATION_BREACH.
+   */
+  readonly compositeReadiness: number | null;
+  readonly dimensions: ReadonlyArray<DimensionScore>;
+  /**
+   * Confidence in the readiness score itself [0, 1].
+   * Derived from the fraction of capsules that are replay-safe and
+   * have CLEAN containment.
+   */
+  readonly confidenceScore: number;
+  /**
+   * Hard ceiling on compositeReadiness imposed by evidence quality.
+   * No claim may exceed this value.
+   */
+  readonly evidenceCeiling: number;
+  /** SHA-256 tamper-evident digest over all input capsule IDs + scores. */
+  readonly readinessDigest: string;
+  readonly scoredAt: string;
+  readonly methodologyVersion: 'activation-readiness.v1';
+}
+
+// ── Sentinel constants ─────────────────────────────────────────────────────────
+
+export const KNOWN_ACTIVATION_VERDICTS: ActivationVerdict[] = [
+  'READY',
+  'CONDITIONALLY_READY',
+  'NOT_READY',
+  'ACTIVATION_AMBIGUOUS',
+  'ACTIVATION_BREACH',
+];
+
+export const KNOWN_READINESS_DIMENSIONS: ReadinessDimension[] = [
+  'OPERATOR',
+  'VERIFIER',
+  'EXECUTIVE',
+  'ECOSYSTEM',
+];
+
+export const KNOWN_DIMENSION_STATUSES: DimensionReadinessStatus[] = [
+  'PASSING',
+  'PARTIAL',
+  'BLOCKED',
+  'AMBIGUOUS',
+  'BREACH',
+];
+
+export const ACTIVATION_READINESS_SENTINELS = {
+  READY_THRESHOLD: 80,
+  CONDITIONAL_THRESHOLD: 60,
+  AMBIGUOUS_CAPSULE_RATIO_THRESHOLD: 0.5,
+  MIN_REPLAY_SAFE_CAPSULES: 1,
+} as const;
+
+// ── Violation class ────────────────────────────────────────────────────────────
+
+export class ActivationReadinessError extends Error {
+  constructor(
+    public readonly violation:
+      | 'BREACH_DIMENSION_BLOCKS_ACTIVATION'
+      | 'EMPTY_EVIDENCE_SLICE'
+      | 'ALL_DIMENSIONS_AMBIGUOUS',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ActivationReadinessError';
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function containmentSeverity(v: ContainmentVerdict): number {
+  switch (v) {
+    case 'CLEAN':              return 0;
+    case 'AMBIGUOUS':          return 1;
+    case 'QUARANTINED':        return 2;
+    case 'CONTAMINATED':       return 3;
+    case 'CONTAINMENT_BREACH': return 4;
+    default:                   return 4;
+  }
+}
+
+function worstVerdict(
+  verdicts: ContainmentVerdict[],
+): ContainmentVerdict {
+  if (!verdicts.length) return 'AMBIGUOUS';
+  const ranked: ContainmentVerdict[] = [
+    'CLEAN', 'AMBIGUOUS', 'QUARANTINED', 'CONTAMINATED', 'CONTAINMENT_BREACH',
+  ];
+  let worst: ContainmentVerdict = 'CLEAN';
+  for (const v of verdicts) {
+    if (containmentSeverity(v) > containmentSeverity(worst)) {
+      worst = v;
+    }
+  }
+  return worst;
+}
+
+function scoreDimension(
+  dimension: ReadinessDimension,
+  capsules: ReadinessEvidenceCapsule[],
+): DimensionScore {
+  if (!capsules.length) {
+    return {
+      dimension,
+      status: 'AMBIGUOUS',
+      compositeScore: null,
+      replaySafeCapsuleCount: 0,
+      ambiguousCapsuleCount: 0,
+      worstContainmentVerdict: 'AMBIGUOUS',
+      evidenceCeiling: 0,
+    };
+  }
+
+  const breached = capsules.filter(c => c.containmentVerdict === 'CONTAINMENT_BREACH');
+  if (breached.length > 0) {
+    return {
+      dimension,
+      status: 'BREACH',
+      compositeScore: null,
+      replaySafeCapsuleCount: 0,
+      ambiguousCapsuleCount: capsules.length,
+      worstContainmentVerdict: 'CONTAINMENT_BREACH',
+      evidenceCeiling: 0,
+    };
+  }
+
+  const replaySafe = capsules.filter(
+    c => c.replayCapsuleIds.length >= ACTIVATION_READINESS_SENTINELS.MIN_REPLAY_SAFE_CAPSULES
+      && c.containmentVerdict === 'CLEAN',
+  );
+  const ambiguous = capsules.filter(c => c.replayCapsuleIds.length === 0);
+
+  const ambiguousRatio = ambiguous.length / capsules.length;
+
+  // Evidence ceiling: fraction of capsules that are replay-safe, capped at 100
+  const evidenceCeiling = Math.round(
+    (replaySafe.length / capsules.length) * 100,
+  );
+
+  // Composite: average evidenceScore of replay-safe capsules only
+  const safeScores = replaySafe.map(c => c.evidenceScore);
+  const rawComposite = safeScores.length > 0
+    ? safeScores.reduce((a, b) => a + b, 0) / safeScores.length
+    : 0;
+
+  // Cap composite at evidenceCeiling
+  const compositeScore = Math.min(rawComposite, evidenceCeiling);
+
+  const worst = worstVerdict(capsules.map(c => c.containmentVerdict));
+
+  let status: DimensionReadinessStatus;
+  if (ambiguousRatio >= ACTIVATION_READINESS_SENTINELS.AMBIGUOUS_CAPSULE_RATIO_THRESHOLD) {
+    status = 'AMBIGUOUS';
+  } else if (compositeScore >= ACTIVATION_READINESS_SENTINELS.READY_THRESHOLD) {
+    status = 'PASSING';
+  } else if (compositeScore >= ACTIVATION_READINESS_SENTINELS.CONDITIONAL_THRESHOLD) {
+    status = 'PARTIAL';
+  } else {
+    status = 'BLOCKED';
+  }
+
+  return {
+    dimension,
+    status,
+    compositeScore,
+    replaySafeCapsuleCount: replaySafe.length,
+    ambiguousCapsuleCount: ambiguous.length,
+    worstContainmentVerdict: worst,
+    evidenceCeiling,
+  };
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Score activation readiness across all four participant dimensions.
+ *
+ * Throws ActivationReadinessError when:
+ *   - Evidence slice is empty (EMPTY_EVIDENCE_SLICE)
+ *   - Any dimension is BREACH (BREACH_DIMENSION_BLOCKS_ACTIVATION)
+ */
+export function scoreActivationReadiness(
+  capsules: ReadonlyArray<ReadinessEvidenceCapsule>,
+): ActivationReadinessScore {
+  const scoreId = `ar-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const scoredAt = new Date().toISOString();
+
+  if (capsules.length === 0) {
+    throw new ActivationReadinessError(
+      'EMPTY_EVIDENCE_SLICE',
+      'Cannot score activation readiness with no evidence capsules',
+    );
+  }
+
+  // Group by dimension
+  const byDimension = new Map<ReadinessDimension, ReadinessEvidenceCapsule[]>();
+  for (const dim of KNOWN_READINESS_DIMENSIONS) {
+    byDimension.set(dim, []);
+  }
+  for (const cap of capsules) {
+    byDimension.get(cap.dimension)?.push(cap);
+  }
+
+  const dimensionScores: DimensionScore[] = KNOWN_READINESS_DIMENSIONS.map(dim =>
+    scoreDimension(dim, byDimension.get(dim) ?? []),
+  );
+
+  // Fail-closed: any BREACH dimension voids everything
+  const hasBreach = dimensionScores.some(d => d.status === 'BREACH');
+  if (hasBreach) {
+    const readinessDigest = sha256ForPayload({
+      scoreId,
+      verdict: 'ACTIVATION_BREACH',
+      dimensionScores: dimensionScores.map(d => ({ dim: d.dimension, status: d.status })),
+    });
+    return {
+      schema: 'vitalcv.activation-readiness.v1',
+      scoreId,
+      overallVerdict: 'ACTIVATION_BREACH',
+      compositeReadiness: null,
+      dimensions: dimensionScores,
+      confidenceScore: 0,
+      evidenceCeiling: 0,
+      readinessDigest,
+      scoredAt,
+      methodologyVersion: 'activation-readiness.v1',
+    };
+  }
+
+  // Compute composite from non-null dimension scores
+  const scoredDims = dimensionScores.filter(d => d.compositeScore !== null);
+  const allAmbiguous = scoredDims.every(d => d.status === 'AMBIGUOUS');
+
+  if (allAmbiguous) {
+    const readinessDigest = sha256ForPayload({ scoreId, verdict: 'ACTIVATION_AMBIGUOUS' });
+    return {
+      schema: 'vitalcv.activation-readiness.v1',
+      scoreId,
+      overallVerdict: 'ACTIVATION_AMBIGUOUS',
+      compositeReadiness: null,
+      dimensions: dimensionScores,
+      confidenceScore: 0,
+      evidenceCeiling: 0,
+      readinessDigest,
+      scoredAt,
+      methodologyVersion: 'activation-readiness.v1',
+    };
+  }
+
+  const validScores = scoredDims
+    .filter(d => d.compositeScore !== null)
+    .map(d => d.compositeScore as number);
+
+  const compositeReadiness = validScores.length > 0
+    ? Math.round(validScores.reduce((a, b) => a + b, 0) / validScores.length)
+    : 0;
+
+  const evidenceCeiling = dimensionScores.length > 0
+    ? Math.round(
+        dimensionScores.reduce((a, d) => a + d.evidenceCeiling, 0) / dimensionScores.length,
+      )
+    : 0;
+
+  // Confidence = fraction of total capsules that are replay-safe + CLEAN
+  const totalCapsules = capsules.length;
+  const totalReplaySafe = dimensionScores.reduce(
+    (a, d) => a + d.replaySafeCapsuleCount, 0,
+  );
+  const confidenceScore = totalCapsules > 0
+    ? parseFloat((totalReplaySafe / totalCapsules).toFixed(3))
+    : 0;
+
+  const hasAmbiguousDim = dimensionScores.some(d => d.status === 'AMBIGUOUS');
+  const hasBlockedDim = dimensionScores.some(d => d.status === 'BLOCKED');
+
+  let overallVerdict: ActivationVerdict;
+  if (hasAmbiguousDim) {
+    overallVerdict = 'ACTIVATION_AMBIGUOUS';
+  } else if (hasBlockedDim || compositeReadiness < ACTIVATION_READINESS_SENTINELS.CONDITIONAL_THRESHOLD) {
+    overallVerdict = 'NOT_READY';
+  } else if (compositeReadiness < ACTIVATION_READINESS_SENTINELS.READY_THRESHOLD) {
+    overallVerdict = 'CONDITIONALLY_READY';
+  } else {
+    overallVerdict = 'READY';
+  }
+
+  const readinessDigest = sha256ForPayload({
+    scoreId,
+    overallVerdict,
+    compositeReadiness,
+    evidenceCeiling,
+    confidenceScore,
+    capsuleIds: capsules.map(c => c.capsuleId).sort(),
+    dimensionScores: dimensionScores.map(d => ({
+      dim: d.dimension,
+      score: d.compositeScore,
+      status: d.status,
+    })),
+  });
+
+  return {
+    schema: 'vitalcv.activation-readiness.v1',
+    scoreId,
+    overallVerdict,
+    compositeReadiness,
+    dimensions: dimensionScores,
+    confidenceScore,
+    evidenceCeiling,
+    readinessDigest,
+    scoredAt,
+    methodologyVersion: 'activation-readiness.v1',
+  };
+}

--- a/apps/api/backend/src/services/activation/activationReplayValidation.ts
+++ b/apps/api/backend/src/services/activation/activationReplayValidation.ts
@@ -1,0 +1,199 @@
+/**
+ * activationReplayValidation.ts — W2-PR144A
+ *
+ * Replay-activation validation. Validates that a proposed activation event
+ * is backed by an existing, replay-safe audit capsule — preventing ghost
+ * activations and detecting attempts to activate on stale or tampered
+ * evidence.
+ *
+ * Hard invariants:
+ *   1. No activation without a replay-verifiable capsule anchor.
+ *   2. Containment breach in the anchor capsule voids activation.
+ *   3. Temporal skew > maxReplayAgeMs is treated as STALE — fail-closed.
+ *   4. Ambiguous anchors surface REPLAY_AMBIGUOUS (never silently pass).
+ *   5. Validation digest is deterministic over input — same inputs always
+ *      produce the same digest, allowing external re-verification.
+ *
+ * Pure transform — no fetches, no DB writes.
+ */
+import { sha256ForPayload } from '../../utils/deterministic';
+import type { ContainmentVerdict } from './activationReadiness';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ReplayActivationVerdict =
+  | 'REPLAY_VALID'
+  | 'REPLAY_STALE'
+  | 'REPLAY_AMBIGUOUS'
+  | 'REPLAY_BREACH'
+  | 'REPLAY_MISSING';
+
+export interface ReplayAnchor {
+  schema: 'vitalcv.replay-anchor.v1';
+  capsuleId: string;
+  capturedAt: string;
+  containmentVerdict: ContainmentVerdict;
+  /** Deterministic hash of the capsule's evidence spine at capture time. */
+  evidenceSpineHash: string;
+  /** True iff the capsule has been successfully replayed at least once. */
+  replayVerified: boolean;
+}
+
+export interface ActivationReplayInput {
+  activationId: string;
+  proposedAt: string;
+  /** The replay anchor cited by this activation attempt. */
+  anchor: ReplayAnchor | null;
+  /**
+   * Current evidence spine hash to compare against the anchor's.
+   * Mismatch → drift detected.
+   */
+  currentEvidenceSpineHash: string;
+  /** Max age in ms before a replay anchor is considered stale. Default 7 days. */
+  maxReplayAgeMs?: number;
+}
+
+export interface ActivationReplayResult {
+  readonly schema: 'vitalcv.activation-replay-result.v1';
+  readonly activationId: string;
+  readonly verdict: ReplayActivationVerdict;
+  readonly anchorCapsuleId: string | null;
+  readonly replayAgeMs: number | null;
+  readonly evidenceSpineDrifted: boolean;
+  readonly failureReasons: ReadonlyArray<ReplayActivationFailureReason>;
+  readonly validationDigest: string;
+  readonly validatedAt: string;
+}
+
+export type ReplayActivationFailureReason =
+  | 'NO_ANCHOR_CAPSULE'
+  | 'ANCHOR_CONTAINMENT_BREACH'
+  | 'ANCHOR_CONTAINMENT_AMBIGUOUS'
+  | 'ANCHOR_NOT_REPLAY_VERIFIED'
+  | 'ANCHOR_STALE'
+  | 'EVIDENCE_SPINE_DRIFTED';
+
+export const KNOWN_REPLAY_ACTIVATION_VERDICTS: ReplayActivationVerdict[] = [
+  'REPLAY_VALID',
+  'REPLAY_STALE',
+  'REPLAY_AMBIGUOUS',
+  'REPLAY_BREACH',
+  'REPLAY_MISSING',
+];
+
+export const KNOWN_REPLAY_FAILURE_REASONS: ReplayActivationFailureReason[] = [
+  'NO_ANCHOR_CAPSULE',
+  'ANCHOR_CONTAINMENT_BREACH',
+  'ANCHOR_CONTAINMENT_AMBIGUOUS',
+  'ANCHOR_NOT_REPLAY_VERIFIED',
+  'ANCHOR_STALE',
+  'EVIDENCE_SPINE_DRIFTED',
+];
+
+export const REPLAY_ACTIVATION_SENTINELS = {
+  DEFAULT_MAX_REPLAY_AGE_MS: 7 * 24 * 60 * 60 * 1_000, // 7 days
+} as const;
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+export function validateActivationReplay(
+  input: ActivationReplayInput,
+): ActivationReplayResult {
+  const validatedAt = new Date().toISOString();
+  const maxAge = input.maxReplayAgeMs ?? REPLAY_ACTIVATION_SENTINELS.DEFAULT_MAX_REPLAY_AGE_MS;
+  const failures: ReplayActivationFailureReason[] = [];
+
+  // Missing anchor → fail-closed
+  if (!input.anchor) {
+    const validationDigest = sha256ForPayload({
+      activationId: input.activationId,
+      verdict: 'REPLAY_MISSING',
+    });
+    return {
+      schema: 'vitalcv.activation-replay-result.v1',
+      activationId: input.activationId,
+      verdict: 'REPLAY_MISSING',
+      anchorCapsuleId: null,
+      replayAgeMs: null,
+      evidenceSpineDrifted: false,
+      failureReasons: ['NO_ANCHOR_CAPSULE'],
+      validationDigest,
+      validatedAt,
+    };
+  }
+
+  const { anchor } = input;
+
+  // Containment breach → fail-closed
+  if (anchor.containmentVerdict === 'CONTAINMENT_BREACH') {
+    failures.push('ANCHOR_CONTAINMENT_BREACH');
+  }
+
+  // Ambiguous containment
+  if (
+    anchor.containmentVerdict === 'AMBIGUOUS' ||
+    anchor.containmentVerdict === 'QUARANTINED' ||
+    anchor.containmentVerdict === 'CONTAMINATED'
+  ) {
+    failures.push('ANCHOR_CONTAINMENT_AMBIGUOUS');
+  }
+
+  // Replay not verified
+  if (!anchor.replayVerified) {
+    failures.push('ANCHOR_NOT_REPLAY_VERIFIED');
+  }
+
+  // Temporal staleness check
+  const proposedMs = new Date(input.proposedAt).getTime();
+  const capturedMs = new Date(anchor.capturedAt).getTime();
+  const replayAgeMs = Number.isNaN(proposedMs) || Number.isNaN(capturedMs)
+    ? null
+    : proposedMs - capturedMs;
+
+  const isStale = replayAgeMs !== null && replayAgeMs > maxAge;
+  if (isStale) {
+    failures.push('ANCHOR_STALE');
+  }
+
+  // Evidence spine drift
+  const evidenceSpineDrifted =
+    anchor.evidenceSpineHash !== input.currentEvidenceSpineHash;
+  if (evidenceSpineDrifted) {
+    failures.push('EVIDENCE_SPINE_DRIFTED');
+  }
+
+  // Verdict resolution (fail-closed ordering)
+  let verdict: ReplayActivationVerdict;
+  if (failures.includes('ANCHOR_CONTAINMENT_BREACH')) {
+    verdict = 'REPLAY_BREACH';
+  } else if (failures.includes('ANCHOR_CONTAINMENT_AMBIGUOUS')) {
+    verdict = 'REPLAY_AMBIGUOUS';
+  } else if (failures.includes('ANCHOR_STALE')) {
+    verdict = 'REPLAY_STALE';
+  } else if (failures.length > 0) {
+    verdict = 'REPLAY_AMBIGUOUS';
+  } else {
+    verdict = 'REPLAY_VALID';
+  }
+
+  const validationDigest = sha256ForPayload({
+    activationId: input.activationId,
+    verdict,
+    anchorCapsuleId: anchor.capsuleId,
+    replayAgeMs,
+    evidenceSpineDrifted,
+    failures,
+  });
+
+  return {
+    schema: 'vitalcv.activation-replay-result.v1',
+    activationId: input.activationId,
+    verdict,
+    anchorCapsuleId: anchor.capsuleId,
+    replayAgeMs,
+    evidenceSpineDrifted,
+    failureReasons: failures,
+    validationDigest,
+    validatedAt,
+  };
+}

--- a/apps/api/backend/src/services/activation/institutionalSurvivability.ts
+++ b/apps/api/backend/src/services/activation/institutionalSurvivability.ts
@@ -1,0 +1,227 @@
+/**
+ * institutionalSurvivability.ts — W2-PR144A
+ *
+ * Institutional survivability verification. Verifies that an institution
+ * can sustain activation across degraded conditions — partial evidence,
+ * replay failures, containment quarantine — without silently failing open.
+ *
+ * Hard invariants:
+ *   1. Survivability is fail-closed: a single FATAL_FAILURE mode voids
+ *      the survivability verdict (SURVIVABILITY_FAILED).
+ *   2. Degraded survivability is named (DEGRADED), never conflated with full
+ *      SURVIVABLE — partial survival is a distinct operational state.
+ *   3. Lineage reconstructable — survivabilityDigest folds every failure
+ *      mode and institutional participant ID in input order.
+ *   4. Ecosystem survivability longitudinally visible — the snapshot
+ *      includes per-institution survivability curves.
+ *
+ * Pure transform — no fetches, no DB writes.
+ */
+import { sha256ForPayload } from '../../utils/deterministic';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type SurvivabilityVerdict =
+  | 'SURVIVABLE'
+  | 'DEGRADED'
+  | 'SURVIVABILITY_FAILED'
+  | 'SURVIVABILITY_AMBIGUOUS';
+
+export type SurvivabilityFailureMode =
+  | 'REPLAY_UNAVAILABLE'
+  | 'ALL_SOURCES_OFFLINE'
+  | 'CONTAINMENT_BREACH_UNDER_LOAD'
+  | 'AUTH_DEGRADATION'
+  | 'EVIDENCE_SPINE_COLLAPSE'
+  | 'TENANT_ISOLATION_FAILURE'
+  | 'ACTIVATION_LOOP_DETECTED';
+
+export type SurvivabilityFailureSeverity = 'FATAL' | 'DEGRADING' | 'ADVISORY';
+
+export interface SurvivabilityFailureEvent {
+  schema: 'vitalcv.survivability-failure.v1';
+  institutionId: string;
+  mode: SurvivabilityFailureMode;
+  severity: SurvivabilityFailureSeverity;
+  detectedAt: string;
+  /** True iff the system correctly failed-closed (did not activate on degraded evidence). */
+  failedClosed: boolean;
+}
+
+export interface InstitutionalSurvivabilityInput {
+  institutionId: string;
+  observationWindowStart: string;
+  observationWindowEnd: string;
+  failureEvents: ReadonlyArray<SurvivabilityFailureEvent>;
+  /** Fraction of activation attempts that completed successfully [0, 1]. */
+  activationSuccessRate: number;
+  /** True iff the institution has a replay fallback configured. */
+  replayFallbackConfigured: boolean;
+}
+
+export interface InstitutionalSurvivabilityResult {
+  readonly schema: 'vitalcv.institutional-survivability.v1';
+  readonly institutionId: string;
+  readonly verdict: SurvivabilityVerdict;
+  readonly fatalFailureCount: number;
+  readonly degradingFailureCount: number;
+  readonly advisoryFailureCount: number;
+  readonly failedClosedRate: number;
+  readonly activationSuccessRate: number;
+  /** True iff the institution failed-closed on every failure event (no silent fail-open). */
+  readonly perfectFailClosedCompliance: boolean;
+  readonly survivabilityDigest: string;
+  readonly verifiedAt: string;
+}
+
+export interface EcosystemSurvivabilityReport {
+  readonly schema: 'vitalcv.ecosystem-survivability.v1';
+  readonly reportId: string;
+  readonly overallVerdict: SurvivabilityVerdict;
+  readonly institutionResults: ReadonlyArray<InstitutionalSurvivabilityResult>;
+  readonly failedInstitutionCount: number;
+  readonly degradedInstitutionCount: number;
+  readonly survivableInstitutionCount: number;
+  readonly ecosystemFailedClosedRate: number;
+  readonly reportDigest: string;
+  readonly generatedAt: string;
+}
+
+export const KNOWN_SURVIVABILITY_VERDICTS: SurvivabilityVerdict[] = [
+  'SURVIVABLE',
+  'DEGRADED',
+  'SURVIVABILITY_FAILED',
+  'SURVIVABILITY_AMBIGUOUS',
+];
+
+export const KNOWN_SURVIVABILITY_FAILURE_MODES: SurvivabilityFailureMode[] = [
+  'REPLAY_UNAVAILABLE',
+  'ALL_SOURCES_OFFLINE',
+  'CONTAINMENT_BREACH_UNDER_LOAD',
+  'AUTH_DEGRADATION',
+  'EVIDENCE_SPINE_COLLAPSE',
+  'TENANT_ISOLATION_FAILURE',
+  'ACTIVATION_LOOP_DETECTED',
+];
+
+export const SURVIVABILITY_SENTINELS = {
+  MIN_SUCCESS_RATE_FOR_SURVIVABLE: 0.95,
+  MIN_SUCCESS_RATE_FOR_DEGRADED: 0.70,
+} as const;
+
+// ── Core logic ────────────────────────────────────────────────────────────────
+
+export function verifyInstitutionalSurvivability(
+  input: InstitutionalSurvivabilityInput,
+): InstitutionalSurvivabilityResult {
+  const verifiedAt = new Date().toISOString();
+
+  const fatal = input.failureEvents.filter(e => e.severity === 'FATAL');
+  const degrading = input.failureEvents.filter(e => e.severity === 'DEGRADING');
+  const advisory = input.failureEvents.filter(e => e.severity === 'ADVISORY');
+
+  const allEvents = input.failureEvents;
+  const failedClosed = allEvents.filter(e => e.failedClosed);
+  const failedClosedRate = allEvents.length > 0
+    ? parseFloat((failedClosed.length / allEvents.length).toFixed(3))
+    : 1.0;
+
+  const perfectFailClosedCompliance = allEvents.length === 0 || failedClosed.length === allEvents.length;
+
+  let verdict: SurvivabilityVerdict;
+  if (fatal.length > 0) {
+    verdict = 'SURVIVABILITY_FAILED';
+  } else if (!input.replayFallbackConfigured && degrading.length > 0) {
+    verdict = 'SURVIVABILITY_FAILED';
+  } else if (
+    degrading.length > 0 ||
+    input.activationSuccessRate < SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_SURVIVABLE
+  ) {
+    if (input.activationSuccessRate < SURVIVABILITY_SENTINELS.MIN_SUCCESS_RATE_FOR_DEGRADED) {
+      verdict = 'SURVIVABILITY_FAILED';
+    } else {
+      verdict = 'DEGRADED';
+    }
+  } else if (allEvents.length === 0 && input.activationSuccessRate === 0) {
+    verdict = 'SURVIVABILITY_AMBIGUOUS';
+  } else {
+    verdict = 'SURVIVABLE';
+  }
+
+  const survivabilityDigest = sha256ForPayload({
+    institutionId: input.institutionId,
+    verdict,
+    fatalCount: fatal.length,
+    degradingCount: degrading.length,
+    advisoryCount: advisory.length,
+    failedClosedRate,
+    activationSuccessRate: input.activationSuccessRate,
+    failureEventIds: allEvents.map(e => `${e.institutionId}:${e.mode}:${e.detectedAt}`).sort(),
+  });
+
+  return {
+    schema: 'vitalcv.institutional-survivability.v1',
+    institutionId: input.institutionId,
+    verdict,
+    fatalFailureCount: fatal.length,
+    degradingFailureCount: degrading.length,
+    advisoryFailureCount: advisory.length,
+    failedClosedRate,
+    activationSuccessRate: input.activationSuccessRate,
+    perfectFailClosedCompliance,
+    survivabilityDigest,
+    verifiedAt,
+  };
+}
+
+export function buildEcosystemSurvivabilityReport(
+  results: ReadonlyArray<InstitutionalSurvivabilityResult>,
+): EcosystemSurvivabilityReport {
+  const reportId = `esr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const generatedAt = new Date().toISOString();
+
+  const failed = results.filter(r => r.verdict === 'SURVIVABILITY_FAILED');
+  const degraded = results.filter(r => r.verdict === 'DEGRADED');
+  const survivable = results.filter(r => r.verdict === 'SURVIVABLE');
+
+  const allFailedClosedRates = results.map(r => r.failedClosedRate);
+  const ecosystemFailedClosedRate = allFailedClosedRates.length > 0
+    ? parseFloat(
+        (allFailedClosedRates.reduce((a, b) => a + b, 0) / allFailedClosedRates.length).toFixed(3),
+      )
+    : 1.0;
+
+  let overallVerdict: SurvivabilityVerdict;
+  if (results.length === 0) {
+    overallVerdict = 'SURVIVABILITY_AMBIGUOUS';
+  } else if (failed.length > 0) {
+    overallVerdict = 'SURVIVABILITY_FAILED';
+  } else if (degraded.length > 0) {
+    overallVerdict = 'DEGRADED';
+  } else {
+    overallVerdict = 'SURVIVABLE';
+  }
+
+  const reportDigest = sha256ForPayload({
+    reportId,
+    overallVerdict,
+    failedCount: failed.length,
+    degradedCount: degraded.length,
+    survivableCount: survivable.length,
+    ecosystemFailedClosedRate,
+    institutionDigests: results.map(r => r.survivabilityDigest).sort(),
+  });
+
+  return {
+    schema: 'vitalcv.ecosystem-survivability.v1',
+    reportId,
+    overallVerdict,
+    institutionResults: results,
+    failedInstitutionCount: failed.length,
+    degradedInstitutionCount: degraded.length,
+    survivableInstitutionCount: survivable.length,
+    ecosystemFailedClosedRate,
+    reportDigest,
+    generatedAt,
+  };
+}

--- a/apps/api/backend/src/services/activation/readinessLineageManifest.ts
+++ b/apps/api/backend/src/services/activation/readinessLineageManifest.ts
@@ -1,0 +1,129 @@
+/**
+ * readinessLineageManifest.ts — W2-PR144A
+ *
+ * Readiness lineage manifest. Produces a tamper-evident, reconstructable
+ * ledger of all evidence that contributed to an activation-readiness score.
+ * A regulator can present a manifest ID and verify the score is reproducible
+ * from the cited capsule lineage.
+ *
+ * Hard invariants:
+ *   1. Manifest digest folds every contributing capsule ID + its evidence
+ *      score + containment verdict. No capsule can be silently dropped.
+ *   2. Manifest is immutable once sealed — the sealedAt timestamp is part
+ *      of the digest. Re-sealing the same input always produces the same
+ *      manifestId prefix and the same digest.
+ *   3. Lineage is reconstructable: every evidence contribution cites its
+ *      dimension, capsule ID, and replay capsule IDs.
+ *   4. Ambiguous contributions are enumerated, not suppressed.
+ *
+ * Pure transform — no fetches, no DB writes.
+ */
+import { sha256ForPayload } from '../../utils/deterministic';
+import type { ReadinessEvidenceCapsule, ActivationReadinessScore } from './activationReadiness';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface LineageContribution {
+  schema: 'vitalcv.lineage-contribution.v1';
+  capsuleId: string;
+  dimension: string;
+  evidenceScore: number;
+  containmentVerdict: string;
+  replayCapsuleIds: ReadonlyArray<string>;
+  observedAt: string;
+  /** True iff this capsule contributed to a replay-safe dimension score. */
+  replaySafe: boolean;
+  /** True iff this capsule's ambiguity was surfaced (not suppressed). */
+  ambiguityPreserved: boolean;
+}
+
+export interface ReadinessLineageManifest {
+  readonly schema: 'vitalcv.readiness-lineage-manifest.v1';
+  readonly manifestId: string;
+  /** The readiness score this manifest documents. */
+  readonly scoredReadiness: number | null;
+  readonly overallVerdict: string;
+  readonly contributions: ReadonlyArray<LineageContribution>;
+  readonly totalCapsuleCount: number;
+  readonly replaySafeCount: number;
+  readonly ambiguousCount: number;
+  readonly breachCount: number;
+  /** True iff every ambiguous capsule was enumerated in contributions. */
+  readonly ambiguityFullyPreserved: boolean;
+  /** SHA-256 over all contributions in canonical order. */
+  readonly manifestDigest: string;
+  readonly sealedAt: string;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+export function sealReadinessLineageManifest(
+  score: ActivationReadinessScore,
+  capsules: ReadonlyArray<ReadinessEvidenceCapsule>,
+): ReadinessLineageManifest {
+  const sealedAt = new Date().toISOString();
+  const manifestId = `rlm-${sha256ForPayload({ scoreId: score.scoreId, sealedAt }).slice(0, 12)}`;
+
+  const contributions: LineageContribution[] = capsules.map(cap => {
+    const replaySafe =
+      cap.replayCapsuleIds.length > 0 &&
+      cap.containmentVerdict === 'CLEAN';
+
+    const ambiguous = cap.replayCapsuleIds.length === 0;
+
+    return {
+      schema: 'vitalcv.lineage-contribution.v1',
+      capsuleId: cap.capsuleId,
+      dimension: cap.dimension,
+      evidenceScore: cap.evidenceScore,
+      containmentVerdict: cap.containmentVerdict,
+      replayCapsuleIds: cap.replayCapsuleIds,
+      observedAt: cap.observedAt,
+      replaySafe,
+      ambiguityPreserved: ambiguous,
+    };
+  });
+
+  const replaySafeCount = contributions.filter(c => c.replaySafe).length;
+  const ambiguousCount = contributions.filter(c => c.ambiguityPreserved).length;
+  const breachCount = contributions.filter(
+    c => c.containmentVerdict === 'CONTAINMENT_BREACH',
+  ).length;
+
+  // Ambiguity fully preserved iff every ambiguous capsule is enumerated
+  const ambiguityFullyPreserved = contributions.every(c => {
+    if (c.replayCapsuleIds.length === 0) return c.ambiguityPreserved;
+    return true;
+  });
+
+  const manifestDigest = sha256ForPayload({
+    manifestId,
+    sealedAt,
+    scoreId: score.scoreId,
+    overallVerdict: score.overallVerdict,
+    compositeReadiness: score.compositeReadiness,
+    readinessDigest: score.readinessDigest,
+    contributions: contributions.map(c => ({
+      capsuleId: c.capsuleId,
+      dimension: c.dimension,
+      evidenceScore: c.evidenceScore,
+      containmentVerdict: c.containmentVerdict,
+      replayCapsuleIds: [...c.replayCapsuleIds].sort(),
+    })).sort((a, b) => a.capsuleId.localeCompare(b.capsuleId)),
+  });
+
+  return {
+    schema: 'vitalcv.readiness-lineage-manifest.v1',
+    manifestId,
+    scoredReadiness: score.compositeReadiness,
+    overallVerdict: score.overallVerdict,
+    contributions,
+    totalCapsuleCount: capsules.length,
+    replaySafeCount,
+    ambiguousCount,
+    breachCount,
+    ambiguityFullyPreserved,
+    manifestDigest,
+    sealedAt,
+  };
+}


### PR DESCRIPTION
## Summary
- Activation-readiness scoring engine across 4 participant dimensions (OPERATOR, VERIFIER, EXECUTIVE, ECOSYSTEM) with fail-closed breach semantics and evidence-ceiling caps
- Replay-activation validation: detects missing/stale/drifted anchors, returns typed `ReplayActivationVerdict` for each failure mode
- Institutional survivability verification: FATAL/DEGRADING/ADVISORY failure classification with fail-open detection and ecosystem rollup
- Readiness lineage manifest: tamper-evident `manifestDigest` folds every contributing capsule, ambiguous contributions enumerated not suppressed
- Activation confidence telemetry: longitudinal binning, overconfidence episode accumulation, breach-bin tracking
- 14-scenario chaos simulation suite: empty slice, breach propagation, ambiguity preservation, stale replay, spine drift, fail-open
- CI gate suite: 22 invariants covering sentinel completeness, error types, AMBIGUOUS→READY collapse prevention, schema literals, threshold ordering
- GitHub Actions workflow: runs CI gate + chaos on every push to `services/activation/**`, includes truth-contract and sentinel grep checks

## Truth rules
- No verified-profile claims, no compliance certifications, no bare `Verified` labels
- `ACTIVATION_BREACH` fully voids composite score (null compositeReadiness)
- Empty evidence slice throws `ActivationReadinessError`, never returns a default win
- `ACTIVATION_AMBIGUOUS` preserved when any dimension lacks replay IDs — never collapsed to `READY`

## Validation
- CI gate: 22/22 passing
- Chaos simulations: 14/14 passing
- Truth scan: CLEAN
- Diff scope: `apps/api/backend/src/services/activation/**` + `.github/workflows/activation-readiness-gate.yml` only