### PR TITLE
feat(replay): cross-surface convergence verifier (operational tool)

### DIFF
--- a/apps/web/__tests__/replay-surface-convergence.test.ts
+++ b/apps/web/__tests__/replay-surface-convergence.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Pure-function tests for analyzeConvergence — the surface-convergence
+ * verifier from scripts/replay/verify-surface-convergence.ts.
+ *
+ * The tests build fixture `ConvergenceObservations` and assert the
+ * findings table reflects the divergence (or lack thereof) correctly.
+ * No live HTTP; no JWT signing — fixtures are inert literals.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeConvergence,
+  type ConvergenceObservations,
+} from '../../../scripts/replay/verify-surface-convergence';
+
+const KID = 'vcv-es256-test-1';
+const LINEAGE = 'lin_v1_aaaabbbbccccdddd';
+const RUN = 'run_v1_1111222233334444';
+const CHECKED_AT = '2026-04-01T15:00:00.000Z';
+const IAT_SECONDS = Math.floor(new Date(CHECKED_AT).getTime() / 1000);
+
+function fixture(overrides: Partial<ConvergenceObservations['surfaces']> = {}): ConvergenceObservations {
+  return {
+    npi: '1346053246',
+    surfaces: {
+      passportNpi: {
+        surface: 'passport_npi',
+        url: 'http://localhost:3030/api/passport/npi/1346053246',
+        ok: true,
+        status: 200,
+        body: {
+          lastCheckedAt: CHECKED_AT,
+          replay: { lineageKey: LINEAGE, runId: RUN, schemeVersion: 'v1' },
+        },
+      },
+      passportProxy: {
+        surface: 'passport_proxy',
+        url: 'http://localhost:3030/api/passport/1346053246',
+        ok: true,
+        status: 200,
+        body: {
+          lastCheckedAt: CHECKED_AT,
+          replay: { lineageKey: LINEAGE, runId: RUN, schemeVersion: 'v1' },
+        },
+      },
+      jwks: {
+        surface: 'jwks',
+        url: 'http://localhost:3030/.well-known/jwks.json',
+        ok: true,
+        status: 200,
+        body: { keys: [{ kid: KID, alg: 'ES256' }] },
+      },
+      didDocument: {
+        surface: 'did.json',
+        url: 'http://localhost:3030/.well-known/did.json',
+        ok: true,
+        status: 200,
+        body: {
+          id: 'did:web:test.vitalcv.com',
+          verificationMethod: [
+            { id: `did:web:test.vitalcv.com#${KID}`, publicKeyJwk: { kid: KID } },
+          ],
+        },
+      },
+      trustRegister: {
+        surface: 'trust-register',
+        url: 'http://localhost:3030/.well-known/trust-register',
+        ok: true,
+        status: 200,
+        body: { signing: { active_kid: KID, algorithm: 'ES256' } },
+      },
+      receipt: {
+        ok: true,
+        status: 200,
+        jwt: 'jwt-token-fixture',
+        decoded: {
+          iss: 'did:web:test.vitalcv.com',
+          sub: 'npi:1346053246',
+          iat: IAT_SECONDS,
+          vcv: {
+            checkedAt: CHECKED_AT,
+            replay: { lineageKey: LINEAGE, runId: RUN, schemeVersion: 'v1' },
+          },
+        },
+        protectedHeader: { alg: 'ES256', kid: KID, typ: 'vc+jwt' },
+        kidHeader: KID,
+        issuerHeader: 'did:web:test.vitalcv.com',
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe('analyzeConvergence — coherent baseline', () => {
+  it('reports every finding ok when all surfaces agree', () => {
+    const findings = analyzeConvergence(fixture());
+    expect(findings.every((f) => f.ok)).toBe(true);
+    const byName = Object.fromEntries(findings.map((f) => [f.finding, f]));
+    expect(byName['lineageKey-consistency'].detail.count).toBe(3);
+    expect(byName['runId-consistency'].detail.count).toBe(3);
+    expect(byName['issuer-kid-consistency'].detail.count).toBe(5);
+    expect(byName['checkedAt-consistency'].detail.count).toBe(3);
+    expect(byName['receipt-chronology'].detail.converged).toBe(true);
+  });
+});
+
+describe('analyzeConvergence — surface divergence', () => {
+  it('detects lineageKey divergence between passport and receipt', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        receipt: {
+          ok: true, status: 200, jwt: 'x',
+          decoded: {
+            iss: 'did:web:test', sub: 'npi:1346053246', iat: IAT_SECONDS,
+            vcv: {
+              checkedAt: CHECKED_AT,
+              replay: { lineageKey: 'lin_v1_DRIFTDRIFTDRIFT', runId: RUN },
+            },
+          },
+          protectedHeader: { alg: 'ES256', kid: KID, typ: 'vc+jwt' },
+          kidHeader: KID, issuerHeader: null,
+        },
+      }),
+    );
+    const lk = findings.find((f) => f.finding === 'lineageKey-consistency')!;
+    expect(lk.ok).toBe(false);
+  });
+
+  it('detects runId divergence — same subject, different snapshot ids across surfaces', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        passportProxy: {
+          surface: 'passport_proxy', url: 'x', ok: true, status: 200,
+          body: {
+            lastCheckedAt: CHECKED_AT,
+            replay: { lineageKey: LINEAGE, runId: 'run_v1_DIFFERENT_RUN_', schemeVersion: 'v1' },
+          },
+        },
+      }),
+    );
+    const ri = findings.find((f) => f.finding === 'runId-consistency')!;
+    expect(ri.ok).toBe(false);
+  });
+
+  it('detects checkedAt divergence between passport and receipt', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        receipt: {
+          ok: true, status: 200, jwt: 'x',
+          decoded: {
+            iss: 'did:web:test', sub: 'npi:1346053246', iat: IAT_SECONDS,
+            vcv: {
+              checkedAt: '2026-04-02T15:00:00.000Z',
+              replay: { lineageKey: LINEAGE, runId: RUN },
+            },
+          },
+          protectedHeader: { alg: 'ES256', kid: KID, typ: 'vc+jwt' },
+          kidHeader: KID, issuerHeader: null,
+        },
+      }),
+    );
+    const ca = findings.find((f) => f.finding === 'checkedAt-consistency')!;
+    expect(ca.ok).toBe(false);
+  });
+
+  it('detects kid divergence between jwks and did.json (key rotation drift)', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        didDocument: {
+          surface: 'did.json', url: 'x', ok: true, status: 200,
+          body: {
+            id: 'did:web:test',
+            verificationMethod: [
+              { id: 'did:web:test#vcv-es256-OLD', publicKeyJwk: { kid: 'vcv-es256-OLD' } },
+            ],
+          },
+        },
+      }),
+    );
+    const kid = findings.find((f) => f.finding === 'issuer-kid-consistency')!;
+    expect(kid.ok).toBe(false);
+  });
+
+  it('detects receipt chronology drift — iat does not match passport checkedAt', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        receipt: {
+          ok: true, status: 200, jwt: 'x',
+          decoded: {
+            iss: 'did:web:test', sub: 'npi:1346053246',
+            iat: IAT_SECONDS + 60, // off by 60s
+            vcv: {
+              checkedAt: CHECKED_AT,
+              replay: { lineageKey: LINEAGE, runId: RUN },
+            },
+          },
+          protectedHeader: { alg: 'ES256', kid: KID, typ: 'vc+jwt' },
+          kidHeader: KID, issuerHeader: null,
+        },
+      }),
+    );
+    const ch = findings.find((f) => f.finding === 'receipt-chronology')!;
+    expect(ch.ok).toBe(false);
+  });
+});
+
+describe('analyzeConvergence — degraded probe handling', () => {
+  it('does not falsely flag divergence when a surface failed to respond', () => {
+    // jwks failed; should drop out of kid-consistency observations but not
+    // cause the other findings to fail.
+    const findings = analyzeConvergence(
+      fixture({
+        jwks: { surface: 'jwks', url: 'x', ok: false, status: 503, body: null, error: 'timeout' },
+      }),
+    );
+    const kid = findings.find((f) => f.finding === 'issuer-kid-consistency')!;
+    expect(kid.ok).toBe(true);
+    expect(kid.detail.count).toBe(4); // jwks dropped, 4 remaining
+  });
+
+  it('treats a missing receipt gracefully (no chronology check)', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        receipt: {
+          ok: false, status: 404, jwt: null, decoded: null,
+          protectedHeader: null, kidHeader: null, issuerHeader: null,
+        },
+      }),
+    );
+    const ch = findings.find((f) => f.finding === 'receipt-chronology')!;
+    expect(ch.ok).toBe(true); // null-iat side short-circuits to ok
+  });
+
+  it('reports ok when only one surface has data for a given dimension', () => {
+    const findings = analyzeConvergence(
+      fixture({
+        passportProxy: { surface: 'x', url: 'x', ok: false, status: 502, body: null },
+        receipt: {
+          ok: false, status: 404, jwt: null, decoded: null,
+          protectedHeader: null, kidHeader: null, issuerHeader: null,
+        },
+      }),
+    );
+    const lk = findings.find((f) => f.finding === 'lineageKey-consistency')!;
+    expect(lk.ok).toBe(true);
+    expect(lk.detail.count).toBe(1); // only passportNpi remains
+  });
+});

--- a/scripts/replay/verify-surface-convergence.ts
+++ b/scripts/replay/verify-surface-convergence.ts
@@ -1,0 +1,370 @@
+#!/usr/bin/env -S node --import=tsx/esm
+/**
+ * verify-surface-convergence.ts
+ *
+ * Probes every trust-bearing surface VitalCV exposes for a given NPI and
+ * verifies they all report THE SAME replay-identity truth — same
+ * `lineageKey`, same `runId`, same `checkedAt`, same active `kid` /
+ * issuer DID. Surface divergence means a verifier reading two surfaces
+ * would see inconsistent claims about the same subject; this script
+ * catches that before a verifier does.
+ *
+ * Probed surfaces (when reachable):
+ *
+ *   /api/passport/npi/:npi             — entity-shape passport (Wave 10 #343)
+ *   /api/passport/:npi                 — passport proxy (#340)
+ *   /api/receipt/:npi                  — signed VC 2.0 receipt (#349)
+ *   /.well-known/jwks.json             — JWK set (#349)
+ *   /.well-known/did.json              — DID document (#349)
+ *   /.well-known/trust-register        — institutional manifest (#349)
+ *
+ * Convergence checks:
+ *
+ *   1. lineageKey consistency  — every surface that emits a lineageKey
+ *                                must report the same value for the
+ *                                same NPI.
+ *   2. runId consistency       — every surface that emits a runId
+ *                                must report the same value for the
+ *                                same snapshot.
+ *   3. checkedAt consistency   — surfaces that emit a freshness
+ *                                timestamp agree on it.
+ *   4. issuer DID consistency  — JWKS kid, did.json verificationMethod,
+ *                                trust-register signing.active_kid,
+ *                                and receipt header X-Receipt-Kid all
+ *                                agree.
+ *   5. receipt chronology      — receipt iat (pinned to lastCheckedAt)
+ *                                matches the passport's lastCheckedAt.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/replay/verify-surface-convergence.ts \
+ *     --base-url http://localhost:3030 \
+ *     --npi 1346053246
+ *
+ * Exit codes:
+ *   0  every surface agrees (perfect convergence)
+ *   2  bad input
+ *   7  divergence detected (verifier-actionable signal)
+ */
+import { decodeJwt, decodeProtectedHeader } from 'jose';
+import {
+  emitHumanLine,
+  emitJsonLine,
+  parseArgs,
+} from './_lib';
+
+const SURFACE_FETCH_TIMEOUT_MS = 8000;
+
+export interface SurfaceProbe<T = unknown> {
+  surface: string;
+  url: string;
+  ok: boolean;
+  status: number;
+  body: T | null;
+  error?: string;
+}
+
+async function probeJson<T = unknown>(url: string): Promise<SurfaceProbe<T>> {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(SURFACE_FETCH_TIMEOUT_MS),
+    });
+    const body = res.ok ? ((await res.json().catch(() => null)) as T | null) : null;
+    return { surface: url, url, ok: res.ok, status: res.status, body };
+  } catch (err) {
+    return {
+      surface: url,
+      url,
+      ok: false,
+      status: 0,
+      body: null,
+      error: String(err),
+    };
+  }
+}
+
+interface ReceiptProbe {
+  ok: boolean;
+  status: number;
+  jwt: string | null;
+  decoded: Record<string, unknown> | null;
+  protectedHeader: Record<string, unknown> | null;
+  kidHeader: string | null;
+  issuerHeader: string | null;
+  error?: string;
+}
+
+async function probeReceipt(url: string): Promise<ReceiptProbe> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(SURFACE_FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return { ok: false, status: res.status, jwt: null, decoded: null, protectedHeader: null, kidHeader: null, issuerHeader: null };
+    }
+    const jwt = await res.text();
+    const decoded = decodeJwt(jwt) as Record<string, unknown>;
+    const header = decodeProtectedHeader(jwt) as Record<string, unknown>;
+    return {
+      ok: true,
+      status: res.status,
+      jwt,
+      decoded,
+      protectedHeader: header,
+      kidHeader: res.headers.get('x-receipt-kid'),
+      issuerHeader: res.headers.get('x-receipt-issuer'),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      jwt: null,
+      decoded: null,
+      protectedHeader: null,
+      kidHeader: null,
+      issuerHeader: null,
+      error: String(err),
+    };
+  }
+}
+
+export interface ConvergenceObservations {
+  npi: string;
+  surfaces: {
+    passportNpi: SurfaceProbe;
+    passportProxy: SurfaceProbe;
+    jwks: SurfaceProbe;
+    didDocument: SurfaceProbe;
+    trustRegister: SurfaceProbe;
+    receipt: ReceiptProbe;
+  };
+}
+
+export interface ConvergenceFinding {
+  finding:
+    | 'lineageKey-consistency'
+    | 'runId-consistency'
+    | 'checkedAt-consistency'
+    | 'issuer-kid-consistency'
+    | 'receipt-chronology';
+  ok: boolean;
+  detail: Record<string, unknown>;
+}
+
+/**
+ * Pure analyzer over a snapshot of surface observations. Extracted from
+ * `main()` so it can be unit-tested with fixture inputs and no live HTTP.
+ */
+export function analyzeConvergence(obs: ConvergenceObservations): ConvergenceFinding[] {
+  const findings: ConvergenceFinding[] = [];
+
+  // ─── lineageKey + runId from each surface that emits them ──────────────
+  const passportNpiReplay = readReplayBlock(obs.surfaces.passportNpi.body);
+  const passportProxyReplay = readReplayBlock(obs.surfaces.passportProxy.body);
+  const receiptReplay = readReceiptReplay(obs.surfaces.receipt);
+
+  const lineageObservations = [
+    { source: 'passport_npi', value: passportNpiReplay?.lineageKey },
+    { source: 'passport_proxy', value: passportProxyReplay?.lineageKey },
+    { source: 'receipt', value: receiptReplay?.lineageKey },
+  ].filter((o): o is { source: string; value: string } => typeof o.value === 'string');
+
+  const runIdObservations = [
+    { source: 'passport_npi', value: passportNpiReplay?.runId },
+    { source: 'passport_proxy', value: passportProxyReplay?.runId },
+    { source: 'receipt', value: receiptReplay?.runId },
+  ].filter((o): o is { source: string; value: string } => typeof o.value === 'string');
+
+  findings.push({
+    finding: 'lineageKey-consistency',
+    ok: allEqual(lineageObservations.map((o) => o.value)),
+    detail: {
+      observed: lineageObservations,
+      count: lineageObservations.length,
+    },
+  });
+
+  findings.push({
+    finding: 'runId-consistency',
+    ok: allEqual(runIdObservations.map((o) => o.value)),
+    detail: {
+      observed: runIdObservations,
+      count: runIdObservations.length,
+    },
+  });
+
+  // ─── checkedAt consistency ─────────────────────────────────────────────
+  const checkedAtObservations = [
+    { source: 'passport_npi', value: readLastCheckedAt(obs.surfaces.passportNpi.body) },
+    { source: 'passport_proxy', value: readLastCheckedAt(obs.surfaces.passportProxy.body) },
+    { source: 'receipt_vcv', value: receiptReplay?.checkedAt ?? null },
+  ].filter((o): o is { source: string; value: string } => typeof o.value === 'string');
+
+  findings.push({
+    finding: 'checkedAt-consistency',
+    ok: allEqual(checkedAtObservations.map((o) => o.value)),
+    detail: {
+      observed: checkedAtObservations,
+      count: checkedAtObservations.length,
+    },
+  });
+
+  // ─── issuer kid consistency across well-known + receipt ────────────────
+  const jwks = obs.surfaces.jwks.body as { keys?: Array<{ kid?: string }> } | null;
+  const did = obs.surfaces.didDocument.body as {
+    verificationMethod?: Array<{ publicKeyJwk?: { kid?: string }; id?: string }>;
+  } | null;
+  const trustRegister = obs.surfaces.trustRegister.body as {
+    signing?: { active_kid?: string };
+  } | null;
+
+  const kidObservations = [
+    { source: 'jwks', value: jwks?.keys?.[0]?.kid },
+    { source: 'did.json', value: did?.verificationMethod?.[0]?.publicKeyJwk?.kid },
+    { source: 'trust-register', value: trustRegister?.signing?.active_kid },
+    { source: 'receipt.header', value: obs.surfaces.receipt.kidHeader ?? undefined },
+    {
+      source: 'receipt.jwt.kid',
+      value: typeof obs.surfaces.receipt.protectedHeader?.kid === 'string'
+        ? (obs.surfaces.receipt.protectedHeader.kid as string)
+        : undefined,
+    },
+  ].filter((o): o is { source: string; value: string } => typeof o.value === 'string');
+
+  findings.push({
+    finding: 'issuer-kid-consistency',
+    ok: allEqual(kidObservations.map((o) => o.value)),
+    detail: {
+      observed: kidObservations,
+      count: kidObservations.length,
+    },
+  });
+
+  // ─── receipt chronology — receipt iat must equal lastCheckedAt seconds ─
+  const receiptIatSeconds =
+    typeof obs.surfaces.receipt.decoded?.iat === 'number'
+      ? (obs.surfaces.receipt.decoded.iat as number)
+      : null;
+  const passportCheckedAtSeconds = (() => {
+    const v = readLastCheckedAt(obs.surfaces.passportNpi.body);
+    if (!v) return null;
+    const t = new Date(v).getTime();
+    return Number.isFinite(t) ? Math.floor(t / 1000) : null;
+  })();
+
+  findings.push({
+    finding: 'receipt-chronology',
+    ok:
+      receiptIatSeconds === null
+      || passportCheckedAtSeconds === null
+      || receiptIatSeconds === passportCheckedAtSeconds,
+    detail: {
+      receipt_iat: receiptIatSeconds,
+      passport_checkedAt_seconds: passportCheckedAtSeconds,
+      converged: receiptIatSeconds === passportCheckedAtSeconds,
+    },
+  });
+
+  return findings;
+}
+
+function readReplayBlock(body: unknown): {
+  lineageKey?: string;
+  runId?: string;
+  schemeVersion?: string;
+} | null {
+  if (!body || typeof body !== 'object') return null;
+  const replay = (body as { replay?: Record<string, unknown> }).replay;
+  if (!replay || typeof replay !== 'object') return null;
+  return {
+    lineageKey: typeof replay.lineageKey === 'string' ? replay.lineageKey : undefined,
+    runId: typeof replay.runId === 'string' ? replay.runId : undefined,
+    schemeVersion: typeof replay.schemeVersion === 'string' ? replay.schemeVersion : undefined,
+  };
+}
+
+function readReceiptReplay(receipt: ReceiptProbe): {
+  lineageKey?: string;
+  runId?: string;
+  checkedAt?: string;
+} | null {
+  if (!receipt.ok || !receipt.decoded) return null;
+  const vcv = receipt.decoded.vcv as Record<string, unknown> | undefined;
+  if (!vcv) return null;
+  const replay = vcv.replay as Record<string, unknown> | null | undefined;
+  return {
+    lineageKey: replay && typeof replay.lineageKey === 'string' ? replay.lineageKey : undefined,
+    runId: replay && typeof replay.runId === 'string' ? replay.runId : undefined,
+    checkedAt: typeof vcv.checkedAt === 'string' ? vcv.checkedAt : undefined,
+  };
+}
+
+function readLastCheckedAt(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null;
+  const v = (body as { lastCheckedAt?: unknown }).lastCheckedAt;
+  return typeof v === 'string' ? v : null;
+}
+
+function allEqual<T>(values: readonly T[]): boolean {
+  if (values.length <= 1) return true;
+  return values.every((v) => v === values[0]);
+}
+
+async function fetchAll(baseUrl: string, npi: string): Promise<ConvergenceObservations> {
+  const base = baseUrl.replace(/\/+$/, '');
+  const [passportNpi, passportProxy, jwks, didDocument, trustRegister, receipt] = await Promise.all([
+    probeJson(`${base}/api/passport/npi/${encodeURIComponent(npi)}`),
+    probeJson(`${base}/api/passport/${encodeURIComponent(npi)}`),
+    probeJson(`${base}/.well-known/jwks.json`),
+    probeJson(`${base}/.well-known/did.json`),
+    probeJson(`${base}/.well-known/trust-register`),
+    probeReceipt(`${base}/api/receipt/${encodeURIComponent(npi)}`),
+  ]);
+  return {
+    npi,
+    surfaces: { passportNpi, passportProxy, jwks, didDocument, trustRegister, receipt },
+  };
+}
+
+async function main(): Promise<void> {
+  const { flags } = parseArgs(process.argv.slice(2));
+  const baseUrl = flags.get('base-url') ?? 'http://localhost:3030';
+  const npi = flags.get('npi');
+
+  if (!npi || !/^\d{10}$/.test(npi)) {
+    emitHumanLine('usage: verify-surface-convergence --base-url <url> --npi <10-digit-npi>');
+    process.exit(2);
+  }
+
+  emitHumanLine(`probing surfaces under ${baseUrl} for NPI ${npi}…`);
+  const observations = await fetchAll(baseUrl, npi);
+  const findings = analyzeConvergence(observations);
+
+  for (const f of findings) {
+    emitJsonLine(f as unknown as Record<string, unknown>);
+  }
+
+  const allOk = findings.every((f) => f.ok);
+  emitJsonLine({
+    finding: 'summary',
+    ok: allOk,
+    detail: {
+      npi,
+      baseUrl,
+      surfacesProbed: Object.keys(observations.surfaces).length,
+      findingsTotal: findings.length,
+      findingsOk: findings.filter((f) => f.ok).length,
+    },
+  });
+
+  emitHumanLine(
+    allOk
+      ? 'verify-surface-convergence: OK (all surfaces agree)'
+      : 'verify-surface-convergence: DIVERGENCE DETECTED (see findings above)',
+  );
+  process.exit(allOk ? 0 : 7);
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  void main();
+}


### PR DESCRIPTION
## Summary

Stacked on #351. Fourth CLI tool — probes every trust-bearing surface VitalCV exposes for a given NPI and verifies they all report THE SAME replay-identity truth.

Where #351's scripts work on offline JSON fixtures, this one talks to a live runtime over HTTP and catches cross-surface drift — the failure mode where a verifier reading the passport page and the receipt JWT for the same NPI would see different `lineageKey` / `runId` / `checkedAt` / active `kid`.

## Probed surfaces

| Surface | Shipped in |
|---|---|
| `/api/passport/npi/:npi` | Wave 10 (#343) |
| `/api/passport/:npi` (proxy) | #340 |
| `/api/receipt/:npi` (signed JWT) | #349 |
| `/.well-known/jwks.json` | #349 |
| `/.well-known/did.json` | #349 |
| `/.well-known/trust-register` | #349 |

## Five convergence findings

| Finding | Asserts |
|---|---|
| `lineageKey-consistency` | every surface emitting one agrees |
| `runId-consistency` | every surface emitting one agrees |
| `checkedAt-consistency` | passport `lastCheckedAt` == receipt `vcv.checkedAt` |
| `issuer-kid-consistency` | JWKS, did.json verificationMethod, trust-register, receipt `X-Receipt-Kid` header, and JWT protected header all carry the same `kid` |
| `receipt-chronology` | receipt `iat` seconds == passport `lastCheckedAt` seconds (proves #349's deterministic pinning) |

## Exit codes

| Code | Meaning |
|---|---|
| 0 | every surface agrees |
| 2 | bad input (missing/invalid NPI) |
| 7 | divergence detected (verifier-actionable signal) |

## Graceful degradation

Failed surface probes (network errors, 5xx, missing routes) drop out of the findings rather than falsely flagging divergence. A missing receipt does not produce a kid mismatch — it just reduces the observation count on the relevant finding.

## Pure analyzer + CLI wrapper

`analyzeConvergence(observations)` is exported separately from the `main()` wrapper, so it's unit-testable with inert fixture observations. No live HTTP, no JWT signing, no process spawning in tests.

## Files

| File | Status |
|---|---|
| `scripts/replay/verify-surface-convergence.ts` | **new** — script + exported `analyzeConvergence` |
| `apps/web/__tests__/replay-surface-convergence.test.ts` | **new** — 9 vitest cases |

## Operational hook

This is **pre-flight tooling for the Tier-1 merge plan** from the canonical merge graph: after each Tier-A merge, operators run this against the Vercel preview URL + Railway preview URL to verify the new surfaces agree BEFORE promoting to production. Faster than full Codex re-runs and catches divergence Codex can't see (which is per-PR, not cross-surface).

## Truth rules
- Banned-strings scan: CLEAN
- No new product claims; tool reports observable cross-surface state

## Validation
- Targeted vitest: **9/9** passing
- Full web build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**
- No new runtime dependencies (uses `jose` for JWT decode, already in deps)

## Out of scope (explicit follow-ups)
- Reverse-lookup variant by `lineageKey` (rather than NPI) — would need a backend endpoint
- Multi-NPI batch mode — trivial extension; deferred until operator demand
- Production-gate CI workflow that runs this against the preview URL on every merge — would be a small `.github/workflows/` PR