### PR TITLE
fix(web): point passport proxy at entity-shape backend route

### DIFF
--- a/apps/web/__tests__/passport-proxy-routes.test.ts
+++ b/apps/web/__tests__/passport-proxy-routes.test.ts
@@ -199,6 +199,24 @@ describe('passport proxy routes', () => {
     }));
   });
 
+  it('/api/passport/[npi] proxies to the entity-shape backend route (/api/passport/npi/:npi)', async () => {
+    // Pins the upstream URL so a regression that re-routes back to
+    // /api/passport/:npi (NPI-shape) can't silently reintroduce the
+    // `invalid_upstream_payload` 502.
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(buildPassportPayload()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { GET } = await import('../app/api/passport/[npi]/route');
+    const response = await GET(new Request('http://localhost/api/passport/1234567890') as never, {
+      params: Promise.resolve({ npi: '1234567890' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchMock.mock.calls[0]?.[0] as string) ?? '';
+    expect(calledUrl).toBe('http://backend.test/api/passport/npi/1234567890');
+  });
+
   it('rejects invalid readiness posture instead of proxying synthetic completeness', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassportPayload({
       readiness: {

--- a/apps/web/app/api/passport/[npi]/route.ts
+++ b/apps/web/app/api/passport/[npi]/route.ts
@@ -10,7 +10,17 @@ export async function GET(
 ) {
   try {
     const { npi } = await params;
-    const upstream = await fetch(`${BACKEND_URL}/api/passport/${encodeURIComponent(npi)}`, {
+    // Backend exposes two passport routes with divergent shapes:
+    //   /api/passport/:npi       — public/wallet/selective NPI-shape from
+    //                              routes/passport.ts (loadPassportData)
+    //   /api/passport/npi/:npi   — entity-shape from routes/passportEntity.ts
+    //                              (buildPassportDataByNpi)
+    // The proxy validator (`assertPassportData`) expects the entity-shape:
+    // top-level `entityId`, `identity`, `authority`, `training`, `standing`,
+    // `readiness`, `sources`, `sourceCoverage`, `lastCheckedAt`, `trustPosture`.
+    // Calling the NPI-shape route returned a different payload and produced
+    // the `502 invalid_upstream_payload` we saw against seeded NPIs.
+    const upstream = await fetch(`${BACKEND_URL}/api/passport/npi/${encodeURIComponent(npi)}`, {
       cache: 'no-store',
       signal: AbortSignal.timeout(8000),
     });


### PR DESCRIPTION
## Summary

The web proxy at `apps/web/app/api/passport/[npi]/route.ts` was fetching the wrong backend endpoint. The backend has **two** passport routes with divergent contracts:

| Backend route | Contract | Function |
|---|---|---|
| `GET /api/passport/:npi` | **NPI-shape** — `{npi, accessMode, public, credentials, sanctions, privileges, decisions, meta}` | `loadPassportData()` in `routes/passport.ts` (public/wallet/selective modes) |
| `GET /api/passport/npi/:npi` | **Entity-shape** — `{entityId, identity, authority, training, standing, readiness, sources, sourceCoverage, lastCheckedAt, trustPosture, ...}` | `buildPassportDataByNpi()` via `routes/passportEntity.ts` |

The web proxy's validator `assertPassportData` (in `apps/web/lib/trust/passport-contract.ts`) is built for the entity-shape, but the proxy was calling the NPI-shape route. Every seeded NPI returned **502 `invalid_upstream_payload`**.

## Fix

One-line URL change in the proxy: `/api/passport/${npi}` → `/api/passport/npi/${npi}`.

Adds a guard test (`passport-proxy-routes.test.ts:` new case) that asserts the upstream URL contains `/api/passport/npi/` so this can't regress.

## Validation against live runtime

```
GET http://localhost:3030/api/passport/1346053246
→ 200, 15075 bytes
→ keys: authority, credentials, decisionPosture, entityId, identity,
        lastCheckedAt, monitoring, npi, readiness, sourceCoverage,
        sources, standing, training, trustPosture, truth
```

## Truth rules
- No banned phrases in changed surfaces.
- No new claims about verification status — the fix only routes the proxy at the correct backend endpoint.

## Validation
- Targeted tests: **4/4** passing (`__tests__/passport-proxy-routes.test.ts`)
- Build: `pnpm turbo run build --filter @vitalcv/web` — **13/13 tasks**, 39s

## Scope
- `apps/web/app/api/passport/[npi]/route.ts` (1-line URL change + comment)
- `apps/web/__tests__/passport-proxy-routes.test.ts` (1 guard test added)