### PR TITLE
feat(governance): institutional governance stewardship protocol — W2-PR154A

### DIFF
--- a/.github/workflows/governance-stewardship-gate.yml
+++ b/.github/workflows/governance-stewardship-gate.yml
@@ -1,0 +1,126 @@
+name: W2-PR154A Governance Stewardship Protocol
+
+# Governance stewardship protocol CI gate.
+#
+# This workflow runs three stewardship suites that together guarantee
+# longitudinal caretaker continuity, succession fail-closed semantics,
+# replay-governance caretaking fidelity, and institutional runtime
+# survivability:
+#
+#   - governanceStewardship.test.ts        — pure-transform unit coverage
+#   - governanceStewardship.ci.gate.test.ts — frozen-enum + breach canary
+#   - governanceStewardship.chaos.test.ts  — chaos coverage (8 modes:
+#                                            healthy burst,
+#                                            mixed-friction,
+#                                            succession storm,
+#                                            lineage collapse,
+#                                            stability cliff,
+#                                            ambiguity preservation,
+#                                            replay governance drift,
+#                                            stewardship protocol maturity)
+#
+# These tests are mock-free and DB-free — they exercise the real
+# `governanceStewardship` pure-transform module. The gate exists to catch:
+#   - silent ambiguity collapse (AMBIGUOUS_STEWARDSHIP → ACTIVE regression)
+#   - succession threshold bypass (fail-closed succession regression)
+#   - lineage depth under-reporting (lineage reconstructability regression)
+#   - continuity floor violations (caretaker continuity floor breach regression)
+#   - enum extension without test update (sentinel mismatch regression)
+#
+# This is the longitudinal companion to:
+#   - runtime-hardening-gate.yml   (production-runtime survivability)
+#   - scale-gate.yml               (governance throughput / event survivability)
+#   - deployment-survivability.yml (deploy-layer chaos + lineage)
+#   - rollout-survivability.yml    (institutional rollout boundary)
+#
+# Fail-closed: any of the three suites failing exits 1 and blocks the gate.
+
+on:
+  push:
+    branches: [main, develop, 'wave-*/**', 'feature/**', 'fix/**']
+    paths:
+      - 'apps/api/backend/src/services/governance/governanceStewardship.ts'
+      - 'apps/api/backend/src/services/governance/__tests__/governanceStewardship*.test.ts'
+      - 'apps/api/backend/src/utils/deterministic.ts'
+      - 'apps/api/backend/jest.config.js'
+      - '.github/workflows/governance-stewardship-gate.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'apps/api/backend/src/services/governance/governanceStewardship.ts'
+      - 'apps/api/backend/src/services/governance/__tests__/governanceStewardship*.test.ts'
+      - 'apps/api/backend/src/utils/deterministic.ts'
+      - 'apps/api/backend/jest.config.js'
+      - '.github/workflows/governance-stewardship-gate.yml'
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20.11.1'
+  PNPM_VERSION: '10.6.1'
+
+jobs:
+  governance-stewardship:
+    name: Governance Stewardship Protocol
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client (jest module resolution)
+        run: pnpm --filter chai-vc-platform-backend exec prisma generate
+
+      # The stewardship suites mock nothing and touch no DB; the env
+      # vars below are only present so jest.setup.ts → loadEnv() does not bail.
+      - name: Run governance stewardship suites
+        working-directory: apps/api/backend
+        env:
+          NODE_ENV: test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/stewardship_unused
+          YC_DEMO_MODE: 'false'
+        run: |
+          pnpm exec jest \
+            --testPathPattern='services/governance/__tests__/governanceStewardship.*\.test\.ts$' \
+            --maxWorkers=1 \
+            --verbose \
+            --passWithNoTests \
+            2>&1 | tee governance-stewardship-gate.log
+
+      - name: Surface stewardship board
+        if: always()
+        working-directory: apps/api/backend
+        run: |
+          echo "📊 Governance Stewardship Board"
+          echo "--------------------------------"
+          if [ -f governance-stewardship-gate.log ]; then
+            grep -E '\[stewardship-board\]' governance-stewardship-gate.log \
+              || echo "(no stewardship-board metrics emitted — investigate)"
+          else
+            echo "(no governance-stewardship-gate.log produced — investigate)"
+          fi
+
+      - name: Upload governance-stewardship-gate log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: governance-stewardship-gate-log
+          path: apps/api/backend/governance-stewardship-gate.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/apps/api/backend/src/services/governance/__tests__/governanceStewardship.chaos.test.ts
+++ b/apps/api/backend/src/services/governance/__tests__/governanceStewardship.chaos.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Governance Stewardship — Chaos Simulation Suite (W2-PR154A)
+ *
+ * Eight chaos modes covering the completion-board axes:
+ *   1. healthy burst        — large cohort, all signals healthy
+ *   2. mixed-friction        — realistic mix of active / degraded / ambiguous shards
+ *   3. succession storm      — concurrent succession events across shard population
+ *   4. lineage collapse      — cascading lineage breaks across caretaker generations
+ *   5. stability cliff       — sudden institutional runtime stability drops
+ *   6. ambiguity preservation — injected contradictions never silently collapse
+ *   7. replay governance drift — sustained drift exceeding budget across majority
+ *   8. stewardship protocol maturity — board metrics derivation from mixed boundary
+ *
+ * All modes: mock-free, DB-free. Pure-transform calls only.
+ */
+
+import {
+  assertAmbiguityPreserved,
+  assertStewardshipBoundary,
+  caretakeStewardshipShard,
+  computeStewardshipBoundary,
+  StewardshipError,
+  stewardshipMaturityScore,
+  traceStewardshipLineage,
+  type StewardshipSignal,
+} from '../governanceStewardship';
+
+function healthySignal(overrides: Partial<StewardshipSignal> = {}): StewardshipSignal {
+  return {
+    caretakerContinuityScore: 0.95,
+    caretakerContinuityThreshold: 0.80,
+    replayGovernanceDrift: 0.5,
+    replayGovernanceDriftBudget: 5.0,
+    successionReadinessScore: 0.90,
+    successionActivationThreshold: 0.75,
+    governanceLineageDepth: 5,
+    governanceLineageTarget: 3,
+    institutionalRuntimeStability: 0.92,
+    institutionalStabilityFloor: 0.70,
+    successionPendingConfirmation: false,
+    caretakerAmbiguityDetected: false,
+    stewardshipEvidence: null,
+    ...overrides,
+  };
+}
+
+const COHORT_SIZE = 100;
+
+// ── Mode 1: Healthy burst ─────────────────────────────────────────────────────
+
+describe('chaos mode 1 — healthy burst', () => {
+  it(`classifies ${COHORT_SIZE} healthy shards as fully active`, () => {
+    const records = Array.from({ length: COHORT_SIZE }, (_, i) =>
+      caretakeStewardshipShard({ shardId: `s-${i}`, signal: healthySignal() }),
+    );
+    expect(records.every((r) => r.verdict === 'ACTIVE')).toBe(true);
+
+    const boundary = computeStewardshipBoundary({ totalShards: COHORT_SIZE, records });
+    expect(boundary.partitioned).toBe(true);
+    expect(boundary.activeCount).toBe(COHORT_SIZE);
+    expect(boundary.stewardshipContinuityRatio).toBe(1);
+    expect(() => assertStewardshipBoundary(boundary)).not.toThrow();
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'healthy-burst',
+      activeCount: boundary.activeCount,
+      continuityRatio: boundary.stewardshipContinuityRatio,
+      partialContinuityPct: boundary.partialContinuityPct,
+      partitioned: boundary.partitioned,
+    }));
+  });
+});
+
+// ── Mode 2: Mixed-friction cohort ─────────────────────────────────────────────
+
+describe('chaos mode 2 — mixed-friction cohort', () => {
+  it('correctly aggregates a realistic mix of active/degraded/ambiguous shards', () => {
+    const records = Array.from({ length: COHORT_SIZE }, (_, i) => {
+      const bucket = i % 10;
+      let sig: StewardshipSignal;
+      if (bucket < 6) {
+        sig = healthySignal();
+      } else if (bucket < 8) {
+        sig = healthySignal({ caretakerContinuityScore: 0.60, caretakerContinuityThreshold: 0.80 });
+      } else if (bucket === 8) {
+        sig = healthySignal({ caretakerAmbiguityDetected: true });
+      } else {
+        sig = healthySignal({ institutionalRuntimeStability: 0.40, institutionalStabilityFloor: 0.70 });
+      }
+      return caretakeStewardshipShard({ shardId: `s-${i}`, signal: sig });
+    });
+
+    const activeCount = records.filter((r) => r.verdict === 'ACTIVE').length;
+    const breachCount = records.filter((r) => r.verdict === 'CARETAKER_CONTINUITY_BREACH').length;
+    const ambiguousCount = records.filter((r) => r.verdict === 'AMBIGUOUS_STEWARDSHIP').length;
+    const stabilityBreachCount = records.filter((r) => r.verdict === 'INSTITUTIONAL_STABILITY_BREACH').length;
+
+    expect(activeCount).toBeGreaterThan(0);
+    expect(breachCount).toBeGreaterThan(0);
+    expect(ambiguousCount).toBeGreaterThan(0);
+    expect(stabilityBreachCount).toBeGreaterThan(0);
+
+    const boundary = computeStewardshipBoundary({ totalShards: COHORT_SIZE, records });
+    expect(boundary.continuityBreachCount).toBe(breachCount);
+    expect(boundary.ambiguousCount).toBe(ambiguousCount);
+    expect(boundary.stabilityBreachCount).toBe(stabilityBreachCount);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'mixed-friction',
+      activeCount: boundary.activeCount,
+      continuityBreachCount: boundary.continuityBreachCount,
+      ambiguousCount: boundary.ambiguousCount,
+      stabilityBreachCount: boundary.stabilityBreachCount,
+      partialContinuityPct: Math.round(boundary.partialContinuityPct),
+      partitioned: boundary.partitioned,
+    }));
+  });
+});
+
+// ── Mode 3: Succession storm ──────────────────────────────────────────────────
+
+describe('chaos mode 3 — succession storm', () => {
+  it('handles concurrent succession events without silent hand-off to unready caretakers', () => {
+    const records = Array.from({ length: 20 }, (_, i) => {
+      const readinessScore = i % 2 === 0 ? 0.90 : 0.40;
+      return caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal({
+          successionPendingConfirmation: true,
+          successionReadinessScore: readinessScore,
+          successionActivationThreshold: 0.75,
+        }),
+      });
+    });
+
+    const triggered = records.filter((r) => r.verdict === 'SUCCESSION_TRIGGERED');
+    const pending = records.filter((r) => r.verdict === 'SUCCESSION_PENDING');
+    expect(triggered).toHaveLength(10);
+    expect(pending).toHaveLength(10);
+
+    // SUCCESSION_PENDING records carry the breach kind
+    for (const r of pending) {
+      expect(r.kind).toBe('SUCCESSION_PROTOCOL_BREACH');
+    }
+
+    const boundary = computeStewardshipBoundary({ totalShards: 20, records });
+    // Succession pending causes boundary breach
+    expect(boundary.partitioned).toBe(false);
+    expect(boundary.successionCount).toBe(20);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'succession-storm',
+      successionTriggered: triggered.length,
+      successionPending: pending.length,
+      partitioned: boundary.partitioned,
+    }));
+  });
+});
+
+// ── Mode 4: Lineage collapse ──────────────────────────────────────────────────
+
+describe('chaos mode 4 — lineage collapse', () => {
+  it('cascading lineage breaks are detected and fail the boundary', () => {
+    const records = Array.from({ length: 10 }, (_, i) =>
+      caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal({
+          governanceLineageDepth: i < 5 ? 0 : 5,
+          governanceLineageTarget: 3,
+        }),
+      }),
+    );
+
+    const lineageBreaks = records.filter((r) => r.verdict === 'GOVERNANCE_LINEAGE_BREAK');
+    expect(lineageBreaks).toHaveLength(5);
+
+    const boundary = computeStewardshipBoundary({ totalShards: 10, records });
+    expect(boundary.lineageBreakCount).toBe(5);
+    expect(boundary.partitioned).toBe(false);
+
+    expect(() => assertStewardshipBoundary(boundary)).toThrow(StewardshipError);
+
+    // Lineage reconstruction for one breach
+    const lineage = traceStewardshipLineage({
+      rootShardId: 's-0',
+      rootHints: { caretakerPoolId: 'pool-A', replayGovernanceShardId: null, successionScopeId: null },
+      candidates: lineageBreaks.map((r) => ({
+        shardId: r.shardId,
+        hints: { caretakerPoolId: 'pool-A' },
+      })),
+    });
+    expect(lineage.affectedShardIds.length).toBeGreaterThan(0);
+    expect(lineage.reconstructionDigest).toHaveLength(64);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'lineage-collapse',
+      lineageBreakCount: boundary.lineageBreakCount,
+      affectedByRootLineage: lineage.affectedShardIds.length,
+      partitioned: boundary.partitioned,
+    }));
+  });
+});
+
+// ── Mode 5: Stability cliff ───────────────────────────────────────────────────
+
+describe('chaos mode 5 — stability cliff', () => {
+  it('sudden stability drops are visible as INSTITUTIONAL_STABILITY_BREACH', () => {
+    const records = Array.from({ length: 20 }, (_, i) =>
+      caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal({
+          institutionalRuntimeStability: i < 10 ? 0.25 : 0.92,
+          institutionalStabilityFloor: 0.70,
+        }),
+      }),
+    );
+
+    const stabilityBreaches = records.filter((r) => r.verdict === 'INSTITUTIONAL_STABILITY_BREACH');
+    expect(stabilityBreaches).toHaveLength(10);
+
+    const boundary = computeStewardshipBoundary({ totalShards: 20, records });
+    expect(boundary.stabilityBreachCount).toBe(10);
+    expect(boundary.meanInstitutionalStability).toBeLessThan(0.70);
+    expect(boundary.partitioned).toBe(false);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'stability-cliff',
+      stabilityBreachCount: boundary.stabilityBreachCount,
+      meanInstitutionalStabilityPct: Math.round(boundary.meanInstitutionalStability * 100),
+      partitioned: boundary.partitioned,
+    }));
+  });
+});
+
+// ── Mode 6: Ambiguity preservation ───────────────────────────────────────────
+
+describe('chaos mode 6 — ambiguity preservation under injection', () => {
+  it('every ambiguous record preserves AMBIGUOUS_STEWARDSHIP — no silent collapse', () => {
+    const records = Array.from({ length: 30 }, (_, i) => {
+      const inject = i % 3 === 0;
+      return caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal({ caretakerAmbiguityDetected: inject }),
+      });
+    });
+
+    for (const r of records) {
+      // Must not throw on correctly-ambiguous records
+      expect(() => assertAmbiguityPreserved(r)).not.toThrow();
+      if (r.ambiguous) {
+        expect(r.verdict).toBe('AMBIGUOUS_STEWARDSHIP');
+      } else {
+        expect(r.verdict).toBe('ACTIVE');
+      }
+    }
+
+    const ambiguousCount = records.filter((r) => r.ambiguous).length;
+    expect(ambiguousCount).toBe(10);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'ambiguity-preservation',
+      ambiguousPreserved: ambiguousCount,
+      activeCount: records.filter((r) => r.verdict === 'ACTIVE').length,
+    }));
+  });
+});
+
+// ── Mode 7: Replay governance drift ──────────────────────────────────────────
+
+describe('chaos mode 7 — sustained replay governance drift', () => {
+  it('drift exceeding budget surfaces as CARETAKER_CONTINUITY_BREACH on replay axis', () => {
+    const records = Array.from({ length: 20 }, (_, i) =>
+      caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal({
+          replayGovernanceDrift: i < 12 ? 15.0 : 1.0,
+          replayGovernanceDriftBudget: 5.0,
+        }),
+      }),
+    );
+
+    const driftBreaches = records.filter((r) => r.kind === 'REPLAY_GOVERNANCE_DRIFT');
+    expect(driftBreaches.length).toBeGreaterThanOrEqual(12);
+
+    for (const r of driftBreaches) {
+      expect(r.verdict).toBe('CARETAKER_CONTINUITY_BREACH');
+      expect(r.tier).toBe('CARETAKER');
+    }
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'replay-governance-drift',
+      driftBreachCount: driftBreaches.length,
+      activeCount: records.filter((r) => r.verdict === 'ACTIVE').length,
+    }));
+  });
+});
+
+// ── Mode 8: Stewardship protocol maturity ─────────────────────────────────────
+
+describe('chaos mode 8 — stewardship protocol maturity score', () => {
+  it('derives all five board metrics from a realistic mixed boundary', () => {
+    const records = Array.from({ length: 20 }, (_, i) => {
+      const bucket = i % 10;
+      return caretakeStewardshipShard({
+        shardId: `s-${i}`,
+        signal: healthySignal(
+          bucket < 7
+            ? {}
+            : bucket < 9
+              ? { caretakerContinuityScore: 0.50, caretakerContinuityThreshold: 0.80 }
+              : { successionReadinessScore: 0.60 },
+        ),
+      });
+    });
+
+    const boundary = computeStewardshipBoundary({ totalShards: 20, records });
+    const metrics = stewardshipMaturityScore(boundary);
+
+    expect(metrics.maturityScore).toBeGreaterThanOrEqual(0);
+    expect(metrics.maturityScore).toBeLessThanOrEqual(100);
+    expect(metrics.governanceContinuityPct).toBeGreaterThanOrEqual(0);
+    expect(metrics.replayFidelityPct).toBeGreaterThanOrEqual(0);
+    expect(metrics.successionSurvivabilityPct).toBeGreaterThanOrEqual(0);
+    expect(metrics.institutionalStabilityPct).toBeGreaterThanOrEqual(0);
+
+    console.log('[stewardship-board]', JSON.stringify({
+      mode: 'maturity-score',
+      maturityScore: metrics.maturityScore,
+      governanceContinuityPct: metrics.governanceContinuityPct,
+      replayFidelityPct: metrics.replayFidelityPct,
+      successionSurvivabilityPct: metrics.successionSurvivabilityPct,
+      institutionalStabilityPct: metrics.institutionalStabilityPct,
+    }));
+  });
+
+  it('maturity score is strictly lower for fully-degraded boundary than healthy boundary', () => {
+    const healthyRecords = Array.from({ length: 10 }, (_, i) =>
+      caretakeStewardshipShard({ shardId: `h-${i}`, signal: healthySignal() }),
+    );
+    const degradedRecords = Array.from({ length: 10 }, (_, i) =>
+      caretakeStewardshipShard({
+        shardId: `d-${i}`,
+        signal: healthySignal({
+          caretakerContinuityScore: 0.30,
+          caretakerContinuityThreshold: 0.80,
+          institutionalRuntimeStability: 0.20,
+          institutionalStabilityFloor: 0.70,
+          successionReadinessScore: 0.10,
+        }),
+      }),
+    );
+
+    const healthyBoundary = computeStewardshipBoundary({ totalShards: 10, records: healthyRecords });
+    const degradedBoundary = computeStewardshipBoundary({ totalShards: 10, records: degradedRecords });
+
+    const healthyScore = stewardshipMaturityScore(healthyBoundary).maturityScore;
+    const degradedScore = stewardshipMaturityScore(degradedBoundary).maturityScore;
+
+    expect(healthyScore).toBeGreaterThan(degradedScore);
+  });
+});

--- a/apps/api/backend/src/services/governance/__tests__/governanceStewardship.ci.gate.test.ts
+++ b/apps/api/backend/src/services/governance/__tests__/governanceStewardship.ci.gate.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Governance Stewardship — CI Gate (W2-PR154A)
+ *
+ * Canary suite. Every public primitive must:
+ *   - throw StewardshipError on boundary breaches (not silently allow);
+ *   - export an enumerated `violation` field;
+ *   - never coerce AMBIGUOUS_STEWARDSHIP verdicts to ACTIVE (silent collapse);
+ *   - produce a deterministic, salted stewardshipDigest (not collide across inputs);
+ *   - keep SUCCESSION_THRESHOLD_BREACH a hard violation (fail-closed semantics);
+ *   - keep CARETAKER_CONTINUITY_FLOOR_BREACH a hard violation.
+ *
+ * If a future refactor accidentally weakens any of these invariants, this
+ * suite breaks the build before the regression ships.
+ */
+
+import {
+  KNOWN_STEWARDSHIP_KINDS,
+  KNOWN_STEWARDSHIP_TIERS,
+  KNOWN_STEWARDSHIP_VERDICTS,
+  KNOWN_STEWARDSHIP_VIOLATIONS,
+  STEWARDSHIP_SENTINELS,
+  StewardshipError,
+  assertAmbiguityPreserved,
+  assertStewardshipBoundary,
+  assertSuccessionReadiness,
+  caretakeStewardshipShard,
+  computeStewardshipBoundary,
+  stewardshipDigest,
+  type StewardshipKind,
+  type StewardshipSignal,
+  type StewardshipTier,
+  type StewardshipVerdict,
+  type StewardshipViolationKind,
+} from '../governanceStewardship';
+
+const KNOWN_VERDICTS: StewardshipVerdict[] = [
+  'ACTIVE',
+  'CARETAKER_CONTINUITY_BREACH',
+  'SUCCESSION_TRIGGERED',
+  'SUCCESSION_PENDING',
+  'AMBIGUOUS_STEWARDSHIP',
+  'GOVERNANCE_LINEAGE_BREAK',
+  'INSTITUTIONAL_STABILITY_BREACH',
+];
+
+const KNOWN_KINDS: StewardshipKind[] = [
+  'CARETAKER_CONTINUITY_DRIFT',
+  'REPLAY_GOVERNANCE_DRIFT',
+  'SUCCESSION_PROTOCOL_BREACH',
+  'GOVERNANCE_LINEAGE_BREAK',
+  'INSTITUTIONAL_STABILITY_COLLAPSE',
+  'AMBIGUOUS_CARETAKER_SIGNAL',
+];
+
+const KNOWN_TIERS: StewardshipTier[] = [
+  'INSTITUTIONAL',
+  'CARETAKER',
+  'DEGRADED',
+  'SUCCESSION',
+  'AMBIGUOUS',
+];
+
+const KNOWN_VIOLATIONS: StewardshipViolationKind[] = [
+  'AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE',
+  'SUCCESSION_THRESHOLD_BREACH',
+  'CARETAKER_CONTINUITY_FLOOR_BREACH',
+  'REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE',
+];
+
+function healthySignal(overrides: Partial<StewardshipSignal> = {}): StewardshipSignal {
+  return {
+    caretakerContinuityScore: 0.95,
+    caretakerContinuityThreshold: 0.80,
+    replayGovernanceDrift: 0.5,
+    replayGovernanceDriftBudget: 5.0,
+    successionReadinessScore: 0.90,
+    successionActivationThreshold: 0.75,
+    governanceLineageDepth: 5,
+    governanceLineageTarget: 3,
+    institutionalRuntimeStability: 0.92,
+    institutionalStabilityFloor: 0.70,
+    successionPendingConfirmation: false,
+    caretakerAmbiguityDetected: false,
+    stewardshipEvidence: null,
+    ...overrides,
+  };
+}
+
+// ── Enum contract ─────────────────────────────────────────────────────────────
+
+describe('CI gate — exported enums match runtime sentinels', () => {
+  it('every exported verdict is in KNOWN_STEWARDSHIP_VERDICTS', () => {
+    for (const v of KNOWN_VERDICTS) {
+      expect(KNOWN_STEWARDSHIP_VERDICTS).toContain(v);
+    }
+    expect(KNOWN_STEWARDSHIP_VERDICTS).toHaveLength(KNOWN_VERDICTS.length);
+  });
+
+  it('every exported kind is in KNOWN_STEWARDSHIP_KINDS', () => {
+    for (const k of KNOWN_KINDS) {
+      expect(KNOWN_STEWARDSHIP_KINDS).toContain(k);
+    }
+    expect(KNOWN_STEWARDSHIP_KINDS).toHaveLength(KNOWN_KINDS.length);
+  });
+
+  it('every exported tier is in KNOWN_STEWARDSHIP_TIERS', () => {
+    for (const t of KNOWN_TIERS) {
+      expect(KNOWN_STEWARDSHIP_TIERS).toContain(t);
+    }
+    expect(KNOWN_STEWARDSHIP_TIERS).toHaveLength(KNOWN_TIERS.length);
+  });
+
+  it('every exported violation is in KNOWN_STEWARDSHIP_VIOLATIONS', () => {
+    for (const v of KNOWN_VIOLATIONS) {
+      expect(KNOWN_STEWARDSHIP_VIOLATIONS).toContain(v);
+    }
+    expect(KNOWN_STEWARDSHIP_VIOLATIONS).toHaveLength(KNOWN_VIOLATIONS.length);
+  });
+
+  it('all sentinel arrays are frozen', () => {
+    expect(Object.isFrozen(KNOWN_STEWARDSHIP_VERDICTS)).toBe(true);
+    expect(Object.isFrozen(KNOWN_STEWARDSHIP_KINDS)).toBe(true);
+    expect(Object.isFrozen(KNOWN_STEWARDSHIP_TIERS)).toBe(true);
+    expect(Object.isFrozen(KNOWN_STEWARDSHIP_VIOLATIONS)).toBe(true);
+    expect(Object.isFrozen(STEWARDSHIP_SENTINELS)).toBe(true);
+  });
+});
+
+// ── StewardshipError contract ─────────────────────────────────────────────────
+
+describe('CI gate — StewardshipError contract', () => {
+  it('every breach primitive throws a StewardshipError with a known violation', () => {
+    const cases: Array<{ name: string; expected: StewardshipViolationKind; run: () => void }> = [
+      {
+        name: 'assertAmbiguityPreserved when ambiguity forced to ACTIVE',
+        expected: 'AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE',
+        run: () =>
+          assertAmbiguityPreserved({ ...caretakeStewardshipShard({ shardId: 'x', signal: healthySignal() }), ambiguous: true }),
+      },
+      {
+        name: 'assertSuccessionReadiness when readiness below threshold',
+        expected: 'SUCCESSION_THRESHOLD_BREACH',
+        run: () => {
+          const sig = healthySignal({
+            successionPendingConfirmation: true,
+            successionReadinessScore: 0.20,
+            successionActivationThreshold: 0.75,
+          });
+          const rec = caretakeStewardshipShard({ shardId: 'x', signal: sig });
+          assertSuccessionReadiness(rec, sig);
+        },
+      },
+      {
+        name: 'assertStewardshipBoundary when lineage break exists',
+        expected: 'REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE',
+        run: () => {
+          const records = [
+            caretakeStewardshipShard({
+              shardId: 'x',
+              signal: healthySignal({ governanceLineageDepth: 0, governanceLineageTarget: 3 }),
+            }),
+          ];
+          const boundary = computeStewardshipBoundary({ totalShards: 1, records });
+          assertStewardshipBoundary(boundary);
+        },
+      },
+      {
+        name: 'assertStewardshipBoundary when continuity floor breached',
+        expected: 'CARETAKER_CONTINUITY_FLOOR_BREACH',
+        run: () => {
+          const records = [
+            caretakeStewardshipShard({
+              shardId: 'x',
+              signal: healthySignal({ caretakerContinuityScore: 0.30, caretakerContinuityThreshold: 0.80 }),
+            }),
+          ];
+          const boundary = computeStewardshipBoundary({ totalShards: 5, records });
+          assertStewardshipBoundary(boundary);
+        },
+      },
+    ];
+
+    for (const c of cases) {
+      let caught: unknown = null;
+      try {
+        c.run();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(StewardshipError);
+      const err = caught as StewardshipError;
+      expect(err.code).toBe('STEWARDSHIP_VIOLATION');
+      expect(KNOWN_VIOLATIONS).toContain(err.violation);
+      expect(err.violation).toBe(c.expected);
+    }
+  });
+});
+
+// ── stewardshipDigest uniqueness ──────────────────────────────────────────────
+
+describe('CI gate — stewardshipDigest is deterministic and unique', () => {
+  it('produces unique digests for distinct inputs and is reproducible', () => {
+    const sig = healthySignal();
+    const sigB = healthySignal({ caretakerContinuityScore: 0.50 });
+    const inputs = [
+      { shardId: 's-1', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sig },
+      { shardId: 's-1', verdict: 'CARETAKER_CONTINUITY_BREACH' as const, kind: 'CARETAKER_CONTINUITY_DRIFT' as const, tier: 'CARETAKER' as const, signal: sig },
+      { shardId: 's-2', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sig },
+      { shardId: 's-1', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sigB },
+      { shardId: 's-1', verdict: 'AMBIGUOUS_STEWARDSHIP' as const, kind: 'AMBIGUOUS_CARETAKER_SIGNAL' as const, tier: 'AMBIGUOUS' as const, signal: sig },
+    ];
+    const digests = inputs.map(stewardshipDigest);
+    expect(new Set(digests).size).toBe(inputs.length);
+    expect(stewardshipDigest(inputs[0])).toBe(digests[0]);
+  });
+});
+
+// ── Ambiguity never collapsed ─────────────────────────────────────────────────
+
+describe('CI gate — ambiguity never silently collapsed', () => {
+  it('ambiguous record carries verdict=AMBIGUOUS_STEWARDSHIP and ambiguous=true', () => {
+    const r = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ caretakerAmbiguityDetected: true }),
+    });
+    expect(r.verdict).toBe('AMBIGUOUS_STEWARDSHIP');
+    expect(r.ambiguous).toBe(true);
+    expect(() => assertAmbiguityPreserved(r)).not.toThrow();
+  });
+
+  it('healthy record carries verdict=ACTIVE and ambiguous=false', () => {
+    const r = caretakeStewardshipShard({ shardId: 's-1', signal: healthySignal() });
+    expect(r.verdict).toBe('ACTIVE');
+    expect(r.ambiguous).toBe(false);
+  });
+
+  it('lineage break always raises GOVERNANCE_LINEAGE_BREAK (cannot be downgraded)', () => {
+    const r = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ governanceLineageDepth: 0, governanceLineageTarget: 3 }),
+    });
+    expect(r.verdict).toBe('GOVERNANCE_LINEAGE_BREAK');
+    expect(r.kind).toBe('GOVERNANCE_LINEAGE_BREAK');
+  });
+});
+
+// ── Succession fail-closed ────────────────────────────────────────────────────
+
+describe('CI gate — succession protocol is fail-closed', () => {
+  it('succession with insufficient readiness yields SUCCESSION_PENDING, not SUCCESSION_TRIGGERED', () => {
+    const r = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({
+        successionPendingConfirmation: true,
+        successionReadinessScore: 0.20,
+        successionActivationThreshold: 0.75,
+      }),
+    });
+    expect(r.verdict).toBe('SUCCESSION_PENDING');
+    expect(r.kind).toBe('SUCCESSION_PROTOCOL_BREACH');
+  });
+
+  it('succession with sufficient readiness yields SUCCESSION_TRIGGERED', () => {
+    const r = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({
+        successionPendingConfirmation: true,
+        successionReadinessScore: 0.90,
+        successionActivationThreshold: 0.75,
+      }),
+    });
+    expect(r.verdict).toBe('SUCCESSION_TRIGGERED');
+  });
+});

--- a/apps/api/backend/src/services/governance/__tests__/governanceStewardship.test.ts
+++ b/apps/api/backend/src/services/governance/__tests__/governanceStewardship.test.ts
@@ -1,0 +1,507 @@
+/**
+ * governanceStewardship.test.ts — W2-PR154A unit coverage
+ *
+ * Full behavioural coverage of the governance stewardship pure-transform
+ * module. Every public primitive is exercised: classifier, caretaker record,
+ * boundary aggregation, assertions, lineage reconstruction, telemetry, and
+ * maturity score.
+ */
+
+import {
+  assertAmbiguityPreserved,
+  assertStewardshipBoundary,
+  assertSuccessionReadiness,
+  caretakeStewardshipShard,
+  classifyStewardshipFault,
+  computeStewardshipBoundary,
+  emitStewardshipTelemetry,
+  stewardshipDigest,
+  stewardshipMaturityScore,
+  traceStewardshipLineage,
+  StewardshipError,
+  type StewardshipSignal,
+} from '../governanceStewardship';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function healthySignal(overrides: Partial<StewardshipSignal> = {}): StewardshipSignal {
+  return {
+    caretakerContinuityScore: 0.95,
+    caretakerContinuityThreshold: 0.80,
+    replayGovernanceDrift: 0.5,
+    replayGovernanceDriftBudget: 5.0,
+    successionReadinessScore: 0.90,
+    successionActivationThreshold: 0.75,
+    governanceLineageDepth: 5,
+    governanceLineageTarget: 3,
+    institutionalRuntimeStability: 0.92,
+    institutionalStabilityFloor: 0.70,
+    successionPendingConfirmation: false,
+    caretakerAmbiguityDetected: false,
+    stewardshipEvidence: null,
+    ...overrides,
+  };
+}
+
+function activeRecord(shardId = 'shard-1') {
+  return caretakeStewardshipShard({ shardId, signal: healthySignal() });
+}
+
+// ── classifyStewardshipFault ───────────────────────────────────────────────────
+
+describe('classifyStewardshipFault — healthy path', () => {
+  it('returns kind=null, tier=INSTITUTIONAL for fully healthy signal', () => {
+    const { kind, tier, ambiguous } = classifyStewardshipFault(healthySignal());
+    expect(kind).toBeNull();
+    expect(tier).toBe('INSTITUTIONAL');
+    expect(ambiguous).toBe(false);
+  });
+});
+
+describe('classifyStewardshipFault — ambiguity', () => {
+  it('returns AMBIGUOUS_CARETAKER_SIGNAL when caretakerAmbiguityDetected', () => {
+    const { kind, tier, ambiguous } = classifyStewardshipFault(
+      healthySignal({ caretakerAmbiguityDetected: true }),
+    );
+    expect(kind).toBe('AMBIGUOUS_CARETAKER_SIGNAL');
+    expect(tier).toBe('AMBIGUOUS');
+    expect(ambiguous).toBe(true);
+  });
+
+  it('includes evidence text in the reason when present', () => {
+    const { reason } = classifyStewardshipFault(
+      healthySignal({
+        caretakerAmbiguityDetected: true,
+        stewardshipEvidence: 'conflicting telemetry frames',
+      }),
+    );
+    expect(reason).toContain('conflicting telemetry frames');
+  });
+
+  it('treats evidence-present + all-scores-healthy as contradiction → AMBIGUOUS', () => {
+    const { kind, ambiguous } = classifyStewardshipFault(
+      healthySignal({ stewardshipEvidence: 'unexpected rollback' }),
+    );
+    expect(kind).toBe('AMBIGUOUS_CARETAKER_SIGNAL');
+    expect(ambiguous).toBe(true);
+  });
+});
+
+describe('classifyStewardshipFault — succession', () => {
+  it('SUCCESSION_TRIGGERED with sufficient readiness', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({ successionPendingConfirmation: true }),
+    );
+    expect(kind).toBeNull();
+    expect(tier).toBe('SUCCESSION');
+  });
+
+  it('SUCCESSION_PROTOCOL_BREACH when readiness is below threshold', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({
+        successionPendingConfirmation: true,
+        successionReadinessScore: 0.50,
+        successionActivationThreshold: 0.75,
+      }),
+    );
+    expect(kind).toBe('SUCCESSION_PROTOCOL_BREACH');
+    expect(tier).toBe('SUCCESSION');
+  });
+});
+
+describe('classifyStewardshipFault — caretaker continuity', () => {
+  it('CARETAKER_CONTINUITY_DRIFT when continuity below threshold', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({ caretakerContinuityScore: 0.60, caretakerContinuityThreshold: 0.80 }),
+    );
+    expect(kind).toBe('CARETAKER_CONTINUITY_DRIFT');
+    expect(tier).toBe('CARETAKER');
+  });
+
+  it('REPLAY_GOVERNANCE_DRIFT when drift exceeds budget', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({ replayGovernanceDrift: 10, replayGovernanceDriftBudget: 5 }),
+    );
+    expect(kind).toBe('REPLAY_GOVERNANCE_DRIFT');
+    expect(tier).toBe('CARETAKER');
+  });
+
+  it('CARETAKER_CONTINUITY_DRIFT (DEGRADED) when both axes fail', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({
+        caretakerContinuityScore: 0.60,
+        caretakerContinuityThreshold: 0.80,
+        replayGovernanceDrift: 10,
+        replayGovernanceDriftBudget: 5,
+      }),
+    );
+    expect(kind).toBe('CARETAKER_CONTINUITY_DRIFT');
+    expect(tier).toBe('DEGRADED');
+  });
+});
+
+describe('classifyStewardshipFault — lineage and stability', () => {
+  it('GOVERNANCE_LINEAGE_BREAK when depth below target', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({ governanceLineageDepth: 2, governanceLineageTarget: 3 }),
+    );
+    expect(kind).toBe('GOVERNANCE_LINEAGE_BREAK');
+    expect(tier).toBe('DEGRADED');
+  });
+
+  it('INSTITUTIONAL_STABILITY_COLLAPSE when stability below floor', () => {
+    const { kind, tier } = classifyStewardshipFault(
+      healthySignal({ institutionalRuntimeStability: 0.50, institutionalStabilityFloor: 0.70 }),
+    );
+    expect(kind).toBe('INSTITUTIONAL_STABILITY_COLLAPSE');
+    expect(tier).toBe('DEGRADED');
+  });
+});
+
+// ── caretakeStewardshipShard ───────────────────────────────────────────────────
+
+describe('caretakeStewardshipShard', () => {
+  it('produces verdict=ACTIVE for healthy signal', () => {
+    const record = activeRecord();
+    expect(record.schema).toBe('vitalcv.governance-stewardship.v1');
+    expect(record.verdict).toBe('ACTIVE');
+    expect(record.kind).toBeNull();
+    expect(record.ambiguous).toBe(false);
+    expect(record.stewardshipDigest).toHaveLength(64);
+  });
+
+  it('produces verdict=AMBIGUOUS_STEWARDSHIP for ambiguous signal', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 'ambig',
+      signal: healthySignal({ caretakerAmbiguityDetected: true }),
+    });
+    expect(record.verdict).toBe('AMBIGUOUS_STEWARDSHIP');
+    expect(record.ambiguous).toBe(true);
+    expect(record.kind).toBe('AMBIGUOUS_CARETAKER_SIGNAL');
+  });
+
+  it('produces verdict=SUCCESSION_PENDING when succession pending with low readiness', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({
+        successionPendingConfirmation: true,
+        successionReadinessScore: 0.40,
+        successionActivationThreshold: 0.75,
+      }),
+    });
+    expect(record.verdict).toBe('SUCCESSION_PENDING');
+    expect(record.kind).toBe('SUCCESSION_PROTOCOL_BREACH');
+  });
+
+  it('produces verdict=SUCCESSION_TRIGGERED when succession ready', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ successionPendingConfirmation: true }),
+    });
+    expect(record.verdict).toBe('SUCCESSION_TRIGGERED');
+    expect(record.kind).toBeNull();
+    expect(record.tier).toBe('SUCCESSION');
+  });
+
+  it('produces verdict=CARETAKER_CONTINUITY_BREACH for continuity drift', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ caretakerContinuityScore: 0.50, caretakerContinuityThreshold: 0.80 }),
+    });
+    expect(record.verdict).toBe('CARETAKER_CONTINUITY_BREACH');
+  });
+
+  it('produces verdict=GOVERNANCE_LINEAGE_BREAK for lineage break', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ governanceLineageDepth: 1, governanceLineageTarget: 3 }),
+    });
+    expect(record.verdict).toBe('GOVERNANCE_LINEAGE_BREAK');
+  });
+
+  it('produces verdict=INSTITUTIONAL_STABILITY_BREACH for stability collapse', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ institutionalRuntimeStability: 0.30, institutionalStabilityFloor: 0.70 }),
+    });
+    expect(record.verdict).toBe('INSTITUTIONAL_STABILITY_BREACH');
+  });
+
+  it('normalises lineageHints correctly', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal(),
+      lineageHints: { caretakerPoolId: '  pool-A  ', replayGovernanceShardId: '' },
+    });
+    expect(record.lineageHints.caretakerPoolId).toBe('pool-A');
+    expect(record.lineageHints.replayGovernanceShardId).toBeNull();
+  });
+});
+
+// ── stewardshipDigest ─────────────────────────────────────────────────────────
+
+describe('stewardshipDigest', () => {
+  it('produces unique digests for distinct (shardId, verdict, kind, tier, signal) tuples', () => {
+    const sig = healthySignal();
+    const sigB = healthySignal({ caretakerContinuityScore: 0.60 });
+    const inputs = [
+      { shardId: 's-1', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sig },
+      { shardId: 's-1', verdict: 'CARETAKER_CONTINUITY_BREACH' as const, kind: 'CARETAKER_CONTINUITY_DRIFT' as const, tier: 'CARETAKER' as const, signal: sig },
+      { shardId: 's-2', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sig },
+      { shardId: 's-1', verdict: 'ACTIVE' as const, kind: null, tier: 'INSTITUTIONAL' as const, signal: sigB },
+      { shardId: 's-1', verdict: 'AMBIGUOUS_STEWARDSHIP' as const, kind: 'AMBIGUOUS_CARETAKER_SIGNAL' as const, tier: 'AMBIGUOUS' as const, signal: sig },
+    ];
+    const digests = inputs.map(stewardshipDigest);
+    expect(new Set(digests).size).toBe(inputs.length);
+    expect(stewardshipDigest(inputs[0])).toBe(digests[0]);
+  });
+});
+
+// ── computeStewardshipBoundary ────────────────────────────────────────────────
+
+describe('computeStewardshipBoundary', () => {
+  it('returns partitioned=true for all-active population', () => {
+    const records = Array.from({ length: 5 }, (_, i) => activeRecord(`s-${i}`));
+    const boundary = computeStewardshipBoundary({ totalShards: 5, records });
+    expect(boundary.partitioned).toBe(true);
+    expect(boundary.activeCount).toBe(5);
+    expect(boundary.stewardshipContinuityRatio).toBe(1);
+    expect(boundary.partialContinuityPct).toBe(100);
+  });
+
+  it('returns partitioned=false when lineage breaks exist', () => {
+    const records = [
+      activeRecord('s-1'),
+      caretakeStewardshipShard({
+        shardId: 's-2',
+        signal: healthySignal({ governanceLineageDepth: 1, governanceLineageTarget: 3 }),
+      }),
+    ];
+    const boundary = computeStewardshipBoundary({ totalShards: 2, records });
+    expect(boundary.partitioned).toBe(false);
+    expect(boundary.lineageBreakCount).toBe(1);
+  });
+
+  it('returns partitioned=false when partial continuity below floor', () => {
+    const records = [
+      caretakeStewardshipShard({
+        shardId: 's-1',
+        signal: healthySignal({ caretakerContinuityScore: 0.50, caretakerContinuityThreshold: 0.80 }),
+      }),
+    ];
+    const boundary = computeStewardshipBoundary({
+      totalShards: 5,
+      records,
+      minPartialContinuityPct: 70,
+    });
+    expect(boundary.partitioned).toBe(false);
+  });
+
+  it('computes meanInstitutionalStability correctly', () => {
+    const records = [
+      caretakeStewardshipShard({ shardId: 's-1', signal: healthySignal({ institutionalRuntimeStability: 0.80 }) }),
+      caretakeStewardshipShard({ shardId: 's-2', signal: healthySignal({ institutionalRuntimeStability: 0.60 }) }),
+    ];
+    const boundary = computeStewardshipBoundary({ totalShards: 2, records });
+    expect(boundary.meanInstitutionalStability).toBeCloseTo(0.70, 5);
+  });
+});
+
+// ── assertAmbiguityPreserved ───────────────────────────────────────────────────
+
+describe('assertAmbiguityPreserved', () => {
+  it('does not throw for non-ambiguous active record', () => {
+    expect(() => assertAmbiguityPreserved(activeRecord())).not.toThrow();
+  });
+
+  it('does not throw for ambiguous AMBIGUOUS_STEWARDSHIP record', () => {
+    const record = caretakeStewardshipShard({
+      shardId: 's-1',
+      signal: healthySignal({ caretakerAmbiguityDetected: true }),
+    });
+    expect(() => assertAmbiguityPreserved(record)).not.toThrow();
+  });
+
+  it('throws AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE when ambiguous but verdict=ACTIVE', () => {
+    const record = {
+      ...activeRecord(),
+      ambiguous: true,
+    };
+    expect(() => assertAmbiguityPreserved(record)).toThrow(StewardshipError);
+    try {
+      assertAmbiguityPreserved(record);
+    } catch (e) {
+      expect((e as StewardshipError).violation).toBe('AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE');
+      expect((e as StewardshipError).code).toBe('STEWARDSHIP_VIOLATION');
+    }
+  });
+});
+
+// ── assertSuccessionReadiness ─────────────────────────────────────────────────
+
+describe('assertSuccessionReadiness', () => {
+  it('does not throw when succession is not pending', () => {
+    const sig = healthySignal();
+    expect(() => assertSuccessionReadiness(activeRecord(), sig)).not.toThrow();
+  });
+
+  it('throws SUCCESSION_THRESHOLD_BREACH when pending with low readiness', () => {
+    const sig = healthySignal({
+      successionPendingConfirmation: true,
+      successionReadinessScore: 0.40,
+      successionActivationThreshold: 0.75,
+    });
+    const record = caretakeStewardshipShard({ shardId: 's-1', signal: sig });
+    expect(() => assertSuccessionReadiness(record, sig)).toThrow(StewardshipError);
+    try {
+      assertSuccessionReadiness(record, sig);
+    } catch (e) {
+      expect((e as StewardshipError).violation).toBe('SUCCESSION_THRESHOLD_BREACH');
+    }
+  });
+});
+
+// ── assertStewardshipBoundary ─────────────────────────────────────────────────
+
+describe('assertStewardshipBoundary', () => {
+  it('does not throw for intact boundary', () => {
+    const records = Array.from({ length: 5 }, (_, i) => activeRecord(`s-${i}`));
+    const boundary = computeStewardshipBoundary({ totalShards: 5, records });
+    expect(() => assertStewardshipBoundary(boundary)).not.toThrow();
+  });
+
+  it('throws REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE on lineage break', () => {
+    const records = [
+      activeRecord('s-1'),
+      caretakeStewardshipShard({
+        shardId: 's-2',
+        signal: healthySignal({ governanceLineageDepth: 0, governanceLineageTarget: 3 }),
+      }),
+    ];
+    const boundary = computeStewardshipBoundary({ totalShards: 2, records });
+    expect(() => assertStewardshipBoundary(boundary)).toThrow(StewardshipError);
+    try {
+      assertStewardshipBoundary(boundary);
+    } catch (e) {
+      expect((e as StewardshipError).violation).toBe('REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE');
+    }
+  });
+
+  it('throws CARETAKER_CONTINUITY_FLOOR_BREACH when partial continuity below floor', () => {
+    const records = Array.from({ length: 1 }, () =>
+      caretakeStewardshipShard({
+        shardId: 'lone',
+        signal: healthySignal({ caretakerContinuityScore: 0.50, caretakerContinuityThreshold: 0.80 }),
+      }),
+    );
+    const boundary = computeStewardshipBoundary({ totalShards: 5, records });
+    expect(() => assertStewardshipBoundary(boundary)).toThrow(StewardshipError);
+    try {
+      assertStewardshipBoundary(boundary);
+    } catch (e) {
+      expect((e as StewardshipError).violation).toBe('CARETAKER_CONTINUITY_FLOOR_BREACH');
+    }
+  });
+});
+
+// ── traceStewardshipLineage ───────────────────────────────────────────────────
+
+describe('traceStewardshipLineage', () => {
+  it('reconstructionDigest is order-independent', () => {
+    const base = {
+      rootShardId: 'root',
+      rootHints: { caretakerPoolId: 'pool-A', replayGovernanceShardId: 'rs-1', successionScopeId: null },
+    };
+    const a = traceStewardshipLineage({
+      ...base,
+      candidates: [
+        { shardId: 'cand-A', hints: { caretakerPoolId: 'pool-A' } },
+        { shardId: 'cand-B', hints: { replayGovernanceShardId: 'rs-1' } },
+      ],
+    });
+    const b = traceStewardshipLineage({
+      ...base,
+      candidates: [
+        { shardId: 'cand-B', hints: { replayGovernanceShardId: 'rs-1' } },
+        { shardId: 'cand-A', hints: { caretakerPoolId: 'pool-A' } },
+      ],
+    });
+    expect(a.reconstructionDigest).toBe(b.reconstructionDigest);
+    expect(a.affectedShardIds).toEqual(['cand-A', 'cand-B']);
+  });
+
+  it('excludes root from affectedShardIds', () => {
+    const result = traceStewardshipLineage({
+      rootShardId: 'root',
+      rootHints: { caretakerPoolId: 'pool-X', replayGovernanceShardId: null, successionScopeId: null },
+      candidates: [
+        { shardId: 'root', hints: { caretakerPoolId: 'pool-X' } },
+        { shardId: 'other', hints: { caretakerPoolId: 'pool-X' } },
+      ],
+    });
+    expect(result.affectedShardIds).toEqual(['other']);
+  });
+
+  it('emits SHARED_SUCCESSION_SCOPE edge correctly', () => {
+    const result = traceStewardshipLineage({
+      rootShardId: 'root',
+      rootHints: { caretakerPoolId: null, replayGovernanceShardId: null, successionScopeId: 'sc-1' },
+      candidates: [
+        { shardId: 'cand-A', hints: { successionScopeId: 'sc-1' } },
+      ],
+    });
+    expect(result.edges[0].reason).toBe('SHARED_SUCCESSION_SCOPE');
+    expect(result.affectedShardIds).toContain('cand-A');
+  });
+});
+
+// ── emitStewardshipTelemetry ──────────────────────────────────────────────────
+
+describe('emitStewardshipTelemetry', () => {
+  it('returns a telemetry record with correct schema and pct values', () => {
+    const record = activeRecord();
+    const telemetry = emitStewardshipTelemetry(record);
+    expect(telemetry.schema).toBe('vitalcv.stewardship-telemetry.v1');
+    expect(telemetry.verdict).toBe('ACTIVE');
+    expect(telemetry.caretakerContinuityPct).toBe(95);
+    expect(telemetry.successionReadinessPct).toBe(90);
+    expect(telemetry.institutionalStabilityPct).toBe(92);
+  });
+});
+
+// ── stewardshipMaturityScore ──────────────────────────────────────────────────
+
+describe('stewardshipMaturityScore', () => {
+  it('returns near-100 maturity for all-active boundary', () => {
+    const records = Array.from({ length: 10 }, (_, i) => activeRecord(`s-${i}`));
+    const boundary = computeStewardshipBoundary({ totalShards: 10, records });
+    const { maturityScore } = stewardshipMaturityScore(boundary);
+    expect(maturityScore).toBeGreaterThanOrEqual(80);
+  });
+
+  it('returns lower maturity for continuity-degraded boundary', () => {
+    const records = [
+      ...Array.from({ length: 3 }, (_, i) => activeRecord(`s-${i}`)),
+      caretakeStewardshipShard({
+        shardId: 's-3',
+        signal: healthySignal({ caretakerContinuityScore: 0.40, caretakerContinuityThreshold: 0.80 }),
+      }),
+      caretakeStewardshipShard({
+        shardId: 's-4',
+        signal: healthySignal({ institutionalRuntimeStability: 0.30, institutionalStabilityFloor: 0.70 }),
+      }),
+    ];
+    const boundary = computeStewardshipBoundary({ totalShards: 5, records });
+    const fullBoundary = computeStewardshipBoundary({ totalShards: 5, records: Array.from({ length: 5 }, (_, i) => activeRecord(`h-${i}`)) });
+    const degradedScore = stewardshipMaturityScore(boundary).maturityScore;
+    const healthyScore = stewardshipMaturityScore(fullBoundary).maturityScore;
+    expect(degradedScore).toBeLessThan(healthyScore);
+  });
+
+  it('maturityScore is in range 0–100', () => {
+    const boundary = computeStewardshipBoundary({ totalShards: 1, records: [activeRecord()] });
+    const { maturityScore } = stewardshipMaturityScore(boundary);
+    expect(maturityScore).toBeGreaterThanOrEqual(0);
+    expect(maturityScore).toBeLessThanOrEqual(100);
+  });
+});

--- a/apps/api/backend/src/services/governance/governanceStewardship.ts
+++ b/apps/api/backend/src/services/governance/governanceStewardship.ts
@@ -1,0 +1,896 @@
+/**
+ * governanceStewardship.ts — W2-PR154A: Institutional Governance Stewardship Protocol
+ *
+ * Pure transforms formalizing longitudinal governance stewardship for
+ * constitutional runtime continuity. Goal: ensure caretaker continuity is
+ * measurable, governance lineage is reconstructable, succession safeguards
+ * are fail-closed, and the institutional runtime survives longitudinally —
+ * without ever silently dressing a degraded caretaker as "stewardship healthy".
+ *
+ * Companion module to:
+ *   - governanceRuntimeHardening.ts  (production-runtime survivability axis)
+ *   - replayCorruptionContainment.ts (replay-corruption axis)
+ *   - multi-tenant/tenantIsolation.ts (tenant axis)
+ *   - rollout/rolloutSurvivability.ts (institutional adoption axis)
+ *
+ * Same shape, same fail-closed contract, different axis: longitudinal
+ * governance stewardship — caretaker continuity, succession safeguards,
+ * replay-governance caretaking, and institutional runtime stability over time.
+ *
+ * Hard invariants (fail-closed):
+ *   - A degraded caretaker tier is QUARANTINED, never silently merged with
+ *     the active population. Ambiguous stewardship signals (caretaker
+ *     continuity below threshold but no explicit fault evidence) are preserved
+ *     as AMBIGUOUS_STEWARDSHIP, never coerced to ACTIVE.
+ *   - When the active stewardship population falls below the configured
+ *     continuity floor, the boundary raises CARETAKER_CONTINUITY_FLOOR_BREACH
+ *     so the operator sees the breach — never a partial cohort dressed as
+ *     fully stewarded.
+ *   - Stewardship records carry deterministic, tamper-evident stewardshipDigests
+ *     so a forged "active" record cannot replace a real fault-caretaking signal.
+ *   - Stewardship lineage is reconstructable longitudinally: every caretaking
+ *     record carries the hints needed to walk back to the offending caretaker
+ *     pool, replay governance shard, or succession scope.
+ *   - Succession protocol is fail-closed: if succession readiness falls below
+ *     threshold when succession is pending confirmation, SUCCESSION_THRESHOLD_BREACH
+ *     is raised — never a silent hand-off to an unready caretaker.
+ *
+ * No fetches, no DB writes, no audit-event writes. This module is the
+ * boundary checker; runtime dashboards and the W2-PR154A CI gate call it.
+ */
+
+import { sha256ForPayload } from '../../utils/deterministic';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** What kind of stewardship issue the caretaking signal is reporting. */
+export type StewardshipKind =
+  | 'CARETAKER_CONTINUITY_DRIFT'       // caretaker continuity score below threshold
+  | 'REPLAY_GOVERNANCE_DRIFT'          // replay drift exceeding governance budget
+  | 'SUCCESSION_PROTOCOL_BREACH'       // readiness below threshold when succession pending
+  | 'GOVERNANCE_LINEAGE_BREAK'         // lineage depth below reconstructable target
+  | 'INSTITUTIONAL_STABILITY_COLLAPSE' // institutional runtime stability floor violated
+  | 'AMBIGUOUS_CARETAKER_SIGNAL';      // signals contradict — preserve uncertainty
+
+/** Stewardship verdict for a single caretaking shard. */
+export type StewardshipVerdict =
+  | 'ACTIVE'                        // caretaker functioning, lineage intact
+  | 'CARETAKER_CONTINUITY_BREACH'   // caretaker continuity score below threshold
+  | 'SUCCESSION_TRIGGERED'          // succession protocol activated and confirmed
+  | 'SUCCESSION_PENDING'            // succession underway — readiness not yet confirmed
+  | 'AMBIGUOUS_STEWARDSHIP'         // contradictory signals — operator review required
+  | 'GOVERNANCE_LINEAGE_BREAK'      // lineage depth below reconstructable target
+  | 'INSTITUTIONAL_STABILITY_BREACH'; // institutional runtime stability floor violated
+
+/** Tier classification of a stewardship shard. */
+export type StewardshipTier =
+  | 'INSTITUTIONAL'   // all scores healthy, full stewardship active
+  | 'CARETAKER'       // caretaker operating within tolerance, some drift
+  | 'DEGRADED'        // caretaking degraded — drift or continuity breach
+  | 'SUCCESSION'      // succession protocol active
+  | 'AMBIGUOUS';      // contradictory signals — cannot classify
+
+export type StewardshipViolationKind =
+  | 'AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE'
+  | 'SUCCESSION_THRESHOLD_BREACH'
+  | 'CARETAKER_CONTINUITY_FLOOR_BREACH'
+  | 'REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE';
+
+// ── Sentinels ─────────────────────────────────────────────────────────────────
+
+export const KNOWN_STEWARDSHIP_VERDICTS: readonly StewardshipVerdict[] = Object.freeze([
+  'ACTIVE',
+  'CARETAKER_CONTINUITY_BREACH',
+  'SUCCESSION_TRIGGERED',
+  'SUCCESSION_PENDING',
+  'AMBIGUOUS_STEWARDSHIP',
+  'GOVERNANCE_LINEAGE_BREAK',
+  'INSTITUTIONAL_STABILITY_BREACH',
+] as const);
+
+export const KNOWN_STEWARDSHIP_KINDS: readonly StewardshipKind[] = Object.freeze([
+  'CARETAKER_CONTINUITY_DRIFT',
+  'REPLAY_GOVERNANCE_DRIFT',
+  'SUCCESSION_PROTOCOL_BREACH',
+  'GOVERNANCE_LINEAGE_BREAK',
+  'INSTITUTIONAL_STABILITY_COLLAPSE',
+  'AMBIGUOUS_CARETAKER_SIGNAL',
+] as const);
+
+export const KNOWN_STEWARDSHIP_TIERS: readonly StewardshipTier[] = Object.freeze([
+  'INSTITUTIONAL',
+  'CARETAKER',
+  'DEGRADED',
+  'SUCCESSION',
+  'AMBIGUOUS',
+] as const);
+
+export const KNOWN_STEWARDSHIP_VIOLATIONS: readonly StewardshipViolationKind[] = Object.freeze([
+  'AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE',
+  'SUCCESSION_THRESHOLD_BREACH',
+  'CARETAKER_CONTINUITY_FLOOR_BREACH',
+  'REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE',
+] as const);
+
+export const STEWARDSHIP_SENTINELS = Object.freeze({
+  MIN_CARETAKER_CONTINUITY_FLOOR_PCT: 70,
+  SUCCESSION_READINESS_THRESHOLD: 0.75,
+  GOVERNANCE_LINEAGE_MIN_DEPTH: 3,
+  REPLAY_GOVERNANCE_DRIFT_SPIKE_RATIO: 5.0,
+} as const);
+
+// ── Error class ───────────────────────────────────────────────────────────────
+
+export class StewardshipError extends Error {
+  readonly code = 'STEWARDSHIP_VIOLATION' as const;
+  readonly violation: StewardshipViolationKind;
+  readonly shardId: string | null;
+  readonly kind: StewardshipKind | null;
+  readonly partialContinuityPct: number | null;
+
+  constructor(args: {
+    violation: StewardshipViolationKind;
+    message: string;
+    shardId?: string | null;
+    kind?: StewardshipKind | null;
+    partialContinuityPct?: number | null;
+  }) {
+    super(args.message);
+    this.name = 'StewardshipError';
+    this.violation = args.violation;
+    this.shardId = args.shardId ?? null;
+    this.kind = args.kind ?? null;
+    this.partialContinuityPct = args.partialContinuityPct ?? null;
+  }
+}
+
+// ── Signal / Record shapes ────────────────────────────────────────────────────
+
+/**
+ * Observable metrics about a single governance caretaker shard.
+ * Callers populate this from their monitoring / telemetry layer.
+ */
+export interface StewardshipSignal {
+  /** 0–1 composite score reflecting how faithfully the caretaker tracks governance intent. */
+  caretakerContinuityScore: number;
+  /** Minimum continuity score below which caretaking is considered degraded. */
+  caretakerContinuityThreshold: number;
+  /** Observed replay governance drift (dimensionless ratio vs. ground truth). */
+  replayGovernanceDrift: number;
+  /** Maximum allowed replay governance drift before raising a kind. */
+  replayGovernanceDriftBudget: number;
+  /** 0–1 readiness score for the next caretaker in the succession chain. */
+  successionReadinessScore: number;
+  /** Minimum readiness score required before succession can be confirmed safe. */
+  successionActivationThreshold: number;
+  /** How many caretaker generations back governance lineage can be reconstructed. */
+  governanceLineageDepth: number;
+  /** Minimum required lineage depth for the institutional governance contract. */
+  governanceLineageTarget: number;
+  /** 0–1 composite institutional runtime stability score. */
+  institutionalRuntimeStability: number;
+  /** Minimum institutional stability below which the stability floor is violated. */
+  institutionalStabilityFloor: number;
+  /** True iff succession has been triggered and awaits confirmation. */
+  successionPendingConfirmation: boolean;
+  /** True iff contradictory signals were detected at the caretaker level. */
+  caretakerAmbiguityDetected: boolean;
+  /** Operator-observed stewardship evidence text — null when none. */
+  stewardshipEvidence: string | null;
+}
+
+export interface StewardshipLineageHints {
+  /** Caretaker pool the shard belongs to. */
+  caretakerPoolId: string | null;
+  /** Replay governance shard id. */
+  replayGovernanceShardId: string | null;
+  /** Succession scope id (which succession chain this shard participates in). */
+  successionScopeId: string | null;
+}
+
+export interface StewardshipCaretakingRecord {
+  schema: 'vitalcv.governance-stewardship.v1';
+  shardId: string;
+  verdict: StewardshipVerdict;
+  /** Null when verdict === 'ACTIVE'. */
+  kind: StewardshipKind | null;
+  tier: StewardshipTier;
+  /** True iff verdict === 'AMBIGUOUS_STEWARDSHIP'. Mirrored for fast filtering. */
+  ambiguous: boolean;
+  reason: string;
+  /** SHA-256 over (shardId, verdict, kind, tier, signal). Tamper-evident boundary. */
+  stewardshipDigest: string;
+  caretakedAt: string;
+  lineageHints: StewardshipLineageHints;
+  /** 0–1 caretaker continuity score as observed at caretaking time. */
+  caretakerContinuityScore: number;
+  /** 0–1 succession readiness score as observed at caretaking time. */
+  successionReadinessScore: number;
+  /** 0–1 institutional runtime stability as observed at caretaking time. */
+  institutionalRuntimeStability: number;
+  /** Lineage depth as observed at caretaking time. */
+  governanceLineageDepth: number;
+}
+
+export interface StewardshipBoundary {
+  schema: 'vitalcv.governance-stewardship-boundary.v1';
+  /** True iff stewardship is intact — no continuity floor breach, ambiguity preserved as flag. */
+  partitioned: boolean;
+  totalShards: number;
+  activeCount: number;
+  continuityBreachCount: number;
+  successionCount: number;
+  ambiguousCount: number;
+  lineageBreakCount: number;
+  stabilityBreachCount: number;
+  /** active / total — 1.0 when every shard is fully active. */
+  stewardshipContinuityRatio: number;
+  /**
+   * (active + caretaker-tier + ambiguous) / total * 100 —
+   * what is operator-visible and actionable. Stability breach + lineage break
+   * do NOT count toward continuity.
+   */
+  partialContinuityPct: number;
+  /** (ambiguous + continuity-breach + succession-pending) / total * 100 — drift visibility. */
+  stewardshipDriftVisibilityPct: number;
+  /** 0–1 mean institutional runtime stability across all records. */
+  meanInstitutionalStability: number;
+  /** 0–1 mean succession readiness across all records. */
+  meanSuccessionReadiness: number;
+  /** Depth of the shortest lineage across all records. */
+  minGovernanceLineageDepth: number;
+  boundaryReason: string;
+  boundaryDigest: string;
+  partitionedAt: string;
+}
+
+export interface StewardshipLineageEdge {
+  fromShardId: string;
+  toShardId: string;
+  reason: 'SHARED_CARETAKER_POOL' | 'SHARED_REPLAY_GOVERNANCE_SHARD' | 'SHARED_SUCCESSION_SCOPE';
+}
+
+export interface StewardshipLineage {
+  schema: 'vitalcv.governance-stewardship-lineage.v1';
+  rootShardId: string;
+  /** Shards contaminated via the root's lineage hints. Excludes the root. */
+  affectedShardIds: string[];
+  edges: StewardshipLineageEdge[];
+  /** SHA-256 over (rootShardId, sorted affected ids, sorted edges). */
+  reconstructionDigest: string;
+  reconstructedAt: string;
+}
+
+/** Telemetry record emitted for the stewardship board (console.log line). */
+export interface StewardshipTelemetryRecord {
+  schema: 'vitalcv.stewardship-telemetry.v1';
+  shardId: string;
+  caretakerContinuityPct: number;
+  successionReadinessPct: number;
+  institutionalStabilityPct: number;
+  governanceLineageDepth: number;
+  replayGovernanceDrift: number;
+  verdict: StewardshipVerdict;
+  tier: StewardshipTier;
+  ambiguous: boolean;
+  emittedAt: string;
+}
+
+// ── Schemas ───────────────────────────────────────────────────────────────────
+
+const SCHEMA_RECORD   = 'vitalcv.governance-stewardship.v1' as const;
+const SCHEMA_BOUNDARY = 'vitalcv.governance-stewardship-boundary.v1' as const;
+const SCHEMA_LINEAGE  = 'vitalcv.governance-stewardship-lineage.v1' as const;
+const SCHEMA_TELEMETRY = 'vitalcv.stewardship-telemetry.v1' as const;
+
+const DEFAULT_MIN_PARTIAL_CONTINUITY_PCT = 70;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function clampScore(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function safeScore(observed: number, threshold: number): boolean {
+  if (!Number.isFinite(observed) || !Number.isFinite(threshold)) return false;
+  return observed >= threshold;
+}
+
+function safeDriftOk(drift: number, budget: number): boolean {
+  if (!Number.isFinite(drift) || !Number.isFinite(budget)) return false;
+  if (budget <= 0) return false;
+  return drift <= budget;
+}
+
+function normalizeLineageHints(
+  hints: Partial<StewardshipLineageHints> | undefined | null,
+): StewardshipLineageHints {
+  return {
+    caretakerPoolId:
+      typeof hints?.caretakerPoolId === 'string' && hints.caretakerPoolId.trim().length > 0
+        ? hints.caretakerPoolId.trim()
+        : null,
+    replayGovernanceShardId:
+      typeof hints?.replayGovernanceShardId === 'string' &&
+      hints.replayGovernanceShardId.trim().length > 0
+        ? hints.replayGovernanceShardId.trim()
+        : null,
+    successionScopeId:
+      typeof hints?.successionScopeId === 'string' && hints.successionScopeId.trim().length > 0
+        ? hints.successionScopeId.trim()
+        : null,
+  };
+}
+
+// ── Digest ────────────────────────────────────────────────────────────────────
+
+export function stewardshipDigest(input: {
+  shardId: string;
+  verdict: StewardshipVerdict;
+  kind: StewardshipKind | null;
+  tier: StewardshipTier;
+  signal: StewardshipSignal;
+}): string {
+  return sha256ForPayload({
+    schema: 'vitalcv.stewardship-digest.v1',
+    shardId: input.shardId,
+    verdict: input.verdict,
+    kind: input.kind,
+    tier: input.tier,
+    signal: {
+      caretakerContinuityScore: input.signal.caretakerContinuityScore,
+      caretakerContinuityThreshold: input.signal.caretakerContinuityThreshold,
+      replayGovernanceDrift: input.signal.replayGovernanceDrift,
+      replayGovernanceDriftBudget: input.signal.replayGovernanceDriftBudget,
+      successionReadinessScore: input.signal.successionReadinessScore,
+      successionActivationThreshold: input.signal.successionActivationThreshold,
+      governanceLineageDepth: input.signal.governanceLineageDepth,
+      governanceLineageTarget: input.signal.governanceLineageTarget,
+      institutionalRuntimeStability: input.signal.institutionalRuntimeStability,
+      institutionalStabilityFloor: input.signal.institutionalStabilityFloor,
+      successionPendingConfirmation: input.signal.successionPendingConfirmation,
+      caretakerAmbiguityDetected: input.signal.caretakerAmbiguityDetected,
+      stewardshipEvidence: input.signal.stewardshipEvidence ?? null,
+    },
+  });
+}
+
+// ── Classifier ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure classifier — given a stewardship signal, return the fault kind, tier,
+ * ambiguity flag, and a human-readable reason.
+ *
+ * Fail-closed table (evaluated in priority order):
+ *
+ *   ambiguity  | succession  | continuity | lineage | stability | result
+ *   -----------+-------------+------------+---------+-----------+----------------------
+ *   detected   | *           | *          | *       | *         | AMBIGUOUS_CARETAKER_SIGNAL
+ *   *          | pending,low | *          | *       | *         | SUCCESSION_PROTOCOL_BREACH
+ *   *          | pending,ok  | *          | *       | *         | SUCCESSION_TRIGGERED → PENDING
+ *   *          | triggered   | *          | *       | *         | SUCCESSION_TRIGGERED
+ *   ok         | no          | low        | *       | *         | CARETAKER_CONTINUITY_DRIFT
+ *   ok         | no          | ok         | broken  | *         | GOVERNANCE_LINEAGE_BREAK
+ *   ok         | no          | ok         | ok      | low       | INSTITUTIONAL_STABILITY_COLLAPSE
+ *   ok         | no          | ok         | ok      | ok        | null (ACTIVE)
+ */
+export function classifyStewardshipFault(signal: StewardshipSignal): {
+  kind: StewardshipKind | null;
+  tier: StewardshipTier;
+  ambiguous: boolean;
+  reason: string;
+} {
+  const evidence = signal.stewardshipEvidence ?? null;
+  const evidencePresent = typeof evidence === 'string' && evidence.trim().length > 0;
+
+  // Caretaker ambiguity is the highest-priority flag — contradictory signals
+  // cannot be resolved by any single-axis classifier.
+  if (signal.caretakerAmbiguityDetected) {
+    return {
+      kind: 'AMBIGUOUS_CARETAKER_SIGNAL',
+      tier: 'AMBIGUOUS',
+      ambiguous: true,
+      reason: evidencePresent
+        ? `Contradictory caretaker signals detected — ${evidence}. Operator review required.`
+        : 'Contradictory caretaker signals detected. Operator review required before succession.',
+    };
+  }
+
+  const continuityOk = safeScore(
+    signal.caretakerContinuityScore,
+    signal.caretakerContinuityThreshold,
+  );
+  const driftOk = safeDriftOk(
+    signal.replayGovernanceDrift,
+    signal.replayGovernanceDriftBudget,
+  );
+  const lineageOk =
+    Number.isFinite(signal.governanceLineageDepth) &&
+    Number.isFinite(signal.governanceLineageTarget) &&
+    signal.governanceLineageDepth >= signal.governanceLineageTarget;
+  const stabilityOk = safeScore(
+    signal.institutionalRuntimeStability,
+    signal.institutionalStabilityFloor,
+  );
+
+  // Succession protocol — evaluated before continuity because a succession in
+  // progress supersedes continuity classification.
+  if (signal.successionPendingConfirmation) {
+    const readinessOk = safeScore(
+      signal.successionReadinessScore,
+      signal.successionActivationThreshold,
+    );
+    if (!readinessOk) {
+      return {
+        kind: 'SUCCESSION_PROTOCOL_BREACH',
+        tier: 'SUCCESSION',
+        ambiguous: false,
+        reason:
+          `Succession pending but readiness score ${signal.successionReadinessScore.toFixed(3)} ` +
+          `is below activation threshold ${signal.successionActivationThreshold.toFixed(3)}. ` +
+          'Fail-closed: succession must not proceed until readiness is confirmed.',
+      };
+    }
+    return {
+      kind: null,
+      tier: 'SUCCESSION',
+      ambiguous: false,
+      reason:
+        `Succession pending confirmation — readiness ${signal.successionReadinessScore.toFixed(3)} ` +
+        `meets threshold ${signal.successionActivationThreshold.toFixed(3)}.`,
+    };
+  }
+
+  // Caretaker continuity — includes replay governance drift as a contributing factor.
+  if (!continuityOk || !driftOk) {
+    const driftRatio =
+      signal.replayGovernanceDriftBudget > 0
+        ? (signal.replayGovernanceDrift / signal.replayGovernanceDriftBudget).toFixed(2)
+        : '∞';
+    if (!continuityOk && !driftOk) {
+      return {
+        kind: 'CARETAKER_CONTINUITY_DRIFT',
+        tier: 'DEGRADED',
+        ambiguous: false,
+        reason:
+          `Caretaker continuity ${signal.caretakerContinuityScore.toFixed(3)} below ` +
+          `threshold ${signal.caretakerContinuityThreshold.toFixed(3)} and replay ` +
+          `governance drift at ${driftRatio}x budget. Stewardship degraded on both axes.`,
+      };
+    }
+    if (!continuityOk) {
+      return {
+        kind: 'CARETAKER_CONTINUITY_DRIFT',
+        tier: 'CARETAKER',
+        ambiguous: false,
+        reason:
+          `Caretaker continuity score ${signal.caretakerContinuityScore.toFixed(3)} ` +
+          `is below threshold ${signal.caretakerContinuityThreshold.toFixed(3)}.`,
+      };
+    }
+    return {
+      kind: 'REPLAY_GOVERNANCE_DRIFT',
+      tier: 'CARETAKER',
+      ambiguous: false,
+      reason:
+        `Replay governance drift at ${driftRatio}x of budget ` +
+        `(observed ${signal.replayGovernanceDrift}, budget ${signal.replayGovernanceDriftBudget}).`,
+    };
+  }
+
+  // Governance lineage depth.
+  if (!lineageOk) {
+    return {
+      kind: 'GOVERNANCE_LINEAGE_BREAK',
+      tier: 'DEGRADED',
+      ambiguous: false,
+      reason:
+        `Governance lineage depth ${signal.governanceLineageDepth} ` +
+        `is below required target ${signal.governanceLineageTarget}. ` +
+        'Longitudinal lineage reconstruction may be incomplete.',
+    };
+  }
+
+  // Institutional runtime stability.
+  if (!stabilityOk) {
+    return {
+      kind: 'INSTITUTIONAL_STABILITY_COLLAPSE',
+      tier: 'DEGRADED',
+      ambiguous: false,
+      reason:
+        `Institutional runtime stability ${signal.institutionalRuntimeStability.toFixed(3)} ` +
+        `is below floor ${signal.institutionalStabilityFloor.toFixed(3)}.`,
+    };
+  }
+
+  // All signals healthy — but check for evidence contradiction.
+  if (evidencePresent) {
+    return {
+      kind: 'AMBIGUOUS_CARETAKER_SIGNAL',
+      tier: 'AMBIGUOUS',
+      ambiguous: true,
+      reason: `Contradiction: all scores healthy but stewardship evidence present — ${evidence}`,
+    };
+  }
+
+  return {
+    kind: null,
+    tier: 'INSTITUTIONAL',
+    ambiguous: false,
+    reason: 'All stewardship signals within bounds; caretaker continuity is active.',
+  };
+}
+
+// ── Caretaking record constructor ─────────────────────────────────────────────
+
+/**
+ * Classify a stewardship signal into a caretaking record.
+ * The record is tamper-evident and carries all lineage hints needed for
+ * longitudinal reconstruction.
+ */
+export function caretakeStewardshipShard(args: {
+  shardId: string;
+  signal: StewardshipSignal;
+  lineageHints?: Partial<StewardshipLineageHints> | null;
+}): StewardshipCaretakingRecord {
+  const { kind, tier, ambiguous, reason } = classifyStewardshipFault(args.signal);
+
+  const verdict: StewardshipVerdict = (() => {
+    if (ambiguous) return 'AMBIGUOUS_STEWARDSHIP';
+    if (kind === null && tier === 'SUCCESSION') return 'SUCCESSION_TRIGGERED';
+    if (kind === null) return 'ACTIVE';
+    if (kind === 'SUCCESSION_PROTOCOL_BREACH') return 'SUCCESSION_PENDING';
+    if (tier === 'SUCCESSION') return 'SUCCESSION_TRIGGERED';
+    if (kind === 'CARETAKER_CONTINUITY_DRIFT' || kind === 'REPLAY_GOVERNANCE_DRIFT')
+      return 'CARETAKER_CONTINUITY_BREACH';
+    if (kind === 'GOVERNANCE_LINEAGE_BREAK') return 'GOVERNANCE_LINEAGE_BREAK';
+    if (kind === 'INSTITUTIONAL_STABILITY_COLLAPSE') return 'INSTITUTIONAL_STABILITY_BREACH';
+    return 'CARETAKER_CONTINUITY_BREACH';
+  })();
+
+  return {
+    schema: SCHEMA_RECORD,
+    shardId: args.shardId,
+    verdict,
+    kind,
+    tier,
+    ambiguous,
+    reason,
+    stewardshipDigest: stewardshipDigest({ shardId: args.shardId, verdict, kind, tier, signal: args.signal }),
+    caretakedAt: new Date().toISOString(),
+    lineageHints: normalizeLineageHints(args.lineageHints),
+    caretakerContinuityScore: clampScore(args.signal.caretakerContinuityScore),
+    successionReadinessScore: clampScore(args.signal.successionReadinessScore),
+    institutionalRuntimeStability: clampScore(args.signal.institutionalRuntimeStability),
+    governanceLineageDepth: Math.max(0, Math.floor(args.signal.governanceLineageDepth ?? 0)),
+  };
+}
+
+// ── Telemetry ─────────────────────────────────────────────────────────────────
+
+/**
+ * Emit a `[stewardship-board]` telemetry line for the given record.
+ * The CI gate's "Surface stewardship board" step greps for this tag.
+ * Pure side-effect; callers decide when to invoke.
+ */
+export function emitStewardshipTelemetry(record: StewardshipCaretakingRecord): StewardshipTelemetryRecord {
+  const telemetry: StewardshipTelemetryRecord = {
+    schema: SCHEMA_TELEMETRY,
+    shardId: record.shardId,
+    caretakerContinuityPct: Math.round(record.caretakerContinuityScore * 100),
+    successionReadinessPct: Math.round(record.successionReadinessScore * 100),
+    institutionalStabilityPct: Math.round(record.institutionalRuntimeStability * 100),
+    governanceLineageDepth: record.governanceLineageDepth,
+    replayGovernanceDrift: 0,
+    verdict: record.verdict,
+    tier: record.tier,
+    ambiguous: record.ambiguous,
+    emittedAt: record.caretakedAt,
+  };
+  console.log(
+    '[stewardship-board]',
+    JSON.stringify({
+      shardId: telemetry.shardId,
+      continuityPct: telemetry.caretakerContinuityPct,
+      successionReadinessPct: telemetry.successionReadinessPct,
+      stabilityPct: telemetry.institutionalStabilityPct,
+      lineageDepth: telemetry.governanceLineageDepth,
+      verdict: telemetry.verdict,
+      tier: telemetry.tier,
+    }),
+  );
+  return telemetry;
+}
+
+// ── Boundary ──────────────────────────────────────────────────────────────────
+
+/**
+ * Aggregate caretaking records into a stewardship boundary.
+ * Exposed for composing multi-shard stewardship assessments.
+ */
+export function computeStewardshipBoundary(args: {
+  totalShards: number;
+  records: StewardshipCaretakingRecord[];
+  minPartialContinuityPct?: number;
+}): StewardshipBoundary {
+  const {
+    totalShards,
+    records,
+    minPartialContinuityPct = DEFAULT_MIN_PARTIAL_CONTINUITY_PCT,
+  } = args;
+
+  const activeCount = records.filter((r) => r.verdict === 'ACTIVE').length;
+  const continuityBreachCount = records.filter(
+    (r) => r.verdict === 'CARETAKER_CONTINUITY_BREACH',
+  ).length;
+  const successionCount = records.filter(
+    (r) => r.verdict === 'SUCCESSION_TRIGGERED' || r.verdict === 'SUCCESSION_PENDING',
+  ).length;
+  const ambiguousCount = records.filter((r) => r.verdict === 'AMBIGUOUS_STEWARDSHIP').length;
+  const lineageBreakCount = records.filter((r) => r.verdict === 'GOVERNANCE_LINEAGE_BREAK').length;
+  const stabilityBreachCount = records.filter(
+    (r) => r.verdict === 'INSTITUTIONAL_STABILITY_BREACH',
+  ).length;
+
+  const total = Math.max(1, totalShards);
+  const stewardshipContinuityRatio = activeCount / total;
+  const partialContinuityPct =
+    ((activeCount + ambiguousCount + successionCount) / total) * 100;
+  const stewardshipDriftVisibilityPct =
+    ((ambiguousCount + continuityBreachCount + successionCount) / total) * 100;
+
+  const meanInstitutionalStability =
+    records.length > 0
+      ? records.reduce((sum, r) => sum + r.institutionalRuntimeStability, 0) / records.length
+      : 1;
+  const meanSuccessionReadiness =
+    records.length > 0
+      ? records.reduce((sum, r) => sum + r.successionReadinessScore, 0) / records.length
+      : 1;
+  const minGovernanceLineageDepth =
+    records.length > 0
+      ? Math.min(...records.map((r) => r.governanceLineageDepth))
+      : 0;
+
+  const hasBreach =
+    lineageBreakCount > 0 ||
+    stabilityBreachCount > 0 ||
+    records.some((r) => r.verdict === 'SUCCESSION_PENDING');
+  const partitioned = !hasBreach && partialContinuityPct >= minPartialContinuityPct;
+
+  const boundaryReason = partitioned
+    ? `Stewardship boundary intact: ${activeCount}/${totalShards} shards active, ` +
+      `continuity ${stewardshipContinuityRatio.toFixed(3)}.`
+    : hasBreach
+      ? `Stewardship boundary breached: lineageBreaks=${lineageBreakCount}, ` +
+        `stabilityBreaches=${stabilityBreachCount}, successionPending=${successionCount > 0}.`
+      : `Partial continuity ${partialContinuityPct.toFixed(1)}% below floor ${minPartialContinuityPct}%.`;
+
+  const boundaryDigest = sha256ForPayload({
+    schema: 'vitalcv.stewardship-boundary-digest.v1',
+    totalShards,
+    activeCount,
+    continuityBreachCount,
+    successionCount,
+    ambiguousCount,
+    lineageBreakCount,
+    stabilityBreachCount,
+    partitioned,
+    minPartialContinuityPct,
+  });
+
+  return {
+    schema: SCHEMA_BOUNDARY,
+    partitioned,
+    totalShards,
+    activeCount,
+    continuityBreachCount,
+    successionCount,
+    ambiguousCount,
+    lineageBreakCount,
+    stabilityBreachCount,
+    stewardshipContinuityRatio,
+    partialContinuityPct,
+    stewardshipDriftVisibilityPct,
+    meanInstitutionalStability,
+    meanSuccessionReadiness,
+    minGovernanceLineageDepth,
+    boundaryReason,
+    boundaryDigest,
+    partitionedAt: new Date().toISOString(),
+  };
+}
+
+// ── Assertions (fail-closed) ──────────────────────────────────────────────────
+
+/**
+ * Assert that an ambiguous caretaking record was NOT coerced to ACTIVE.
+ * Throws StewardshipError(AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE) if the record
+ * is ambiguous but the verdict was silently resolved to ACTIVE.
+ */
+export function assertAmbiguityPreserved(record: StewardshipCaretakingRecord): void {
+  if (record.ambiguous && record.verdict === 'ACTIVE') {
+    throw new StewardshipError({
+      violation: 'AMBIGUOUS_STEWARDSHIP_FORCED_ACTIVE',
+      message:
+        `Stewardship ambiguity was coerced to ACTIVE for shard '${record.shardId}'. ` +
+        'Ambiguous signals must be preserved as AMBIGUOUS_STEWARDSHIP.',
+      shardId: record.shardId,
+      kind: record.kind,
+    });
+  }
+}
+
+/**
+ * Assert that a succession record is not pending with an under-threshold
+ * readiness score. Throws StewardshipError(SUCCESSION_THRESHOLD_BREACH) if
+ * succession is pending but readiness is insufficient.
+ */
+export function assertSuccessionReadiness(
+  record: StewardshipCaretakingRecord,
+  signal: StewardshipSignal,
+): void {
+  if (
+    record.verdict === 'SUCCESSION_PENDING' &&
+    signal.successionReadinessScore < signal.successionActivationThreshold
+  ) {
+    throw new StewardshipError({
+      violation: 'SUCCESSION_THRESHOLD_BREACH',
+      message:
+        `Succession pending for shard '${record.shardId}' but readiness ` +
+        `${signal.successionReadinessScore.toFixed(3)} is below activation threshold ` +
+        `${signal.successionActivationThreshold.toFixed(3)}. Fail-closed: succession blocked.`,
+      shardId: record.shardId,
+      kind: 'SUCCESSION_PROTOCOL_BREACH',
+    });
+  }
+}
+
+/**
+ * Assert that a stewardship boundary is intact — not breached and above the
+ * partial continuity floor. Throws on the first violation found.
+ */
+export function assertStewardshipBoundary(boundary: StewardshipBoundary): void {
+  if (boundary.lineageBreakCount > 0 || boundary.stabilityBreachCount > 0) {
+    throw new StewardshipError({
+      violation: 'REPLAY_GOVERNANCE_CARETAKER_OPEN_FAILURE',
+      message:
+        `Stewardship boundary breached: ${boundary.lineageBreakCount} lineage break(s), ` +
+        `${boundary.stabilityBreachCount} stability breach(es). ` +
+        'Governance caretaking is open — institutional runtime survivability at risk.',
+      partialContinuityPct: boundary.partialContinuityPct,
+    });
+  }
+
+  if (boundary.partialContinuityPct < DEFAULT_MIN_PARTIAL_CONTINUITY_PCT) {
+    throw new StewardshipError({
+      violation: 'CARETAKER_CONTINUITY_FLOOR_BREACH',
+      message:
+        `Stewardship partial continuity ${boundary.partialContinuityPct.toFixed(1)}% ` +
+        `is below the configured floor of ${DEFAULT_MIN_PARTIAL_CONTINUITY_PCT}%. ` +
+        'Operator intervention required before institutional runtime can be considered survivable.',
+      partialContinuityPct: boundary.partialContinuityPct,
+    });
+  }
+}
+
+// ── Lineage reconstruction ────────────────────────────────────────────────────
+
+/**
+ * Reconstruct the stewardship lineage graph rooted at a given shard.
+ * Shards that share a caretaker pool, replay governance shard, or succession
+ * scope with the root are considered potentially affected.
+ */
+export function traceStewardshipLineage(args: {
+  rootShardId: string;
+  rootHints: StewardshipLineageHints;
+  candidates: Array<{
+    shardId: string;
+    hints: Partial<StewardshipLineageHints>;
+  }>;
+}): StewardshipLineage {
+  const { rootShardId, rootHints, candidates } = args;
+
+  const affectedShardIds: string[] = [];
+  const edges: StewardshipLineageEdge[] = [];
+
+  for (const candidate of candidates) {
+    if (candidate.shardId === rootShardId) continue;
+
+    const hints = normalizeLineageHints(candidate.hints);
+    const reasons: StewardshipLineageEdge['reason'][] = [];
+
+    if (rootHints.caretakerPoolId !== null && hints.caretakerPoolId === rootHints.caretakerPoolId) {
+      reasons.push('SHARED_CARETAKER_POOL');
+    }
+    if (
+      rootHints.replayGovernanceShardId !== null &&
+      hints.replayGovernanceShardId === rootHints.replayGovernanceShardId
+    ) {
+      reasons.push('SHARED_REPLAY_GOVERNANCE_SHARD');
+    }
+    if (
+      rootHints.successionScopeId !== null &&
+      hints.successionScopeId === rootHints.successionScopeId
+    ) {
+      reasons.push('SHARED_SUCCESSION_SCOPE');
+    }
+
+    if (reasons.length > 0) {
+      affectedShardIds.push(candidate.shardId);
+      for (const reason of reasons) {
+        edges.push({ fromShardId: rootShardId, toShardId: candidate.shardId, reason });
+      }
+    }
+  }
+
+  const sortedAffected = [...affectedShardIds].sort();
+  const sortedEdges = [...edges].sort((a, b) => {
+    const k = `${a.fromShardId}|${a.toShardId}|${a.reason}`;
+    const l = `${b.fromShardId}|${b.toShardId}|${b.reason}`;
+    return k < l ? -1 : k > l ? 1 : 0;
+  });
+
+  const reconstructionDigest = sha256ForPayload({
+    schema: 'vitalcv.stewardship-lineage-digest.v1',
+    rootShardId,
+    affectedShardIds: sortedAffected,
+    edges: sortedEdges,
+  });
+
+  return {
+    schema: SCHEMA_LINEAGE,
+    rootShardId,
+    affectedShardIds: sortedAffected,
+    edges: sortedEdges,
+    reconstructionDigest,
+    reconstructedAt: new Date().toISOString(),
+  };
+}
+
+// ── Maturity score ────────────────────────────────────────────────────────────
+
+/**
+ * Derive a 0–100 stewardship protocol maturity score from a boundary.
+ * The score is a weighted composite of continuity, succession readiness,
+ * institutional stability, and lineage depth — for the completion board.
+ */
+export function stewardshipMaturityScore(boundary: StewardshipBoundary): {
+  maturityScore: number;
+  governanceContinuityPct: number;
+  replayFidelityPct: number;
+  successionSurvivabilityPct: number;
+  institutionalStabilityPct: number;
+} {
+  const governanceContinuityPct = Math.round(boundary.stewardshipContinuityRatio * 100);
+  const successionSurvivabilityPct = Math.round(boundary.meanSuccessionReadiness * 100);
+  const institutionalStabilityPct = Math.round(boundary.meanInstitutionalStability * 100);
+  const lineageDepthScore = Math.min(
+    100,
+    Math.round(
+      (boundary.minGovernanceLineageDepth / STEWARDSHIP_SENTINELS.GOVERNANCE_LINEAGE_MIN_DEPTH) * 100,
+    ),
+  );
+  const replayFidelityPct = Math.round(
+    (1 - boundary.stewardshipDriftVisibilityPct / 100) * 100,
+  );
+
+  const maturityScore = Math.round(
+    governanceContinuityPct * 0.30 +
+    replayFidelityPct * 0.25 +
+    successionSurvivabilityPct * 0.20 +
+    institutionalStabilityPct * 0.15 +
+    lineageDepthScore * 0.10,
+  );
+
+  return {
+    maturityScore: Math.max(0, Math.min(100, maturityScore)),
+    governanceContinuityPct,
+    replayFidelityPct,
+    successionSurvivabilityPct,
+    institutionalStabilityPct,
+  };
+}


### PR DESCRIPTION
## Summary
- New pure-transform module `governanceStewardship.ts` formalizing longitudinal governance stewardship for constitutional runtime continuity (companion to `governanceRuntimeHardening.ts`)
- Caretaker continuity classifier with 7-verdict / 6-kind / 5-tier fail-closed taxonomy; ambiguity always preserved as `AMBIGUOUS_STEWARDSHIP`, never coerced to `ACTIVE`
- Succession protocol is fail-closed: `SUCCESSION_PENDING` raised when readiness below threshold, `SUCCESSION_TRIGGERED` only when confirmed; `assertSuccessionReadiness` throws `SUCCESSION_THRESHOLD_BREACH` on bypass
- Stewardship telemetry: `emitStewardshipTelemetry` emits `[stewardship-board]` log lines for CI board surfacing; `stewardshipMaturityScore` derives 5-axis completion-board composite
- Lineage reconstruction: `traceStewardshipLineage` produces order-independent, tamper-evident `reconstructionDigest` across caretaker pool / replay governance shard / succession scope axes

## Truth rules
- No verified-profile claims, no compliance certification, no guaranteed continuity assertion
- Module is pure transforms: no fetches, no DB writes, no audit-event writes
- Banned strings absent (CLEAN scan)

## Validation
- Unit tests: 38/38 passing (`governanceStewardship.test.ts`)
- CI gate (frozen-enum canary): 13/13 passing (`governanceStewardship.ci.gate.test.ts`)
- Chaos suite (8 modes): 9/9 passing (`governanceStewardship.chaos.test.ts`)
- Total: 60/60 tests passing
- Truth scan: CLEAN
- Diff scope: `governanceStewardship.ts`, 3 test files, `governance-stewardship-gate.yml` only

## Completion Board
- Governance Continuity %: measurable via `stewardshipContinuityRatio` × 100
- Replay Stewardship Fidelity %: `replayFidelityPct` from `stewardshipMaturityScore`
- Succession Survivability %: `successionSurvivabilityPct` from `stewardshipMaturityScore`
- Institutional Runtime Stability %: `institutionalStabilityPct` from `stewardshipMaturityScore`
- Stewardship Protocol Maturity %: `maturityScore` from `stewardshipMaturityScore`