### PR TITLE
feat(api): structured CORS rejection body + ReplayActorState formalization

### DIFF
--- a/apps/web/__tests__/structured-cors-and-replay-actor-state.test.ts
+++ b/apps/web/__tests__/structured-cors-and-replay-actor-state.test.ts
@@ -1,0 +1,183 @@
+/**
+ * STRUCTURED-CORS-REJECTION + REPLAY-ACTOR-STATE lockdown.
+ *
+ * Pins two truth-contract changes:
+ *
+ * 1. CORS rejection body — middleware.ts now emits structured JSON
+ *    with `error`, `reason`, `retryable` fields so the client can
+ *    distinguish CORS rejection from auth/source/rate-limit failures.
+ *
+ * 2. ReplayActorState — typed union of 4 states with:
+ *    - narrowReplayActorState(unknown) → state | null (no silent default)
+ *    - isWriteAllowedForActor — encodes the write-policy gate
+ *    - Description map for human-readable surfacing
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  REPLAY_ACTOR_STATES,
+  REPLAY_ACTOR_STATE_DESCRIPTION,
+  isWriteAllowedForActor,
+  narrowReplayActorState,
+  type ReplayActorState,
+} from '../lib/trust/replay-actor-state';
+
+// ─────── Structured CORS rejection ────────────────────────────────
+
+describe('STRUCTURED-CORS-REJECTION — middleware emits structured JSON', () => {
+  const MIDDLEWARE = readFileSync(resolve(__dirname, '../middleware.ts'), 'utf8');
+
+  it('CORS rejection branch emits a JSON body (not empty)', () => {
+    expect(MIDDLEWARE).toContain('JSON.stringify({');
+    expect(MIDDLEWARE).toContain("error: 'origin_blocked'");
+  });
+
+  it('rejection body includes reason field with discriminator value', () => {
+    expect(MIDDLEWARE).toContain("reason: reasonByCheck[cors.reason]");
+  });
+
+  it('rejection body includes retryable: false (allowlist drift is config, not transient)', () => {
+    expect(MIDDLEWARE).toContain('retryable: false');
+  });
+
+  it('rejection sets content-type: application/json (so clients parse correctly)', () => {
+    expect(MIDDLEWARE).toContain("'content-type': 'application/json'");
+  });
+
+  it('preserves x-cors-blocked: 1 header for cheap header-only diagnostics', () => {
+    expect(MIDDLEWARE).toContain("'x-cors-blocked': '1'");
+  });
+
+  it('three reason values map to three discriminators', () => {
+    expect(MIDDLEWARE).toContain('no_origin_header');
+    expect(MIDDLEWARE).toContain('allowlist_not_configured');
+    expect(MIDDLEWARE).toContain('origin_not_allowlisted');
+  });
+
+  it('HTTP status remains 403', () => {
+    // The 403 in the CORS branch — there are other 403s elsewhere in
+    // middleware; pin specifically that this branch returns 403.
+    expect(MIDDLEWARE).toMatch(/JSON\.stringify\(\{[\s\S]*?error: 'origin_blocked'[\s\S]*?\}\)[\s\S]*?status:\s*403/);
+  });
+});
+
+// ─────── ReplayActorState ─────────────────────────────────────────
+
+describe('REPLAY-ACTOR-STATE — union shape', () => {
+  it('exports exactly 4 states', () => {
+    expect(REPLAY_ACTOR_STATES).toHaveLength(4);
+  });
+
+  it('contains all 4 documented states in canonical order', () => {
+    expect([...REPLAY_ACTOR_STATES]).toEqual([
+      'anonymous_exploration',
+      'authenticated_holder',
+      'verifier_actor',
+      'system_actor',
+    ]);
+  });
+
+  it('union has a description for every state', () => {
+    for (const state of REPLAY_ACTOR_STATES) {
+      expect(REPLAY_ACTOR_STATE_DESCRIPTION[state]).toBeDefined();
+      expect(REPLAY_ACTOR_STATE_DESCRIPTION[state].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('descriptions explicitly mark anonymous_exploration as a first-class state', () => {
+    expect(REPLAY_ACTOR_STATE_DESCRIPTION.anonymous_exploration.toLowerCase()).toContain(
+      'no actor binding',
+    );
+  });
+
+  it('description for authenticated_holder references Clerk session + NPI', () => {
+    const d = REPLAY_ACTOR_STATE_DESCRIPTION.authenticated_holder;
+    expect(d).toContain('Clerk');
+    expect(d).toContain('NPI');
+  });
+});
+
+describe('REPLAY-ACTOR-STATE — narrowReplayActorState', () => {
+  it('returns the state for every valid string', () => {
+    for (const state of REPLAY_ACTOR_STATES) {
+      expect(narrowReplayActorState(state)).toBe(state);
+    }
+  });
+
+  it('returns null for unknown string (no silent default)', () => {
+    expect(narrowReplayActorState('rogue_state')).toBeNull();
+    expect(narrowReplayActorState('')).toBeNull();
+    expect(narrowReplayActorState('AUTHENTICATED_HOLDER')).toBeNull(); // case-sensitive
+  });
+
+  it('returns null for non-string input', () => {
+    expect(narrowReplayActorState(null)).toBeNull();
+    expect(narrowReplayActorState(undefined)).toBeNull();
+    expect(narrowReplayActorState(123)).toBeNull();
+    expect(narrowReplayActorState({})).toBeNull();
+    expect(narrowReplayActorState([])).toBeNull();
+  });
+});
+
+describe('REPLAY-ACTOR-STATE — isWriteAllowedForActor write-policy gate', () => {
+  it('authenticated_holder: writes allowed', () => {
+    expect(isWriteAllowedForActor('authenticated_holder')).toBe(true);
+  });
+
+  it('system_actor: writes allowed', () => {
+    expect(isWriteAllowedForActor('system_actor')).toBe(true);
+  });
+
+  it('anonymous_exploration: writes BLOCKED (read-only public surface)', () => {
+    expect(isWriteAllowedForActor('anonymous_exploration')).toBe(false);
+  });
+
+  it('verifier_actor: writes BLOCKED (read-only verification path)', () => {
+    expect(isWriteAllowedForActor('verifier_actor')).toBe(false);
+  });
+});
+
+describe('REPLAY-ACTOR-STATE — typed union is exhaustive', () => {
+  it('switch over ReplayActorState is structurally exhaustive', () => {
+    // Compile-time test: this would fail TypeScript narrowing if a
+    // state were added without updating isWriteAllowedForActor's
+    // switch. We assert at runtime by exercising every state.
+    const seen = new Set<ReplayActorState>();
+    for (const state of REPLAY_ACTOR_STATES) {
+      const ok = isWriteAllowedForActor(state);
+      expect(typeof ok).toBe('boolean');
+      seen.add(state);
+    }
+    expect(seen.size).toBe(REPLAY_ACTOR_STATES.length);
+  });
+
+  it('description map is frozen (prevents downstream mutation)', () => {
+    expect(Object.isFrozen(REPLAY_ACTOR_STATE_DESCRIPTION)).toBe(true);
+  });
+});
+
+describe('REPLAY-ACTOR-STATE + STRUCTURED-CORS — banned strings', () => {
+  const REPLAY_SRC = readFileSync(
+    resolve(__dirname, '../lib/trust/replay-actor-state.ts'),
+    'utf8',
+  );
+  const MIDDLEWARE = readFileSync(resolve(__dirname, '../middleware.ts'), 'utf8');
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  for (const phrase of BANNED) {
+    it(`replay-actor-state.ts does not contain banned phrase: ${phrase}`, () => {
+      expect(REPLAY_SRC).not.toContain(phrase);
+    });
+    it(`middleware.ts CORS branch does not contain banned phrase: ${phrase}`, () => {
+      expect(MIDDLEWARE).not.toContain(phrase);
+    });
+  }
+});

--- a/apps/web/lib/trust/replay-actor-state.ts
+++ b/apps/web/lib/trust/replay-actor-state.ts
@@ -1,0 +1,96 @@
+/**
+ * ReplayActorState — formalized replay attribution states.
+ *
+ * Replaces ad-hoc "anonymous vs. authenticated" boolean checks with
+ * an explicit typed union. Replay lineage becomes structurally
+ * inspectable: any consumer reading a replay event can branch on
+ * `actorState` and know exactly which trust posture applies.
+ *
+ * Doctrine:
+ *   - Every replay event has an actorState. There is no implicit
+ *     default — the producer must choose one.
+ *   - `anonymous_exploration` is a FIRST-CLASS state, not an absence.
+ *     Public readiness preview (NPI lookup, /passport without auth)
+ *     intentionally allows anonymous reads and they ARE attributable
+ *     to "exploration with no actor binding". This preserves the
+ *     frictionless exploration brief while keeping replay integrity
+ *     legible.
+ *   - `authenticated_holder` covers a clinician acting on their own
+ *     credentials (Clerk session + owned NPI binding).
+ *   - `verifier_actor` covers an external party validating a
+ *     credential (status check, JWKS fetch, OID4VP roundtrip).
+ *   - `system_actor` covers cron jobs, scheduled re-verifications,
+ *     and any non-human-driven write (e.g., revocation cascade
+ *     from a state board signal).
+ *
+ * Truth contract:
+ *   - The union is closed. New states require an explicit code change
+ *     plus a lockdown-test update — never silently widened.
+ *   - `narrowReplayActorState` returns null on unknown input rather
+ *     than coercing to a default. Producers must always choose.
+ *   - `isWriteAllowedForActor` encodes the write policy: only
+ *     `authenticated_holder` and `system_actor` may produce durable
+ *     writes. `anonymous_exploration` and `verifier_actor` are
+ *     read-only by policy. Enforcement at the route boundary;
+ *     this module is the typed source of truth.
+ */
+
+export const REPLAY_ACTOR_STATES = [
+  'anonymous_exploration',
+  'authenticated_holder',
+  'verifier_actor',
+  'system_actor',
+] as const;
+
+export type ReplayActorState = (typeof REPLAY_ACTOR_STATES)[number];
+
+/**
+ * Structural narrowing for an unknown value (e.g., from JSON parse,
+ * env var, or upstream API response). Returns null when the input
+ * is not a valid state — callers MUST handle this rather than
+ * defaulting silently.
+ */
+export function narrowReplayActorState(value: unknown): ReplayActorState | null {
+  if (typeof value !== 'string') return null;
+  return (REPLAY_ACTOR_STATES as readonly string[]).includes(value)
+    ? (value as ReplayActorState)
+    : null;
+}
+
+/**
+ * Write-policy gate. Encodes the doctrine that anonymous exploration
+ * and verifier validation are read-only paths; durable writes
+ * require an authenticated holder OR an explicit system actor.
+ *
+ * Route handlers consult this AT the auth boundary, alongside the
+ * Clerk session.userId check. Returning true here is necessary but
+ * not sufficient — the route must ALSO verify the actorState matches
+ * what the request actually presented (e.g., a Clerk session is
+ * required for `authenticated_holder`).
+ */
+export function isWriteAllowedForActor(state: ReplayActorState): boolean {
+  switch (state) {
+    case 'authenticated_holder':
+    case 'system_actor':
+      return true;
+    case 'anonymous_exploration':
+    case 'verifier_actor':
+      return false;
+  }
+}
+
+/**
+ * Human-readable description per state. Used by surfaces that need
+ * to render the attribution to a compliance officer or director
+ * (see /truth-boundary, PR #325 doctrine).
+ */
+export const REPLAY_ACTOR_STATE_DESCRIPTION: Readonly<Record<ReplayActorState, string>> = Object.freeze({
+  anonymous_exploration:
+    'Anonymous exploration. No actor binding. Read-only public surfaces (readiness preview, NPI inspection).',
+  authenticated_holder:
+    'Authenticated clinician acting on their own credentials. Clerk session present; NPI ownership bound.',
+  verifier_actor:
+    'External verifier validating a credential. Read-only access to public verification surfaces (JWKS, status list, /api/receipts/verify).',
+  system_actor:
+    'System-driven write. Cron job, scheduled re-verification, or cascade from upstream source signal. No human actor.',
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -115,10 +115,36 @@ export default async function middleware(req: NextRequest, event: NextFetchEvent
     if (origin !== null) {
       const cors = checkCorsAllowlist(origin, getAllowedOrigins());
       if (!cors.allowed) {
-        return new NextResponse(null, {
-          status: 403,
-          headers: { 'x-cors-blocked': '1' },
-        });
+        // STRUCTURED-CORS-REJECTION:
+        // Previously this returned an empty 403 body. Clients couldn't
+        // distinguish CORS rejection from auth rejection, source outage,
+        // or rate limiting — all surfaced as opaque 403/empty.
+        // Now we emit structured JSON so the client can branch on
+        // `reason` and decide whether to retry, prompt for re-auth,
+        // or surface a configuration message.
+        //
+        // `retryable: false` because allowlist drift is operator
+        // config, not a transient condition. A retry against the same
+        // origin will hit the same gate.
+        const reasonByCheck: Record<typeof cors.reason, string> = {
+          no_origin_header: 'no_origin_header',
+          allowlist_empty: 'allowlist_not_configured',
+          origin_not_in_allowlist: 'origin_not_allowlisted',
+        };
+        return new NextResponse(
+          JSON.stringify({
+            error: 'origin_blocked',
+            reason: reasonByCheck[cors.reason],
+            retryable: false,
+          }),
+          {
+            status: 403,
+            headers: {
+              'content-type': 'application/json',
+              'x-cors-blocked': '1',
+            },
+          },
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
Stacked on **#332** (pilot-events 401 gate). Consolidates two related briefs from the same turn into a single coherent PR.

## 1. Structured CORS rejection (replaces silent 403)
**Before**: middleware's CORS branch returned an empty 403 body. Clients couldn't distinguish CORS rejection from auth, source outage, or rate limiting.

**After**: structured JSON body:
\`\`\`json
{ "error": "origin_blocked", "reason": "<discriminator>", "retryable": false }
\`\`\`
Three \`reason\` discriminators:
- \`no_origin_header\` — request had no Origin header (rare since middleware already short-circuits this case, kept for completeness)
- \`allowlist_not_configured\` — \`ALLOWED_CORS_ORIGINS\` is unset/empty
- \`origin_not_allowlisted\` — origin not in the configured list

\`retryable: false\` because allowlist drift is operator config, not a transient condition. Preserves \`x-cors-blocked: 1\` header for cheap header-only diagnostics.

## 2. ReplayActorState formalization
New typed union at \`apps/web/lib/trust/replay-actor-state.ts\`:

| State | Write-allowed? | Meaning |
|---|---|---|
| \`anonymous_exploration\` | NO | Public readiness preview / NPI lookup. No actor binding. **First-class state, not an absence.** |
| \`authenticated_holder\` | YES | Clinician acting on own credentials (Clerk session + NPI ownership). |
| \`verifier_actor\` | NO | External verifier validating a credential. Read-only access to JWKS / status / verify routes. |
| \`system_actor\` | YES | Cron job, scheduled re-verification, cascade from upstream source signal. |

API:
- \`narrowReplayActorState(unknown)\` → state | null. No silent default.
- \`isWriteAllowedForActor(state)\` → boolean write-policy gate.
- \`REPLAY_ACTOR_STATE_DESCRIPTION\` — frozen description map for compliance-officer surfaces (pairs with #325 TruthBoundary).

## Truth-contract invariants (31-test lockdown)
- Structured CORS body has all 4 required fields + content-type header.
- 3 CORS reason discriminators present.
- HTTP status remains 403 in the CORS branch.
- \`x-cors-blocked: 1\` header preserved (cheap header-only diagnostics).
- \`REPLAY_ACTOR_STATES\` has exactly 4 entries in canonical order.
- \`narrowReplayActorState\` returns null on every non-matching input.
- \`isWriteAllowedForActor\` switch is exhaustive (2 allowed, 2 blocked).
- Description map is frozen.
- Banned-strings scan: clean.

## What this PR does NOT do
- Does NOT wire \`ReplayActorState\` into actual replay event rows yet. The type + gate exist; route handlers adopt them in follow-up PRs as they touch each surface.
- Does NOT modify the \`corsAllowlist\` module — its return type already exposed the 3 reason discriminators. Only the rendering in \`middleware.ts\` is changed.

## Validation
- Targeted tests: 31/31.
- Full web build: 13/13.
- Truth-contract scan: CLEAN.
- Diff scope: 1 modified (\`middleware.ts\`) + 2 new (\`replay-actor-state.ts\`, test). Zero modifications to corsAllowlist.

## Closes briefs
- "Replace silent ingest failures" — structured CORS body.
- "Formalize replay attribution states" — ReplayActorState union.