### PR TITLE
feat(trust): recent-NPI replay-memory rendering on passport surface

### DIFF
--- a/apps/web/__tests__/recent-npis.test.tsx
+++ b/apps/web/__tests__/recent-npis.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Pins the recent-NPI replay-memory primitive on three load-bearing
+ * properties:
+ *
+ *   1. The pure `applyRecentNpiUpdate()` reducer enforces dedupe +
+ *      move-to-head + replayCount-increment + cap=10.
+ *   2. The `<RecentNpis>` primitive renders identifiers as visible
+ *      monospace text (not aria-only), surfaces the "replayed Nx"
+ *      indicator on re-touched entries, and renders an empty state
+ *      that reads as institutional absence-of-history.
+ *   3. Doctrine: no banned strings; no bare `Verified` label.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import {
+  applyRecentNpiUpdate,
+  RECENT_NPIS_CAP,
+  type RecentNpiEntry,
+} from '@/lib/hooks/useRecentNpis';
+import { RecentNpis } from '@/components/trust';
+
+const FIXED_NOW = new Date('2026-05-12T12:00:00.000Z');
+
+function entry(npi: string, overrides: Partial<RecentNpiEntry> = {}): RecentNpiEntry {
+  return {
+    npi,
+    displayName: 'Test Clinician',
+    lineageKey: `lin_v1_${npi}`,
+    runId: `run_v1_${npi}aaaa`,
+    lastCheckedAt: '2026-04-01T15:00:00.000Z',
+    viewedAt: '2026-05-01T10:00:00.000Z',
+    replayCount: 1,
+    ...overrides,
+  };
+}
+
+describe('applyRecentNpiUpdate — reducer contract', () => {
+  it('inserts a new NPI at the head with replayCount=1', () => {
+    const out = applyRecentNpiUpdate([], { npi: '1346053246' }, FIXED_NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].npi).toBe('1346053246');
+    expect(out[0].replayCount).toBe(1);
+    expect(out[0].viewedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it('moves an existing NPI to the head and increments replayCount', () => {
+    const prior = [entry('1111111111'), entry('1346053246'), entry('2222222222')];
+    const out = applyRecentNpiUpdate(prior, { npi: '2222222222' }, FIXED_NOW);
+    expect(out.map((e) => e.npi)).toEqual(['2222222222', '1111111111', '1346053246']);
+    expect(out[0].replayCount).toBe(2);
+    expect(out[0].viewedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it('does not duplicate when re-touching the same NPI multiple times', () => {
+    let state: RecentNpiEntry[] = [];
+    state = applyRecentNpiUpdate(state, { npi: '1346053246' }, FIXED_NOW);
+    state = applyRecentNpiUpdate(state, { npi: '1346053246' }, FIXED_NOW);
+    state = applyRecentNpiUpdate(state, { npi: '1346053246' }, FIXED_NOW);
+    expect(state).toHaveLength(1);
+    expect(state[0].replayCount).toBe(3);
+  });
+
+  it('rejects an invalid NPI and returns the prior state unchanged', () => {
+    const prior = [entry('1111111111')];
+    const out = applyRecentNpiUpdate(prior, { npi: 'not-a-npi' });
+    expect(out).toEqual(prior);
+  });
+
+  it(`caps the list at ${RECENT_NPIS_CAP}`, () => {
+    let state: RecentNpiEntry[] = [];
+    for (let i = 0; i < 15; i += 1) {
+      // Generate 10-digit NPIs by left-padding the index.
+      const npi = `${1000000000 + i}`;
+      state = applyRecentNpiUpdate(state, { npi }, FIXED_NOW);
+    }
+    expect(state).toHaveLength(RECENT_NPIS_CAP);
+    // Newest first → highest-indexed should be at the head.
+    expect(state[0].npi).toBe('1000000014');
+  });
+
+  it('preserves prior metadata when re-touching with absent fields', () => {
+    const prior = [entry('1346053246', { displayName: 'Macie Miller', runId: 'run_v1_AAAA' })];
+    const out = applyRecentNpiUpdate(prior, { npi: '1346053246' }, FIXED_NOW);
+    expect(out[0].displayName).toBe('Macie Miller');
+    expect(out[0].runId).toBe('run_v1_AAAA');
+  });
+
+  it('overrides prior metadata when re-touching with present fields', () => {
+    const prior = [entry('1346053246', { runId: 'run_v1_OLD_' })];
+    const out = applyRecentNpiUpdate(
+      prior,
+      { npi: '1346053246', runId: 'run_v1_NEW_' },
+      FIXED_NOW,
+    );
+    expect(out[0].runId).toBe('run_v1_NEW_');
+  });
+});
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+describe('<RecentNpis> — visibility + replay rendering', () => {
+  it('empty state renders explicit no-history line (not a placeholder card)', () => {
+    const html = render(<RecentNpis items={[]} />);
+    expect(html).toContain('No recent inspections on this client.');
+    expect(html).toContain('data-recent-npis-count="0"');
+  });
+
+  it('renders the NPI as visible monospace text + clickable link', () => {
+    const html = render(<RecentNpis items={[entry('1346053246')]} />);
+    expect(html).toMatch(/>1346053246</);
+    expect(html).toContain('href="/passport/1346053246"');
+    expect(html).toContain('data-npi="1346053246"');
+  });
+
+  it('surfaces the "replayed Nx" indicator when replayCount > 1', () => {
+    const html = render(
+      <RecentNpis items={[entry('1346053246', { replayCount: 3 })]} />,
+    );
+    expect(html).toContain('replayed 3x');
+    expect(html).toContain('data-replay-count="3"');
+  });
+
+  it('does not render the replay indicator on first-time entries', () => {
+    const html = render(
+      <RecentNpis items={[entry('1346053246', { replayCount: 1 })]} />,
+    );
+    expect(html).not.toContain('replayed');
+  });
+
+  it('highlights the currentNpi entry', () => {
+    const html = render(
+      <RecentNpis
+        items={[entry('1346053246'), entry('1111111111')]}
+        currentNpi="1346053246"
+      />,
+    );
+    // The current entry carries data-current="true" and a visible "current" label
+    expect(html).toMatch(/data-npi="1346053246"[^>]*data-replay-count="\d+"[^>]*data-current="true"/);
+    expect(html).toContain('>current</span>');
+  });
+
+  it('respects the max prop', () => {
+    const items = Array.from({ length: 8 }, (_, i) => entry(`${1000000000 + i}`));
+    const html = render(<RecentNpis items={items} max={3} />);
+    expect(html).toContain('data-recent-npis-count="3"');
+  });
+});
+
+describe('doctrine — banned-strings scan', () => {
+  it('renders no banned phrases', () => {
+    const items = [
+      entry('1346053246', { replayCount: 3 }),
+      entry('1111111111'),
+    ];
+    const html = render(<RecentNpis items={items} currentNpi="1346053246" />);
+    const banned = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+    ];
+    for (const phrase of banned) {
+      expect(html).not.toContain(phrase);
+    }
+    // No bare "Verified" label
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+});

--- a/apps/web/app/passport/[id]/PassportEntityClient.tsx
+++ b/apps/web/app/passport/[id]/PassportEntityClient.tsx
@@ -5,9 +5,10 @@ import Link from 'next/link';
 import PassportWallet from '@/components/passport/PassportWallet';
 import { Button } from '@/components/ui/button';
 import { TrustStateCard } from '@/components/trust/TrustStateCard';
-import { TrustHeader } from '@/components/trust';
+import { TrustHeader, RecentNpis } from '@/components/trust';
 import { fetchPassportEntity } from '@/lib/api';
 import type { PassportData } from '@/lib/trust/passport-contract';
+import { useRecentNpis } from '@/lib/hooks/useRecentNpis';
 import { KnowledgeInboxPanel } from '@/components/knowledge-inbox/KnowledgeInboxPanel';
 import type { KnowledgeInboxItem } from '@/lib/knowledge-inbox/types';
 import { LaneHealthMount } from '@/components/source-health/LaneHealthMount';
@@ -19,6 +20,7 @@ interface PassportEntityClientProps {
 export default function PassportEntityClient({ entityId }: PassportEntityClientProps) {
   const [passport, setPassport] = useState<PassportData | null>(null);
   const [loading, setLoading] = useState(true);
+  const { items: recentNpis, recordRecentNpi } = useRecentNpis();
 
   useEffect(() => {
     let cancelled = false;
@@ -38,6 +40,27 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
       cancelled = true;
     };
   }, [entityId]);
+
+  // Record this inspection in the client's replay memory once the
+  // passport resolves. The hook handles dedupe + replayCount increment.
+  useEffect(() => {
+    if (!passport) return;
+    const npi = passport.identity.npi;
+    if (!npi || !/^\d{10}$/.test(npi)) return;
+    // Wave 10 (#343) adds `replay.runId` + `replay.lineageKey` on
+    // PassportData; until that lands, the optional cast reads them
+    // when present and silently omits them when not.
+    const replay = (passport as PassportData & {
+      replay?: { runId: string; lineageKey: string; schemeVersion: 'v1' };
+    }).replay;
+    recordRecentNpi({
+      npi,
+      displayName: passport.identity.displayName,
+      lastCheckedAt: passport.lastCheckedAt,
+      runId: replay?.runId,
+      lineageKey: replay?.lineageKey,
+    });
+  }, [passport, recordRecentNpi]);
 
   if (loading) {
     return <PassportWallet loading />;
@@ -127,6 +150,12 @@ export default function PassportEntityClient({ entityId }: PassportEntityClientP
             </p>
           </header>
           <KnowledgeInboxPanel items={inboxItems} />
+        </section>
+        <section
+          aria-label="Recent NPI inspections"
+          data-testid="passport-recent-npis-mount"
+        >
+          <RecentNpis items={recentNpis} currentNpi={passport.identity.npi} />
         </section>
       </div>
     </div>

--- a/apps/web/components/trust/RecentNpis.tsx
+++ b/apps/web/components/trust/RecentNpis.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { CheckedAtStamp } from './CheckedAtStamp';
+import { RunIdentity } from './RunIdentity';
+import type { RecentNpiEntry } from '@/lib/hooks/useRecentNpis';
+
+/**
+ * RecentNpis — institutional replay-chain rendering of NPIs inspected
+ * on this client. Reads as an audit log, not as a card grid: monospace
+ * identifiers, left-aligned, no shadows, no decoration. Replay
+ * indicator is explicit text (`replayed Nx`) when an NPI has been
+ * re-touched, so a verifier reads "this subject has been inspected
+ * multiple times in this session" without inspecting devtools.
+ *
+ * Composition (reuses Lane B primitives — no new visual vocabulary):
+ *  - <CheckedAtStamp>     per row's `lastCheckedAt`
+ *  - <RunIdentity>        per row's `runId`
+ *
+ * Empty state renders an explicit "No recent inspections" line — never
+ * a placeholder card or skeleton, since absence-of-history is a real
+ * institutional signal (this is a fresh client / cleared cache) and
+ * should read as such.
+ */
+export interface RecentNpisProps {
+  items: readonly RecentNpiEntry[];
+  /** Highlight a particular NPI (e.g. the one the surface currently shows). */
+  currentNpi?: string;
+  /** Optional header label. Defaults to "recent inspections". */
+  label?: string;
+  /** Max items to render. Defaults to 10 (= storage cap). */
+  max?: number;
+  className?: string;
+}
+
+export function RecentNpis({
+  items,
+  currentNpi,
+  label = 'recent inspections',
+  max = 10,
+  className,
+}: RecentNpisProps): React.ReactElement {
+  const shown = items.slice(0, max);
+  return (
+    <section
+      className={cn(
+        'flex flex-col gap-2 border-t border-border pt-3',
+        className,
+      )}
+      data-recent-npis-count={shown.length}
+      aria-label="Recent NPI inspections"
+    >
+      <header className="flex items-baseline justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+          {label}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider opacity-60">
+          {shown.length} / {max}
+        </span>
+      </header>
+
+      {shown.length === 0 && (
+        <p className="text-[11px] italic opacity-70">
+          No recent inspections on this client.
+        </p>
+      )}
+
+      {shown.length > 0 && (
+        <ol className="flex flex-col" role="list">
+          {shown.map((entry, i) => {
+            const isCurrent = currentNpi === entry.npi;
+            const replayed = entry.replayCount > 1;
+            return (
+              <li
+                key={entry.npi}
+                className={cn(
+                  'flex flex-wrap items-baseline gap-x-3 gap-y-1 py-1.5 text-[11px]',
+                  i > 0 && 'border-t border-border/40',
+                  isCurrent && 'bg-foreground/[0.02] -mx-2 px-2',
+                )}
+                data-npi={entry.npi}
+                data-replay-count={entry.replayCount}
+                data-current={isCurrent ? 'true' : 'false'}
+              >
+                <span
+                  aria-hidden="true"
+                  className="font-mono text-muted-foreground"
+                >
+                  {i === 0 ? '┌' : i === shown.length - 1 ? '└' : '├'}
+                </span>
+                <Link
+                  href={`/passport/${entry.npi}`}
+                  className="font-mono text-foreground hover:underline"
+                  prefetch={false}
+                >
+                  {entry.npi}
+                </Link>
+                {entry.displayName && (
+                  <span className="opacity-80">{entry.displayName}</span>
+                )}
+                {replayed && (
+                  <span
+                    className="font-mono uppercase tracking-wider text-[10px] text-amber-700 dark:text-amber-300"
+                    title="previously checked on this client"
+                  >
+                    replayed {entry.replayCount}x
+                  </span>
+                )}
+                {isCurrent && (
+                  <span className="font-mono uppercase tracking-wider text-[10px] text-emerald-700 dark:text-emerald-300">
+                    current
+                  </span>
+                )}
+                {entry.lastCheckedAt && (
+                  <CheckedAtStamp
+                    checkedAt={entry.lastCheckedAt}
+                    label="checked"
+                    format="long"
+                    className="text-[10px]"
+                  />
+                )}
+                {entry.runId && (
+                  <RunIdentity
+                    runId={entry.runId}
+                    label="run"
+                    displayChars={10}
+                    className="text-[10px]"
+                  />
+                )}
+                <CheckedAtStamp
+                  checkedAt={entry.viewedAt}
+                  label="viewed"
+                  format="long"
+                  className="text-[10px] ml-auto opacity-70"
+                />
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/trust/index.ts
+++ b/apps/web/components/trust/index.ts
@@ -64,3 +64,7 @@ export {
   type TrustHeaderOwnership,
   type TrustHeaderReplay,
 } from './TrustHeader';
+export {
+  RecentNpis,
+  type RecentNpisProps,
+} from './RecentNpis';

--- a/apps/web/lib/hooks/useRecentNpis.ts
+++ b/apps/web/lib/hooks/useRecentNpis.ts
@@ -1,0 +1,176 @@
+'use client';
+/**
+ * Recent-NPI session memory hook.
+ *
+ * The Lane A audit (PR #341/#345 era) flagged that the only durable
+ * "what was inspected in this session" surface was the in-process
+ * `useIngestStream` state plus a session-storage key
+ * (`vitalcv:preview:${npi}`) — neither was rendered to the user.
+ *
+ * This hook persists a small list (cap=10) of recently-inspected NPIs
+ * across page navigations and tabs, so the `<RecentNpis>` primitive
+ * can render the replay-chain visibly. Storage is `localStorage` (not
+ * sessionStorage) so a verifier returning to the surface after a
+ * browser restart still sees the recent inspection lineage.
+ *
+ * Storage shape (versioned for forward compatibility):
+ *   localStorage['vitalcv:recent-npis'] = JSON.stringify({
+ *     version: 1,
+ *     items: Array<RecentNpiEntry>,  // newest first, cap 10
+ *   })
+ *
+ * Determinism: an existing NPI being re-inspected is moved to the head
+ * of the list (not duplicated). The hook surfaces `replayCount` per
+ * entry — incremented every time the NPI is re-touched — so the UI
+ * can render a "previously checked Nx" replay indicator without
+ * client-side rederivation.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+export const RECENT_NPIS_STORAGE_KEY = 'vitalcv:recent-npis';
+export const RECENT_NPIS_CAP = 10;
+export const RECENT_NPIS_VERSION = 1;
+
+export interface RecentNpiEntry {
+  /** 10-digit NPI as observed on the surface. */
+  npi: string;
+  /** Display name from the passport, if known. */
+  displayName?: string;
+  /** Stable canonical replay key for the subject. */
+  lineageKey?: string;
+  /** Most recent run id observed for this NPI. */
+  runId?: string;
+  /** Most recent passport `lastCheckedAt` observed for this NPI. */
+  lastCheckedAt?: string;
+  /** ISO timestamp of when the user last viewed this NPI in this client. */
+  viewedAt: string;
+  /** How many times this NPI has been re-touched on this client. */
+  replayCount: number;
+}
+
+interface StoredShape {
+  version: number;
+  items: RecentNpiEntry[];
+}
+
+function readStorage(): RecentNpiEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_NPIS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Partial<StoredShape>;
+    if (!parsed || typeof parsed !== 'object') return [];
+    if (parsed.version !== RECENT_NPIS_VERSION) return [];
+    if (!Array.isArray(parsed.items)) return [];
+    return parsed.items.filter(isValidEntry);
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(items: RecentNpiEntry[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload: StoredShape = { version: RECENT_NPIS_VERSION, items };
+    window.localStorage.setItem(RECENT_NPIS_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage may be unavailable in some sandboxed contexts.
+    // Failing silently is correct here — recent-NPIs is a UX enhancement,
+    // not a load-bearing trust signal.
+  }
+}
+
+function isValidEntry(v: unknown): v is RecentNpiEntry {
+  if (!v || typeof v !== 'object') return false;
+  const e = v as Record<string, unknown>;
+  return (
+    typeof e.npi === 'string'
+    && /^\d{10}$/.test(e.npi)
+    && typeof e.viewedAt === 'string'
+    && typeof e.replayCount === 'number'
+    && Number.isFinite(e.replayCount)
+  );
+}
+
+export interface RecordRecentNpiInput {
+  npi: string;
+  displayName?: string;
+  lineageKey?: string;
+  runId?: string;
+  lastCheckedAt?: string;
+}
+
+/**
+ * Move-to-head + replayCount-increment update. Pure function — extracted
+ * so it can be unit-tested independent of the React hook.
+ */
+export function applyRecentNpiUpdate(
+  prior: readonly RecentNpiEntry[],
+  input: RecordRecentNpiInput,
+  now: Date = new Date(),
+): RecentNpiEntry[] {
+  if (!/^\d{10}$/.test(input.npi)) return [...prior];
+  const existingIndex = prior.findIndex((e) => e.npi === input.npi);
+  const viewedAt = now.toISOString();
+  let next: RecentNpiEntry;
+  if (existingIndex >= 0) {
+    const existing = prior[existingIndex];
+    next = {
+      ...existing,
+      displayName: input.displayName ?? existing.displayName,
+      lineageKey: input.lineageKey ?? existing.lineageKey,
+      runId: input.runId ?? existing.runId,
+      lastCheckedAt: input.lastCheckedAt ?? existing.lastCheckedAt,
+      viewedAt,
+      replayCount: existing.replayCount + 1,
+    };
+  } else {
+    next = {
+      npi: input.npi,
+      displayName: input.displayName,
+      lineageKey: input.lineageKey,
+      runId: input.runId,
+      lastCheckedAt: input.lastCheckedAt,
+      viewedAt,
+      replayCount: 1,
+    };
+  }
+  const filtered = prior.filter((e) => e.npi !== input.npi);
+  return [next, ...filtered].slice(0, RECENT_NPIS_CAP);
+}
+
+export interface UseRecentNpisResult {
+  items: RecentNpiEntry[];
+  recordRecentNpi: (input: RecordRecentNpiInput) => void;
+  clearRecentNpis: () => void;
+}
+
+export function useRecentNpis(): UseRecentNpisResult {
+  const [items, setItems] = useState<RecentNpiEntry[]>([]);
+
+  // Hydrate from storage on mount only — no SSR storage access.
+  useEffect(() => {
+    setItems(readStorage());
+  }, []);
+
+  const recordRecentNpi = useCallback((input: RecordRecentNpiInput) => {
+    setItems((prior) => {
+      const next = applyRecentNpiUpdate(prior, input);
+      writeStorage(next);
+      return next;
+    });
+  }, []);
+
+  const clearRecentNpis = useCallback(() => {
+    setItems([]);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(RECENT_NPIS_STORAGE_KEY);
+      } catch {
+        // see writeStorage()
+      }
+    }
+  }, []);
+
+  return { items, recordRecentNpi, clearRecentNpis };
+}


### PR DESCRIPTION
## Summary

Closes the lone remaining gap from the "finish replay lineage rendering" brief — recent-NPI rendering. All other items in that brief were already shipped:

| Brief item | Existing PR |
|---|---|
| checked_at rendering | `<CheckedAtStamp>` #341 |
| run_id rendering | `<RunIdentity>` #341 |
| ownership state | `<OwnershipState>` #341 |
| T1–T4 badges | `<TierBadge>` #341 |
| replay continuity panel | `<ReplayLineage>` #341 |
| canonical render order | `<TrustHeader>` #341 |
| surfaces match | #342 + #345 |
| **recent-NPI rendering** | **this PR** |

**Stacked on #342** so the `PassportEntityClient.tsx` adoption folds into the same file authority #342 already owns.

## What ships

| File | Status |
|---|---|
| `apps/web/lib/hooks/useRecentNpis.ts` | **new** — pure reducer + React hook, localStorage-backed, SSR-safe, versioned schema |
| `apps/web/components/trust/RecentNpis.tsx` | **new** — primitive reusing Lane B `<CheckedAtStamp>` + `<RunIdentity>` |
| `apps/web/components/trust/index.ts` | barrel export |
| `apps/web/app/passport/[id]/PassportEntityClient.tsx` | adopts hook + primitive; renders below KnowledgeInboxPanel |
| `apps/web/__tests__/recent-npis.test.tsx` | **new** — 14 vitest cases |

## Reducer contract (test-pinned)

| Property | Behavior |
|---|---|
| Insert | new NPI lands at head with `replayCount=1` |
| Re-touch | existing NPI moves to head; `replayCount` increments |
| Triple-touch | one entry, `replayCount=3` (no duplicates) |
| Invalid NPI | prior state returned unchanged |
| Cap | 10 entries max; oldest evicted |
| Metadata merge | re-touch with present fields overrides; absent fields preserved |

## UI contract (test-pinned)

- NPI rendered as **visible monospace text** inside a `<Link>` to `/passport/<npi>` (not aria-only, not tooltip-only)
- `replayed Nx` indicator surfaces when `replayCount > 1` — a verifier reads "previously checked" without inspecting devtools
- Empty state is explicit "No recent inspections on this client." — institutional absence-of-history, not a placeholder card
- `currentNpi` prop highlights the matching entry with a visible "current" badge

## Aesthetic compliance

Per requirements: reuses existing Lane B primitives only; no new visual vocabulary; mono identifiers; left-aligned; no cards, no shadows, no gradients, no decorative UI. Each row is a single flex line with `┌ ├ └` connector glyphs.

## Truth rules
- Banned-strings scan: CLEAN
- No bare `Verified` label

## Validation
- Targeted vitest: **14/14** passing
- Full build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**
- Adoption files modified: 1 (`PassportEntityClient.tsx` — same file #342 modifies; net additive)

## Out of scope (explicit follow-ups)
- `/verify` page adoption — requires stacking on #345 or folding via amend; one-line change
- `/replay/[runId]` standalone surface — Wave 17 (doesn't exist as a route)