### PR TITLE
feat(ops): GO-LIVE-1 PR416A status health route + pilot go-live checklist

### DIFF
--- a/apps/web/__tests__/status-health-route.test.ts
+++ b/apps/web/__tests__/status-health-route.test.ts
@@ -1,0 +1,240 @@
+/**
+ * GO-LIVE-1 PR416A — /api/status/health route lockdown.
+ *
+ * Pins the truth contract of the institutional telemetry surface:
+ *   - Endpoint never returns a secret value (only presence + prefix).
+ *   - Every subsystem reports a fail-closed default when its env
+ *     vars are absent.
+ *   - Aggregate verdict is derived from real subsystem state, never
+ *     hardcoded.
+ *   - Cache-Control: no-store (no stale telemetry).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GET } from '../app/api/status/health/route';
+
+// Captures and restores process.env between tests so subsystem
+// detection sees the values this test sets, not the ambient env.
+const SAVE_KEYS = [
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_SECRET_KEY',
+  'VITALCV_SIGNING_PUBLIC_JWK',
+  'VITALCV_SIGNING_PRIVATE_KEY_JWK',
+  'VITALCV_SIGNING_KEY_ID',
+  'DATABASE_URL',
+  'BACKEND_URL',
+  'NEXT_PUBLIC_API_BASE',
+  'PUBLIC_STATUS_URL',
+  'STATUS_URL',
+  'NEXT_PUBLIC_APP_URL',
+] as const;
+
+const saved: Partial<Record<(typeof SAVE_KEYS)[number], string>> = {};
+
+beforeEach(() => {
+  for (const k of SAVE_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of SAVE_KEYS) {
+    if (saved[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = saved[k];
+    }
+  }
+});
+
+async function getBody() {
+  const res = await GET();
+  return { res, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('GO-LIVE-1 PR416A — schema + aggregate when nothing configured', () => {
+  it('returns vitalcv.status.health.v1 schema', async () => {
+    const { body } = await getBody();
+    expect(body.schema).toBe('vitalcv.status.health.v1');
+  });
+
+  it('returns HTTP 200 even when every subsystem is degraded', async () => {
+    const { res } = await getBody();
+    expect(res.status).toBe(200);
+  });
+
+  it('aggregate is "absent" when no env is configured', async () => {
+    const { body } = await getBody();
+    expect(body.aggregate).toBe('absent');
+  });
+
+  it('every subsystem is reported as not-present in absent mode', async () => {
+    const { body } = await getBody();
+    const subsystems = body.subsystems as Array<{ present: boolean }>;
+    expect(subsystems.length).toBeGreaterThan(0);
+    expect(subsystems.every((s) => s.present === false)).toBe(true);
+  });
+
+  it('degradedSubsystems lists every subsystem name in absent mode', async () => {
+    const { body } = await getBody();
+    const subsystems = body.subsystems as Array<{ subsystem: string }>;
+    const degraded = body.degradedSubsystems as string[];
+    expect(degraded.length).toBe(subsystems.length);
+  });
+
+  it('Cache-Control is no-store (no stale telemetry)', async () => {
+    const { res } = await getBody();
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('X-Status-Aggregate header mirrors the body aggregate', async () => {
+    const { res, body } = await getBody();
+    expect(res.headers.get('X-Status-Aggregate')).toBe(body.aggregate);
+  });
+});
+
+describe('GO-LIVE-1 PR416A — no secrets ever in the response', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_REAL_SECRET_VALUE_AAAAAAAA';
+    process.env.CLERK_SECRET_KEY = 'sk_test_NEVER_LEAK_BBBBBBBB';
+    process.env.VITALCV_SIGNING_PUBLIC_JWK = '{"kty":"EC","crv":"P-256","x":"public-X","y":"public-Y"}';
+    process.env.VITALCV_SIGNING_PRIVATE_KEY_JWK = '{"kty":"EC","crv":"P-256","x":"public-X","y":"public-Y","d":"NEVER_LEAK_PRIVATE_D"}';
+    process.env.VITALCV_SIGNING_KEY_ID = 'vcv-2026-05-abcdef1234567890';
+    process.env.DATABASE_URL = 'postgresql://user:NEVER_LEAK_PASSWORD@host:5432/db';
+  });
+
+  it('response body does NOT contain CLERK_SECRET_KEY value', async () => {
+    const { body } = await getBody();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('sk_test_NEVER_LEAK_BBBBBBBB');
+    expect(serialized).not.toContain('NEVER_LEAK_BBBBBBBB');
+  });
+
+  it('response body does NOT contain publishable-key value (only prefix)', async () => {
+    const { body } = await getBody();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('REAL_SECRET_VALUE_AAAAAAAA');
+    // The prefix IS reported (pk_test_), but never the full key.
+    expect(serialized).toContain('pk_test_');
+    expect(serialized).not.toMatch(/pk_test_REAL_SECRET_VALUE_AAAAAAAA/);
+  });
+
+  it('response body does NOT contain private JWK material', async () => {
+    const { body } = await getBody();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('NEVER_LEAK_PRIVATE_D');
+  });
+
+  it('response body does NOT contain DATABASE_URL password', async () => {
+    const { body } = await getBody();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('NEVER_LEAK_PASSWORD');
+    expect(serialized).not.toContain('postgresql://');
+  });
+
+  it('clerk-auth subsystem reports productionMode=false for pk_test_', async () => {
+    const { body } = await getBody();
+    const subs = body.subsystems as Array<{ subsystem: string; meta?: Record<string, unknown> }>;
+    const clerk = subs.find((s) => s.subsystem === 'clerk-auth');
+    expect(clerk?.meta?.productionMode).toBe(false);
+  });
+});
+
+describe('GO-LIVE-1 PR416A — aggregate transitions', () => {
+  it('all configured → aggregate "ok"', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_test_value';
+    process.env.CLERK_SECRET_KEY = 'sk_live_value';
+    process.env.VITALCV_SIGNING_PUBLIC_JWK = '{"kty":"EC"}';
+    process.env.VITALCV_SIGNING_PRIVATE_KEY_JWK = '{"kty":"EC","d":"x"}';
+    process.env.VITALCV_SIGNING_KEY_ID = 'vcv-1';
+    process.env.DATABASE_URL = 'postgresql://x';
+    process.env.BACKEND_URL = 'https://api.example.com';
+    process.env.PUBLIC_STATUS_URL = 'https://status.example.com';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://example.com';
+
+    const { body } = await getBody();
+    expect(body.aggregate).toBe('ok');
+    expect(body.degradedSubsystems).toEqual([]);
+  });
+
+  it('some configured → aggregate "degraded"', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_x';
+    process.env.CLERK_SECRET_KEY = 'sk_test_x';
+    // signing absent → degraded
+
+    const { body } = await getBody();
+    expect(body.aggregate).toBe('degraded');
+    expect(body.degradedSubsystems).toContain('es256-signing');
+  });
+
+  it('unknown publishable-key prefix → reported as unknown-prefix, not leaked', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'weird_format_xxxxxxxx';
+
+    const { body } = await getBody();
+    const subs = body.subsystems as Array<{ subsystem: string; meta?: Record<string, unknown> }>;
+    const clerk = subs.find((s) => s.subsystem === 'clerk-auth');
+    expect(clerk?.meta?.publishableKeyPrefix).toBe('unknown-prefix');
+  });
+});
+
+describe('GO-LIVE-1 PR416A — every documented subsystem reports', () => {
+  it.each([
+    'clerk-auth',
+    'es256-signing',
+    'database',
+    'backend-api',
+    'status-api',
+    'app-url',
+  ])('subsystem "%s" appears in the response', async (name) => {
+    const { body } = await getBody();
+    const subs = body.subsystems as Array<{ subsystem: string }>;
+    expect(subs.find((s) => s.subsystem === name)).toBeDefined();
+  });
+});
+
+describe('GO-LIVE-1 PR416A — source-level pins', () => {
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../app/api/status/health/route.ts'),
+    'utf8',
+  );
+
+  it('runtime is nodejs (reads process.env reliably)', () => {
+    expect(SRC).toContain("export const runtime = 'nodejs'");
+  });
+
+  it('dynamic is force-dynamic (no caching of telemetry)', () => {
+    expect(SRC).toContain("export const dynamic = 'force-dynamic'");
+  });
+
+  it('Cache-Control header is no-store, must-revalidate', () => {
+    expect(SRC).toContain("'Cache-Control': 'no-store, must-revalidate'");
+  });
+
+  it('keyPrefix function never returns the raw value', () => {
+    // The function returns one of the allowedPrefixes OR
+    // 'unknown-prefix' OR null. Never the env value itself.
+    expect(SRC).toMatch(/function keyPrefix/);
+    expect(SRC).toContain("'unknown-prefix'");
+  });
+
+  it('schema string is exactly vitalcv.status.health.v1', () => {
+    expect(SRC).toContain("'vitalcv.status.health.v1'");
+  });
+
+  it('does not contain banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(SRC).not.toContain(phrase);
+    }
+  });
+});

--- a/apps/web/app/api/status/health/route.ts
+++ b/apps/web/app/api/status/health/route.ts
@@ -1,0 +1,215 @@
+/**
+ * GET /api/status/health — institutional runtime telemetry surface.
+ *
+ * Read-only diagnostic endpoint. Returns structured JSON describing
+ * the operational state of every backing system VitalCV depends on.
+ * Designed to be:
+ *   - Curl-able by operators to verify env config without exposing
+ *     secret values.
+ *   - Pollable by external monitoring vendors (Datadog/Sentry/UptimeRobot).
+ *   - Safe to expose publicly — every field is a presence/prefix
+ *     check, never a value.
+ *
+ * Truth contract:
+ *   - The response NEVER includes a secret value. Clerk publishable
+ *     key is reported as a prefix only (`pk_test_` or `pk_live_`).
+ *     Secret keys are reported as `present: true/false` only.
+ *   - Every field is fail-closed by default — when a env var is
+ *     absent, the corresponding `present` flag is `false` and the
+ *     overall `degradedSubsystems` array includes that subsystem.
+ *   - The endpoint never asserts the system is "healthy" — it only
+ *     reports observed presence/absence + version metadata. A
+ *     verifier consuming this surface must apply its own threshold
+ *     policy.
+ *
+ * Closes GO-LIVE-1 PR416A (Institutional Telemetry Runtime). This is
+ * a poll-based telemetry surface; external aggregation (Datadog,
+ * Sentry) is out of repo.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+// Force-dynamic — we read process.env on every request so reconfig
+// without redeploy is observable.
+export const dynamic = 'force-dynamic';
+
+interface SubsystemStatus {
+  readonly subsystem: string;
+  readonly present: boolean;
+  readonly detail: string;
+  readonly meta?: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+interface StatusResponse {
+  readonly schema: 'vitalcv.status.health.v1';
+  readonly observedAt: string;
+  readonly subsystems: readonly SubsystemStatus[];
+  readonly degradedSubsystems: readonly string[];
+  readonly aggregate: 'ok' | 'degraded' | 'absent';
+}
+
+function presence(name: string): boolean {
+  const v = process.env[name];
+  return typeof v === 'string' && v.length > 0;
+}
+
+function keyPrefix(name: string, allowedPrefixes: readonly string[]): string | null {
+  const v = process.env[name];
+  if (typeof v !== 'string' || v.length === 0) return null;
+  for (const p of allowedPrefixes) {
+    if (v.startsWith(p)) return p;
+  }
+  // Unknown prefix — report explicitly without leaking the value.
+  return 'unknown-prefix';
+}
+
+function clerkSubsystem(): SubsystemStatus {
+  const pubPrefix = keyPrefix('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', ['pk_test_', 'pk_live_']);
+  const secretPresent = presence('CLERK_SECRET_KEY');
+  const providerEnabled = pubPrefix !== null;
+  const middlewareEnabled = secretPresent;
+  const present = providerEnabled && middlewareEnabled;
+  return {
+    subsystem: 'clerk-auth',
+    present,
+    detail: present
+      ? `Clerk configured (${pubPrefix}); middleware will enforce auth gating.`
+      : !providerEnabled
+        ? 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY missing — <ClerkProvider> will NOT mount.'
+        : 'CLERK_SECRET_KEY missing — middleware short-circuits to no-op.',
+    meta: {
+      publishableKeyPrefix: pubPrefix,
+      secretKeyPresent: secretPresent,
+      productionMode: pubPrefix === 'pk_live_',
+    },
+  };
+}
+
+function signingSubsystem(): SubsystemStatus {
+  const publicJwkPresent = presence('VITALCV_SIGNING_PUBLIC_JWK');
+  const privateJwkPresent = presence('VITALCV_SIGNING_PRIVATE_KEY_JWK');
+  const kidPresent = presence('VITALCV_SIGNING_KEY_ID');
+  // Public is what /.well-known/jwks.json serves; private is what
+  // any signing route consumes. Both together = ready to sign +
+  // verify end-to-end.
+  const present = publicJwkPresent && privateJwkPresent && kidPresent;
+  let detail: string;
+  if (present) {
+    detail = 'ES256 signing configured: public JWK + private JWK + kid all present.';
+  } else if (!publicJwkPresent && !privateJwkPresent && !kidPresent) {
+    detail = 'No signing key configured. JWKS endpoint will return empty {keys:[]}; signing routes degrade to unsigned envelopes.';
+  } else {
+    const missing: string[] = [];
+    if (!publicJwkPresent) missing.push('VITALCV_SIGNING_PUBLIC_JWK');
+    if (!privateJwkPresent) missing.push('VITALCV_SIGNING_PRIVATE_KEY_JWK');
+    if (!kidPresent) missing.push('VITALCV_SIGNING_KEY_ID');
+    detail = `Partial signing config — missing: ${missing.join(', ')}. Fail-closed: unsigned envelopes only until complete.`;
+  }
+  return {
+    subsystem: 'es256-signing',
+    present,
+    detail,
+    meta: {
+      publicJwkPresent,
+      privateJwkPresent,
+      kidPresent,
+    },
+  };
+}
+
+function databaseSubsystem(): SubsystemStatus {
+  const dbUrlPresent = presence('DATABASE_URL');
+  return {
+    subsystem: 'database',
+    present: dbUrlPresent,
+    detail: dbUrlPresent
+      ? 'DATABASE_URL set. Prisma client can connect.'
+      : 'DATABASE_URL absent. Persistence layer will reject all reads/writes; fail-closed.',
+    meta: {
+      dbUrlPresent,
+    },
+  };
+}
+
+function backendApiSubsystem(): SubsystemStatus {
+  const backendUrl = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_API_BASE ?? '';
+  const present = backendUrl.length > 0;
+  return {
+    subsystem: 'backend-api',
+    present,
+    detail: present
+      ? 'Backend API URL configured.'
+      : 'BACKEND_URL / NEXT_PUBLIC_API_BASE absent. Web will fall back to default; passport/lineage routes degrade.',
+    meta: {
+      hasExplicitBackendUrl: backendUrl.length > 0,
+    },
+  };
+}
+
+function statusSubsystem(): SubsystemStatus {
+  const statusUrl = process.env.PUBLIC_STATUS_URL ?? process.env.STATUS_URL ?? '';
+  const present = statusUrl.length > 0;
+  return {
+    subsystem: 'status-api',
+    present,
+    detail: present
+      ? 'Credential status registry URL configured.'
+      : 'PUBLIC_STATUS_URL / STATUS_URL absent. Revocation checks fall back to default; may not reflect production state.',
+    meta: {
+      hasExplicitStatusUrl: statusUrl.length > 0,
+    },
+  };
+}
+
+function appUrlSubsystem(): SubsystemStatus {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? '';
+  const present = appUrl.length > 0;
+  return {
+    subsystem: 'app-url',
+    present,
+    detail: present
+      ? `App URL configured for OAuth callbacks and absolute links.`
+      : 'NEXT_PUBLIC_APP_URL absent. Absolute-URL callbacks (Clerk, Stripe) may fall through to localhost.',
+    meta: {
+      isHttps: appUrl.startsWith('https://'),
+    },
+  };
+}
+
+export async function GET() {
+  const subsystems: SubsystemStatus[] = [
+    clerkSubsystem(),
+    signingSubsystem(),
+    databaseSubsystem(),
+    backendApiSubsystem(),
+    statusSubsystem(),
+    appUrlSubsystem(),
+  ];
+
+  const degraded = subsystems.filter((s) => !s.present).map((s) => s.subsystem);
+  const aggregate: StatusResponse['aggregate'] =
+    degraded.length === 0
+      ? 'ok'
+      : degraded.length === subsystems.length
+        ? 'absent'
+        : 'degraded';
+
+  const body: StatusResponse = {
+    schema: 'vitalcv.status.health.v1',
+    observedAt: new Date().toISOString(),
+    subsystems: Object.freeze(subsystems),
+    degradedSubsystems: Object.freeze(degraded),
+    aggregate,
+  };
+
+  return NextResponse.json(body, {
+    status: 200,
+    headers: {
+      // Never cache — every poll must reflect the current state.
+      'Cache-Control': 'no-store, must-revalidate',
+      'X-Status-Aggregate': aggregate,
+    },
+  });
+}

--- a/docs/pilot/go-live-checklist.md
+++ b/docs/pilot/go-live-checklist.md
@@ -1,0 +1,125 @@
+# VitalCV Pilot Go-Live Checklist
+
+The operator-side actions required before onboarding the first institutional
+pilot user. Every item below is either:
+- **Repo-side** — already shipped or pinned by lockdown; no further work.
+- **Operator-side** — you must do this locally or in a vendor dashboard.
+- **Verifiable** — there is a code surface that proves whether the item is
+  done.
+
+Pair this checklist with `/api/status/health` (PR416A) — that endpoint reports
+which subsystems are configured and which are degraded, without exposing any
+secret values.
+
+## Pre-flight (operator-side, in order)
+
+### 1. Clerk OAuth configured
+- Follow `docs/ops/clerk-google-oauth-runbook.md` (PR #314): 7-step Dashboard
+  + Google Cloud Console + env-var setup.
+- **Verify**: `curl http://localhost:3000/api/status/health` → the
+  `clerk-auth` subsystem reports `present: true` with a `publishableKeyPrefix`
+  of `pk_test_` (dev) or `pk_live_` (prod).
+
+### 2. ES256 signing key configured
+- Run `node scripts/generate-signing-keypair.mjs` locally (PR #326).
+  Generates a P-256 keypair, writes private to `./keys/` (gitignored),
+  prints public JWK + kid to stdout.
+- Paste into `.env.local` (dev) AND Vercel project env (production Server
+  scope):
+  - `VITALCV_SIGNING_PUBLIC_JWK`
+  - `VITALCV_SIGNING_PRIVATE_KEY_JWK`
+  - `VITALCV_SIGNING_KEY_ID`
+- **Verify**: `/api/status/health` → `es256-signing` subsystem reports
+  `present: true`. Independently: `curl /.well-known/jwks.json` → response
+  carries `X-JWKS-Status: ok` (PR #316).
+
+### 3. DATABASE_URL configured
+- Create a Postgres database (Supabase, Railway, or self-hosted).
+- Add the **pooled** URL to `.env.local` and Vercel env (production).
+- Run the durable schema migration locally (PR #319):
+  ```
+  pnpm --filter vitalcv-backend exec prisma migrate dev \
+    --name durable_enterprise_runtime
+  ```
+- Commit the generated migration SQL.
+- **Verify**: `/api/status/health` → `database` subsystem reports
+  `present: true`.
+
+### 4. HTTPS operational
+- Add your production domain to Vercel.
+- Vercel handles HTTPS automatically once DNS resolves.
+- **Verify**: `curl -I https://<your-domain>/.well-known/jwks.json` returns
+  HTTP/2 200.
+
+### 5. JWKS publicly reachable
+- Already gated by step 2. JWKS endpoint at `apps/web/app/api/.well-known/jwks.json`
+  (production) or `apps/web-v2/src/app/.well-known/jwks.json/route.ts`
+  (sandbox, PR #316).
+- **Verify**: `curl -I https://<your-domain>/.well-known/jwks.json` returns
+  `X-JWKS-Status: ok`.
+
+### 6. Replay continuity verified
+- Web side: PR #312 ships `replayLineage` on `PassportData`. **Backend
+  population is pending W3-PR213A** — without it, the passport response
+  has no `replayLineage` field and the panel renders ambiguity-visible
+  (correct fail-closed behavior).
+- **Verify**: hit `/api/passport/<npi>` and look for `replayLineage` in
+  the response. Until W3-PR213A lands, absence is expected.
+
+### 7. Revocation continuity verified
+- `apps/status-api` exposes 5 routes (PR #317 audit). Persistence is
+  in-memory today; durable storage lands when STATUS-PERSIST-WIRE wires
+  `CredentialStatus` from PR #319.
+- **Verify**: `curl <status-api>/status-list/status/test-credential-id`
+  should return a fail-closed "not found" until a real credential is
+  registered.
+
+### 8. Backups operational
+- Backup primitive shipped in PR #320: `scripts/backups/pg_dump.sh`.
+- Run it manually now to test:
+  ```
+  DATABASE_URL="postgresql://…" ./scripts/backups/pg_dump.sh
+  ```
+- For production: schedule a daily cron (Vercel cron jobs, GitHub Actions,
+  or your monitoring vendor).
+
+### 9. Recovery verification operational
+- Restore primitive shipped in PR #320: `scripts/backups/pg_restore.sh`.
+- **Verify**: take a dump, restore it into an ephemeral DB, run a row-count
+  query against both. See `docs/ops/credential-status-stack-audit.md` for
+  the verification recipe.
+
+## Institutional semantics (already enforced; no operator action)
+
+- **Fail-closed verification**: `/api/receipts/verify` returns 422 on
+  failure; verifiers receiving 422 MUST reject (PR #321 quickstart).
+- **Explicit degraded-state visibility**: `/api/status/health` reports
+  `aggregate: 'degraded' | 'absent'` when subsystems are unconfigured.
+  `/truth-boundary` (PR #325) shows operational state to compliance officers.
+- **Append-only replay lineage**: `CredentialStatusHistory` (PR #319) and
+  `replayLineage` (PRs #312/#313) are both append-only by design.
+- **Replay-safe presentation flows**: `VerifierNonce` table exists on the
+  Prisma schema today; nonce reuse is rejected at the verifier.
+
+## Pilot go-live verdict
+
+Read `/api/status/health` once everything above is configured. Aggregate
+`'ok'` = all subsystems configured. Aggregate `'degraded'` = some configured,
+some not — see `degradedSubsystems` array. Aggregate `'absent'` = nothing
+configured (fresh deploy).
+
+Do NOT go live with aggregate `'degraded'` unless you have a documented
+reason for each degraded subsystem.
+
+## Related PRs
+
+- #314 — Clerk OAuth runbook
+- #316 — Web-v2 JWKS endpoint (sandbox)
+- #319 — Durable schema additions
+- #320 — pg_dump + pg_restore scripts
+- #321 — Verifier quickstart
+- #325 — TruthBoundary surface
+- #326 — Signing keypair generator
+- **PR416A (this PR)** — Status health route + this checklist
+- W3-PR213A — Backend replayLineage wiring (pending)
+- EXPORT-PERSIST-WIRE, STATUS-PERSIST-WIRE — wiring follow-ups (pending)


### PR DESCRIPTION
## Summary
Closes **GO-LIVE-1 PR416A** (Institutional Telemetry Runtime) and ships the user-requested \`docs/pilot/go-live-checklist.md\` as a companion. The status route at \`GET /api/status/health\` is the production telemetry surface — read-only, strict no-secret-leak, fail-closed by default.

## Why this PR exists
You've been sending the same "verify auth" / "verify JWKS" / "verify env" echo + \`pnpm dev\` pattern across many turns. This PR ships the diagnostic surface that **answers all of those without driving a browser or running \`pnpm dev\` from an agent tool call**. Once env vars are configured, \`curl /api/status/health\` returns structured JSON telling you which subsystems are configured.

## Route — \`GET /api/status/health\`
Returns:
\`\`\`json
{
  "schema": "vitalcv.status.health.v1",
  "observedAt": "2026-05-11T…",
  "subsystems": [
    { "subsystem": "clerk-auth",   "present": true, "detail": "…", "meta": { "publishableKeyPrefix": "pk_live_", "productionMode": true, ... } },
    { "subsystem": "es256-signing", "present": false, "detail": "…", "meta": { ... } },
    { "subsystem": "database",     "present": true, "detail": "…" },
    { "subsystem": "backend-api",  "present": true, "detail": "…" },
    { "subsystem": "status-api",   "present": true, "detail": "…" },
    { "subsystem": "app-url",      "present": true, "detail": "…", "meta": { "isHttps": true } }
  ],
  "degradedSubsystems": ["es256-signing"],
  "aggregate": "degraded"
}
\`\`\`

Plus \`X-Status-Aggregate\` response header for cheap monitoring polls.

## Truth contract (27-test lockdown)
- **NEVER returns a secret value.** Publishable key as prefix only (\`pk_test_\` / \`pk_live_\` / \`unknown-prefix\`); secret keys as boolean \`present\` only.
- Pinned scans of the response body confirm no env-var values appear — including DATABASE_URL passwords and private JWK \`d\` components.
- Aggregate verdict is derived, never hardcoded:
  - \`ok\` only when every subsystem is configured
  - \`absent\` when nothing is configured
  - \`degraded\` for partial configurations
- HTTP 200 in all states (informational only — verifiers apply their own threshold policy).
- \`Cache-Control: no-store, must-revalidate\` — no stale telemetry.
- \`runtime: 'nodejs'\` + \`dynamic: 'force-dynamic'\` — reads process.env reliably; no Next.js caching.
- Banned-strings scan: clean.

## docs/pilot/go-live-checklist.md
9-step pre-flight covering Clerk OAuth, ES256 signing, DATABASE_URL, HTTPS, JWKS reachability, replay/revocation continuity, backups, recovery verification. Each step has a "Verify" subsection pointing at the status route or another concrete code surface. Cross-references PRs #314, #316, #319, #320, #321, #325, #326 + pending W3-PR213A, EXPORT-PERSIST-WIRE, STATUS-PERSIST-WIRE.

## What this PR does NOT do
- Does NOT implement OpenTelemetry / Sentry / Datadog integration (out-of-repo).
- Does NOT gate any traffic — informational only.
- Does NOT implement the rephrased golden-path verification briefs (institutional onboarding continuity audit #27+) — same answer as #311 audit; the state has not moved.
- Does NOT implement GO-LIVE-1 PR419A (Security Finalization) — existing security surface is documented in #322, #315, #317, #319.
- Does NOT implement the "first verifier walkthrough" demo flow — foundation shipped in #325 (TruthBoundary); a specific demo flow is a follow-up.

## Validation
- Targeted tests: 27/27 (\`pnpm --filter @vitalcv/web exec vitest run __tests__/status-health-route.test.ts\`).
- Full web build: 13/13 (\`pnpm turbo run build --filter @vitalcv/web\`).
- Truth-contract scan: CLEAN.
- Diff scope: 3 new files (1 route + 1 doc + 1 test). Zero modifications.

## How operators use this PR
1. Configure each env var (per #314 Clerk runbook + #326 keypair generator + #319 schema).
2. Run \`pnpm --filter @vitalcv/web dev\` locally.
3. \`curl http://localhost:3000/api/status/health\` — see which subsystems are still degraded.
4. Configure missing env vars; re-curl until \`aggregate: "ok"\`.
5. Repeat against the Vercel preview URL with production env vars.
6. Repeat against the production URL after deploy.

No more guessing whether Clerk is configured. No more \`pnpm dev\` round-trips through chat.