### PR TITLE
feat(backend): W3-PR213A passport lineage bridge primitive

### DIFF
--- a/apps/api/backend/src/services/passport/__tests__/buildPassportLineage.test.ts
+++ b/apps/api/backend/src/services/passport/__tests__/buildPassportLineage.test.ts
@@ -1,0 +1,209 @@
+/**
+ * W3-PR213A — buildPassportLineage pure-function lockdown.
+ *
+ * Tests the bridge between IngestEvent Prisma rows and the lineage
+ * primitive from #313. Pure transform — runs without a DB. The live
+ * wiring step (call site in passport.ts that queries Prisma + attaches
+ * the lineage to the response) is documented as out-of-scope in the
+ * PR body; it requires integration tests against the project's
+ * Postgres fixture.
+ */
+
+import { buildPassportLineage, type IngestEventRow } from '../buildPassportLineage';
+import { verifyReplayLineageDigest } from '../replayLineage';
+
+const NOW = '2026-05-11T00:00:00Z';
+const RUN_ID = 'run-1346053246-1715000000000';
+
+function row(overrides: Partial<IngestEventRow> = {}): IngestEventRow {
+  return {
+    ingestRunId: RUN_ID,
+    sequence: 0,
+    eventType: 'source_start',
+    sourceId: 'nppes',
+    payload: {},
+    createdAt: new Date('2026-05-11T00:00:01Z'),
+    ...overrides,
+  };
+}
+
+function basicRows(): IngestEventRow[] {
+  return [
+    row({ sequence: 0, eventType: 'source_start',    sourceId: 'nppes', createdAt: new Date('2026-05-11T00:00:01Z') }),
+    row({ sequence: 1, eventType: 'source_complete', sourceId: 'nppes', createdAt: new Date('2026-05-11T00:00:02Z') }),
+    row({ sequence: 2, eventType: 'source_start',    sourceId: 'oig',   createdAt: new Date('2026-05-11T00:00:03Z') }),
+    row({ sequence: 3, eventType: 'source_complete', sourceId: 'oig',   createdAt: new Date('2026-05-11T00:00:04Z') }),
+    row({ sequence: 4, eventType: 'passport_ready',  sourceId: null,    createdAt: new Date('2026-05-11T00:00:05Z') }),
+  ];
+}
+
+describe('W3-PR213A — buildPassportLineage: structural null returns', () => {
+  it('returns null when runId is missing', () => {
+    expect(buildPassportLineage({ rows: basicRows(), runId: null, nowIso: NOW })).toBeNull();
+    expect(buildPassportLineage({ rows: basicRows(), runId: '', nowIso: NOW })).toBeNull();
+    expect(buildPassportLineage({ rows: basicRows(), runId: undefined, nowIso: NOW })).toBeNull();
+  });
+
+  it('returns null when rows is empty', () => {
+    expect(buildPassportLineage({ rows: [], runId: RUN_ID, nowIso: NOW })).toBeNull();
+  });
+
+  it('returns null when rows is null/undefined', () => {
+    expect(buildPassportLineage({ rows: null, runId: RUN_ID, nowIso: NOW })).toBeNull();
+    expect(buildPassportLineage({ rows: undefined, runId: RUN_ID, nowIso: NOW })).toBeNull();
+  });
+});
+
+describe('W3-PR213A — buildPassportLineage: ordering + determinism', () => {
+  it('sorts events by sequence ASC regardless of input order', () => {
+    // Shuffle the input rows.
+    const shuffled = [...basicRows()].reverse();
+    const lineage = buildPassportLineage({
+      rows: shuffled,
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage).not.toBeNull();
+    const types = lineage!.events.map((e) => e.eventType);
+    expect(types).toEqual([
+      'source_start',
+      'source_complete',
+      'source_start',
+      'source_complete',
+      'passport_ready',
+    ]);
+  });
+
+  it('produces the same digest regardless of input row order (sort-stable)', () => {
+    const forward = buildPassportLineage({ rows: basicRows(),                runId: RUN_ID, nowIso: NOW });
+    const reversed = buildPassportLineage({ rows: [...basicRows()].reverse(), runId: RUN_ID, nowIso: NOW });
+    expect(forward!.eventDigest).toBe(reversed!.eventDigest);
+  });
+
+  it('verifyReplayLineageDigest passes on a freshly-built lineage', () => {
+    const lineage = buildPassportLineage({ rows: basicRows(), runId: RUN_ID, nowIso: NOW });
+    expect(verifyReplayLineageDigest(lineage!)).toBe(true);
+  });
+});
+
+describe('W3-PR213A — buildPassportLineage: comprehensive flag', () => {
+  it('comprehensive=true when every claimed source has a source_complete', () => {
+    const lineage = buildPassportLineage({
+      rows: basicRows(),
+      runId: RUN_ID,
+      claimedSources: ['nppes', 'oig'],
+      nowIso: NOW,
+    });
+    expect(lineage!.comprehensive).toBe(true);
+  });
+
+  it('comprehensive=false when a claimed source is missing', () => {
+    const lineage = buildPassportLineage({
+      rows: basicRows(),
+      runId: RUN_ID,
+      claimedSources: ['nppes', 'oig', 'pecos'],
+      nowIso: NOW,
+    });
+    expect(lineage!.comprehensive).toBe(false);
+  });
+
+  it('claimedSources omitted → comprehensive=true (caller waives check)', () => {
+    const lineage = buildPassportLineage({
+      rows: basicRows(),
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage!.comprehensive).toBe(true);
+  });
+});
+
+describe('W3-PR213A — buildPassportLineage: row → IngestEventLike mapping', () => {
+  it('sourceId null is normalized to lineage event sourceId null', () => {
+    const lineage = buildPassportLineage({
+      rows: [
+        row({ sequence: 0, eventType: 'passport_ready', sourceId: null }),
+      ],
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage!.events[0]!.sourceId).toBeNull();
+  });
+
+  it('createdAt Date is serialized to ISO string', () => {
+    const lineage = buildPassportLineage({
+      rows: [
+        row({
+          sequence: 0,
+          eventType: 'source_complete',
+          sourceId: 'nppes',
+          createdAt: new Date('2026-05-11T12:34:56.789Z'),
+        }),
+      ],
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage!.events[0]!.observedAt).toBe('2026-05-11T12:34:56.789Z');
+  });
+
+  it('createdAt ISO string is passed through unchanged', () => {
+    const lineage = buildPassportLineage({
+      rows: [
+        row({
+          sequence: 0,
+          eventType: 'source_complete',
+          sourceId: 'nppes',
+          createdAt: '2026-05-11T08:00:00Z',
+        }),
+      ],
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage!.events[0]!.observedAt).toBe('2026-05-11T08:00:00Z');
+  });
+
+  it('payload is passed through (used for eventId extraction if present)', () => {
+    const lineage = buildPassportLineage({
+      rows: [
+        row({ sequence: 0, eventType: 'source_complete', sourceId: 'nppes', payload: { eventId: 'evt-canonical-1' } }),
+      ],
+      runId: RUN_ID,
+      nowIso: NOW,
+    });
+    expect(lineage!.events[0]!.eventId).toBe('evt-canonical-1');
+  });
+});
+
+describe('W3-PR213A — buildPassportLineage: output is frozen', () => {
+  it('returned lineage is frozen', () => {
+    const lineage = buildPassportLineage({ rows: basicRows(), runId: RUN_ID, nowIso: NOW });
+    expect(Object.isFrozen(lineage)).toBe(true);
+  });
+
+  it('events array is frozen', () => {
+    const lineage = buildPassportLineage({ rows: basicRows(), runId: RUN_ID, nowIso: NOW });
+    expect(Object.isFrozen(lineage!.events)).toBe(true);
+  });
+
+  it('does not mutate the input rows array', () => {
+    const rows = basicRows();
+    const originalOrder = rows.map((r) => r.sequence);
+    buildPassportLineage({ rows, runId: RUN_ID, nowIso: NOW });
+    expect(rows.map((r) => r.sequence)).toEqual(originalOrder);
+  });
+});
+
+describe('W3-PR213A — source-level pin: integration call site documented', () => {
+  it('module documents the next-step call site shape', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../buildPassportLineage.ts'),
+      'utf8',
+    ) as string;
+    // The comment block documents the call site so future PRs can
+    // wire it without re-deriving the contract.
+    expect(src).toContain('await prisma.ingestEvent.findMany');
+    expect(src).toContain('buildPassportLineage');
+    expect(src).toContain('runId');
+  });
+});

--- a/apps/api/backend/src/services/passport/buildPassportLineage.ts
+++ b/apps/api/backend/src/services/passport/buildPassportLineage.ts
@@ -1,0 +1,107 @@
+/**
+ * buildPassportLineage — W3-PR213A bridge.
+ *
+ * Bridges the existing `IngestEvent` Prisma rows (apps/api/backend/
+ * prisma/schema.prisma:754) into the `ReplayLineage` shape from #313
+ * (apps/api/backend/src/services/passport/replayLineage.ts).
+ *
+ * Pure function: takes a pre-fetched list of IngestEvent rows + the
+ * passport's claimed sources + a wall-clock timestamp, returns a
+ * frozen `ReplayLineage` (or null when input is insufficient).
+ *
+ * NOT included in this PR: the call-site that actually queries Prisma
+ * by runId and attaches the result to the passport response. That is
+ * the live wiring step. Reasoning:
+ *
+ *   - Live wiring requires knowing which runId is associated with
+ *     which passport request. The existing passport service does not
+ *     yet record this binding on the response path; adding it touches
+ *     the data flow in passport.ts and passportService.ts and needs
+ *     integration tests against a real Postgres fixture.
+ *   - This PR is the PURE-FUNCTION foundation. The integration step
+ *     becomes a one-line call site: `lineage = buildPassportLineage(
+ *     await prisma.ingestEvent.findMany({ where: { ingestRunId } }),
+ *     runId, sources, new Date().toISOString())`.
+ *
+ * Tests run without a DB (pure transform). Integration is the
+ * follow-up.
+ */
+
+import { buildReplayLineage, type ReplayLineage, type IngestEventLike } from './replayLineage';
+
+/**
+ * Structural shape of an `IngestEvent` Prisma row. Typed loosely so
+ * this module does not depend on the generated Prisma client (which
+ * pulls in the entire schema type).
+ */
+export interface IngestEventRow {
+  readonly ingestRunId: string;
+  readonly sequence: number;
+  readonly eventType: string;
+  readonly sourceId: string | null;
+  readonly payload: unknown;
+  readonly createdAt: Date | string;
+}
+
+/**
+ * Adapts an IngestEventRow into the IngestEventLike shape that
+ * `buildReplayLineage` expects. We map:
+ *   - sourceId: null → undefined (the primitive expects optional)
+ *   - createdAt Date → ISO string (lineage stores ISO strings)
+ *   - payload: passed through, including the eventId if present
+ */
+function toIngestEventLike(row: IngestEventRow): IngestEventLike {
+  const observedAt =
+    typeof row.createdAt === 'string'
+      ? row.createdAt
+      : row.createdAt instanceof Date
+        ? row.createdAt.toISOString()
+        : new Date().toISOString();
+  return {
+    type: row.eventType,
+    sourceId: row.sourceId ?? undefined,
+    timestamp: observedAt,
+    payload: row.payload,
+  };
+}
+
+/**
+ * Builds a `ReplayLineage` from a pre-fetched list of `IngestEvent`
+ * rows + the passport's claimed sources.
+ *
+ * Returns null when:
+ *   - rows is empty
+ *   - rows is non-array
+ *   - runId is missing
+ *
+ * Sorts rows by `sequence` ascending before lineage construction —
+ * the database's `(ingestRunId, sequence)` unique constraint
+ * guarantees this is deterministic per run.
+ *
+ * `claimedSources` is the list of sources the passport response
+ * claims as `sources.checked`. The lineage's `comprehensive` flag
+ * derives from whether every claimed source has a `source_complete`
+ * event in the trace.
+ */
+export function buildPassportLineage(input: {
+  rows: readonly IngestEventRow[] | null | undefined;
+  runId: string | null | undefined;
+  claimedSources?: readonly string[];
+  nowIso: string;
+}): ReplayLineage | null {
+  if (!input.runId || input.runId.length === 0) return null;
+  if (!Array.isArray(input.rows) || input.rows.length === 0) return null;
+
+  // Sort ascending by sequence — the DB unique index guarantees
+  // (ingestRunId, sequence) is deterministic per run.
+  const sorted = [...input.rows].sort((a, b) => a.sequence - b.sequence);
+
+  const events = sorted.map(toIngestEventLike);
+
+  return buildReplayLineage({
+    runId: input.runId,
+    events,
+    claimedSources: input.claimedSources,
+    nowIso: input.nowIso,
+  });
+}


### PR DESCRIPTION
## Summary
Stacked on **#313** (backend \`replayLineage\` primitive). Adds the pure-function bridge between the existing \`IngestEvent\` Prisma rows (\`apps/api/backend/prisma/schema.prisma:754\`) and the lineage shape that the web side (#312) expects on \`PassportData.replayLineage\`.

**The keystone scope** the queue has been waiting on, ship-disciplined:
- This PR is the **pure-function foundation only**. Sorts events, maps Prisma rows → \`IngestEventLike\`, delegates to \`buildReplayLineage\` from #313.
- The live wiring step (calling Prisma at the response builder + attaching to the response payload) is documented as the next code action. It requires integration tests against the project's Postgres fixture, which needs the DATABASE_URL env you have not yet configured.
- This PR is **mergeable today, without DB env**, because the unit tests are pure transforms.

## Why the live wiring is NOT in this PR
The wiring needs: which \`runId\` is associated with which passport request? The existing \`passport.ts\` response builder does NOT currently surface this binding on the response path. Adding it touches data flow in \`passport.ts\` + \`passportService.ts\` and requires integration tests against real Postgres to prove no regression. Doing that without a configured test DB is reckless — the static analysis tells me nothing about whether the existing service hot path can read \`ingest_events\` reliably.

## Files
- **New** \`apps/api/backend/src/services/passport/buildPassportLineage.ts\`:
  - \`IngestEventRow\` type — structural shape of the Prisma row.
  - \`toIngestEventLike\` — maps Prisma row → \`IngestEventLike\`. \`sourceId\` null→undefined; \`Date\`→ISO; payload preserved.
  - \`buildPassportLineage\` — top-level builder. Sorts by \`sequence\` ASC, delegates to \`buildReplayLineage\` from #313.
- **New** \`apps/api/backend/src/services/passport/__tests__/buildPassportLineage.test.ts\` — 17-test Jest lockdown.

## Truth-contract invariants (17 tests)
- Returns null on missing \`runId\`, empty rows, null/undefined rows.
- Sorts events by \`sequence\` ASC regardless of input order. Same digest for shuffled input.
- \`verifyReplayLineageDigest\` passes on a freshly-built lineage.
- \`comprehensive\` flag derived from claimed-sources vs \`source_complete\` events.
- Row→event mapping: \`sourceId\` null normalized, \`createdAt\` Date serialized to ISO, ISO string passed through unchanged, payload preserved (eventId from payload propagates).
- Output is frozen.
- Input rows array is not mutated.
- Source-level pin: module documents the integration call site shape for the follow-up wiring PR.

## Live wiring (NEXT PR, not this one)
\`\`\`ts
// In apps/api/backend/src/routes/passport.ts at the response builder:
const events = await prisma.ingestEvent.findMany({
  where: { ingestRunId },
  orderBy: { sequence: 'asc' },
});
const lineage = buildPassportLineage({
  rows: events,
  runId: ingestRunId,
  claimedSources: passport.sources.checked,
  nowIso: new Date().toISOString(),
});
if (lineage) {
  (passport as PassportWithLineage).replayLineage = lineage;
}
\`\`\`

The remaining work is identifying WHERE \`ingestRunId\` comes from on the response hot path. Most likely candidates:
1. The passport entity itself (add a \`lastIngestRunId\` column).
2. The most-recent successful run for the NPI (query \`IngestEvent\` for the latest \`ingest_run_id\` with at least one \`source_complete\`).
3. A new \`runId\` query parameter on the route.

Each requires a separate small migration + an integration test. Pick one in the follow-up.

## Validation
- Jest: 17/17 (\`DATABASE_URL="postgresql://test:test@localhost:5432/test" NODE_ENV=test npx jest src/services/passport/__tests__/buildPassportLineage.test.ts --no-coverage\` from \`apps/api/backend\`). The env-override is the same shape as the existing backend test pattern; no real DB is contacted.
- Truth-contract scan: CLEAN.
- Diff scope: 2 new files in \`apps/api/backend/src/services/passport/\`. Zero modifications.

## Doctrine
Canonical-JSON-then-SHA-256 scheme matches #312 (web replay-lineage), #313 (backend primitive), #318 (signed export envelope), #319 (CredentialStatusHistory eventDigest). End-to-end attribution chain uses a uniform digest grammar.