### PR TITLE
feat(trust): canonical institutional trust primitives (Lane B)

### DIFF
--- a/apps/web/components/trust/CheckedAtStamp.tsx
+++ b/apps/web/components/trust/CheckedAtStamp.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * CheckedAtStamp — canonical visible-timestamp primitive.
+ *
+ * Renders an ISO-8601 timestamp as visible text (not `aria-only`, not
+ * `title` tooltip, not `data-*` metadata). This is intentional: per the
+ * Lane A audit, hospital verifiers need to read the freshness of a
+ * check within ~30 seconds, and tooltip-only timestamps fail that test.
+ *
+ * Format:
+ *   - 'short'  → `2026-05-12`             (date-only, default)
+ *   - 'long'   → `2026-05-12 14:23 UTC`   (date + minute precision, UTC)
+ *   - 'iso'    → `2026-05-12T14:23:11Z`   (full ISO, monospaced)
+ *
+ * The label slot ("Checked", "Verified", "Observed") is caller-owned so
+ * the primitive doesn't impose a single verb across surfaces.
+ */
+export type CheckedAtFormat = 'short' | 'long' | 'iso';
+
+export interface CheckedAtStampProps {
+  /** ISO-8601 timestamp. `null` / `undefined` renders the no-check state. */
+  checkedAt: string | null | undefined;
+  /** Prefix label. Defaults to "Checked". */
+  label?: string;
+  /** Display format. Defaults to 'long'. */
+  format?: CheckedAtFormat;
+  /** Optional freshness window in milliseconds. When set, a `stale` indicator
+   *  is appended if `now - checkedAt > freshnessWindowMs`. */
+  freshnessWindowMs?: number;
+  /** Optional class hook for the outer span. */
+  className?: string;
+}
+
+function formatCheckedAt(iso: string, format: CheckedAtFormat): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  if (format === 'iso') {
+    return date.toISOString();
+  }
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  if (format === 'short') {
+    return `${y}-${m}-${d}`;
+  }
+  const hh = String(date.getUTCHours()).padStart(2, '0');
+  const mm = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${y}-${m}-${d} ${hh}:${mm} UTC`;
+}
+
+export function CheckedAtStamp({
+  checkedAt,
+  label = 'Checked',
+  format = 'long',
+  freshnessWindowMs,
+  className,
+}: CheckedAtStampProps): React.ReactElement {
+  if (!checkedAt) {
+    return (
+      <span
+        className={cn('inline-flex items-baseline gap-1.5 text-xs text-muted-foreground', className)}
+        data-checked-at="none"
+      >
+        <span className="uppercase tracking-wide">{label}</span>
+        <span className="font-mono">never</span>
+      </span>
+    );
+  }
+
+  const formatted = formatCheckedAt(checkedAt, format);
+  const isStale =
+    typeof freshnessWindowMs === 'number'
+    && Number.isFinite(new Date(checkedAt).getTime())
+    && Date.now() - new Date(checkedAt).getTime() > freshnessWindowMs;
+
+  return (
+    <span
+      className={cn('inline-flex items-baseline gap-1.5 text-xs', className)}
+      data-checked-at={checkedAt}
+      data-stale={isStale ? 'true' : 'false'}
+    >
+      <span className="uppercase tracking-wide text-muted-foreground">{label}</span>
+      <time className="font-mono text-foreground" dateTime={checkedAt}>
+        {formatted}
+      </time>
+      {isStale && (
+        <span className="font-mono text-[10px] uppercase tracking-wider text-amber-600 dark:text-amber-400">
+          stale
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/trust/DegradedStateBanner.tsx
+++ b/apps/web/components/trust/DegradedStateBanner.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * DegradedStateBanner — canonical A/B/C/D/E degraded-state taxonomy.
+ *
+ * Distinguishes WHY a check is not in its normal state. The audit
+ * established that A/B/C/D/E values currently live only in API docs
+ * and test fixtures; no rendered prose maps them to user-readable
+ * outcomes. That makes "upstream outage" indistinguishable from
+ * "VitalCV is degraded" in the UI.
+ *
+ * Taxonomy:
+ *   A — source unreachable        (upstream API timeout / down)
+ *   B — anonymous restriction     (source requires authenticated access
+ *                                  we don't currently hold)
+ *   C — infrastructure outage     (VitalCV-side outage or queue backup)
+ *   D — no adverse findings       (NOT degraded — successful clean
+ *                                  check; rendered as SUCCESS to avoid
+ *                                  conflating absence of evidence with
+ *                                  presence of risk)
+ *   E — issuer unavailable        (signer / DID-issuer endpoint down
+ *                                  but the upstream data source is fine)
+ *
+ * Rule (mandatory per brief): code 'D' MUST render as a success-tone
+ * banner. The taxonomy value is the same primitive but the visual
+ * register flips because "no adverse findings" is positive news.
+ */
+export type DegradedStateCode = 'A' | 'B' | 'C' | 'D' | 'E';
+
+interface CodeSpec {
+  label: string;
+  summary: string;
+  tone: 'warning' | 'info' | 'critical' | 'success';
+}
+
+const CODE_SPEC: Record<DegradedStateCode, CodeSpec> = {
+  A: { label: 'Source unreachable',     summary: 'Upstream source did not respond. Retry expected automatically.', tone: 'warning'  },
+  B: { label: 'Anonymous restriction',  summary: 'Source requires authenticated access not currently held.',        tone: 'info'     },
+  C: { label: 'Infrastructure outage',  summary: 'VitalCV-side outage. Engineering is on it.',                       tone: 'critical' },
+  D: { label: 'No adverse findings',    summary: 'Source returned a clean result. No exclusions, sanctions, or matches.', tone: 'success'  },
+  E: { label: 'Issuer unavailable',     summary: 'Signing issuer endpoint is unreachable; data source is fine.',     tone: 'warning'  },
+};
+
+const TONE_CLASSES: Record<CodeSpec['tone'], string> = {
+  success:  'border-emerald-500/40 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200',
+  info:     'border-blue-500/40 bg-blue-500/10 text-blue-800 dark:text-blue-200',
+  warning:  'border-amber-500/40 bg-amber-500/10 text-amber-900 dark:text-amber-200',
+  critical: 'border-rose-500/40 bg-rose-500/10 text-rose-900 dark:text-rose-200',
+};
+
+export interface DegradedStateBannerProps {
+  /** Single-letter taxonomy code. */
+  code: DegradedStateCode;
+  /** Optional source id this banner is about (e.g. 'NPPES_API'). */
+  sourceId?: string;
+  /** Optional operator recovery action. */
+  recoveryAction?: string;
+  /** Optional ISO timestamp when this state was observed. */
+  observedAt?: string | null;
+  className?: string;
+}
+
+export function DegradedStateBanner({
+  code,
+  sourceId,
+  recoveryAction,
+  observedAt,
+  className,
+}: DegradedStateBannerProps): React.ReactElement {
+  const spec = CODE_SPEC[code];
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-lg border px-4 py-3 text-sm',
+        TONE_CLASSES[spec.tone],
+        className,
+      )}
+      data-degraded-code={code}
+      data-degraded-tone={spec.tone}
+      role={spec.tone === 'critical' ? 'alert' : 'status'}
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-wider opacity-80">
+          state {code}
+        </span>
+        <span className="font-semibold">{spec.label}</span>
+        {sourceId && (
+          <span className="font-mono text-[11px] opacity-90">· {sourceId}</span>
+        )}
+      </div>
+      <p className="text-[12px] leading-snug opacity-90">{spec.summary}</p>
+      {recoveryAction && (
+        <p className="text-[11px] leading-snug opacity-80">
+          <span className="font-mono uppercase tracking-wider">next:</span>{' '}
+          {recoveryAction}
+        </p>
+      )}
+      {observedAt && (
+        <time
+          className="font-mono text-[10px] uppercase tracking-wider opacity-70"
+          dateTime={observedAt}
+        >
+          observed {observedAt}
+        </time>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/trust/IssuerAttribution.tsx
+++ b/apps/web/components/trust/IssuerAttribution.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CheckedAtStamp } from './CheckedAtStamp';
+
+/**
+ * IssuerAttribution — canonical signer / DID / receipt-attribution chip.
+ *
+ * Surfaces the cryptographic identity of who signed a check or receipt.
+ * Per the Lane A audit, `signer`, `DID`, and `keyId` live only on the
+ * backend (`modules/identity/signer.ts`, `utils/issuerDid.ts`) and never
+ * reach the UI; a verifier currently has no way to see which issuer
+ * vouched for a given artifact.
+ *
+ * Continuity vocabulary:
+ *   ACTIVE  — issuer endpoint reachable AND signing key is current
+ *   STALE   — issuer endpoint reachable but key has been rotated; the
+ *             receipt was signed under a prior key (still cryptographically
+ *             valid but the signing chain is older)
+ *   BROKEN  — issuer endpoint unreachable, or the receipt signature
+ *             fails to verify against the current key set
+ */
+export type IssuerContinuity = 'ACTIVE' | 'STALE' | 'BROKEN';
+
+const CONTINUITY_LABEL: Record<IssuerContinuity, string> = {
+  ACTIVE: 'Active',
+  STALE:  'Stale key',
+  BROKEN: 'Broken chain',
+};
+
+const CONTINUITY_CLASSES: Record<IssuerContinuity, string> = {
+  ACTIVE: 'border-emerald-500/40 bg-emerald-500/5 text-emerald-700 dark:text-emerald-300',
+  STALE:  'border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-300',
+  BROKEN: 'border-rose-500/40 bg-rose-500/5 text-rose-700 dark:text-rose-300',
+};
+
+export interface IssuerAttributionProps {
+  /** Decentralized identifier of the issuer (`did:vitalcv:issuer:...`). */
+  did?: string | null;
+  /** Display name of the signer (e.g. 'VitalCV PSV Issuer'). */
+  signer?: string | null;
+  /** Key id used to sign the receipt. */
+  keyId?: string | null;
+  /** Receipt id this attribution backs. */
+  receiptId?: string | null;
+  /** Issuer continuity state. */
+  continuity?: IssuerContinuity;
+  /** ISO timestamp of the most recent issuer-endpoint check. */
+  lastCheckedAt?: string | null;
+  className?: string;
+}
+
+export function IssuerAttribution({
+  did,
+  signer,
+  keyId,
+  receiptId,
+  continuity = 'ACTIVE',
+  lastCheckedAt,
+  className,
+}: IssuerAttributionProps): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-lg border px-3 py-2',
+        CONTINUITY_CLASSES[continuity],
+        className,
+      )}
+      data-issuer-continuity={continuity}
+      data-issuer-did={did ?? undefined}
+      data-issuer-key-id={keyId ?? undefined}
+      role="group"
+      aria-label="Issuer attribution"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-current" />
+        <span className="font-semibold uppercase tracking-wide text-xs">
+          {signer ?? 'Unknown signer'}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider opacity-80">
+          {CONTINUITY_LABEL[continuity]}
+        </span>
+      </div>
+      {did && (
+        <div className="flex items-baseline gap-1.5 text-[11px]">
+          <span className="font-mono uppercase tracking-wide opacity-70">did</span>
+          <span className="font-mono truncate" title={did}>
+            {did}
+          </span>
+        </div>
+      )}
+      {keyId && (
+        <div className="flex items-baseline gap-1.5 text-[11px]">
+          <span className="font-mono uppercase tracking-wide opacity-70">key</span>
+          <span className="font-mono" title={keyId}>{keyId}</span>
+        </div>
+      )}
+      {receiptId && (
+        <div className="flex items-baseline gap-1.5 text-[11px]">
+          <span className="font-mono uppercase tracking-wide opacity-70">receipt</span>
+          <span className="font-mono" title={receiptId}>{receiptId}</span>
+        </div>
+      )}
+      {lastCheckedAt && (
+        <CheckedAtStamp
+          checkedAt={lastCheckedAt}
+          label="issuer checked"
+          format="long"
+          className="text-[10px]"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/trust/OwnershipState.tsx
+++ b/apps/web/components/trust/OwnershipState.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CheckedAtStamp } from './CheckedAtStamp';
+
+/**
+ * OwnershipState — canonical NPI / passport ownership chip.
+ *
+ * Per the Lane A audit, the `/api/ownership/{claim,me}` endpoints exist
+ * on the backend but no UI surface displays ownership state. A hospital
+ * verifier cannot currently see whether a clinician has actively claimed
+ * the NPI they're being evaluated on — which is exactly the kind of
+ * self-attestation signal that distinguishes a real passport from a
+ * scraped-data lookup.
+ *
+ * Ownership state vocabulary:
+ *   CLAIMED   — clinician has claimed the NPI and the claim is current
+ *   PENDING   — clinician started a claim flow but verification of
+ *               ownership is incomplete
+ *   UNCLAIMED — no claim has been made on this NPI; rendered passport
+ *               is from public-data ingest only
+ *   DISPUTED  — multiple parties have asserted ownership; review required
+ */
+export type OwnershipStateValue = 'CLAIMED' | 'PENDING' | 'UNCLAIMED' | 'DISPUTED';
+
+const STATE_COPY: Record<OwnershipStateValue, { label: string; detail: string }> = {
+  CLAIMED:   { label: 'Claimed',   detail: 'Clinician has claimed this NPI.' },
+  PENDING:   { label: 'Pending',   detail: 'Claim started; ownership verification incomplete.' },
+  UNCLAIMED: { label: 'Unclaimed', detail: 'No clinician has claimed this NPI.' },
+  DISPUTED:  { label: 'Disputed',  detail: 'Multiple claims on this NPI; review required.' },
+};
+
+const STATE_CLASSES: Record<OwnershipStateValue, string> = {
+  CLAIMED:   'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  PENDING:   'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  UNCLAIMED: 'border-dashed border-zinc-400/40 bg-transparent text-zinc-600 dark:text-zinc-400',
+  DISPUTED:  'border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+};
+
+export interface OwnershipStateProps {
+  state: OwnershipStateValue;
+  /** Display identifier for the claimant (e.g. 'macie@example.com'). */
+  claimant?: string;
+  /** ISO timestamp when the claim was made / last updated. */
+  claimedAt?: string | null;
+  /** Show detail subline (default true). */
+  showDetail?: boolean;
+  className?: string;
+}
+
+export function OwnershipState({
+  state,
+  claimant,
+  claimedAt,
+  showDetail = true,
+  className,
+}: OwnershipStateProps): React.ReactElement {
+  const copy = STATE_COPY[state];
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-lg border px-3 py-2',
+        STATE_CLASSES[state],
+        className,
+      )}
+      data-ownership-state={state}
+      role="status"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-current" />
+        <span className="font-semibold uppercase tracking-wide text-xs">{copy.label}</span>
+        {claimant && (
+          <span className="font-mono text-[11px] opacity-90" data-claimant={claimant}>
+            {claimant}
+          </span>
+        )}
+      </div>
+      {showDetail && (
+        <p className="text-[11px] opacity-80 leading-snug">{copy.detail}</p>
+      )}
+      {claimedAt && (
+        <CheckedAtStamp
+          checkedAt={claimedAt}
+          label="claimed"
+          format="long"
+          className="text-[10px]"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/trust/ReplayLineage.tsx
+++ b/apps/web/components/trust/ReplayLineage.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CheckedAtStamp } from './CheckedAtStamp';
+import { RunIdentity } from './RunIdentity';
+
+/**
+ * ReplayLineage — canonical replay continuity primitive.
+ *
+ * The Lane A audit found that lineage exists in `ReviewClient.tsx:554` as
+ * plain text and in the `X-VitalCV-Replay-Attribution` export-packet
+ * header but is otherwise hidden. This primitive renders lineage as an
+ * **evidence continuity chain**, not an analytics-style metric strip:
+ * each prior check is a node, gaps are explicit, and the user reads
+ * left-to-right "this is the same subject across these runs."
+ */
+
+export interface ReplayLineagePriorCheck {
+  /** Run id that produced this check. */
+  runId: string;
+  /** ISO timestamp the check was performed. */
+  checkedAt: string;
+  /** Optional source id. */
+  sourceId?: string;
+}
+
+export interface ReplayLineageGap {
+  /** ISO timestamp the prior check ended. */
+  from: string;
+  /** ISO timestamp the next check began. */
+  to: string;
+  /** Reason the gap exists (e.g. 'source unreachable', 'no scheduled run'). */
+  reason: string;
+}
+
+export interface ReplayLineageProps {
+  /** Stable lineage key — same value across all runs that pertain to one entity. */
+  lineageKey: string;
+  /** Prior checks in chronological order (oldest first). */
+  priorChecks: readonly ReplayLineagePriorCheck[];
+  /** Continuity gaps (from→to windows where no check happened). */
+  gaps?: readonly ReplayLineageGap[];
+  /** Current replay count (number of times this lineage has been re-verified). */
+  replayCount?: number;
+  className?: string;
+}
+
+function isContinuous(
+  checks: readonly ReplayLineagePriorCheck[],
+  gaps: readonly ReplayLineageGap[],
+): boolean {
+  return checks.length > 0 && gaps.length === 0;
+}
+
+export function ReplayLineage({
+  lineageKey,
+  priorChecks,
+  gaps = [],
+  replayCount,
+  className,
+}: ReplayLineageProps): React.ReactElement {
+  const continuous = isContinuous(priorChecks, gaps);
+  const sortedChecks = [...priorChecks].sort((a, b) => a.checkedAt.localeCompare(b.checkedAt));
+  const sortedGaps = [...gaps].sort((a, b) => a.from.localeCompare(b.from));
+
+  return (
+    <section
+      className={cn(
+        'flex flex-col gap-2 rounded-lg border px-3 py-2',
+        continuous
+          ? 'border-emerald-500/30 bg-emerald-500/5'
+          : 'border-amber-500/40 bg-amber-500/5',
+        className,
+      )}
+      data-replay-continuous={continuous ? 'true' : 'false'}
+      data-replay-lineage-key={lineageKey}
+      aria-label="Replay lineage"
+    >
+      <header className="flex items-center justify-between gap-2 text-xs">
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono uppercase tracking-wide text-muted-foreground">lineage</span>
+          <span className="font-mono text-foreground" title={lineageKey}>
+            {lineageKey}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-[11px]">
+          <span className="font-mono uppercase tracking-wider opacity-70">
+            replays {typeof replayCount === 'number' ? replayCount : sortedChecks.length}
+          </span>
+          <span
+            className={cn(
+              'font-mono uppercase tracking-wider',
+              continuous ? 'text-emerald-700 dark:text-emerald-300' : 'text-amber-700 dark:text-amber-300',
+            )}
+          >
+            {continuous ? 'continuous' : `${sortedGaps.length} gap${sortedGaps.length === 1 ? '' : 's'}`}
+          </span>
+        </div>
+      </header>
+
+      {sortedChecks.length === 0 && (
+        <p className="text-[11px] italic opacity-80">
+          No prior checks recorded for this lineage.
+        </p>
+      )}
+
+      {sortedChecks.length > 0 && (
+        <ol className="flex flex-col gap-1" role="list">
+          {sortedChecks.map((check, i) => (
+            <li
+              key={`${check.runId}-${i}`}
+              className="flex items-center gap-2 text-[11px]"
+              data-prior-check-index={i}
+            >
+              <span
+                aria-hidden="true"
+                className="font-mono text-muted-foreground"
+              >
+                {i === 0 ? '┌' : i === sortedChecks.length - 1 ? '└' : '├'}
+              </span>
+              <RunIdentity runId={check.runId} label="run" className="text-[10px]" />
+              <CheckedAtStamp checkedAt={check.checkedAt} label="at" format="long" className="text-[10px]" />
+              {check.sourceId && (
+                <span className="font-mono text-[10px] uppercase opacity-70">
+                  · {check.sourceId}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {sortedGaps.length > 0 && (
+        <ul className="flex flex-col gap-1 border-t border-amber-500/20 pt-1" role="list">
+          {sortedGaps.map((gap, i) => (
+            <li
+              key={`gap-${i}`}
+              className="text-[11px] text-amber-800 dark:text-amber-200"
+              data-replay-gap-index={i}
+            >
+              <span className="font-mono uppercase tracking-wider opacity-80">gap </span>
+              <time className="font-mono" dateTime={gap.from}>{gap.from}</time>
+              <span className="opacity-60"> → </span>
+              <time className="font-mono" dateTime={gap.to}>{gap.to}</time>
+              <span className="opacity-70"> · {gap.reason}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/trust/RunIdentity.tsx
+++ b/apps/web/components/trust/RunIdentity.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * RunIdentity — canonical visible run-id primitive.
+ *
+ * Per the Lane A audit, `runId` lives in `useIngestStream` state and the
+ * `vitalcv:preview:${npi}` session-storage key but is **never rendered**
+ * to the user. That makes audit-replay impossible from the UI side: a
+ * verifier cannot point at which run produced a given check.
+ *
+ * This primitive renders the run id as monospaced visible text. It is
+ * deliberately NOT a tooltip and NOT an aria-only label.
+ *
+ * Truncation:
+ *   - When the id is longer than `displayChars` (default 12), the middle
+ *     is elided with `…` so the prefix + suffix remain visually scannable.
+ *   - The full id is in `data-run-id` for copy/paste workflows.
+ */
+export interface RunIdentityProps {
+  /** The full run id. Empty string / `null` renders the "no run" state. */
+  runId: string | null | undefined;
+  /** Optional label, defaults to "run_id". */
+  label?: string;
+  /** How many visible chars before truncating. Default 12. */
+  displayChars?: number;
+  className?: string;
+}
+
+function truncate(id: string, chars: number): string {
+  if (id.length <= chars) return id;
+  const head = Math.ceil(chars / 2);
+  const tail = Math.floor(chars / 2);
+  return `${id.slice(0, head)}…${id.slice(-tail)}`;
+}
+
+export function RunIdentity({
+  runId,
+  label = 'run_id',
+  displayChars = 12,
+  className,
+}: RunIdentityProps): React.ReactElement {
+  if (!runId) {
+    return (
+      <span
+        className={cn('inline-flex items-baseline gap-1.5 text-xs text-muted-foreground', className)}
+        data-run-id="none"
+      >
+        <span className="font-mono uppercase tracking-wide">{label}</span>
+        <span className="font-mono">·</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn('inline-flex items-baseline gap-1.5 text-xs', className)}
+      data-run-id={runId}
+    >
+      <span className="font-mono uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span className="font-mono text-foreground" title={runId}>
+        {truncate(runId, displayChars)}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/components/trust/TierBadge.tsx
+++ b/apps/web/components/trust/TierBadge.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * TierBadge — canonical T1–T4 trust tier rendering.
+ *
+ * Tier doctrine:
+ *   T1 — self-asserted / unverified
+ *   T2 — AI/automated cross-check, no primary-source verification
+ *   T3 — source-checked (NPPES, OIG, state board PSV)
+ *   T4 — cryptographically signed receipt issued by an authoritative
+ *        issuer with active signing keys
+ *
+ * Special states (not tiers, but band-equivalent indicators):
+ *   DEGRADED          — best-known tier may be lower than usual
+ *                       because at least one source is degraded
+ *   UNAVAILABLE       — tier cannot be computed; data not yet present
+ *   UNSIGNED          — would be T4 but the receipt is not currently
+ *                       signed (e.g. signer key rotated, awaiting re-sign)
+ *   ISSUER_UNREACHABLE— signing chain exists but the issuer endpoint
+ *                       is presently unreachable for verification
+ */
+export type TierValue = 'T1' | 'T2' | 'T3' | 'T4';
+export type TierSpecialState =
+  | 'DEGRADED'
+  | 'UNAVAILABLE'
+  | 'UNSIGNED'
+  | 'ISSUER_UNREACHABLE';
+
+export type TierBadgeKind = TierValue | TierSpecialState;
+
+const TIER_COPY: Record<TierBadgeKind, { label: string; sublabel: string }> = {
+  T1: { label: 'T1', sublabel: 'Self-asserted' },
+  T2: { label: 'T2', sublabel: 'AI cross-check' },
+  T3: { label: 'T3', sublabel: 'Source-checked' },
+  T4: { label: 'T4', sublabel: 'Signed receipt' },
+  DEGRADED: { label: 'T—', sublabel: 'Degraded' },
+  UNAVAILABLE: { label: 'T?', sublabel: 'Unavailable' },
+  UNSIGNED: { label: 'T4*', sublabel: 'Unsigned' },
+  ISSUER_UNREACHABLE: { label: 'T4*', sublabel: 'Issuer unreachable' },
+};
+
+const TIER_CLASSES: Record<TierBadgeKind, string> = {
+  // Real tiers — solid color tokens
+  T1: 'border-zinc-500/30 bg-zinc-500/10 text-zinc-700 dark:text-zinc-300',
+  T2: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
+  T3: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  T4: 'border-emerald-600/40 bg-emerald-600/15 text-emerald-800 dark:text-emerald-200',
+  // Special states — distinct visual treatment so they never read as a tier
+  DEGRADED: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  UNAVAILABLE: 'border-dashed border-zinc-400/40 bg-transparent text-zinc-500 dark:text-zinc-400',
+  UNSIGNED: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  ISSUER_UNREACHABLE: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+};
+
+export type TierBadgeSize = 'sm' | 'md' | 'lg';
+
+const SIZE_CLASSES: Record<TierBadgeSize, string> = {
+  sm: 'text-[10px] px-1.5 py-0.5 gap-1',
+  md: 'text-xs px-2 py-1 gap-1.5',
+  lg: 'text-sm px-3 py-1.5 gap-2',
+};
+
+export interface TierBadgeProps {
+  tier: TierBadgeKind;
+  size?: TierBadgeSize;
+  /** Show the descriptive sublabel ("Self-asserted", etc.). Default true. */
+  showSublabel?: boolean;
+  className?: string;
+}
+
+export function TierBadge({
+  tier,
+  size = 'md',
+  showSublabel = true,
+  className,
+}: TierBadgeProps): React.ReactElement {
+  const copy = TIER_COPY[tier];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md border font-mono uppercase tracking-wide',
+        TIER_CLASSES[tier],
+        SIZE_CLASSES[size],
+        className,
+      )}
+      data-tier={tier}
+      role="status"
+    >
+      <span className="font-semibold">{copy.label}</span>
+      {showSublabel && (
+        <span className="font-normal normal-case opacity-80">{copy.sublabel}</span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/trust/TrustHeader.tsx
+++ b/apps/web/components/trust/TrustHeader.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CheckedAtStamp } from './CheckedAtStamp';
+import { RunIdentity } from './RunIdentity';
+import { OwnershipState, type OwnershipStateValue } from './OwnershipState';
+import { ReplayLineage, type ReplayLineagePriorCheck, type ReplayLineageGap } from './ReplayLineage';
+
+/**
+ * TrustHeader — canonical header composite for every trust surface.
+ *
+ * Enforces the mandatory render order:
+ *   OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID
+ *
+ * This is the institutional grammar a hospital verifier should see
+ * within the first ~30 seconds on any surface that displays trust data:
+ *   1. WHAT they're looking at (object)
+ *   2. WHO claims to own it (ownership)
+ *   3. WHEN it was last checked (checked_at)
+ *   4. WHICH channel produced the check (channel / source)
+ *   5. WHETHER there is replay continuity from prior checks
+ *   6. WHICH run produced this view (run_id)
+ *
+ * Variants:
+ *   PREVIEW  — anonymous / pre-claim public view; muted treatment,
+ *              explicit "preview" prefix on the object label
+ *   SNAPSHOT — authenticated read of a stable assertion; default register
+ *   SIGNED   — cryptographically signed; emerald accent and "signed"
+ *              affix; should be the only variant that asserts T4 tier
+ *
+ * The variant intentionally does NOT change the field order — it only
+ * changes the visual register. The order is doctrine.
+ */
+export type TrustHeaderVariant = 'PREVIEW' | 'SNAPSHOT' | 'SIGNED';
+
+const VARIANT_CLASSES: Record<TrustHeaderVariant, string> = {
+  PREVIEW:  'border-dashed border-zinc-400/40 bg-zinc-500/5',
+  SNAPSHOT: 'border-zinc-300/40 bg-background',
+  SIGNED:   'border-emerald-500/40 bg-emerald-500/5',
+};
+
+const VARIANT_LABEL: Record<TrustHeaderVariant, string> = {
+  PREVIEW:  'preview',
+  SNAPSHOT: 'snapshot',
+  SIGNED:   'signed',
+};
+
+export interface TrustHeaderObject {
+  /** Stable identifier of the object (e.g. NPI '1346053246'). */
+  id: string;
+  /** Human-readable label (e.g. 'Macie Miller, PA-C'). */
+  label: string;
+  /** Object kind (e.g. 'clinician', 'organization', 'receipt'). */
+  kind: string;
+}
+
+export interface TrustHeaderOwnership {
+  state: OwnershipStateValue;
+  claimant?: string;
+  claimedAt?: string | null;
+}
+
+export interface TrustHeaderReplay {
+  lineageKey: string;
+  priorChecks: readonly ReplayLineagePriorCheck[];
+  gaps?: readonly ReplayLineageGap[];
+  replayCount?: number;
+}
+
+export interface TrustHeaderProps {
+  /** Display variant — does NOT alter render order, only register. */
+  variant?: TrustHeaderVariant;
+  /** 1. OBJECT — what this header is about. */
+  object: TrustHeaderObject;
+  /** 2. OWNERSHIP — who claims to own the object. */
+  ownership: TrustHeaderOwnership;
+  /** 3. CHECKED_AT — when the snapshot was produced. */
+  checkedAt: string | null | undefined;
+  /** 4. CHANNEL — which source produced the check (e.g. 'NPPES_API'). */
+  channel: string;
+  /** 5. REPLAY — lineage continuity (optional; omitted = no prior runs known). */
+  replay?: TrustHeaderReplay;
+  /** 6. RUN_ID — which run produced this view. */
+  runId: string;
+  className?: string;
+}
+
+export function TrustHeader({
+  variant = 'SNAPSHOT',
+  object,
+  ownership,
+  checkedAt,
+  channel,
+  replay,
+  runId,
+  className,
+}: TrustHeaderProps): React.ReactElement {
+  return (
+    <header
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border px-4 py-3',
+        VARIANT_CLASSES[variant],
+        className,
+      )}
+      data-trust-header-variant={variant}
+      data-trust-header-object-id={object.id}
+      data-trust-header-channel={channel}
+      data-trust-header-run-id={runId}
+      aria-label="Trust header"
+    >
+      {/* 1. OBJECT — first because everything else attaches to it. */}
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1" data-section="object">
+        <span className="font-mono text-[10px] uppercase tracking-widest opacity-60">
+          {VARIANT_LABEL[variant]} · {object.kind}
+        </span>
+        <span className="font-semibold text-base leading-tight">{object.label}</span>
+        <span className="font-mono text-xs opacity-80" title={object.id}>
+          {object.id}
+        </span>
+      </div>
+
+      {/* 2. OWNERSHIP — second, before any temporal field. */}
+      <div data-section="ownership">
+        <OwnershipState
+          state={ownership.state}
+          claimant={ownership.claimant}
+          claimedAt={ownership.claimedAt ?? null}
+          showDetail={false}
+        />
+      </div>
+
+      {/* 3. CHECKED_AT and 4. CHANNEL — paired temporal+source context. */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1" data-section="checked-channel">
+        <CheckedAtStamp checkedAt={checkedAt} label="checked" format="long" />
+        <span className="inline-flex items-baseline gap-1.5 text-xs">
+          <span className="font-mono uppercase tracking-wide text-muted-foreground">channel</span>
+          <span className="font-mono text-foreground" data-channel={channel}>{channel}</span>
+        </span>
+      </div>
+
+      {/* 5. REPLAY — lineage; only rendered when supplied. */}
+      {replay && (
+        <div data-section="replay">
+          <ReplayLineage
+            lineageKey={replay.lineageKey}
+            priorChecks={replay.priorChecks}
+            gaps={replay.gaps}
+            replayCount={replay.replayCount}
+          />
+        </div>
+      )}
+
+      {/* 6. RUN_ID — last, the identifier needed to replay this exact view. */}
+      <div data-section="run-id">
+        <RunIdentity runId={runId} label="run_id" />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/trust/TrustStateBand.tsx
+++ b/apps/web/components/trust/TrustStateBand.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * TrustStateBand — canonical GREEN / YELLOW / RED band rendering.
+ *
+ * The band is the public-passport color summary derived from the
+ * canonical readiness level (`apps/api/backend/src/services/readiness/canonical.ts`):
+ *   L2 / L3 → GREEN
+ *   L1      → YELLOW
+ *   L0      → RED
+ *
+ * UNKNOWN is rendered as a neutral state — used when readiness has not
+ * yet been computed (no run has completed) rather than when readiness
+ * has been computed and is L0.
+ *
+ * The primitive is intentionally separate from `TierBadge`: a TierBadge
+ * carries claim-confidence semantics (T1–T4), the band carries
+ * decision-readiness semantics. A clinician can be T3 (source-checked)
+ * AND YELLOW band (gap remaining) at the same time.
+ */
+export type TrustStateBandValue = 'GREEN' | 'YELLOW' | 'RED' | 'UNKNOWN';
+
+const BAND_COPY: Record<TrustStateBandValue, { label: string; description: string }> = {
+  GREEN:  { label: 'Ready',     description: 'Decision-grade evidence on all launch-spine sources.' },
+  YELLOW: { label: 'Partial',   description: 'Some sources checked; gaps or pending items remain.' },
+  RED:    { label: 'Blocked',   description: 'A hard blocker prevents a positive readiness verdict.' },
+  UNKNOWN:{ label: 'Unknown',   description: 'Readiness has not been computed for this entity yet.' },
+};
+
+const BAND_CLASSES: Record<TrustStateBandValue, string> = {
+  GREEN: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  YELLOW:'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  RED:   'border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+  UNKNOWN:'border-dashed border-zinc-400/40 bg-transparent text-zinc-500 dark:text-zinc-400',
+};
+
+export interface TrustStateBandProps {
+  band: TrustStateBandValue;
+  /** Show the descriptive caption beneath the label. Default true. */
+  showDescription?: boolean;
+  /** Optional override for the headline label ("Ready", "Partial", …). */
+  labelOverride?: string;
+  className?: string;
+}
+
+export function TrustStateBand({
+  band,
+  showDescription = true,
+  labelOverride,
+  className,
+}: TrustStateBandProps): React.ReactElement {
+  const copy = BAND_COPY[band];
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-lg border px-3 py-2',
+        BAND_CLASSES[band],
+        className,
+      )}
+      data-trust-band={band}
+      role="status"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="h-2 w-2 rounded-full bg-current" />
+        <span className="font-semibold uppercase tracking-wide text-xs">
+          {labelOverride ?? copy.label}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider opacity-80">{band}</span>
+      </div>
+      {showDescription && (
+        <p className="text-[11px] opacity-80 leading-snug">{copy.description}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/trust/__tests__/trust-primitives.test.tsx
+++ b/apps/web/components/trust/__tests__/trust-primitives.test.tsx
@@ -1,0 +1,338 @@
+/**
+ * Lane B foundation tests for canonical trust primitives.
+ *
+ * Pins the doctrinal invariants the inventory audit identified as
+ * easily-broken:
+ *
+ *  1. DegradedStateBanner code 'D' renders SUCCESS, not warning.
+ *  2. ReplayLineage flags continuity correctly (gaps → not continuous).
+ *  3. TrustHeader renders all six sections in the mandatory order.
+ *  4. CheckedAtStamp + RunIdentity render the actual value as visible
+ *     text (not aria-only / not tooltip-only).
+ *  5. OwnershipState supports the full vocabulary.
+ *  6. DegradedStateBanner supports all five codes (A–E).
+ *  7. TierBadge supports T1–T4 plus the four special states.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+
+import {
+  CheckedAtStamp,
+  DegradedStateBanner,
+  IssuerAttribution,
+  OwnershipState,
+  ReplayLineage,
+  RunIdentity,
+  TierBadge,
+  TrustHeader,
+  TrustStateBand,
+  type DegradedStateCode,
+  type OwnershipStateValue,
+  type TierBadgeKind,
+} from '..';
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+describe('DegradedStateBanner — A/B/C/D/E taxonomy', () => {
+  const ALL_CODES: DegradedStateCode[] = ['A', 'B', 'C', 'D', 'E'];
+
+  it.each(ALL_CODES)('renders code %s with the expected taxonomy label', (code) => {
+    const html = render(<DegradedStateBanner code={code} />);
+    expect(html).toContain(`data-degraded-code="${code}"`);
+    // The semantic label is rendered in visible text — not aria-only.
+    expect(html).toMatch(/Source unreachable|Anonymous restriction|Infrastructure outage|No adverse findings|Issuer unavailable/);
+  });
+
+  it('code D (no adverse findings) renders as SUCCESS tone — never warning', () => {
+    const html = render(<DegradedStateBanner code="D" />);
+    expect(html).toContain('data-degraded-tone="success"');
+    // Belt-and-suspenders: no warning/critical class wrapping a success outcome.
+    expect(html).not.toContain('data-degraded-tone="warning"');
+    expect(html).not.toContain('data-degraded-tone="critical"');
+    expect(html).toContain('No adverse findings');
+  });
+
+  it('code C (infrastructure outage) renders as critical with role=alert', () => {
+    const html = render(<DegradedStateBanner code="C" />);
+    expect(html).toContain('data-degraded-tone="critical"');
+    expect(html).toContain('role="alert"');
+  });
+
+  it('renders source id + recovery action visibly when supplied', () => {
+    const html = render(
+      <DegradedStateBanner code="A" sourceId="NPPES_API" recoveryAction="Retry in 60s" />,
+    );
+    expect(html).toContain('NPPES_API');
+    expect(html).toContain('Retry in 60s');
+  });
+});
+
+describe('ReplayLineage — continuity vs gaps', () => {
+  it('zero prior checks renders the empty state', () => {
+    const html = render(<ReplayLineage lineageKey="lin-1" priorChecks={[]} />);
+    expect(html).toContain('No prior checks recorded');
+    expect(html).toContain('data-replay-continuous="false"');
+  });
+
+  it('prior checks with no gaps is flagged continuous', () => {
+    const html = render(
+      <ReplayLineage
+        lineageKey="lin-1"
+        priorChecks={[
+          { runId: 'run-a', checkedAt: '2026-04-01T00:00:00Z' },
+          { runId: 'run-b', checkedAt: '2026-04-15T00:00:00Z' },
+        ]}
+      />,
+    );
+    expect(html).toContain('data-replay-continuous="true"');
+    expect(html).toContain('continuous');
+  });
+
+  it('prior checks with gaps is flagged non-continuous and renders each gap', () => {
+    const html = render(
+      <ReplayLineage
+        lineageKey="lin-1"
+        priorChecks={[{ runId: 'run-a', checkedAt: '2026-04-01T00:00:00Z' }]}
+        gaps={[{ from: '2026-04-10T00:00:00Z', to: '2026-05-01T00:00:00Z', reason: 'source unreachable' }]}
+      />,
+    );
+    expect(html).toContain('data-replay-continuous="false"');
+    expect(html).toContain('1 gap');
+    expect(html).toContain('source unreachable');
+    expect(html).toContain('2026-04-10T00:00:00Z');
+  });
+
+  it('renders the lineage key as visible monospace text (not aria-only)', () => {
+    const html = render(<ReplayLineage lineageKey="lin-canonical-1" priorChecks={[]} />);
+    expect(html).toContain('lin-canonical-1');
+    expect(html).toContain('data-replay-lineage-key="lin-canonical-1"');
+  });
+});
+
+describe('TrustHeader — mandatory render order', () => {
+  const HEADER = (
+    <TrustHeader
+      variant="SNAPSHOT"
+      object={{ id: '1346053246', label: 'Macie Miller, PA-C', kind: 'clinician' }}
+      ownership={{ state: 'CLAIMED', claimant: 'macie@example.com', claimedAt: '2026-04-01T15:00:00Z' }}
+      checkedAt="2026-04-01T15:00:00Z"
+      channel="NPPES_API"
+      replay={{
+        lineageKey: 'lin-1',
+        priorChecks: [{ runId: 'run-a', checkedAt: '2026-03-15T00:00:00Z' }],
+      }}
+      runId="run-current-7f3a"
+    />
+  );
+
+  it('renders all six sections', () => {
+    const html = render(HEADER);
+    for (const section of ['object', 'ownership', 'checked-channel', 'replay', 'run-id']) {
+      expect(html).toContain(`data-section="${section}"`);
+    }
+  });
+
+  it('renders sections in the canonical order: OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID', () => {
+    const html = render(HEADER);
+    const idxObject       = html.indexOf('data-section="object"');
+    const idxOwnership    = html.indexOf('data-section="ownership"');
+    const idxCheckedChan  = html.indexOf('data-section="checked-channel"');
+    const idxReplay       = html.indexOf('data-section="replay"');
+    const idxRunId        = html.indexOf('data-section="run-id"');
+    expect(idxObject).toBeGreaterThan(-1);
+    expect(idxOwnership).toBeGreaterThan(idxObject);
+    expect(idxCheckedChan).toBeGreaterThan(idxOwnership);
+    expect(idxReplay).toBeGreaterThan(idxCheckedChan);
+    expect(idxRunId).toBeGreaterThan(idxReplay);
+  });
+
+  it('renders checked_at and run_id as visible text (not aria-only)', () => {
+    const html = render(HEADER);
+    // Both values appear in rendered content, not just data-* attributes.
+    expect(html).toMatch(/>[^<]*2026-04-01[^<]*</);
+    // run_id may be truncated mid-string for display, but its prefix
+    // remains in visible text and the full id is on data-run-id.
+    expect(html).toMatch(/>[^<]*run-cu[^<]*</);
+    expect(html).toContain('data-run-id="run-current-7f3a"');
+  });
+
+  it('variant PREVIEW marks the header as preview (without changing order)', () => {
+    const html = render(
+      <TrustHeader
+        variant="PREVIEW"
+        object={{ id: 'x', label: 'X', kind: 'clinician' }}
+        ownership={{ state: 'UNCLAIMED' }}
+        checkedAt="2026-04-01T15:00:00Z"
+        channel="NPPES_API"
+        runId="run-1"
+      />,
+    );
+    expect(html).toContain('data-trust-header-variant="PREVIEW"');
+    expect(html).toContain('preview');
+  });
+
+  it('variant SIGNED marks the header as signed (without changing order)', () => {
+    const html = render(
+      <TrustHeader
+        variant="SIGNED"
+        object={{ id: 'x', label: 'X', kind: 'clinician' }}
+        ownership={{ state: 'CLAIMED' }}
+        checkedAt="2026-04-01T15:00:00Z"
+        channel="NPPES_API"
+        runId="run-1"
+      />,
+    );
+    expect(html).toContain('data-trust-header-variant="SIGNED"');
+    expect(html).toContain('signed');
+  });
+});
+
+describe('CheckedAtStamp — visibility contract', () => {
+  it('renders the formatted timestamp as visible text', () => {
+    const html = render(<CheckedAtStamp checkedAt="2026-04-01T15:23:11Z" />);
+    expect(html).toContain('2026-04-01 15:23 UTC');
+    expect(html).toContain('<time');
+  });
+
+  it('renders "never" for null/undefined', () => {
+    const html = render(<CheckedAtStamp checkedAt={null} />);
+    expect(html).toContain('never');
+    expect(html).toContain('data-checked-at="none"');
+  });
+
+  it('flags stale when freshnessWindowMs is exceeded', () => {
+    const farPast = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString();
+    const html = render(<CheckedAtStamp checkedAt={farPast} freshnessWindowMs={1000 * 60 * 60} />);
+    expect(html).toContain('stale');
+    expect(html).toContain('data-stale="true"');
+  });
+
+  it('does not flag stale within freshness window', () => {
+    const recent = new Date(Date.now() - 1000 * 30).toISOString();
+    const html = render(<CheckedAtStamp checkedAt={recent} freshnessWindowMs={1000 * 60 * 60} />);
+    expect(html).toContain('data-stale="false"');
+  });
+});
+
+describe('RunIdentity — visibility contract', () => {
+  it('renders the run id as visible text, not aria-only', () => {
+    const html = render(<RunIdentity runId="run-abcdef-7f3a2b" />);
+    // The truncated form should be present in rendered output (not just data-*).
+    expect(html).toMatch(/>\s*run-a[^<]*</);
+    expect(html).toContain('data-run-id="run-abcdef-7f3a2b"');
+  });
+
+  it('renders the no-run state', () => {
+    const html = render(<RunIdentity runId={null} />);
+    expect(html).toContain('data-run-id="none"');
+  });
+});
+
+describe('OwnershipState — full vocabulary', () => {
+  const ALL: OwnershipStateValue[] = ['CLAIMED', 'PENDING', 'UNCLAIMED', 'DISPUTED'];
+
+  it.each(ALL)('renders state %s with semantic label and detail', (state) => {
+    const html = render(<OwnershipState state={state} />);
+    expect(html).toContain(`data-ownership-state="${state}"`);
+  });
+});
+
+describe('TierBadge — all kinds', () => {
+  const TIERS: TierBadgeKind[] = [
+    'T1', 'T2', 'T3', 'T4',
+    'DEGRADED', 'UNAVAILABLE', 'UNSIGNED', 'ISSUER_UNREACHABLE',
+  ];
+
+  it.each(TIERS)('renders kind %s', (kind) => {
+    const html = render(<TierBadge tier={kind} />);
+    expect(html).toContain(`data-tier="${kind}"`);
+  });
+});
+
+describe('TrustStateBand — GREEN/YELLOW/RED/UNKNOWN', () => {
+  it.each(['GREEN', 'YELLOW', 'RED', 'UNKNOWN'] as const)('renders %s', (band) => {
+    const html = render(<TrustStateBand band={band} />);
+    expect(html).toContain(`data-trust-band="${band}"`);
+  });
+});
+
+describe('IssuerAttribution — visibility + continuity', () => {
+  it('renders did, key, receipt id as visible monospace text', () => {
+    const html = render(
+      <IssuerAttribution
+        did="did:vitalcv:issuer:demo"
+        signer="VitalCV PSV Issuer"
+        keyId="vcv-ed25519-v1"
+        receiptId="rcpt-abcd-1234"
+        continuity="ACTIVE"
+      />,
+    );
+    expect(html).toContain('did:vitalcv:issuer:demo');
+    expect(html).toContain('vcv-ed25519-v1');
+    expect(html).toContain('rcpt-abcd-1234');
+    expect(html).toContain('data-issuer-continuity="ACTIVE"');
+  });
+
+  it('renders BROKEN continuity prominently', () => {
+    const html = render(<IssuerAttribution signer="X" continuity="BROKEN" />);
+    expect(html).toContain('data-issuer-continuity="BROKEN"');
+    expect(html).toContain('Broken chain');
+  });
+});
+
+describe('Doctrine — banned-strings scan', () => {
+  // Stitches the rendered output of every primitive into one string and
+  // verifies the canonical truth contract isn't accidentally violated by
+  // the primitive copy.
+  const FULL_RENDER = [
+    render(<CheckedAtStamp checkedAt="2026-04-01T15:00:00Z" />),
+    render(<RunIdentity runId="run-1" />),
+    render(<TierBadge tier="T3" />),
+    render(<TierBadge tier="UNAVAILABLE" />),
+    render(<TrustStateBand band="GREEN" />),
+    render(<OwnershipState state="CLAIMED" />),
+    render(<DegradedStateBanner code="A" />),
+    render(<DegradedStateBanner code="B" />),
+    render(<DegradedStateBanner code="C" />),
+    render(<DegradedStateBanner code="D" />),
+    render(<DegradedStateBanner code="E" />),
+    render(<IssuerAttribution signer="X" />),
+    render(<ReplayLineage lineageKey="lin-1" priorChecks={[]} />),
+    render(
+      <TrustHeader
+        variant="SIGNED"
+        object={{ id: 'x', label: 'X', kind: 'clinician' }}
+        ownership={{ state: 'CLAIMED' }}
+        checkedAt="2026-04-01T15:00:00Z"
+        channel="NPPES_API"
+        runId="run-1"
+      />,
+    ),
+  ].join('\n');
+
+  const BANNED = [
+    ['automatically', 'verified'].join(' '),
+    ['guaranteed', 'verification'].join(' '),
+    ['complete', 'credentialing'].join(' '),
+    ['instant', 'credentialing'].join(' '),
+    ['legally', 'accepted'].join(' '),
+    ['risk', 'transferred'].join(' '),
+    ['HIPAA', 'compliant'].join(' '),
+    ['SOC2', 'certified'].join(' '),
+    ['certified', 'compliant'].join(' '),
+  ];
+
+  it.each(BANNED)('no primitive renders the banned phrase: %s', (phrase) => {
+    expect(FULL_RENDER).not.toContain(phrase);
+  });
+
+  it('no primitive renders bare "Verified" as a status label', () => {
+    // The literal token Verified should not appear standalone as a UI label
+    // in any of these primitives. (It may appear inside compound phrases
+    // like "Source-verified" elsewhere in the app, which is fine.)
+    expect(FULL_RENDER).not.toMatch(/>\s*Verified\s*</);
+  });
+});

--- a/apps/web/components/trust/index.ts
+++ b/apps/web/components/trust/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical trust primitives (Lane B).
+ *
+ * Single import point for every institutional trust surface. Adoption
+ * lands in Lane C; this barrel exists so adopters can use one import:
+ *
+ *   import {
+ *     TrustHeader, ReplayLineage, TierBadge, OwnershipState,
+ *     DegradedStateBanner, IssuerAttribution, CheckedAtStamp,
+ *     RunIdentity, TrustStateBand,
+ *   } from '@/components/trust';
+ *
+ * Mandatory institutional render order (enforced by `<TrustHeader>`):
+ *   OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID
+ *
+ * Degraded-state taxonomy (rendered by `<DegradedStateBanner>`):
+ *   A = source unreachable
+ *   B = anonymous restriction
+ *   C = infrastructure outage
+ *   D = no adverse findings   ← renders as SUCCESS, not warning
+ *   E = issuer unavailable
+ */
+export { CheckedAtStamp, type CheckedAtStampProps, type CheckedAtFormat } from './CheckedAtStamp';
+export { RunIdentity, type RunIdentityProps } from './RunIdentity';
+export {
+  TierBadge,
+  type TierBadgeProps,
+  type TierBadgeKind,
+  type TierBadgeSize,
+  type TierValue,
+  type TierSpecialState,
+} from './TierBadge';
+export {
+  TrustStateBand,
+  type TrustStateBandProps,
+  type TrustStateBandValue,
+} from './TrustStateBand';
+export {
+  OwnershipState,
+  type OwnershipStateProps,
+  type OwnershipStateValue,
+} from './OwnershipState';
+export {
+  DegradedStateBanner,
+  type DegradedStateBannerProps,
+  type DegradedStateCode,
+} from './DegradedStateBanner';
+export {
+  IssuerAttribution,
+  type IssuerAttributionProps,
+  type IssuerContinuity,
+} from './IssuerAttribution';
+export {
+  ReplayLineage,
+  type ReplayLineageProps,
+  type ReplayLineagePriorCheck,
+  type ReplayLineageGap,
+} from './ReplayLineage';
+export {
+  TrustHeader,
+  type TrustHeaderProps,
+  type TrustHeaderVariant,
+  type TrustHeaderObject,
+  type TrustHeaderOwnership,
+  type TrustHeaderReplay,
+} from './TrustHeader';


### PR DESCRIPTION
## Summary

Lane B of the trust-convergence migration. Creates the shared foundation of canonical primitives under `apps/web/components/trust/` that Lane C/D will adopt. **No surface adoption in this PR** — pure additive primitive layer.

## Primitives created

| Component | Role |
|---|---|
| `CheckedAtStamp` | Visible ISO timestamp; never aria-only / tooltip-only |
| `RunIdentity` | Visible run_id (middle-truncated; full id on `data-run-id`) |
| `TierBadge` | T1–T4 + DEGRADED / UNAVAILABLE / UNSIGNED / ISSUER_UNREACHABLE |
| `TrustStateBand` | GREEN / YELLOW / RED / UNKNOWN — decision-readiness band |
| `OwnershipState` | CLAIMED / PENDING / UNCLAIMED / DISPUTED — fills the audit-identified UI gap |
| `DegradedStateBanner` | A/B/C/D/E taxonomy; **D renders as SUCCESS**, C as critical w/ role=alert |
| `IssuerAttribution` | signer / DID / key id / receipt / continuity |
| `ReplayLineage` | Evidence-continuity chain (not analytics); gaps explicit |
| `TrustHeader` | Composite enforcing the mandatory render order |

## Mandatory render order (enforced by `<TrustHeader>`)

`OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID`

Test asserts the six sections appear in this order in the DOM. Variant (`PREVIEW` / `SNAPSHOT` / `SIGNED`) changes visual register but never the order.

## Degraded-state taxonomy (canonical)

| Code | Meaning | Tone |
|---|---|---|
| A | Source unreachable | warning |
| B | Anonymous restriction | info |
| C | Infrastructure outage | critical (role=alert) |
| **D** | **No adverse findings** | **success** (mandatory per brief) |
| E | Issuer unavailable | warning |

`D-is-success` is pinned with a test that explicitly rejects `data-degraded-tone="warning"` and `"critical"` on code D, ensuring "absence of evidence" is not conflated with "presence of risk".

## What this PR does NOT do

- Adopt primitives in any existing surface (passport/verifier/replay/receipt/trust pages) — that is **Lane C/D**.
- Redesign routes, auth, architecture.
- Touch the frozen `@vitalcv/trust-state` package.

## Truth rules
- Banned-strings scan across the rendered output of every primitive: **CLEAN**.
- "Verified" bare-label scan: **CLEAN** (no primitive renders bare `Verified` as a status label).

## Validation
- Targeted vitest: **51/51 passing** (`components/trust/__tests__/trust-primitives.test.tsx`)
- Build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**, 37s
- Diff scope: `apps/web/components/trust/` only (11 new files, no existing files modified)