### PR TITLE
feat(web-v2): DegradedState typed union + visually distinct renderer (5 failure modes)

### DIFF
--- a/apps/web-v2/src/__tests__/degraded-state.test.tsx
+++ b/apps/web-v2/src/__tests__/degraded-state.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * DegradedState + DegradedStateRow lockdown.
+ *
+ * Pins the truth-contract behavior:
+ *   - Union has exactly 5 mutually-exclusive states.
+ *   - Each state has a label, meaning, actionableBy, and isPositive.
+ *   - `no_adverse_findings` is the ONLY positive state.
+ *   - `narrowDegradedState` rejects unknown input (no silent default).
+ *   - Renderer emits `data-degraded-state` attribute per state.
+ *   - Renderer encodes positive vs. failure via glyph + ink weight,
+ *     never via vibrant color.
+ *   - Renderer never renders bare-word "Verified" as a label.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  DEGRADED_STATES,
+  DEGRADED_STATE_METADATA,
+  narrowDegradedState,
+  isPositiveDegradedState,
+  actionableBy,
+  type DegradedState,
+} from '../lib/degraded-state';
+import { DegradedStateRow } from '../components/DegradedStateRow';
+
+describe('DegradedState — union shape', () => {
+  it('contains exactly 5 states in canonical order', () => {
+    expect([...DEGRADED_STATES]).toEqual([
+      'source_unreachable',
+      'anonymous_restriction',
+      'infra_outage',
+      'no_adverse_findings',
+      'issuer_unavailable',
+    ]);
+  });
+
+  it('every state has complete metadata', () => {
+    for (const state of DEGRADED_STATES) {
+      const meta = DEGRADED_STATE_METADATA[state];
+      expect(meta.label).toBeDefined();
+      expect(meta.label.length).toBeGreaterThan(0);
+      expect(meta.meaning).toBeDefined();
+      expect(meta.meaning.length).toBeGreaterThan(0);
+      expect(['caller', 'source-operator', 'vitalcv-ops', 'no-action-needed']).toContain(
+        meta.actionableBy,
+      );
+      expect(typeof meta.isPositive).toBe('boolean');
+    }
+  });
+
+  it('description map is frozen', () => {
+    expect(Object.isFrozen(DEGRADED_STATE_METADATA)).toBe(true);
+  });
+});
+
+describe('DegradedState — exactly one positive state', () => {
+  it('no_adverse_findings is the only positive state', () => {
+    const positives = DEGRADED_STATES.filter((s) => DEGRADED_STATE_METADATA[s].isPositive);
+    expect(positives).toEqual(['no_adverse_findings']);
+  });
+
+  it('all other states are explicitly NOT positive', () => {
+    const expectedNegative: DegradedState[] = [
+      'source_unreachable',
+      'anonymous_restriction',
+      'infra_outage',
+      'issuer_unavailable',
+    ];
+    for (const s of expectedNegative) {
+      expect(DEGRADED_STATE_METADATA[s].isPositive).toBe(false);
+    }
+  });
+
+  it('isPositiveDegradedState matches metadata', () => {
+    for (const s of DEGRADED_STATES) {
+      expect(isPositiveDegradedState(s)).toBe(DEGRADED_STATE_METADATA[s].isPositive);
+    }
+  });
+});
+
+describe('DegradedState — actionableBy mapping', () => {
+  it('anonymous_restriction is actionable by caller', () => {
+    expect(actionableBy('anonymous_restriction')).toBe('caller');
+  });
+
+  it('source_unreachable is actionable by source-operator (external)', () => {
+    expect(actionableBy('source_unreachable')).toBe('source-operator');
+  });
+
+  it('infra_outage is actionable by vitalcv-ops (we own it)', () => {
+    expect(actionableBy('infra_outage')).toBe('vitalcv-ops');
+  });
+
+  it('issuer_unavailable is actionable by vitalcv-ops (config / ops)', () => {
+    expect(actionableBy('issuer_unavailable')).toBe('vitalcv-ops');
+  });
+
+  it('no_adverse_findings requires no action', () => {
+    expect(actionableBy('no_adverse_findings')).toBe('no-action-needed');
+  });
+});
+
+describe('narrowDegradedState — fail-closed narrowing', () => {
+  it('returns the state for every valid string', () => {
+    for (const state of DEGRADED_STATES) {
+      expect(narrowDegradedState(state)).toBe(state);
+    }
+  });
+
+  it('returns null for unknown strings (no silent default)', () => {
+    expect(narrowDegradedState('rogue_state')).toBeNull();
+    expect(narrowDegradedState('')).toBeNull();
+    expect(narrowDegradedState('SOURCE_UNREACHABLE')).toBeNull(); // case-sensitive
+  });
+
+  it('returns null for non-string input', () => {
+    expect(narrowDegradedState(null)).toBeNull();
+    expect(narrowDegradedState(undefined)).toBeNull();
+    expect(narrowDegradedState(0)).toBeNull();
+    expect(narrowDegradedState({})).toBeNull();
+    expect(narrowDegradedState([])).toBeNull();
+  });
+});
+
+describe('DegradedStateRow — visually distinct rendering', () => {
+  it('every state renders with its data-degraded-state attribute', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      expect(html).toContain(`data-degraded-state="${state}"`);
+    }
+  });
+
+  it('renders data-is-positive matching the metadata', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      const expected = DEGRADED_STATE_METADATA[state].isPositive ? 'true' : 'false';
+      expect(html).toContain(`data-is-positive="${expected}"`);
+    }
+  });
+
+  it('renders data-actionable-by matching the metadata', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      const expected = DEGRADED_STATE_METADATA[state].actionableBy;
+      expect(html).toContain(`data-actionable-by="${expected}"`);
+    }
+  });
+
+  it('renders the state label', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      expect(html).toContain(DEGRADED_STATE_METADATA[state].label);
+    }
+  });
+
+  it('renders the explanatory meaning text', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      // The first 30 chars of the meaning should appear; truncated to
+      // avoid false-positives on minor wording changes.
+      const snippet = DEGRADED_STATE_METADATA[state].meaning.slice(0, 30);
+      expect(html).toContain(snippet);
+    }
+  });
+
+  it('NO state renders bare-word "Verified" as a label', () => {
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      expect(html).not.toMatch(/>\s*Verified\s*</);
+    }
+  });
+
+  it('renders optional context when supplied', () => {
+    const html = renderToStaticMarkup(
+      <DegradedStateRow state="source_unreachable" context="NPPES" />,
+    );
+    expect(html).toContain('NPPES');
+  });
+
+  it('renders optional checkedAt as a <time> element', () => {
+    const html = renderToStaticMarkup(
+      <DegradedStateRow state="no_adverse_findings" checkedAt="2026-05-12T00:00:00Z" />,
+    );
+    expect(html).toMatch(/<time\s[^>]*=["']2026-05-12T00:00:00Z["']/);
+  });
+
+  it('NO vibrant hue appears — monochrome doctrine inherited from #323', () => {
+    // Every state renders with grayscale (RGB max-diff ≤ 16).
+    for (const state of DEGRADED_STATES) {
+      const html = renderToStaticMarkup(<DegradedStateRow state={state} />);
+      // Catch obvious red/green hex leaks that would indicate the
+      // renderer reached for color hue instead of glyph/weight.
+      const redLeak = html.match(/#(?:[d-f][0-9a-f]{2})(?:00[0-9a-f]{2}|0[0-9a-f]00)/i);
+      const greenLeak = html.match(/#(?:00[0-9a-f]{2})[d-f][0-9a-f]{2}/i);
+      expect(redLeak).toBeNull();
+      expect(greenLeak).toBeNull();
+    }
+  });
+});
+
+describe('DegradedStateRow — positive vs. failure visual encoding', () => {
+  it('no_adverse_findings renders with the OK glyph (■)', () => {
+    const html = renderToStaticMarkup(<DegradedStateRow state="no_adverse_findings" />);
+    expect(html).toContain('■');
+  });
+
+  it('source_unreachable + anonymous_restriction render with ambiguity glyph (◐)', () => {
+    const a = renderToStaticMarkup(<DegradedStateRow state="source_unreachable" />);
+    const b = renderToStaticMarkup(<DegradedStateRow state="anonymous_restriction" />);
+    expect(a).toContain('◐');
+    expect(b).toContain('◐');
+  });
+
+  it('infra_outage + issuer_unavailable render with failed glyph (✕)', () => {
+    const a = renderToStaticMarkup(<DegradedStateRow state="infra_outage" />);
+    const b = renderToStaticMarkup(<DegradedStateRow state="issuer_unavailable" />);
+    expect(a).toContain('✕');
+    expect(b).toContain('✕');
+  });
+});
+
+describe('DegradedState — banned strings', () => {
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const SRC = fs.readFileSync(path.resolve(__dirname, '../lib/degraded-state.ts'), 'utf8');
+  const COMPONENT = fs.readFileSync(
+    path.resolve(__dirname, '../components/DegradedStateRow.tsx'),
+    'utf8',
+  );
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  for (const phrase of BANNED) {
+    it(`module does not contain: ${phrase}`, () => {
+      expect(SRC).not.toContain(phrase);
+    });
+    it(`component does not contain: ${phrase}`, () => {
+      expect(COMPONENT).not.toContain(phrase);
+    });
+  }
+});

--- a/apps/web-v2/src/components/DegradedStateRow.tsx
+++ b/apps/web-v2/src/components/DegradedStateRow.tsx
@@ -1,0 +1,156 @@
+/**
+ * DegradedStateRow — visually distinct renderer for each of the 5
+ * mutually-exclusive UI failure modes.
+ *
+ * Doctrine (inherits #323 design tokens):
+ *   - Monochrome. State encoded via glyph + ink density + an
+ *     explicit `actionableBy` chip — never via vibrant color.
+ *   - `no_adverse_findings` is rendered as a positive (strong ink)
+ *     — visually distinguished from the four real failures.
+ *   - Each row exposes a `data-degraded-state` attribute matching
+ *     the underlying state id, so verifier tooling can inspect the
+ *     surface programmatically.
+ *
+ * Used by result lists where each fact may resolve to a different
+ * degraded state per source.
+ */
+
+import * as React from 'react';
+import { colors, space, type, trustGlyph } from '../lib/design-tokens';
+import {
+  DEGRADED_STATE_METADATA,
+  type ActionableBy,
+  type DegradedState,
+} from '../lib/degraded-state';
+
+interface Props {
+  /** The state to render. */
+  readonly state: DegradedState;
+  /** Optional context (e.g., source name or fact label). */
+  readonly context?: string;
+  /** Optional ISO timestamp for "checked at" surfacing. */
+  readonly checkedAt?: string | null;
+}
+
+const ACTIONABLE_BY_LABEL: Readonly<Record<ActionableBy, string>> = {
+  caller: 'Caller can resolve',
+  'source-operator': 'External source — wait or escalate to source',
+  'vitalcv-ops': 'VitalCV operations',
+  'no-action-needed': 'No action — positive result',
+};
+
+// Map degraded states to the existing 4-color trust glyph palette.
+// no_adverse_findings → ok (strong ink). The 4 failures map to:
+//   anonymous_restriction → ambiguous (caller can resolve)
+//   source_unreachable    → ambiguous (transient external)
+//   infra_outage          → failed (we own it; bad signal)
+//   issuer_unavailable    → failed (we own it; bad signal)
+const GLYPH_BY_STATE: Readonly<Record<DegradedState, keyof typeof trustGlyph>> = {
+  no_adverse_findings: 'ok',
+  anonymous_restriction: 'ambiguous',
+  source_unreachable: 'ambiguous',
+  infra_outage: 'failed',
+  issuer_unavailable: 'failed',
+};
+
+export function DegradedStateRow({ state, context, checkedAt }: Props): React.ReactElement {
+  const meta = DEGRADED_STATE_METADATA[state];
+  const glyphState = GLYPH_BY_STATE[state];
+  const glyph = trustGlyph[glyphState];
+
+  return (
+    <div
+      data-testid="degraded-state-row"
+      data-degraded-state={state}
+      data-is-positive={meta.isPositive ? 'true' : 'false'}
+      data-actionable-by={meta.actionableBy}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        gap: space['4'],
+        alignItems: 'baseline',
+        padding: `${space['3']} 0`,
+        borderBottom: `1px solid ${colors.surfaceSub}`,
+        fontFamily: type.fontSans,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          color: glyph.color,
+          fontFamily: type.fontMono,
+          fontSize: '14px',
+          width: '14px',
+          display: 'inline-block',
+        }}
+      >
+        {glyph.glyph}
+      </span>
+
+      <div>
+        <div
+          style={{
+            color: meta.isPositive ? colors.ink : colors.inkSub,
+            fontSize: type.sizeSm,
+            fontWeight: meta.isPositive ? type.weightMedium : type.weightRegular,
+            lineHeight: type.leadingBody,
+          }}
+        >
+          <span data-testid="degraded-state-label">{meta.label}</span>
+          {context && (
+            <span style={{ color: colors.inkMuted, marginLeft: space['2'] }}>· {context}</span>
+          )}
+        </div>
+        <div
+          style={{
+            color: colors.inkMuted,
+            fontSize: type.sizeXs,
+            lineHeight: type.leadingBody,
+            marginTop: space['1'],
+            maxWidth: '60ch',
+          }}
+        >
+          {meta.meaning}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: space['1'],
+        }}
+      >
+        <span
+          data-testid="degraded-state-actionable-by"
+          style={{
+            fontFamily: type.fontMono,
+            fontSize: type.sizeXxs,
+            textTransform: 'uppercase',
+            letterSpacing: type.trackingMono,
+            color: meta.isPositive ? colors.inkSub : colors.inkMuted,
+            padding: `${space['1']} ${space['2']}`,
+            border: `1px solid ${colors.border}`,
+            borderRadius: '2px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {ACTIONABLE_BY_LABEL[meta.actionableBy]}
+        </span>
+        {checkedAt && (
+          <time
+            dateTime={checkedAt}
+            style={{
+              color: colors.inkMuted,
+              fontFamily: type.fontMono,
+              fontSize: type.sizeXxs,
+            }}
+          >
+            {checkedAt}
+          </time>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-v2/src/lib/degraded-state.ts
+++ b/apps/web-v2/src/lib/degraded-state.ts
@@ -1,0 +1,120 @@
+/**
+ * DegradedState — typed union for the 5 distinct UI failure modes.
+ *
+ * Today, surfaces conflate these states: an unreachable source, an
+ * anonymous-user restriction, an infra outage, a clean result with
+ * no adverse findings, and a missing issuer all render with similar
+ * "Unknown" / "Not available" / "—" affordances. Users (clinicians +
+ * compliance directors + verifiers) cannot tell WHAT failed, which
+ * means they cannot tell WHO to escalate to.
+ *
+ * Doctrine:
+ *   - The 5 states are MUTUALLY EXCLUSIVE. A surface MUST pick one.
+ *   - `no_adverse_findings` is NOT a failure state — it's a clean
+ *     positive result that's often visually confused with failure
+ *     ("nothing to show" looks like "we couldn't check"). It's
+ *     included in this union explicitly so renderers can mark it
+ *     as a positive outcome, not an empty cell.
+ *   - The other 4 are all degraded states but each has a different
+ *     remediation path:
+ *       * `source_unreachable`   → external dependency; retry later
+ *       * `anonymous_restriction` → caller needs to sign in / get auth
+ *       * `infra_outage`         → VitalCV internal; we own the fix
+ *       * `issuer_unavailable`   → signing key not configured; ops issue
+ *   - Each state has a distinct `actionableBy` field telling the user
+ *     who can resolve it. This is what makes the typing valuable.
+ *
+ * Truth contract:
+ *   - Closed union. New states require an explicit code change AND a
+ *     lockdown-test update — never silently widened by a producer.
+ *   - `narrowDegradedState` returns null on unknown input (no silent
+ *     default). Producers must always choose.
+ *   - `isPositive` distinguishes the clean-result state from the
+ *     four real failures, so badge color/glyph encoding is correct.
+ */
+
+export const DEGRADED_STATES = [
+  'source_unreachable',
+  'anonymous_restriction',
+  'infra_outage',
+  'no_adverse_findings',
+  'issuer_unavailable',
+] as const;
+
+export type DegradedState = (typeof DEGRADED_STATES)[number];
+
+export type ActionableBy = 'caller' | 'source-operator' | 'vitalcv-ops' | 'no-action-needed';
+
+export interface DegradedStateMetadata {
+  /** Short human-readable label suitable for badge text. Compound forms only. */
+  readonly label: string;
+  /** One-sentence operational meaning. */
+  readonly meaning: string;
+  /** Who can resolve this state. */
+  readonly actionableBy: ActionableBy;
+  /**
+   * Whether this state is a POSITIVE outcome (true) vs. a degraded
+   * one (false). `no_adverse_findings` is the only positive entry.
+   */
+  readonly isPositive: boolean;
+}
+
+/**
+ * Description map. Each entry is the authoritative explanation of a
+ * single state — paired with the renderer in DegradedStateRow.tsx
+ * and the legend on the TruthBoundary surface (PR #325).
+ */
+export const DEGRADED_STATE_METADATA: Readonly<
+  Record<DegradedState, DegradedStateMetadata>
+> = Object.freeze({
+  source_unreachable: {
+    label: 'Source unreachable',
+    meaning:
+      'The external source authority did not respond within the configured timeout. The check was attempted; the result is unknown until the source recovers.',
+    actionableBy: 'source-operator',
+    isPositive: false,
+  },
+  anonymous_restriction: {
+    label: 'Sign-in required',
+    meaning:
+      'The caller is not authenticated. Some surfaces require a Clerk session for actor attribution before the check is permitted.',
+    actionableBy: 'caller',
+    isPositive: false,
+  },
+  infra_outage: {
+    label: 'VitalCV infrastructure degraded',
+    meaning:
+      'A VitalCV-owned subsystem (backend, database, signing) is unavailable. The check was not attempted because we cannot honor the truth contract right now.',
+    actionableBy: 'vitalcv-ops',
+    isPositive: false,
+  },
+  no_adverse_findings: {
+    label: 'No adverse findings',
+    meaning:
+      'The check completed successfully against the source authority and returned no flagging or concerning records. This is a POSITIVE result, not an empty one.',
+    actionableBy: 'no-action-needed',
+    isPositive: true,
+  },
+  issuer_unavailable: {
+    label: 'Issuer unavailable',
+    meaning:
+      'VitalCV cannot sign credentials right now — signing key, kid, or issuer route is not configured. Existing credentials remain verifiable; new issuance is paused.',
+    actionableBy: 'vitalcv-ops',
+    isPositive: false,
+  },
+});
+
+export function narrowDegradedState(value: unknown): DegradedState | null {
+  if (typeof value !== 'string') return null;
+  return (DEGRADED_STATES as readonly string[]).includes(value)
+    ? (value as DegradedState)
+    : null;
+}
+
+export function isPositiveDegradedState(state: DegradedState): boolean {
+  return DEGRADED_STATE_METADATA[state].isPositive;
+}
+
+export function actionableBy(state: DegradedState): ActionableBy {
+  return DEGRADED_STATE_METADATA[state].actionableBy;
+}


### PR DESCRIPTION
## Summary
Stacked on **#325** (TruthBoundary + design tokens). Closes the brief: *"separate the 5 distinct UI failure modes — source unreachable, anonymous restriction, infra outage, no adverse findings, issuer unavailable. Render distinct UI states for each. Users always know WHAT failed."*

## The 5 states + their distinct remediation paths

| State | Glyph | Actionable by | Notes |
|---|---|---|---|
| \`no_adverse_findings\` | ■ | no-action-needed | **The only positive state.** Often visually confused with an empty cell. |
| \`anonymous_restriction\` | ◐ | caller | Sign-in required. |
| \`source_unreachable\` | ◐ | source-operator | External authority not responding. Transient. |
| \`infra_outage\` | ✕ | vitalcv-ops | We own it. Bad signal to ship. |
| \`issuer_unavailable\` | ✕ | vitalcv-ops | Signing key / kid not configured. New issuance paused. |

## Why each axis matters
- **Glyph encoding (no color hue)**: monochrome doctrine inherited from #323. Trust signal must work for color-blind users.
- **`isPositive` flag**: distinguishes the clean-result state from the four real failures. \`no_adverse_findings\` renders with strong ink (medium weight), not faint — it's a positive outcome.
- **`actionableBy` chip**: tells the user WHO can resolve. Caller / external source-operator / vitalcv-ops / no-action-needed. This is the truth-contract value-add: a bare "failure" badge doesn't tell anyone where to escalate.

## Files
- **\`apps/web-v2/src/lib/degraded-state.ts\`** — typed union + metadata map + 3 narrowing helpers.
- **\`apps/web-v2/src/components/DegradedStateRow.tsx\`** — pure renderer.
- **\`apps/web-v2/src/__tests__/degraded-state.test.tsx\`** — 36-test lockdown.

## Truth-contract invariants (36-test lockdown)
- Union has exactly 5 states in canonical order.
- Every state has complete metadata; map is frozen.
- \`no_adverse_findings\` is the ONLY positive state.
- \`actionableBy\` maps correctly per state.
- \`narrowDegradedState\` returns null on every non-matching input (case-sensitive, no silent default, rejects non-strings).
- Every state renders with its \`data-degraded-state\` attribute, \`data-is-positive\`, and \`data-actionable-by\` (programmatic inspection contract).
- Every state renders label + meaning snippet.
- NO state renders bare-word "Verified" as a label.
- Optional \`context\` and \`<time>checkedAt</time>\` render correctly.
- NO vibrant red/green hex leaks — monochrome doctrine inherited.
- Glyph assignments verified per state (■, ◐, ✕).
- Banned-strings scan: clean (module + component).

## What this PR does NOT do
- Does NOT wire \`DegradedStateRow\` into existing result list surfaces. The primitive is ready; per-surface wiring is a follow-up family of PRs (one per result type: passport, holder dashboard, verifier console).
- Does NOT add a \`/trust\` route. The TruthBoundary page (#325) + \`/api/status/health\` (#327) cover that intent.
- Does NOT implement the \`.well-known/did.json\` / \`openid-credential-issuer\` discovery endpoints brief from the same turn — that's distinct scope; would be its own PR.

## Validation
- Targeted tests: 36/36.
- Build: clean.
- Truth-contract scan: CLEAN.
- Diff scope: 3 new files in \`apps/web-v2/\`.

## Stack ordering
#308 → #323 → #325 → this PR. Or merge-queue resolves it.