### PR TITLE
feat(ops): production-activation audit surface (/api/health expansion + build-time env verifier)

### DIFF
--- a/apps/web/__tests__/health-route-production-flags.test.ts
+++ b/apps/web/__tests__/health-route-production-flags.test.ts
@@ -1,0 +1,255 @@
+/**
+ * /api/health expansion + verify-clerk-env-in-build.sh lockdown.
+ *
+ * Pins:
+ *   - /api/health returns the 4 new production-activation flags
+ *     (deployment_id, runtime_mode, clerk_enabled, jwks_enabled,
+ *     issuer_enabled, trust_endpoints_enabled) AS TOP-LEVEL fields.
+ *   - Wave-136 backward-compat shape preserved (config.clerk.enabled,
+ *     config.apiBase, config.sentry).
+ *   - NEVER returns secret values — only booleans + prefix.
+ *   - verify-clerk-env-in-build.sh greps for SUBSTITUTED keys only
+ *     (16+ char tail), not the bare prefix used by source code's
+ *     startsWith() checks.
+ *   - Script has the SKIP_IF_NO_ENV override and fail-closed exit.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { GET } from '../app/api/health/route';
+
+const SAVE_KEYS = [
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'VITALCV_SIGNING_PUBLIC_JWK',
+  'VITALCV_SIGNING_PRIVATE_KEY_JWK',
+  'VITALCV_SIGNING_KEY_ID',
+  'DATABASE_URL',
+  'BACKEND_URL',
+  'NEXT_PUBLIC_API_BASE',
+  'PUBLIC_STATUS_URL',
+  'STATUS_URL',
+  'VERCEL_ENV',
+  'VERCEL_DEPLOYMENT_ID',
+  'VERCEL_GIT_COMMIT_SHA',
+  'NEXT_PUBLIC_SENTRY_DSN',
+] as const;
+
+const saved: Partial<Record<(typeof SAVE_KEYS)[number], string>> = {};
+
+beforeEach(() => {
+  for (const k of SAVE_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of SAVE_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+async function getBody() {
+  const res = await GET();
+  return (await res.json()) as Record<string, unknown>;
+}
+
+describe('/api/health — production-activation flags present (absent state)', () => {
+  it('clerk_enabled is a boolean false when env unset', async () => {
+    const body = await getBody();
+    expect(typeof body.clerk_enabled).toBe('boolean');
+    expect(body.clerk_enabled).toBe(false);
+  });
+
+  it('jwks_enabled is false when VITALCV_SIGNING_PUBLIC_JWK is unset', async () => {
+    const body = await getBody();
+    expect(body.jwks_enabled).toBe(false);
+  });
+
+  it('issuer_enabled is false when private JWK or kid unset', async () => {
+    const body = await getBody();
+    expect(body.issuer_enabled).toBe(false);
+  });
+
+  it('trust_endpoints_enabled is false when backend / status URLs unset', async () => {
+    const body = await getBody();
+    expect(body.trust_endpoints_enabled).toBe(false);
+  });
+
+  it('deployment_id is null when not on Vercel', async () => {
+    const body = await getBody();
+    expect(body.deployment_id).toBeNull();
+  });
+
+  it('runtime_mode falls back to development when VERCEL_ENV unset', async () => {
+    process.env.NODE_ENV = 'test';
+    const body = await getBody();
+    expect(body.runtime_mode).toBe('development');
+  });
+});
+
+describe('/api/health — production-activation flags present (configured state)', () => {
+  it('all flags true when fully configured', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_REAL_VALUE_NEVER_LOGGED';
+    process.env.VITALCV_SIGNING_PUBLIC_JWK = '{"kty":"EC"}';
+    process.env.VITALCV_SIGNING_PRIVATE_KEY_JWK = '{"kty":"EC","d":"x"}';
+    process.env.VITALCV_SIGNING_KEY_ID = 'vcv-1';
+    process.env.BACKEND_URL = 'https://api.example.com';
+    process.env.PUBLIC_STATUS_URL = 'https://status.example.com';
+
+    const body = await getBody();
+    expect(body.clerk_enabled).toBe(true);
+    expect(body.jwks_enabled).toBe(true);
+    expect(body.issuer_enabled).toBe(true);
+    expect(body.trust_endpoints_enabled).toBe(true);
+  });
+
+  it('runtime_mode honors VERCEL_ENV=production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    const body = await getBody();
+    expect(body.runtime_mode).toBe('production');
+  });
+
+  it('runtime_mode honors VERCEL_ENV=preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    const body = await getBody();
+    expect(body.runtime_mode).toBe('preview');
+  });
+
+  it('deployment_id prefers VERCEL_DEPLOYMENT_ID over git sha', async () => {
+    process.env.VERCEL_DEPLOYMENT_ID = 'dpl_abc123';
+    process.env.VERCEL_GIT_COMMIT_SHA = 'sha_xyz';
+    const body = await getBody();
+    expect(body.deployment_id).toBe('dpl_abc123');
+  });
+
+  it('deployment_id falls back to commit sha if no deployment id', async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = 'sha_xyz';
+    const body = await getBody();
+    expect(body.deployment_id).toBe('sha_xyz');
+  });
+});
+
+describe('/api/health — NEVER leaks secret values', () => {
+  it('publishable key value does NOT appear in response body', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_NEVER_LEAK_THIS_AAAAAAAA';
+    const body = await getBody();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('NEVER_LEAK_THIS_AAAAAAAA');
+    expect(serialized).not.toContain('pk_live_NEVER_LEAK');
+  });
+
+  it('publishable key mode reported (production/development/none) but never the value', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_X';
+    const body = await getBody();
+    const config = body.config as { clerk: { mode: string } };
+    expect(config.clerk.mode).toBe('production');
+  });
+
+  it('signing JWK values never appear in response', async () => {
+    process.env.VITALCV_SIGNING_PRIVATE_KEY_JWK = '{"kty":"EC","d":"NEVER_LEAK_PRIVATE_D_AAAA"}';
+    const body = await getBody();
+    expect(JSON.stringify(body)).not.toContain('NEVER_LEAK_PRIVATE_D');
+  });
+});
+
+describe('/api/health — backward-compat shape preserved (Wave 136)', () => {
+  it('config.clerk.enabled mirrors top-level clerk_enabled', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_x';
+    const body = await getBody();
+    expect((body.config as { clerk: { enabled: boolean } }).clerk.enabled).toBe(true);
+    expect(body.clerk_enabled).toBe(true);
+  });
+
+  it('config.clerk.mode resolves to development for pk_test_', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_x';
+    const body = await getBody();
+    expect((body.config as { clerk: { mode: string } }).clerk.mode).toBe('development');
+  });
+
+  it('config.clerk.mode resolves to none for empty publishable key', async () => {
+    const body = await getBody();
+    expect((body.config as { clerk: { mode: string } }).clerk.mode).toBe('none');
+  });
+
+  it('config.apiBase + config.sentry preserved', async () => {
+    process.env.NEXT_PUBLIC_API_BASE = 'https://api.example.com';
+    process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://sentry.example.com';
+    const body = await getBody();
+    const config = body.config as { apiBase: boolean; sentry: boolean };
+    expect(config.apiBase).toBe(true);
+    expect(config.sentry).toBe(true);
+  });
+});
+
+describe('verify-clerk-env-in-build.sh — script truth contract', () => {
+  const REPO_ROOT = resolve(__dirname, '../../..');
+  const SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/verify-clerk-env-in-build.sh');
+  const SCRIPT = readFileSync(SCRIPT_PATH, 'utf8');
+
+  it('script is executable', () => {
+    expect(statSync(SCRIPT_PATH).mode & 0o100).not.toBe(0);
+  });
+
+  it('uses set -euo pipefail', () => {
+    expect(SCRIPT).toMatch(/set\s+-euo\s+pipefail/);
+  });
+
+  it('greps for SUBSTITUTED key (16+ char tail), not bare prefix', () => {
+    // Source code does .startsWith('pk_live_') for mode-detection;
+    // bare prefix appears in bundle without being a real substituted
+    // key. The regex must require trailing characters.
+    expect(SCRIPT).toMatch(/pk_live_\[A-Za-z0-9_-\]\{16,\}/);
+    expect(SCRIPT).toMatch(/pk_test_\[A-Za-z0-9_-\]\{16,\}/);
+  });
+
+  it('supports SKIP_IF_NO_ENV override for dev builds', () => {
+    expect(SCRIPT).toContain('SKIP_IF_NO_ENV');
+  });
+
+  it('exits 1 on missing key (fail-closed deploy gate)', () => {
+    expect(SCRIPT).toMatch(/^exit 1$/m);
+  });
+
+  it('error message names the failure modes (Clerk not mounting)', () => {
+    expect(SCRIPT).toContain('<ClerkProvider> will not render');
+    expect(SCRIPT).toContain('/sign-in will show');
+  });
+
+  it('points operator at .env.local and Vercel for fix', () => {
+    expect(SCRIPT).toContain('.env.local');
+    expect(SCRIPT).toContain('Vercel');
+  });
+
+  it('does NOT log the actual key value', () => {
+    // Only prefix should ever be echoed — never full value.
+    const echoLines = SCRIPT.split('\n').filter((l) => /\b(echo|printf|cat)\b/.test(l));
+    for (const l of echoLines) {
+      // No echo line should reference the env var name AND a regex
+      // capture group that would print the value.
+      expect(l).not.toMatch(/\$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY/);
+    }
+  });
+});
+
+describe('production-activation banned-strings scan', () => {
+  const REPO_ROOT = resolve(__dirname, '../../..');
+  const ROUTE_SRC = readFileSync(resolve(REPO_ROOT, 'apps/web/app/api/health/route.ts'), 'utf8');
+  const SCRIPT_SRC = readFileSync(resolve(REPO_ROOT, 'scripts/verify-clerk-env-in-build.sh'), 'utf8');
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  it.each(BANNED)('route does not contain banned phrase: %s', (phrase) => {
+    expect(ROUTE_SRC).not.toContain(phrase);
+  });
+  it.each(BANNED)('script does not contain banned phrase: %s', (phrase) => {
+    expect(SCRIPT_SRC).not.toContain(phrase);
+  });
+});

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,20 +1,73 @@
 /**
- * Health route — Wave 136: includes Clerk production-readiness signal.
+ * Health route — production activation diagnostic.
+ *
+ * Wave 136 baseline + production-activation expansion:
+ *   - deployment_id     — Vercel deployment id (if present)
+ *   - runtime_mode      — 'production' | 'preview' | 'development'
+ *   - clerk_enabled     — boolean
+ *   - jwks_enabled      — boolean (signing public JWK present)
+ *   - issuer_enabled    — boolean (signing private JWK + kid present)
+ *   - trust_endpoints_enabled — boolean (status URL + backend URL set)
+ *
+ * Distinct from /api/status/health (PR #327): that route is a
+ * structured subsystem audit (vitalcv.status.health.v1 schema). This
+ * route is the lightweight legacy probe with operator-facing flags;
+ * preserved for backward-compat with Wave-136 monitoring + Vercel
+ * uptime checks.
+ *
+ * Both routes follow the same no-secret-leak contract: presence
+ * booleans only, never values.
  */
+
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function resolveRuntimeMode(): 'production' | 'preview' | 'development' {
+  // VERCEL_ENV is 'production' | 'preview' | 'development' on Vercel.
+  const vercel = process.env.VERCEL_ENV;
+  if (vercel === 'production' || vercel === 'preview' || vercel === 'development') {
+    return vercel;
+  }
+  return process.env.NODE_ENV === 'production' ? 'production' : 'development';
+}
+
+function resolveDeploymentId(): string | null {
+  // Prefer VERCEL_DEPLOYMENT_ID; fall back to the git commit sha.
+  return (
+    process.env.VERCEL_DEPLOYMENT_ID ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    null
+  );
+}
 
 export async function GET() {
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
+  const clerkEnabled = publishableKey.length > 0;
+  const jwksEnabled = Boolean(process.env.VITALCV_SIGNING_PUBLIC_JWK);
+  const issuerEnabled =
+    Boolean(process.env.VITALCV_SIGNING_PRIVATE_KEY_JWK) &&
+    Boolean(process.env.VITALCV_SIGNING_KEY_ID);
+  const trustEndpointsEnabled =
+    Boolean(process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_API_BASE) &&
+    Boolean(process.env.PUBLIC_STATUS_URL ?? process.env.STATUS_URL);
 
   return Response.json(
     {
       status: 'ok',
       service: 'web',
       timestamp: new Date().toISOString(),
+      // Production-activation flags (flat for monitoring scrape).
+      deployment_id: resolveDeploymentId(),
+      runtime_mode: resolveRuntimeMode(),
+      clerk_enabled: clerkEnabled,
+      jwks_enabled: jwksEnabled,
+      issuer_enabled: issuerEnabled,
+      trust_endpoints_enabled: trustEndpointsEnabled,
+      // Backward-compat (Wave 136 + later monitoring).
       config: {
         apiBase: Boolean(process.env.NEXT_PUBLIC_API_BASE),
         clerk: {
-          enabled: Boolean(publishableKey),
+          enabled: clerkEnabled,
           mode: publishableKey.startsWith('pk_live_')
             ? 'production'
             : publishableKey.startsWith('pk_test_')
@@ -24,7 +77,12 @@ export async function GET() {
         sentry: Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN),
       },
     },
-    { status: 200 },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store, must-revalidate',
+      },
+    },
   );
 }
 

--- a/scripts/verify-clerk-env-in-build.sh
+++ b/scripts/verify-clerk-env-in-build.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# verify-clerk-env-in-build.sh — postbuild env-substitution verifier.
+#
+# Confirms that NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY was actually
+# substituted into the apps/web build output. Without this check, a
+# deploy can silently ship a broken-auth bundle: the env var is unset
+# at build time → Next.js substitutes empty string → CLERK_ENABLED
+# resolves false → <ClerkProvider> never mounts → sign-in is dead.
+# That failure mode is invisible until a user clicks sign-in.
+#
+# This script converts that into a loud build-time failure.
+#
+# Usage (CI / postbuild):
+#   ./scripts/verify-clerk-env-in-build.sh
+#
+# Skip in development (env intentionally absent):
+#   SKIP_IF_NO_ENV=1 ./scripts/verify-clerk-env-in-build.sh
+#
+# Truth contract:
+#   - Reads only the build output (gitignored .next/static), never
+#     the env file itself.
+#   - Prints only the prefix (pk_test_ or pk_live_) when found;
+#     never the full key. Even though pk_* prefixes ARE public by
+#     design (they're shipped to every browser that loads the page),
+#     we still don't echo the full value back to a CI log we don't
+#     control.
+#
+set -euo pipefail
+
+WEB_BUILD_DIR="${WEB_BUILD_DIR:-apps/web/.next}"
+SKIP_IF_NO_ENV="${SKIP_IF_NO_ENV:-0}"
+
+if [ ! -d "$WEB_BUILD_DIR" ]; then
+  echo "ERROR: build directory not found: $WEB_BUILD_DIR"
+  echo "Run \`pnpm turbo run build --filter @vitalcv/web\` first."
+  exit 66  # EX_NOINPUT
+fi
+
+# Search the static chunks for a pk_test_ or pk_live_ literal. Next.js
+# substitutes NEXT_PUBLIC_* env vars as text literals at build time.
+STATIC_DIR="$WEB_BUILD_DIR/static"
+if [ ! -d "$STATIC_DIR" ]; then
+  echo "ERROR: static chunk directory not found: $STATIC_DIR"
+  exit 66
+fi
+
+# Grep for a SUBSTITUTED key: pk_test_ or pk_live_ followed by at
+# least 16 chars of key material. The bare prefix `pk_live_` (without
+# trailing chars) appears in the bundle because the source code does
+# `.startsWith('pk_live_')` for mode-detection — we ignore those.
+#
+# Real Clerk publishable keys are typically 50+ chars after the
+# prefix; 16 is a conservative floor.
+FOUND_PREFIX=""
+if grep -Erql 'pk_live_[A-Za-z0-9_-]{16,}' "$STATIC_DIR" 2>/dev/null; then
+  FOUND_PREFIX="pk_live_"
+elif grep -Erql 'pk_test_[A-Za-z0-9_-]{16,}' "$STATIC_DIR" 2>/dev/null; then
+  FOUND_PREFIX="pk_test_"
+fi
+
+if [ -n "$FOUND_PREFIX" ]; then
+  echo "OK: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY substituted into build (prefix: $FOUND_PREFIX)"
+  exit 0
+fi
+
+# Not found — either the env wasn't set at build time, or this is
+# an intentional dev build without auth configured.
+if [ "$SKIP_IF_NO_ENV" = "1" ]; then
+  echo "WARN: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY not found in build."
+  echo "  Skipping because SKIP_IF_NO_ENV=1 (dev build without auth)."
+  exit 0
+fi
+
+cat <<MSG >&2
+ERROR: NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY was NOT substituted into the build.
+
+This means Clerk auth will NOT mount in this deploy:
+  - <ClerkProvider> will not render (apps/web/app/layout.tsx)
+  - /sign-in will show "not configured" message
+  - All authenticated routes will redirect to /sign-in indefinitely
+
+Possible causes:
+  1. The env var was not set at the moment 'next build' ran.
+     - Local: confirm it's in apps/web/.env.local (per #329 template).
+     - Vercel: confirm it's set in the project's env vars for the
+       current environment (Production / Preview / Development).
+  2. The env var was set but is an empty string.
+  3. The build cache reused output from a prior failed build.
+     - Try a clean rebuild: rm -rf apps/web/.next && pnpm turbo run build --filter @vitalcv/web
+
+To skip this check intentionally (dev build without auth):
+  SKIP_IF_NO_ENV=1 ./scripts/verify-clerk-env-in-build.sh
+
+This is a deploy gate. Failing the build is the correct fail-closed
+behavior: shipping a silent-broken-auth bundle is strictly worse than
+a loud build failure.
+MSG
+exit 1


### PR DESCRIPTION
## Summary
Closes three closely-related briefs from this turn:
- "Audit production Clerk activation path" (verification surface)
- "Expand /api/health with deployment + runtime + enabled flags"
- "Verify NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY reaches the client bundle"

## Two artifacts (one coherent PR — both gate production activation)

### 1. \`apps/web/app/api/health/route.ts\` — expanded

New top-level production-activation flags (flat, easy to scrape):
- \`deployment_id\` — VERCEL_DEPLOYMENT_ID, falls back to commit sha
- \`runtime_mode\` — \`production\` | \`preview\` | \`development\`
- \`clerk_enabled\` — Clerk publishable key present
- \`jwks_enabled\` — \`VITALCV_SIGNING_PUBLIC_JWK\` present
- \`issuer_enabled\` — private JWK + kid both present
- \`trust_endpoints_enabled\` — backend URL + status URL configured

Wave-136 backward-compat shape preserved (\`config.clerk.enabled\`, \`config.clerk.mode\`, \`config.apiBase\`, \`config.sentry\`) so existing monitoring doesn't regress. \`Cache-Control: no-store, must-revalidate\`.

### 2. \`scripts/verify-clerk-env-in-build.sh\` — new

Postbuild deploy gate. Greps \`apps/web/.next/static\` for a **substituted** publishable key (\`pk_live_\` or \`pk_test_\` + 16+ chars). Exits 1 with operator-facing error if absent, converting "silent broken-auth bundle" into a loud build failure.

The tightening: source code does \`.startsWith('pk_live_')\` for mode detection, so the bare prefix appears in the bundle without a substituted key. Regex requires trailing chars to filter that noise (verified during this PR — bare-prefix grep had a false positive on the dev build, hence the 16+ char requirement).

\`SKIP_IF_NO_ENV=1\` override for dev builds without auth. Never echoes the full key value.

## How operators use these together
\`\`\`bash
# Local dev (no auth configured — expected)
SKIP_IF_NO_ENV=1 ./scripts/verify-clerk-env-in-build.sh

# CI / Vercel preview (auth required)
pnpm turbo run build --filter @vitalcv/web && \\
  ./scripts/verify-clerk-env-in-build.sh

# Production runtime check (after deploy)
curl https://<your-domain>/api/health | jq '.clerk_enabled, .jwks_enabled, .issuer_enabled, .trust_endpoints_enabled'
\`\`\`

## Truth-contract invariants (36-test lockdown)
- 6 production-activation flags present at top level; resolve correctly in absent + configured states.
- \`VERCEL_ENV\` honored over \`NODE_ENV\`; \`VERCEL_DEPLOYMENT_ID\` preferred over commit sha.
- Publishable key VALUE never leaks (only mode: production / development / none).
- Private JWK \`d\` component never leaks.
- Wave-136 backward-compat shape preserved.
- Script regex requires 16+ trailing chars (no source-code prefix false positives).
- \`SKIP_IF_NO_ENV\` override works.
- Script exits 1 on missing key.
- Script error message names the failure modes + points at \`.env.local\` + Vercel for the fix.
- Script never echoes \`$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY\` directly.
- Banned-strings scan: clean (both files).

## What this PR does NOT do
- Does NOT verify the Vercel env exists (item 1 of the audit brief). That's a dashboard check the operator must do.
- Does NOT chain the verifier into \`apps/web/package.json\`'s \`build\` script automatically. Operators wire it in CI explicitly (snippet above).
- Does NOT replace \`/api/status/health\` (PR #327). That route is the structured subsystem audit (vitalcv.status.health.v1 schema). This route is the flat-flag Wave-136 backward-compat probe with operational additions.

## Validation
- Targeted tests: 36/36.
- Full web build: 13/13.
- Truth-contract scan: CLEAN.
- Diff scope: 1 modified file + 1 new executable script + 1 new test.