### PR TITLE
test(issuer): source-scan purity guards for receiptCandidate + policyReview

### DIFF
--- a/apps/web/__tests__/issuer-policy-review.test.ts
+++ b/apps/web/__tests__/issuer-policy-review.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -521,5 +522,45 @@ describe('Policy Review Surface — UI render guards', () => {
     for (const phrase of BANNED) {
       expect(lower).not.toContain(phrase.toLowerCase());
     }
+  });
+});
+
+describe('policyReview.ts — purity guard (no I/O, no DB, no audit writes)', () => {
+  it('source contains no fetch / axios / network / db / audit-writer tokens', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/policyReview.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const banned = [
+      'fetch(',
+      'axios',
+      'XMLHttpRequest',
+      'navigator.sendBeacon',
+      'prisma.',
+      'recordAudit',
+      'recordAuditEvent',
+      "import('@/",
+      'require(',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('does not statically import any backend module', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/policyReview.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(src).not.toMatch(/from ['"]apps\/api/);
+    expect(src).not.toMatch(/from ['"]@vitalcv\/psv['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*prisma_client['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*psvReceipts\.repo['"]/);
   });
 });

--- a/apps/web/__tests__/issuer-verification.test.ts
+++ b/apps/web/__tests__/issuer-verification.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   PARTNER_CATEGORY_LABEL,
@@ -242,5 +243,45 @@ describe('Issuer Verification — Banned Strings', () => {
     for (const banned of BANNED) {
       expect(blob).not.toContain(banned.toLowerCase());
     }
+  });
+});
+
+describe('receiptCandidate.ts — purity guard (no I/O, no DB, no audit writes)', () => {
+  it('source contains no fetch / axios / network / db / audit-writer tokens', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/receiptCandidate.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const banned = [
+      'fetch(',
+      'axios',
+      'XMLHttpRequest',
+      'navigator.sendBeacon',
+      'prisma.',
+      'recordAudit',
+      'recordAuditEvent',
+      "import('@/",
+      'require(',
+    ];
+    for (const phrase of banned) {
+      expect(src).not.toContain(phrase);
+    }
+  });
+
+  it('does not statically import any backend module', () => {
+    const src = readFileSync(
+      new URL(
+        '../lib/issuer-verification/receiptCandidate.ts',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(src).not.toMatch(/from ['"]apps\/api/);
+    expect(src).not.toMatch(/from ['"]@vitalcv\/psv['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*prisma_client['"]/);
+    expect(src).not.toMatch(/from ['"][^'"]*psvReceipts\.repo['"]/);
   });
 });


### PR DESCRIPTION
## Summary

- Extends the existing source-scan purity test pattern to cover the two most doctrine-critical pure transforms in the issuer/PSV chain: `apps/web/lib/issuer-verification/receiptCandidate.ts` and `policyReview.ts`.
- Closes a gap surfaced by the promotion-governance audit (2026-05-12): both helpers had only behavioral coverage, so a silent `fetch()` or audit-row write could be added without breaking any existing assertion.
- No production code changes — two test files only, +82/-0 lines.

## Why this matters

`receiptCandidate.ts` and `policyReview.ts` are the modules that materialize the literal `decisionGrade: false` / `proofTier: 'receipt_candidate'` / `proofTier: 'psv_receipt_candidate'` invariants of the issuer/PSV chain. Their CLAUDE.md contract explicitly states they are **pure transforms — no fetches, no DB writes, no audit-event writes**. Until now that was a comment, not a checked invariant.

## What changed

Each helper now has two new tests that `readFileSync` the source and assert:

1. The text contains none of: `fetch(`, `axios`, `XMLHttpRequest`, `navigator.sendBeacon`, `prisma.`, `recordAudit`, `recordAuditEvent`, dynamic `import('@/`, `require(`.
2. The module does not statically import from `apps/api`, `@vitalcv/psv`, any `prisma_client` path, or `psvReceipts.repo`.

Pattern copied from:
- `apps/web/__tests__/issuer-backend-persistence-decision.test.ts:235–271`
- `apps/web/__tests__/issuer-persistence-adapter.test.ts:325–363`

## Test plan

- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/issuer-policy-review.test.ts __tests__/issuer-verification.test.ts` — 67 tests pass (4 new)
- [ ] Codex SAFE verdict required before merge per repo merge hook (do **not** merge without `codex exec` verifier output in transcript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)