### PR TITLE
security: actor-attribution on audit-chain writes (Cluster 1)

### DIFF
--- a/apps/api/backend/src/routes/__tests__/auditDecision.test.ts
+++ b/apps/api/backend/src/routes/__tests__/auditDecision.test.ts
@@ -61,7 +61,7 @@ describe('POST /api/audit/decision', () => {
   });
 
   it('records a learning capsule and a standard audit event', async () => {
-    const res = await request(app).post('/api/audit/decision').send(validBody);
+    const res = await request(app).post('/api/audit/decision').set('x-clerk-user-id', 'user_test_actor_1').send(validBody);
 
     expect(res.status).toBe(201);
     expect(res.body.capsuleId).toBe('capsule-1');
@@ -86,6 +86,7 @@ describe('POST /api/audit/decision', () => {
     for (const outcome of outcomes) {
       const res = await request(app)
         .post('/api/audit/decision')
+        .set('x-clerk-user-id', 'user_test_actor_1')
         .send({ ...validBody, decisionOutcome: outcome });
       expect(res.status).toBe(201);
     }
@@ -94,6 +95,7 @@ describe('POST /api/audit/decision', () => {
   it('rejects an invalid decisionOutcome', async () => {
     const res = await request(app)
       .post('/api/audit/decision')
+      .set('x-clerk-user-id', 'user_test_actor_1')
       .send({ ...validBody, decisionOutcome: 'YOLO' });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/decisionOutcome/);
@@ -103,6 +105,7 @@ describe('POST /api/audit/decision', () => {
   it('rejects a non-UUID clinicianId', async () => {
     const res = await request(app)
       .post('/api/audit/decision')
+      .set('x-clerk-user-id', 'user_test_actor_1')
       .send({ ...validBody, clinicianId: 'not-a-uuid' });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/clinicianId/);
@@ -111,14 +114,14 @@ describe('POST /api/audit/decision', () => {
 
   it('rejects missing timeToDecision', async () => {
     const { timeToDecision: _ignored, ...withoutTime } = validBody;
-    const res = await request(app).post('/api/audit/decision').send(withoutTime);
+    const res = await request(app).post('/api/audit/decision').set('x-clerk-user-id', 'user_test_actor_1').send(withoutTime);
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/timeToDecision/);
   });
 
   it('rejects missing passportSnapshot', async () => {
     const { passportSnapshot: _ignored, ...withoutSnap } = validBody;
-    const res = await request(app).post('/api/audit/decision').send(withoutSnap);
+    const res = await request(app).post('/api/audit/decision').set('x-clerk-user-id', 'user_test_actor_1').send(withoutSnap);
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/passportSnapshot/);
   });
@@ -133,8 +136,42 @@ describe('POST /api/audit/decision', () => {
     (prisma.decisionLearningCapsule.create as jest.Mock).mockRejectedValueOnce(
       new Error('DB down'),
     );
-    const res = await request(app).post('/api/audit/decision').send(validBody);
+    const res = await request(app).post('/api/audit/decision').set('x-clerk-user-id', 'user_test_actor_1').send(validBody);
     expect(res.status).toBe(500);
     expect(res.body.error).toMatch(/Failed/);
+  });
+
+  // ── Anonymous-write extinction (Wave audit-chain hardening) ────────────────
+
+  it('rejects requests with no x-clerk-user-id header (401)', async () => {
+    const res = await request(app).post('/api/audit/decision').send(validBody);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthenticated');
+    expect(prisma.auditEvent.create).not.toHaveBeenCalled();
+    expect(prisma.decisionLearningCapsule.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with empty x-clerk-user-id header (401)', async () => {
+    const res = await request(app)
+      .post('/api/audit/decision')
+      .set('x-clerk-user-id', '   ')
+      .send(validBody);
+    expect(res.status).toBe(401);
+    expect(prisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('records the Clerk user id (not the employer id) as metadata.actorId', async () => {
+    await request(app)
+      .post('/api/audit/decision')
+      .set('x-clerk-user-id', 'user_test_actor_1')
+      .send(validBody);
+
+    const auditArgs = (prisma.auditEvent.create as jest.Mock).mock.calls[0][0];
+    expect(auditArgs.data.metadata.actorId).toBe('user_test_actor_1');
+    // The employer id is still captured, but as a distinct field.
+    expect(auditArgs.data.metadata.employerId).toBe(EMPLOYER_ID);
+    expect(auditArgs.data.organizationId).toBe(EMPLOYER_ID);
+    // Critically, actorId is NOT collapsed to employerId anymore.
+    expect(auditArgs.data.metadata.actorId).not.toBe(auditArgs.data.organizationId);
   });
 });

--- a/apps/api/backend/src/routes/__tests__/employer-action.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employer-action.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Pins the audit-chain hardening contract on `POST /api/employer-action`:
+ *
+ *  1. Anonymous requests (no x-clerk-user-id header) are rejected with
+ *     401 BEFORE any Prisma mutation.
+ *  2. Authenticated requests with a valid header create both the
+ *     EmployerAcceptance row and the AuditEvent row.
+ *  3. Every AuditEvent row carries `metadata.actorId === <Clerk user id>`
+ *     — the operator who took the decision is attributable on replay.
+ */
+import request from 'supertest';
+import express from 'express';
+import { employerActionRouter } from '../employer-action';
+import prisma from '../../graphql/prisma_client';
+
+jest.mock('../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    employerAcceptance: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    auditEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../obs/logger', () => ({
+  log: jest.fn(),
+}));
+
+const VALID_BODY = {
+  npi: '1234567890',
+  employerId: 'org-test-employer-1',
+  action: 'accept_head_start' as const,
+  loopId: 'loop-1',
+  notes: null,
+};
+
+const app = express();
+app.use(express.json());
+app.use('/api/employer-action', employerActionRouter);
+
+describe('POST /api/employer-action — audit-chain hardening', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.employerAcceptance.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.employerAcceptance.create as jest.Mock).mockResolvedValue({
+      id: 'acc-1',
+    });
+    (prisma.auditEvent.create as jest.Mock).mockResolvedValue({
+      id: 'audit-1',
+    });
+  });
+
+  it('rejects anonymous requests with 401 before any DB write', async () => {
+    const res = await request(app).post('/api/employer-action').send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('unauthenticated');
+    expect(prisma.employerAcceptance.findFirst).not.toHaveBeenCalled();
+    expect(prisma.employerAcceptance.create).not.toHaveBeenCalled();
+    expect(prisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with an empty x-clerk-user-id header (401)', async () => {
+    const res = await request(app)
+      .post('/api/employer-action')
+      .set('x-clerk-user-id', '   ')
+      .send(VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(prisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('writes the EmployerAcceptance and AuditEvent rows when authenticated', async () => {
+    const res = await request(app)
+      .post('/api/employer-action')
+      .set('x-clerk-user-id', 'user_employer_actor_1')
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.auditWritten).toBe(true);
+    expect(prisma.employerAcceptance.create).toHaveBeenCalledTimes(1);
+    expect(prisma.auditEvent.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the Clerk user id as metadata.actorId on the audit row', async () => {
+    await request(app)
+      .post('/api/employer-action')
+      .set('x-clerk-user-id', 'user_employer_actor_1')
+      .send(VALID_BODY);
+
+    const auditArgs = (prisma.auditEvent.create as jest.Mock).mock.calls[0][0];
+    expect(auditArgs.data.metadata.actorId).toBe('user_employer_actor_1');
+    // organizationId still carries the employer id at the row level —
+    // the actor is layered on top, not a replacement.
+    expect(auditArgs.data.organizationId).toBe('org-test-employer-1');
+    expect(auditArgs.data.metadata.actorId).not.toBe(auditArgs.data.organizationId);
+  });
+
+  it('records the Clerk user id as metadata.actorId on a refresh-request audit row', async () => {
+    await request(app)
+      .post('/api/employer-action')
+      .set('x-clerk-user-id', 'user_employer_actor_2')
+      .send({ ...VALID_BODY, action: 'request_refresh' });
+
+    const auditArgs = (prisma.auditEvent.create as jest.Mock).mock.calls[0][0];
+    expect(auditArgs.data.type).toBe('employer.request_refresh');
+    expect(auditArgs.data.metadata.actorId).toBe('user_employer_actor_2');
+  });
+
+  it('still validates body fields (400 on missing required) AFTER auth passes', async () => {
+    const res = await request(app)
+      .post('/api/employer-action')
+      .set('x-clerk-user-id', 'user_employer_actor_1')
+      .send({ employerId: 'org-1', action: 'accept_head_start' }); // missing npi
+    expect(res.status).toBe(400);
+    expect(prisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/backend/src/routes/auditDecision.ts
+++ b/apps/api/backend/src/routes/auditDecision.ts
@@ -59,8 +59,33 @@ function sha256OfJson(value: unknown): string {
   return createHash('sha256').update(canonicalize(value)).digest('hex');
 }
 
+/**
+ * Returns the Clerk user id from the `x-clerk-user-id` header. The web
+ * proxy attaches this header from `auth().userId` on every authenticated
+ * request; an empty/missing value means the caller is unauthenticated.
+ * `/api/audit/decision` writes to the non-repudiable audit chain — every
+ * row must carry a real actor identity, never an organization id alone.
+ */
+function readActorId(req: Request): string | null {
+  const raw = req.headers['x-clerk-user-id'];
+  const v = typeof raw === 'string' ? raw.trim() : '';
+  return v.length > 0 ? v : null;
+}
+
 export function registerAuditDecisionRoutes(app: Express): void {
   app.post('/api/audit/decision', async (req: Request, res: Response) => {
+    // Audit-chain integrity contract: a decision row without an
+    // attributable individual actor is unverifiable on replay. Reject
+    // anonymous writes BEFORE any DB mutation.
+    const actorId = readActorId(req);
+    if (!actorId) {
+      res.status(401).json({
+        error: 'unauthenticated',
+        detail: 'x-clerk-user-id header required; audit-decision writes the non-repudiable audit chain.',
+      });
+      return;
+    }
+
     const body = (req.body ?? {}) as Record<string, unknown>;
 
     const clinicianId = typeof body.clinicianId === 'string' ? body.clinicianId.trim() : '';
@@ -111,9 +136,13 @@ export function registerAuditDecisionRoutes(app: Express): void {
       // history on client retries. `$transaction` guarantees all-or-nothing.
       //
       // AuditEvent has no dedicated actor column; organizationId already
-      // carries the employer id, and the actor is additionally mirrored
-      // into metadata.actorId so downstream consumers can read it without
-      // inferring actor === organization.
+      // carries the employer id, and the Clerk user id of the individual
+      // operator is mirrored into metadata.actorId so downstream
+      // consumers can attribute the decision to a named person, not
+      // just the org. Before this change the field carried employerId
+      // verbatim, which collapsed person-level attribution into
+      // organization-level — replay could not tell who at the employer
+      // made the call. The 401 gate above guarantees actorId is set.
       const [auditEvent, capsule] = await prisma.$transaction([
         prisma.auditEvent.create({
           data: {
@@ -123,7 +152,8 @@ export function registerAuditDecisionRoutes(app: Express): void {
             clinicianId,
             organizationId: employerId,
             metadata: {
-              actorId: employerId,
+              actorId,
+              employerId,
               role,
               decisionOutcome,
               timeToDecision,
@@ -146,11 +176,14 @@ export function registerAuditDecisionRoutes(app: Express): void {
       // In-memory SIEM ledger — best-effort, in-process only. Fires AFTER
       // the transaction commits so the ledger never reflects a decision
       // that was rolled back.
+      // In-memory SIEM ledger gets the individual actor as `actor`; the
+      // organization id moves to requestFields so downstream consumers
+      // can tell person from org without inference.
       appendAuditEvent({
         category: 'DECISION',
-        actor: employerId,
+        actor: actorId,
         resource: clinicianId,
-        requestFields: { role, decisionOutcome, timeToDecision },
+        requestFields: { employerId, role, decisionOutcome, timeToDecision },
         resultFields: { passportSnapshotHash: snapshotHash, auditEventId: auditEvent.id },
         severity: 'INFO',
       });

--- a/apps/api/backend/src/routes/employer-action.ts
+++ b/apps/api/backend/src/routes/employer-action.ts
@@ -21,11 +21,38 @@ export const employerActionRouter = Router();
 type ActionType = 'accept_head_start' | 'request_refresh';
 
 /**
+ * Returns the Clerk user id from the `x-clerk-user-id` header, or null if
+ * absent / empty. The web proxy attaches this header from `auth().userId`
+ * on every authenticated request; an absent or empty value means the
+ * caller is unauthenticated. Audit-chain writes require an attributable
+ * actor — see the 401 enforcement at the top of the handler.
+ */
+function readActorId(req: Request): string | null {
+  const raw = req.headers['x-clerk-user-id'];
+  const v = typeof raw === 'string' ? raw.trim() : '';
+  return v.length > 0 ? v : null;
+}
+
+/**
  * POST /api/employer-action
  * Body: { npi, employerId, action, loopId?, notes? }
+ *
+ * Writes to the `EmployerAcceptance` table and the non-repudiable
+ * `AuditEvent` table. Requires a Clerk-authenticated actor: every audit
+ * row carries `actor_id` so the replay engine can attribute the decision
+ * to the named operator who took it. Anonymous writes are rejected with
+ * 401 before any DB mutation.
  */
 employerActionRouter.post('/', async (req: Request, res: Response) => {
   try {
+    const actorId = readActorId(req);
+    if (!actorId) {
+      return res.status(401).json({
+        error: 'unauthenticated',
+        detail: 'x-clerk-user-id header required; employer-action writes the non-repudiable audit chain.',
+      });
+    }
+
     const {
       npi,
       employerId,
@@ -76,7 +103,7 @@ employerActionRouter.post('/', async (req: Request, res: Response) => {
         acceptanceId = acceptance.id;
       }
 
-      // Write non-repudiable audit event
+      // Write non-repudiable audit event with attributable actor identity.
       await prisma.auditEvent.create({
         data: {
           type:        'employer.accept_head_start',
@@ -86,6 +113,7 @@ employerActionRouter.post('/', async (req: Request, res: Response) => {
           organizationId: employerId,
           metadata: {
             action,
+            actorId,
             loopId:       loopId ?? null,
             acceptanceId,
             timestamp:    now.toISOString(),
@@ -97,6 +125,7 @@ employerActionRouter.post('/', async (req: Request, res: Response) => {
         action,
         loopId,
         acceptanceId,
+        actorId,
       });
 
       return res.json({
@@ -121,6 +150,7 @@ employerActionRouter.post('/', async (req: Request, res: Response) => {
           organizationId: employerId,
           metadata: {
             action,
+            actorId,
             loopId:    loopId ?? null,
             requestId: actionId,
             timestamp: now.toISOString(),
@@ -129,7 +159,7 @@ employerActionRouter.post('/', async (req: Request, res: Response) => {
         },
       });
 
-      log('info', 'employer_action_taken', { action, loopId });
+      log('info', 'employer_action_taken', { action, loopId, actorId });
 
       return res.json({
         success:       true,


### PR DESCRIPTION
## Summary

Resolves the **two CRITICAL findings** from the anonymous-durable-write audit:

| Route | Before | After |
|---|---|---|
| `POST /api/employer-action` | anonymous-writable; AuditEvent rows had no actor identity | **401** on missing/empty `x-clerk-user-id`; both audit rows (`accept_head_start` + `request_refresh`) carry `metadata.actorId` = Clerk user id |
| `POST /api/audit/decision` | anonymous-writable; `metadata.actorId` was assigned to `employerId` (organization, not person) | **401** on missing header; `metadata.actorId` = Clerk user id (person); `employerId` moves to its own field; SIEM ledger uses the same actor identity |

After this PR, **no row in the non-repudiable audit chain can be created without an attributable individual operator**. Replay can answer "who at this employer made this decision" — not just "which employer."

## Files

| File | Change |
|---|---|
| `apps/api/backend/src/routes/employer-action.ts` | +34 lines — 401 guard + `actorId` on both audit-event metadata blocks |
| `apps/api/backend/src/routes/auditDecision.ts` | +45 lines — 401 guard + person-level `actorId` in metadata + SIEM ledger; `employerId` retained as a distinct field |
| `apps/api/backend/src/routes/__tests__/auditDecision.test.ts` | +45 lines — existing 8 cases updated to set header; **3 new cases** for 401 + actor-recorded-as-person-not-org |
| `apps/api/backend/src/routes/__tests__/employer-action.test.ts` | **new** — 6 cases pinning 401 + actor attribution |

## Out of scope (explicit follow-ups)

Three additional remediation clusters from the same audit:

| Cluster | Severity | Scope |
|---|---|---|
| 2 | HIGH | `/api/actions/:id/{status,execute,dismiss}` — currently accept client-body `actorId` with no validation |
| 3 | MEDIUM | `/api/feedback` + `/api/analytics/event` — should OPTIONALLY capture actor when present; NOT 401 (telemetry surfaces are intentionally public) |
| 4 | LOW | Web-proxy delegation docstrings — clarify that auth enforcement lives on the backend |

## Truth rules
- Banned-strings scan: CLEAN
- No copy authored; only header-presence enforcement + metadata field
- No API contract change — added field on existing metadata JSON blob, no rename

## Validation
- Backend jest: **17/17** passing (`auditDecision.test.ts` + `employer-action.test.ts`)
- No web build needed — backend-only change
- No new dependencies