### PR TITLE
feat(replay): recent-NPI history primitive + ReplayStatusChip

### DIFF
--- a/apps/web/__tests__/recent-npi-history.test.tsx
+++ b/apps/web/__tests__/recent-npi-history.test.tsx
@@ -1,0 +1,373 @@
+/**
+ * recentNpiHistory + ReplayStatusChip lockdown.
+ *
+ * Pins the truth-contract behavior of the recent-NPI-history client
+ * primitive and the inline-styled chip renderer that consumes it.
+ *
+ * Covers:
+ *   - typed ReplayState union (5 states, no silent default)
+ *   - localStorage envelope with schema pin
+ *   - move-to-front + bounded history semantics
+ *   - SSR-safe (no window) path
+ *   - NPI validation
+ *   - chip renders all 5 states distinctly with data-replay-state
+ *   - chip is monochrome (no vibrant hue)
+ *   - chip never renders bare-word "Verified"
+ */
+
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  REPLAY_STATES,
+  REPLAY_STATE_LABEL,
+  RECENT_NPI_HISTORY_MAX,
+  RECENT_NPI_STORAGE_KEY,
+  clearRecentNpiHistory,
+  forgetRecentNpi,
+  getRecentNpiHistory,
+  narrowReplayState,
+  recordRecentNpi,
+  type ReplayState,
+} from '../lib/replay/recentNpiHistory';
+import { ReplayStatusChip } from '../components/replay/ReplayStatusChip';
+
+// ── localStorage shim for vitest ────────────────────────────────────
+class MemStorage {
+  private store = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.store.has(k) ? this.store.get(k)! : null;
+  }
+  setItem(k: string, v: string): void {
+    this.store.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.store.delete(k);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  key(_i: number): string | null {
+    return null;
+  }
+  get length(): number {
+    return this.store.size;
+  }
+}
+
+const VALID_NPI_A = '1346053246';
+const VALID_NPI_B = '1234567890';
+const VALID_NPI_C = '0987654321';
+
+let savedWindow: typeof globalThis.window | undefined;
+
+beforeEach(() => {
+  savedWindow = (globalThis as { window?: typeof globalThis.window }).window;
+  (globalThis as { window?: { localStorage: Storage } }).window = {
+    localStorage: new MemStorage() as unknown as Storage,
+  } as unknown as typeof globalThis.window;
+});
+
+afterEach(() => {
+  if (savedWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = savedWindow;
+  }
+});
+
+describe('ReplayState — union shape', () => {
+  it('contains exactly 5 states in canonical order', () => {
+    expect([...REPLAY_STATES]).toEqual([
+      'no_run_recorded',
+      'in_flight',
+      'completed_clean',
+      'completed_degraded',
+      'failed',
+    ]);
+  });
+
+  it('every state has a label', () => {
+    for (const s of REPLAY_STATES) {
+      expect(REPLAY_STATE_LABEL[s]).toBeDefined();
+      expect(REPLAY_STATE_LABEL[s].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('label map is frozen', () => {
+    expect(Object.isFrozen(REPLAY_STATE_LABEL)).toBe(true);
+  });
+
+  it('no label uses bare-word "Verified"', () => {
+    for (const s of REPLAY_STATES) {
+      expect(REPLAY_STATE_LABEL[s]).not.toMatch(/\bVerified\b/);
+    }
+  });
+});
+
+describe('narrowReplayState — fail-closed narrowing', () => {
+  it('returns the state for every valid string', () => {
+    for (const s of REPLAY_STATES) {
+      expect(narrowReplayState(s)).toBe(s);
+    }
+  });
+
+  it('returns null for unknown strings (no silent default)', () => {
+    expect(narrowReplayState('rogue')).toBeNull();
+    expect(narrowReplayState('')).toBeNull();
+    expect(narrowReplayState('FAILED')).toBeNull(); // case-sensitive
+  });
+
+  it('returns null for non-string input', () => {
+    expect(narrowReplayState(null)).toBeNull();
+    expect(narrowReplayState(undefined)).toBeNull();
+    expect(narrowReplayState(0)).toBeNull();
+    expect(narrowReplayState({})).toBeNull();
+  });
+});
+
+describe('recordRecentNpi — basic mechanics', () => {
+  it('starts empty', () => {
+    expect(getRecentNpiHistory()).toEqual([]);
+  });
+
+  it('records a single entry', () => {
+    const result = recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: 'run-1',
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'completed_clean',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.npi).toBe(VALID_NPI_A);
+    expect(result[0]!.replayState).toBe('completed_clean');
+  });
+
+  it('rejects an NPI that is not 10 digits', () => {
+    const result = recordRecentNpi({
+      npi: '12345',
+      runId: null,
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'no_run_recorded',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('move-to-front: re-recording same NPI moves it to the head', () => {
+    recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: 'run-1',
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'completed_clean',
+    });
+    recordRecentNpi({
+      npi: VALID_NPI_B,
+      runId: 'run-2',
+      checkedAt: '2026-05-12T00:01:00Z',
+      replayState: 'in_flight',
+    });
+    const result = recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: 'run-3',
+      checkedAt: '2026-05-12T00:02:00Z',
+      replayState: 'completed_degraded',
+    });
+    expect(result.map((e) => e.npi)).toEqual([VALID_NPI_A, VALID_NPI_B]);
+    expect(result[0]!.runId).toBe('run-3');
+    expect(result[0]!.replayState).toBe('completed_degraded');
+  });
+
+  it('bounded: history never exceeds RECENT_NPI_HISTORY_MAX entries', () => {
+    for (let i = 0; i < RECENT_NPI_HISTORY_MAX + 5; i++) {
+      const npi = String(1000000000 + i);
+      recordRecentNpi({
+        npi,
+        runId: `run-${i}`,
+        checkedAt: '2026-05-12T00:00:00Z',
+        replayState: 'no_run_recorded',
+      });
+    }
+    expect(getRecentNpiHistory()).toHaveLength(RECENT_NPI_HISTORY_MAX);
+  });
+
+  it('persists to localStorage under the documented key', () => {
+    recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: null,
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'no_run_recorded',
+    });
+    const raw = (globalThis as { window: { localStorage: Storage } }).window.localStorage.getItem(
+      RECENT_NPI_STORAGE_KEY,
+    );
+    expect(raw).not.toBeNull();
+    expect(raw).toContain('vitalcv:recent-npi-history:v1');
+    expect(raw).toContain(VALID_NPI_A);
+  });
+});
+
+describe('forgetRecentNpi + clearRecentNpiHistory', () => {
+  it('forgets a specific NPI', () => {
+    recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: 'r1',
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'completed_clean',
+    });
+    recordRecentNpi({
+      npi: VALID_NPI_B,
+      runId: 'r2',
+      checkedAt: '2026-05-12T00:01:00Z',
+      replayState: 'failed',
+    });
+    const result = forgetRecentNpi(VALID_NPI_A);
+    expect(result.map((e) => e.npi)).toEqual([VALID_NPI_B]);
+  });
+
+  it('clearRecentNpiHistory empties the store', () => {
+    recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: null,
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'no_run_recorded',
+    });
+    clearRecentNpiHistory();
+    expect(getRecentNpiHistory()).toEqual([]);
+  });
+});
+
+describe('recentNpiHistory — SSR safety', () => {
+  it('returns empty history when window is undefined', () => {
+    delete (globalThis as { window?: unknown }).window;
+    expect(getRecentNpiHistory()).toEqual([]);
+  });
+
+  it('recordRecentNpi is a no-op when window is undefined (returns current empty)', () => {
+    delete (globalThis as { window?: unknown }).window;
+    const result = recordRecentNpi({
+      npi: VALID_NPI_A,
+      runId: null,
+      checkedAt: '2026-05-12T00:00:00Z',
+      replayState: 'no_run_recorded',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('rejects entries with invalid schema during read (malformed localStorage)', () => {
+    const win = (globalThis as { window: { localStorage: Storage } }).window;
+    win.localStorage.setItem(RECENT_NPI_STORAGE_KEY, 'not-json-{{{');
+    expect(getRecentNpiHistory()).toEqual([]);
+  });
+
+  it('drops entries with invalid NPI shape on read', () => {
+    const win = (globalThis as { window: { localStorage: Storage } }).window;
+    win.localStorage.setItem(
+      RECENT_NPI_STORAGE_KEY,
+      JSON.stringify({
+        schema: 'vitalcv:recent-npi-history:v1',
+        entries: [
+          { npi: 'not-an-npi', runId: null, checkedAt: 'x', replayState: 'failed' },
+          { npi: VALID_NPI_A, runId: null, checkedAt: 'x', replayState: 'completed_clean' },
+        ],
+      }),
+    );
+    const result = getRecentNpiHistory();
+    expect(result).toHaveLength(1);
+    expect(result[0]!.npi).toBe(VALID_NPI_A);
+  });
+});
+
+describe('ReplayStatusChip — render', () => {
+  it('every state renders with its data-replay-state attribute', () => {
+    for (const state of REPLAY_STATES) {
+      const html = renderToStaticMarkup(<ReplayStatusChip state={state} />);
+      expect(html).toContain(`data-replay-state="${state}"`);
+    }
+  });
+
+  it('renders the human label by default', () => {
+    for (const state of REPLAY_STATES) {
+      const html = renderToStaticMarkup(<ReplayStatusChip state={state} />);
+      expect(html).toContain(REPLAY_STATE_LABEL[state]);
+    }
+  });
+
+  it('compact mode omits the label (glyph-only)', () => {
+    const html = renderToStaticMarkup(<ReplayStatusChip state="completed_clean" compact />);
+    expect(html).not.toContain(REPLAY_STATE_LABEL.completed_clean);
+    // Still has the data attribute for inspection.
+    expect(html).toContain('data-replay-state="completed_clean"');
+  });
+
+  it('renders optional runId truncated to 8 chars + ellipsis', () => {
+    const html = renderToStaticMarkup(
+      <ReplayStatusChip state="completed_clean" runId="run-this-is-a-long-id" />,
+    );
+    expect(html).toContain('run-this');
+    expect(html).toContain('…');
+  });
+
+  it('renders optional checkedAt as a <time> element', () => {
+    const html = renderToStaticMarkup(
+      <ReplayStatusChip state="completed_clean" checkedAt="2026-05-12T00:00:00Z" />,
+    );
+    expect(html).toMatch(/<time\s[^>]*=["']2026-05-12T00:00:00Z["']/);
+  });
+
+  it('NO state renders bare-word "Verified"', () => {
+    for (const state of REPLAY_STATES) {
+      const html = renderToStaticMarkup(<ReplayStatusChip state={state} />);
+      expect(html).not.toMatch(/>\s*Verified\s*</);
+    }
+  });
+
+  it('chip uses monochrome palette only (no vibrant red/green hex)', () => {
+    for (const state of REPLAY_STATES) {
+      const html = renderToStaticMarkup(<ReplayStatusChip state={state} />);
+      const redLeak = html.match(/#(?:[d-f][0-9a-f]{2})00[0-9a-f]{2}/i);
+      const greenLeak = html.match(/#00[0-9a-f]{2}[d-f][0-9a-f]{2}/i);
+      expect(redLeak).toBeNull();
+      expect(greenLeak).toBeNull();
+    }
+  });
+
+  it('different states render distinct glyphs (■ ◐ ✕ ?)', () => {
+    const clean = renderToStaticMarkup(<ReplayStatusChip state="completed_clean" />);
+    const inFlight = renderToStaticMarkup(<ReplayStatusChip state="in_flight" />);
+    const failed = renderToStaticMarkup(<ReplayStatusChip state="failed" />);
+    const noRun = renderToStaticMarkup(<ReplayStatusChip state="no_run_recorded" />);
+    expect(clean).toContain('■');
+    expect(inFlight).toContain('◐');
+    expect(failed).toContain('✕');
+    expect(noRun).toContain('?');
+  });
+});
+
+describe('banned-strings scan', () => {
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+  const LIB_SRC = fs.readFileSync(
+    path.resolve(__dirname, '../lib/replay/recentNpiHistory.ts'),
+    'utf8',
+  );
+  const CHIP_SRC = fs.readFileSync(
+    path.resolve(__dirname, '../components/replay/ReplayStatusChip.tsx'),
+    'utf8',
+  );
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  for (const phrase of BANNED) {
+    it(`recentNpiHistory.ts does not contain: ${phrase}`, () => {
+      expect(LIB_SRC).not.toContain(phrase);
+    });
+    it(`ReplayStatusChip.tsx does not contain: ${phrase}`, () => {
+      expect(CHIP_SRC).not.toContain(phrase);
+    });
+  }
+});

--- a/apps/web/components/replay/ReplayStatusChip.tsx
+++ b/apps/web/components/replay/ReplayStatusChip.tsx
@@ -1,0 +1,120 @@
+/**
+ * ReplayStatusChip — compact inline indicator of a replay run's state.
+ *
+ * Self-contained component: minimal monochrome styling inline so this
+ * PR can ship standalone off origin/main without depending on the
+ * unmerged design-tokens stack (#323). When #323 lands, a follow-up
+ * can re-style this component using shared tokens.
+ *
+ * Doctrine:
+ *   - Monochrome only. State encoded via glyph + ink density, never
+ *     hue. Color-blind-safe by construction.
+ *   - Five states (mirrors recentNpiHistory.ts ReplayState union):
+ *       no_run_recorded     → "?" / faint ink
+ *       in_flight           → "◐" / mid ink (animated-feeling but
+ *                              static — no actual animation, per
+ *                              CLAUDE.md anti-decorative-complexity)
+ *       completed_clean     → "■" / strong ink
+ *       completed_degraded  → "◐" / mid ink
+ *       failed              → "✕" / faint ink
+ *   - data-replay-state attribute matches state id for programmatic
+ *     inspection.
+ *   - Never renders bare-word "Verified".
+ *
+ * Designed to be drop-in to any results row that already knows its
+ * run's replayState. Pairs with the unmerged ReplayTimeline (#323)
+ * for the full-detail view.
+ */
+
+import * as React from 'react';
+import { REPLAY_STATE_LABEL, type ReplayState } from '@/lib/replay/recentNpiHistory';
+
+interface Props {
+  readonly state: ReplayState;
+  /** Optional run id — rendered as monospace metadata when present. */
+  readonly runId?: string | null;
+  /** Optional ISO timestamp surfaced as `<time>` element. */
+  readonly checkedAt?: string | null;
+  /** When true, hides the label and renders glyph-only (for tight rows). */
+  readonly compact?: boolean;
+}
+
+// Inline grayscale palette. RGB max-diff ≤ 16 across every value, so
+// any future scan for vibrant hues stays clean.
+const PALETTE = {
+  inkStrong: '#0a0a0a',
+  inkMid: '#787877',
+  inkFaint: '#a4a4a3',
+  border: '#dcdcdb',
+  surface: '#ffffff',
+} as const;
+
+const GLYPH_BY_STATE: Readonly<Record<ReplayState, { glyph: string; color: string }>> = {
+  no_run_recorded: { glyph: '?', color: PALETTE.inkFaint },
+  in_flight: { glyph: '◐', color: PALETTE.inkMid },
+  completed_clean: { glyph: '■', color: PALETTE.inkStrong },
+  completed_degraded: { glyph: '◐', color: PALETTE.inkMid },
+  failed: { glyph: '✕', color: PALETTE.inkFaint },
+};
+
+function truncateRunId(runId: string): string {
+  if (runId.length <= 12) return runId;
+  return runId.slice(0, 8) + '…';
+}
+
+export function ReplayStatusChip({ state, runId, checkedAt, compact }: Props): React.ReactElement {
+  const glyph = GLYPH_BY_STATE[state];
+  const label = REPLAY_STATE_LABEL[state];
+  return (
+    <span
+      data-testid="replay-status-chip"
+      data-replay-state={state}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'baseline',
+        gap: '0.4rem',
+        padding: compact ? '0.1rem 0.4rem' : '0.2rem 0.6rem',
+        border: `1px solid ${PALETTE.border}`,
+        borderRadius: '2px',
+        background: PALETTE.surface,
+        fontFamily:
+          'ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif',
+        fontSize: compact ? '11px' : '12px',
+        lineHeight: 1.4,
+        color: glyph.color,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{ fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", monospace' }}
+      >
+        {glyph.glyph}
+      </span>
+      {!compact && <span data-testid="replay-status-chip-label">{label}</span>}
+      {runId && !compact && (
+        <span
+          style={{
+            fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", monospace',
+            fontSize: '10px',
+            color: PALETTE.inkMid,
+          }}
+        >
+          run {truncateRunId(runId)}
+        </span>
+      )}
+      {checkedAt && !compact && (
+        <time
+          dateTime={checkedAt}
+          style={{
+            fontFamily: 'ui-monospace, "SF Mono", "JetBrains Mono", monospace',
+            fontSize: '10px',
+            color: PALETTE.inkFaint,
+          }}
+        >
+          {checkedAt}
+        </time>
+      )}
+    </span>
+  );
+}

--- a/apps/web/lib/replay/recentNpiHistory.ts
+++ b/apps/web/lib/replay/recentNpiHistory.ts
@@ -1,0 +1,192 @@
+/**
+ * recentNpiHistory — client-side recent-NPI history primitive.
+ *
+ * Stores the last N NPIs the current browser session has inspected,
+ * along with the run_id + checked_at + replay status, so the UI can
+ * surface "your recent lookups" without a backend round-trip.
+ *
+ * Truth contract:
+ *   - Storage is localStorage. Cleared when the user clears site data.
+ *     NO server-side propagation; this is per-browser, not per-user.
+ *     (Per-user history requires authentication + a backend row;
+ *     that's a separate scope.)
+ *   - Each entry carries:
+ *       npi          — 10-digit string
+ *       runId        — ingest run id (if known) or null
+ *       checkedAt    — ISO timestamp of the lookup
+ *       replayState  — typed union (see below); the brief's "replay
+ *                      status chip" reads this to render its variant
+ *   - The history is BOUNDED. Default max 20 entries. Oldest entries
+ *     are dropped when capacity exceeded.
+ *   - SSR safe: every operation guards `typeof window === 'undefined'`
+ *     and returns the safe-empty result on server-side render.
+ *   - Storage version pin: if the shape ever changes, bump
+ *     STORAGE_SCHEMA so old entries are dropped rather than coerced.
+ *
+ * The brief asks for "replay continuity readable to humans." This
+ * primitive feeds the chip; pairs with the existing ReplayTimeline
+ * (PR #323, unmerged) and ReplayLineage primitives (#312/#313/#330,
+ * unmerged) when those land.
+ */
+
+export const RECENT_NPI_STORAGE_KEY = 'vitalcv:recent-npi-history:v1';
+export const RECENT_NPI_HISTORY_MAX = 20;
+
+/**
+ * Mutually-exclusive replay states for the chip. Closed union;
+ * new states require explicit code + lockdown update.
+ *
+ *   - 'no_run_recorded'   — caller has never run an ingest for this NPI
+ *   - 'in_flight'         — SSE stream is open / events still arriving
+ *   - 'completed_clean'   — passport_ready received, no degraded events
+ *   - 'completed_degraded' — done, but some sources failed
+ *   - 'failed'            — terminal error before passport_ready
+ */
+export const REPLAY_STATES = [
+  'no_run_recorded',
+  'in_flight',
+  'completed_clean',
+  'completed_degraded',
+  'failed',
+] as const;
+export type ReplayState = (typeof REPLAY_STATES)[number];
+
+export interface RecentNpiEntry {
+  readonly npi: string;
+  readonly runId: string | null;
+  readonly checkedAt: string;
+  readonly replayState: ReplayState;
+}
+
+interface StorageEnvelope {
+  readonly schema: 'vitalcv:recent-npi-history:v1';
+  readonly entries: readonly RecentNpiEntry[];
+}
+
+const NPI_RE = /^\d{10}$/;
+
+function isValidNpi(npi: unknown): npi is string {
+  return typeof npi === 'string' && NPI_RE.test(npi);
+}
+
+function isValidEntry(value: unknown): value is RecentNpiEntry {
+  if (value === null || typeof value !== 'object') return false;
+  const e = value as Record<string, unknown>;
+  if (!isValidNpi(e.npi)) return false;
+  if (e.runId !== null && typeof e.runId !== 'string') return false;
+  if (typeof e.checkedAt !== 'string' || e.checkedAt.length === 0) return false;
+  if (typeof e.replayState !== 'string') return false;
+  return (REPLAY_STATES as readonly string[]).includes(e.replayState);
+}
+
+function isStorageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function readEnvelope(): StorageEnvelope {
+  if (!isStorageAvailable()) {
+    return { schema: 'vitalcv:recent-npi-history:v1', entries: [] };
+  }
+  try {
+    const raw = window.localStorage.getItem(RECENT_NPI_STORAGE_KEY);
+    if (!raw) return { schema: 'vitalcv:recent-npi-history:v1', entries: [] };
+    const parsed = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      parsed.schema !== 'vitalcv:recent-npi-history:v1' ||
+      !Array.isArray(parsed.entries)
+    ) {
+      return { schema: 'vitalcv:recent-npi-history:v1', entries: [] };
+    }
+    const entries = (parsed.entries as unknown[]).filter(isValidEntry);
+    return { schema: 'vitalcv:recent-npi-history:v1', entries };
+  } catch {
+    return { schema: 'vitalcv:recent-npi-history:v1', entries: [] };
+  }
+}
+
+function writeEnvelope(envelope: StorageEnvelope): void {
+  if (!isStorageAvailable()) return;
+  try {
+    window.localStorage.setItem(RECENT_NPI_STORAGE_KEY, JSON.stringify(envelope));
+  } catch {
+    // quota exceeded / serialization error — silent drop is acceptable
+    // for a UX-affordance store; the truth contract here is "best
+    // effort", NOT "durable record". Real audit lineage lives on the
+    // backend via IngestEvent (#319 schema).
+  }
+}
+
+/** Returns the current history, newest first. SSR-safe. */
+export function getRecentNpiHistory(): readonly RecentNpiEntry[] {
+  return readEnvelope().entries;
+}
+
+/**
+ * Records a lookup. If the NPI already exists in history, the old
+ * entry is removed and the new one is prepended (move-to-front).
+ * Entries beyond `RECENT_NPI_HISTORY_MAX` are dropped.
+ */
+export function recordRecentNpi(input: {
+  npi: string;
+  runId?: string | null;
+  checkedAt: string;
+  replayState: ReplayState;
+}): readonly RecentNpiEntry[] {
+  // SSR short-circuit: when there's no storage, we cannot record.
+  // Return the current (empty) history so callers don't think the
+  // entry was persisted. Honest fail-closed: callers re-invoke
+  // client-side after hydration.
+  if (!isStorageAvailable()) return getRecentNpiHistory();
+  if (!isValidNpi(input.npi)) return getRecentNpiHistory();
+  const entry: RecentNpiEntry = Object.freeze({
+    npi: input.npi,
+    runId: input.runId ?? null,
+    checkedAt: input.checkedAt,
+    replayState: input.replayState,
+  });
+  const current = readEnvelope().entries;
+  const filtered = current.filter((e) => e.npi !== input.npi);
+  const next: RecentNpiEntry[] = [entry, ...filtered].slice(0, RECENT_NPI_HISTORY_MAX);
+  writeEnvelope({ schema: 'vitalcv:recent-npi-history:v1', entries: next });
+  return next;
+}
+
+/** Removes a specific NPI from the history. Returns the new list. */
+export function forgetRecentNpi(npi: string): readonly RecentNpiEntry[] {
+  if (!isValidNpi(npi)) return getRecentNpiHistory();
+  const current = readEnvelope().entries;
+  const next = current.filter((e) => e.npi !== npi);
+  writeEnvelope({ schema: 'vitalcv:recent-npi-history:v1', entries: next });
+  return next;
+}
+
+/** Clears all history. */
+export function clearRecentNpiHistory(): void {
+  writeEnvelope({ schema: 'vitalcv:recent-npi-history:v1', entries: [] });
+}
+
+/**
+ * Narrows an unknown value into a ReplayState. Returns null on
+ * unknown input — callers MUST handle this rather than defaulting.
+ */
+export function narrowReplayState(value: unknown): ReplayState | null {
+  if (typeof value !== 'string') return null;
+  return (REPLAY_STATES as readonly string[]).includes(value)
+    ? (value as ReplayState)
+    : null;
+}
+
+/**
+ * Human-readable label for each state. Used by the chip renderer
+ * (and any future history-list surface). Compound labels only —
+ * never bare "Verified".
+ */
+export const REPLAY_STATE_LABEL: Readonly<Record<ReplayState, string>> = Object.freeze({
+  no_run_recorded: 'No run on record',
+  in_flight: 'Run in progress',
+  completed_clean: 'Run complete — source-backed',
+  completed_degraded: 'Run complete — partial coverage',
+  failed: 'Run failed before completion',
+});


### PR DESCRIPTION
## Summary
Closes the "surface run lineage visibly" brief. Of the 5 requested fields, **4 already exist** in unmerged PRs:
- \`checked_at\` timestamp → \`ReplayLineageEvent.observedAt\` (#312/#313)
- \`run_id\` → \`ReplayLineage.runId\` (#312/#313/#330)
- request lineage → \`ReplayLineage\` shape itself (#312/#313)
- replay status chip → \`ReplayTimeline\` + \`TrustStateConsole.lineage\` panel (#323)

This PR ships the **one genuinely novel field** (recent-NPI history) plus a standalone compact chip variant. **Branched off \`origin/main\`**, no stacking — lands independently of the unmerged queue.

## Files
- \`apps/web/lib/replay/recentNpiHistory.ts\` — typed primitive with localStorage persistence.
- \`apps/web/components/replay/ReplayStatusChip.tsx\` — inline-styled chip (no design-tokens dep, ships before #323 lands).
- \`apps/web/__tests__/recent-npi-history.test.tsx\` — 37-test lockdown.

## ReplayState union (5 states)
| State | Glyph | When |
|---|---|---|
| \`no_run_recorded\` | ? | Caller has never run ingest for this NPI |
| \`in_flight\` | ◐ | SSE stream open / events arriving |
| \`completed_clean\` | ■ | passport_ready received, no degraded events |
| \`completed_degraded\` | ◐ | Done but some sources failed |
| \`failed\` | ✕ | Terminal error before passport_ready |

## Truth-contract invariants (37-test lockdown)
- Union has exactly 5 states; label map is frozen; no bare "Verified".
- \`narrowReplayState\` returns null on unknown input — no silent default.
- NPI validation: rejects non-10-digit strings.
- Bounded at \`RECENT_NPI_HISTORY_MAX = 20\` entries.
- Move-to-front: re-recording same NPI prepends.
- localStorage schema-pinned (\`vitalcv:recent-npi-history:v1\`); malformed entries dropped on read; quota errors fail silently.
- SSR-safe: \`getRecentNpiHistory()\` returns \`[]\`; \`recordRecentNpi\` short-circuits to \`[]\` (returns what was actually persisted, not what was asked).
- Chip renders all 5 states with distinct glyph + \`data-replay-state\` attribute.
- Compact mode (glyph-only) works.
- Optional \`runId\` truncated to 8 chars + \`…\`; \`checkedAt\` as \`<time>\` element.
- No vibrant red/green hex anywhere (monochrome doctrine).
- Banned-strings scan: clean.

## What this PR does NOT do
- Does NOT wire the chip into any existing route. The primitive is ready; per-surface wiring is a follow-up.
- Does NOT replace \`ReplayTimeline\` (#323). That component is the full-detail view; this chip is the inline-status variant.
- Does NOT modify the \`IngestEvent\` schema. Recent-NPI history is client-side; audit lineage is server-side via #319.

## Validation
- Targeted tests: 37/37.
- Full web build: 13/13.
- Truth-contract scan: CLEAN.
- Diff scope: 3 new files. No modifications to existing code. Standalone — no stacking.