### PR TITLE
feat(onboarding): wire /get-ready — first clinician NPI binding

### DIFF
--- a/apps/web/app/get-ready/GetReadyClient.tsx
+++ b/apps/web/app/get-ready/GetReadyClient.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, ShieldCheck, AlertCircle, CheckCircle2 } from 'lucide-react';
+
+type Phase = 'idle' | 'looking_up' | 'confirm' | 'claiming' | 'done' | 'error';
+
+interface NpiLookupResult {
+  npi: string;
+  npiType: 'TYPE_1' | 'TYPE_2';
+  inferredPersona: 'CLINICIAN' | 'VERIFIER' | 'UNKNOWN';
+  firstName?: string;
+  lastName?: string;
+  specialty?: string;
+  state?: string;
+  alreadyRegistered: boolean;
+}
+
+export function GetReadyClient() {
+  const [npi, setNpi] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [result, setResult] = useState<NpiLookupResult | null>(null);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleLookup(e: React.FormEvent) {
+    e.preventDefault();
+    if (!/^\d{10}$/.test(npi)) {
+      setErrorMsg('NPI must be exactly 10 digits.');
+      return;
+    }
+    setErrorMsg('');
+    setPhase('looking_up');
+
+    try {
+      const res = await fetch(`/api/identity/bootstrap/${npi}`);
+      const data = await res.json() as NpiLookupResult & { error?: string };
+
+      if (!res.ok) {
+        setErrorMsg(data.error ?? `NPPES lookup failed (${res.status}). Check the NPI and try again.`);
+        setPhase('error');
+        return;
+      }
+
+      setResult(data);
+      setPhase('confirm');
+    } catch {
+      setErrorMsg('Network error. Check your connection and try again.');
+      setPhase('error');
+    }
+  }
+
+  async function handleBind() {
+    if (!result) return;
+    setPhase('claiming');
+
+    try {
+      // 1. Create PersonProfile linked to this user (critical — makes holder page show NPI)
+      const profileRes = await fetch('/api/profile/npi/bootstrap', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ npi: result.npi }),
+      });
+
+      if (!profileRes.ok) {
+        const data = await profileRes.json().catch(() => ({})) as { error?: string };
+        const msg = data.error ?? `Profile binding failed (${profileRes.status})`;
+        // 401 means not signed in — specific guidance
+        if (profileRes.status === 401) {
+          setErrorMsg('Sign in first, then return here to bind your NPI.');
+        } else {
+          setErrorMsg(msg);
+        }
+        setPhase('error');
+        return;
+      }
+
+      // 2. Record ownership claim
+      const claimRes = await fetch('/api/ownership/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ npi: result.npi }),
+      });
+      if (!claimRes.ok) {
+        const data = await claimRes.json().catch(() => ({})) as { error?: string };
+        setErrorMsg(data.error ?? `Ownership claim failed (${claimRes.status})`);
+        setPhase('error');
+        return;
+      }
+
+      // 3. Ingest NPI credentials — best-effort; failure is non-fatal
+      await fetch('/api/credentials/ingest-npi', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ npi: result.npi }),
+      }).catch(() => undefined);
+
+      setPhase('done');
+    } catch {
+      setErrorMsg('Network error during NPI binding. Try again.');
+      setPhase('error');
+    }
+  }
+
+  function reset() {
+    setNpi('');
+    setPhase('idle');
+    setResult(null);
+    setErrorMsg('');
+  }
+
+  /* ── Done ── */
+  if (phase === 'done' && result) {
+    const name = [result.firstName, result.lastName].filter(Boolean).join(' ');
+    return (
+      <div className="space-y-5 text-center">
+        <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10 border border-emerald-500/30 mx-auto">
+          <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+        </div>
+        <div>
+          <h2 className="text-base font-semibold">NPI {result.npi} bound</h2>
+          {name && (
+            <p className="mt-1 text-sm text-muted-foreground">{name} · your credential record is building.</p>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Source-backed evidence is separate from this binding. NPI lookup is not government-ID identity proofing.
+        </p>
+        <a
+          href="/holder"
+          className="inline-flex h-10 items-center justify-center rounded-lg bg-foreground px-6 text-sm font-medium text-background hover:opacity-90"
+        >
+          Open your wallet
+        </a>
+      </div>
+    );
+  }
+
+  /* ── Confirm ── */
+  if (phase === 'confirm' && result) {
+    const name = [result.firstName, result.lastName].filter(Boolean).join(' ') || 'Unknown';
+    return (
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Confirm this is you</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            NPPES returned the following for NPI {result.npi}. NPI lookup resolves an identifier — it is not
+            government-ID identity proofing.
+          </p>
+        </div>
+
+        <dl className="rounded-xl border border-border bg-muted/40 p-4 text-sm space-y-2.5">
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground shrink-0">Name</dt>
+            <dd className="font-medium text-right">{name}</dd>
+          </div>
+          {result.specialty && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-muted-foreground shrink-0">Specialty</dt>
+              <dd className="text-right">{result.specialty}</dd>
+            </div>
+          )}
+          {result.state && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-muted-foreground shrink-0">State</dt>
+              <dd className="text-right">{result.state}</dd>
+            </div>
+          )}
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground shrink-0">Type</dt>
+            <dd className="text-right">
+              {result.npiType === 'TYPE_1' ? 'Individual (Type 1)' : 'Organization (Type 2)'}
+            </dd>
+          </div>
+        </dl>
+
+        {result.alreadyRegistered && (
+          <p className="text-xs text-amber-700 bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2">
+            This NPI is already registered. You can still bind it to your account.
+          </p>
+        )}
+
+        <div className="flex gap-3 pt-1">
+          <button
+            onClick={() => void handleBind()}
+            className="flex-1 inline-flex h-10 items-center justify-center rounded-lg bg-foreground text-sm font-medium text-background hover:opacity-90"
+          >
+            <ShieldCheck className="mr-1.5 h-4 w-4" />
+            Yes, bind NPI {result.npi}
+          </button>
+          <button
+            onClick={reset}
+            className="h-10 rounded-lg border border-border px-4 text-sm hover:bg-muted"
+          >
+            Try another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  /* ── Claiming ── */
+  if (phase === 'claiming') {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Binding NPI to your account…</p>
+      </div>
+    );
+  }
+
+  /* ── Error ── */
+  if (phase === 'error') {
+    return (
+      <div className="space-y-4">
+        <div className="flex gap-2.5 rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">{errorMsg}</p>
+        </div>
+        <button
+          onClick={reset}
+          className="w-full h-10 rounded-lg border border-border text-sm hover:bg-muted"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  /* ── Idle / Looking up ── */
+  return (
+    <form onSubmit={(e) => void handleLookup(e)} className="space-y-4">
+      <div>
+        <label htmlFor="npi-input" className="block text-sm font-medium mb-1.5">
+          National Provider Identifier (NPI)
+        </label>
+        <input
+          id="npi-input"
+          type="text"
+          inputMode="numeric"
+          autoComplete="off"
+          maxLength={10}
+          value={npi}
+          onChange={(e) => setNpi(e.target.value.replace(/\D/g, '').slice(0, 10))}
+          placeholder="10-digit NPI"
+          className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          disabled={phase === 'looking_up'}
+        />
+        {errorMsg && <p className="mt-1.5 text-xs text-destructive">{errorMsg}</p>}
+      </div>
+
+      <p className="text-xs text-muted-foreground leading-relaxed">
+        We look up your NPI in NPPES (the federal source of record). This resolves your identifier and links it to
+        your account. It is not government-ID identity proofing.
+      </p>
+
+      <button
+        type="submit"
+        disabled={phase === 'looking_up' || npi.length !== 10}
+        className="w-full inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-medium text-background hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {phase === 'looking_up' ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Looking up…
+          </>
+        ) : (
+          'Look up NPI'
+        )}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/get-ready/page.tsx
+++ b/apps/web/app/get-ready/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { GetReadyClient } from './GetReadyClient';
+
+export const metadata: Metadata = {
+  title: 'Get Ready · VitalCV',
+  description: 'Bind your NPI to start building your source-backed credential record.',
+};
+
+export default function GetReadyPage() {
+  return (
+    <main className="mx-auto w-full max-w-md px-4 py-12 sm:py-16">
+      <header className="mb-8">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Clinician setup
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold leading-tight">
+          Bind your NPI
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Your 10-digit NPI is the starting point for your source-backed credential record. We resolve
+          it from NPPES and link it to your account.
+        </p>
+      </header>
+
+      <div className="rounded-xl border border-border bg-card p-5 sm:p-6">
+        <GetReadyClient />
+      </div>
+
+      <p className="mt-6 text-center text-xs text-muted-foreground">
+        Already have an account?{' '}
+        <a href="/holder" className="underline underline-offset-2 hover:text-foreground">
+          Go to your wallet
+        </a>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Creates `apps/web/app/get-ready/GetReadyClient.tsx` — interactive NPI entry, NPPES confirmation, and three-step binding
- Creates `apps/web/app/get-ready/page.tsx` — server wrapper with metadata

Closes the **broken link** from `/holder` (no-NPI empty state → `/get-ready`). Previously `/get-ready` only existed in `_archive/wave119/` as a redirect to `/onboarding` (a static foundation-plan page with no interactive form). This was the only gap blocking the first actual clinician onboarding.

## End-to-end flow after this PR

| Step | Mechanism | Status |
|------|-----------|--------|
| Google OAuth | Clerk `/sign-in` with Google social provider | ✅ pre-existing |
| Session persistence | Clerk JWT → middleware → `resolve-role` → Prisma `User` row | ✅ pre-existing |
| NPI bind | `/get-ready` → `POST /api/profile/npi/bootstrap` upserts `PersonProfile.npi` for `userId` | ✅ **this PR** |
| Replay attribution | `bootstrapNpiIntake` emits `npi_bootstrapped` `AuditEvent` | ✅ covered |
| Credential issuance | `POST /api/credentials/ingest-npi` → NPPES credential artifact pipeline | ✅ covered (best-effort) |

## Binding sequence (on "Yes, bind NPI")

1. `POST /api/profile/npi/bootstrap` — upserts `PersonProfile` with `userId` and NPI; emits audit event
2. `POST /api/ownership/claim` — creates `NpiOwnership` record
3. `POST /api/credentials/ingest-npi` — credential ingestion (non-fatal if feature flag off)

After step 1, `/holder` immediately transitions from `no_npi → has_npi` on next load.

## UX states

`idle → looking_up → confirm → claiming → done | error`

- **Looking up**: NPPES result shown (name, specialty, state, type) before any write
- **401 on claim**: shows "Sign in first" guidance (unauthenticated path)
- **Already registered**: amber notice, binding still allowed
- **Ingest failure**: non-fatal — ownership claim and profile binding both succeed

## Verification

- TypeScript: `pnpm --filter @vitalcv/web exec tsc --noEmit` — clean
- Rendered: `/get-ready` serves correctly, button enables at 10 digits, no new console errors

## Test plan

- [ ] Sign in with Google via Clerk on `vitalcv.com`
- [ ] Navigate to `/holder` — confirm no-NPI empty state appears with "Get ready" CTA
- [ ] Click CTA → lands on `/get-ready`
- [ ] Enter 10-digit NPI → "Look up NPI" button activates
- [ ] Submit → NPPES result shows (name, specialty, state)
- [ ] Click "Yes, bind NPI" → all three calls succeed → success state
- [ ] Click "Open your wallet" → `/holder` shows `has_npi` state with wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)