### PR TITLE
feat(runtime): formalize 4-value runtime channel taxonomy

### DIFF
--- a/apps/web/__tests__/runtime-channel.test.tsx
+++ b/apps/web/__tests__/runtime-channel.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * Runtime channel taxonomy lockdown.
+ *
+ * Pins:
+ *   - Closed 4-value union (no silent expansion).
+ *   - resolveRuntimeChannel resolution order is deterministic.
+ *   - Explicit override wins over Vercel detection.
+ *   - Preview-with-staging-URL → 'staging', not 'operator_preview'.
+ *   - /api/health surfaces runtime_channel field.
+ *   - Footer renders null in production, chip otherwise.
+ *   - alwaysRender prop forces production chip (for /status page).
+ */
+
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  RUNTIME_CHANNELS,
+  RUNTIME_CHANNEL_LABEL,
+  isPreReleaseChannel,
+  isProductionChannel,
+  narrowRuntimeChannel,
+  resolveRuntimeChannel,
+  type RuntimeChannel,
+} from '../lib/runtime/channel';
+import { RuntimeChannelFooter } from '../components/runtime/RuntimeChannelFooter';
+import { GET } from '../app/api/health/route';
+
+const SAVE_KEYS = [
+  'VITALCV_RUNTIME_CHANNEL',
+  'VERCEL_ENV',
+  'VERCEL_URL',
+  'NODE_ENV',
+  'VITALCV_STAGING_URL_PATTERN',
+] as const;
+
+const saved: Partial<Record<(typeof SAVE_KEYS)[number], string>> = {};
+
+beforeEach(() => {
+  for (const k of SAVE_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of SAVE_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('RuntimeChannel — union shape', () => {
+  it('contains exactly 4 channels in canonical order', () => {
+    expect([...RUNTIME_CHANNELS]).toEqual([
+      'local_dev',
+      'operator_preview',
+      'staging',
+      'production',
+    ]);
+  });
+
+  it('every channel has a label', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      expect(RUNTIME_CHANNEL_LABEL[c]).toBeDefined();
+      expect(RUNTIME_CHANNEL_LABEL[c].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('label map is frozen', () => {
+    expect(Object.isFrozen(RUNTIME_CHANNEL_LABEL)).toBe(true);
+  });
+
+  it('no label uses bare-word "Verified"', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      expect(RUNTIME_CHANNEL_LABEL[c]).not.toMatch(/\bVerified\b/);
+    }
+  });
+});
+
+describe('narrowRuntimeChannel — fail-closed narrowing', () => {
+  it('returns the channel for every valid string', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      expect(narrowRuntimeChannel(c)).toBe(c);
+    }
+  });
+
+  it('returns null on unknown / case-mismatched / non-string', () => {
+    expect(narrowRuntimeChannel('LOCAL_DEV')).toBeNull();
+    expect(narrowRuntimeChannel('prod')).toBeNull();
+    expect(narrowRuntimeChannel('')).toBeNull();
+    expect(narrowRuntimeChannel(null)).toBeNull();
+    expect(narrowRuntimeChannel(undefined)).toBeNull();
+    expect(narrowRuntimeChannel(0)).toBeNull();
+  });
+});
+
+describe('resolveRuntimeChannel — resolution order', () => {
+  it('returns local_dev when no env is set', () => {
+    expect(resolveRuntimeChannel({})).toBe('local_dev');
+  });
+
+  it('honors VITALCV_RUNTIME_CHANNEL override (valid)', () => {
+    expect(resolveRuntimeChannel({ VITALCV_RUNTIME_CHANNEL: 'staging' })).toBe('staging');
+    expect(
+      resolveRuntimeChannel({ VITALCV_RUNTIME_CHANNEL: 'production', VERCEL_ENV: 'preview' }),
+    ).toBe('production');
+  });
+
+  it('ignores invalid VITALCV_RUNTIME_CHANNEL and falls through', () => {
+    expect(
+      resolveRuntimeChannel({ VITALCV_RUNTIME_CHANNEL: 'rogue', VERCEL_ENV: 'production' }),
+    ).toBe('production');
+  });
+
+  it('VERCEL_ENV=production → production', () => {
+    expect(resolveRuntimeChannel({ VERCEL_ENV: 'production' })).toBe('production');
+  });
+
+  it('VERCEL_ENV=preview + staging URL → staging', () => {
+    expect(
+      resolveRuntimeChannel({
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'vitalcv-staging.vercel.app',
+      }),
+    ).toBe('staging');
+    expect(
+      resolveRuntimeChannel({
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'app-stage.vitalcv.com',
+      }),
+    ).toBe('staging');
+  });
+
+  it('VERCEL_ENV=preview + non-staging URL → operator_preview', () => {
+    expect(
+      resolveRuntimeChannel({
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'vitalcv-pr-123-blockchaincv.vercel.app',
+      }),
+    ).toBe('operator_preview');
+  });
+
+  it('VERCEL_ENV=preview without VERCEL_URL → operator_preview', () => {
+    expect(resolveRuntimeChannel({ VERCEL_ENV: 'preview' })).toBe('operator_preview');
+  });
+
+  it('custom VITALCV_STAGING_URL_PATTERN overrides default', () => {
+    expect(
+      resolveRuntimeChannel({
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'verify.vitalcv.com',
+        VITALCV_STAGING_URL_PATTERN: '^verify\\.',
+      }),
+    ).toBe('staging');
+  });
+
+  it('VERCEL_ENV=development → local_dev', () => {
+    expect(resolveRuntimeChannel({ VERCEL_ENV: 'development' })).toBe('local_dev');
+  });
+
+  it('NODE_ENV=production without VERCEL_ENV → production (self-hosted)', () => {
+    expect(resolveRuntimeChannel({ NODE_ENV: 'production' })).toBe('production');
+  });
+
+  it('is deterministic: same env → same channel', () => {
+    const env = { VERCEL_ENV: 'preview', VERCEL_URL: 'a-staging-b.vercel.app' } as const;
+    const first = resolveRuntimeChannel(env);
+    const second = resolveRuntimeChannel(env);
+    const third = resolveRuntimeChannel(env);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+});
+
+describe('isProductionChannel + isPreReleaseChannel', () => {
+  it('only production is the production channel', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      expect(isProductionChannel(c)).toBe(c === 'production');
+    }
+  });
+
+  it('all non-production channels are pre-release', () => {
+    expect(isPreReleaseChannel('local_dev')).toBe(true);
+    expect(isPreReleaseChannel('operator_preview')).toBe(true);
+    expect(isPreReleaseChannel('staging')).toBe(true);
+    expect(isPreReleaseChannel('production')).toBe(false);
+  });
+});
+
+describe('/api/health — runtime_channel surface', () => {
+  it('returns runtime_channel field in the response body', async () => {
+    process.env.VERCEL_ENV = 'production';
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runtime_channel).toBe('production');
+  });
+
+  it('runtime_channel reports operator_preview by default in preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_URL = 'vitalcv-pr-1.vercel.app';
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runtime_channel).toBe('operator_preview');
+  });
+
+  it('runtime_channel reports staging when URL matches staging pattern', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_URL = 'vitalcv-staging.vercel.app';
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runtime_channel).toBe('staging');
+  });
+
+  it('runtime_channel reports local_dev when nothing is set', async () => {
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runtime_channel).toBe('local_dev');
+  });
+
+  it('preserves backward-compat config.clerk shape (Wave 136)', async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_x';
+    const res = await GET();
+    const body = (await res.json()) as { config: { clerk: { enabled: boolean; mode: string } } };
+    expect(body.config.clerk.enabled).toBe(true);
+    expect(body.config.clerk.mode).toBe('production');
+  });
+});
+
+describe('RuntimeChannelFooter — render shape', () => {
+  it('production channel renders nothing by default (silent on customer-facing)', () => {
+    const html = renderToStaticMarkup(<RuntimeChannelFooter channel="production" />);
+    expect(html).toBe('');
+  });
+
+  it('alwaysRender forces production chip', () => {
+    const html = renderToStaticMarkup(
+      <RuntimeChannelFooter channel="production" alwaysRender />,
+    );
+    expect(html).toContain('data-runtime-channel="production"');
+    expect(html).toContain('Production');
+  });
+
+  it('staging renders distinct chip', () => {
+    const html = renderToStaticMarkup(<RuntimeChannelFooter channel="staging" />);
+    expect(html).toContain('data-runtime-channel="staging"');
+    expect(html).toContain('Staging');
+  });
+
+  it('operator_preview renders distinct chip', () => {
+    const html = renderToStaticMarkup(<RuntimeChannelFooter channel="operator_preview" />);
+    expect(html).toContain('data-runtime-channel="operator_preview"');
+    expect(html).toContain('Operator preview');
+  });
+
+  it('local_dev renders distinct chip', () => {
+    const html = renderToStaticMarkup(<RuntimeChannelFooter channel="local_dev" />);
+    expect(html).toContain('data-runtime-channel="local_dev"');
+    expect(html).toContain('Local development');
+  });
+
+  it('every channel chip carries data-testid="runtime-channel-footer"', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      const html = renderToStaticMarkup(
+        <RuntimeChannelFooter channel={c} alwaysRender />,
+      );
+      expect(html).toContain('data-testid="runtime-channel-footer"');
+    }
+  });
+
+  it('no chip uses vibrant red/green hex (monochrome)', () => {
+    for (const c of RUNTIME_CHANNELS) {
+      const html = renderToStaticMarkup(<RuntimeChannelFooter channel={c} alwaysRender />);
+      const redLeak = html.match(/#(?:[d-f][0-9a-f]{2})00[0-9a-f]{2}/i);
+      const greenLeak = html.match(/#00[0-9a-f]{2}[d-f][0-9a-f]{2}/i);
+      expect(redLeak).toBeNull();
+      expect(greenLeak).toBeNull();
+    }
+  });
+});
+
+describe('banned-strings scan', () => {
+  const LIB = readFileSync(resolve(__dirname, '../lib/runtime/channel.ts'), 'utf8');
+  const FOOTER = readFileSync(
+    resolve(__dirname, '../components/runtime/RuntimeChannelFooter.tsx'),
+    'utf8',
+  );
+  const ROUTE = readFileSync(resolve(__dirname, '../app/api/health/route.ts'), 'utf8');
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+  for (const phrase of BANNED) {
+    it(`channel.ts does not contain: ${phrase}`, () => {
+      expect(LIB).not.toContain(phrase);
+    });
+    it(`RuntimeChannelFooter.tsx does not contain: ${phrase}`, () => {
+      expect(FOOTER).not.toContain(phrase);
+    });
+    it(`/api/health route.ts does not contain: ${phrase}`, () => {
+      expect(ROUTE).not.toContain(phrase);
+    });
+  }
+});

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,16 +1,28 @@
 /**
- * Health route — Wave 136: includes Clerk production-readiness signal.
+ * Health route — Wave 136 baseline + runtime_channel taxonomy.
+ *
+ * Adds runtime_channel (the 4-value VitalCV taxonomy from
+ * apps/web/lib/runtime/channel.ts) so verifiers + footer renderers
+ * + monitoring tooling can disambiguate operator-preview from
+ * staging — something Vercel's 3-value VERCEL_ENV can't express.
+ *
+ * Backward-compat with Wave-136 monitoring is preserved (existing
+ * config.clerk shape unchanged).
  */
+import { resolveRuntimeChannel } from '@/lib/runtime/channel';
+
 export const runtime = 'nodejs';
 
 export async function GET() {
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
+  const channel = resolveRuntimeChannel();
 
   return Response.json(
     {
       status: 'ok',
       service: 'web',
       timestamp: new Date().toISOString(),
+      runtime_channel: channel,
       config: {
         apiBase: Boolean(process.env.NEXT_PUBLIC_API_BASE),
         clerk: {

--- a/apps/web/components/runtime/RuntimeChannelFooter.tsx
+++ b/apps/web/components/runtime/RuntimeChannelFooter.tsx
@@ -1,0 +1,76 @@
+/**
+ * RuntimeChannelFooter — inline render of the current runtime channel.
+ *
+ * Server component (reads process.env via resolveRuntimeChannel).
+ * Drop into a page footer to make the environment unambiguous at a
+ * glance. Operators reading the page should never wonder which
+ * environment they're looking at.
+ *
+ * Doctrine:
+ *   - Monochrome inline styling (no design-token dep so this PR
+ *     stands alone).
+ *   - Renders distinctly per channel:
+ *       production       → minimal text, no chip
+ *       staging          → chip with label
+ *       operator_preview → chip with label
+ *       local_dev        → chip with label
+ *   - The customer-facing 'production' channel is the silent
+ *     default — chips only render in pre-release contexts so
+ *     production pages don't carry a banner.
+ *   - data-runtime-channel attribute for programmatic inspection.
+ */
+
+import * as React from 'react';
+import {
+  RUNTIME_CHANNEL_LABEL,
+  isProductionChannel,
+  resolveRuntimeChannel,
+  type RuntimeChannel,
+} from '@/lib/runtime/channel';
+
+interface Props {
+  /** Override the resolved channel (used by tests). */
+  readonly channel?: RuntimeChannel;
+  /** When true, always render the chip — even in production. */
+  readonly alwaysRender?: boolean;
+}
+
+const PALETTE = {
+  inkStrong: '#0a0a0a',
+  inkMuted: '#787877',
+  border: '#dcdcdb',
+  surface: '#ffffff',
+} as const;
+
+export function RuntimeChannelFooter({ channel, alwaysRender }: Props): React.ReactElement | null {
+  const resolved = channel ?? resolveRuntimeChannel();
+  if (isProductionChannel(resolved) && !alwaysRender) {
+    return null;
+  }
+  const label = RUNTIME_CHANNEL_LABEL[resolved];
+  return (
+    <span
+      data-testid="runtime-channel-footer"
+      data-runtime-channel={resolved}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'baseline',
+        gap: '0.4rem',
+        padding: '0.15rem 0.5rem',
+        border: `1px solid ${PALETTE.border}`,
+        borderRadius: '2px',
+        background: PALETTE.surface,
+        fontFamily:
+          'ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", "Menlo", monospace',
+        fontSize: '10px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+        color: PALETTE.inkMuted,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true" style={{ color: PALETTE.inkStrong }}>·</span>
+      <span data-testid="runtime-channel-footer-label">{label}</span>
+    </span>
+  );
+}

--- a/apps/web/lib/runtime/channel.ts
+++ b/apps/web/lib/runtime/channel.ts
@@ -1,0 +1,124 @@
+/**
+ * Runtime channel — formalized 4-value taxonomy.
+ *
+ * Vercel's `VERCEL_ENV` is a 3-value union (production / preview /
+ * development) that conflates two things that matter to operators:
+ *
+ *   - "operator preview" — per-PR Vercel preview deploy. Ephemeral.
+ *     Used by reviewers + dogfooders mid-PR.
+ *   - "staging"          — long-running stable deployment that mirrors
+ *     production env vars but lives on a different domain. Used for
+ *     pre-production verification + partner integration testing.
+ *
+ * Both map to `VERCEL_ENV=preview` today. That's the ambiguity this
+ * module fixes: each runtime context now has a distinct channel id
+ * a verifier / monitoring tool / footer can read.
+ *
+ * The 4 channels:
+ *   - 'local_dev'         — `pnpm dev` on a developer machine
+ *   - 'operator_preview'  — Vercel per-PR preview deploy
+ *   - 'staging'           — long-running staging environment
+ *   - 'production'        — live customer-facing deploy
+ *
+ * Resolution rules (deterministic, no inference):
+ *   1. Explicit override via VITALCV_RUNTIME_CHANNEL env var wins.
+ *      Allows ops to label a deploy explicitly (e.g., a one-off
+ *      audit environment marked as 'staging' even on a preview URL).
+ *   2. VERCEL_ENV=production → 'production'.
+ *   3. VERCEL_ENV=preview AND VERCEL_URL matches a documented
+ *      staging-hostname pattern → 'staging'.
+ *      Default pattern: contains 'staging' or 'stage' substring.
+ *   4. VERCEL_ENV=preview otherwise → 'operator_preview'.
+ *   5. VERCEL_ENV=development → 'local_dev'.
+ *   6. Neither set, NODE_ENV=production → 'production' (rare; only
+ *      relevant outside Vercel — e.g., self-hosted).
+ *   7. Fallback → 'local_dev'.
+ *
+ * Truth contract:
+ *   - Closed union. New channels require explicit code + lockdown.
+ *   - Resolution is pure: same env → same channel. No randomness,
+ *     no time-dependent logic.
+ *   - `narrowRuntimeChannel(unknown)` returns null on unknown input.
+ */
+
+export const RUNTIME_CHANNELS = [
+  'local_dev',
+  'operator_preview',
+  'staging',
+  'production',
+] as const;
+
+export type RuntimeChannel = (typeof RUNTIME_CHANNELS)[number];
+
+export const RUNTIME_CHANNEL_LABEL: Readonly<Record<RuntimeChannel, string>> = Object.freeze({
+  local_dev: 'Local development',
+  operator_preview: 'Operator preview',
+  staging: 'Staging',
+  production: 'Production',
+});
+
+export interface ResolveRuntimeChannelEnv {
+  readonly VITALCV_RUNTIME_CHANNEL?: string;
+  readonly VERCEL_ENV?: string;
+  readonly VERCEL_URL?: string;
+  readonly NODE_ENV?: string;
+  /**
+   * Optional injection point: a regex string the resolver uses to
+   * detect staging URLs when VERCEL_ENV=preview. Defaults to a
+   * pattern matching the substring 'staging' or 'stage'.
+   */
+  readonly VITALCV_STAGING_URL_PATTERN?: string;
+}
+
+const DEFAULT_STAGING_PATTERN = /(^|[\.-])(staging|stage)([\.-]|$)/i;
+
+export function resolveRuntimeChannel(
+  env: ResolveRuntimeChannelEnv = process.env as ResolveRuntimeChannelEnv,
+): RuntimeChannel {
+  // 1. Explicit override wins.
+  const override = env.VITALCV_RUNTIME_CHANNEL;
+  if (typeof override === 'string') {
+    const narrowed = narrowRuntimeChannel(override);
+    if (narrowed) return narrowed;
+  }
+
+  // 2. Vercel production is unambiguous.
+  if (env.VERCEL_ENV === 'production') return 'production';
+
+  // 3+4. Disambiguate preview into staging vs operator_preview.
+  if (env.VERCEL_ENV === 'preview') {
+    const pattern = typeof env.VITALCV_STAGING_URL_PATTERN === 'string'
+      ? new RegExp(env.VITALCV_STAGING_URL_PATTERN, 'i')
+      : DEFAULT_STAGING_PATTERN;
+    if (typeof env.VERCEL_URL === 'string' && pattern.test(env.VERCEL_URL)) {
+      return 'staging';
+    }
+    return 'operator_preview';
+  }
+
+  // 5. Vercel dev (rare — Vercel rarely sets this on dev box).
+  if (env.VERCEL_ENV === 'development') return 'local_dev';
+
+  // 6. Self-hosted prod.
+  if (env.NODE_ENV === 'production') return 'production';
+
+  // 7. Fallback.
+  return 'local_dev';
+}
+
+export function narrowRuntimeChannel(value: unknown): RuntimeChannel | null {
+  if (typeof value !== 'string') return null;
+  return (RUNTIME_CHANNELS as readonly string[]).includes(value)
+    ? (value as RuntimeChannel)
+    : null;
+}
+
+/** True iff the channel is a customer-facing live deploy. */
+export function isProductionChannel(channel: RuntimeChannel): boolean {
+  return channel === 'production';
+}
+
+/** True iff the channel is a developer / preview surface (i.e., not customer-facing). */
+export function isPreReleaseChannel(channel: RuntimeChannel): boolean {
+  return channel === 'local_dev' || channel === 'operator_preview' || channel === 'staging';
+}


### PR DESCRIPTION
## Summary
Closes the brief "formalize runtime channels — render visibly in /api/health, /status, /footer."

**The ambiguity this fixes**: Vercel's \`VERCEL_ENV\` is 3 values (\`production\`/\`preview\`/\`development\`) that conflate **operator-preview** (ephemeral per-PR deploy) with **staging** (long-running stable pre-prod). Operators can't tell which one they're looking at; audit findings can attach to the wrong environment.

## The 4 channels

| Channel | When |
|---|---|
| \`local_dev\` | \`pnpm dev\` on a developer machine |
| \`operator_preview\` | Vercel per-PR preview deploy (ephemeral) |
| \`staging\` | Long-running stable staging environment |
| \`production\` | Live customer-facing deploy |

## Resolution rules (deterministic)
1. Explicit \`VITALCV_RUNTIME_CHANNEL\` env override wins.
2. \`VERCEL_ENV=production\` → \`production\`.
3. \`VERCEL_ENV=preview\` AND \`VERCEL_URL\` matches staging pattern → \`staging\`. Default pattern matches \`staging\` or \`stage\` substring; overridable via \`VITALCV_STAGING_URL_PATTERN\`.
4. \`VERCEL_ENV=preview\` otherwise → \`operator_preview\`.
5. \`VERCEL_ENV=development\` → \`local_dev\`.
6. \`NODE_ENV=production\` fallback → \`production\` (self-hosted).
7. Final fallback → \`local_dev\`.

## Files
- **New** \`apps/web/lib/runtime/channel.ts\` — typed union + resolver + label map.
- **Modified** \`apps/web/app/api/health/route.ts\` — adds \`runtime_channel\` to the response body.
- **New** \`apps/web/components/runtime/RuntimeChannelFooter.tsx\` — inline-styled server component. Renders null in production by default; \`alwaysRender\` prop forces the chip (for audit pages).
- **New** \`apps/web/__tests__/runtime-channel.test.tsx\` — 46-test lockdown.

## Truth-contract invariants (46-test lockdown)
- Closed union of exactly 4 channels in canonical order.
- Every channel has a label; map is frozen; no bare "Verified".
- \`narrowRuntimeChannel\` returns null on every non-matching input.
- Resolver respects priority order in all 7 rules above.
- Custom \`VITALCV_STAGING_URL_PATTERN\` overrides default.
- Resolver is deterministic — same env always returns same channel.
- \`/api/health\` surfaces \`runtime_channel\` field in response body.
- \`/api/health\` resolves all 4 channels correctly under matching env.
- Wave-136 \`config.clerk\` shape preserved.
- Footer renders null in production by default; \`alwaysRender\` forces chip.
- Every chip has distinct \`data-runtime-channel\` + visible label + \`data-testid\`.
- No vibrant red/green hex (monochrome doctrine).
- Banned-strings scan: clean (3 files).

## What this PR does NOT do
- Does NOT mount the footer into any specific page. Component is ready; wiring is a one-line import per page (recommended: \`app/layout.tsx\`).
- Does NOT modify the \`/status\` page. If you want the chip mounted there, it's a one-line follow-up.
- Does NOT remove the existing \`runtime_mode\` field from open PR #334. Two fields coexist:
  - \`runtime_mode\` — Vercel's 3-value (existing on #334)
  - \`runtime_channel\` — VitalCV's 4-value disambiguated taxonomy (this PR)

## Validation
- Targeted tests: 46/46.
- Full web build: 13/13.
- Truth-contract scan: CLEAN.
- Diff scope: 3 new files + 1 modified.
- Standalone: branches off \`origin/main\`, no stacking.