### PR TITLE
feat(verifier): well-known discovery surfaces + signed VC 2.0 receipt endpoint

### DIFF
--- a/apps/web/__tests__/receipt-route.test.ts
+++ b/apps/web/__tests__/receipt-route.test.ts
@@ -1,0 +1,179 @@
+/**
+ * /api/receipt/[npi] — end-to-end verifier flow.
+ *
+ * The load-bearing property of this endpoint is that an external
+ * verifier with NO privileged access can:
+ *
+ *   1. fetch the receipt at /api/receipt/<npi>
+ *   2. fetch the JWKS at /.well-known/jwks.json
+ *   3. cryptographically validate the receipt against the JWKS
+ *
+ * The tests below execute exactly that flow in-process against mocked
+ * backend data, plus pin the shape contract (ES256 + kid + replay
+ * fields) and the `?format=download` content-disposition.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { jwtVerify, createLocalJWKSet, decodeJwt, decodeProtectedHeader } from 'jose';
+
+function buildPassport(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1346053246',
+    identity: {
+      displayName: 'Macie Miller',
+      entityType: 'PERSON',
+      specialty: 'PA-C',
+      status: 'ACTIVE',
+    },
+    readiness: { score: 50, level: 'L1', status: 'PARTIAL' },
+    trustPosture: { band: 'YELLOW' },
+    lastCheckedAt: '2026-04-01T15:00:00.000Z',
+    replay: {
+      lineageKey: 'lin_v1_aaaabbbbccccdddd',
+      runId: 'run_v1_1111222233334444',
+      schemeVersion: 'v1' as const,
+    },
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  process.env.VITALCV_ISSUER_ORIGIN = 'https://issuer.test.vitalcv.com';
+  process.env.BACKEND_URL = 'http://backend.test';
+});
+
+async function callReceiptRoute(npi: string, search = '') {
+  const mod = await import('../app/api/receipt/[npi]/route');
+  const req = new Request(`http://localhost/api/receipt/${npi}${search}`) as never;
+  return mod.GET(req, { params: Promise.resolve({ npi }) });
+}
+
+describe('/api/receipt/[npi]', () => {
+  it('returns 400 on a non-10-digit NPI', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassport())));
+    const res = await callReceiptRoute('not-a-npi');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 502 when the upstream passport is malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ nope: true })));
+    const res = await callReceiptRoute('1346053246');
+    expect(res.status).toBe(502);
+  });
+
+  it('returns the backend status code when the upstream is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not found', { status: 404 })));
+    const res = await callReceiptRoute('1346053246');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 with application/jwt and the active kid on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassport())));
+    const res = await callReceiptRoute('1346053246');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/jwt/);
+    expect(res.headers.get('x-receipt-kid')).toBeTruthy();
+    expect(res.headers.get('x-receipt-issuer')).toBe('did:web:issuer.test.vitalcv.com');
+
+    const jwt = await res.text();
+    const header = decodeProtectedHeader(jwt);
+    expect(header.alg).toBe('ES256');
+    expect(header.typ).toBe('vc+jwt');
+    expect(header.kid).toBeTruthy();
+  });
+
+  it('produces a JWT whose payload carries the W3C VC 2.0 + VitalCV claim blocks', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassport())));
+    const res = await callReceiptRoute('1346053246');
+    const jwt = await res.text();
+    const payload = decodeJwt(jwt) as Record<string, unknown> & {
+      vc: Record<string, unknown>;
+      vcv: Record<string, unknown>;
+    };
+
+    expect(payload.iss).toBe('did:web:issuer.test.vitalcv.com');
+    expect(payload.sub).toBe('npi:1346053246');
+    expect(typeof payload.jti).toBe('string');
+    expect((payload.jti as string).startsWith('receipt:')).toBe(true);
+
+    // VC 2.0
+    expect(payload.vc).toMatchObject({
+      type: ['VerifiableCredential', 'VitalCVTrustReceipt'],
+      issuer: 'did:web:issuer.test.vitalcv.com',
+    });
+
+    // VitalCV claim block with replay identity
+    expect(payload.vcv.replay).toMatchObject({
+      lineageKey: 'lin_v1_aaaabbbbccccdddd',
+      runId: 'run_v1_1111222233334444',
+      schemeVersion: 'v1',
+    });
+    expect(payload.vcv.checkedAt).toBe('2026-04-01T15:00:00.000Z');
+    expect(payload.vcv.jwksUri).toBe('https://issuer.test.vitalcv.com/.well-known/jwks.json');
+    expect(payload.vcv.didDocumentUri).toBe('https://issuer.test.vitalcv.com/.well-known/did.json');
+  });
+
+  it('produces a deterministic jti derived from replay.runId', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => jsonResponse(buildPassport())));
+    const a = decodeJwt(await (await callReceiptRoute('1346053246')).text()) as { jti: string };
+    const b = decodeJwt(await (await callReceiptRoute('1346053246')).text()) as { jti: string };
+    expect(a.jti).toBe('receipt:run_v1_1111222233334444');
+    expect(a.jti).toBe(b.jti);
+  });
+
+  it('pins iat to lastCheckedAt seconds so the payload is stable across re-issuance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => jsonResponse(buildPassport())));
+    const a = decodeJwt(await (await callReceiptRoute('1346053246')).text()) as { iat: number; exp: number };
+    const b = decodeJwt(await (await callReceiptRoute('1346053246')).text()) as { iat: number; exp: number };
+    expect(a.iat).toBe(Math.floor(new Date('2026-04-01T15:00:00.000Z').getTime() / 1000));
+    expect(a.iat).toBe(b.iat);
+    expect(a.exp - a.iat).toBe(90 * 24 * 60 * 60);
+  });
+
+  it('end-to-end: an external verifier can validate the receipt against the published JWKS', async () => {
+    // 1. Receipt
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassport())));
+    const receiptRes = await callReceiptRoute('1346053246');
+    const jwt = await receiptRes.text();
+
+    // 2. JWKS (same handler the well-known route exposes)
+    const jwksMod = await import('../app/.well-known/jwks.json/route');
+    const jwksRes = await jwksMod.GET();
+    const jwks = (await jwksRes.json()) as { keys: Array<Record<string, unknown>> };
+
+    // 3. Verifier flow — validate signature against the JWKS
+    const jwkSet = createLocalJWKSet(jwks as never);
+    const verified = await jwtVerify(jwt, jwkSet, { algorithms: ['ES256'] });
+    expect(verified.payload.iss).toBe('did:web:issuer.test.vitalcv.com');
+    expect(verified.payload.sub).toBe('npi:1346053246');
+    expect(verified.protectedHeader.alg).toBe('ES256');
+    expect(verified.protectedHeader.kid).toBe(jwks.keys[0].kid);
+  });
+
+  it('?format=download adds Content-Disposition: attachment', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(buildPassport())));
+    const res = await callReceiptRoute('1346053246', '?format=download');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toMatch(/attachment; filename="vitalcv-receipt-1346053246\.jwt"/);
+  });
+
+  it('omits the replay block gracefully when the backend response has no replay field', async () => {
+    const noReplay = buildPassport({ replay: undefined });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(noReplay)));
+    const res = await callReceiptRoute('1346053246');
+    expect(res.status).toBe(200);
+    const payload = decodeJwt(await res.text()) as { vcv: Record<string, unknown>; jti: string };
+    expect(payload.vcv.replay).toBeNull();
+    // jti falls back to npi-derived form
+    expect(payload.jti).toBe('receipt:npi:1346053246');
+  });
+});

--- a/apps/web/__tests__/well-known-surfaces.test.ts
+++ b/apps/web/__tests__/well-known-surfaces.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Wave 9 — four well-known surfaces pinned at RFC-correct paths.
+ *
+ *   /.well-known/jwks.json                (RFC 8615 + RFC 7517)
+ *   /.well-known/did.json                 (W3C DID Core, did:web method)
+ *   /.well-known/openid-credential-issuer (OID4VCI)
+ *   /.well-known/trust-register           (VitalCV institutional manifest)
+ *
+ * The tests pin:
+ *   - HTTP 200 + the canonical content-type for each surface
+ *   - RFC-valid shape (top-level required fields per spec)
+ *   - Cross-surface coherence: same DID, same kid, same JWKS URI
+ *
+ * Cross-surface coherence is the load-bearing invariant — any change
+ * that lets the four surfaces disagree on issuer identity breaks
+ * external verifier resolution.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  process.env.VITALCV_ISSUER_ORIGIN = 'https://issuer.test.vitalcv.com';
+  process.env.VITALCV_RUNTIME_CHANNEL = 'staging';
+});
+
+describe('/.well-known/jwks.json (root, RFC-correct)', () => {
+  it('returns 200 with application/jwk-set+json and a `keys` array', async () => {
+    const mod = await import('../app/.well-known/jwks.json/route');
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/jwk-set\+json/);
+    const body = await res.json();
+    expect(Array.isArray(body.keys)).toBe(true);
+    expect(body.keys.length).toBeGreaterThan(0);
+    const key = body.keys[0];
+    expect(key.kty).toBeDefined();
+    expect(key.alg).toBe('ES256');
+    expect(key.use).toBe('sig');
+    expect(typeof key.kid).toBe('string');
+    expect(key.kid.length).toBeGreaterThan(0);
+    // Private component must NOT be present.
+    expect(key.d).toBeUndefined();
+  });
+});
+
+describe('/.well-known/did.json (W3C DID Core, did:web)', () => {
+  it('returns 200 with application/did+json and a valid DID document', async () => {
+    const mod = await import('../app/.well-known/did.json/route');
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/did\+json/);
+
+    const doc = await res.json();
+    expect(Array.isArray(doc['@context'])).toBe(true);
+    expect(doc['@context']).toContain('https://www.w3.org/ns/did/v1');
+    expect(typeof doc.id).toBe('string');
+    expect(doc.id.startsWith('did:web:')).toBe(true);
+    expect(Array.isArray(doc.verificationMethod)).toBe(true);
+    expect(doc.verificationMethod.length).toBeGreaterThan(0);
+
+    const vm = doc.verificationMethod[0];
+    expect(vm.id.startsWith(doc.id + '#')).toBe(true);
+    expect(vm.type).toBe('JsonWebKey2020');
+    expect(vm.controller).toBe(doc.id);
+    expect(vm.publicKeyJwk).toBeDefined();
+    expect(vm.publicKeyJwk.d).toBeUndefined();
+
+    expect(doc.assertionMethod).toContain(vm.id);
+    expect(doc.authentication).toContain(vm.id);
+
+    // Sibling well-known endpoints discoverable from the document.
+    const services = doc.service as Array<{ id: string; type: string; serviceEndpoint: string }>;
+    expect(services.some((s) => s.type === 'JsonWebKeySet')).toBe(true);
+    expect(services.some((s) => s.type === 'OID4VCIIssuer')).toBe(true);
+    expect(services.some((s) => s.type === 'VitalCVTrustRegister')).toBe(true);
+  });
+});
+
+describe('/.well-known/openid-credential-issuer (OID4VCI)', () => {
+  it('returns 200 with application/json and minimum required fields', async () => {
+    const mod = await import('../app/.well-known/openid-credential-issuer/route');
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+
+    const meta = await res.json();
+    expect(typeof meta.credential_issuer).toBe('string');
+    expect(typeof meta.credential_endpoint).toBe('string');
+    expect(typeof meta.jwks_uri).toBe('string');
+    expect(meta.jwks_uri.endsWith('/.well-known/jwks.json')).toBe(true);
+
+    // draft-13+ shape
+    expect(meta.credential_configurations_supported).toBeDefined();
+    expect(typeof meta.credential_configurations_supported).toBe('object');
+
+    // draft-11 back-compat shape
+    expect(Array.isArray(meta.credentials_supported)).toBe(true);
+    expect(meta.credentials_supported.length).toBeGreaterThan(0);
+
+    // Display block carries an issuer name.
+    expect(Array.isArray(meta.display)).toBe(true);
+    expect(meta.display[0].name).toBe('VitalCV');
+  });
+});
+
+describe('/.well-known/trust-register (VitalCV manifest)', () => {
+  it('returns 200 with application/json and schema_version pinned', async () => {
+    const mod = await import('../app/.well-known/trust-register/route');
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+
+    const manifest = await res.json();
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.issuer.did.startsWith('did:web:')).toBe(true);
+    expect(typeof manifest.issuer.origin).toBe('string');
+
+    expect(typeof manifest.signing.active_kid).toBe('string');
+    expect(manifest.signing.algorithm).toBe('ES256');
+    expect(manifest.signing.jwks_uri).toMatch(/\/\.well-known\/jwks\.json$/);
+    expect(manifest.signing.did_document_uri).toMatch(/\/\.well-known\/did\.json$/);
+
+    expect(manifest.runtime.channel).toBe('staging');
+    expect(typeof manifest.runtime.deploy_commit).toBe('string');
+    expect(typeof manifest.runtime.published_at).toBe('string');
+
+    expect(Array.isArray(manifest.launch_spine)).toBe(true);
+    expect(manifest.launch_spine.length).toBe(4);
+    const ids = manifest.launch_spine.map((s: { id: string }) => s.id).sort();
+    expect(ids).toEqual(['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC', 'STATE_BOARD']);
+
+    expect(Array.isArray(manifest.credentials)).toBe(true);
+    expect(manifest.credentials.length).toBeGreaterThan(0);
+
+    // Disclaimers must be present and non-empty.
+    expect(Array.isArray(manifest.disclaimers)).toBe(true);
+    expect(manifest.disclaimers.length).toBeGreaterThan(0);
+  });
+});
+
+describe('cross-surface coherence (load-bearing institutional invariant)', () => {
+  it('all four surfaces agree on issuer DID, JWKS URI, and kid', async () => {
+    const [jwks, did, oidc, trust] = await Promise.all([
+      import('../app/.well-known/jwks.json/route').then((m) => m.GET()).then((r) => r.json()),
+      import('../app/.well-known/did.json/route').then((m) => m.GET()).then((r) => r.json()),
+      import('../app/.well-known/openid-credential-issuer/route').then((m) => m.GET()).then((r) => r.json()),
+      import('../app/.well-known/trust-register/route').then((m) => m.GET()).then((r) => r.json()),
+    ]);
+
+    const kid = jwks.keys[0].kid;
+    expect(typeof kid).toBe('string');
+
+    // DID document's verification-method id includes the same kid.
+    const vm = did.verificationMethod[0];
+    expect(vm.id).toBe(`${did.id}#${kid}`);
+    expect(vm.publicKeyJwk.kid).toBe(kid);
+
+    // OID4VCI metadata points at the same JWKS.
+    expect(oidc.jwks_uri).toBe(trust.signing.jwks_uri);
+
+    // Trust register agrees on DID + kid.
+    expect(trust.issuer.did).toBe(did.id);
+    expect(trust.signing.active_kid).toBe(kid);
+    expect(trust.signing.did_document_uri).toBe(`${trust.issuer.origin}/.well-known/did.json`);
+
+    // No private key leakage in any surface.
+    expect(jwks.keys[0].d).toBeUndefined();
+    expect(did.verificationMethod[0].publicKeyJwk.d).toBeUndefined();
+  });
+});

--- a/apps/web/app/.well-known/did.json/route.ts
+++ b/apps/web/app/.well-known/did.json/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /.well-known/did.json
+ *
+ * W3C DID Core document for `did:web:<origin>`. Verifiers resolve the
+ * VitalCV issuer DID by fetching this URL; the public key material
+ * here MUST match what is published at `/.well-known/jwks.json`. Both
+ * surfaces share `getPublicKeyJwk()` so kid + key never diverge.
+ *
+ * Spec: https://w3c-ccg.github.io/did-method-web/
+ *
+ * The verification-method id `<did>#<kid>` lets a verifier inspecting
+ * a receipt's `kid` header navigate directly to the matching key entry.
+ */
+import { NextResponse } from 'next/server';
+import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
+import {
+  getIssuerDid,
+  getIssuerOrigin,
+  getVerificationMethodId,
+} from '@/lib/trust/wellKnownIdentity';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+export async function GET() {
+  const did = getIssuerDid();
+  const origin = getIssuerOrigin();
+  const publicKeyJwk = await getPublicKeyJwk();
+  const kid = typeof publicKeyJwk.kid === 'string' ? publicKeyJwk.kid : 'vcv-es256';
+  const vmId = getVerificationMethodId(did, kid);
+
+  const document = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/suites/jws-2020/v1',
+    ],
+    id: did,
+    verificationMethod: [
+      {
+        id: vmId,
+        type: 'JsonWebKey2020',
+        controller: did,
+        publicKeyJwk,
+      },
+    ],
+    assertionMethod: [vmId],
+    authentication: [vmId],
+    service: [
+      {
+        id: `${did}#jwks`,
+        type: 'JsonWebKeySet',
+        serviceEndpoint: `${origin}/.well-known/jwks.json`,
+      },
+      {
+        id: `${did}#trust-register`,
+        type: 'VitalCVTrustRegister',
+        serviceEndpoint: `${origin}/.well-known/trust-register`,
+      },
+      {
+        id: `${did}#oid4vci`,
+        type: 'OID4VCIIssuer',
+        serviceEndpoint: `${origin}/.well-known/openid-credential-issuer`,
+      },
+    ],
+  };
+
+  return NextResponse.json(document, {
+    headers: {
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      'Content-Type': 'application/did+json',
+    },
+  });
+}

--- a/apps/web/app/.well-known/jwks.json/route.ts
+++ b/apps/web/app/.well-known/jwks.json/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /.well-known/jwks.json
+ *
+ * RFC 8615 + RFC 7517 well-known location for the issuer's public JWK Set.
+ *
+ * VitalCV historically published its JWKS under the namespaced path
+ * `/api/.well-known/jwks.json`, which is functional but RFC-incorrect:
+ * external verifiers expect the JWKS at the bare `/.well-known/jwks.json`
+ * root. This handler is a thin re-export so the same key material is
+ * reachable at both paths — the namespaced one is kept for backward
+ * compatibility with any internal caller; the root path is the
+ * RFC-compliant one for institutional verifiers.
+ *
+ * Both routes share `getPublicKeyJwk()` so kid + key never diverge.
+ */
+import { NextResponse } from 'next/server';
+import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+export async function GET() {
+  const publicKeyJwk = await getPublicKeyJwk();
+  return NextResponse.json(
+    { keys: [publicKeyJwk] },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'Content-Type': 'application/jwk-set+json',
+      },
+    },
+  );
+}

--- a/apps/web/app/.well-known/openid-credential-issuer/route.ts
+++ b/apps/web/app/.well-known/openid-credential-issuer/route.ts
@@ -1,0 +1,81 @@
+/**
+ * GET /.well-known/openid-credential-issuer
+ *
+ * OID4VCI (OpenID for Verifiable Credential Issuance) issuer metadata.
+ *
+ * Spec: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+ *
+ * Verifiers and credential consumers fetch this endpoint to discover:
+ *   - the canonical credential-issuer URL
+ *   - the credential-issuance endpoint(s)
+ *   - the list of supported credential types (`credential_configurations_supported`)
+ *   - display metadata for the issuer
+ *
+ * The credential types listed here correspond to the SD-JWT receipt
+ * formats VitalCV currently issues. `credentials_supported` (the
+ * older OID4VCI draft-11 field) is also emitted for verifiers that
+ * predate the rename in draft-13.
+ */
+import { NextResponse } from 'next/server';
+import { getIssuerOrigin } from '@/lib/trust/wellKnownIdentity';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+interface CredentialConfiguration {
+  format: 'vc+sd-jwt';
+  vct: string;
+  cryptographic_binding_methods_supported: readonly string[];
+  credential_signing_alg_values_supported: readonly string[];
+  display: ReadonlyArray<{ name: string; locale: string }>;
+}
+
+const CREDENTIAL_CONFIGURATIONS: Readonly<Record<string, CredentialConfiguration>> = {
+  VitalCVClinicianPassport: {
+    format: 'vc+sd-jwt',
+    vct: 'https://vct.vitalcv.com/clinician-passport/v1',
+    cryptographic_binding_methods_supported: ['did:web'],
+    credential_signing_alg_values_supported: ['ES256'],
+    display: [{ name: 'VitalCV Clinician Passport', locale: 'en-US' }],
+  },
+  VitalCVTrustReceipt: {
+    format: 'vc+sd-jwt',
+    vct: 'https://vct.vitalcv.com/trust-receipt/v1',
+    cryptographic_binding_methods_supported: ['did:web'],
+    credential_signing_alg_values_supported: ['ES256'],
+    display: [{ name: 'VitalCV Trust Receipt', locale: 'en-US' }],
+  },
+};
+
+export async function GET() {
+  const origin = getIssuerOrigin();
+
+  const metadata = {
+    credential_issuer: origin,
+    credential_endpoint: `${origin}/api/credentials/issue`,
+    jwks_uri: `${origin}/.well-known/jwks.json`,
+    display: [
+      {
+        name: 'VitalCV',
+        locale: 'en-US',
+        logo: {
+          uri: `${origin}/brand/vitalcv-logo.svg`,
+          alt_text: 'VitalCV',
+        },
+      },
+    ],
+    // OID4VCI draft-13+ field.
+    credential_configurations_supported: CREDENTIAL_CONFIGURATIONS,
+    // OID4VCI draft-11 back-compat: same content, older field name.
+    credentials_supported: Object.entries(CREDENTIAL_CONFIGURATIONS).map(
+      ([id, cfg]) => ({ id, ...cfg }),
+    ),
+  };
+
+  return NextResponse.json(metadata, {
+    headers: {
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/apps/web/app/.well-known/trust-register/route.ts
+++ b/apps/web/app/.well-known/trust-register/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /.well-known/trust-register
+ *
+ * VitalCV-specific institutional trust manifest. Not an external RFC
+ * — it's the structured self-description an institutional verifier
+ * (NCQA, Joint Commission, hospital procurement) can fetch to inspect
+ * VitalCV's trust posture without needing privileged access.
+ *
+ * Schema version: 1.
+ *
+ * Contents:
+ *   - `issuer`           the canonical issuer DID + origin
+ *   - `signing`          algorithm + active kid + JWKS URI
+ *   - `runtime`          channel + deploy commit + last-published-at
+ *   - `launch_spine`     the four canonical primary-source domains
+ *                        VitalCV builds readiness on (NPPES, OIG LEIE,
+ *                        PECOS, state board)
+ *   - `credentials`      SD-JWT VCT types the issuer can produce
+ *   - `endpoints`        sibling .well-known + discovery URIs
+ *   - `doctrine`         pointers to the operational doctrine documents
+ *                        every verifier can consult
+ *   - `disclaimers`      explicit non-claims (no fake PSV, no implied
+ *                        compliance certification)
+ *
+ * Any change to the schema MUST bump `schema_version`.
+ */
+import { NextResponse } from 'next/server';
+import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
+import {
+  getDeployCommit,
+  getIssuerDid,
+  getIssuerOrigin,
+  getRuntimeChannel,
+} from '@/lib/trust/wellKnownIdentity';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+const SCHEMA_VERSION = 1 as const;
+
+const LAUNCH_SPINE = [
+  { id: 'NPPES_API', label: 'CMS NPPES', kind: 'identity' },
+  { id: 'OIG_LEIE', label: 'OIG LEIE', kind: 'exclusion' },
+  { id: 'PECOS_PUBLIC', label: 'CMS PECOS (public)', kind: 'enrollment' },
+  { id: 'STATE_BOARD', label: 'State Medical Board', kind: 'licensure' },
+] as const;
+
+const CREDENTIALS = [
+  {
+    type: 'VitalCVClinicianPassport',
+    vct: 'https://vct.vitalcv.com/clinician-passport/v1',
+    format: 'vc+sd-jwt',
+  },
+  {
+    type: 'VitalCVTrustReceipt',
+    vct: 'https://vct.vitalcv.com/trust-receipt/v1',
+    format: 'vc+sd-jwt',
+  },
+] as const;
+
+const DISCLAIMERS = [
+  'Source-backed checks are reported with explicit provenance per source; absence of an adverse finding is rendered as "no adverse findings", not as a positive verification claim.',
+  'VitalCV does not assert primary-source verification beyond the source it cites for each credential. Where a source could not be reached, the relevant lane is rendered as degraded with an A/B/C/E taxonomy code.',
+  'Receipts are cryptographically signed (ES256); signature verification establishes integrity and issuer attribution, not external compliance certification.',
+  'Replay identity is deterministic per evidence snapshot; identical persisted inputs produce identical runIds across restart and deploy.',
+] as const;
+
+export async function GET() {
+  const origin = getIssuerOrigin();
+  const did = getIssuerDid();
+  const publicKeyJwk = await getPublicKeyJwk();
+  const kid = typeof publicKeyJwk.kid === 'string' ? publicKeyJwk.kid : 'vcv-es256';
+  const alg = typeof publicKeyJwk.alg === 'string' ? publicKeyJwk.alg : 'ES256';
+
+  const manifest = {
+    schema_version: SCHEMA_VERSION,
+    schema_url: 'https://vitalcv.com/schemas/trust-register/v1',
+    issuer: {
+      did,
+      origin,
+    },
+    signing: {
+      active_kid: kid,
+      algorithm: alg,
+      jwks_uri: `${origin}/.well-known/jwks.json`,
+      did_document_uri: `${origin}/.well-known/did.json`,
+    },
+    runtime: {
+      channel: getRuntimeChannel(),
+      deploy_commit: getDeployCommit(),
+      published_at: new Date().toISOString(),
+    },
+    launch_spine: LAUNCH_SPINE,
+    credentials: CREDENTIALS,
+    endpoints: {
+      jwks: `${origin}/.well-known/jwks.json`,
+      did_document: `${origin}/.well-known/did.json`,
+      oid4vci_metadata: `${origin}/.well-known/openid-credential-issuer`,
+      receipt_verify: `${origin}/api/receipts/verify`,
+      verify_surface: `${origin}/verify`,
+      passport_by_npi: `${origin}/api/passport/npi/{npi}`,
+      health: `${origin}/api/health`,
+    },
+    doctrine: {
+      production_promotion_protocol: `${origin}/docs/ops/production-promotion-protocol.md`,
+      replay_survivability_matrix: `${origin}/docs/architecture/replay-survivability-matrix.md`,
+    },
+    disclaimers: DISCLAIMERS,
+  };
+
+  return NextResponse.json(manifest, {
+    headers: {
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/apps/web/app/api/receipt/[npi]/route.ts
+++ b/apps/web/app/api/receipt/[npi]/route.ts
@@ -1,0 +1,189 @@
+/**
+ * GET /api/receipt/:npi
+ *
+ * Issues a cryptographically-signed VC 2.0 receipt for the current
+ * passport state of an NPI. An external verifier can fetch this
+ * receipt and validate it against the JWKS published at
+ * `/.well-known/jwks.json` (and the issuer DID at `/.well-known/did.json`)
+ * without any privileged access to VitalCV.
+ *
+ * Receipt shape (ES256 JWT, kid header points to active key):
+ *
+ *   header   { alg: 'ES256', kid: <active-kid>, typ: 'vc+jwt' }
+ *   payload  { iss: <issuer-did>,
+ *              sub: <npi>,
+ *              jti: <deterministic per evidence snapshot>,
+ *              iat, exp,
+ *              vc: W3C VC 2.0 credential block,
+ *              vcv: VitalCV-specific claim block including replay identity }
+ *
+ * Determinism:
+ *   - `jti` is derived from `replay.runId` so the same evidence snapshot
+ *     produces an identifiable receipt. Re-issuance for the same evidence
+ *     remains observable because timestamps differ, but the jti acts as
+ *     a stable cross-receipt key for the underlying snapshot.
+ *   - `iat` is pinned to `lastCheckedAt` so two receipts issued for the
+ *     same snapshot are byte-identical (the signature itself is
+ *     non-deterministic by ES256 spec, but the payload is).
+ *
+ * Download flow:
+ *   `?format=download` adds `Content-Disposition: attachment` so a
+ *   verifier engineer can save the JWT to disk for offline validation.
+ *
+ * Replay-linked:
+ *   `vcv.replay = { lineageKey, runId, schemeVersion }` echoes the same
+ *   identity contract Wave 10 (#343) emits on the passport response,
+ *   so a verifier can join a receipt to its passport snapshot via
+ *   `lineageKey`.
+ */
+import { type NextRequest, NextResponse } from 'next/server';
+import { SignJWT } from 'jose';
+import { BACKEND_URL } from '@/lib/backend-url';
+import { getOrInitKeypair } from '@/lib/crypto/receiptIssuer';
+import {
+  getIssuerDid,
+  getIssuerOrigin,
+} from '@/lib/trust/wellKnownIdentity';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const VCT_URL = 'https://vct.vitalcv.com/trust-receipt/v1';
+const NINETY_DAYS_SEC = 90 * 24 * 60 * 60;
+
+interface PassportShape {
+  entityId: string;
+  npi?: string;
+  identity?: { displayName?: string; entityType?: string; specialty?: string; status?: string };
+  readiness?: { score?: number; level?: string; status?: string };
+  trustPosture?: { band?: string };
+  lastCheckedAt?: string;
+  replay?: { lineageKey: string; runId: string; schemeVersion: 'v1' };
+}
+
+async function fetchPassport(npi: string): Promise<{ ok: true; passport: PassportShape } | { ok: false; status: number; error: string }> {
+  if (!/^\d{10}$/.test(npi)) {
+    return { ok: false, status: 400, error: 'NPI must be a 10-digit string.' };
+  }
+  let res: Response;
+  try {
+    res = await fetch(`${BACKEND_URL}/api/passport/npi/${encodeURIComponent(npi)}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch (err) {
+    return { ok: false, status: 503, error: `Upstream unreachable: ${String(err)}` };
+  }
+  if (!res.ok) {
+    return { ok: false, status: res.status, error: `Backend returned ${res.status}.` };
+  }
+  const payload = (await res.json().catch(() => null)) as PassportShape | null;
+  if (!payload || typeof payload.entityId !== 'string') {
+    return { ok: false, status: 502, error: 'Invalid upstream payload.' };
+  }
+  return { ok: true, passport: payload };
+}
+
+function buildReceiptJti(runId: string | undefined, npi: string): string {
+  // Stable across re-issuance for the same evidence snapshot.
+  const base = runId && runId.length > 0 ? runId : `npi:${npi}`;
+  return `receipt:${base}`;
+}
+
+function buildReceiptPayload(passport: PassportShape, npi: string, iat: number) {
+  const did = getIssuerDid();
+  const origin = getIssuerOrigin();
+  const jti = buildReceiptJti(passport.replay?.runId, npi);
+
+  return {
+    iss: did,
+    sub: `npi:${npi}`,
+    jti,
+    iat,
+    nbf: iat,
+    exp: iat + NINETY_DAYS_SEC,
+    // W3C VC 2.0 credential block. https://www.w3.org/TR/vc-data-model-2.0/
+    vc: {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      id: `urn:vitalcv:receipt:${jti}`,
+      type: ['VerifiableCredential', 'VitalCVTrustReceipt'],
+      issuer: did,
+      validFrom: new Date(iat * 1000).toISOString(),
+      validUntil: new Date((iat + NINETY_DAYS_SEC) * 1000).toISOString(),
+      credentialSubject: {
+        id: `npi:${npi}`,
+        displayName: passport.identity?.displayName ?? null,
+        entityType: passport.identity?.entityType ?? null,
+        specialty: passport.identity?.specialty ?? null,
+        readinessLevel: passport.readiness?.level ?? null,
+        readinessScore: passport.readiness?.score ?? null,
+        trustBand: passport.trustPosture?.band ?? null,
+      },
+      // Cross-link to the canonical verifier surfaces.
+      credentialSchema: { id: VCT_URL, type: 'JsonSchema' },
+    },
+    // VitalCV claim block — same shape conventions as `signIssuerReceipt`
+    // in `lib/crypto/receiptIssuer.ts`, extended with replay identity
+    // so a verifier can join the receipt to a passport snapshot.
+    vcv: {
+      npi,
+      entityId: passport.entityId,
+      checkedAt: passport.lastCheckedAt ?? null,
+      replay: passport.replay
+        ? {
+            lineageKey: passport.replay.lineageKey,
+            runId: passport.replay.runId,
+            schemeVersion: passport.replay.schemeVersion,
+          }
+        : null,
+      issuerOrigin: origin,
+      jwksUri: `${origin}/.well-known/jwks.json`,
+      didDocumentUri: `${origin}/.well-known/did.json`,
+    },
+  };
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ npi: string }> },
+) {
+  const { npi } = await params;
+  const result = await fetchPassport(npi);
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: 'passport_unavailable', detail: result.error },
+      { status: result.status },
+    );
+  }
+  const { passport } = result;
+
+  // iat pinned to lastCheckedAt seconds so two receipts for the same
+  // snapshot share the same iat (signature itself stays
+  // non-deterministic per ES256, payload byte-identical).
+  const iat = passport.lastCheckedAt
+    ? Math.floor(new Date(passport.lastCheckedAt).getTime() / 1000)
+    : Math.floor(Date.now() / 1000);
+
+  const { privateKey, kid } = await getOrInitKeypair();
+  const payload = buildReceiptPayload(passport, npi, iat);
+
+  const jwt = await new SignJWT(payload as unknown as Record<string, unknown>)
+    .setProtectedHeader({ alg: 'ES256', kid, typ: 'vc+jwt' })
+    .sign(privateKey);
+
+  // Use plain URL parsing rather than `req.nextUrl` so the handler is
+  // portable between NextRequest and bare Request inputs (tests use the
+  // latter; production uses NextRequest, which is a superset).
+  const wantsDownload = new URL(req.url).searchParams.get('format') === 'download';
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/jwt',
+    'Cache-Control': 'private, no-store',
+    'X-Receipt-Kid': kid,
+    'X-Receipt-Issuer': getIssuerDid(),
+  };
+  if (wantsDownload) {
+    headers['Content-Disposition'] = `attachment; filename="vitalcv-receipt-${npi}.jwt"`;
+  }
+
+  return new NextResponse(jwt, { status: 200, headers });
+}

--- a/apps/web/lib/trust/wellKnownIdentity.ts
+++ b/apps/web/lib/trust/wellKnownIdentity.ts
@@ -1,0 +1,120 @@
+/**
+ * Canonical identity derivation for the four `.well-known/*` surfaces
+ * (Wave 9). All surfaces must agree on:
+ *
+ *  - the issuer origin (host)
+ *  - the issuer DID (currently `did:web:<host>`)
+ *  - the kid + algorithm published in JWKS
+ *  - the credential-issuer endpoint URLs
+ *
+ * Centralizing the derivation here means a future host rename or DID
+ * method change touches one file, not four. Each handler imports from
+ * this module and never invents identifiers locally.
+ */
+
+const DEFAULT_HOST = 'app.vitalcv.com';
+
+/**
+ * Returns the origin the issuer publishes itself under. Order of preference:
+ *   1. `VITALCV_ISSUER_ORIGIN` explicit override (production / staging)
+ *   2. `VERCEL_PROJECT_PRODUCTION_URL` / `VERCEL_URL` (deploy-derived)
+ *   3. `DEFAULT_HOST` fallback
+ *
+ * The origin is always returned WITHOUT a trailing slash so callers can
+ * concatenate paths safely.
+ */
+export function getIssuerOrigin(): string {
+  const explicit = (process.env.VITALCV_ISSUER_ORIGIN ?? '').trim();
+  if (explicit) return normalizeOrigin(explicit);
+
+  const vercelProd = (process.env.VERCEL_PROJECT_PRODUCTION_URL ?? '').trim();
+  if (vercelProd) return normalizeOrigin(`https://${vercelProd}`);
+
+  const vercel = (process.env.VERCEL_URL ?? '').trim();
+  if (vercel) return normalizeOrigin(`https://${vercel}`);
+
+  return `https://${DEFAULT_HOST}`;
+}
+
+function normalizeOrigin(raw: string): string {
+  let value = raw.trim();
+  if (!value.startsWith('http://') && !value.startsWith('https://')) {
+    value = `https://${value}`;
+  }
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * Returns the host portion of the issuer origin (no scheme, no port for
+ * standard ports). Used to derive the `did:web:` identifier so it stays
+ * in lock-step with the public origin.
+ */
+export function getIssuerHost(): string {
+  const origin = getIssuerOrigin();
+  try {
+    const url = new URL(origin);
+    // did:web encodes the port if non-default. Strip default ports.
+    if (
+      (url.protocol === 'https:' && (url.port === '' || url.port === '443')) ||
+      (url.protocol === 'http:' && (url.port === '' || url.port === '80'))
+    ) {
+      return url.hostname;
+    }
+    return `${url.hostname}%3A${url.port}`;
+  } catch {
+    return DEFAULT_HOST;
+  }
+}
+
+/**
+ * Canonical issuer DID. `did:web:` is used because the JWKS is already
+ * published at the same origin — verifiers resolve `did:web:<host>` by
+ * fetching `https://<host>/.well-known/did.json`, which this PR mounts.
+ */
+export function getIssuerDid(): string {
+  return `did:web:${getIssuerHost()}`;
+}
+
+/**
+ * Verification-method id format per W3C DID Core. The fragment matches
+ * the JWK `kid` so a verifier reading a receipt's `kid` header can
+ * navigate directly to the matching verificationMethod in did.json.
+ *
+ * The kid is currently produced by `getOrInitKeypair()` in
+ * `lib/crypto/receiptIssuer.ts`; this helper accepts the resolved kid
+ * so the route handler stays the single point that touches keypair
+ * state.
+ */
+export function getVerificationMethodId(did: string, kid: string): string {
+  return `${did}#${kid}`;
+}
+
+/**
+ * Runtime channel — surfaced on the trust register so external
+ * verifiers can tell whether they're inspecting a production issuer or
+ * a preview deploy.
+ */
+export type RuntimeChannel = 'production' | 'staging' | 'operator_preview' | 'local_dev';
+
+export function getRuntimeChannel(): RuntimeChannel {
+  const explicit = (process.env.VITALCV_RUNTIME_CHANNEL ?? '').trim().toLowerCase();
+  if (explicit === 'production' || explicit === 'staging' || explicit === 'operator_preview' || explicit === 'local_dev') {
+    return explicit;
+  }
+  if (process.env.VERCEL_ENV === 'production') return 'production';
+  if (process.env.VERCEL_ENV === 'preview') return 'operator_preview';
+  if (process.env.NODE_ENV === 'production') return 'production';
+  return 'local_dev';
+}
+
+/**
+ * Deploy commit (used as a build-identity stamp on the trust register).
+ * Falls back to 'unknown' when the env isn't populated (local dev).
+ */
+export function getDeployCommit(): string {
+  return (
+    process.env.VITALCV_DEPLOY_COMMIT ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    'unknown'
+  ).trim() || 'unknown';
+}


### PR DESCRIPTION
## Summary

Closes the verifier-continuity gap end-to-end. An external verifier with no privileged access can now:

1. Discover the issuer at `/.well-known/did.json`
2. Resolve key material at `/.well-known/jwks.json` (RFC 8615)
3. Read OID4VCI metadata at `/.well-known/openid-credential-issuer`
4. Inspect the institutional manifest at `/.well-known/trust-register`
5. Fetch a signed receipt at `/api/receipt/<npi>`
6. Cryptographically validate the receipt against the JWKS

All six surfaces share `getPublicKeyJwk()` + `getIssuerDid()` so kid + DID coherence is structural.

## Surfaces

| Surface | Spec | Content-Type |
|---|---|---|
| `/.well-known/jwks.json` | RFC 8615 + RFC 7517 | `application/jwk-set+json` |
| `/.well-known/did.json` | W3C DID Core (`did:web`) | `application/did+json` |
| `/.well-known/openid-credential-issuer` | OID4VCI (drafts 11 + 13+) | `application/json` |
| `/.well-known/trust-register` | VitalCV institutional manifest (`schema_version: 1`) | `application/json` |
| `/api/receipt/[npi]` | ES256 JWT, W3C VC 2.0 | `application/jwt` |

## Receipt endpoint

Signs an ES256 JWT using the same private key whose public component is published at `/.well-known/jwks.json`. Payload contains both the W3C VC 2.0 credential block (`VitalCVTrustReceipt`) and a VitalCV claim block carrying the deterministic replay identity (`lineageKey` + `runId` + `schemeVersion`).

**Determinism contract:**
- `jti = 'receipt:<replay.runId>'` — same evidence snapshot → same jti
- `iat = lastCheckedAt` (seconds) — payload byte-identical across re-issuance for the same snapshot
- `exp = iat + 90 days`

**Self-describing:** `vcv.jwksUri` and `vcv.didDocumentUri` in the payload point at the well-known surfaces this same PR mounts. Response headers (`X-Receipt-Kid`, `X-Receipt-Issuer`) let verifiers short-circuit JWKS lookup if cached.

**Download mode:** `?format=download` adds `Content-Disposition: attachment` for offline validation.

## Cross-surface invariant (pinned)

5 vitest cases for well-known surfaces include a coherence check: all four surfaces agree on issuer DID, JWKS URI, and active kid. The 10-case receipt suite includes an **end-to-end verifier flow**: `createLocalJWKSet(jwks) + jwtVerify(receipt)` — the receipt validates against the JWKS using the same library an external verifier would use.

## Truth rules
- Banned-strings scan: CLEAN
- `trust-register` carries explicit `disclaimers[]`: no implied PSV beyond cited source; signature verification ≠ compliance certification; absence of adverse findings ≠ positive verification
- No fake compliance claims

## Validation
- Targeted vitest: **15/15** passing (5 well-known + 10 receipt)
- Full build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**
- Diff scope: 6 new route files + 1 helper module + 2 test files; **zero existing files modified**

## Backward compatibility
- Pre-existing `/api/.well-known/jwks.json` handler is preserved
- All new routes are purely additive

## Out of scope (explicit follow-ups)
- `/replay/[runId]` page + `/api/replay/[runId]` — Wave 17
- `/trust` overview page — separate
- Middleware 404-not-500 doctrine fix — separate
- DIF `did-configuration` linkage — depends on cross-signing infra