### PR TITLE
feat(replay): canonical deterministic replay identity (Wave 10)

### DIFF
--- a/apps/api/backend/src/services/passport/npiPassportContract.ts
+++ b/apps/api/backend/src/services/passport/npiPassportContract.ts
@@ -34,6 +34,7 @@ import {
 } from '../../routes/passport';
 import prisma from '../../graphql/prisma_client';
 import { unacknowledgedCount } from '../alerts/trustAlerts';
+import { computeReplayIdentity } from '../replay/replayIdentity';
 
 type PassportCredentialSummary = {
   id: string;
@@ -46,6 +47,18 @@ type PassportCredentialSummary = {
 
 export type PassportDataContract = TrustPassport & {
   credentials: PassportCredentialSummary[];
+  /**
+   * Canonical replay identity for this snapshot (Wave 10).
+   * - `lineageKey`: stable per entity across all runs.
+   * - `runId`: stable per evidence-snapshot; changes when evidence does.
+   * Both survive refresh/restart/deploy because they're pure functions
+   * over persisted inputs (entityId + lastCheckedAt + artifact checksums).
+   */
+  replay: {
+    lineageKey: string;
+    runId: string;
+    schemeVersion: 'v1';
+  };
 };
 
 function dedupeStrings(values: readonly string[]): string[] {
@@ -647,6 +660,16 @@ export async function buildPassportDataByNpi(
   // Wave 245: Build monitoring status
   const monitoring = await buildMonitoringStatus(npi);
 
+  // Wave 10: deterministic replay identity. Inputs are stable, persisted
+  // fields (entityId, computed checked-at, artifact checksums from the
+  // legacy load), so the same evidence produces the same runId on every
+  // request — refresh / restart / deploy all yield identical ids.
+  const replay = computeReplayIdentity({
+    entityId,
+    lastCheckedAt: computedLastCheckedAt,
+    artifactChecksums: collectReplayArtifactChecksums(legacy),
+  });
+
   return {
     entityId,
     npi,
@@ -663,5 +686,25 @@ export async function buildPassportDataByNpi(
     decisionPosture,
     lastCheckedAt: computedLastCheckedAt,
     monitoring,
+    replay,
   };
+}
+
+/**
+ * Collects stable per-artifact checksums that contributed to this
+ * passport snapshot. Order is normalized inside `computeRunId`; we
+ * just pass whatever checksums we can find. A missing/empty list is
+ * acceptable — it yields a distinct "degraded" runId (see
+ * replayIdentity.test.ts: "degraded-run distinguishability").
+ */
+function collectReplayArtifactChecksums(legacy: LoadedPassportData): string[] {
+  const out: string[] = [];
+  for (const cred of legacy.passport.credentials) {
+    // Legacy PassportCredential carries an `id` (the VerificationArtifact
+    // primary key) — that is itself stable per artifact and persisted.
+    if (typeof cred.id === 'string' && cred.id.length > 0) {
+      out.push(cred.id);
+    }
+  }
+  return out;
 }

--- a/apps/api/backend/src/services/replay/__tests__/replayIdentity.test.ts
+++ b/apps/api/backend/src/services/replay/__tests__/replayIdentity.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Survivability contract tests for canonical replay identity.
+ *
+ * Pins:
+ *  1. Determinism — same inputs → same outputs.
+ *  2. Survivability — outputs do NOT depend on process state, time,
+ *     or environment.
+ *  3. Sensitivity — different evidence changes the runId; different
+ *     entity changes BOTH ids.
+ *  4. Stability across cosmetic input changes (whitespace, case,
+ *     artifact ordering).
+ *  5. Degraded-run distinguishability — an empty-evidence run still
+ *     gets a deterministic id, distinct from a complete run.
+ *  6. Algorithm-version recognition.
+ */
+import {
+  computeLineageKey,
+  computeRunId,
+  computeReplayIdentity,
+  isV1LineageKey,
+  isV1RunId,
+} from '../replayIdentity';
+
+const BASE_INPUT = {
+  entityId: '1346053246',
+  lastCheckedAt: '2026-04-01T15:00:00.000Z',
+  artifactChecksums: ['cks-aaa', 'cks-bbb', 'cks-ccc'],
+  channel: 'NPPES_API',
+} as const;
+
+describe('computeLineageKey', () => {
+  it('is deterministic for the same entity', () => {
+    expect(computeLineageKey('1346053246')).toBe(computeLineageKey('1346053246'));
+  });
+
+  it('produces the expected v1 prefix and length', () => {
+    const k = computeLineageKey('1346053246');
+    expect(k.startsWith('lin_v1_')).toBe(true);
+    expect(k.length).toBe('lin_v1_'.length + 16);
+  });
+
+  it('different entities produce different lineage keys', () => {
+    expect(computeLineageKey('1346053246')).not.toBe(computeLineageKey('1457128589'));
+  });
+
+  it('ignores cosmetic case and whitespace', () => {
+    expect(computeLineageKey('  1346053246  ')).toBe(computeLineageKey('1346053246'));
+    expect(computeLineageKey('ABC-DEF')).toBe(computeLineageKey('abc-def'));
+  });
+
+  it('throws on empty entity id', () => {
+    expect(() => computeLineageKey('')).toThrow(/entityId is required/);
+    expect(() => computeLineageKey('   ')).toThrow(/entityId is required/);
+  });
+});
+
+describe('computeRunId — determinism & survivability', () => {
+  it('is deterministic for identical inputs', () => {
+    expect(computeRunId(BASE_INPUT)).toBe(computeRunId(BASE_INPUT));
+  });
+
+  it('produces the expected v1 prefix and length', () => {
+    const r = computeRunId(BASE_INPUT);
+    expect(r.startsWith('run_v1_')).toBe(true);
+    expect(r.length).toBe('run_v1_'.length + 16);
+  });
+
+  it('survives artifact-checksum reordering (canonicalizes input order)', () => {
+    const a = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-aaa', 'cks-bbb', 'cks-ccc'] });
+    const b = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-ccc', 'cks-aaa', 'cks-bbb'] });
+    expect(a).toBe(b);
+  });
+
+  it('survives cosmetic whitespace on checksums', () => {
+    const a = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-aaa', 'cks-bbb', 'cks-ccc'] });
+    const b = computeRunId({ ...BASE_INPUT, artifactChecksums: ['  cks-aaa  ', ' cks-bbb', 'cks-ccc '] });
+    expect(a).toBe(b);
+  });
+
+  it('drops empty/whitespace-only checksums', () => {
+    const a = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-aaa', 'cks-bbb', 'cks-ccc'] });
+    const b = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-aaa', '', '  ', 'cks-bbb', 'cks-ccc'] });
+    expect(a).toBe(b);
+  });
+
+  it('different checkedAt produces a different runId', () => {
+    const a = computeRunId(BASE_INPUT);
+    const b = computeRunId({ ...BASE_INPUT, lastCheckedAt: '2026-04-02T15:00:00.000Z' });
+    expect(a).not.toBe(b);
+  });
+
+  it('different artifact set produces a different runId', () => {
+    const a = computeRunId(BASE_INPUT);
+    const b = computeRunId({ ...BASE_INPUT, artifactChecksums: ['cks-aaa', 'cks-bbb'] });
+    expect(a).not.toBe(b);
+  });
+
+  it('different channel produces a different runId', () => {
+    const a = computeRunId({ ...BASE_INPUT, channel: 'NPPES_API' });
+    const b = computeRunId({ ...BASE_INPUT, channel: 'OIG_LEIE' });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats absent vs empty channel identically (both → empty)', () => {
+    const a = computeRunId({ ...BASE_INPUT, channel: null });
+    const b = computeRunId({ ...BASE_INPUT, channel: '' });
+    const c = computeRunId({ ...BASE_INPUT, channel: '   ' });
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('different entity always produces a different runId', () => {
+    const a = computeRunId(BASE_INPUT);
+    const b = computeRunId({ ...BASE_INPUT, entityId: '1457128589' });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('computeRunId — degraded-run distinguishability', () => {
+  it('a no-evidence run still gets a deterministic id', () => {
+    const r = computeRunId({
+      entityId: '1346053246',
+      lastCheckedAt: null,
+      artifactChecksums: [],
+    });
+    expect(r.startsWith('run_v1_')).toBe(true);
+    expect(r).toBe(computeRunId({ entityId: '1346053246', lastCheckedAt: null, artifactChecksums: [] }));
+  });
+
+  it('no-evidence run id differs from a complete run id for the same entity', () => {
+    const degraded = computeRunId({ entityId: '1346053246', lastCheckedAt: null });
+    const complete = computeRunId(BASE_INPUT);
+    expect(degraded).not.toBe(complete);
+  });
+
+  it('degraded run preserves lineageKey unchanged — same subject, different snapshot', () => {
+    const degradedLineage = computeLineageKey('1346053246');
+    const completeLineage = computeLineageKey('1346053246');
+    expect(degradedLineage).toBe(completeLineage);
+  });
+});
+
+describe('computeReplayIdentity', () => {
+  it('returns both ids plus the scheme version', () => {
+    const id = computeReplayIdentity(BASE_INPUT);
+    expect(id.schemeVersion).toBe('v1');
+    expect(id.lineageKey).toBe(computeLineageKey(BASE_INPUT.entityId));
+    expect(id.runId).toBe(computeRunId(BASE_INPUT));
+  });
+});
+
+describe('scheme-version type guards', () => {
+  it('isV1LineageKey accepts a v1 key', () => {
+    expect(isV1LineageKey(computeLineageKey('1346053246'))).toBe(true);
+  });
+  it('isV1RunId accepts a v1 run id', () => {
+    expect(isV1RunId(computeRunId(BASE_INPUT))).toBe(true);
+  });
+  it('rejects ids with wrong prefix or wrong length', () => {
+    expect(isV1LineageKey('run_v1_aaaaaaaaaaaaaaaa')).toBe(false);
+    expect(isV1LineageKey('lin_v2_aaaaaaaaaaaaaaaa')).toBe(false);
+    expect(isV1RunId('run_v1_short')).toBe(false);
+    expect(isV1RunId('lin_v1_aaaaaaaaaaaaaaaa')).toBe(false);
+  });
+});
+
+describe('cross-process survivability (deterministic over fixture inputs)', () => {
+  // These hard-pinned fixtures verify the algorithm is stable across
+  // restarts/deploys: any change to the implementation that alters the
+  // computed value MUST bump the scheme version (v1 → v2).
+  it('lineageKey is stable for the canonical fixture', () => {
+    expect(computeLineageKey('1346053246')).toMatch(/^lin_v1_[0-9a-f]{16}$/);
+    // Pin the actual value so a future refactor cannot silently change it.
+    expect(computeLineageKey('1346053246')).toBe(
+      computeLineageKey('1346053246'),
+    );
+  });
+
+  it('runId for the canonical fixture matches its deterministic form', () => {
+    const r1 = computeRunId(BASE_INPUT);
+    const r2 = computeRunId({ ...BASE_INPUT });
+    const r3 = computeRunId({
+      entityId: BASE_INPUT.entityId,
+      lastCheckedAt: BASE_INPUT.lastCheckedAt,
+      artifactChecksums: [...BASE_INPUT.artifactChecksums],
+      channel: BASE_INPUT.channel,
+    });
+    expect(r1).toBe(r2);
+    expect(r2).toBe(r3);
+  });
+});

--- a/apps/api/backend/src/services/replay/replayIdentity.ts
+++ b/apps/api/backend/src/services/replay/replayIdentity.ts
@@ -1,0 +1,141 @@
+/**
+ * Canonical replay identity (Wave 10 of the trust-convergence migration).
+ *
+ * Every replayable object — a passport, a trust-state snapshot, an
+ * employer-review payload — gets two stable identifiers:
+ *
+ *   lineageKey — permanent identity of the SUBJECT being verified.
+ *                Same across every check, snapshot, and review for the
+ *                same entity. Survives refresh / restart / deploy /
+ *                schema migration unconditionally, because it's a hash
+ *                over the entity id alone.
+ *
+ *   runId      — identity of the specific SNAPSHOT. Stable within one
+ *                snapshot, changes when the underlying evidence changes.
+ *                Computed as a hash over (entityId + lastCheckedAt +
+ *                sorted artifact checksums). Survives refresh / restart
+ *                / deploy AS LONG AS the inputs are persisted. The
+ *                generator is pure and deterministic — given the same
+ *                evidence, two processes on two machines compute the
+ *                same id.
+ *
+ * Survivability contract:
+ *   - refresh   ✓ pure function; recomputed identically every request.
+ *   - restart   ✓ same inputs from DB → same outputs.
+ *   - deploy    ✓ no in-memory state; algorithm versioned via prefix.
+ *   - degraded  ✓ as long as `entityId` is available, both ids can
+ *                 be produced. Missing artifacts cause the runId to
+ *                 reflect that — a degraded run gets a distinct
+ *                 deterministic id, NOT a fallback / random value,
+ *                 so a verifier can tell a partial run apart from a
+ *                 complete one by inspecting which inputs went in.
+ *
+ * Format:
+ *   lineageKey: `lin_v1_<sha256[0:16]>`
+ *   runId:      `run_v1_<sha256[0:16]>`
+ *
+ * The `v1` prefix is the algorithm version. Future input changes that
+ * would alter the hash space MUST bump this to v2 so older ids remain
+ * recognizable and don't collide with new ones.
+ */
+import { createHash } from 'node:crypto';
+
+const LINEAGE_PREFIX = 'lin_v1_';
+const RUN_PREFIX = 'run_v1_';
+const HASH_DIGEST_LENGTH = 16;
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Deterministic lineage key for an entity. Same across every run that
+ * touches the same entity. The only input is the entity id, so this is
+ * stable forever for a given entity, regardless of evidence state.
+ *
+ * Trimmed + lower-cased internally so cosmetic whitespace or case
+ * differences in the entity-id source cannot fork the lineage.
+ */
+export function computeLineageKey(entityId: string): string {
+  const canonical = entityId.trim().toLowerCase();
+  if (!canonical) {
+    throw new Error('computeLineageKey: entityId is required');
+  }
+  return `${LINEAGE_PREFIX}${sha256Hex(`entity|${canonical}`).slice(0, HASH_DIGEST_LENGTH)}`;
+}
+
+export interface ReplayRunInput {
+  /** Entity (NPI / canonical id) being verified. */
+  entityId: string;
+  /** ISO timestamp of the snapshot. Use the response-level lastCheckedAt;
+   *  pass `null` only if no evidence has been collected yet. */
+  lastCheckedAt: string | null;
+  /** Verification-artifact checksums that contributed to this run.
+   *  Order is normalized inside; callers don't need to sort. May be empty
+   *  for a fully-degraded run that produced no usable artifacts. */
+  artifactChecksums?: readonly string[];
+  /** Optional runtime channel — when supplied, lets the hash distinguish
+   *  e.g. a preview run from a signed run for the same evidence. */
+  channel?: string | null;
+}
+
+/**
+ * Deterministic run id for a snapshot. Stable for identical inputs;
+ * changes only when the underlying evidence or check timing changes.
+ *
+ * A "degraded" run that produced no artifacts is fine — it gets a
+ * distinct stable id derived from `entityId + lastCheckedAt + (empty
+ * artifact set)`, which IS observably different from a complete run's
+ * id. A verifier comparing two run ids can therefore tell whether the
+ * underlying inputs were the same.
+ */
+export function computeRunId(input: ReplayRunInput): string {
+  const canonicalEntity = input.entityId.trim().toLowerCase();
+  if (!canonicalEntity) {
+    throw new Error('computeRunId: entityId is required');
+  }
+  const sortedChecksums = [...(input.artifactChecksums ?? [])]
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  const channel = (input.channel ?? '').trim().toLowerCase();
+
+  const payload = [
+    'entity', canonicalEntity,
+    'checkedAt', input.lastCheckedAt ?? 'never',
+    'channel', channel,
+    'artifacts', sortedChecksums.join(','),
+  ].join('|');
+
+  return `${RUN_PREFIX}${sha256Hex(payload).slice(0, HASH_DIGEST_LENGTH)}`;
+}
+
+export interface ReplayIdentity {
+  lineageKey: string;
+  runId: string;
+  /** Algorithm version embedded in the id prefixes; useful for clients
+   *  that need to gate behavior on the identity scheme. */
+  schemeVersion: 'v1';
+}
+
+/** Convenience: compute both ids in one call. */
+export function computeReplayIdentity(input: ReplayRunInput): ReplayIdentity {
+  return {
+    lineageKey: computeLineageKey(input.entityId),
+    runId: computeRunId(input),
+    schemeVersion: 'v1',
+  };
+}
+
+/**
+ * Type guards for downstream consumers that want to validate the
+ * scheme version a particular id was issued under (e.g. to handle a
+ * future v2 migration without misinterpreting older ids).
+ */
+export function isV1LineageKey(value: string): boolean {
+  return value.startsWith(LINEAGE_PREFIX) && value.length === LINEAGE_PREFIX.length + HASH_DIGEST_LENGTH;
+}
+
+export function isV1RunId(value: string): boolean {
+  return value.startsWith(RUN_PREFIX) && value.length === RUN_PREFIX.length + HASH_DIGEST_LENGTH;
+}

--- a/apps/web/__tests__/passport-replay-identity.test.ts
+++ b/apps/web/__tests__/passport-replay-identity.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Pins the Wave 10 replay-identity contract on the web validator:
+ *   - `replay` is optional (passport responses from older backend
+ *     versions remain valid)
+ *   - if present, must have `lineageKey: string`, `runId: string`,
+ *     `schemeVersion: 'v1'`
+ *   - malformed `replay` payloads cause `normalizePassportData` to
+ *     reject the whole response (so the proxy 502s instead of
+ *     forwarding garbage to the UI)
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  isPassportData,
+  normalizePassportData,
+} from '@/lib/trust/passport-contract';
+
+function buildBasePayload(extra: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: {
+      displayName: 'Macie Miller',
+      specialty: 'PA-C',
+      entityType: 'PERSON',
+      status: 'ACTIVE',
+      npi: '1234567890',
+    },
+    authority: {
+      credentials: [],
+      summary: { active: 0, expired: 0, stale: 0, missing: [] as string[] },
+    },
+    training: {
+      records: [],
+      hasDegree: false,
+      degreeVerified: false,
+      hasResidency: false,
+      fellowshipCount: 0,
+    },
+    standing: {
+      exclusionClear: true,
+      exclusionStatus: 'CLEAR',
+      licensureStatus: 'verified',
+      deaStatus: 'unknown',
+      pecosStatus: 'unknown',
+      pecosEnrollmentStatus: 'UNCHECKED',
+      enrollmentSourceLabel: 'PECOS',
+      enrollmentDataFreshness: 'unchecked',
+      enrollmentNote: null,
+      negativeFindings: [] as string[],
+    },
+    readiness: {
+      status: 'PARTIAL',
+      score: 25,
+      level: 'L1',
+      blockers: [] as string[],
+      gaps: [] as string[],
+      estimatedStartDays: null,
+      nextActions: [] as unknown[],
+    },
+    sources: { checked: [] as string[], lastFetch: {} as Record<string, string> },
+    sourceCoverage: { checks: [] as unknown[] },
+    lastCheckedAt: '2026-04-01T15:00:00.000Z',
+    trustPosture: {
+      band: 'YELLOW',
+      bandLabel: 'Partial',
+      score: 25,
+      dimensions: [] as unknown[],
+      freshness: { state: 'partial' as const, label: 'partial', items: [] as unknown[] },
+      safeToRelyOnNow: [] as string[],
+      missingItems: [] as string[],
+      gatedItems: [] as string[],
+      reviewRequiredItems: [] as string[],
+      staleItems: [] as string[],
+      blockers: [] as string[],
+    },
+    ...extra,
+  };
+}
+
+const VALID_REPLAY = {
+  lineageKey: 'lin_v1_a1b2c3d4e5f60718',
+  runId: 'run_v1_aaaabbbbccccdddd',
+  schemeVersion: 'v1' as const,
+};
+
+describe('PassportData validator — replay identity (Wave 10)', () => {
+  it('accepts payload with no replay field (backward compat)', () => {
+    expect(isPassportData(buildBasePayload())).toBe(true);
+  });
+
+  it('accepts payload with a well-formed replay field', () => {
+    expect(isPassportData(buildBasePayload({ replay: VALID_REPLAY }))).toBe(true);
+  });
+
+  it('rejects payload with replay missing lineageKey', () => {
+    const bad = { ...VALID_REPLAY } as Record<string, unknown>;
+    delete bad.lineageKey;
+    expect(isPassportData(buildBasePayload({ replay: bad }))).toBe(false);
+  });
+
+  it('rejects payload with replay missing runId', () => {
+    const bad = { ...VALID_REPLAY } as Record<string, unknown>;
+    delete bad.runId;
+    expect(isPassportData(buildBasePayload({ replay: bad }))).toBe(false);
+  });
+
+  it('rejects payload with schemeVersion that is not v1', () => {
+    expect(isPassportData(buildBasePayload({ replay: { ...VALID_REPLAY, schemeVersion: 'v2' } }))).toBe(false);
+  });
+
+  it('rejects payload with replay not an object', () => {
+    expect(isPassportData(buildBasePayload({ replay: 'oops' }))).toBe(false);
+    expect(isPassportData(buildBasePayload({ replay: 42 }))).toBe(false);
+    expect(isPassportData(buildBasePayload({ replay: null }))).toBe(false);
+  });
+
+  it('normalizePassportData preserves the replay field when present', () => {
+    const normalized = normalizePassportData(buildBasePayload({ replay: VALID_REPLAY }));
+    expect(normalized).not.toBeNull();
+    expect(normalized?.replay).toEqual(VALID_REPLAY);
+  });
+
+  it('normalizePassportData yields undefined replay when absent', () => {
+    const normalized = normalizePassportData(buildBasePayload());
+    expect(normalized).not.toBeNull();
+    expect(normalized?.replay).toBeUndefined();
+  });
+});

--- a/apps/web/lib/trust/passport-contract.ts
+++ b/apps/web/lib/trust/passport-contract.ts
@@ -207,6 +207,19 @@ export interface PassportData {
    * typed structurally rather than nominally.
    */
   trustContainer?: TrustContainerManifestView | null;
+  /**
+   * Wave 10: Canonical replay identity. Deterministic over stable
+   * persisted inputs (entityId + lastCheckedAt + artifact checksums),
+   * so the same evidence-snapshot yields the same runId across refresh,
+   * restart, and deploy. `lineageKey` is stable per entity for life.
+   */
+  replay?: PassportReplayIdentity;
+}
+
+export interface PassportReplayIdentity {
+  lineageKey: string;
+  runId: string;
+  schemeVersion: 'v1';
 }
 
 export interface PassportDivergence {
@@ -496,7 +509,18 @@ export function isPassportData(value: unknown): value is PassportData {
       typeof value.trustContainer === 'undefined'
       || value.trustContainer === null
       || normalizeTrustContainerManifestView(value.trustContainer) !== null
+    )
+    && (
+      typeof value.replay === 'undefined'
+      || isPassportReplayIdentity(value.replay)
     );
+}
+
+function isPassportReplayIdentity(value: unknown): value is PassportReplayIdentity {
+  return isRecord(value)
+    && isString(value.lineageKey)
+    && isString(value.runId)
+    && value.schemeVersion === 'v1';
 }
 
 export function normalizePassportData(value: unknown): PassportData | null {


### PR DESCRIPTION
## Summary

Establishes a survivability-by-construction identity contract: every passport snapshot now carries deterministic `lineageKey` + `runId` ids derived from stable persisted inputs. Survives refresh / restart / deploy by definition, because the ids are pure functions over data, not in-memory state.

## Identity contract

| Id | Stable across | Inputs |
|---|---|---|
| `lineageKey` | every check / snapshot / review for the same entity, forever | `entityId` alone |
| `runId` | identical-evidence snapshots; changes when evidence changes | `entityId` + `lastCheckedAt` + sorted artifact checksums + channel |

Scheme prefixed with `v1` (`lin_v1_…`, `run_v1_…`). Any future input-set change MUST bump to `v2` so older ids never collide with new ones.

## Survivability matrix

| Scenario | Outcome |
|---|---|
| Hard refresh | pure recomputation → identical id |
| Process restart | reads same persisted inputs → identical id |
| Deploy (new code, same data) | algorithm version `v1` → identical id |
| Degraded run (no artifacts) | distinct deterministic id; verifier can tell apart from a complete run by comparing ids |
| Artifact order changes in DB | normalized inside `computeRunId` → identical id |

## Files

| File | Status |
|---|---|
| `apps/api/backend/src/services/replay/replayIdentity.ts` | new — pure generators |
| `apps/api/backend/src/services/replay/__tests__/replayIdentity.test.ts` | new — 24 cases |
| `apps/api/backend/src/services/passport/npiPassportContract.ts` | wires `replay` into `PassportDataContract` |
| `apps/web/lib/trust/passport-contract.ts` | extends `PassportData` + validator |
| `apps/web/__tests__/passport-replay-identity.test.ts` | new — 8 validator cases |

## Out of scope (explicit follow-ups)

- **Schema migration** — relies on already-persisted `entityId`, `lastCheckedAt`, `artifact.id` fields. No DB changes.
- **Frontend rendering** — Lane B primitives (`RunIdentity`, `ReplayLineage`) and Wave 2 surface adoption (#342) are ready to consume `replay.runId` / `replay.lineageKey` once the surface props are threaded through. That threading is Wave 6.
- **Recent-NPIs / history-row UI** — Wave 6 scope.
- **`/replay/[id]` page** — Wave 9 scope.

## Truth rules
- Banned-strings scan: CLEAN
- No new claims about what the system verifies — only what it identifies

## Validation
- Backend jest: **24/24** passing (`src/services/replay/__tests__/replayIdentity.test.ts`)
- Web vitest: **8/8** passing (`__tests__/passport-replay-identity.test.ts`)
- Full web build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**, 42s