### PR TITLE
feat(api): HARDEN-PILOT-EVENTS-401 reject anonymous pilot event writes

### DIFF
--- a/apps/web/__tests__/pilot-ops-events-auth-gate.test.ts
+++ b/apps/web/__tests__/pilot-ops-events-auth-gate.test.ts
@@ -1,0 +1,102 @@
+/**
+ * HARDEN-PILOT-EVENTS-401 lockdown.
+ *
+ * Pins the auth gate on POST /api/pilot-ops/events:
+ *   - Anonymous callers (no Clerk session.userId) → HTTP 401.
+ *   - Response header `x-pilot-events-anonymous: rejected`.
+ *   - 401 fires BEFORE any backend round-trip (no fetch is made).
+ *   - Authenticated callers proceed to the backend with an explicit
+ *     x-actor-id header attached.
+ *
+ * Source-level pin so the gate cannot regress without the test
+ * failing. A separate integration test against the live backend
+ * would verify the durable side; this test pins the proxy contract.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROUTE_PATH = resolve(__dirname, '../app/api/pilot-ops/events/route.ts');
+const ROUTE = readFileSync(ROUTE_PATH, 'utf8');
+
+describe('HARDEN-PILOT-EVENTS-401 — auth gate is present', () => {
+  it('imports auth from @clerk/nextjs/server', () => {
+    expect(ROUTE).toContain("from '@clerk/nextjs/server'");
+    expect(ROUTE).toMatch(/import\s+\{\s*auth\s*\}/);
+  });
+
+  it('awaits auth() at the top of POST', () => {
+    expect(ROUTE).toMatch(/export\s+async\s+function\s+POST[\s\S]{0,200}const\s+session\s*=\s*await\s+auth\(\)/);
+  });
+
+  it('rejects anonymous callers with HTTP 401', () => {
+    expect(ROUTE).toMatch(/if\s*\(\s*!\s*session\.userId\s*\)\s*\{[\s\S]*?status:\s*401/);
+  });
+
+  it('401 response body carries explicit "unauthorized" error', () => {
+    expect(ROUTE).toContain("error: 'unauthorized'");
+    expect(ROUTE).toContain('Anonymous event writes are no longer accepted');
+  });
+
+  it('401 response carries diagnostic header x-pilot-events-anonymous: rejected', () => {
+    expect(ROUTE).toContain("'x-pilot-events-anonymous': 'rejected'");
+  });
+});
+
+describe('HARDEN-PILOT-EVENTS-401 — 401 fires before backend round-trip', () => {
+  it('the 401 return statement appears BEFORE the fetch call', () => {
+    const returnIndex = ROUTE.indexOf("status: 401");
+    const fetchIndex = ROUTE.indexOf('fetch(`${getBackendBase()}/api/pilot-ops/events`');
+    expect(returnIndex).toBeGreaterThan(0);
+    expect(fetchIndex).toBeGreaterThan(0);
+    // The 401 branch terminates the function before the fetch.
+    expect(returnIndex).toBeLessThan(fetchIndex);
+  });
+
+  it('no fetch call exists between the auth() call and the 401 gate', () => {
+    const authIndex = ROUTE.indexOf('await auth()');
+    const gateIndex = ROUTE.indexOf('if (!session.userId)');
+    const between = ROUTE.slice(authIndex, gateIndex);
+    expect(between).not.toContain('fetch(');
+  });
+});
+
+describe('HARDEN-PILOT-EVENTS-401 — authenticated path attaches actor attribution', () => {
+  it('sets x-actor-id header from session.userId', () => {
+    expect(ROUTE).toContain("headers.set('x-actor-id', session.userId)");
+  });
+
+  it('keeps the existing role / orgId header forwarding', () => {
+    expect(ROUTE).toContain("'x-clerk-user-role'");
+    expect(ROUTE).toContain("'x-org-id'");
+  });
+
+  it('the actor-id header set occurs AFTER the 401 gate', () => {
+    const gateIndex = ROUTE.indexOf('if (!session.userId)');
+    const actorSetIndex = ROUTE.indexOf("'x-actor-id'");
+    expect(gateIndex).toBeGreaterThan(0);
+    expect(actorSetIndex).toBeGreaterThan(gateIndex);
+  });
+});
+
+describe('HARDEN-PILOT-EVENTS-401 — banned-strings + doctrine', () => {
+  it('does not contain banned strings', () => {
+    const BANNED = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of BANNED) {
+      expect(ROUTE).not.toContain(phrase);
+    }
+  });
+
+  it('comment block explicitly documents the fail-closed reason', () => {
+    expect(ROUTE).toContain('HARDEN-PILOT-EVENTS-401');
+    expect(ROUTE).toMatch(/anonymous/i);
+    expect(ROUTE).toMatch(/durable\s+events/i);
+  });
+});

--- a/apps/web/app/api/pilot-ops/events/route.ts
+++ b/apps/web/app/api/pilot-ops/events/route.ts
@@ -7,10 +7,42 @@ export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();
+
+  // HARDEN-PILOT-EVENTS-401:
+  // Reject anonymous callers with HTTP 401. Without this gate, the
+  // backend at apps/api/backend/src/routes/pilotOps.ts records the
+  // event regardless of authentication — durable events with no
+  // actor attribution. The fix lives at the proxy boundary so the
+  // 401 surfaces to the caller before any backend round-trip; that
+  // also means no backend record is created and no actor_id has to
+  // be fabricated.
+  //
+  // x-cors-blocked is the OTHER 4xx surface the middleware can emit
+  // for /api/* routes (apps/web/middleware.ts:108–125). 401 here
+  // composes cleanly with that: a request that fails the CORS gate
+  // never reaches this handler.
+  if (!session.userId) {
+    return NextResponse.json(
+      {
+        error: 'unauthorized',
+        error_description:
+          'POST /api/pilot-ops/events requires an authenticated Clerk session. Anonymous event writes are no longer accepted.',
+      },
+      { status: 401, headers: { 'x-pilot-events-anonymous': 'rejected' } },
+    );
+  }
+
   const body = await req.text();
   const headers = buildMarketplaceHeaders(session, {
     'Content-Type': 'application/json',
   });
+
+  // Attach actor attribution explicitly. The marketplace headers
+  // already include the Clerk user id, but emit the explicit
+  // x-actor-id header so the backend's requestActorContext has a
+  // stable, route-specific field for audit lineage on durable
+  // pilot event rows.
+  headers.set('x-actor-id', session.userId);
 
   const role = (session.sessionClaims as Record<string, unknown> | undefined)?.vitalcv;
   if (role && typeof role === 'object') {


### PR DESCRIPTION
## Summary
Closes the brief "harden \`POST /api/pilot/events\`" — actual route is \`/api/pilot-ops/events\`; the brief's path was approximate.

**Pre-PR state**: anonymous callers could write durable events.
- Proxy at \`apps/web/app/api/pilot-ops/events/route.ts\` called \`await auth()\` but did NOT reject on missing session — it just forwarded whatever session info was present.
- Backend at \`apps/api/backend/src/routes/pilotOps.ts:174\` records the event regardless via \`recordPilotMetricEvent(...)\`.
- Net: durable rows in the pilot-events table could be written by unauthenticated callers, with no actor attribution.

**This PR** fixes at the proxy boundary:
- Reject \`!session.userId\` with HTTP 401 + explicit error body.
- Response header \`x-pilot-events-anonymous: rejected\` for cheap diagnostic monitoring.
- 401 fires **before** the backend fetch — no spurious round-trip, no actor_id fabrication.
- Authenticated path attaches explicit \`x-actor-id\` header so the backend's \`requestActorContext\` has a stable, route-specific attribution field for audit lineage on durable rows.
- Preserves the existing \`x-clerk-user-role\` / \`x-org-id\` forwarding for downstream tenant guards.

## Sibling briefs from the same turn — NOT shipped (phantom routes)
- \`/api/track/apply\` — does NOT exist on \`origin/main\`. Grep returns zero matches.
- \`/api/autopilot\` — does NOT exist on \`origin/main\`. Grep returns zero matches.

I'm not opening PRs for routes that don't exist. If you want those routes created, that's a separate scoping conversation (what they do, what they persist, what the contract is).

## Truth-contract invariants (12-test lockdown)
- \`auth()\` imported + awaited at the top of \`POST\`.
- 401 reject branch present with \`status: 401\`.
- Body carries \`error: 'unauthorized'\` + an explicit description.
- Response header \`x-pilot-events-anonymous: rejected\`.
- 401 \`return\` appears **before** the backend \`fetch\` in source order.
- No fetch call between \`auth()\` and the 401 gate (verified by substring slicing).
- Authenticated path sets \`x-actor-id\` from \`session.userId\`.
- Existing role / orgId header forwarding preserved.
- \`x-actor-id\` set occurs **after** the 401 gate.
- Banned-strings scan: clean.
- Comment block documents the fail-closed rationale.

## What this PR does NOT do
- Does NOT modify the backend handler. The proxy-boundary gate is sufficient: requests to this proxy without a Clerk session never reach the backend. If you want defense-in-depth at the backend too (recommended for prod), that's a follow-up PR in \`apps/api/backend\` that I'd need DB env to test.
- Does NOT implement the phantom \`/api/track/apply\` / \`/api/autopilot\` routes.
- Does NOT formalize \`ReplayActorState\` — separate brief from the same turn; should be a stacked PR if you confirm.

## Validation
- Targeted tests: 12/12 (\`pnpm --filter @vitalcv/web exec vitest run __tests__/pilot-ops-events-auth-gate.test.ts\`).
- Full web build: 13/13 (\`pnpm turbo run build --filter @vitalcv/web\`).
- Truth-contract scan: CLEAN.
- Diff scope: 1 modified file + 1 new test.

## Success condition
> No unattributed durable events possible.

Met at the proxy boundary. Backend defense-in-depth is the recommended follow-up if you want unauthenticated-direct-to-backend calls blocked too (currently the backend accepts the call but the proxy gate prevents the web-side surface).