### PR TITLE
feat(verifier): completion surfaces — openid-configuration, /trust, receipt-by-lineage

### DIFF
--- a/apps/web/__tests__/verifier-continuity-completion.test.ts
+++ b/apps/web/__tests__/verifier-continuity-completion.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the three verifier-continuity completion surfaces shipped
+ * in this PR (stacked on #349):
+ *
+ *   /.well-known/openid-configuration   — OIDC discovery (courtesy)
+ *   /trust                              — institutional overview page
+ *   /api/receipt/[lineageKey]           — lineageKey-keyed receipt
+ *
+ * Cross-surface coherence with the existing #349 surfaces is also pinned.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { decodeJwt, decodeProtectedHeader } from 'jose';
+
+const ORIGIN = 'https://issuer.test.vitalcv.com';
+const TEST_NPI = '1346053246';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  process.env.VITALCV_ISSUER_ORIGIN = ORIGIN;
+  process.env.VITALCV_RUNTIME_CHANNEL = 'staging';
+  process.env.BACKEND_URL = 'http://backend.test';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─── /.well-known/openid-configuration ─────────────────────────────────────
+
+describe('/.well-known/openid-configuration', () => {
+  it('returns 200 with the required OIDC fields', async () => {
+    const mod = await import('../app/.well-known/openid-configuration/route');
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.issuer).toBe(ORIGIN);
+    expect(body.jwks_uri).toBe(`${ORIGIN}/.well-known/jwks.json`);
+    expect(body.id_token_signing_alg_values_supported).toEqual(['ES256']);
+    expect(body.subject_types_supported).toEqual(['public']);
+  });
+
+  it('emits empty response_types_supported (no OAuth flow) — honest, not a placeholder', async () => {
+    const mod = await import('../app/.well-known/openid-configuration/route');
+    const res = await mod.GET();
+    const body = await res.json();
+    expect(body.response_types_supported).toEqual([]);
+  });
+
+  it('emits the vitalcv:role + pointer to credential-issuer metadata', async () => {
+    const mod = await import('../app/.well-known/openid-configuration/route');
+    const res = await mod.GET();
+    const body = await res.json();
+    expect(body['vitalcv:role']).toBe('credential_issuer_only');
+    expect(body['vitalcv:credential_issuer_metadata']).toBe(
+      `${ORIGIN}/.well-known/openid-credential-issuer`,
+    );
+    expect(body['vitalcv:notes']).toContain('VitalCV is a Verifiable Credential issuer');
+  });
+
+  it('points authorization_endpoint and token_endpoint at the credential-issuer metadata (no placeholder URLs)', async () => {
+    const mod = await import('../app/.well-known/openid-configuration/route');
+    const res = await mod.GET();
+    const body = await res.json();
+    const expected = `${ORIGIN}/.well-known/openid-credential-issuer`;
+    expect(body.authorization_endpoint).toBe(expected);
+    expect(body.token_endpoint).toBe(expected);
+  });
+
+  it('has production-safe Cache-Control (public, max-age=3600, swr=86400)', async () => {
+    const mod = await import('../app/.well-known/openid-configuration/route');
+    const res = await mod.GET();
+    expect(res.headers.get('cache-control')).toMatch(/public.*max-age=3600.*stale-while-revalidate=86400/);
+  });
+});
+
+// ─── /trust page ──────────────────────────────────────────────────────────
+
+describe('/trust page', () => {
+  it('server-renders the institutional overview using the trust-register payload', async () => {
+    const mod = await import('../app/trust/page');
+    // Async server component — call as function, await the JSX, render to string.
+    const element = await (mod.default as () => Promise<React.ReactElement>)();
+    const html = renderToStaticMarkup(element);
+
+    // Header text
+    expect(html).toContain('Institutional trust infrastructure');
+    expect(html).toContain('VitalCV · trust');
+
+    // Section anchors (institutional reading order)
+    expect(html).toContain('data-section="issuer identity"');
+    expect(html).toContain('data-section="signing"');
+    expect(html).toContain('data-section="runtime"');
+    expect(html).toContain('data-section="launch-spine sources"');
+    expect(html).toContain('data-section="supported credentials"');
+    expect(html).toContain('data-section="discovery endpoints"');
+    expect(html).toContain('data-section="operational doctrine"');
+    expect(html).toContain('data-section="disclaimers"');
+
+    // Real values from the trust-register (issuer DID, kid, jwks URI)
+    expect(html).toContain('did:web:issuer.test.vitalcv.com');
+    expect(html).toContain('/.well-known/jwks.json');
+    expect(html).toContain('ES256');
+
+    // All four launch-spine source ids visible
+    expect(html).toContain('data-source-id="NPPES_API"');
+    expect(html).toContain('data-source-id="OIG_LEIE"');
+    expect(html).toContain('data-source-id="PECOS_PUBLIC"');
+    expect(html).toContain('data-source-id="STATE_BOARD"');
+  });
+});
+
+// ─── /api/receipt/[lineageKey] ────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function buildPassport(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: TEST_NPI,
+    identity: { displayName: 'Macie Miller', entityType: 'PERSON', specialty: 'PA-C', status: 'ACTIVE' },
+    readiness: { score: 50, level: 'L1', status: 'PARTIAL' },
+    trustPosture: { band: 'YELLOW' },
+    lastCheckedAt: '2026-04-01T15:00:00.000Z',
+    replay: {
+      lineageKey: 'lin_v1_aaaabbbbccccdddd',
+      runId: 'run_v1_1111222233334444',
+      schemeVersion: 'v1' as const,
+    },
+    ...overrides,
+  };
+}
+
+async function callReceiptByLineage(lineageKey: string, search = '') {
+  const mod = await import('../app/api/receipt/by-lineage/[lineageKey]/route');
+  const req = new Request(`http://localhost/api/receipt/by-lineage/${lineageKey}${search}`) as never;
+  return mod.GET(req, { params: Promise.resolve({ lineageKey }) });
+}
+
+describe('/api/receipt/[lineageKey]', () => {
+  it('returns 400 on a malformed lineageKey (not lin_v1_<16 hex>)', async () => {
+    const res = await callReceiptByLineage('not-a-key', '?npi=1346053246');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('invalid_lineage_key');
+  });
+
+  it('returns 501 when no ?npi= query is supplied (claim required, no backend index)', async () => {
+    const res = await callReceiptByLineage('lin_v1_aaaabbbbccccdddd');
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.error).toBe('npi_query_required');
+    expect(body.alternative_path).toBe('/api/receipt/<npi>');
+  });
+
+  it('returns 400 when ?npi= is not 10 digits', async () => {
+    const res = await callReceiptByLineage('lin_v1_aaaabbbbccccdddd', '?npi=not-a-npi');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when computeLineageKey(npi) does not match the path lineageKey', async () => {
+    const res = await callReceiptByLineage('lin_v1_aaaabbbbccccdddd', `?npi=${TEST_NPI}`);
+    // The fixed string lin_v1_aaaabbbbccccdddd is unlikely to equal sha256("entity|1346053246")[0:16].
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('lineage_mismatch');
+    expect(body.path_lineageKey).toBe('lin_v1_aaaabbbbccccdddd');
+    expect(body.expected_lineageKey).toMatch(/^lin_v1_[0-9a-f]{16}$/);
+  });
+
+  it('issues a real signed JWT receipt when lineageKey + npi cross-check passes', async () => {
+    // Step 1: compute the real lineageKey for our test NPI by hitting the
+    // 401 path and reading expected_lineageKey from the response body.
+    const probe = await callReceiptByLineage('lin_v1_aaaabbbbccccdddd', `?npi=${TEST_NPI}`);
+    const probeBody = await probe.json();
+    const realLineageKey: string = probeBody.expected_lineageKey;
+    expect(realLineageKey).toMatch(/^lin_v1_[0-9a-f]{16}$/);
+
+    // Step 2: stub the upstream backend so the NPI receipt handler can
+    // build its JWT payload.
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => jsonResponse(buildPassport())));
+
+    // Step 3: call with the correct lineageKey + npi pair — should issue.
+    const res = await callReceiptByLineage(realLineageKey, `?npi=${TEST_NPI}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/jwt/);
+
+    const jwt = await res.text();
+    const header = decodeProtectedHeader(jwt);
+    const payload = decodeJwt(jwt) as Record<string, unknown> & {
+      vcv: { replay: { lineageKey: string } };
+    };
+    expect(header.alg).toBe('ES256');
+    expect(payload.sub).toBe(`npi:${TEST_NPI}`);
+    expect(payload.vcv.replay.lineageKey).toBe('lin_v1_aaaabbbbccccdddd'); // from passport fixture
+  });
+});
+
+// ─── cross-surface coherence — net-new surfaces agree with #349 ───────────
+
+describe('verifier-continuity completion — cross-surface coherence', () => {
+  it('openid-configuration jwks_uri matches the JWKS surface from #349', async () => {
+    const [oidc, jwks] = await Promise.all([
+      import('../app/.well-known/openid-configuration/route').then((m) => m.GET()).then((r) => r.json()),
+      import('../app/.well-known/jwks.json/route').then((m) => m.GET()).then((r) => ({
+        status: r.status,
+        body: r.json().then((b) => b),
+      })),
+    ]);
+    expect(jwks.status).toBe(200);
+    expect(oidc.jwks_uri).toMatch(/\/\.well-known\/jwks\.json$/);
+  });
+
+  it('openid-configuration issuer matches the did.json id and trust-register issuer.did host', async () => {
+    const oidc = await import('../app/.well-known/openid-configuration/route').then((m) => m.GET()).then((r) => r.json());
+    const did = await import('../app/.well-known/did.json/route').then((m) => m.GET()).then((r) => r.json());
+    const trustReg = await import('../app/.well-known/trust-register/route').then((m) => m.GET()).then((r) => r.json());
+    expect(oidc.issuer).toBe(trustReg.issuer.origin);
+    expect(did.id).toBe(trustReg.issuer.did);
+  });
+});
+
+describe('doctrine — banned-strings scan', () => {
+  it('no surface emits banned phrases', async () => {
+    const [oidc, trustHtml] = await Promise.all([
+      import('../app/.well-known/openid-configuration/route').then((m) => m.GET()).then((r) => r.text()),
+      (async () => {
+        const mod = await import('../app/trust/page');
+        const el = await (mod.default as () => Promise<React.ReactElement>)();
+        return renderToStaticMarkup(el);
+      })(),
+    ]);
+    const combined = oidc + '\n' + trustHtml;
+    const banned = [
+      ['automatically', 'verified'].join(' '),
+      ['guaranteed', 'verification'].join(' '),
+      ['HIPAA', 'compliant'].join(' '),
+      ['SOC2', 'certified'].join(' '),
+      ['certified', 'compliant'].join(' '),
+      ['complete', 'credentialing'].join(' '),
+      ['legally', 'accepted'].join(' '),
+      ['risk', 'transferred'].join(' '),
+    ];
+    for (const p of banned) expect(combined).not.toContain(p);
+  });
+});

--- a/apps/web/app/.well-known/openid-configuration/route.ts
+++ b/apps/web/app/.well-known/openid-configuration/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /.well-known/openid-configuration
+ *
+ * OpenID Connect Discovery 1.0 surface. VitalCV is a **Verifiable
+ * Credential issuer**, not a full OpenID Provider — we don't run
+ * authorization or token endpoints. This handler is published as a
+ * COURTESY for verifiers that probe `openid-configuration` before
+ * (or instead of) `openid-credential-issuer`.
+ *
+ * The payload contains:
+ *
+ *   - `issuer` and `jwks_uri`     — real, identical to what's published
+ *                                   in the OID4VCI metadata + DID document
+ *   - `id_token_signing_alg_values_supported` — `['ES256']` (real)
+ *   - `subject_types_supported`    — `['public']` (real)
+ *   - `response_types_supported`   — `[]` (we issue VCs, not OIDC tokens)
+ *   - `authorization_endpoint`     — pointer to the credential-issuer
+ *                                   metadata; intentionally not an
+ *                                   OAuth flow endpoint
+ *   - `token_endpoint`             — same pointer
+ *   - `vitalcv:role`               — non-standard extension; signals
+ *                                   "credential_issuer_only"
+ *   - `vitalcv:credential_issuer_metadata` — pointer to the canonical
+ *                                   discovery surface
+ *
+ * Verifiers that are strictly RFC-OIDC will see the empty
+ * `response_types_supported` and recognize that no OAuth flow is
+ * available; verifiers that understand VC issuance will follow the
+ * extension pointer to OID4VCI metadata.
+ *
+ * "No placeholder values" rule (from the shipping brief):
+ *   We do NOT fabricate authorization_endpoint / token_endpoint URLs
+ *   that look like OAuth flows but aren't. The pointer values are
+ *   honest — they go to the OID4VCI metadata endpoint, which is the
+ *   real entry point for VitalCV credential issuance.
+ */
+import { NextResponse } from 'next/server';
+import { getIssuerOrigin } from '@/lib/trust/wellKnownIdentity';
+
+export const runtime = 'nodejs';
+export const revalidate = 3600;
+
+export async function GET() {
+  const origin = getIssuerOrigin();
+  const credentialIssuerMetadata = `${origin}/.well-known/openid-credential-issuer`;
+
+  const metadata = {
+    issuer: origin,
+    jwks_uri: `${origin}/.well-known/jwks.json`,
+    response_types_supported: [] as string[],
+    subject_types_supported: ['public'],
+    id_token_signing_alg_values_supported: ['ES256'],
+    // RFC-required by OIDC discovery; we point them at the credential
+    // issuer's discovery surface rather than fabricate OAuth endpoints.
+    authorization_endpoint: credentialIssuerMetadata,
+    token_endpoint: credentialIssuerMetadata,
+    'vitalcv:role': 'credential_issuer_only',
+    'vitalcv:credential_issuer_metadata': credentialIssuerMetadata,
+    'vitalcv:notes':
+      'VitalCV is a Verifiable Credential issuer (OID4VCI), not an OIDC Provider. '
+      + 'Use openid-credential-issuer metadata for credential discovery. '
+      + 'response_types_supported is intentionally empty.',
+  };
+
+  return NextResponse.json(metadata, {
+    headers: {
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/apps/web/app/api/receipt/by-lineage/[lineageKey]/route.ts
+++ b/apps/web/app/api/receipt/by-lineage/[lineageKey]/route.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/receipt/by-lineage/:lineageKey
+ *
+ * Receipt retrieval keyed by `lineageKey` rather than NPI. Mirrors the
+ * shape of the NPI-keyed handler at `apps/web/app/api/receipt/[npi]/`
+ * but accepts the institutional-identity claim a verifier already has
+ * (the lineageKey) as the path parameter.
+ *
+ * Path note: this route lives under `/by-lineage/` because Next.js
+ * cannot have two different dynamic-slug names at the same path level.
+ * The sister NPI route is `/api/receipt/[npi]`; both share the same
+ * downstream signing path.
+ *
+ * Why a separate route: a verifier holding a signed receipt has the
+ * `lineageKey` in the JWT's `vcv.replay.lineageKey` claim. They can
+ * use this endpoint to re-fetch a fresh receipt for the same subject
+ * without needing to know the NPI behind the lineage — but ONLY if
+ * they ALSO supply the NPI as a query param so the route can verify
+ * the claim: `computeLineageKey(npi) === path.lineageKey`.
+ *
+ * The cross-check prevents callers from probing arbitrary lineageKeys
+ * without proof of the underlying subject; it also makes the route's
+ * semantics symmetric with the NPI handler — both require the NPI to
+ * actually issue.
+ *
+ * Why not a backend-side lineageKey → NPI lookup: that would require
+ * a persistent index that doesn't exist on the current schema.
+ * Adding it is a separate piece of work; this handler ships the
+ * convenience surface today using a verifier-supplied claim instead.
+ *
+ *   200 — receipt issued (proxies to the NPI handler)
+ *   400 — missing or malformed `?npi=`
+ *   401 — `computeLineageKey(npi) !== path.lineageKey` (claim rejected)
+ *   404 — passport not available for this NPI
+ *   501 — no `?npi=` supplied AND no backend lookup index available
+ *
+ * Response is the same `application/jwt` body as the NPI handler.
+ */
+import { type NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'node:crypto';
+import { GET as receiptByNpi } from '../../[npi]/route';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const LINEAGE_PREFIX = 'lin_v1_';
+
+function isV1LineageKey(value: string): boolean {
+  return value.startsWith(LINEAGE_PREFIX) && value.length === LINEAGE_PREFIX.length + 16;
+}
+
+/**
+ * Server-side recomputation of `computeLineageKey(npi)`. We MUST use
+ * the same algorithm the backend canonical (`apps/api/backend/src/services/
+ * replay/replayIdentity.ts`, PR #343) uses; this is a small inline mirror
+ * because importing the backend module into this web route would cross
+ * an app boundary unnecessarily for one hash. The contract doc
+ * (`docs/contracts/replay-identity-contract.md`, PR #353) pins both
+ * implementations to byte-identical output.
+ */
+function computeLineageKeyFromNpi(npi: string): string {
+  const canonical = npi.trim().toLowerCase();
+  const digest = createHash('sha256').update(`entity|${canonical}`).digest('hex');
+  return `${LINEAGE_PREFIX}${digest.slice(0, 16)}`;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ lineageKey: string }> },
+) {
+  const { lineageKey } = await params;
+
+  if (!isV1LineageKey(lineageKey)) {
+    return NextResponse.json(
+      {
+        error: 'invalid_lineage_key',
+        detail: 'Path parameter must be a v1 lineage key (lin_v1_<16 hex chars>).',
+      },
+      { status: 400 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const npi = url.searchParams.get('npi')?.trim() ?? '';
+
+  if (!npi) {
+    return NextResponse.json(
+      {
+        error: 'npi_query_required',
+        detail:
+          'Receipt retrieval by lineageKey requires the NPI as a verifier-supplied claim '
+          + '(?npi=<10-digit-npi>). The route will verify computeLineageKey(npi) matches '
+          + 'the path lineageKey before issuing. A backend-side lineageKey→NPI lookup '
+          + 'index is not currently available.',
+        alternative_path: '/api/receipt/<npi>',
+      },
+      { status: 501 },
+    );
+  }
+
+  if (!/^\d{10}$/.test(npi)) {
+    return NextResponse.json(
+      { error: 'invalid_npi', detail: 'NPI must be a 10-digit string.' },
+      { status: 400 },
+    );
+  }
+
+  const expectedLineageKey = computeLineageKeyFromNpi(npi);
+  if (expectedLineageKey !== lineageKey) {
+    return NextResponse.json(
+      {
+        error: 'lineage_mismatch',
+        detail: 'The supplied NPI does not match the path lineageKey.',
+        path_lineageKey: lineageKey,
+        expected_lineageKey: expectedLineageKey,
+      },
+      { status: 401 },
+    );
+  }
+
+  // Delegate to the NPI handler — same JWT signing path, same caching
+  // headers, same deterministic jti.
+  return receiptByNpi(req, { params: Promise.resolve({ npi }) });
+}

--- a/apps/web/app/trust/page.tsx
+++ b/apps/web/app/trust/page.tsx
@@ -1,0 +1,256 @@
+/**
+ * /trust — Institutional trust overview surface.
+ *
+ * The single public page where an institutional verifier (NCQA, Joint
+ * Commission, hospital procurement, security engineer) lands to inspect
+ * VitalCV's trust infrastructure end-to-end. Renders the same data the
+ * machine-readable `/.well-known/trust-register` surface (#349) emits,
+ * laid out for a human reader in the institutional register: monochrome,
+ * mono identifiers, left-aligned, no decorative iconography.
+ *
+ * Data source: the in-process `/.well-known/trust-register` handler is
+ * called directly via dynamic import, not over HTTP. That keeps the
+ * page server-rendering deterministic and avoids hostname resolution
+ * concerns at SSR time.
+ *
+ * Section order (institutional reading order):
+ *
+ *   1. Issuer identity            (DID + origin + scheme version)
+ *   2. Signing infrastructure      (kid, algorithm, JWKS, DID document URIs)
+ *   3. Runtime context             (channel, deploy commit, published_at)
+ *   4. Launch-spine sources        (the four canonical primary sources)
+ *   5. Supported credential types  (SD-JWT VCTs)
+ *   6. Sibling discovery endpoints (well-known + verify + receipt URLs)
+ *   7. Operational doctrine        (pointers to the public doc artifacts)
+ *   8. Disclaimers                 (explicit non-claims — no fake PSV,
+ *                                   no compliance certification)
+ */
+import type { Metadata } from 'next';
+import * as React from 'react';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export const metadata: Metadata = {
+  title: 'Trust · VitalCV',
+  description: 'Institutional trust infrastructure overview.',
+};
+
+interface TrustRegisterPayload {
+  schema_version: number;
+  schema_url: string;
+  issuer: { did: string; origin: string };
+  signing: {
+    active_kid: string;
+    algorithm: string;
+    jwks_uri: string;
+    did_document_uri: string;
+  };
+  runtime: {
+    channel: string;
+    deploy_commit: string;
+    published_at: string;
+  };
+  launch_spine: ReadonlyArray<{ id: string; label: string; kind: string }>;
+  credentials: ReadonlyArray<{ type: string; vct: string; format: string }>;
+  endpoints: Record<string, string>;
+  doctrine: Record<string, string>;
+  disclaimers: ReadonlyArray<string>;
+}
+
+async function loadTrustRegister(): Promise<TrustRegisterPayload> {
+  const mod = await import('../.well-known/trust-register/route');
+  const res = await mod.GET();
+  return (await res.json()) as TrustRegisterPayload;
+}
+
+export default async function TrustPage() {
+  const manifest = await loadTrustRegister();
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10 space-y-8">
+      <header className="space-y-2 border-b border-border pb-4">
+        <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+          VitalCV · trust
+        </p>
+        <h1 className="text-2xl font-semibold leading-tight">Institutional trust infrastructure</h1>
+        <p className="text-sm text-muted-foreground max-w-xl">
+          Verifier-facing surface for inspecting VitalCV&apos;s issuer identity,
+          signing topology, launch-spine sources, supported credentials,
+          and operational doctrine. The same data is available
+          machine-readable at{' '}
+          <Link href="/.well-known/trust-register" className="font-mono underline">
+            /.well-known/trust-register
+          </Link>{' '}
+          (schema v{manifest.schema_version}).
+        </p>
+      </header>
+
+      <Section label="issuer identity">
+        <Row k="did" v={manifest.issuer.did} mono />
+        <Row k="origin" v={manifest.issuer.origin} mono />
+        <Row k="schema version" v={String(manifest.schema_version)} />
+        <Row k="schema url" v={manifest.schema_url} mono />
+      </Section>
+
+      <Section label="signing">
+        <Row k="active kid" v={manifest.signing.active_kid} mono />
+        <Row k="algorithm" v={manifest.signing.algorithm} />
+        <Row k="jwks_uri" v={manifest.signing.jwks_uri} mono link={manifest.signing.jwks_uri} />
+        <Row
+          k="did document"
+          v={manifest.signing.did_document_uri}
+          mono
+          link={manifest.signing.did_document_uri}
+        />
+      </Section>
+
+      <Section label="runtime">
+        <Row k="channel" v={manifest.runtime.channel} mono />
+        <Row k="deploy commit" v={manifest.runtime.deploy_commit} mono />
+        <Row k="published at" v={manifest.runtime.published_at} mono />
+      </Section>
+
+      <Section label="launch-spine sources">
+        <ul className="flex flex-col" role="list">
+          {manifest.launch_spine.map((s, i) => (
+            <li
+              key={s.id}
+              className="flex items-baseline gap-3 py-1 text-[12px] border-t border-border/40 first:border-t-0"
+              data-source-id={s.id}
+            >
+              <span aria-hidden="true" className="font-mono text-muted-foreground">
+                {i === 0 ? '┌' : i === manifest.launch_spine.length - 1 ? '└' : '├'}
+              </span>
+              <span className="font-mono text-foreground">{s.id}</span>
+              <span className="opacity-80">{s.label}</span>
+              <span className="font-mono text-[10px] uppercase opacity-60">· {s.kind}</span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section label="supported credentials">
+        <ul className="flex flex-col" role="list">
+          {manifest.credentials.map((c) => (
+            <li
+              key={c.type}
+              className="flex items-baseline gap-3 py-1 text-[12px] border-t border-border/40 first:border-t-0"
+              data-credential-type={c.type}
+            >
+              <span className="font-mono">{c.type}</span>
+              <span className="font-mono text-[10px] uppercase opacity-60">{c.format}</span>
+              <span className="font-mono text-[11px] opacity-80">{c.vct}</span>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section label="discovery endpoints">
+        <ul className="flex flex-col" role="list">
+          {Object.entries(manifest.endpoints).map(([k, v]) => (
+            <li
+              key={k}
+              className="flex items-baseline gap-3 py-1 text-[12px] border-t border-border/40 first:border-t-0"
+            >
+              <span className="font-mono text-muted-foreground uppercase tracking-wide text-[10px]">
+                {k.replace(/_/g, ' ')}
+              </span>
+              <Link href={v} className="font-mono hover:underline break-all">
+                {v}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section label="operational doctrine">
+        <ul className="flex flex-col" role="list">
+          {Object.entries(manifest.doctrine).map(([k, v]) => (
+            <li
+              key={k}
+              className="flex items-baseline gap-3 py-1 text-[12px] border-t border-border/40 first:border-t-0"
+            >
+              <span className="font-mono text-muted-foreground uppercase tracking-wide text-[10px]">
+                {k.replace(/_/g, ' ')}
+              </span>
+              <Link href={v} className="font-mono hover:underline break-all">
+                {v}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <Section label="disclaimers">
+        <ul className="flex flex-col gap-2" role="list">
+          {manifest.disclaimers.map((d, i) => (
+            <li
+              key={i}
+              className="text-[11px] leading-snug opacity-80 border-l-2 border-border pl-3"
+              data-disclaimer-index={i}
+            >
+              {d}
+            </li>
+          ))}
+        </ul>
+      </Section>
+
+      <footer className="border-t border-border pt-3 text-[11px] opacity-70">
+        Machine-readable form:{' '}
+        <Link href="/.well-known/trust-register" className="font-mono underline">
+          /.well-known/trust-register
+        </Link>
+        {' · '}
+        DID document:{' '}
+        <Link href="/.well-known/did.json" className="font-mono underline">
+          /.well-known/did.json
+        </Link>
+        {' · '}
+        JWKS:{' '}
+        <Link href="/.well-known/jwks.json" className="font-mono underline">
+          /.well-known/jwks.json
+        </Link>
+      </footer>
+    </main>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2" aria-label={label} data-section={label}>
+      <h2 className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </h2>
+      <div className="flex flex-col gap-1">{children}</div>
+    </section>
+  );
+}
+
+function Row({
+  k,
+  v,
+  mono = false,
+  link,
+}: {
+  k: string;
+  v: string;
+  mono?: boolean;
+  link?: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[12px]" data-row-key={k}>
+      <span className="font-mono uppercase tracking-wide text-[10px] text-muted-foreground min-w-[7rem]">
+        {k}
+      </span>
+      {link ? (
+        <Link href={link} className={mono ? 'font-mono hover:underline break-all' : 'hover:underline'}>
+          {v}
+        </Link>
+      ) : (
+        <span className={mono ? 'font-mono break-all' : ''}>{v}</span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stacked on #349. Closes the three genuinely net-new items from the "finish verifier continuity" brief that weren't already in the queue:

| Brief item | Status |
|---|---|
| `/.well-known/jwks.json` | already in #349 |
| `/.well-known/did.json` | already in #349 |
| `/.well-known/openid-credential-issuer` | already in #349 |
| **`/.well-known/openid-configuration`** | **this PR** |
| **`/trust`** | **this PR** |
| `/verify` | already in #345 |
| **`/api/receipt/[lineageKey]`** | **this PR** (mounted at `/api/receipt/by-lineage/[lineageKey]`) |

## Files

| File | Status |
|---|---|
| `apps/web/app/.well-known/openid-configuration/route.ts` | **new** |
| `apps/web/app/trust/page.tsx` | **new** — server-rendered institutional overview |
| `apps/web/app/api/receipt/by-lineage/[lineageKey]/route.ts` | **new** — lineageKey-keyed receipt with NPI cross-check |
| `apps/web/__tests__/verifier-continuity-completion.test.ts` | **new** — 14 vitest cases |

## Key design notes

### openid-configuration honesty

VitalCV is a Verifiable Credential issuer (OID4VCI), not a full OIDC Provider. The handler:
- emits real values for `issuer`, `jwks_uri`, `id_token_signing_alg_values_supported: ['ES256']`, `subject_types_supported: ['public']`
- emits an **empty** `response_types_supported` array (we don't run an OAuth flow — honest, not a placeholder)
- points `authorization_endpoint` + `token_endpoint` at `/.well-known/openid-credential-issuer` (real URL, signals where to actually go)
- adds `vitalcv:role: "credential_issuer_only"` + `vitalcv:notes` explaining the relationship

**"no placeholder values" rule honored:** no fictional OAuth URLs, no fabricated scopes.

### /trust page

Server-rendered overview consuming the in-process trust-register payload (no HTTP round-trip). Eight sections in institutional reading order: issuer identity → signing → runtime → launch-spine sources → supported credentials → discovery endpoints → operational doctrine → disclaimers. Monochrome, mono identifiers, left-aligned, no decorative iconography. Every row + section carries data-* attributes for automated inspection.

### receipt-by-lineage path naming

Brief asked for `/api/receipt/[lineageKey]`. Next.js doesn't allow two different dynamic-slug names at the same path level — `[npi]` is already in #349. Mounted instead at **`/api/receipt/by-lineage/[lineageKey]`**, which is unambiguous about the lookup method and keeps the existing NPI route intact.

The route requires `?npi=` as a verifier-supplied claim and cross-checks `computeLineageKey(npi) === path.lineageKey` before delegating to the NPI handler. **501 with structured pointer body** when no NPI is supplied — honest acknowledgment that a backend-side lineageKey→NPI index would be required for direct lookup; not a placeholder.

## Cross-surface coherence (pinned)

| Property | Verified across |
|---|---|
| `jwks_uri` | openid-configuration ↔ JWKS surface |
| `issuer` | openid-configuration ↔ trust-register `issuer.origin` |
| DID `id` | did.json ↔ trust-register `issuer.did` |

## Truth rules
- Banned-strings scan: CLEAN across all new surfaces
- No fictional OAuth endpoints
- No bare `Verified` labels

## Validation
- Targeted vitest: **14/14** passing
- Full web build: `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks**
- Diff scope: 4 new files (3 routes/pages + 1 test); zero existing files modified