### PR TITLE
feat(trust): adopt canonical primitives across 5 trust surfaces (Wave 2)

### DIFF
--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -17,6 +17,7 @@ import { ProofSplitPane } from '@/components/proof/LanePanel';
 import { LiveStateLog, buildStateLog } from '@/components/proof/LiveStateLog';
 import { PostureBadge, ProofTierBadge, MetricBadge } from '@/components/proof/TrustLabel';
 import type { ReadinessSnapshot, StateLogEntry, LaneSnapshot } from '@/components/proof/trust-types';
+import { TrustHeader } from '@/components/trust';
 
 // ─── Demo/fallback state for when no API is wired ─────────────────
 // Replace with real API call in production
@@ -102,14 +103,20 @@ export default function ReadinessSurface() {
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6">
 
-        {/* Posture header */}
+        {/* Canonical TrustHeader — institutional reading order on the
+            readiness surface. PREVIEW variant because this surface
+            renders a public/anonymous exploration view before claim. */}
         {snapshot && (
-          <div className="flex flex-wrap items-center gap-4">
-            <div>
-              <h1 className="text-2xl font-extrabold text-slate-900">{snapshot.name}</h1>
-              <p className="font-mono text-sm text-slate-500 mt-0.5 tracking-wide">NPI {snapshot.npi}</p>
-            </div>
-            <div className="flex flex-wrap items-center gap-2 ml-auto">
+          <>
+            <TrustHeader
+              variant="PREVIEW"
+              object={{ id: snapshot.npi, label: snapshot.name, kind: 'clinician' }}
+              ownership={{ state: 'UNCLAIMED' }}
+              checkedAt={new Date(snapshot.generatedAt).toISOString()}
+              channel={snapshot.lanes.find((l) => l.status === 'verified')?.source ?? 'preview'}
+              runId={`readiness-${snapshot.generatedAt}`}
+            />
+            <div className="flex flex-wrap items-center gap-2">
               <PostureBadge posture={snapshot.posture} size="md" />
               <ProofTierBadge tier={snapshot.proofTier} />
               {snapshot.score !== null
@@ -117,7 +124,7 @@ export default function ReadinessSurface() {
                 : <MetricBadge label="score unavailable" type="unverified" />
               }
             </div>
-          </div>
+          </>
         )}
 
         {/* Live state log */}

--- a/apps/web/app/passport/[id]/PassportEntityClient.tsx
+++ b/apps/web/app/passport/[id]/PassportEntityClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import PassportWallet from '@/components/passport/PassportWallet';
 import { Button } from '@/components/ui/button';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
+import { TrustHeader } from '@/components/trust';
 import { fetchPassportEntity } from '@/lib/api';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { KnowledgeInboxPanel } from '@/components/knowledge-inbox/KnowledgeInboxPanel';
@@ -74,8 +75,30 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
   // in classification — see lib/knowledge-inbox/classifyInboxItem.ts.
   const inboxItems: KnowledgeInboxItem[] = [];
 
+  // Canonical TrustHeader — single source for the institutional reading
+  // order on the passport surface. Adopts Lane B primitives without
+  // changing the existing PassportWallet rendering below.
+  // Channel = the first checked launch-spine source; ownership and runId
+  // are stubbed where data isn't threaded yet (Lane D plumbing).
+  const channel = passport.sources?.checked?.[0] ?? 'unknown';
+  const ownershipClaimant = passport.identity.displayName;
+
   return (
     <div className="flex flex-col gap-8 pb-16">
+      <div className="mx-auto max-w-[480px] sm:max-w-[640px] md:max-w-3xl lg:max-w-4xl px-4 w-full">
+        <TrustHeader
+          variant="SNAPSHOT"
+          object={{
+            id: passport.identity.npi ?? passport.entityId,
+            label: passport.identity.displayName,
+            kind: passport.identity.entityType.toLowerCase(),
+          }}
+          ownership={{ state: 'UNCLAIMED', claimant: ownershipClaimant }}
+          checkedAt={passport.lastCheckedAt}
+          channel={channel}
+          runId={passport.entityId}
+        />
+      </div>
       <PassportWallet passport={passport} />
       <div className="mx-auto max-w-[480px] sm:max-w-[640px] md:max-w-3xl lg:max-w-4xl px-4 w-full space-y-8">
         <section

--- a/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
+++ b/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@/components/review/EmployerDecisionConsole';
 import type { LaneSnapshot, ReadinessPosture } from '@/components/proof/trust-types';
 import { normalizeTrustContainerManifestView } from '@/lib/trust/trust-container-view';
+import { TrustHeader } from '@/components/trust';
 
 // ─── Data adapter ─────────────────────────────────────────────────
 
@@ -205,5 +206,29 @@ export default function ConsoleWrapper({ entityId }: { entityId: string }) {
     );
   }
 
-  return <EmployerDecisionConsole {...data} onAction={handleAction} />;
+  // Canonical TrustHeader at the top of the review surface. Channel is
+  // derived from the first verified lane; runId uses the loopId thread
+  // that the audit pipeline keys on. Ownership defaults to UNCLAIMED
+  // because employer-review entry points don't currently thread the
+  // claim state (Lane D plumbing).
+  const channel = data.lanes.find((l) => l.status === 'verified')?.source ?? 'review';
+  const earliestCheck = data.lanes
+    .map((l) => l.checkedAt)
+    .filter((t): t is number => typeof t === 'number')
+    .sort((a, b) => b - a)[0];
+  const checkedAtIso = earliestCheck ? new Date(earliestCheck).toISOString() : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <TrustHeader
+        variant="SNAPSHOT"
+        object={{ id: data.entityId, label: data.name, kind: 'clinician' }}
+        ownership={{ state: 'UNCLAIMED', claimant: data.name }}
+        checkedAt={checkedAtIso}
+        channel={channel}
+        runId={data.loopId ?? data.entityId}
+      />
+      <EmployerDecisionConsole {...data} onAction={handleAction} />
+    </div>
+  );
 }

--- a/apps/web/components/passport/PassportWallet.tsx
+++ b/apps/web/components/passport/PassportWallet.tsx
@@ -40,6 +40,7 @@ import { PassportTrustPosture } from '@/components/passport/PassportTrustPosture
 import { useTrackEvent } from '@/lib/learning/useTrackEvent';
 import { EvidenceDisclosureCard } from '@/components/trust/EvidenceDisclosureCard';
 import { PassportSourceCoveragePanel } from '@/components/trust/PassportSourceCoveragePanel';
+import { CheckedAtStamp } from '@/components/trust';
 import { SharePacketModal } from '@/components/passport/SharePacketModal';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
 import { DivergenceSummaryCard } from '@/components/trust/DivergenceSummaryCard';
@@ -171,7 +172,10 @@ function buildIdentitySection(passport: PassportData): AccordionItem {
         <DetailRow label="NPI"        value={identity.npi} />
         <DetailRow label="Type"       value={identity.entityType === 'PERSON' ? 'Individual provider' : 'Organization'} />
         <DetailRow label="Source"     value="CMS NPPES" />
-        <DetailRow label="Last check" value={new Date(lastCheckedAt).toLocaleDateString()} />
+        <div className="flex items-center justify-between py-1">
+          <span className="text-sm text-muted-foreground">Last check</span>
+          <CheckedAtStamp checkedAt={lastCheckedAt} label="" format="long" />
+        </div>
       </div>
     ),
   };

--- a/apps/web/components/proof/LanePanel.tsx
+++ b/apps/web/components/proof/LanePanel.tsx
@@ -12,6 +12,7 @@ import {
   STATUS_COLORS, STATUS_EXPLANATIONS, KNOWN_LANES,
   type LaneSnapshot, type SourceStatus,
 } from './trust-types';
+import { CheckedAtStamp, RunIdentity } from '@/components/trust';
 
 // ─── Split-Pane Layout ────────────────────────────────────────────
 
@@ -144,17 +145,24 @@ function LaneDetail({
         <MetaRow label="Lane ID"       value={lane.laneId}    mono />
         <MetaRow label="Freshness"     value={def.freshnessWindowLabel} />
         {lane.checkedAt && (
-          <MetaRow
-            label="Checked at"
-            value={new Date(lane.checkedAt).toLocaleString()}
-            mono
-          />
+          <div className="flex items-center justify-between py-1">
+            <span className="text-xs text-slate-500">Checked at</span>
+            <CheckedAtStamp
+              checkedAt={new Date(lane.checkedAt).toISOString()}
+              label=""
+              format="long"
+              className="text-xs"
+            />
+          </div>
         )}
         {lane.value && (
           <MetaRow label="Value"       value={lane.value} />
         )}
         {lane.receiptId && (
-          <MetaRow label="Receipt ID"  value={lane.receiptId} mono />
+          <div className="flex items-center justify-between py-1">
+            <span className="text-xs text-slate-500">Receipt ID</span>
+            <RunIdentity runId={lane.receiptId} label="receipt" className="text-xs" />
+          </div>
         )}
       </div>
 
@@ -165,7 +173,17 @@ function LaneDetail({
           <div className="bg-slate-50 border border-slate-200 rounded-lg px-4 py-3 font-mono text-xs text-slate-600 space-y-1">
             <div className="flex justify-between"><span>receipt_id</span><span className="text-slate-400">{lane.receiptId.slice(0, 16)}…</span></div>
             <div className="flex justify-between"><span>source</span><span className="text-slate-400">{def.source}</span></div>
-            {lane.checkedAt && <div className="flex justify-between"><span>checked_at</span><span className="text-slate-400">{lane.checkedAt}</span></div>}
+            {lane.checkedAt && (
+              <div className="flex justify-between items-center">
+                <span>checked_at</span>
+                <CheckedAtStamp
+                  checkedAt={new Date(lane.checkedAt).toISOString()}
+                  label=""
+                  format="iso"
+                  className="text-slate-400"
+                />
+              </div>
+            )}
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Summary

Wave 2 of the trust-convergence migration. **Stacked on #341** (Lane B primitives). Adopts the canonical primitives in 5 of the 6 brief-listed surfaces, replacing fragmented inline trust rendering. No layout redesign, no new data fetching, no auth/backend changes.

## Surfaces adopted

| Surface | File | Adoption |
|---|---|---|
| `/passport/[id]` | `app/passport/[id]/PassportEntityClient.tsx` | `<TrustHeader variant="SNAPSHOT">` at the top of the surface |
| `PassportWallet` (identity row) | `components/passport/PassportWallet.tsx` | `<CheckedAtStamp>` replaces inline `toLocaleDateString` |
| `LanePanel` (proof) | `components/proof/LanePanel.tsx` | `<CheckedAtStamp>` for the Details + Receipt blocks; `<RunIdentity>` for the visible receipt id chip |
| `ReadinessSurface` | `app/holder/readiness/ReadinessSurface.tsx` | `<TrustHeader variant="PREVIEW">` because this is the anonymous/pre-claim exploration view |
| `ConsoleWrapper` (employer review) | `app/review/[entityId]/ConsoleWrapper.tsx` | `<TrustHeader variant="SNAPSHOT">` above EmployerDecisionConsole |

## Deferred (explicit follow-up)

| Surface | File | Reason |
|---|---|---|
| `ReviewClient` | `components/review/ReviewClient.tsx` | 2093-line surface; multiple inline timestamp sites with complex layout context. Needs a focused follow-up PR. |

## Doctrine notes

- Mandatory render order `OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID` is enforced by `<TrustHeader>` (the primitive itself, validated by tests in #341).
- `OwnershipState` defaults to `UNCLAIMED` because none of the 5 surfaces currently thread per-user ownership data — that plumbing is **Lane D scope**, not Wave 2.
- `runId` falls back to `entityId` / `loopId` where no real run identifier is yet threaded. Surfaces gain a *visible* identifier chip today; tightening to actual run ids is Wave 10 (replay continuity & survivability).

## Truth rules
- Banned-strings scan: CLEAN
- No new copy was authored — primitives carry the canonical labels

## Validation
- `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**, green
- 5 files modified; 0 API contract changes; 0 schema changes