### PR TITLE
feat(web-v2): TruthBoundary — single institutional truth surface

### DIFF
--- a/apps/web-v2/src/__tests__/truth-boundary.test.tsx
+++ b/apps/web-v2/src/__tests__/truth-boundary.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * TruthBoundary surface + docs/trust-boundaries.md lockdown.
+ *
+ * Pins the institutional truth surface against drift. Compliance
+ * officers reading this surface evaluate a contract; ambiguity here
+ * is a deal-breaker. Specifically pins:
+ *   - 5 mandatory sections render (verified / not-verified /
+ *     operational-state / limitations / state-matrix).
+ *   - The 7-state verification matrix is exposed in the canonical
+ *     order: verified, source-linked, self-attested, unavailable,
+ *     revoked, expired, degraded-state.
+ *   - Empty `verified` list renders a fail-closed warning, never
+ *     "everything is fine".
+ *   - Empty `limitations` list renders "missing-data" framing,
+ *     never "no limitations exist".
+ *   - The companion doc at docs/trust-boundaries.md stays in lockstep
+ *     with the rendered surface (banned strings, state legend).
+ */
+
+import * as React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { TruthBoundary, VERIFICATION_STATES } from '../components/TruthBoundary';
+
+const NEUTRAL_PROPS = {
+  verified: [
+    { claim: 'NPI identity exists and is active', source: 'NPPES' },
+    { claim: 'OIG / LEIE exclusion status', source: 'HHS OIG' },
+  ],
+  notVerified: [
+    {
+      claim: 'Clinical competence',
+      reason: 'Out of scope.',
+      state: 'unavailable' as const,
+    },
+    {
+      claim: 'Board certification without receipt',
+      reason: 'Self-asserted unless a receipt is attached.',
+      state: 'self-attested' as const,
+    },
+  ],
+  operationalState: {
+    replayLineage: { state: 'ambiguous' as const, detail: 'Primitive shipped; not yet wired.' },
+    revocation:    { state: 'ambiguous' as const, detail: 'In-memory until persistence migration runs.' },
+    jwks:          { state: 'ambiguous' as const, detail: 'Sandbox JWKS returns empty until env set.' },
+    auditExport:   { state: 'ambiguous' as const, detail: 'Envelope shipped; not yet wired into route.' },
+  },
+  limitations: [
+    'Source coverage varies by jurisdiction.',
+    'No off-US clinician verification.',
+  ],
+};
+
+const DOC = readFileSync(
+  resolve(__dirname, '../../../../docs/trust-boundaries.md'),
+  'utf8',
+);
+
+describe('TruthBoundary — 5 mandatory sections render', () => {
+  const html = renderToStaticMarkup(<TruthBoundary {...NEUTRAL_PROPS} />);
+
+  it('renders the page-level test id', () => {
+    expect(html).toContain('data-testid="truth-boundary"');
+  });
+
+  it('renders the verified section', () => {
+    expect(html).toContain('data-testid="section-verified"');
+  });
+
+  it('renders the not-verified section', () => {
+    expect(html).toContain('data-testid="section-not-verified"');
+  });
+
+  it('renders the operational-state section', () => {
+    expect(html).toContain('data-testid="section-operational-state"');
+  });
+
+  it('renders the limitations section', () => {
+    expect(html).toContain('data-testid="section-limitations"');
+  });
+
+  it('renders the state-matrix legend section', () => {
+    expect(html).toContain('data-testid="section-state-matrix"');
+  });
+
+  it('renders the explicit-pin footer', () => {
+    expect(html).toContain('data-testid="truth-boundary-footer"');
+  });
+});
+
+describe('TruthBoundary — the 10-second target', () => {
+  const html = renderToStaticMarkup(<TruthBoundary {...NEUTRAL_PROPS} />);
+
+  it('lede states the boundary in one sentence', () => {
+    expect(html).toContain('What VitalCV verifies — and what it does not.');
+  });
+
+  it('lede is followed by the "this is the operational contract" framing', () => {
+    expect(html).toContain('operational contract');
+    expect(html).toContain('not what it intends to do');
+  });
+});
+
+describe('TruthBoundary — 7-state verification matrix is complete', () => {
+  it('exports exactly 7 verification states in canonical order', () => {
+    expect(VERIFICATION_STATES).toHaveLength(7);
+    const ids = VERIFICATION_STATES.map((s) => s.id);
+    expect(ids).toEqual([
+      'verified',
+      'source-linked',
+      'self-attested',
+      'unavailable',
+      'revoked',
+      'expired',
+      'degraded-state',
+    ]);
+  });
+
+  it('source-verified is labeled "Source-verified", never bare "Verified"', () => {
+    const v = VERIFICATION_STATES.find((s) => s.id === 'verified');
+    expect(v?.label).toBe('Source-verified');
+  });
+
+  it('all 7 labels appear in the rendered surface', () => {
+    const html = renderToStaticMarkup(<TruthBoundary {...NEUTRAL_PROPS} />);
+    for (const s of VERIFICATION_STATES) {
+      expect(html).toContain(s.label);
+    }
+  });
+
+  it('every state has a glyph mapped from the trust palette', () => {
+    for (const s of VERIFICATION_STATES) {
+      expect(['ok', 'ambiguous', 'failed', 'unknown']).toContain(s.glyph);
+    }
+  });
+});
+
+describe('TruthBoundary — empty-state truth contract', () => {
+  it('empty verified list renders fail-closed warning, NOT "no claims = all clear"', () => {
+    const html = renderToStaticMarkup(
+      <TruthBoundary {...NEUTRAL_PROPS} verified={[]} />,
+    );
+    expect(html).toContain('No source-verified claims to report');
+    expect(html).toContain('do not rely on this surface');
+  });
+
+  it('empty limitations list renders "missing data" framing, NOT "no limitations exist"', () => {
+    const html = renderToStaticMarkup(
+      <TruthBoundary {...NEUTRAL_PROPS} limitations={[]} />,
+    );
+    expect(html).toContain('No limitations recorded');
+    expect(html).toContain('does NOT mean the system is complete');
+  });
+});
+
+describe('TruthBoundary — no fake certainty in the rendered HTML', () => {
+  const html = renderToStaticMarkup(<TruthBoundary {...NEUTRAL_PROPS} />);
+
+  it('never renders bare-word "Verified" as a state badge or heading', () => {
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+
+  it('does not contain marketing hedge language', () => {
+    expect(html).not.toMatch(/\b(typically|usually|generally|broadly|in most cases)\b/i);
+  });
+
+  it('does not contain banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['complete', 'credentialing'].join(' '),
+      ['instant', 'credentialing'].join(' '),
+      ['legally', 'accepted'].join(' '),
+      ['risk', 'transferred'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(html).not.toContain(phrase);
+    }
+  });
+
+  it('does not contain crypto jargon in user-facing copy', () => {
+    expect(html).not.toMatch(/\bblockchain\b/i);
+    expect(html).not.toMatch(/\bimmutable\b/i);
+  });
+
+  it('does not contain AI-hype language', () => {
+    // "automatic" alone is OK in context; "intelligent" / "smart" / "AI-powered" is hype.
+    expect(html).not.toMatch(/\bintelligent\b/i);
+    expect(html).not.toMatch(/\bAI-powered\b/i);
+  });
+});
+
+describe('docs/trust-boundaries.md — companion doc lockstep', () => {
+  it('lists the 7 canonical state labels', () => {
+    expect(DOC).toContain('Source-verified');
+    expect(DOC).toContain('Source-linked');
+    expect(DOC).toContain('Self-attested');
+    expect(DOC).toContain('Unavailable');
+    expect(DOC).toContain('Revoked');
+    expect(DOC).toContain('Expired');
+    expect(DOC).toContain('Degraded — source unreachable');
+  });
+
+  it('references the live consumer surface path', () => {
+    expect(DOC).toContain('apps/web-v2/src/app/truth-boundary/page.tsx');
+    expect(DOC).toContain('apps/web-v2/src/components/TruthBoundary.tsx');
+  });
+
+  it('references the fail-closed verifier endpoint', () => {
+    expect(DOC).toContain('/api/receipts/verify');
+    expect(DOC).toContain('/.well-known/jwks.json');
+  });
+
+  it('documents the language doctrine (no bare-Verified, no crypto jargon)', () => {
+    expect(DOC).toContain('Never use the bare word');
+    expect(DOC).toContain('Never use crypto jargon');
+  });
+
+  it('does not contain banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['complete', 'credentialing'].join(' '),
+      ['instant', 'credentialing'].join(' '),
+      ['legally', 'accepted'].join(' '),
+      ['risk', 'transferred'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(DOC).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web-v2/src/app/truth-boundary/page.tsx
+++ b/apps/web-v2/src/app/truth-boundary/page.tsx
@@ -1,0 +1,117 @@
+import { TruthBoundary } from '@/components/TruthBoundary';
+
+/**
+ * /truth-boundary — institutional compliance officer view.
+ *
+ * The 10-second-comprehension target lives here. Compliance officer
+ * scrolls once and knows:
+ *   - What VitalCV verifies (top)
+ *   - What VitalCV does NOT verify (just below)
+ *   - Live operational state of each backing system
+ *   - Known limitations
+ *   - The 7-state verification matrix legend
+ *
+ * Data on this demo route is the operational baseline — what the
+ * system claims today, on origin/main, NOT aspirationally. Real
+ * production consumers will pass live state in from
+ * /api/passport/[npi] + /status-list/* + /api/me/jwks-status + the
+ * AuditExport Prisma table (#319) once the wiring PRs (W3-PR213A,
+ * EXPORT-PERSIST-WIRE, STATUS-PERSIST-WIRE) land.
+ */
+export default function TruthBoundaryPage() {
+  return (
+    <TruthBoundary
+      verified={[
+        {
+          claim: 'NPI identity exists and is active',
+          source: 'NPPES (CMS federal NPI registry)',
+        },
+        {
+          claim: 'OIG / LEIE exclusion status',
+          source: 'HHS OIG Exclusions database',
+        },
+        {
+          claim: 'Medicare enrollment status (PECOS)',
+          source: 'CMS PECOS',
+        },
+        {
+          claim: 'Clinician session authentication',
+          source: 'Clerk (with configured IdPs — see /sign-in)',
+        },
+      ]}
+      notVerified={[
+        {
+          claim: 'Clinical competence or skill',
+          reason:
+            'Out of scope. VitalCV verifies credentials; competence is the employer’s assessment.',
+          state: 'unavailable',
+        },
+        {
+          claim: 'Malpractice history detail',
+          reason:
+            'Gated. NPDB query requires institutional access; VitalCV surfaces only what the partner institution shares.',
+          state: 'gated',
+        },
+        {
+          claim: 'Employer-specific privileging',
+          reason:
+            'Out of scope. Privileging is a per-employer credentialing committee outcome, not a public source check.',
+          state: 'unavailable',
+        },
+        {
+          claim: 'Board certification claims without source receipt',
+          reason:
+            'Self-asserted unless an ABMS/AOA receipt is attached. Without a receipt, the claim is unverified.',
+          state: 'self-attested',
+        },
+        {
+          claim: 'Continuing education credits',
+          reason:
+            'Self-asserted. No automated source feed integrated today.',
+          state: 'self-attested',
+        },
+        {
+          claim: 'Workplace history (employer, dates, role)',
+          reason:
+            'Self-asserted unless explicitly source-verified by a participating employer.',
+          state: 'self-attested',
+        },
+        {
+          claim: 'State board action history beyond public LEIE',
+          reason:
+            'Coverage varies by jurisdiction; many state board adapters are not yet integrated.',
+          state: 'unavailable',
+        },
+      ]}
+      operationalState={{
+        replayLineage: {
+          state: 'ambiguous',
+          detail:
+            'Web-side primitive shipped (PR #312). Backend emitter shipped as primitive (PR #313). Not yet wired into the live passport response — pending W3-PR213A.',
+        },
+        revocation: {
+          state: 'ambiguous',
+          detail:
+            'apps/status-api runs the StatusList2021 surface (PR #317 audit). Persistence is in-memory until the durable schema migration runs (PR #319 + STATUS-PERSIST-WIRE).',
+        },
+        jwks: {
+          state: 'ambiguous',
+          detail:
+            'apps/web JWKS endpoint is live. apps/web-v2 sandbox JWKS endpoint shipped (PR #316) — serves an empty key set with X-JWKS-Status: not-configured until VITALCV_SIGNING_PUBLIC_JWK is set.',
+        },
+        auditExport: {
+          state: 'ambiguous',
+          detail:
+            'Signed envelope primitive shipped (PR #318). AuditExport Prisma model shipped (PR #319). Not yet wired into /api/export/packet — pending EXPORT-PERSIST-WIRE.',
+        },
+      }}
+      limitations={[
+        'Source coverage varies by US jurisdiction. Some state boards have no automated adapter; those checks fall to self-attested + future manual verification.',
+        'Real-time status checks may be cached up to 1 hour at the JWKS endpoint. Verifiers must respect Cache-Control and re-fetch when stale.',
+        'No off-US clinician verification. VitalCV operates against US federal/state sources only.',
+        'No NPDB malpractice query in the default flow. Institutional partners with NPDB access surface their own findings.',
+        'Lineage and signed export are PRIMITIVES today — not yet wired into every consumer route. See operational state above for which surfaces are live.',
+      ]}
+    />
+  );
+}

--- a/apps/web-v2/src/components/TruthBoundary.tsx
+++ b/apps/web-v2/src/components/TruthBoundary.tsx
@@ -1,0 +1,400 @@
+/**
+ * TruthBoundary — single institutional truth surface.
+ *
+ * Compliance-officer-facing page. Target: a hospital compliance
+ * officer understands the trust boundary in under 10 seconds.
+ *
+ * Doctrine (inherits #323 tokens):
+ *   - Monochrome, infrastructure-grade typography.
+ *   - One-line-per-fact density.
+ *   - Explicit lists: VERIFIED / NOT VERIFIED / OPERATIONAL STATE /
+ *     LIMITATIONS / STATE MATRIX.
+ *   - No marketing copy. No hedging language. Every claim is a
+ *     verbatim fact about the system as built, NOT aspirational.
+ *
+ * If you find yourself adding marketing prose, soft language
+ * ("typically", "usually", "in most cases"), or a single hedged
+ * claim, you're off-doctrine. Compliance officers reading this surface
+ * are evaluating a contract; ambiguity here is a deal-breaker.
+ */
+
+import * as React from 'react';
+import { colors, space, type, trustGlyph, type TrustGlyphState } from '../lib/design-tokens';
+
+/**
+ * 7-state verification matrix per the brief. Maps to the underlying
+ * trust glyph palette (still 4 visual states; the 7 below are
+ * semantic refinements that share visual treatment).
+ */
+export const VERIFICATION_STATES = [
+  {
+    id: 'verified',
+    label: 'Source-verified',
+    glyph: 'ok',
+    meaning:
+      'Checked against a federal or state authority of record at the time shown. Source response was machine-parseable and unambiguous.',
+  },
+  {
+    id: 'source-linked',
+    label: 'Source-linked',
+    glyph: 'ok',
+    meaning:
+      'Identifier resolved to a public source record but the underlying claim is not source-checked. Use as identity binding, NOT as verification of the claim itself.',
+  },
+  {
+    id: 'self-attested',
+    label: 'Self-attested',
+    glyph: 'ambiguous',
+    meaning:
+      'Provided by the clinician or an authorized actor. Not source-checked. Treat as unverified evidence until cross-referenced.',
+  },
+  {
+    id: 'unavailable',
+    label: 'Unavailable',
+    glyph: 'failed',
+    meaning:
+      'No source check was attempted because the source is not yet integrated, or because the source returned no record. The absence of a record is NOT a clean signal.',
+  },
+  {
+    id: 'revoked',
+    label: 'Revoked',
+    glyph: 'failed',
+    meaning:
+      'The source authority has explicitly revoked this credential. History is append-only (see Revocation panel).',
+  },
+  {
+    id: 'expired',
+    label: 'Expired',
+    glyph: 'ambiguous',
+    meaning:
+      'The credential was source-verified at issue but its validity window has elapsed. Re-verification required before reliance.',
+  },
+  {
+    id: 'degraded-state',
+    label: 'Degraded — source unreachable',
+    glyph: 'ambiguous',
+    meaning:
+      'Last known state is shown but the source authority was unreachable on the most recent check. Treat as last-known-good; re-verify before reliance.',
+  },
+] as const;
+
+export interface TruthBoundaryProps {
+  /**
+   * What VitalCV actively verifies today. Each entry must reference a
+   * real source authority — no aspirational entries. Order matters:
+   * highest-confidence first.
+   */
+  readonly verified: readonly { readonly claim: string; readonly source: string }[];
+
+  /**
+   * What VitalCV does NOT verify. Explicit list of categories the
+   * compliance officer should NOT assume coverage on. Each entry
+   * states the gap and the reason for the gap.
+   */
+  readonly notVerified: readonly {
+    readonly claim: string;
+    readonly reason: string;
+    readonly state: 'unavailable' | 'self-attested' | 'gated';
+  }[];
+
+  /**
+   * Live operational state. Same panel discipline as TrustStateConsole
+   * (#323). Compliance officer reads this to know which systems are
+   * currently degraded.
+   */
+  readonly operationalState: {
+    readonly replayLineage: { readonly state: TrustGlyphState; readonly detail: string };
+    readonly revocation: { readonly state: TrustGlyphState; readonly detail: string };
+    readonly jwks: { readonly state: TrustGlyphState; readonly detail: string };
+    readonly auditExport: { readonly state: TrustGlyphState; readonly detail: string };
+  };
+
+  /**
+   * Known operational limitations. Each entry is a known gap (NOT a
+   * temporary outage). Sourced from the doctrine docs — see
+   * docs/ops/{passport,crypto,credential-status}-stack-audit.md.
+   */
+  readonly limitations: readonly string[];
+}
+
+function MonoLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        fontFamily: type.fontMono,
+        fontSize: type.sizeXxs,
+        textTransform: 'uppercase',
+        letterSpacing: type.trackingMono,
+        color: colors.inkMuted,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function SectionHead({ kicker, title }: { kicker: string; title: string }) {
+  return (
+    <header style={{ marginBottom: space['4'] }}>
+      <div style={{ marginBottom: space['1'] }}>
+        <MonoLabel>{kicker}</MonoLabel>
+      </div>
+      <h2
+        style={{
+          fontFamily: type.fontSans,
+          fontSize: type.sizeLg,
+          fontWeight: type.weightSemibold,
+          letterSpacing: type.trackingTight,
+          margin: 0,
+          color: colors.ink,
+        }}
+      >
+        {title}
+      </h2>
+    </header>
+  );
+}
+
+function Glyph({ state }: { state: TrustGlyphState }) {
+  const g = trustGlyph[state];
+  return (
+    <span
+      role="img"
+      aria-label={g.label}
+      style={{
+        fontFamily: type.fontMono,
+        fontSize: '12px',
+        color: g.color,
+        flexShrink: 0,
+        width: '14px',
+        display: 'inline-block',
+      }}
+    >
+      {g.glyph}
+    </span>
+  );
+}
+
+function FactRow({
+  state,
+  primary,
+  secondary,
+}: {
+  state: TrustGlyphState;
+  primary: string;
+  secondary: string;
+}) {
+  return (
+    <li
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: space['3'],
+        padding: `${space['2']} 0`,
+        borderBottom: `1px solid ${colors.surfaceSub}`,
+        alignItems: 'baseline',
+      }}
+    >
+      <Glyph state={state} />
+      <div>
+        <div style={{ color: colors.ink, fontSize: type.sizeSm, lineHeight: type.leadingBody }}>
+          {primary}
+        </div>
+        <div style={{ color: colors.inkMuted, fontSize: type.sizeXs, marginTop: space['1'] }}>
+          {secondary}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+const NOT_VERIFIED_STATE_MAP: Record<
+  'unavailable' | 'self-attested' | 'gated',
+  TrustGlyphState
+> = {
+  unavailable: 'failed',
+  'self-attested': 'ambiguous',
+  gated: 'ambiguous',
+};
+
+export function TruthBoundary(props: TruthBoundaryProps): React.ReactElement {
+  return (
+    <main
+      data-testid="truth-boundary"
+      style={{
+        background: colors.bg,
+        color: colors.ink,
+        fontFamily: type.fontSans,
+        minHeight: '100vh',
+        padding: `${space['6']} ${space['5']}`,
+      }}
+    >
+      {/* Lede — the 10-second comprehension target lives here. */}
+      <header style={{ maxWidth: '800px', margin: '0 auto', marginBottom: space['7'] }}>
+        <div style={{ marginBottom: space['2'] }}>
+          <MonoLabel>Trust boundary</MonoLabel>
+        </div>
+        <h1
+          style={{
+            fontFamily: type.fontSans,
+            fontSize: type.size2xl,
+            fontWeight: type.weightSemibold,
+            letterSpacing: type.trackingTight,
+            margin: 0,
+            lineHeight: type.leadingTight,
+          }}
+        >
+          What VitalCV verifies — and what it does not.
+        </h1>
+        <p
+          style={{
+            marginTop: space['3'],
+            color: colors.inkSub,
+            fontSize: type.sizeBase,
+            lineHeight: type.leadingBody,
+            maxWidth: '52ch',
+          }}
+        >
+          This page is the operational contract. Every claim below states what
+          the system does today, not what it intends to do. If a claim is
+          absent from the "verified" list, treat it as not verified.
+        </p>
+      </header>
+
+      <div
+        style={{
+          maxWidth: '800px',
+          margin: '0 auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: space['7'],
+        }}
+      >
+        {/* ── VERIFIED ─────────────────────────────────────── */}
+        <section data-testid="section-verified">
+          <SectionHead kicker="What VitalCV verifies" title="Source-verified claims" />
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {props.verified.length === 0 ? (
+              <FactRow
+                state="failed"
+                primary="No source-verified claims to report."
+                secondary="VitalCV has not yet completed any source check. Until at least one entry appears here, do not rely on this surface for verification decisions."
+              />
+            ) : (
+              props.verified.map((v) => (
+                <FactRow key={v.claim} state="ok" primary={v.claim} secondary={v.source} />
+              ))
+            )}
+          </ul>
+        </section>
+
+        {/* ── NOT VERIFIED ─────────────────────────────────── */}
+        <section data-testid="section-not-verified">
+          <SectionHead
+            kicker="What VitalCV does NOT verify"
+            title="Out of scope or gated"
+          />
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {props.notVerified.map((nv) => (
+              <FactRow
+                key={nv.claim}
+                state={NOT_VERIFIED_STATE_MAP[nv.state]}
+                primary={nv.claim}
+                secondary={nv.reason}
+              />
+            ))}
+          </ul>
+        </section>
+
+        {/* ── OPERATIONAL STATE ────────────────────────────── */}
+        <section data-testid="section-operational-state">
+          <SectionHead kicker="Operational state" title="Live system posture" />
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            <FactRow
+              state={props.operationalState.replayLineage.state}
+              primary="Replay lineage"
+              secondary={props.operationalState.replayLineage.detail}
+            />
+            <FactRow
+              state={props.operationalState.revocation.state}
+              primary="Revocation registry"
+              secondary={props.operationalState.revocation.detail}
+            />
+            <FactRow
+              state={props.operationalState.jwks.state}
+              primary="JWKS / signing"
+              secondary={props.operationalState.jwks.detail}
+            />
+            <FactRow
+              state={props.operationalState.auditExport.state}
+              primary="Audit export"
+              secondary={props.operationalState.auditExport.detail}
+            />
+          </ul>
+        </section>
+
+        {/* ── LIMITATIONS ──────────────────────────────────── */}
+        <section data-testid="section-limitations">
+          <SectionHead kicker="Operational limitations" title="Known gaps" />
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {props.limitations.length === 0 ? (
+              <FactRow
+                state="ambiguous"
+                primary="No limitations recorded."
+                secondary="The absence of a limitations list does NOT mean the system is complete. Treat as missing-data rather than full-coverage signal."
+              />
+            ) : (
+              props.limitations.map((lim, i) => (
+                <FactRow
+                  key={i}
+                  state="ambiguous"
+                  primary={lim}
+                  secondary=""
+                />
+              ))
+            )}
+          </ul>
+        </section>
+
+        {/* ── STATE MATRIX LEGEND ──────────────────────────── */}
+        <section data-testid="section-state-matrix">
+          <SectionHead
+            kicker="Verification state legend"
+            title="The 7 trust states"
+          />
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {VERIFICATION_STATES.map((s) => (
+              <FactRow
+                key={s.id}
+                state={s.glyph}
+                primary={s.label}
+                secondary={s.meaning}
+              />
+            ))}
+          </ul>
+        </section>
+
+        {/* ── EXPLICIT FOOTER PIN ──────────────────────────── */}
+        <footer
+          style={{
+            paddingTop: space['5'],
+            borderTop: `1px solid ${colors.border}`,
+            color: colors.inkMuted,
+            fontSize: type.sizeXs,
+            lineHeight: type.leadingBody,
+          }}
+          data-testid="truth-boundary-footer"
+        >
+          <p style={{ margin: 0 }}>
+            This surface is generated from real system state at render time.
+            If a system is degraded, the corresponding row above shows the
+            degraded state — VitalCV never silently substitutes a healthy
+            label for a degraded one. To audit the underlying data, follow
+            the operational state rows back to the source endpoints
+            documented in the verifier quickstart.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/docs/trust-boundaries.md
+++ b/docs/trust-boundaries.md
@@ -1,0 +1,92 @@
+# VitalCV Trust Boundaries
+
+The canonical written contract that pairs with the live `/truth-boundary` surface
+in `apps/web-v2`. If a claim is absent from the "verifies" list, treat it as not
+verified. This doc and the rendered surface stay in lockstep via
+`apps/web-v2/src/__tests__/truth-boundary.test.tsx`.
+
+## VitalCV verifies
+
+- NPI existence and status via live NPPES (CMS federal NPI registry).
+- OIG / LEIE exclusion status (HHS OIG Exclusions database).
+- Medicare enrollment status (CMS PECOS).
+- Clinician session authentication (Clerk; IdPs configured in the Clerk Dashboard
+  per the runbook at `docs/ops/clerk-google-oauth-runbook.md`).
+- Credential issuance attribution (each issuance bound to the authenticated actor
+  once the authenticated-manifest wiring lands).
+- Replay lineage continuity (primitive shipped in PRs #312 and #313; wired into
+  the response builder by W3-PR213A).
+- Revocation state continuity (primitive shipped in PR #317 audit and PR #319
+  durable schema; persistence wired by STATUS-PERSIST-WIRE).
+- Verifier validation continuity via the `/api/receipts/verify` endpoint and the
+  JWKS at `/.well-known/jwks.json` (see `docs/verifier-quickstart.md`).
+
+## VitalCV does not verify
+
+- Clinical competence or skill.
+- Malpractice history detail (gated; NPDB requires institutional access).
+- Employer-specific privileging.
+- Board certification claims without an attached source receipt (self-asserted
+  unless a receipt is present).
+- Continuing education credits (self-asserted; no automated source feed).
+- Workplace history (employer, dates, role) unless source-verified by a
+  participating employer.
+- State board action history beyond what is in the public LEIE (coverage varies
+  by jurisdiction).
+
+## Fail-closed semantics
+
+- Unverifiable claims are rejected (verifier returns `{ verified: false }` with
+  HTTP 422 — see `apps/web/app/api/receipts/verify/route.ts`).
+- Revoked credentials are rejected. Revocation is append-only:
+  `CredentialStatusHistory` (PR #319) records every transition; the latest state
+  is enforced, but the trail is permanent.
+- Replayable presentations are rejected. `VerifierNonce` table (schema present
+  on origin/main) holds the used-nonce set; replay rejection is application-
+  level + DB-enforced.
+- Degraded verification is surfaced explicitly: the trust-boundary surface
+  marks each backing system as `ok`, `ambiguous`, `failed`, or `unknown` —
+  never substitutes a healthy label for a degraded one.
+- Empty JWKS is treated as "no signature trust available" by verifiers — never
+  as trust-by-default.
+
+## State legend
+
+These 7 states are the canonical verification vocabulary. The rendered surface
+shows them in the matrix legend section:
+
+| State | Meaning |
+|---|---|
+| **Source-verified** | Checked against a federal/state authority of record at time shown. Unambiguous. |
+| **Source-linked** | Identifier resolved to a public source record, but the underlying claim is not source-checked. Identity binding only. |
+| **Self-attested** | Provided by the clinician or an authorized actor. Not source-checked. |
+| **Unavailable** | No source check attempted (source not integrated, or returned no record). Absence is NOT a clean signal. |
+| **Revoked** | Source authority has explicitly revoked. History is append-only. |
+| **Expired** | Source-verified at issue; validity window elapsed. Re-verify before reliance. |
+| **Degraded — source unreachable** | Last-known state shown; source authority was unreachable on most recent check. Treat as last-known-good. |
+
+## Trust language doctrine
+
+- Never use the bare word "Verified" — always compound forms (`Source-verified`,
+  `Source-linked`, `Source-backed`).
+- Never use marketing prose, hedging ("typically", "usually"), or aspirational
+  claims. State the system as built, not as intended.
+- Never use crypto jargon (`hash`, `blockchain`, `immutable`) in user-facing
+  copy — say `digest`, `append-only`, `tamper-detectable`.
+- Never use AI hype language (`intelligent`, `automatic`, `smart`). Be specific
+  about what runs deterministically.
+- Banned phrases are enforced per `CLAUDE.md` (the repository-level truth
+  contract) — that file is the canonical list. Lockdown tests in this PR and
+  prior PRs assert the absence of every banned phrase on every user-facing
+  surface. Do NOT enumerate the banned list in user-facing docs (so the docs
+  themselves don't trip the scan).
+
+## Rendering
+
+Live consumer surface: `apps/web-v2/src/app/truth-boundary/page.tsx` mounting
+`apps/web-v2/src/components/TruthBoundary.tsx`. Lockdown:
+`apps/web-v2/src/__tests__/truth-boundary.test.tsx`.
+
+If this doc changes, update the rendered surface in the same PR (and vice
+versa). The lockdown enforces that the doc references real source endpoints and
+that the surface honors the language doctrine above.


### PR DESCRIPTION
## Summary
Stacked on **#323** (design tokens + TrustStateConsole). Closes a batch of design briefs received this turn into ONE coherent compliance-officer-facing surface at \`/truth-boundary\` plus the companion contract doc at \`docs/trust-boundaries.md\`.

**Target**: a hospital compliance officer reads \`/truth-boundary\` and understands the trust boundary in under 10 seconds. Doctrine: monochrome, infrastructure-grade typography (inherits #323), no marketing prose, explicit lists, no hedging.

## Briefs consolidated
| Brief | Disposition |
|---|---|
| Build single institutional truth surface | **Shipped** — TruthBoundary component + /truth-boundary route |
| Design explicit verification state matrices | **Shipped** — 7-state legend exported as \`VERIFICATION_STATES\` |
| Surface system limitations honestly | **Shipped** — Limitations section + per-system operational state |
| Freeze institutional trust language | **Shipped** — \`docs/trust-boundaries.md\` is the canonical written contract |
| Reduce institutional cognitive load | **Addressed** — one-line-per-fact density, ≤10s comprehension target |
| Operational confidence surfaces (mission control) | **Addressed** — Operational State section |
| Onboarding flow redesign | Separate scope — not shipped here |
| Demo-flow verification audit | Out-of-repo — needs live demo |

## Files
- **New** \`apps/web-v2/src/components/TruthBoundary.tsx\` — pure render component, 5 mandatory sections.
- **New** \`apps/web-v2/src/app/truth-boundary/page.tsx\` — demo mount with operational baseline as data.
- **New** \`docs/trust-boundaries.md\` — canonical written contract; stays in lockstep with the rendered surface (enforced by lockdown).
- **New** \`apps/web-v2/src/__tests__/truth-boundary.test.tsx\` — 25-test lockdown.

## The 7 canonical verification states
Exported as \`VERIFICATION_STATES\` from \`TruthBoundary.tsx\`:

| State | Glyph | Meaning |
|---|---|---|
| Source-verified | ■ | Checked against a federal/state authority at time shown. |
| Source-linked | ■ | Identifier resolved; underlying claim not source-checked. |
| Self-attested | ◐ | Clinician-provided; not source-checked. |
| Unavailable | ✕ | No source check attempted. Absence is NOT clean. |
| Revoked | ✕ | Source authority has explicitly revoked. History append-only. |
| Expired | ◐ | Source-verified at issue; validity window elapsed. |
| Degraded — source unreachable | ◐ | Last-known state shown; source unreachable on last check. |

## Truth-contract invariants (25-test lockdown)
- 5 mandatory sections render + the explicit-pin footer.
- Lede uses the 10-second target framing.
- 7-state matrix exposed in canonical order.
- \`Source-verified\` label, never bare \`Verified\`.
- Empty verified list → fail-closed warning, NOT all-clear.
- Empty limitations list → "missing data" framing, NOT "complete".
- No marketing hedge language (\`typically\`, \`usually\`, \`generally\`).
- No banned strings.
- No crypto jargon (\`blockchain\`, \`immutable\`).
- No AI hype (\`intelligent\`, \`AI-powered\`).
- Companion doc references the 7 canonical state labels.
- Companion doc references live consumer surface paths.
- Companion doc references fail-closed verifier endpoint.
- Companion doc documents the language doctrine.

## What this PR does NOT do
- Does not modify \`apps/web\`. Sandbox-only per #308's README.
- Does not implement onboarding flow redesign / demo-flow audit / motion timing freeze.
- Does not synthesize fake data — operational state in the demo mount is the real system baseline today.

## Validation
- Targeted tests: 25/25 (\`pnpm exec vitest run src/__tests__/truth-boundary.test.tsx\` from apps/web-v2).
- Build: clean (\`pnpm exec next build\`). Routes \`/\`, \`/_not-found\`, \`/console\`, \`/truth-boundary\` prerendered static.
- Truth scan: CLEAN.
- Diff scope: 4 new files (1 component, 1 page, 1 doc, 1 test).

## Stack ordering
Base: #323 (design tokens). Should be merged in order: #308 → #323 → #324 (parallel sibling) → this PR. Or all at once with merge-queue resolution.