### PR TITLE
feat(replay): operational integrity scripts (verify, find-gaps, reconcile)

### DIFF
--- a/apps/web/__tests__/replay-scripts.test.ts
+++ b/apps/web/__tests__/replay-scripts.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for the three replay-integrity CLI scripts.
+ *
+ * Each script exports a pure function (verifyReplayIntegrity,
+ * findReplayGaps, reconcileLineage) that the `main()` wrapper drives.
+ * Tests exercise the pure function directly — fast, deterministic,
+ * no process spawning, no filesystem fixtures beyond _lib parsing.
+ */
+import { findReplayGaps } from '../../../scripts/replay/find-replay-gaps';
+import { reconcileLineage } from '../../../scripts/replay/reconcile-lineage';
+import { verifyReplayIntegrity } from '../../../scripts/replay/verify-replay-integrity';
+import {
+  normalizeEvidence,
+  parseArgs,
+  hoursBetween,
+  chronologyKey,
+  type ReplayEvidence,
+} from '../../../scripts/replay/_lib';
+
+const BASE_EVIDENCE: ReplayEvidence = {
+  entityId: '1346053246',
+  lastCheckedAt: '2026-04-01T15:00:00.000Z',
+  artifactChecksums: ['cks-aaa', 'cks-bbb', 'cks-ccc'],
+  channel: 'NPPES_API',
+};
+
+describe('_lib parseArgs', () => {
+  it('parses --key=value form', () => {
+    const { flags } = parseArgs(['--evidence=/tmp/x.json', '--expected-run-id=run_v1_a']);
+    expect(flags.get('evidence')).toBe('/tmp/x.json');
+    expect(flags.get('expected-run-id')).toBe('run_v1_a');
+  });
+  it('parses --key value form', () => {
+    const { flags } = parseArgs(['--evidence', '/tmp/x.json', '--max-gap-hours', '720']);
+    expect(flags.get('evidence')).toBe('/tmp/x.json');
+    expect(flags.get('max-gap-hours')).toBe('720');
+  });
+  it('treats a flag without a value as "1"', () => {
+    const { flags } = parseArgs(['--verbose']);
+    expect(flags.get('verbose')).toBe('1');
+  });
+  it('separates positional args', () => {
+    const { flags, positional } = parseArgs(['cmd', '--flag', 'value', 'arg']);
+    expect(positional).toEqual(['cmd', 'arg']);
+    expect(flags.get('flag')).toBe('value');
+  });
+});
+
+describe('_lib normalizeEvidence', () => {
+  it('coerces a permissive shape into strict ReplayEvidence', () => {
+    const result = normalizeEvidence({
+      entityId: '  1346053246  ',
+      lastCheckedAt: '2026-04-01T15:00:00.000Z',
+      artifactChecksums: ['cks-aaa', '', '  cks-bbb', 42, 'cks-ccc'],
+      channel: ' NPPES_API ',
+    });
+    expect(result.entityId).toBe('1346053246');
+    expect(result.artifactChecksums).toEqual(['cks-aaa', 'cks-bbb', 'cks-ccc']);
+    expect(result.channel).toBe('NPPES_API');
+  });
+  it('throws on missing entityId', () => {
+    expect(() => normalizeEvidence({})).toThrow(/entityId is required/);
+  });
+  it('accepts null lastCheckedAt for degraded runs', () => {
+    const result = normalizeEvidence({
+      entityId: '1346053246',
+      lastCheckedAt: null,
+    });
+    expect(result.lastCheckedAt).toBeNull();
+  });
+});
+
+describe('_lib chronologyKey + hoursBetween', () => {
+  it('chronologyKey returns a sortable lexicographic key', () => {
+    const a = chronologyKey('2026-04-01T00:00:00Z');
+    const b = chronologyKey('2026-04-02T00:00:00Z');
+    expect(a < b).toBe(true);
+  });
+  it('chronologyKey returns sentinel for null', () => {
+    const k = chronologyKey(null);
+    expect(k.startsWith('0000')).toBe(true);
+  });
+  it('hoursBetween computes positive hours forward', () => {
+    expect(hoursBetween('2026-04-01T00:00:00Z', '2026-04-01T12:00:00Z')).toBe(12);
+  });
+  it('hoursBetween returns null when either side is null/invalid', () => {
+    expect(hoursBetween(null, '2026-04-01T00:00:00Z')).toBeNull();
+    expect(hoursBetween('not-a-date', '2026-04-01T00:00:00Z')).toBeNull();
+  });
+});
+
+// ─── verifyReplayIntegrity ─────────────────────────────────────────────────
+
+describe('verifyReplayIntegrity', () => {
+  it('reports all integrity properties OK for a clean fixture', () => {
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, null);
+    expect(findings.every((f) => f.ok)).toBe(true);
+    const summary = findings.find((f) => f.finding === 'summary');
+    expect(summary?.detail.runId).toMatch(/^run_v1_[0-9a-f]{16}$/);
+    expect(summary?.detail.lineageKey).toMatch(/^lin_v1_[0-9a-f]{16}$/);
+  });
+
+  it('determinism finding reports a single uniqueRunId across 25 iterations', () => {
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, null);
+    const det = findings.find((f) => f.finding === 'determinism');
+    expect(det?.ok).toBe(true);
+    expect(det?.detail.iterations).toBe(25);
+    expect(det?.detail.uniqueRunIds).toBe(1);
+  });
+
+  it('cosmetic-invariance finding is OK (reverse + whitespace pad does not change id)', () => {
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, null);
+    const cos = findings.find((f) => f.finding === 'cosmetic-invariance');
+    expect(cos?.ok).toBe(true);
+    expect(cos?.detail.original).toBe(cos?.detail.cosmeticVariant);
+  });
+
+  it('sensitivity finding is OK (tampered inputs diverge)', () => {
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, null);
+    const sens = findings.find((f) => f.finding === 'sensitivity');
+    expect(sens?.ok).toBe(true);
+    expect(sens?.detail.tamperedCheckedAt).not.toBe(sens?.detail.runId);
+    expect(sens?.detail.tamperedChecksums).not.toBe(sens?.detail.runId);
+  });
+
+  it('reports expected-match OK when expectedRunId equals recomputed', () => {
+    // Compute the canonical runId first so we can pass it as "expected"
+    const probe = verifyReplayIntegrity(BASE_EVIDENCE, null);
+    const summary = probe.find((f) => f.finding === 'summary');
+    const expected = summary?.detail.runId as string;
+
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, expected);
+    const match = findings.find((f) => f.finding === 'expected-match');
+    expect(match?.ok).toBe(true);
+  });
+
+  it('reports expected-match FAILED when expectedRunId diverges (audit-corruption signal)', () => {
+    const findings = verifyReplayIntegrity(BASE_EVIDENCE, 'run_v1_deadbeefdeadbeef');
+    const match = findings.find((f) => f.finding === 'expected-match');
+    const summary = findings.find((f) => f.finding === 'summary');
+    expect(match?.ok).toBe(false);
+    expect(summary?.ok).toBe(false);
+  });
+});
+
+// ─── findReplayGaps ───────────────────────────────────────────────────────
+
+describe('findReplayGaps', () => {
+  it('reports continuous when all snapshots are within threshold', () => {
+    const report = findReplayGaps(
+      {
+        entityId: '1346053246',
+        snapshots: [
+          { runId: 'run_v1_a', lastCheckedAt: '2026-03-01T00:00:00Z' },
+          { runId: 'run_v1_b', lastCheckedAt: '2026-03-15T00:00:00Z' },
+          { runId: 'run_v1_c', lastCheckedAt: '2026-03-25T00:00:00Z' },
+        ],
+      },
+      720, // 30 days
+    );
+    expect(report.continuous).toBe(true);
+    expect(report.gaps).toHaveLength(0);
+    expect(report.snapshotCount).toBe(3);
+  });
+
+  it('detects a single gap above threshold', () => {
+    const report = findReplayGaps(
+      {
+        entityId: '1346053246',
+        snapshots: [
+          { runId: 'run_v1_a', lastCheckedAt: '2026-01-01T00:00:00Z' },
+          { runId: 'run_v1_b', lastCheckedAt: '2026-04-01T00:00:00Z' }, // 90 days later
+        ],
+      },
+      720,
+    );
+    expect(report.continuous).toBe(false);
+    expect(report.gaps).toHaveLength(1);
+    expect(report.gaps[0].from).toBe('2026-01-01T00:00:00Z');
+    expect(report.gaps[0].to).toBe('2026-04-01T00:00:00Z');
+    expect(report.gaps[0].hoursMissing).toBeGreaterThan(720);
+    expect(report.gaps[0].priorRunId).toBe('run_v1_a');
+    expect(report.gaps[0].nextRunId).toBe('run_v1_b');
+  });
+
+  it('sorts unsorted input chronologically before scanning', () => {
+    const report = findReplayGaps(
+      {
+        entityId: '1346053246',
+        snapshots: [
+          { runId: 'run_v1_b', lastCheckedAt: '2026-04-01T00:00:00Z' },
+          { runId: 'run_v1_a', lastCheckedAt: '2026-01-01T00:00:00Z' },
+        ],
+      },
+      720,
+    );
+    expect(report.gaps[0].priorRunId).toBe('run_v1_a');
+    expect(report.gaps[0].nextRunId).toBe('run_v1_b');
+  });
+
+  it('drops snapshots with null/missing lastCheckedAt', () => {
+    const report = findReplayGaps(
+      {
+        entityId: '1346053246',
+        snapshots: [
+          { runId: 'run_v1_a', lastCheckedAt: '2026-03-01T00:00:00Z' },
+          { runId: 'run_v1_partial', lastCheckedAt: null },
+          { runId: 'run_v1_b', lastCheckedAt: '2026-03-15T00:00:00Z' },
+        ],
+      },
+      720,
+    );
+    expect(report.snapshotCount).toBe(2);
+  });
+
+  it('attaches the canonical lineageKey to every report', () => {
+    const report = findReplayGaps(
+      { entityId: '1346053246', snapshots: [] },
+      720,
+    );
+    expect(report.lineageKey).toMatch(/^lin_v1_[0-9a-f]{16}$/);
+  });
+});
+
+// ─── reconcileLineage ─────────────────────────────────────────────────────
+
+describe('reconcileLineage', () => {
+  it('same evidence → same-lineage-same-snapshot', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, BASE_EVIDENCE);
+    expect(result.outcome).toBe('same-lineage-same-snapshot');
+    expect(result.left.runId).toBe(result.right.runId);
+    expect(result.evidenceDelta.artifactsAdded).toHaveLength(0);
+    expect(result.evidenceDelta.artifactsRemoved).toHaveLength(0);
+  });
+
+  it('same entity + added artifact → same-lineage-different-snapshot', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, {
+      ...BASE_EVIDENCE,
+      artifactChecksums: [...BASE_EVIDENCE.artifactChecksums, 'cks-ddd'],
+    });
+    expect(result.outcome).toBe('same-lineage-different-snapshot');
+    expect(result.left.lineageKey).toBe(result.right.lineageKey);
+    expect(result.left.runId).not.toBe(result.right.runId);
+    expect(result.evidenceDelta.artifactsAdded).toEqual(['cks-ddd']);
+    expect(result.evidenceDelta.artifactsRemoved).toEqual([]);
+  });
+
+  it('same entity + removed artifact → same-lineage-different-snapshot with removal recorded', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, {
+      ...BASE_EVIDENCE,
+      artifactChecksums: ['cks-aaa', 'cks-bbb'],
+    });
+    expect(result.outcome).toBe('same-lineage-different-snapshot');
+    expect(result.evidenceDelta.artifactsRemoved).toEqual(['cks-ccc']);
+  });
+
+  it('different entities → different-lineage', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, {
+      ...BASE_EVIDENCE,
+      entityId: '0000000000',
+    });
+    expect(result.outcome).toBe('different-lineage');
+    expect(result.left.lineageKey).not.toBe(result.right.lineageKey);
+  });
+
+  it('lastCheckedAt-only delta → same lineage, different snapshot, delta flagged', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, {
+      ...BASE_EVIDENCE,
+      lastCheckedAt: '2026-04-15T00:00:00.000Z',
+    });
+    expect(result.outcome).toBe('same-lineage-different-snapshot');
+    expect(result.evidenceDelta.lastCheckedAtChanged).toBe(true);
+    expect(result.evidenceDelta.artifactsAdded).toHaveLength(0);
+  });
+
+  it('channel-only delta → same lineage, different snapshot, channelChanged flagged', () => {
+    const result = reconcileLineage(BASE_EVIDENCE, {
+      ...BASE_EVIDENCE,
+      channel: 'OIG_LEIE',
+    });
+    expect(result.outcome).toBe('same-lineage-different-snapshot');
+    expect(result.evidenceDelta.channelChanged).toBe(true);
+  });
+});

--- a/scripts/replay/_lib.ts
+++ b/scripts/replay/_lib.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared helpers for the replay-integrity CLI scripts.
+ *
+ * Each script under scripts/replay/* is a small operational tool that
+ * exercises the canonical replay-identity contract (apps/api/backend/
+ * src/services/replay/replayIdentity.ts, shipped in PR #343 + #344).
+ *
+ * The helpers here:
+ *   - resolve evidence inputs for an NPI either from a Prisma
+ *     connection or from a JSON file (so the scripts work in CI / dev
+ *     without a live DB)
+ *   - format human-readable + machine-readable output blocks
+ *   - parse CLI args without pulling in yargs/commander (keep the
+ *     scripts dependency-light)
+ *
+ * Scripts intentionally do NOT mutate state. They are read-only audits
+ * over persisted inputs.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Subset of `verificationArtifact` rows the replay-identity scheme
+ * cares about — entity id + lastCheckedAt + artifact checksums.
+ * Either provided via a JSON fixture or fetched from a Prisma client.
+ */
+export interface ReplayEvidence {
+  /** Canonical entity / NPI. */
+  entityId: string;
+  /** ISO timestamp of the most recent passport snapshot, or null. */
+  lastCheckedAt: string | null;
+  /** Stable artifact identifiers / checksums that contributed to this
+   *  snapshot. Order does not matter — the replay-identity generator
+   *  normalizes it inside. */
+  artifactChecksums: string[];
+  /** Optional channel — see `computeRunId` semantics. */
+  channel?: string;
+}
+
+/**
+ * Loads a JSON fixture from disk. Used by the scripts for offline
+ * verification + by unit tests. Schema is documented in
+ * `scripts/replay/__tests__/fixtures/sample-evidence.json` (added in
+ * the test suite below).
+ */
+export function loadEvidenceFromFile(path: string): ReplayEvidence {
+  const abs = resolve(path);
+  if (!existsSync(abs)) {
+    throw new Error(`evidence file not found: ${abs}`);
+  }
+  const raw = readFileSync(abs, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`evidence file ${abs} is not valid JSON: ${String(err)}`);
+  }
+  return normalizeEvidence(parsed);
+}
+
+/**
+ * Pure normalizer: accepts a permissive shape and returns the strict
+ * `ReplayEvidence` the scripts operate on. Throws on invalid input —
+ * scripts surface the error to stderr and exit non-zero.
+ */
+export function normalizeEvidence(input: unknown): ReplayEvidence {
+  if (!input || typeof input !== 'object') {
+    throw new Error('evidence must be a JSON object');
+  }
+  const obj = input as Record<string, unknown>;
+  const entityId = typeof obj.entityId === 'string' ? obj.entityId.trim() : '';
+  if (!entityId) {
+    throw new Error('evidence.entityId is required (string)');
+  }
+  const lastCheckedAt = obj.lastCheckedAt === null
+    ? null
+    : (typeof obj.lastCheckedAt === 'string' ? obj.lastCheckedAt.trim() : null);
+
+  const artifacts = Array.isArray(obj.artifactChecksums)
+    ? obj.artifactChecksums
+        .filter((c): c is string => typeof c === 'string')
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0)
+    : [];
+
+  const channel = typeof obj.channel === 'string' ? obj.channel.trim() : undefined;
+
+  return { entityId, lastCheckedAt, artifactChecksums: artifacts, channel };
+}
+
+/**
+ * Parses a simple `--key=value` / `--key value` arg vector. Returns a
+ * Map of resolved key→value plus a list of bare positional args.
+ */
+export interface ParsedArgs {
+  flags: Map<string, string>;
+  positional: string[];
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const flags = new Map<string, string>();
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq >= 0) {
+        flags.set(a.slice(2, eq), a.slice(eq + 1));
+      } else {
+        const next = argv[i + 1];
+        if (typeof next === 'string' && !next.startsWith('--')) {
+          flags.set(a.slice(2), next);
+          i += 1;
+        } else {
+          flags.set(a.slice(2), '1');
+        }
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+/**
+ * Returns a sortable order key derived from an ISO timestamp.
+ * Stable lexicographic order is used so the scripts don't depend on
+ * Date arithmetic precision.
+ */
+export function chronologyKey(iso: string | null): string {
+  return iso ?? '0000-00-00T00:00:00.000Z';
+}
+
+/**
+ * Returns hours-difference between two ISO timestamps (b - a).
+ * `null` on either side returns `null` (no signal).
+ */
+export function hoursBetween(a: string | null, b: string | null): number | null {
+  if (!a || !b) return null;
+  const ta = new Date(a).getTime();
+  const tb = new Date(b).getTime();
+  if (!Number.isFinite(ta) || !Number.isFinite(tb)) return null;
+  return (tb - ta) / (1000 * 60 * 60);
+}
+
+/**
+ * Stream a structured-JSON line for machine-readable output.
+ * Scripts emit one JSON object per "finding" or "summary" line, so a
+ * piped consumer can do `… | jq` cleanly.
+ */
+export function emitJsonLine(obj: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(obj)}\n`);
+}
+
+export function emitHumanLine(line: string): void {
+  process.stderr.write(`${line}\n`);
+}

--- a/scripts/replay/find-replay-gaps.ts
+++ b/scripts/replay/find-replay-gaps.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S node --import=tsx/esm
+/**
+ * find-replay-gaps.ts
+ *
+ * Scans a chronological list of evidence snapshots for the same
+ * `lineageKey` (i.e. the same entity over time) and reports continuity
+ * gaps — windows longer than the configured threshold during which
+ * no new check was recorded.
+ *
+ * Gaps are operationally meaningful: they tell a verifier "between
+ * 2026-03-10 and 2026-04-15, this subject was not re-inspected."
+ * The Lane B `<ReplayLineage>` primitive renders these gaps visibly;
+ * this script is the offline / CI equivalent.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/replay/find-replay-gaps.ts \
+ *     --snapshots path/to/snapshots.json \
+ *     [--max-gap-hours 720]
+ *
+ * Input shape (snapshots.json):
+ *   {
+ *     "entityId": "1346053246",
+ *     "snapshots": [
+ *       { "runId": "...", "lastCheckedAt": "2026-03-01T00:00:00Z" },
+ *       { "runId": "...", "lastCheckedAt": "2026-04-15T00:00:00Z" }
+ *     ]
+ *   }
+ *
+ * Exit codes:
+ *   0   no gaps above threshold (or single-snapshot lineage)
+ *   2   bad input
+ *   4   one or more gaps detected (informational; not a hard failure
+ *       because gaps may be legitimate — a verifier decides)
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { computeLineageKey } from '../../apps/api/backend/src/services/replay/replayIdentity';
+import {
+  chronologyKey,
+  emitHumanLine,
+  emitJsonLine,
+  hoursBetween,
+  parseArgs,
+} from './_lib';
+
+const DEFAULT_MAX_GAP_HOURS = 720; // 30 days
+
+export interface SnapshotInput {
+  entityId: string;
+  snapshots: ReadonlyArray<{
+    runId?: string;
+    lastCheckedAt: string | null;
+  }>;
+}
+
+export interface ReplayGap {
+  from: string;
+  to: string;
+  hoursMissing: number;
+  priorRunId: string | null;
+  nextRunId: string | null;
+}
+
+export interface GapReport {
+  entityId: string;
+  lineageKey: string;
+  snapshotCount: number;
+  maxGapHours: number;
+  gaps: ReplayGap[];
+  continuous: boolean;
+}
+
+export function findReplayGaps(input: SnapshotInput, maxGapHours: number): GapReport {
+  const sorted = [...input.snapshots]
+    .filter((s) => typeof s.lastCheckedAt === 'string' && s.lastCheckedAt.length > 0)
+    .sort((a, b) => chronologyKey(a.lastCheckedAt).localeCompare(chronologyKey(b.lastCheckedAt)));
+
+  const gaps: ReplayGap[] = [];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const prev = sorted[i - 1];
+    const cur = sorted[i];
+    const delta = hoursBetween(prev.lastCheckedAt, cur.lastCheckedAt);
+    if (delta !== null && delta > maxGapHours) {
+      gaps.push({
+        from: prev.lastCheckedAt as string,
+        to: cur.lastCheckedAt as string,
+        hoursMissing: Math.round(delta),
+        priorRunId: prev.runId ?? null,
+        nextRunId: cur.runId ?? null,
+      });
+    }
+  }
+
+  return {
+    entityId: input.entityId,
+    lineageKey: computeLineageKey(input.entityId),
+    snapshotCount: sorted.length,
+    maxGapHours,
+    gaps,
+    continuous: gaps.length === 0,
+  };
+}
+
+function loadSnapshots(path: string): SnapshotInput {
+  const abs = resolve(path);
+  if (!existsSync(abs)) {
+    throw new Error(`snapshots file not found: ${abs}`);
+  }
+  const parsed = JSON.parse(readFileSync(abs, 'utf8')) as Record<string, unknown>;
+  const entityId = typeof parsed.entityId === 'string' ? parsed.entityId.trim() : '';
+  if (!entityId) throw new Error('snapshots.entityId is required');
+  const snapshots = Array.isArray(parsed.snapshots)
+    ? parsed.snapshots.map((s) => ({
+        runId: typeof (s as Record<string, unknown>).runId === 'string'
+          ? ((s as Record<string, unknown>).runId as string)
+          : undefined,
+        lastCheckedAt: typeof (s as Record<string, unknown>).lastCheckedAt === 'string'
+          ? ((s as Record<string, unknown>).lastCheckedAt as string)
+          : null,
+      }))
+    : [];
+  return { entityId, snapshots };
+}
+
+function main(): void {
+  const { flags } = parseArgs(process.argv.slice(2));
+  const snapshotsPath = flags.get('snapshots');
+  const maxGap = Number.parseInt(flags.get('max-gap-hours') ?? `${DEFAULT_MAX_GAP_HOURS}`, 10);
+
+  if (!snapshotsPath) {
+    emitHumanLine('usage: find-replay-gaps --snapshots <path.json> [--max-gap-hours 720]');
+    process.exit(2);
+  }
+  if (!Number.isFinite(maxGap) || maxGap <= 0) {
+    emitHumanLine('error: --max-gap-hours must be a positive number');
+    process.exit(2);
+  }
+
+  let input: SnapshotInput;
+  try {
+    input = loadSnapshots(snapshotsPath);
+  } catch (err) {
+    emitHumanLine(`error: ${String(err)}`);
+    process.exit(2);
+  }
+
+  const report = findReplayGaps(input, maxGap);
+
+  for (const gap of report.gaps) {
+    emitJsonLine({ finding: 'replay-gap', ok: false, detail: gap });
+  }
+  emitJsonLine({
+    finding: 'summary',
+    ok: report.continuous,
+    detail: {
+      entityId: report.entityId,
+      lineageKey: report.lineageKey,
+      snapshotCount: report.snapshotCount,
+      maxGapHours: report.maxGapHours,
+      gapCount: report.gaps.length,
+      continuous: report.continuous,
+    },
+  });
+
+  emitHumanLine(
+    report.continuous
+      ? `find-replay-gaps: continuous (${report.snapshotCount} snapshots, no gaps > ${maxGap}h)`
+      : `find-replay-gaps: ${report.gaps.length} gap(s) detected (threshold ${maxGap}h)`,
+  );
+  process.exit(report.continuous ? 0 : 4);
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  main();
+}

--- a/scripts/replay/reconcile-lineage.ts
+++ b/scripts/replay/reconcile-lineage.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env -S node --import=tsx/esm
+/**
+ * reconcile-lineage.ts
+ *
+ * Reconciles two candidate evidence sets and reports whether they
+ * belong to the SAME subject (same `lineageKey`) and, if so, whether
+ * they represent the SAME snapshot (same `runId`) or two distinct
+ * snapshots in the lineage.
+ *
+ * Operationally: when a verifier sees two candidate receipts (e.g.
+ * one downloaded from a clinician's email and one fetched fresh from
+ * the issuer), they need to know:
+ *
+ *   - Are these the same person? → same `lineageKey`
+ *   - Are these the same check?  → same `runId`
+ *   - If different `runId`: is it explained by an evidence change?
+ *
+ * The output is a structured reconciliation that a human reviewer
+ * can read in <30 seconds.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/replay/reconcile-lineage.ts \
+ *     --left  path/to/left.json \
+ *     --right path/to/right.json
+ *
+ * Exit codes:
+ *   0  same lineage AND same snapshot — perfectly reconciled
+ *   2  bad input
+ *   5  same lineage, different snapshot (lineage continuous; new evidence)
+ *   6  different lineage (DIFFERENT SUBJECTS — verifier should investigate)
+ */
+import {
+  computeLineageKey,
+  computeRunId,
+} from '../../apps/api/backend/src/services/replay/replayIdentity';
+import {
+  emitHumanLine,
+  emitJsonLine,
+  loadEvidenceFromFile,
+  parseArgs,
+  type ReplayEvidence,
+} from './_lib';
+
+export type ReconcileOutcome =
+  | 'same-lineage-same-snapshot'
+  | 'same-lineage-different-snapshot'
+  | 'different-lineage';
+
+export interface ReconcileResult {
+  outcome: ReconcileOutcome;
+  left: { entityId: string; lineageKey: string; runId: string };
+  right: { entityId: string; lineageKey: string; runId: string };
+  evidenceDelta: {
+    lastCheckedAtChanged: boolean;
+    artifactsAdded: string[];
+    artifactsRemoved: string[];
+    channelChanged: boolean;
+  };
+}
+
+export function reconcileLineage(
+  left: ReplayEvidence,
+  right: ReplayEvidence,
+): ReconcileResult {
+  const leftIdentity = {
+    entityId: left.entityId,
+    lineageKey: computeLineageKey(left.entityId),
+    runId: computeRunId(left),
+  };
+  const rightIdentity = {
+    entityId: right.entityId,
+    lineageKey: computeLineageKey(right.entityId),
+    runId: computeRunId(right),
+  };
+
+  let outcome: ReconcileOutcome;
+  if (leftIdentity.lineageKey !== rightIdentity.lineageKey) {
+    outcome = 'different-lineage';
+  } else if (leftIdentity.runId === rightIdentity.runId) {
+    outcome = 'same-lineage-same-snapshot';
+  } else {
+    outcome = 'same-lineage-different-snapshot';
+  }
+
+  const leftCksSet = new Set(left.artifactChecksums);
+  const rightCksSet = new Set(right.artifactChecksums);
+  const artifactsAdded = right.artifactChecksums.filter((c) => !leftCksSet.has(c));
+  const artifactsRemoved = left.artifactChecksums.filter((c) => !rightCksSet.has(c));
+
+  return {
+    outcome,
+    left: leftIdentity,
+    right: rightIdentity,
+    evidenceDelta: {
+      lastCheckedAtChanged: left.lastCheckedAt !== right.lastCheckedAt,
+      artifactsAdded,
+      artifactsRemoved,
+      channelChanged: (left.channel ?? '') !== (right.channel ?? ''),
+    },
+  };
+}
+
+function main(): void {
+  const { flags } = parseArgs(process.argv.slice(2));
+  const leftPath = flags.get('left');
+  const rightPath = flags.get('right');
+
+  if (!leftPath || !rightPath) {
+    emitHumanLine('usage: reconcile-lineage --left <path.json> --right <path.json>');
+    process.exit(2);
+  }
+
+  let left: ReplayEvidence;
+  let right: ReplayEvidence;
+  try {
+    left = loadEvidenceFromFile(leftPath);
+    right = loadEvidenceFromFile(rightPath);
+  } catch (err) {
+    emitHumanLine(`error: ${String(err)}`);
+    process.exit(2);
+  }
+
+  const result = reconcileLineage(left, right);
+  emitJsonLine({
+    finding: 'reconciliation',
+    ok: result.outcome !== 'different-lineage',
+    detail: result,
+  });
+
+  switch (result.outcome) {
+    case 'same-lineage-same-snapshot':
+      emitHumanLine('reconcile-lineage: SAME SUBJECT, SAME SNAPSHOT (perfectly reconciled)');
+      process.exit(0);
+    case 'same-lineage-different-snapshot':
+      emitHumanLine('reconcile-lineage: SAME SUBJECT, DIFFERENT SNAPSHOT (lineage continuous; evidence changed)');
+      process.exit(5);
+    case 'different-lineage':
+      emitHumanLine('reconcile-lineage: DIFFERENT LINEAGES (verifier action required — these are NOT the same subject)');
+      process.exit(6);
+  }
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  main();
+}

--- a/scripts/replay/verify-replay-integrity.ts
+++ b/scripts/replay/verify-replay-integrity.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S node --import=tsx/esm
+/**
+ * verify-replay-integrity.ts
+ *
+ * Recomputes the canonical replay identity (`lineageKey` + `runId`) for
+ * a given evidence set and verifies the survivability contract from
+ * the Wave 14 doc (docs/architecture/replay-survivability-matrix.md):
+ *
+ *   1. Determinism — N recomputations of the same input → one unique id
+ *   2. Cosmetic-input invariance — whitespace / ordering changes do NOT
+ *      change the id
+ *   3. Sensitivity — any input field change DOES change the runId
+ *
+ * If an `expectedRunId` is supplied (e.g. recovered from a prior
+ * snapshot manifest), the script also verifies that the recomputed
+ * runId matches it — this is the "no silent corruption" check the
+ * audit-chain integrity property depends on.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/replay/verify-replay-integrity.ts \
+ *     --evidence path/to/evidence.json \
+ *     [--expected-run-id run_v1_...]
+ *
+ * Exit codes:
+ *   0   integrity verified
+ *   2   bad inputs (missing file, malformed JSON, etc.)
+ *   3   integrity FAILED (drift detected vs --expected-run-id)
+ */
+import {
+  computeLineageKey,
+  computeRunId,
+} from '../../apps/api/backend/src/services/replay/replayIdentity';
+import {
+  emitHumanLine,
+  emitJsonLine,
+  loadEvidenceFromFile,
+  parseArgs,
+  type ReplayEvidence,
+} from './_lib';
+
+interface Finding {
+  finding: 'determinism' | 'cosmetic-invariance' | 'sensitivity' | 'expected-match' | 'summary';
+  ok: boolean;
+  detail: Record<string, unknown>;
+}
+
+export function verifyReplayIntegrity(
+  evidence: ReplayEvidence,
+  expectedRunId: string | null,
+): Finding[] {
+  const findings: Finding[] = [];
+
+  const lineageKey = computeLineageKey(evidence.entityId);
+  const baseRunId = computeRunId(evidence);
+
+  // 1. Determinism — recompute 25 times, must collapse to one value.
+  const repeated: string[] = [];
+  for (let i = 0; i < 25; i += 1) {
+    repeated.push(computeRunId(evidence));
+  }
+  const uniqueCount = new Set(repeated).size;
+  findings.push({
+    finding: 'determinism',
+    ok: uniqueCount === 1,
+    detail: { iterations: 25, uniqueRunIds: uniqueCount, runId: baseRunId },
+  });
+
+  // 2. Cosmetic invariance — re-order artifacts + whitespace-pad → same id.
+  const cosmetic = computeRunId({
+    ...evidence,
+    artifactChecksums: [...evidence.artifactChecksums].reverse().map((c) => ` ${c} `),
+  });
+  findings.push({
+    finding: 'cosmetic-invariance',
+    ok: cosmetic === baseRunId,
+    detail: { original: baseRunId, cosmeticVariant: cosmetic },
+  });
+
+  // 3. Sensitivity — mutating any input changes the id.
+  const tamperedCheckedAt = computeRunId({
+    ...evidence,
+    lastCheckedAt: evidence.lastCheckedAt
+      ? new Date(new Date(evidence.lastCheckedAt).getTime() + 1000).toISOString()
+      : '2099-01-01T00:00:00.000Z',
+  });
+  const tamperedChecksums = computeRunId({
+    ...evidence,
+    artifactChecksums: [...evidence.artifactChecksums, 'cks-tampered'],
+  });
+  findings.push({
+    finding: 'sensitivity',
+    ok:
+      tamperedCheckedAt !== baseRunId
+      && tamperedChecksums !== baseRunId,
+    detail: {
+      runId: baseRunId,
+      tamperedCheckedAt,
+      tamperedChecksums,
+    },
+  });
+
+  // 4. Optional: expected-match check against a previously-captured runId.
+  if (expectedRunId !== null) {
+    findings.push({
+      finding: 'expected-match',
+      ok: baseRunId === expectedRunId,
+      detail: { recomputed: baseRunId, expected: expectedRunId },
+    });
+  }
+
+  const allOk = findings.every((f) => f.ok);
+  findings.push({
+    finding: 'summary',
+    ok: allOk,
+    detail: {
+      entityId: evidence.entityId,
+      lineageKey,
+      runId: baseRunId,
+      schemeVersion: 'v1',
+      artifactCount: evidence.artifactChecksums.length,
+    },
+  });
+
+  return findings;
+}
+
+function main(): void {
+  const { flags } = parseArgs(process.argv.slice(2));
+  const evidencePath = flags.get('evidence');
+  const expectedRunId = flags.get('expected-run-id') ?? null;
+
+  if (!evidencePath) {
+    emitHumanLine('usage: verify-replay-integrity --evidence <path.json> [--expected-run-id <id>]');
+    process.exit(2);
+  }
+
+  let evidence: ReplayEvidence;
+  try {
+    evidence = loadEvidenceFromFile(evidencePath);
+  } catch (err) {
+    emitHumanLine(`error: ${String(err)}`);
+    process.exit(2);
+  }
+
+  const findings = verifyReplayIntegrity(evidence, expectedRunId);
+  for (const f of findings) {
+    emitJsonLine(f as unknown as Record<string, unknown>);
+  }
+
+  const summary = findings[findings.length - 1];
+  const integrityFailed = !findings.every((f) => f.ok);
+  emitHumanLine(
+    integrityFailed
+      ? 'verify-replay-integrity: FAILED (see findings above)'
+      : `verify-replay-integrity: OK (runId=${(summary.detail.runId as string) ?? '<unknown>'})`,
+  );
+  process.exit(integrityFailed ? 3 : 0);
+}
+
+// Execute only when invoked as a script (not when imported by tests).
+if (typeof require !== 'undefined' && require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

Stacked on #344 (Wave 14 survivability suite). Adds three read-only CLI tools under `scripts/replay/` that operators can run against arbitrary evidence inputs (JSON fixtures or, in future, exported snapshot manifests) to verify the canonical replay-identity contract from PR #343 + #344.

Where #344 pins survivability inside an in-process jest run, these scripts let operators verify the contract against **real production evidence** after restart, deploy, or as part of CI integrity gates.

## Files

| File | Role |
|---|---|
| `scripts/replay/_lib.ts` | Shared helpers: `parseArgs`, `normalizeEvidence`, `loadEvidenceFromFile`, `chronologyKey`, `hoursBetween`, JSON-line emitters |
| `scripts/replay/verify-replay-integrity.ts` | Recomputes `lineageKey` + `runId` and asserts determinism, cosmetic-invariance, sensitivity, optional expected-match |
| `scripts/replay/find-replay-gaps.ts` | Scans chronological snapshots for continuity gaps above `--max-gap-hours` |
| `scripts/replay/reconcile-lineage.ts` | Compares two evidence candidates → `same-lineage-same-snapshot` / `same-lineage-different-snapshot` / `different-lineage` |
| `apps/web/__tests__/replay-scripts.test.ts` | 28 vitest cases — every exported pure function + `_lib` helpers |

## Exit-code taxonomy

| Script | 0 | 2 | 3 / 4 / 5 / 6 |
|---|---|---|---|
| `verify-replay-integrity` | integrity verified | bad input | **3** = integrity FAILED |
| `find-replay-gaps` | continuous | bad input | **4** = gap(s) detected |
| `reconcile-lineage` | same subject + same snapshot | bad input | **5** = same lineage, different snapshot; **6** = different lineages (verifier action required) |

Distinct exit codes mean a CI pipeline can react differently — gap detection is informational (exit 4) while different-lineage on a receipt reconciliation is a hard alarm (exit 6).

## Survivability matrix coverage

The scripts collectively cover all six runtime-turbulence scenarios from `docs/architecture/replay-survivability-matrix.md` (shipped in #344):

| Scenario | Script |
|---|---|
| Deploy replacement | `verify-replay-integrity` — determinism + expected-match |
| Replay corruption attempt | `verify-replay-integrity` — sensitivity + expected-match |
| Degraded restoration | `verify-replay-integrity` on degraded fixture |
| Runtime restart | `verify-replay-integrity` — determinism over 25 iterations |
| Partial persistence outage | `reconcile-lineage` — surfaces evidence delta |
| Stale replay recovery | `verify-replay-integrity` — wall-clock-independent ids |
| Audit-chain gap detection | `find-replay-gaps` |
| Cross-subject reconciliation | `reconcile-lineage` |

## Truth rules
- Banned-strings scan: CLEAN
- No new product claims; scripts are read-only operational tooling

## Validation
- Targeted vitest: **28/28** passing
- Full web build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**
- No new dependencies; scripts use only Node built-ins + existing `replayIdentity` module
- Tests live under `apps/web/__tests__/` so they run via the existing vitest config; scripts themselves remain at repo root per the brief

## Usage

```bash
pnpm exec tsx scripts/replay/verify-replay-integrity.ts \
  --evidence path/to/evidence.json \
  [--expected-run-id run_v1_...]

pnpm exec tsx scripts/replay/find-replay-gaps.ts \
  --snapshots path/to/snapshots.json \
  [--max-gap-hours 720]

pnpm exec tsx scripts/replay/reconcile-lineage.ts \
  --left path/to/left.json \
  --right path/to/right.json
```

## Out of scope (explicit follow-ups)
- Direct Prisma integration (read evidence from the live DB without JSON fixtures) — needs a thin connector + a per-NPI evidence fetcher; bounded follow-up
- A `scripts/runtime/verify-runtime-truth.ts` (the runtime-coherence gate mentioned in a separate brief) — different concern, different worktree