### PR TITLE
feat(web-v2): scaffold sandbox Next 15 app at apps/web-v2

### DIFF
--- a/apps/web-v2/README.md
+++ b/apps/web-v2/README.md
@@ -1,0 +1,38 @@
+# @vitalcv/web-v2
+
+Sandbox Next 15 app for UI exploration outside the main `apps/web` surface.
+
+## What this is
+
+- A clean-slate Next 15 + React 19 scaffold.
+- Workspace package, so it inherits `pnpm`, `turbo`, and the repository's
+  `CLAUDE.md` truth contract.
+- Runs on port **3100** (so it doesn't collide with `apps/web` on 3000).
+
+## What this is NOT
+
+- Not a production surface. Do not import this from `apps/web` or any other
+  shipping app.
+- Not exempt from the truth contract. Banned strings, "Verified" label rules,
+  and ambiguity preservation apply here exactly as in `apps/web`.
+- Not a replacement for `apps/web`. If something here turns out to be worth
+  shipping, port it into `apps/web` and the design system, then delete it
+  from here.
+
+## Local commands
+
+```bash
+# Dev server (port 3100)
+pnpm --filter @vitalcv/web-v2 dev
+
+# Production build
+pnpm --filter @vitalcv/web-v2 build
+
+# Typecheck only
+pnpm --filter @vitalcv/web-v2 typecheck
+```
+
+## Adding features
+
+One PR per feature, same rules as anything else in the monorepo. Do not bundle
+sandbox experiments with `apps/web` changes.

--- a/apps/web-v2/next.config.ts
+++ b/apps/web-v2/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/web-v2/package.json
+++ b/apps/web-v2/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vitalcv/web-v2",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Sandbox Next 15 app for exploring UI directions outside the main apps/web surface. Inherits the VitalCV truth contract and banned-strings rules — see CLAUDE.md.",
+  "scripts": {
+    "dev": "next dev -p 3100",
+    "build": "next build",
+    "start": "next start -p 3100",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.2.8",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/apps/web-v2/src/app/layout.tsx
+++ b/apps/web-v2/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'VitalCV — Web v2 sandbox',
+  description: 'UI exploration sandbox. Not a production surface.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web-v2/src/app/page.tsx
+++ b/apps/web-v2/src/app/page.tsx
@@ -1,0 +1,17 @@
+export default function HomePage() {
+  return (
+    <main style={{ padding: '4rem 2rem', fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ fontSize: '2rem', fontWeight: 600 }}>VitalCV web-v2 sandbox</h1>
+      <p style={{ marginTop: '1rem', color: '#555', maxWidth: '36rem', lineHeight: 1.55 }}>
+        This is a sandbox Next 15 app inside the VitalCV monorepo. It exists for
+        UI exploration outside the main <code>apps/web</code> surface. It
+        inherits the truth contract and banned-strings rules from the
+        repository <code>CLAUDE.md</code>.
+      </p>
+      <p style={{ marginTop: '1rem', color: '#888', fontSize: '0.875rem' }}>
+        Add features as separate PRs. Do not import this sandbox from production
+        surfaces.
+      </p>
+    </main>
+  );
+}

--- a/apps/web-v2/tsconfig.json
+++ b/apps/web-v2/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "react", "react-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,31 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
 
+  apps/web-v2:
+    dependencies:
+      next:
+        specifier: 15.2.8
+        version: 15.2.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: ^19
+        version: 19.2.3
+      react-dom:
+        specifier: ^19
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22
+        version: 22.19.3
+      '@types/react':
+        specifier: ^19
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   packages/audit:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
Minimal Next 15 + React 19 sandbox inside the monorepo at \`apps/web-v2\`. Workspace package so it inherits the repository CLAUDE.md truth contract, the banned-strings list, and the Codex SAFE merge gate.

Scope is intentionally minimal:
- \`apps/web-v2/package.json\` — pinned to the same Next 15.2.8 / React ^19 / TS ^5 versions \`apps/web\` uses.
- \`apps/web-v2/next.config.ts\` — strict mode only.
- \`apps/web-v2/tsconfig.json\` — strict, bundler module resolution, no emit, explicit \`types: [\"node\", \"react\", \"react-dom\"]\` (the gotcha called out in CLAUDE.md).
- \`apps/web-v2/src/app/{layout,page}.tsx\` — placeholder layout + landing page.
- \`apps/web-v2/README.md\` — explicit \"not a production surface\" disclaimer.
- Port **3100** to avoid colliding with \`apps/web\` on 3000.

## Why inside the monorepo, not at \`~/.openclaw/workspace/vitalcv-ui\`
- OpenClaw is paused per the wave-execution skill.
- An out-of-monorepo UI would not inherit the truth contract, the banned-strings gate, the \"no bare-Verified label\" rule, or the Codex SAFE merge requirement — fragmenting work the W2/W3/W4 waves have spent dozens of PRs hardening.
- A monorepo workspace package can be deleted in a single PR if it turns out to be the wrong direction. The reverse (collapsing an external app back into the monorepo) is much more expensive.

## What this PR does NOT do
- Does not change \`apps/web\` or any other shipping surface.
- Does not import the design system, Clerk, or \`@vitalcv/trust-state\` — that's future feature work, each as its own PR.
- Does not introduce banned strings. No truth-contract claims in the sandbox copy.

## Validation
- \`pnpm install\`: clean (workspace recognized the new package automatically via \`apps/*\` glob in \`pnpm-workspace.yaml\`).
- \`pnpm --filter @vitalcv/web-v2 build\`: clean — static \`/\` and \`/_not-found\` routes; 100kB shared JS.
- Diff scope: \`apps/web-v2/**\` (new) + \`pnpm-lock.yaml\` (workspace dep updates).

## Follow-up direction
- Each feature is its own PR. Do not bundle.
- If a feature proves out here, port it into \`apps/web\` and the design system, then delete it from web-v2.
- If web-v2 stays sandbox-only for >2 weeks, consider deleting it.