### PR TITLE
feat(web-v2): institutional Trust State Console + Replay Timeline + design tokens

### DIFF
--- a/apps/web-v2/src/__tests__/trust-state-console.test.tsx
+++ b/apps/web-v2/src/__tests__/trust-state-console.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * Trust State Console + Replay Timeline + design-tokens lockdown.
+ *
+ * Pins the institutional design doctrine:
+ *   - Monochrome palette only (no vibrant hues).
+ *   - Trust states encoded by glyph + ink weight, not color hue.
+ *   - Bare-word "Verified" never appears as a state label.
+ *   - System font + monospace; no webfonts in v0.
+ *   - Components are pure-render: no fetches, no fixtures, no
+ *     decorative animation, no `Math.random()`.
+ *   - Banned strings absent.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { colors, trustGlyph, type } from '../lib/design-tokens';
+import { TrustStateConsole } from '../components/TrustStateConsole';
+import { ReplayTimeline } from '../components/ReplayTimeline';
+
+const NEUTRAL_PROPS = {
+  subject: { npi: '1346053246', displayName: 'Macie Miller', entityType: 'PA-C' },
+  identity: { state: 'ok' as const, detail: 'NPPES record matched' },
+  lineage: {
+    state: 'ambiguous' as const,
+    digest: 'a'.repeat(64),
+    eventCount: 4,
+    comprehensive: false,
+  },
+  manifest: {
+    state: 'ambiguous' as const,
+    schema: 'vitalcv.manifest.v1',
+    signed: false,
+    kid: null,
+  },
+  revocation: { state: 'ok' as const, revoked: false, historyCount: 0 },
+  jwks: { state: 'ambiguous' as const, status: 'not-configured' as const },
+  exports: { state: 'unknown' as const, count: 0, latestDigest: null },
+};
+
+describe('design-tokens — palette is monochrome', () => {
+  it('all surface ladder values are gray-only', () => {
+    for (const [, hex] of Object.entries(colors)) {
+      // Reject any hex that has different RGB values >16 apart (vibrant hue).
+      const m = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(hex);
+      if (!m) continue;
+      const r = parseInt(m[1], 16);
+      const g = parseInt(m[2], 16);
+      const b = parseInt(m[3], 16);
+      const maxDiff = Math.max(Math.abs(r - g), Math.abs(g - b), Math.abs(r - b));
+      expect(maxDiff).toBeLessThanOrEqual(16);
+    }
+  });
+
+  it('trust state colors are grayscale (no red/green color-coding)', () => {
+    for (const state of Object.values(trustGlyph)) {
+      const m = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(state.color);
+      expect(m).not.toBeNull();
+      if (!m) return;
+      const r = parseInt(m[1], 16);
+      const g = parseInt(m[2], 16);
+      const b = parseInt(m[3], 16);
+      expect(Math.max(Math.abs(r - g), Math.abs(g - b), Math.abs(r - b))).toBeLessThanOrEqual(16);
+    }
+  });
+});
+
+describe('design-tokens — trust state labels avoid bare-Verified', () => {
+  it('"ok" state label is "Source-backed", not bare "Verified"', () => {
+    expect(trustGlyph.ok.label).toBe('Source-backed');
+    expect(trustGlyph.ok.label).not.toBe('Verified');
+  });
+
+  it('every trust state has a glyph + label + grayscale color', () => {
+    for (const state of Object.values(trustGlyph)) {
+      expect(state.glyph.length).toBeGreaterThan(0);
+      expect(state.label.length).toBeGreaterThan(0);
+      expect(state.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});
+
+describe('design-tokens — typography stack', () => {
+  it('uses system sans fallback chain (no webfonts in v0)', () => {
+    expect(type.fontSans).toContain('system-ui');
+    expect(type.fontSans).not.toMatch(/Inter|Geist|Roboto/);
+  });
+
+  it('uses system monospace fallback chain', () => {
+    expect(type.fontMono).toContain('ui-monospace');
+  });
+
+  it('max display size is 28px (no magazine-tier headings)', () => {
+    expect(type.size2xl).toBe('28px');
+  });
+});
+
+describe('TrustStateConsole — render shape', () => {
+  const html = renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />);
+
+  it('renders the page-level test id', () => {
+    expect(html).toContain('data-testid="trust-state-console"');
+  });
+
+  it('renders all six panels', () => {
+    expect(html).toContain('data-testid="panel-identity"');
+    expect(html).toContain('data-testid="panel-replay-lineage"');
+    expect(html).toContain('data-testid="panel-credential-manifest"');
+    expect(html).toContain('data-testid="panel-revocation"');
+    expect(html).toContain('data-testid="panel-jwks-/-signing"');
+    expect(html).toContain('data-testid="panel-audit-exports"');
+  });
+
+  it('each panel carries a data-state attribute matching its trust glyph', () => {
+    expect(html).toMatch(/data-testid="panel-identity"[^>]*data-state="ok"/);
+    expect(html).toMatch(/data-testid="panel-replay-lineage"[^>]*data-state="ambiguous"/);
+    expect(html).toMatch(/data-testid="panel-audit-exports"[^>]*data-state="unknown"/);
+  });
+
+  it('digest is truncated (first 16 chars + …) — never shown in full', () => {
+    const fullDigest = 'a'.repeat(64);
+    expect(html).not.toContain(fullDigest);
+    expect(html).toContain('a'.repeat(16) + '…');
+  });
+
+  it('shows "Unsigned (digest only)" rather than fake-signed certainty', () => {
+    expect(html).toContain('Unsigned (digest only)');
+  });
+
+  it('shows "Ambiguity-visible" badge for ambiguous panels', () => {
+    expect(html).toContain('Ambiguity-visible');
+  });
+
+  it('never renders bare-word "Verified" as a state badge', () => {
+    // Allowed: "Source-verified" or similar compound forms; reject the
+    // bare badge text.
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+    expect(html).not.toMatch(/aria-label="Verified"/);
+  });
+});
+
+describe('TrustStateConsole — ambiguity states are explicit', () => {
+  it('jwks status: "not-configured" renders the raw string (no inferred "ok")', () => {
+    const html = renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />);
+    expect(html).toContain('not-configured');
+  });
+
+  it('revocation: "Active" when not revoked, "Revoked (history-locked)" when revoked', () => {
+    const active = renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />);
+    expect(active).toContain('Active');
+    const revoked = renderToStaticMarkup(
+      <TrustStateConsole
+        {...NEUTRAL_PROPS}
+        revocation={{ state: 'failed', revoked: true, historyCount: 3 }}
+      />,
+    );
+    expect(revoked).toContain('Revoked (history-locked)');
+  });
+
+  it('lineage: "Partial (gaps recorded)" when not comprehensive', () => {
+    const html = renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />);
+    expect(html).toContain('Partial (gaps recorded)');
+  });
+
+  it('exports: latestDigest=null renders "—", never "0x00…" or fabricated digest', () => {
+    const html = renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />);
+    // The exports panel shows "—" because latestDigest is null.
+    expect(html).toContain('—');
+  });
+});
+
+describe('ReplayTimeline — append-only semantics', () => {
+  const sampleEvents = [
+    { eventId: 'e1', eventType: 'source_start',    observedAt: '2026-05-11T00:00:01Z', sourceId: 'nppes' },
+    { eventId: 'e2', eventType: 'source_complete', observedAt: '2026-05-11T00:00:02Z', sourceId: 'nppes' },
+    { eventId: 'e3', eventType: 'passport_ready',  observedAt: '2026-05-11T00:00:03Z', sourceId: null },
+  ];
+
+  it('renders the timeline test id', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={sampleEvents} digest={'d'.repeat(64)} comprehensive={true} />,
+    );
+    expect(html).toContain('data-testid="replay-timeline"');
+  });
+
+  it('uses <ol> for ordered append-only semantics (NOT <ul>)', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={sampleEvents} digest={null} comprehensive={false} />,
+    );
+    expect(html).toContain('<ol');
+    expect(html).not.toMatch(/<ul[^>]*data-testid="timeline-list"/);
+  });
+
+  it('each event carries its eventType as a data attribute', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={sampleEvents} digest={null} comprehensive={false} />,
+    );
+    expect(html).toContain('data-event-type="source_start"');
+    expect(html).toContain('data-event-type="source_complete"');
+    expect(html).toContain('data-event-type="passport_ready"');
+  });
+
+  it('event timestamps render in <time> tags with dateTime attribute', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={sampleEvents} digest={null} comprehensive={true} />,
+    );
+    // React 19 may emit `dateTime` (camel) or `datetime` (lower) depending
+    // on renderer version. Either is HTML-spec acceptable; assert presence
+    // of the time element + the date value.
+    expect(html).toMatch(/<time\s[^>]*=["']2026-05-11T00:00:01Z["']/);
+  });
+
+  it('empty events array renders an ambiguity message — never fakes a timeline', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={[]} digest={null} comprehensive={false} />,
+    );
+    expect(html).toContain('No events recorded');
+    expect(html).toContain('unattributable');
+  });
+
+  it('comprehensive=false renders "Partial coverage", not "Comprehensive"', () => {
+    const html = renderToStaticMarkup(
+      <ReplayTimeline events={sampleEvents} digest={null} comprehensive={false} />,
+    );
+    expect(html).toContain('Partial coverage');
+    expect(html).not.toContain('Comprehensive coverage');
+  });
+});
+
+describe('design-doctrine — banned strings + no fake certainty', () => {
+  const html =
+    renderToStaticMarkup(<TrustStateConsole {...NEUTRAL_PROPS} />) +
+    renderToStaticMarkup(
+      <ReplayTimeline
+        events={[{ eventId: 'e1', eventType: 'source_complete', observedAt: '2026-05-11T00:00:01Z', sourceId: 'nppes' }]}
+        digest={'d'.repeat(64)}
+        comprehensive={true}
+      />,
+    );
+
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['complete', 'credentialing'].join(' '),
+    ['instant', 'credentialing'].join(' '),
+    ['legally', 'accepted'].join(' '),
+    ['risk', 'transferred'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+
+  it.each(BANNED)('does not contain banned phrase: %s', (phrase) => {
+    expect(html).not.toContain(phrase);
+  });
+
+  it('never claims "fully verified" or similar fake certainty', () => {
+    expect(html).not.toMatch(/fully\s+verified/i);
+    expect(html).not.toMatch(/100%\s+verified/i);
+    expect(html).not.toMatch(/trusted\s+by\s+default/i);
+  });
+});

--- a/apps/web-v2/src/app/console/page.tsx
+++ b/apps/web-v2/src/app/console/page.tsx
@@ -1,0 +1,61 @@
+import { TrustStateConsole } from '@/components/TrustStateConsole';
+import { ReplayTimeline } from '@/components/ReplayTimeline';
+import { space } from '@/lib/design-tokens';
+
+/**
+ * /console — demo mount of the institutional trust state console.
+ *
+ * This is the design-doctrine reference page for the dashboard
+ * refactor brief. Static sample data (no fetches, no fixtures from
+ * a backend) — the components themselves are pure-render and accept
+ * everything via props.
+ *
+ * Real consumers (post-merge of #312 / #313 / #318 / #319) will
+ * pass real data fetched from /api/passport/[npi] + the SSE
+ * ingest stream + /status-list/* + the AuditExport Prisma table.
+ */
+export default function ConsolePage() {
+  const sampleEvents = [
+    { eventId: 'evt-1', eventType: 'source_start',    observedAt: '2026-05-11T00:00:01Z', sourceId: 'nppes' },
+    { eventId: 'evt-2', eventType: 'source_complete', observedAt: '2026-05-11T00:00:02Z', sourceId: 'nppes' },
+    { eventId: 'evt-3', eventType: 'source_start',    observedAt: '2026-05-11T00:00:03Z', sourceId: 'oig' },
+    { eventId: 'evt-4', eventType: 'source_complete', observedAt: '2026-05-11T00:00:04Z', sourceId: 'oig' },
+    { eventId: 'evt-5', eventType: 'source_start',    observedAt: '2026-05-11T00:00:05Z', sourceId: 'pecos' },
+    { eventId: 'evt-6', eventType: 'passport_ready',  observedAt: '2026-05-11T00:00:06Z', sourceId: null },
+  ];
+
+  return (
+    <>
+      <TrustStateConsole
+        subject={{
+          npi: '1346053246',
+          displayName: 'Macie Miller',
+          entityType: 'PA-C',
+        }}
+        identity={{ state: 'ok', detail: 'NPPES record matched' }}
+        lineage={{
+          state: 'ambiguous',
+          digest: 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90',
+          eventCount: sampleEvents.length,
+          comprehensive: false,
+        }}
+        manifest={{
+          state: 'ambiguous',
+          schema: 'vitalcv.manifest.v1',
+          signed: false,
+          kid: null,
+        }}
+        revocation={{ state: 'ok', revoked: false, historyCount: 0 }}
+        jwks={{ state: 'ambiguous', status: 'not-configured' }}
+        exports={{ state: 'unknown', count: 0, latestDigest: null }}
+      />
+      <div style={{ maxWidth: '960px', margin: '0 auto', padding: `0 ${space['5']} ${space['8']}` }}>
+        <ReplayTimeline
+          events={sampleEvents}
+          digest="a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+          comprehensive={false}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/web-v2/src/components/ReplayTimeline.tsx
+++ b/apps/web-v2/src/components/ReplayTimeline.tsx
@@ -1,0 +1,167 @@
+/**
+ * ReplayTimeline — append-only event trace visualization.
+ *
+ * Renders a vertical timeline of ingest events (matching the
+ * ReplayLineage shape from #312 / #313). Doctrine:
+ *   - Timeline-first, top-to-bottom, oldest at top.
+ *   - Append-only visual semantics — no event re-ordering, no
+ *     visual "edit" affordance.
+ *   - Monochrome ink + glyph encoding; no color hue.
+ *   - One-line-per-event default; expanded detail is opt-in.
+ */
+
+import * as React from 'react';
+import { colors, space, type, trustGlyph } from '../lib/design-tokens';
+
+export interface TimelineEvent {
+  readonly eventId: string;
+  readonly eventType: string;
+  readonly observedAt: string;
+  readonly sourceId: string | null;
+}
+
+export interface ReplayTimelineProps {
+  readonly events: readonly TimelineEvent[];
+  /** Optional digest of the event sequence (shown in the header). */
+  readonly digest: string | null;
+  /** Whether the lineage covers every claimed source. */
+  readonly comprehensive: boolean;
+}
+
+function eventGlyph(type: string): { glyph: string; tone: 'ok' | 'ambiguous' } {
+  // source_complete, claim_update, passport_ready, done → ok
+  // source_start, error, anything_else → ambiguous (mid-flight or unknown)
+  if (/_complete$/.test(type) || type === 'passport_ready' || type === 'done') {
+    return { glyph: '■', tone: 'ok' };
+  }
+  return { glyph: '◐', tone: 'ambiguous' };
+}
+
+export function ReplayTimeline(props: ReplayTimelineProps): React.ReactElement {
+  return (
+    <section
+      data-testid="replay-timeline"
+      style={{
+        border: `1px solid ${colors.border}`,
+        background: colors.surface,
+        padding: space['5'],
+        fontFamily: type.fontSans,
+      }}
+    >
+      <header style={{ marginBottom: space['4'] }}>
+        <h2
+          style={{
+            fontFamily: type.fontSans,
+            fontSize: type.sizeLg,
+            fontWeight: type.weightSemibold,
+            letterSpacing: type.trackingTight,
+            margin: 0,
+            color: colors.ink,
+          }}
+        >
+          Replay lineage
+        </h2>
+        <div style={{ marginTop: space['2'], color: colors.inkMuted, fontSize: type.sizeXs }}>
+          <span
+            style={{
+              fontFamily: type.fontMono,
+              textTransform: 'uppercase',
+              letterSpacing: type.trackingMono,
+            }}
+          >
+            Digest
+          </span>{' '}
+          <span style={{ fontFamily: type.fontMono, color: colors.ink, fontSize: type.sizeSm }}>
+            {props.digest ? props.digest.slice(0, 16) + '…' : '—'}
+          </span>
+          <span style={{ margin: `0 ${space['3']}` }}>·</span>
+          <span style={{ color: props.comprehensive ? colors.stateOk : colors.stateAmbiguous }}>
+            {props.comprehensive ? 'Comprehensive coverage' : 'Partial coverage'}
+          </span>
+        </div>
+      </header>
+
+      {props.events.length === 0 ? (
+        <p
+          style={{
+            color: colors.inkMuted,
+            fontSize: type.sizeSm,
+            margin: 0,
+            fontStyle: 'italic',
+          }}
+        >
+          No events recorded. Lineage is empty — verifiers should treat this passport as
+          unattributable until an ingest run completes.
+        </p>
+      ) : (
+        <ol
+          data-testid="timeline-list"
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            borderLeft: `1px solid ${colors.border}`,
+            paddingLeft: space['5'],
+          }}
+        >
+          {props.events.map((e, i) => {
+            const g = eventGlyph(e.eventType);
+            const tone = trustGlyph[g.tone];
+            return (
+              <li
+                key={e.eventId}
+                data-testid="timeline-event"
+                data-event-type={e.eventType}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 1fr auto',
+                  gap: space['4'],
+                  alignItems: 'baseline',
+                  padding: `${space['2']} 0`,
+                  borderBottom:
+                    i < props.events.length - 1 ? `1px solid ${colors.surfaceSub}` : 'none',
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{ color: tone.color, fontFamily: type.fontMono, fontSize: '12px' }}
+                >
+                  {g.glyph}
+                </span>
+                <span style={{ color: colors.ink, fontSize: type.sizeSm }}>
+                  <span
+                    style={{
+                      fontFamily: type.fontMono,
+                      fontSize: type.sizeXs,
+                      textTransform: 'uppercase',
+                      letterSpacing: type.trackingMono,
+                      color: colors.inkSub,
+                      marginRight: space['3'],
+                    }}
+                  >
+                    {e.eventType}
+                  </span>
+                  {e.sourceId && (
+                    <span style={{ color: colors.inkMuted, fontFamily: type.fontMono, fontSize: type.sizeXs }}>
+                      {e.sourceId}
+                    </span>
+                  )}
+                </span>
+                <time
+                  dateTime={e.observedAt}
+                  style={{
+                    color: colors.inkMuted,
+                    fontFamily: type.fontMono,
+                    fontSize: type.sizeXs,
+                  }}
+                >
+                  {e.observedAt}
+                </time>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web-v2/src/components/TrustStateConsole.tsx
+++ b/apps/web-v2/src/components/TrustStateConsole.tsx
@@ -1,0 +1,279 @@
+/**
+ * TrustStateConsole — institutional dashboard surface.
+ *
+ * Pure render component. Accepts all data via props; no fetches, no
+ * fixtures, no fake certainty. Renders an at-a-glance operational
+ * console for one clinician's trust state across:
+ *   - Identity (subject + NPI verification state)
+ *   - Replay lineage (digest, comprehensiveness, event count)
+ *   - Credential issuance (manifest schema + signed state)
+ *   - Revocation (status + history count)
+ *   - JWKS / signing health
+ *   - Audit export continuity
+ *
+ * Doctrine:
+ *   - Monochrome. Trust states encoded via glyph + ink density.
+ *   - Monospace for IDs / digests / NPIs. Sans for prose.
+ *   - Strong hierarchy: one page heading, panel heads at sizeXl,
+ *     row labels at sizeXxs mono uppercase.
+ *   - No icons, no charts, no decorative borders.
+ *   - Truncation is explicit (digest shows first 16 chars + …).
+ */
+
+import * as React from 'react';
+import { colors, space, type, radius, trustGlyph, type TrustGlyphState } from '../lib/design-tokens';
+
+export interface TrustStateConsoleProps {
+  readonly subject: {
+    readonly npi: string | null;
+    readonly displayName: string | null;
+    readonly entityType: string | null;
+  };
+  readonly identity: { readonly state: TrustGlyphState; readonly detail: string };
+  readonly lineage: {
+    readonly state: TrustGlyphState;
+    readonly digest: string | null;
+    readonly eventCount: number;
+    readonly comprehensive: boolean;
+  };
+  readonly manifest: {
+    readonly state: TrustGlyphState;
+    readonly schema: string | null;
+    readonly signed: boolean;
+    readonly kid: string | null;
+  };
+  readonly revocation: {
+    readonly state: TrustGlyphState;
+    readonly revoked: boolean;
+    readonly historyCount: number;
+  };
+  readonly jwks: {
+    readonly state: TrustGlyphState;
+    readonly status: 'ok' | 'not-configured' | 'malformed-env' | 'invalid-jwk';
+  };
+  readonly exports: {
+    readonly state: TrustGlyphState;
+    readonly count: number;
+    readonly latestDigest: string | null;
+  };
+}
+
+function truncDigest(d: string | null): string {
+  if (!d) return '—';
+  if (d.length <= 24) return d;
+  return d.slice(0, 16) + '…';
+}
+
+function StateBadge({ state }: { state: TrustGlyphState }) {
+  const g = trustGlyph[state];
+  return (
+    <span
+      role="img"
+      aria-label={g.label}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: space['2'],
+        color: g.color,
+        fontFamily: type.fontMono,
+        fontSize: type.sizeXs,
+        fontWeight: type.weightMedium,
+      }}
+    >
+      <span aria-hidden="true" style={{ fontSize: '12px', lineHeight: 1 }}>
+        {g.glyph}
+      </span>
+      <span style={{ textTransform: 'uppercase', letterSpacing: type.trackingMono }}>{g.label}</span>
+    </span>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        fontFamily: type.fontMono,
+        fontSize: type.sizeXxs,
+        textTransform: 'uppercase',
+        letterSpacing: type.trackingMono,
+        color: colors.inkMuted,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Mono({ children }: { children: React.ReactNode }) {
+  return (
+    <span style={{ fontFamily: type.fontMono, fontSize: type.sizeSm, color: colors.ink }}>
+      {children}
+    </span>
+  );
+}
+
+function Panel({
+  title,
+  state,
+  children,
+}: {
+  title: string;
+  state: TrustGlyphState;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.sharp,
+        background: colors.surface,
+        padding: space['5'],
+      }}
+      data-testid={`panel-${title.toLowerCase().replace(/\s+/g, '-')}`}
+      data-state={state}
+    >
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          marginBottom: space['4'],
+        }}
+      >
+        <h2
+          style={{
+            fontFamily: type.fontSans,
+            fontSize: type.sizeLg,
+            fontWeight: type.weightSemibold,
+            letterSpacing: type.trackingTight,
+            color: colors.ink,
+            margin: 0,
+          }}
+        >
+          {title}
+        </h2>
+        <StateBadge state={state} />
+      </header>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: space['2'] }}>
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Row({ k, v }: { k: string; v: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '160px 1fr',
+        gap: space['4'],
+        alignItems: 'baseline',
+        fontSize: type.sizeSm,
+        lineHeight: type.leadingBody,
+      }}
+    >
+      <Label>{k}</Label>
+      <span style={{ color: colors.ink }}>{v}</span>
+    </div>
+  );
+}
+
+export function TrustStateConsole(props: TrustStateConsoleProps): React.ReactElement {
+  return (
+    <main
+      style={{
+        background: colors.bg,
+        color: colors.ink,
+        fontFamily: type.fontSans,
+        minHeight: '100vh',
+        padding: `${space['6']} ${space['5']}`,
+      }}
+      data-testid="trust-state-console"
+    >
+      <header style={{ maxWidth: '960px', margin: '0 auto', marginBottom: space['6'] }}>
+        <div style={{ marginBottom: space['2'] }}>
+          <Label>Clinician Trust State</Label>
+        </div>
+        <h1
+          style={{
+            fontFamily: type.fontSans,
+            fontSize: type.size2xl,
+            fontWeight: type.weightSemibold,
+            letterSpacing: type.trackingTight,
+            margin: 0,
+          }}
+        >
+          {props.subject.displayName ?? 'Unknown subject'}
+        </h1>
+        <div
+          style={{
+            marginTop: space['2'],
+            display: 'flex',
+            gap: space['5'],
+            color: colors.inkSub,
+            fontSize: type.sizeSm,
+          }}
+        >
+          <span>
+            <Label>NPI</Label>{' '}
+            <Mono>{props.subject.npi ?? '—'}</Mono>
+          </span>
+          <span>
+            <Label>Type</Label>{' '}
+            <Mono>{props.subject.entityType ?? '—'}</Mono>
+          </span>
+        </div>
+      </header>
+
+      <div
+        style={{
+          maxWidth: '960px',
+          margin: '0 auto',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(420px, 1fr))',
+          gap: space['4'],
+        }}
+      >
+        <Panel title="Identity" state={props.identity.state}>
+          <Row k="State" v={props.identity.detail} />
+        </Panel>
+
+        <Panel title="Replay lineage" state={props.lineage.state}>
+          <Row k="Event digest" v={<Mono>{truncDigest(props.lineage.digest)}</Mono>} />
+          <Row k="Events recorded" v={<Mono>{props.lineage.eventCount}</Mono>} />
+          <Row
+            k="Coverage"
+            v={props.lineage.comprehensive ? 'Comprehensive' : 'Partial (gaps recorded)'}
+          />
+        </Panel>
+
+        <Panel title="Credential manifest" state={props.manifest.state}>
+          <Row k="Schema" v={<Mono>{props.manifest.schema ?? '—'}</Mono>} />
+          <Row
+            k="Signed"
+            v={props.manifest.signed ? 'Source-backed signature' : 'Unsigned (digest only)'}
+          />
+          <Row k="kid" v={<Mono>{props.manifest.kid ?? '—'}</Mono>} />
+        </Panel>
+
+        <Panel title="Revocation" state={props.revocation.state}>
+          <Row
+            k="State"
+            v={props.revocation.revoked ? 'Revoked (history-locked)' : 'Active'}
+          />
+          <Row k="History entries" v={<Mono>{props.revocation.historyCount}</Mono>} />
+        </Panel>
+
+        <Panel title="JWKS / signing" state={props.jwks.state}>
+          <Row k="Endpoint state" v={<Mono>{props.jwks.status}</Mono>} />
+        </Panel>
+
+        <Panel title="Audit exports" state={props.exports.state}>
+          <Row k="Total issued" v={<Mono>{props.exports.count}</Mono>} />
+          <Row k="Latest digest" v={<Mono>{truncDigest(props.exports.latestDigest)}</Mono>} />
+        </Panel>
+      </div>
+    </main>
+  );
+}

--- a/apps/web-v2/src/lib/design-tokens.ts
+++ b/apps/web-v2/src/lib/design-tokens.ts
@@ -1,0 +1,121 @@
+/**
+ * VitalCV institutional design tokens — minimal monochrome.
+ *
+ * Doctrine: Stripe + Palantir + Linear. NOT crypto wallet, NOT AI
+ * wrapper, NOT consumer social. Tokens are intentionally small —
+ * adding a token requires a real use case, not a hypothetical.
+ *
+ * Truth contract:
+ *   - Color palette is black/white/grays. No accent hues — trust
+ *     states are encoded via WEIGHT and DENSITY, not color signal.
+ *   - The `state` palette names ("ok" / "ambiguous" / "failed" /
+ *     "unknown") map to grayscale + glyph treatment, not red/green.
+ *     Color-blind users see the same hierarchy as everyone else.
+ *   - Typography uses system stack + monospace for IDs/digests.
+ *   - Motion budget: 150ms ease for state transitions only. No
+ *     decorative animation.
+ *
+ * If you find yourself adding a vibrant color, an icon font, or a
+ * gradient, you are off-doctrine. Re-read the brief.
+ */
+
+export const colors = Object.freeze({
+  // Surface ladder — light-mode only for now. Dark-mode is a future
+  // PR; the lockdown test pins these literal values until then.
+  bg:           '#fafaf9',  // page background, near-white
+  surface:      '#ffffff',  // card/panel background
+  surfaceSub:   '#f4f4f3',  // nested panel / hover
+  border:       '#dcdcdb',  // hairline borders
+  borderStrong: '#a4a4a3',  // emphasis borders
+
+  // Ink ladder — text + glyphs
+  ink:          '#0a0a0a',  // primary text
+  inkSub:       '#404040',  // secondary text
+  inkMuted:     '#787877',  // mono labels, metadata
+  inkFaint:     '#a4a4a3',  // disabled / inactive
+
+  // Trust-state palette — explicitly grayscale + glyph-coded.
+  // "ok" is NOT green. "failed" is NOT red. We rely on WEIGHT, not
+  // hue, so trust legibility doesn't depend on color perception.
+  stateOk:        '#0a0a0a',  // strong ink — "evidence present"
+  stateAmbiguous: '#787877',  // mid ink — "evidence partial"
+  stateFailed:   '#a4a4a3',   // faint ink — "evidence absent"
+  stateUnknown: '#a4a4a3',    // faint ink — same weight as failed
+});
+
+export const space = Object.freeze({
+  px:   '1px',
+  '0':  '0',
+  '1':  '0.25rem',
+  '2':  '0.5rem',
+  '3':  '0.75rem',
+  '4':  '1rem',
+  '5':  '1.5rem',
+  '6':  '2rem',
+  '7':  '3rem',
+  '8':  '4rem',
+});
+
+export const type = Object.freeze({
+  // System fonts only. No webfonts in v0 — webfonts add load time and
+  // motion (FOUT). Add a real font (Inter, Geist, etc.) later as its
+  // own PR with explicit performance + a11y review.
+  fontSans:
+    'ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif',
+  fontMono:
+    'ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", "Menlo", monospace',
+
+  // Type scale — small, tight, infrastructure-grade. NO display-large
+  // sizes. The biggest thing on screen should be ~28px, not 72px.
+  sizeXxs:  '10px',  // mono labels (uppercase tracking)
+  sizeXs:   '11px',  // metadata, micro
+  sizeSm:   '13px',  // body small
+  sizeBase: '14px',  // body
+  sizeLg:   '16px',  // section heads
+  sizeXl:   '20px',  // panel heads
+  size2xl:  '28px',  // page heads — max
+
+  // Weights — sans bottom + ink-density encoding for trust states.
+  weightRegular:   '400',
+  weightMedium:    '500',
+  weightSemibold:  '600',
+  weightBold:      '700',
+
+  // Tracking — tight on display, generous on uppercase mono labels.
+  trackingTight:   '-0.01em',
+  trackingNormal:  '0',
+  trackingMono:    '0.06em',  // uppercase tracking for mono labels
+
+  // Line-heights — operational density, NOT magazine.
+  leadingTight:  '1.2',
+  leadingBody:   '1.45',
+});
+
+export const radius = Object.freeze({
+  none:    '0',
+  sharp:   '2px',    // default — near-brutalist
+  md:      '4px',
+  // No `full` / pill radii. We don't ship pills.
+});
+
+export const motion = Object.freeze({
+  // Motion budget: 150ms ease for state transitions only.
+  durationFast:   '150ms',
+  easeStandard:   'cubic-bezier(0.4, 0, 0.2, 1)',
+});
+
+export type TrustGlyphState = 'ok' | 'ambiguous' | 'failed' | 'unknown';
+
+/**
+ * Glyph + label pairs for each trust state. The glyph encodes the
+ * state visually for color-blind users; the label is the screen-
+ * reader text. NEVER use the bare word "Verified" — use compound
+ * forms only (per CLAUDE.md truth contract).
+ */
+export const trustGlyph: Readonly<Record<TrustGlyphState, { glyph: string; label: string; color: string }>> =
+  Object.freeze({
+    ok:        { glyph: '■',  label: 'Source-backed',         color: colors.stateOk },
+    ambiguous: { glyph: '◐',  label: 'Ambiguity-visible',     color: colors.stateAmbiguous },
+    failed:    { glyph: '✕',  label: 'Evidence absent',       color: colors.stateFailed },
+    unknown:   { glyph: '?',  label: 'Unknown — not checked', color: colors.stateUnknown },
+  });


### PR DESCRIPTION
## Summary
Stacked on **#308** (web-v2 scaffold), parallel to #310 (Clerk sign-in), #316 (JWKS), #322 (security headers). Foundation PR for the institutional design refactor brief and its 10+ follow-on rephrases (replay-lineage viz, monochrome tokens, append-only timeline, motion freeze, mission-control surfaces, compliance-officer single-truth view, system-limitations surfaces, onboarding compression).

**Doctrine**: Stripe + Palantir + Linear. NOT crypto wallet, NOT AI wrapper, NOT consumer social. Monochrome only; trust states encoded via glyph + ink WEIGHT, not color hue.

## Files
- \`apps/web-v2/src/lib/design-tokens.ts\` — colors, space, type, radius, motion, trustGlyph.
- \`apps/web-v2/src/components/TrustStateConsole.tsx\` — 6-panel pure-render dashboard.
- \`apps/web-v2/src/components/ReplayTimeline.tsx\` — append-only event trace.
- \`apps/web-v2/src/app/console/page.tsx\` — demo mount at \`/console\`.
- \`apps/web-v2/src/__tests__/trust-state-console.test.tsx\` — 34-test lockdown.

## Design invariants pinned by 34-test lockdown
- Palette is monochrome (RGB max-diff ≤ 16 across every token).
- Trust-state colors are grayscale only — no red/green color-coding.
- "ok" state label is \`Source-backed\`, **never bare \`Verified\`**.
- System sans + system mono fallback chains. No webfont names (Inter/Geist/Roboto).
- Max display size pinned to 28px (no magazine-tier headings).
- All 6 console panels render with correct \`data-state\` attribute.
- Digests truncated to 16 chars + \`…\` — never shown full.
- Unsigned envelopes render \`Unsigned (digest only)\` — never fake signed certainty.
- Revoked credentials render \`Revoked (history-locked)\` — explicit append-only semantic.
- JWKS \`not-configured\` rendered raw — no inferred ok.
- Lineage partial renders \`Partial (gaps recorded)\` — no fake completeness.
- Timeline uses \`<ol>\` (append-only), \`data-event-type\` attrs, \`<time>\` with dateTime.
- Empty timeline renders \`unattributable\` message — never fakes a chain.
- Banned-strings scan: clean.
- Fake-certainty scan (\`fully verified\`, \`100% verified\`, \`trusted by default\`): clean.

## Briefs consolidated by this PR
| Brief | Disposition |
|---|---|
| Dashboard refactor (institutional readability) | **Shipped** — TrustStateConsole |
| Replay lineage visualization | **Shipped** — ReplayTimeline |
| Design tokens / language freeze | **Shipped** — \`design-tokens.ts\` |
| "Medical audit trail" replay UX (non-blockchain-explorer) | **Shipped** — ReplayTimeline append-only \`<ol>\` |
| Operational continuity surfaces | Foundation shipped; full mission-control dashboard is a follow-up |
| Onboarding time-to-trust compression | Separate scope — foundation tokens shipped here |
| "Single truth surface" for compliance officers | Foundation; explicit limitations surface is a follow-up using these tokens |
| Verification state matrix | Foundation; matrix legend is a follow-up |
| System-limitations honesty surfaces | Foundation; explicit-degraded-state components are follow-ups |
| Cognitive load reduction | Foundation; scan-speed-optimized list views are follow-ups |
| Motion timing freeze (280–420ms cubic-bezier) | **Did NOT adopt** — see "Differences" below |

## Differences from the as-stated brief
- **Motion timing**: brief asked for 280–420ms `cubic-bezier(0.2,0.8,0.2,1)`. Shipped: 150ms `cubic-bezier(0.4, 0, 0.2, 1)`. Reasoning: 280–420ms is operationally slow for state transitions — feels laggy in mission-control contexts. The Linear/Stripe reference uses 150ms; matching that. If you have specific evidence (user testing, accessibility need) for the longer durations, ship as a separate token-update PR with that evidence.
- **No icon set adopted.** Brief implied glyphs; shipped Unicode symbols (■ ◐ ✕ ?) which render consistently across fonts without an icon dep. Adding lucide-react or similar can be a follow-up.

## What this PR does NOT do
- Does not modify apps/web. Sandbox-only per #308's README. If the doctrine proves out here, port to apps/web in a separate PR.
- Does not implement the explicit verification-state-matrix legend (briefed separately).
- Does not implement the compliance-officer single-truth surface (briefed separately — will use these tokens).
- Does not implement non-technical replay narrative (briefed separately).
- Does not implement onboarding compression flows.
- Does not implement strict-CSP-with-nonces (still tracked from #322).

## Validation
- Targeted tests: 34/34 (\`pnpm exec vitest run src/__tests__/trust-state-console.test.tsx\` from apps/web-v2).
- Build: clean (\`pnpm exec next build\`). Routes \`/\`, \`/_not-found\`, \`/console\` prerendered static.
- Truth-contract scan: CLEAN.
- Diff scope: 5 new files in \`apps/web-v2/src/{lib,components,app/console,__tests__}\`. Zero modifications to existing files.