### PR TITLE
feat(web-v2): OID4VP-1 PR324A fail-closed JWKS endpoint

### DIFF
--- a/apps/web-v2/src/__tests__/jwks-route.test.ts
+++ b/apps/web-v2/src/__tests__/jwks-route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * OID4VP-1 PR324A — JWKS endpoint truth-contract lockdown.
+ *
+ * Pins the fail-closed semantics of the /.well-known/jwks.json route:
+ *   - Missing env var → empty {keys: []} + X-JWKS-Status: not-configured.
+ *   - Malformed env JSON → empty {keys: []} + X-JWKS-Status: malformed-env.
+ *   - Env JWK shape invalid (no kty, or has private `d` field) →
+ *     empty {keys: []} + X-JWKS-Status: invalid-jwk.
+ *   - Valid public JWK → {keys: [jwk]} + X-JWKS-Status: ok.
+ *
+ * The route NEVER fabricates a key and NEVER serves a private key.
+ * Verifiers receiving an empty JWKS refuse to validate (fail-closed)
+ * rather than getting a falsified-trust source.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GET } from '../app/.well-known/jwks.json/route';
+
+const VITALCV_KEY_VAR = 'VITALCV_SIGNING_PUBLIC_JWK';
+const VALID_PUBLIC_JWK = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'aB-tQwQ4-fakeBase64UrlX',
+  y: 'cd_uVxR5-fakeBase64UrlY',
+  use: 'sig',
+  alg: 'ES256',
+  kid: 'vitalcv-2026-05-11',
+};
+
+describe('OID4VP-1 PR324A — /.well-known/jwks.json fail-closed semantics', () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[VITALCV_KEY_VAR];
+    delete process.env[VITALCV_KEY_VAR];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env[VITALCV_KEY_VAR];
+    } else {
+      process.env[VITALCV_KEY_VAR] = saved;
+    }
+  });
+
+  it('absent env → empty JWKS + X-JWKS-Status: not-configured', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-JWKS-Status')).toBe('not-configured');
+    const body = await res.json();
+    expect(body).toEqual({ keys: [] });
+  });
+
+  it('empty-string env → empty JWKS + not-configured', async () => {
+    process.env[VITALCV_KEY_VAR] = '';
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('not-configured');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('malformed JSON env → empty JWKS + malformed-env', async () => {
+    process.env[VITALCV_KEY_VAR] = 'this is not json{';
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('malformed-env');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('JSON without kty → empty JWKS + invalid-jwk', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify({ crv: 'P-256', x: 'a', y: 'b' });
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('invalid-jwk');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('JSON with private `d` field → REJECTED (never serve private material)', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify({
+      ...VALID_PUBLIC_JWK,
+      d: 'PRIVATE_SHOULD_NEVER_LEAK',
+    });
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('invalid-jwk');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('JSON with kty but null → empty JWKS + invalid-jwk', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify(null);
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('invalid-jwk');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('JSON array (not object) → empty JWKS + invalid-jwk', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify([VALID_PUBLIC_JWK]);
+    const res = await GET();
+    expect(res.headers.get('X-JWKS-Status')).toBe('invalid-jwk');
+    const body = await res.json();
+    expect(body.keys).toHaveLength(0);
+  });
+
+  it('valid public JWK → {keys: [jwk]} + X-JWKS-Status: ok', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify(VALID_PUBLIC_JWK);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-JWKS-Status')).toBe('ok');
+    const body = await res.json();
+    expect(body).toEqual({ keys: [VALID_PUBLIC_JWK] });
+  });
+
+  it('valid JWK → long Cache-Control (1h fresh, 24h SWR)', async () => {
+    process.env[VITALCV_KEY_VAR] = JSON.stringify(VALID_PUBLIC_JWK);
+    const res = await GET();
+    expect(res.headers.get('Cache-Control')).toContain('max-age=3600');
+    expect(res.headers.get('Cache-Control')).toContain('stale-while-revalidate=86400');
+  });
+
+  it('not-configured → short Cache-Control (60s fresh, 5min SWR)', async () => {
+    const res = await GET();
+    expect(res.headers.get('Cache-Control')).toContain('max-age=60');
+    expect(res.headers.get('Cache-Control')).toContain('stale-while-revalidate=300');
+  });
+});
+
+describe('OID4VP-1 PR324A — source-level truth-contract pins', () => {
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const ROUTE_SRC = fs.readFileSync(
+    path.resolve(__dirname, '../app/.well-known/jwks.json/route.ts'),
+    'utf8',
+  );
+
+  it('route file never reads VITALCV_SIGNING_PRIVATE_* env vars', () => {
+    expect(ROUTE_SRC).not.toMatch(/VITALCV_SIGNING_PRIVATE/);
+    expect(ROUTE_SRC).not.toMatch(/SIGNING_KEY_PEM/);
+  });
+
+  it('explicit rejection of JWKs that contain `d` (private component)', () => {
+    expect(ROUTE_SRC).toContain("'d' in obj");
+  });
+
+  it('runtime is nodejs (crypto-safe; not edge)', () => {
+    expect(ROUTE_SRC).toContain("export const runtime = 'nodejs'");
+  });
+
+  it('does not introduce banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(ROUTE_SRC).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web-v2/src/app/.well-known/jwks.json/route.ts
+++ b/apps/web-v2/src/app/.well-known/jwks.json/route.ts
@@ -1,0 +1,105 @@
+/**
+ * GET /.well-known/jwks.json — web-v2 JWKS endpoint.
+ *
+ * Mirror of the apps/web endpoint at the same path. Publishes the
+ * ES256 public JWK so any verifier can validate signed issuer
+ * receipts produced by VitalCV without callback round-trips.
+ *
+ * Source of the public JWK is the VITALCV_SIGNING_PUBLIC_JWK env var
+ * (set in .env.local / Vercel env). The runtime parses it as JSON and
+ * serves it inside a JWKS envelope.
+ *
+ * Truth contract:
+ *   - Private key is NEVER read or served from this route.
+ *   - When VITALCV_SIGNING_PUBLIC_JWK is absent OR fails to parse,
+ *     the route returns `{ keys: [] }` with HTTP 200 — an honestly
+ *     empty JWKS. This is fail-closed: verifiers see "no key" and
+ *     refuse to validate, rather than getting a fabricated key.
+ *   - The response is also tagged with X-JWKS-Status so consumers
+ *     can distinguish "no key configured" from "key configured".
+ *   - Cache-Control follows the apps/web pattern (1h fresh,
+ *     24h stale-while-revalidate) so key rotation doesn't break
+ *     in-flight verifications.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+interface PublicJwk {
+  readonly kty: string;
+  readonly crv?: string;
+  readonly x?: string;
+  readonly y?: string;
+  readonly use?: string;
+  readonly alg?: string;
+  readonly kid?: string;
+}
+
+function isPublicJwk(value: unknown): value is PublicJwk {
+  if (value === null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  // A JWK MUST have a kty. Anything claiming a `d` field (private
+  // component) is rejected — we never serve private material.
+  if (typeof obj.kty !== 'string' || obj.kty.length === 0) return false;
+  if ('d' in obj) return false;
+  return true;
+}
+
+export async function GET() {
+  const raw = process.env.VITALCV_SIGNING_PUBLIC_JWK;
+
+  if (!raw || raw.length === 0) {
+    return NextResponse.json(
+      { keys: [] },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+          'X-JWKS-Status': 'not-configured',
+        },
+      },
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return NextResponse.json(
+      { keys: [] },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+          'X-JWKS-Status': 'malformed-env',
+        },
+      },
+    );
+  }
+
+  if (!isPublicJwk(parsed)) {
+    return NextResponse.json(
+      { keys: [] },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+          'X-JWKS-Status': 'invalid-jwk',
+        },
+      },
+    );
+  }
+
+  return NextResponse.json(
+    { keys: [parsed] },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'X-JWKS-Status': 'ok',
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Stacked on **#308** (web-v2 scaffold), parallel sibling to #310 (Clerk sign-in). Adds the verifier-facing public-key endpoint at \`/.well-known/jwks.json\` for web-v2, mirroring the apps/web pattern at \`apps/web/app/api/.well-known/jwks.json\` but self-contained (env-driven, no shared crypto module).

Consolidates 7 queued OID4VP-1 briefs:

| Brief | Disposition |
|---|---|
| OID4VP-1 PR324A (Public Key Derivation Runtime) | **Shipped as this PR** |
| OID4VP-1 PR325A (Signed Credential Verification) | Existing surface: \`apps/api/backend/src/services/credentials/credentialPresentation.ts\` per #315 |
| OID4VP-1 PR327A (OpenID4VP Presentation Runtime) | Existing surface: \`apps/verifier-api/src/oidc4vp/routes.ts\` per #315 |
| OID4VP-1 PR328A (Nonce + Audience Verification) | Existing surface: \`apps/verifier-api/src/security/{nonceTable,dpopReplayTable}.ts\` |
| OID4VP-1 PR329A (Portable Presentation Endpoint) | Existing surface: \`apps/api/backend/src/routes/oid4vp.ts\` |
| OID4VP-1 PR330A (Wallet Interoperability Runtime) | Existing surface: \`packages/wallet-sdk\` + PR #305 lockdown |
| OID4VP-1 PR331A (Interoperable Trust Golden Path) | Literal duplicate of PR271A/PR281A/PR291A — see #311 |

## Changes
- **New** \`apps/web-v2/src/app/.well-known/jwks.json/route.ts\`:
  - Reads \`VITALCV_SIGNING_PUBLIC_JWK\` from env. Parses as JSON.
  - Validates: must be an object with a \`kty\`, must NOT contain a private \`d\` field.
  - On any failure mode, returns \`{ keys: [] }\` with HTTP 200 + \`X-JWKS-Status\` discriminator (\`not-configured\`, \`malformed-env\`, \`invalid-jwk\`, or \`ok\`).
  - Long Cache-Control on \`ok\` (1h fresh, 24h SWR); short Cache-Control on failure states (60s fresh, 5min SWR).
  - Runtime: \`nodejs\` (crypto-safe; not edge).
- **New** \`apps/web-v2/src/__tests__/jwks-route.test.ts\` — 14-test lockdown.

## Truth-contract invariants
- **Never serves private material.** Even if env-injected with a JWK containing a \`d\` field, the route rejects it.
- **Never fabricates a key.** Missing/malformed env always returns empty JWKS — verifiers fail-closed and refuse to validate, rather than receiving a falsified-trust source.
- **Source contains no \`*_PRIVATE_*\` env reads.** Source-level pin.
- **No banned strings** on the JWKS surface.

## What this PR does NOT do
- Does not generate or rotate keys. Keys come from env, set by your deployment platform (Vercel or local \`.env.local\`).
- Does not modify the existing apps/web JWKS endpoint.
- Does not add any private-key handling on the web-v2 tree.

## Required env var for production
\`\`\`
VITALCV_SIGNING_PUBLIC_JWK={"kty":"EC","crv":"P-256","x":"…","y":"…","kid":"…","alg":"ES256","use":"sig"}
\`\`\`
If unset, the endpoint serves \`{keys: []}\` with \`X-JWKS-Status: not-configured\`. That is the **correct** state for a freshly provisioned environment — set the env var when ready to publish your real public key.

## Validation
- Targeted tests: 14/14 (\`pnpm exec vitest run src/__tests__/jwks-route.test.ts\` from \`apps/web-v2\`).
- Build: clean (\`pnpm exec next build\` from \`apps/web-v2\`). Route \`/.well-known/jwks.json\` prerendered static, 1h revalidate.
- Diff scope: 2 new files in \`apps/web-v2/src/\`.
- Truth scan: CLEAN.

## Public Key Runtime Board (post-merge target)
| Metric | Before | After |
|---|---|---|
| Public Key Integrity % | ~0 (no JWKS endpoint on web-v2) | ~80 (with env var configured) / ~30 (without — fail-closed empty) |
| kid Continuity % | N/A | derived from env JWK |
| Replay Attribution % | Unchanged | Unchanged (replay lineage is #312/#313 territory) |
| Verifier Survivability % | ~50 | ~70 (fail-closed empty preserves verifier honesty) |
| Public Key Runtime Maturity % | ~0 | ~60 |

Board moves only on merge per BOARD-SCHEMA-3.