### PR TITLE
feat(web-v2): ACTIVATE-1 PR379A security headers for the sandbox

### DIFF
--- a/apps/web-v2/next.config.ts
+++ b/apps/web-v2/next.config.ts
@@ -1,7 +1,17 @@
 import type { NextConfig } from 'next';
+import { getSecurityHeadersForNext } from './src/lib/security-headers';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        // Match every route — security headers are response-level.
+        source: '/(.*)',
+        headers: getSecurityHeadersForNext(),
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web-v2/src/__tests__/security-headers.test.ts
+++ b/apps/web-v2/src/__tests__/security-headers.test.ts
@@ -1,0 +1,184 @@
+/**
+ * ACTIVATE-1 PR379A — web-v2 security headers lockdown.
+ *
+ * Pins the headers list + CSP directives + the next.config.ts wiring
+ * against drift. If any of the required security headers is removed
+ * or the CSP loses a critical directive, this test fails.
+ *
+ * Doctrine link: mirrors apps/web/__tests__/security-headers.test.ts
+ * (the SEC-HEADERS-1 lockdown) but for the web-v2 sandbox surface.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { securityHeaders, getSecurityHeadersForNext } from '../lib/security-headers';
+
+const NEXT_CONFIG = readFileSync(
+  resolve(__dirname, '../../next.config.ts'),
+  'utf8',
+);
+const HEADERS_SRC = readFileSync(
+  resolve(__dirname, '../lib/security-headers.ts'),
+  'utf8',
+);
+
+function findHeader(key: string): string | undefined {
+  return securityHeaders.find((h) => h.key === key)?.value;
+}
+
+describe('ACTIVATE-1 PR379A — required headers are present', () => {
+  it('Strict-Transport-Security with preload + 2y max-age', () => {
+    const v = findHeader('Strict-Transport-Security');
+    expect(v).toBeDefined();
+    expect(v).toContain('max-age=63072000');
+    expect(v).toContain('includeSubDomains');
+    expect(v).toContain('preload');
+  });
+
+  it('X-Content-Type-Options: nosniff', () => {
+    expect(findHeader('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('X-Frame-Options: DENY (defense-in-depth alongside CSP frame-ancestors)', () => {
+    expect(findHeader('X-Frame-Options')).toBe('DENY');
+  });
+
+  it('Referrer-Policy: strict-origin-when-cross-origin', () => {
+    expect(findHeader('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('Permissions-Policy disables high-risk surfaces', () => {
+    const v = findHeader('Permissions-Policy');
+    expect(v).toBeDefined();
+    for (const directive of ['camera=()', 'microphone=()', 'geolocation=()', 'payment=()', 'usb=()']) {
+      expect(v).toContain(directive);
+    }
+  });
+
+  it('Content-Security-Policy is present and parses', () => {
+    const v = findHeader('Content-Security-Policy');
+    expect(v).toBeDefined();
+  });
+});
+
+describe('ACTIVATE-1 PR379A — CSP directives', () => {
+  const csp = findHeader('Content-Security-Policy') ?? '';
+  const directives = new Map<string, string>();
+  for (const part of csp.split(';').map((p) => p.trim()).filter(Boolean)) {
+    const space = part.indexOf(' ');
+    if (space === -1) {
+      directives.set(part, '');
+    } else {
+      directives.set(part.slice(0, space), part.slice(space + 1));
+    }
+  }
+
+  it('default-src is self only', () => {
+    expect(directives.get('default-src')).toBe("'self'");
+  });
+
+  it("frame-ancestors is 'none' (clickjacking defense)", () => {
+    expect(directives.get('frame-ancestors')).toBe("'none'");
+  });
+
+  it("object-src is 'none' (legacy plugin defense)", () => {
+    expect(directives.get('object-src')).toBe("'none'");
+  });
+
+  it("form-action is restricted to 'self'", () => {
+    expect(directives.get('form-action')).toBe("'self'");
+  });
+
+  it("base-uri is restricted to 'self' (base-tag injection defense)", () => {
+    expect(directives.get('base-uri')).toBe("'self'");
+  });
+
+  it('upgrade-insecure-requests is enabled', () => {
+    expect(directives.has('upgrade-insecure-requests')).toBe(true);
+  });
+
+  it('script-src allows Clerk hosts (Clerk widget needs them)', () => {
+    const v = directives.get('script-src') ?? '';
+    expect(v).toContain('https://*.clerk.accounts.dev');
+    expect(v).toContain('https://*.clerk.com');
+  });
+
+  it('script-src does NOT allow http: schemes (no plaintext script sources)', () => {
+    const v = directives.get('script-src') ?? '';
+    expect(v).not.toMatch(/\bhttp:\/\//);
+  });
+
+  it('connect-src allows Clerk + self only (no third-party telemetry yet)', () => {
+    const v = directives.get('connect-src') ?? '';
+    expect(v).toContain("'self'");
+    expect(v).toContain('https://*.clerk.com');
+    // Web-v2 has no Sentry/PostHog/Stripe wiring; if those land,
+    // update both the CSP AND this test in the same PR.
+    expect(v).not.toContain('sentry.io');
+    expect(v).not.toContain('posthog.com');
+  });
+});
+
+describe('ACTIVATE-1 PR379A — next.config.ts wiring', () => {
+  it('imports getSecurityHeadersForNext from the local module', () => {
+    expect(NEXT_CONFIG).toContain("from './src/lib/security-headers'");
+    expect(NEXT_CONFIG).toContain('getSecurityHeadersForNext');
+  });
+
+  it('declares async headers() function on the nextConfig', () => {
+    expect(NEXT_CONFIG).toMatch(/async\s+headers\(\)/);
+  });
+
+  it('applies headers to every route (source: /(.*) )', () => {
+    expect(NEXT_CONFIG).toMatch(/source:\s*['"]\/\(\.\*\)['"]/);
+  });
+});
+
+describe('ACTIVATE-1 PR379A — frozen output + helper', () => {
+  it('securityHeaders array is frozen', () => {
+    expect(Object.isFrozen(securityHeaders)).toBe(true);
+  });
+
+  it('getSecurityHeadersForNext returns a fresh copy (not the frozen original)', () => {
+    const a = getSecurityHeadersForNext();
+    const b = getSecurityHeadersForNext();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it('helper output is shaped for Next.js headers() consumption', () => {
+    const out = getSecurityHeadersForNext();
+    for (const entry of out) {
+      expect(typeof entry.key).toBe('string');
+      expect(typeof entry.value).toBe('string');
+      expect(entry.key.length).toBeGreaterThan(0);
+      expect(entry.value.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('ACTIVATE-1 PR379A — source-level pins', () => {
+  it('HSTS uses preload (no production rollback path)', () => {
+    expect(HEADERS_SRC).toContain('preload');
+  });
+
+  it('no localhost / 127.0.0.1 baked into the CSP', () => {
+    expect(HEADERS_SRC).not.toMatch(/localhost/);
+    expect(HEADERS_SRC).not.toMatch(/127\.0\.0\.1/);
+  });
+
+  it('does not contain banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(HEADERS_SRC).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web-v2/src/lib/security-headers.ts
+++ b/apps/web-v2/src/lib/security-headers.ts
@@ -1,0 +1,92 @@
+/**
+ * Web-v2 security headers — ACTIVATE-1 PR379A.
+ *
+ * Mirrors apps/web/security-headers.mjs (the canonical pattern shipped
+ * earlier as SEC-HEADERS-1) but scoped to the web-v2 sandbox. Used by
+ * apps/web-v2/next.config.ts to wire the headers into every response
+ * AND by the lockdown test at apps/web-v2/src/__tests__/security-headers.test.ts.
+ *
+ * Truth contract:
+ *   - These headers are a NECESSARY defense layer; NOT sufficient on
+ *     their own. Server-side validation, output encoding, CSRF, and
+ *     authn/authz remain required (see apps/web-v2 middleware.ts +
+ *     clerkConfig.ts from PR #310).
+ *   - The CSP allows 'unsafe-inline' for styles (Next inlines critical
+ *     CSS) and 'unsafe-inline'/'unsafe-eval' for scripts (React 19 +
+ *     Next 15 RSC, Clerk runtime). Strict-CSP-with-nonces is a
+ *     follow-up after Next 15 RSC nonce support stabilizes.
+ *   - frame-ancestors 'none' is enforced via CSP AND duplicated via
+ *     X-Frame-Options: DENY for legacy verifier compatibility.
+ *
+ * Differences from apps/web:
+ *   - No Stripe / PostHog / Sentry allow-lists (web-v2 doesn't load
+ *     those vendors yet — adding them would be a security regression
+ *     until those integrations actually exist).
+ *   - Connect-src only allows Clerk + self.
+ */
+
+const SELF = "'self'";
+const CLERK_HOSTS = 'https://*.clerk.accounts.dev https://*.clerk.com';
+
+const cspDirectives = [
+  `default-src ${SELF}`,
+  `script-src ${SELF} 'unsafe-inline' 'unsafe-eval' ${CLERK_HOSTS}`,
+  `style-src ${SELF} 'unsafe-inline' https://fonts.googleapis.com`,
+  `font-src ${SELF} data: https://fonts.gstatic.com`,
+  `img-src ${SELF} data: blob: https:`,
+  `connect-src ${SELF} ${CLERK_HOSTS}`,
+  `frame-src ${CLERK_HOSTS}`,
+  `frame-ancestors 'none'`,
+  `form-action ${SELF}`,
+  `base-uri ${SELF}`,
+  `object-src 'none'`,
+  `upgrade-insecure-requests`,
+];
+
+const permissionsDirectives = [
+  'accelerometer=()',
+  'camera=()',
+  'geolocation=()',
+  'gyroscope=()',
+  'magnetometer=()',
+  'microphone=()',
+  'payment=()',
+  'usb=()',
+  'interest-cohort=()',
+];
+
+export interface SecurityHeader {
+  readonly key: string;
+  readonly value: string;
+}
+
+export const securityHeaders: readonly SecurityHeader[] = Object.freeze([
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: permissionsDirectives.join(', '),
+  },
+  {
+    key: 'Content-Security-Policy',
+    value: cspDirectives.join('; '),
+  },
+]);
+
+export function getSecurityHeadersForNext(): SecurityHeader[] {
+  return securityHeaders.map((h) => ({ key: h.key, value: h.value }));
+}


### PR DESCRIPTION
## Summary
Stacked on **#308** (web-v2 scaffold). Closes the institutional security-hardening gap for the web-v2 sandbox surface. Mirrors the SEC-HEADERS-1 pattern from \`apps/web/security-headers.mjs\` (which already exists on origin/main) onto web-v2.

**Before this PR**: web-v2 served zero security headers — every CSP / HSTS / X-Frame-Options gate the main app enforces was silently absent on the parallel surface. A clickjacking attack against the sandbox sign-in widget (#310) was not blocked by frame-ancestors. HSTS was not pinned.

## Headers added
| Header | Value |
|---|---|
| Strict-Transport-Security | \`max-age=63072000; includeSubDomains; preload\` |
| X-Content-Type-Options | \`nosniff\` |
| X-Frame-Options | \`DENY\` (defense-in-depth alongside CSP frame-ancestors) |
| Referrer-Policy | \`strict-origin-when-cross-origin\` |
| Permissions-Policy | disables camera, microphone, geolocation, payment, usb, sensors, FLoC |
| Content-Security-Policy | strict default-src 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'; base-uri 'self'; upgrade-insecure-requests |

CSP script/connect/frame allow-lists are restricted to Clerk hosts (\`*.clerk.accounts.dev\`, \`*.clerk.com\`) since the only third-party web-v2 actually loads is Clerk per PR #310.

## Intentional differences from apps/web
- **No Stripe / PostHog / Sentry allow-lists.** web-v2 doesn't load those vendors yet; allow-listing them prematurely would be a security regression. When integrations land in web-v2, the CSP AND the lockdown test must be updated in the same PR (the lockdown explicitly asserts those domains are absent).

## Truth-contract invariants enforced by the 24-test lockdown
- All 6 required headers present with documented values.
- HSTS includes preload (no production rollback path).
- Permissions-Policy disables 5 high-risk surfaces explicitly.
- CSP \`default-src\` is \`'self'\` only.
- CSP \`frame-ancestors\` / \`object-src\` are \`'none'\`.
- CSP \`form-action\` / \`base-uri\` are \`'self'\`.
- CSP \`script-src\` does NOT allow \`http://\` schemes.
- CSP \`connect-src\` does NOT contain \`sentry.io\` / \`posthog.com\` (vendor allow-list drift defense).
- \`next.config.ts\` wires headers via \`async headers()\` to source \`/(.*)\`.
- \`securityHeaders\` array is frozen; helper returns fresh copies.
- No localhost / 127.0.0.1 baked into the CSP source.
- Banned-strings scan: clean.

## What this PR does NOT do
- Does NOT modify \`apps/web/security-headers.mjs\` (the canonical source for the main app, unchanged).
- Does NOT implement ACTIVATE-1 PR380A (Pilot Readiness Verification) — that's the 23rd rephrase of the golden-path audit pattern from #311.
- Does NOT implement ACTIVATE-1 PR381A (Institutional Golden Path) — that's the 24th rephrase, same answer as #311.
- Does NOT introduce strict-CSP-with-nonces — follow-up after Next 15 RSC nonce support stabilizes.

## Validation
- Targeted tests: 24/24 (\`pnpm exec vitest run src/__tests__/security-headers.test.ts\` from \`apps/web-v2\`).
- Build: clean (\`pnpm exec next build\` from \`apps/web-v2\`). Routes \`/\`, \`/_not-found\` prerendered static.
- Truth scan: CLEAN.
- Diff scope: 2 new files (\`security-headers.ts\`, test) + 1 modified (\`next.config.ts\`).

## Institutional Security Board (post-merge target)
| Metric | Before | After |
|---|---|---|
| Abuse Protection % | ~10 (no CSP, no HSTS, no X-Frame) | ~70 (CSP + HSTS + frame defense) |
| Secret Hygiene % | Unchanged (already pinned by #310 + #316) | Unchanged |
| Replay Protection % | Unchanged (replay protection lives in apps/api/backend; not a header concern) | Unchanged |
| Runtime Exposure % | ~30 | ~75 (Permissions-Policy + restricted connect-src) |
| Institutional Security Maturity % | ~30 | ~65 |

Board moves only on merge per BOARD-SCHEMA-3.