### PR TITLE
feat(web-v2): W5-PR256A real Clerk sign-in for web-v2 sandbox

### DIFF
--- a/apps/web-v2/README.md
+++ b/apps/web-v2/README.md
@@ -32,6 +32,34 @@ pnpm --filter @vitalcv/web-v2 build
 pnpm --filter @vitalcv/web-v2 typecheck
 ```
 
+## Auth (Clerk)
+
+This sandbox uses [Clerk](https://clerk.com) for authentication, mirroring the
+pattern in `apps/web`. Required env vars (set in `.env.local`, gitignored):
+
+```
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_... | pk_live_...
+CLERK_SECRET_KEY=sk_test_... | sk_live_...
+```
+
+Optional overrides:
+
+```
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
+```
+
+**Fail-closed behavior:** When `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is missing,
+`<ClerkProvider>` is not mounted; the middleware short-circuits to a no-op
+pass-through; `/sign-in` renders an explicit "not configured" message. The
+sandbox stays usable for non-auth UI work rather than crashing.
+
+**Google OAuth** (or any other IdP) is configured inside the Clerk Dashboard,
+not in this repo. The mounted `<SignIn />` widget honors whatever providers
+are enabled on the Clerk instance.
+
 ## Adding features
 
 One PR per feature, same rules as anything else in the monorepo. Do not bundle

--- a/apps/web-v2/package.json
+++ b/apps/web-v2/package.json
@@ -8,9 +8,11 @@
     "build": "next build",
     "start": "next start -p 3100",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@clerk/nextjs": "^6.37.3",
     "next": "15.2.8",
     "react": "^19",
     "react-dom": "^19"
@@ -19,6 +21,7 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.0"
   }
 }

--- a/apps/web-v2/src/__tests__/auth-fail-closed.test.ts
+++ b/apps/web-v2/src/__tests__/auth-fail-closed.test.ts
@@ -1,0 +1,128 @@
+/**
+ * W5-PR256A — web-v2 auth fail-closed lockdown.
+ *
+ * Source-level invariants on the Clerk wiring:
+ *   - clerkConfig derives CLERK_PROVIDER_ENABLED from the publishable
+ *     key (never hardcoded true).
+ *   - layout.tsx mounts ClerkProvider ONLY when CLERK_PROVIDER_ENABLED.
+ *   - middleware.ts short-circuits to a no-op when CLERK_SECRET_KEY
+ *     is absent (sandbox stays usable instead of crashing).
+ *   - sign-in page renders an explicit "not configured" message when
+ *     the publishable key is missing — never a broken widget.
+ *
+ * These are deliberately source-text assertions (the runtime tests
+ * would need a Next bootstrap). The PR's CI surface is `pnpm
+ * --filter @vitalcv/web-v2 build`, which compiles all four files
+ * end-to-end; this test pins the truth-contract shape that lets the
+ * build mean what we claim it means.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '..');
+
+const CLERK_CONFIG_SRC = readFileSync(resolve(ROOT, 'lib/auth/clerkConfig.ts'), 'utf8');
+const LAYOUT_SRC = readFileSync(resolve(ROOT, 'app/layout.tsx'), 'utf8');
+const MIDDLEWARE_SRC = readFileSync(resolve(ROOT, 'middleware.ts'), 'utf8');
+const SIGN_IN_SRC = readFileSync(
+  resolve(ROOT, 'app/sign-in/[[...sign-in]]/page.tsx'),
+  'utf8',
+);
+const README = readFileSync(resolve(ROOT, '../README.md'), 'utf8');
+
+describe('W5-PR256A — clerkConfig fail-closed derivation', () => {
+  it('CLERK_PROVIDER_ENABLED derives from publishable key, never hardcoded true', () => {
+    expect(CLERK_CONFIG_SRC).toMatch(
+      /CLERK_ENABLED\s*=\s*Boolean\(\s*process\.env\.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY\s*,?\s*\)/,
+    );
+    expect(CLERK_CONFIG_SRC).toMatch(/CLERK_PROVIDER_ENABLED\s*=\s*CLERK_ENABLED/);
+    expect(CLERK_CONFIG_SRC).not.toMatch(/CLERK_PROVIDER_ENABLED\s*=\s*true/);
+  });
+
+  it('CLERK_PRODUCTION_MODE derives from pk_live_ prefix, never hardcoded', () => {
+    expect(CLERK_CONFIG_SRC).toContain("startsWith('pk_live_')");
+    expect(CLERK_CONFIG_SRC).not.toMatch(/CLERK_PRODUCTION_MODE\s*=\s*true/);
+  });
+});
+
+describe('W5-PR256A — layout.tsx fail-closed ClerkProvider mount', () => {
+  it('imports CLERK_PROVIDER_ENABLED from local clerkConfig', () => {
+    expect(LAYOUT_SRC).toContain("from '@/lib/auth/clerkConfig'");
+    expect(LAYOUT_SRC).toContain('CLERK_PROVIDER_ENABLED');
+  });
+
+  it('does not wrap with ClerkProvider when CLERK_PROVIDER_ENABLED is false', () => {
+    // The control-flow shape: early-return the unwrapped tree.
+    expect(LAYOUT_SRC).toMatch(/if\s*\(!\s*CLERK_PROVIDER_ENABLED\)/);
+  });
+
+  it('imports ClerkProvider from @clerk/nextjs (real, not mock)', () => {
+    expect(LAYOUT_SRC).toContain("from '@clerk/nextjs'");
+    expect(LAYOUT_SRC).toContain('ClerkProvider');
+  });
+});
+
+describe('W5-PR256A — middleware.ts fail-closed pass-through', () => {
+  it('short-circuits to NextResponse.next() when CLERK_SECRET_KEY is absent', () => {
+    expect(MIDDLEWARE_SRC).toMatch(
+      /CLERK_MIDDLEWARE_ENABLED\s*=\s*Boolean\(\s*process\.env\.CLERK_SECRET_KEY\s*\)/,
+    );
+    expect(MIDDLEWARE_SRC).toMatch(/if\s*\(!\s*CLERK_MIDDLEWARE_ENABLED\)/);
+  });
+
+  it('uses real clerkMiddleware from @clerk/nextjs/server', () => {
+    expect(MIDDLEWARE_SRC).toContain("from '@clerk/nextjs/server'");
+    expect(MIDDLEWARE_SRC).toContain('clerkMiddleware');
+  });
+
+  it('redirects unauthenticated requests to /sign-in', () => {
+    expect(MIDDLEWARE_SRC).toContain('/sign-in');
+    expect(MIDDLEWARE_SRC).toContain('NextResponse.redirect');
+  });
+
+  it('keeps /sign-in itself public', () => {
+    expect(MIDDLEWARE_SRC).toMatch(/createRouteMatcher\(\[\s*['"]\/sign-in/);
+  });
+});
+
+describe('W5-PR256A — sign-in page truth-contract', () => {
+  it('renders explicit not-configured message when key absent', () => {
+    expect(SIGN_IN_SRC).toContain('Sign-in is not configured');
+    expect(SIGN_IN_SRC).toContain('CLERK_PROVIDER_ENABLED');
+  });
+
+  it('mounts the real Clerk <SignIn /> widget when configured', () => {
+    expect(SIGN_IN_SRC).toContain("import { SignIn } from '@clerk/nextjs'");
+    expect(SIGN_IN_SRC).toMatch(/<SignIn\s*\/>/);
+  });
+
+  it('does not silently render a broken widget', () => {
+    // The not-configured branch returns the explainer element, not
+    // null and not an empty fragment.
+    expect(SIGN_IN_SRC).toMatch(/data-testid="sign-in-not-configured"/);
+  });
+});
+
+describe('W5-PR256A — banned-strings scan on auth surface', () => {
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['complete', 'credentialing'].join(' '),
+    ['instant', 'credentialing'].join(' '),
+    ['legally', 'accepted'].join(' '),
+    ['risk', 'transferred'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  const surfaces = [CLERK_CONFIG_SRC, LAYOUT_SRC, MIDDLEWARE_SRC, SIGN_IN_SRC, README];
+  for (const phrase of BANNED) {
+    for (let i = 0; i < surfaces.length; i++) {
+      it(`surface[${i}] does not contain banned phrase: ${phrase}`, () => {
+        expect(surfaces[i]).not.toContain(phrase);
+      });
+    }
+  }
+});

--- a/apps/web-v2/src/app/layout.tsx
+++ b/apps/web-v2/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { ClerkProvider } from '@clerk/nextjs';
+import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
 
 export const metadata: Metadata = {
   title: 'VitalCV — Web v2 sandbox',
@@ -7,9 +9,14 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
+  const body = (
     <html lang="en">
       <body>{children}</body>
     </html>
   );
+  // When Clerk is not configured (no publishable key in env), render
+  // the tree unwrapped. The middleware is also a no-op in that case
+  // so the sandbox stays usable for non-auth UI exploration.
+  if (!CLERK_PROVIDER_ENABLED) return body;
+  return <ClerkProvider>{body}</ClerkProvider>;
 }

--- a/apps/web-v2/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web-v2/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,53 @@
+import { SignIn } from '@clerk/nextjs';
+import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
+
+/**
+ * /sign-in — real Clerk-hosted sign-in surface for web-v2.
+ *
+ * When Clerk env keys are absent, renders an explicit "not configured"
+ * message instead of a broken widget. This makes the auth state
+ * legible at the URL surface rather than silently failing.
+ *
+ * Google OAuth (or any other IdP) is configured *inside the Clerk
+ * Dashboard*, not here — this page just mounts the <SignIn /> widget
+ * which honors whatever providers are enabled on the Clerk instance.
+ */
+
+export default function SignInPage() {
+  if (!CLERK_PROVIDER_ENABLED) {
+    return (
+      <main
+        style={{
+          padding: '4rem 2rem',
+          fontFamily: 'system-ui, sans-serif',
+          maxWidth: '36rem',
+          margin: '0 auto',
+        }}
+        data-testid="sign-in-not-configured"
+      >
+        <h1 style={{ fontSize: '1.5rem', fontWeight: 600 }}>
+          Sign-in is not configured
+        </h1>
+        <p style={{ marginTop: '1rem', color: '#555', lineHeight: 1.55 }}>
+          The <code>NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY</code> environment
+          variable is not set. The sandbox runs without authentication
+          until Clerk env vars are configured. See <code>apps/web-v2/README.md</code>.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      style={{
+        display: 'flex',
+        minHeight: '100vh',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+      }}
+    >
+      <SignIn />
+    </main>
+  );
+}

--- a/apps/web-v2/src/lib/auth/clerkConfig.ts
+++ b/apps/web-v2/src/lib/auth/clerkConfig.ts
@@ -1,0 +1,35 @@
+/**
+ * Web-v2 Clerk configuration — mirrors apps/web/lib/auth/clerkConfig.ts.
+ *
+ * Centralizes Clerk env-var reads. All auth logic in web-v2 should
+ * import from here rather than touching process.env directly.
+ *
+ * Truth contract:
+ *   - CLERK_PROVIDER_ENABLED is derived from the presence of the
+ *     publishable key. When the key is absent, ClerkProvider is NOT
+ *     mounted and protected routes are NOT gated by Clerk — the app
+ *     degrades to an unauthenticated sandbox rather than crashing.
+ *   - Production-mode is derived from the pk_live_ prefix; never
+ *     asserted independently.
+ */
+
+export const CLERK_ENABLED = Boolean(
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+);
+
+export const CLERK_PROVIDER_ENABLED = CLERK_ENABLED;
+
+export const CLERK_PRODUCTION_MODE =
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.startsWith('pk_live_') ?? false;
+
+export const CLERK_SIGN_IN_URL =
+  process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL ?? '/sign-in';
+
+export const CLERK_SIGN_UP_URL =
+  process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL ?? '/sign-up';
+
+export const CLERK_AFTER_SIGN_IN_URL =
+  process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL ?? '/';
+
+export const CLERK_AFTER_SIGN_UP_URL =
+  process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL ?? '/';

--- a/apps/web-v2/src/middleware.ts
+++ b/apps/web-v2/src/middleware.ts
@@ -1,0 +1,49 @@
+/**
+ * Web-v2 middleware — sandbox auth gate.
+ *
+ * Mirrors the apps/web middleware pattern but with a smaller surface:
+ * only /sign-in is public; everything else requires a Clerk session.
+ *
+ * If CLERK_SECRET_KEY is absent, the middleware is a no-op pass-through
+ * — the sandbox runs unauthenticated rather than crashing. This is
+ * the fail-closed-toward-development direction documented in CLAUDE.md
+ * for the main app.
+ */
+
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import type { NextFetchEvent, NextRequest } from 'next/server';
+
+const CLERK_MIDDLEWARE_ENABLED = Boolean(process.env.CLERK_SECRET_KEY);
+
+const isPublicRoute = createRouteMatcher([
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/_next(.*)',
+  '/favicon.ico',
+]);
+
+const clerkHandler = clerkMiddleware(async (auth, req) => {
+  if (isPublicRoute(req)) {
+    return NextResponse.next();
+  }
+  const session = await auth();
+  if (!session.userId) {
+    const signInUrl = req.nextUrl.clone();
+    signInUrl.pathname = '/sign-in';
+    signInUrl.searchParams.set('redirect_url', req.nextUrl.pathname);
+    return NextResponse.redirect(signInUrl);
+  }
+  return NextResponse.next();
+});
+
+export default async function middleware(req: NextRequest, event: NextFetchEvent) {
+  if (!CLERK_MIDDLEWARE_ENABLED) {
+    return NextResponse.next();
+  }
+  return clerkHandler(req, event);
+}
+
+export const config = {
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
 
   apps/web-v2:
     dependencies:
+      '@clerk/nextjs':
+        specifier: ^6.37.3
+        version: 6.37.3(next@15.2.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 15.2.8
         version: 15.2.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -910,6 +913,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
 
   packages/audit:
     devDependencies:
@@ -5466,6 +5472,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}


### PR DESCRIPTION
## Summary
Stacked on **#308** (web-v2 scaffold). Adds \`@clerk/nextjs@^6.37.3\` (version-matched to \`apps/web\`) as a dependency of \`@vitalcv/web-v2\` only — root and \`apps/web\` are not modified. Mirrors the apps/web fail-closed Clerk pattern.

Consolidates these queued briefs into one shippable bucket: AUTH-1 PR265A (replace mock sign-in) and W5-PR256A (real sign-in flow) describe the same scope. No mock sign-in was present to replace — web-v2 had no auth before this PR; the patterns being asserted (no \`vcv_mock_jwt\`, no \`setTimeout(800)\`, etc.) were already clean.

## Changes
- \`apps/web-v2/src/lib/auth/clerkConfig.ts\` — mirrors \`apps/web/lib/auth/clerkConfig.ts\`. \`CLERK_PROVIDER_ENABLED\` derived from publishable key, never hardcoded.
- \`apps/web-v2/src/middleware.ts\` — \`clerkMiddleware\` with redirect to \`/sign-in\` for unauthenticated requests. Short-circuits to a no-op pass-through when \`CLERK_SECRET_KEY\` is absent so the sandbox stays usable for non-auth UI work.
- \`apps/web-v2/src/app/layout.tsx\` — \`<ClerkProvider>\` conditional on \`CLERK_PROVIDER_ENABLED\` (mirrors \`apps/web/app/layout.tsx\`).
- \`apps/web-v2/src/app/sign-in/[[...sign-in]]/page.tsx\` — real \`<SignIn />\` widget when configured; explicit "Sign-in is not configured" message when the publishable key is absent (never a silently broken widget).
- \`apps/web-v2/README.md\` — documents required env vars + fail-closed semantics + Google-OAuth-in-dashboard guidance.
- \`apps/web-v2/src/__tests__/auth-fail-closed.test.ts\` — 57-test source-level lockdown.
- \`apps/web-v2/package.json\` — adds \`@clerk/nextjs\` dependency + \`vitest\` devDep + \`test\` script.

## Truth-contract invariants enforced
- \`CLERK_PROVIDER_ENABLED\` is never hardcoded true.
- \`CLERK_PRODUCTION_MODE\` is never hardcoded true (derived from \`pk_live_\` prefix only).
- \`layout.tsx\` returns the unwrapped tree when \`CLERK_PROVIDER_ENABLED\` is false.
- \`middleware.ts\` short-circuits to \`NextResponse.next()\` when \`CLERK_SECRET_KEY\` is absent.
- Sign-in page renders an explicit not-configured message instead of a broken widget.
- Banned-strings scan over the entire auth surface: clean.

## What this PR does NOT do
- Does not touch \`apps/web\` or the root \`package.json\`.
- Does not configure Google OAuth itself — that lives in the Clerk Dashboard. The \`<SignIn />\` widget honors whatever providers are enabled there.
- Does not export sandbox routes from production surfaces (still isolated per the scaffold README).

## Required env vars (set in \`.env.local\`, gitignored)
\`\`\`
NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_... | pk_live_...
CLERK_SECRET_KEY=sk_test_... | sk_live_...
\`\`\`

## Validation
- Targeted tests: 57/57 (\`pnpm --filter @vitalcv/web-v2 test\`).
- Build: clean (\`pnpm --filter @vitalcv/web-v2 build\`). Routes: \`/\`, \`/_not-found\`, \`/sign-in/[[...sign-in]]\`. Middleware: 84.1 kB.
- Diff scope: \`apps/web-v2/**\` only + \`pnpm-lock.yaml\`.

## Real Sign-In Board (post-merge target)
| Metric | Before | After |
|---|---|---|
| OAuth Viability % | 0 (no auth in web-v2) | ~70 (widget mounted; IdP config in Clerk Dashboard) |
| Session Persistence % | 0 | ~70 (Clerk handles) |
| Identity Attribution % | 0 | ~65 (auth() in middleware) |
| Replay Continuity % | 0 | ~30 (no replay-lineage wiring yet — that's W4-PR249A territory) |
| Sign-In Maturity % | 0 | ~60 |

Board moves only on merge per BOARD-SCHEMA-3.