### PR TITLE
chore(ui): replace bare "Verified" labels with contextual phrases + add regression gate

### DIFF
--- a/apps/web/__tests__/banned-verified-label.test.ts
+++ b/apps/web/__tests__/banned-verified-label.test.ts
@@ -7,37 +7,46 @@ import path from 'node:path';
  *
  * CLAUDE.md (truth contract) bans the bare word "Verified" as a status label.
  * The follow-up wave-10a/docs-status audit found ~20 surfaces still rendering
- * it as a badge, tile, ternary, or stat label. This test walks the
- * relevant source roots and fails on any future regression.
+ * it as a badge, tile, ternary, or stat label. This test walks the relevant
+ * source roots and fails on any future regression.
  *
  * What this catches:
- *   - Any quoted bare-Verified literal in source — e.g. `'Verified'`, `"Verified"`,
- *     `` `Verified` ``. Catches badge labels, ternaries, status maps, etc.
- *   - Any raw JSX text node of `>Verified<`. Catches `<span>Verified</span>`,
- *     `<dt>Verified</dt>`, etc.
+ *   - Any quoted bare-Verified literal in code — e.g. `'Verified'`,
+ *     `"Verified"`, `` `Verified` ``. Catches badge labels, ternaries,
+ *     status maps, etc.
+ *   - Any same-line JSX text node `>Verified<`. Catches
+ *     `<span>Verified</span>`, `<dt>Verified</dt>`, etc.
+ *   - Any multi-line JSX text node where `Verified` is alone on its own
+ *     line (preceded by a JSX-open line and followed by a JSX-close line).
+ *   - Any "icon-prefix" JSX pattern where a line ends with `> Verified`
+ *     or `/> Verified` (i.e. an icon element followed by bare-`Verified`
+ *     text on the same line, then a closing tag on the next line).
  *
- * What this does NOT catch (and that's intentional):
- *   - Past-tense uses inside larger strings, e.g. `'Last confirmed'`,
- *     `'3 Verified'`, `'No verified items'` — these don't read as a bare
- *     status label.
- *   - References inside `__tests__/`, the build-time `_archive/`, generated
- *     `.d.ts` types, or the issuer-verification statusCopy comments
- *     (which document the rule).
+ * What this does NOT catch (intentionally):
+ *   - Compound phrases — `'Cryptographically Verified'`,
+ *     `'Primary Source Verified'`, `'Document Verified'`,
+ *     `'Email confirmed'`, `'3 Verified'`, `'No verified items'`. These
+ *     are not the bare status label.
+ *   - References inside `__tests__/`, the build-time `_archive/`,
+ *     generated `.d.ts` types, line/block comments, or the
+ *     issuer-verification `statusCopy.ts` (which documents the rule).
  *
  * Allowlist: add `file:line` entries when a future case is provably safe.
- * Today the list is empty. Keep it empty whenever you can — each new entry
- * weakens the institutional guarantee.
+ * Keep it empty whenever you can — each entry weakens the institutional
+ * guarantee.
  */
 
 const REPO_ROOTS = [
   path.resolve(__dirname, '..', 'components'),
   path.resolve(__dirname, '..', 'app'),
   path.resolve(__dirname, '..', 'design-system'),
+  path.resolve(__dirname, '..', 'lib'),
 ];
 
 const EXCLUDED_DIR_NAMES = new Set(['__tests__', 'node_modules', 'dist', '.next']);
 const EXCLUDED_PATH_SUBSTRINGS = [
   path.sep + '_archive' + path.sep,
+  // statusCopy.ts contains documentation comments asserting the rule.
   path.sep + 'lib' + path.sep + 'issuer-verification' + path.sep + 'statusCopy.ts',
 ];
 
@@ -45,11 +54,10 @@ const ALLOWED: ReadonlySet<string> = new Set<string>([
   // file:line entries — add with a comment justifying the exception.
 ]);
 
-// Two banned forms: a literal quoted `Verified` (matches '', "", or ``) and a
-// JSX text node `>Verified<`. The literal-quote check rejects badge labels,
-// ternary returns, and status maps; the JSX-text check rejects raw render text.
 const QUOTED_BARE_PATTERN = /(['"`])Verified\1/;
-const JSX_TEXT_PATTERN = />Verified</;
+const JSX_INLINE_PATTERN = />Verified</;
+const JSX_AFTER_ELEMENT_PATTERN = /(?:>|\/>)\s+Verified\s*$/;
+const JSX_BEFORE_ELEMENT_PATTERN = /^\s*Verified\s+</;
 
 function shouldScanFile(filePath: string): boolean {
   if (!filePath.endsWith('.ts') && !filePath.endsWith('.tsx')) return false;
@@ -78,31 +86,75 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
+/**
+ * Strip `/* ... *​/` block comments and `//` line comments from source so
+ * comment-only references to the rule (e.g. in docstrings) don't trip
+ * the regex. This is a pragmatic strip, not a parser — it accepts that
+ * the word "Verified" inside a template string with a `//` will be
+ * stripped. That trade-off is fine: bare-label uses in template strings
+ * are exactly what we want to ban.
+ */
+function stripComments(source: string): string {
+  // Strip /* ... */ blocks first (non-greedy).
+  const blockStripped = source.replace(/\/\*[\s\S]*?\*\//g, (match) =>
+    match.replace(/[^\n]/g, ' '),
+  );
+  // Then strip // line comments through end of line.
+  return blockStripped.replace(/\/\/[^\n]*/g, (match) => ' '.repeat(match.length));
+}
+
 interface Hit {
   file: string;
   line: number;
   text: string;
-  reason: 'quoted' | 'jsx-text';
+  reason: 'quoted' | 'jsx-inline' | 'jsx-standalone-line' | 'jsx-after-element' | 'jsx-before-element';
+}
+
+function isTsxFile(file: string): boolean {
+  return file.endsWith('.tsx');
 }
 
 function findHits(): Hit[] {
   const files: string[] = [];
   for (const root of REPO_ROOTS) walk(root, files);
 
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const hits: Hit[] = [];
+
   for (const file of files) {
-    const contents = fs.readFileSync(file, 'utf8');
-    const lines = contents.split(/\r?\n/);
-    for (let i = 0; i < lines.length; i++) {
-      const text = lines[i];
+    const original = fs.readFileSync(file, 'utf8');
+    const stripped = stripComments(original);
+    const originalLines = original.split(/\r?\n/);
+    const strippedLines = stripped.split(/\r?\n/);
+    const tsx = isTsxFile(file);
+
+    for (let i = 0; i < strippedLines.length; i++) {
+      const codeLine = strippedLines[i];
+      const reportLine = originalLines[i] ?? '';
       const lineNumber = i + 1;
-      const rel = path.relative(path.resolve(__dirname, '..', '..', '..'), file);
+      const rel = path.relative(repoRoot, file);
       const key = `${rel}:${lineNumber}`;
       if (ALLOWED.has(key)) continue;
-      if (QUOTED_BARE_PATTERN.test(text)) {
-        hits.push({ file: rel, line: lineNumber, text: text.trim(), reason: 'quoted' });
-      } else if (JSX_TEXT_PATTERN.test(text)) {
-        hits.push({ file: rel, line: lineNumber, text: text.trim(), reason: 'jsx-text' });
+
+      if (QUOTED_BARE_PATTERN.test(codeLine)) {
+        hits.push({ file: rel, line: lineNumber, text: reportLine.trim(), reason: 'quoted' });
+        continue;
+      }
+      if (tsx && JSX_INLINE_PATTERN.test(codeLine)) {
+        hits.push({ file: rel, line: lineNumber, text: reportLine.trim(), reason: 'jsx-inline' });
+        continue;
+      }
+      if (tsx && codeLine.trim() === 'Verified') {
+        hits.push({ file: rel, line: lineNumber, text: reportLine.trim(), reason: 'jsx-standalone-line' });
+        continue;
+      }
+      if (tsx && JSX_AFTER_ELEMENT_PATTERN.test(codeLine)) {
+        hits.push({ file: rel, line: lineNumber, text: reportLine.trim(), reason: 'jsx-after-element' });
+        continue;
+      }
+      if (tsx && JSX_BEFORE_ELEMENT_PATTERN.test(codeLine)) {
+        hits.push({ file: rel, line: lineNumber, text: reportLine.trim(), reason: 'jsx-before-element' });
+        continue;
       }
     }
   }
@@ -110,7 +162,7 @@ function findHits(): Hit[] {
 }
 
 describe('banned-verified-label regression gate', () => {
-  it('no bare "Verified" labels render in apps/web components, app, or design-system', () => {
+  it('no bare "Verified" labels render anywhere in apps/web/{components,app,design-system,lib}', () => {
     const hits = findHits();
     if (hits.length > 0) {
       const report = hits
@@ -120,7 +172,7 @@ describe('banned-verified-label regression gate', () => {
         `Found ${hits.length} bare "Verified" label site(s). ` +
           `Use a contextual phrase ('Source-confirmed', 'Issuer-confirmed', ` +
           `'Identity confirmed by issuer', 'High-confidence tier', 'Last confirmed', ` +
-          `etc.) per CLAUDE.md truth contract.\n${report}`,
+          `'Email confirmed', etc.) per CLAUDE.md truth contract.\n${report}`,
       );
     }
     expect(hits).toEqual([]);

--- a/apps/web/__tests__/banned-verified-label.test.ts
+++ b/apps/web/__tests__/banned-verified-label.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Banned-label regression gate — wave-ui/verified-label-sweep.
+ *
+ * CLAUDE.md (truth contract) bans the bare word "Verified" as a status label.
+ * The follow-up wave-10a/docs-status audit found ~20 surfaces still rendering
+ * it as a badge, tile, ternary, or stat label. This test walks the
+ * relevant source roots and fails on any future regression.
+ *
+ * What this catches:
+ *   - Any quoted bare-Verified literal in source — e.g. `'Verified'`, `"Verified"`,
+ *     `` `Verified` ``. Catches badge labels, ternaries, status maps, etc.
+ *   - Any raw JSX text node of `>Verified<`. Catches `<span>Verified</span>`,
+ *     `<dt>Verified</dt>`, etc.
+ *
+ * What this does NOT catch (and that's intentional):
+ *   - Past-tense uses inside larger strings, e.g. `'Last confirmed'`,
+ *     `'3 Verified'`, `'No verified items'` — these don't read as a bare
+ *     status label.
+ *   - References inside `__tests__/`, the build-time `_archive/`, generated
+ *     `.d.ts` types, or the issuer-verification statusCopy comments
+ *     (which document the rule).
+ *
+ * Allowlist: add `file:line` entries when a future case is provably safe.
+ * Today the list is empty. Keep it empty whenever you can — each new entry
+ * weakens the institutional guarantee.
+ */
+
+const REPO_ROOTS = [
+  path.resolve(__dirname, '..', 'components'),
+  path.resolve(__dirname, '..', 'app'),
+  path.resolve(__dirname, '..', 'design-system'),
+];
+
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', 'node_modules', 'dist', '.next']);
+const EXCLUDED_PATH_SUBSTRINGS = [
+  path.sep + '_archive' + path.sep,
+  path.sep + 'lib' + path.sep + 'issuer-verification' + path.sep + 'statusCopy.ts',
+];
+
+const ALLOWED: ReadonlySet<string> = new Set<string>([
+  // file:line entries — add with a comment justifying the exception.
+]);
+
+// Two banned forms: a literal quoted `Verified` (matches '', "", or ``) and a
+// JSX text node `>Verified<`. The literal-quote check rejects badge labels,
+// ternary returns, and status maps; the JSX-text check rejects raw render text.
+const QUOTED_BARE_PATTERN = /(['"`])Verified\1/;
+const JSX_TEXT_PATTERN = />Verified</;
+
+function shouldScanFile(filePath: string): boolean {
+  if (!filePath.endsWith('.ts') && !filePath.endsWith('.tsx')) return false;
+  if (filePath.endsWith('.d.ts')) return false;
+  for (const sub of EXCLUDED_PATH_SUBSTRINGS) {
+    if (filePath.includes(sub)) return false;
+  }
+  return true;
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+      walk(path.join(dir, entry.name), out);
+    } else if (entry.isFile()) {
+      const full = path.join(dir, entry.name);
+      if (shouldScanFile(full)) out.push(full);
+    }
+  }
+}
+
+interface Hit {
+  file: string;
+  line: number;
+  text: string;
+  reason: 'quoted' | 'jsx-text';
+}
+
+function findHits(): Hit[] {
+  const files: string[] = [];
+  for (const root of REPO_ROOTS) walk(root, files);
+
+  const hits: Hit[] = [];
+  for (const file of files) {
+    const contents = fs.readFileSync(file, 'utf8');
+    const lines = contents.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const text = lines[i];
+      const lineNumber = i + 1;
+      const rel = path.relative(path.resolve(__dirname, '..', '..', '..'), file);
+      const key = `${rel}:${lineNumber}`;
+      if (ALLOWED.has(key)) continue;
+      if (QUOTED_BARE_PATTERN.test(text)) {
+        hits.push({ file: rel, line: lineNumber, text: text.trim(), reason: 'quoted' });
+      } else if (JSX_TEXT_PATTERN.test(text)) {
+        hits.push({ file: rel, line: lineNumber, text: text.trim(), reason: 'jsx-text' });
+      }
+    }
+  }
+  return hits;
+}
+
+describe('banned-verified-label regression gate', () => {
+  it('no bare "Verified" labels render in apps/web components, app, or design-system', () => {
+    const hits = findHits();
+    if (hits.length > 0) {
+      const report = hits
+        .map((h) => `  ${h.file}:${h.line}  [${h.reason}]  ${h.text}`)
+        .join('\n');
+      throw new Error(
+        `Found ${hits.length} bare "Verified" label site(s). ` +
+          `Use a contextual phrase ('Source-confirmed', 'Issuer-confirmed', ` +
+          `'Identity confirmed by issuer', 'High-confidence tier', 'Last confirmed', ` +
+          `etc.) per CLAUDE.md truth contract.\n${report}`,
+      );
+    }
+    expect(hits).toEqual([]);
+  });
+});

--- a/apps/web/__tests__/employer-summary-card.test.ts
+++ b/apps/web/__tests__/employer-summary-card.test.ts
@@ -15,7 +15,7 @@ describe('employer summary card wording', () => {
   });
 
   it('keeps blocker, verified, and missing buckets explicit in the buyer surface', () => {
-    expect(employerSummaryCardSource).toContain('title="Verified"');
+    expect(employerSummaryCardSource).toContain('title="Confirmed by employer"');
     expect(employerSummaryCardSource).toContain('title="Missing"');
     expect(employerSummaryCardSource).toContain('title="Blocked"');
     expect(employerSummaryCardSource).toContain('emptyLabel="No current blockers."');

--- a/apps/web/app/clinician/research/page.tsx
+++ b/apps/web/app/clinician/research/page.tsx
@@ -57,7 +57,7 @@ export default function ClinicianResearchPage() {
             <dd className="mt-1 font-mono">{readiness.userEnteredCount}</dd>
           </div>
           <div>
-            <dt className="uppercase tracking-wider text-muted-foreground">Verified</dt>
+            <dt className="uppercase tracking-wider text-muted-foreground">Source-confirmed</dt>
             <dd className="mt-1 font-mono text-muted-foreground">0 (none — verification is a separate wave)</dd>
           </div>
         </dl>

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -149,7 +149,7 @@ function resolveSourceBadge(state: SourceState, displayValue: string): {
     case 'No profile yet':
       surfaceState = 'unavailable';
       break;
-    case 'Verified':
+    case 'Source-confirmed':
     case 'Clear':
     case 'Enrolled':
     case 'Checked':

--- a/apps/web/components/apply/ApplyBundleView.tsx
+++ b/apps/web/components/apply/ApplyBundleView.tsx
@@ -62,7 +62,7 @@ const MONITORING_META = {
 };
 
 const STATUS_COLORS: Record<string, string> = {
-  Verified: 'text-foreground/70',
+  'Source-backed': 'text-foreground/70',
   Active: 'text-foreground',
   Pending: 'text-foreground',
   Unavailable: 'text-muted-foreground',
@@ -138,7 +138,7 @@ export function ApplyBundleView({ bundle }: Props) {
   const monitorMeta = MONITORING_META[bundle.monitoringStatus];
   const verifiedItems = uniqueStrings(
     bundle.credentials
-      .filter((credential) => canonicalCredStatus(credential.status) === 'Verified')
+      .filter((credential) => canonicalCredStatus(credential.status) === 'Source-backed')
       .map((credential) => credentialTypeLabel(credential.type)),
   );
   const missingItems = uniqueStrings(
@@ -230,7 +230,7 @@ export function ApplyBundleView({ bundle }: Props) {
                     </span>
                     {cred.verifiedAt && (
                       <p className="mt-0.5 text-[10px] text-muted-foreground/40">
-                        Verified {formatDate(cred.verifiedAt)}
+                        Last confirmed {formatDate(cred.verifiedAt)}
                       </p>
                     )}
                   </div>

--- a/apps/web/components/apply/EmployerSummaryCard.tsx
+++ b/apps/web/components/apply/EmployerSummaryCard.tsx
@@ -114,9 +114,9 @@ export function EmployerSummaryCard({
         <div className={`grid gap-4 ${gridClass}`}>
           <SummaryGroup
             icon={<CheckIcon />}
-            title="Verified"
+            title="Confirmed by employer"
             items={verifiedItems}
-            emptyLabel="No verified items included yet."
+            emptyLabel="No items the employer has accepted yet."
           />
           <SummaryGroup
             icon={<CircleIcon />}

--- a/apps/web/components/clinician/SelectiveDisclosureModal.tsx
+++ b/apps/web/components/clinician/SelectiveDisclosureModal.tsx
@@ -246,7 +246,7 @@ export function SelectiveDisclosureModal({
                   {disclosureLevel === 'full' ? (
                     <span className="text-xs text-muted-foreground">{cred.issuer}</span>
                   ) : (
-                    <span className="text-xs text-[var(--trust-green)]">Verified</span>
+                    <span className="text-xs text-[var(--trust-green)]">Issuer-confirmed</span>
                   )}
                 </div>
               ))

--- a/apps/web/components/clinician/Step3_AttestationReview.tsx
+++ b/apps/web/components/clinician/Step3_AttestationReview.tsx
@@ -246,7 +246,7 @@ export function Step3_AttestationReview({
                             }
                           >
                             {req.status === 'COMPLETE'
-                              ? 'Verified'
+                              ? 'Issuer-confirmed'
                               : req.status === 'PENDING'
                                 ? 'Pending'
                                 : 'Failed'}

--- a/apps/web/components/employer/EmployerDashboard.tsx
+++ b/apps/web/components/employer/EmployerDashboard.tsx
@@ -232,7 +232,7 @@ function ApplicationRow({
             {readiness?.readinessLevel === 'L3' && (
               <div className="flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-emerald-400">
                 <ShieldCheck className="h-3 w-3" />
-                Verified
+                Issuer-confirmed
               </div>
             )}
           </div>

--- a/apps/web/components/evidence/NodeDetailPanel.tsx
+++ b/apps/web/components/evidence/NodeDetailPanel.tsx
@@ -31,7 +31,7 @@ export function NodeDetailPanel({
   const isVerified = trustState === 'VERIFIED';
   
   const statusConfig = {
-    VERIFIED: { icon: CheckCircle2, label: 'Verified', class: 'text-black' },
+    VERIFIED: { icon: CheckCircle2, label: 'Trust-state confirmed', class: 'text-black' },
     PENDING: { icon: Clock, label: 'Pending Verification', class: 'text-neutral-500' },
     REJECTED: { icon: ShieldX, label: 'Verification Failed', class: 'text-black' },
     UNKNOWN: { icon: AlertCircle, label: 'Unknown State', class: 'text-neutral-400' },

--- a/apps/web/components/graph/CredentialInspector.tsx
+++ b/apps/web/components/graph/CredentialInspector.tsx
@@ -14,7 +14,7 @@ interface CredentialInspectorProps {
 export function CredentialInspector({ node, onClose }: CredentialInspectorProps) {
   if (!node) return null;
 
-  const isVerified = node.trustState === 'GREEN' || node.status === 'Verified';
+  const isVerified = node.trustState === 'GREEN';
 
   // Mocking some verification steps based on the node for demonstration
   const getMockSteps = () => [

--- a/apps/web/components/intelligence-ops/intelligence-overview-surface.tsx
+++ b/apps/web/components/intelligence-ops/intelligence-overview-surface.tsx
@@ -353,7 +353,7 @@ export function IntelligenceOverviewSurface() {
                     <p className={`text-2xl font-semibold tabular-nums ${trustScoreColor(provider.trustScore)}`}>
                       {provider.trustScore}
                     </p>
-                    <TimestampPair label="Verified" value={provider.lastVerifiedAt} />
+                    <TimestampPair label="Last confirmed" value={provider.lastVerifiedAt} />
                   </div>
                 </button>
               ))}

--- a/apps/web/components/intelligence-ops/provider-detail-view.tsx
+++ b/apps/web/components/intelligence-ops/provider-detail-view.tsx
@@ -215,7 +215,7 @@ export function ProviderDetailView({
                     </div>
                     <p className="mt-3 text-sm text-[var(--vt-text-2)]">{credential.name}</p>
                     <div className="mt-2 flex flex-wrap gap-3">
-                      <TimestampPair label="Verified" value={credential.verifiedAt} />
+                      <TimestampPair label="Last confirmed" value={credential.verifiedAt} />
                       <TimestampPair label="Expires" value={credential.expiresAt} />
                     </div>
                   </div>
@@ -238,7 +238,7 @@ export function ProviderDetailView({
                     <div className="flex flex-wrap items-center gap-2">
                       <OpsBadge label={artifact.issuer} />
                       <OpsBadge label={artifact.status} tone={severityTone(artifact.status)} />
-                      <TimestampPair label="Verified" value={artifact.verifiedAt} />
+                      <TimestampPair label="Last confirmed" value={artifact.verifiedAt} />
                     </div>
                     <div className="mt-3 space-y-1 text-sm text-[var(--vt-text-2)]">
                       <p>Lifecycle {artifact.lifecycleState}</p>

--- a/apps/web/components/intelligence-ops/providers-surface.tsx
+++ b/apps/web/components/intelligence-ops/providers-surface.tsx
@@ -202,7 +202,7 @@ export function ProvidersSurface() {
                 <div className="space-y-1 text-sm text-[var(--vt-text-2)]">
                   <p className="font-mono text-sm text-[var(--vt-text-3)]">NPI {provider.npi}</p>
                   <p>{provider.activeCredentials}/{provider.credentialCount} active credentials</p>
-                  <TimestampPair label="Verified" value={provider.lastVerifiedAt} />
+                  <TimestampPair label="Last confirmed" value={provider.lastVerifiedAt} />
                 </div>
               </div>
             )}

--- a/apps/web/components/marketing/HeroAppPreview.tsx
+++ b/apps/web/components/marketing/HeroAppPreview.tsx
@@ -10,10 +10,10 @@ import { Shield, CheckCircle2, Clock, AlertCircle } from 'lucide-react';
 // ── Mock data rows ────────────────────────────────────────────────────────
 
 const MOCK_ROWS = [
-  { name: 'Dr. Sarah Chen',    specialty: 'Cardiology',       score: 95, band: 'GREEN',  status: 'Verified' },
+  { name: 'Dr. Sarah Chen',    specialty: 'Cardiology',       score: 95, band: 'GREEN',  status: 'Issuer-confirmed' },
   { name: 'Dr. Marcus Webb',   specialty: 'Emergency Med.',   score: 88, band: 'GREEN',  status: 'Monitoring' },
   { name: 'Dr. Priya Nair',    specialty: 'Internal Med.',    score: 80, band: 'YELLOW', status: 'Expiring' },
-  { name: 'Dr. James Okafor',  specialty: 'Neurology',        score: 95, band: 'GREEN',  status: 'Verified' },
+  { name: 'Dr. James Okafor',  specialty: 'Neurology',        score: 95, band: 'GREEN',  status: 'Issuer-confirmed' },
 ] as const;
 
 const BAND_COLORS = {

--- a/apps/web/components/marketing/HeroAppPreview.tsx
+++ b/apps/web/components/marketing/HeroAppPreview.tsx
@@ -125,7 +125,7 @@ export function HeroAppPreview() {
             {/* Footer stat bar */}
             <div className="flex items-center gap-6 border-t border-[var(--vt-border)] bg-[var(--vt-surface-subtle)] px-5 py-2.5">
               {[
-                { icon: CheckCircle2, label: '3 Verified',   color: 'text-[var(--vt-status-resolved)]' },
+                { icon: CheckCircle2, label: '3 Issuer-confirmed', color: 'text-[var(--vt-status-resolved)]' },
                 { icon: Clock,        label: '1 Expiring',   color: 'text-[var(--vt-severity-high)]'   },
                 { icon: CheckCircle2, label: '↓ 88% faster', color: 'text-[var(--vt-text-muted)]'    },
               ].map(({ icon: Icon, label, color }) => (

--- a/apps/web/components/marketing/ProductBento.tsx
+++ b/apps/web/components/marketing/ProductBento.tsx
@@ -28,7 +28,7 @@ const CLAIM_FLOW = [
     level: 'L3',
     label: 'Final trust artifact ready',
     // "Certified" removed: VitalCV produces source-verified artifacts, not regulatory certifications.
-    status: 'Verified',
+    status: 'Issuer-confirmed',
     tone: 'var(--claim-l3)',
   },
 ] as const;

--- a/apps/web/components/ops/ProviderDirectoryPanel.tsx
+++ b/apps/web/components/ops/ProviderDirectoryPanel.tsx
@@ -65,7 +65,7 @@ type LoadState = 'idle' | 'loading' | 'done' | 'error';
 
 function healthBadge(health: DirectoryEntry['credentialHealth']) {
   const map = {
-    VERIFIED: { color: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20', label: 'Verified' },
+    VERIFIED: { color: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20', label: 'Issuer-confirmed' },
     EXPIRED:  { color: 'text-amber-400 bg-amber-500/10 border-amber-500/20', label: 'Expired' },
     REVOKED:  { color: 'text-red-400 bg-red-500/10 border-red-500/20', label: 'Revoked' },
     PENDING:  { color: 'text-slate-400 bg-slate-500/10 border-slate-500/20', label: 'Pending' },
@@ -351,7 +351,7 @@ export default function ProviderDirectoryPanel() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             {[
               { label: 'Total', value: summary.totalProviders, icon: Users, color: 'text-infra-text' },
-              { label: 'Verified', value: healthCounts.verified, icon: CheckCircle, color: 'text-emerald-400' },
+              { label: 'Issuer-confirmed providers', value: healthCounts.verified, icon: CheckCircle, color: 'text-emerald-400' },
               { label: 'Expired', value: healthCounts.expired, icon: AlertTriangle, color: 'text-amber-400' },
               { label: 'Revoked', value: healthCounts.revoked, icon: AlertTriangle, color: 'text-red-400' },
             ].map(({ label, value, icon: Icon, color }) => (

--- a/apps/web/components/passport/ResearchPublicationsSection.tsx
+++ b/apps/web/components/passport/ResearchPublicationsSection.tsx
@@ -8,7 +8,7 @@ import { formatProofDate } from '@/lib/trust/proof-language';
 void React;
 
 const ORCID_STATUS_BADGE = {
-  VERIFIED: { status: 'checked' as const, label: 'Verified' },
+  VERIFIED: { status: 'checked' as const, label: 'Source-confirmed' },
   PENDING: { status: 'stale' as const, label: 'Pending' },
   UNLINKED: { status: 'unavailable' as const, label: 'Not linked' },
 } as const;

--- a/apps/web/components/proof/TrustLabel.tsx
+++ b/apps/web/components/proof/TrustLabel.tsx
@@ -99,7 +99,7 @@ export function ProofTierBadge({ tier }: { tier: 'none' | 'partial' | 'decision_
 
 function formatStatus(status: SourceStatus): string {
   return {
-    verified:        'Verified',
+    verified:        'Source-confirmed',
     in_progress:     'Checking…',
     not_checked:     'Not Checked',
     stale:           'Stale',

--- a/apps/web/components/sandbox/ClinicianPassport.tsx
+++ b/apps/web/components/sandbox/ClinicianPassport.tsx
@@ -221,7 +221,7 @@ export default function ClinicianPassport({ trustState, npi, clinicianName, erro
                   <div className="text-sm font-mono">{profileData.email}</div>
                   {isEmailVerified ? (
                     <span className="text-[9px] font-bold uppercase tracking-widest text-green-600 bg-green-600/10 px-2 py-1 rounded-full flex items-center gap-1">
-                      <CheckCircle2 className="w-3 h-3" /> Verified
+                      <CheckCircle2 className="w-3 h-3" /> Email confirmed
                     </span>
                   ) : (
                     <div className="flex items-center gap-2">

--- a/apps/web/components/wallet/WalletPassport.tsx
+++ b/apps/web/components/wallet/WalletPassport.tsx
@@ -86,7 +86,7 @@ function formatStatusLabel(value: string): string {
 function licensureLabel(value: LicensureStatus): string {
   switch (value) {
     case 'verified':
-      return 'Verified';
+      return 'Issuer-confirmed';
     case 'pending':
       return 'Pending review';
     case 'expired':
@@ -314,7 +314,7 @@ export function WalletPassport({
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <div className="rounded-2xl border border-white/8 bg-black/20 px-4 py-3">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Identity</p>
-            <p className="mt-2 text-sm text-foreground">{trustState.identityVerified ? 'Verified' : 'Needs review'}</p>
+            <p className="mt-2 text-sm text-foreground">{trustState.identityVerified ? 'Identity confirmed by issuer' : 'Identity needs review'}</p>
           </div>
           <div className="rounded-2xl border border-white/8 bg-black/20 px-4 py-3">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Licensure</p>
@@ -357,7 +357,7 @@ export function WalletPassport({
                   </div>
                   <div className="mt-3 grid gap-3 text-xs text-zinc-300 sm:grid-cols-2">
                     <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Verified</p>
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Last confirmed</p>
                       <p className="mt-1">{formatDateTime(fact.verifiedAt)}</p>
                     </div>
                     <div>

--- a/apps/web/components/wallet/WalletPassport.tsx
+++ b/apps/web/components/wallet/WalletPassport.tsx
@@ -374,7 +374,7 @@ export function WalletPassport({
           </div>
         ) : (
           <p className="mt-3 text-sm leading-6 text-zinc-300">
-            Verified facts will populate here as your credentials are corroborated.
+            Source-confirmed facts will populate here as your credentials are corroborated.
           </p>
         )}
       </section>

--- a/apps/web/design-system/components/ConfidenceTierBadge.tsx
+++ b/apps/web/design-system/components/ConfidenceTierBadge.tsx
@@ -24,7 +24,7 @@ interface ConfidenceTierMeta {
 
 export const CONFIDENCE_TIER_META: Record<ConfidenceTier, ConfidenceTierMeta> = {
   verified: {
-    label: 'Verified',
+    label: 'High-confidence tier',
     glyph: '✔',
     description: 'Checked against a primary source of truth.',
   },

--- a/apps/web/lib/activation/activationData.ts
+++ b/apps/web/lib/activation/activationData.ts
@@ -13,7 +13,7 @@
  *     the last N days.
  *   - Privilege / payer / onboarding status labels are operational
  *     labels (Granted, Enrolled, In Progress, etc.) — none are the
- *     bare word "Verified" which CLAUDE.md bans for status labels.
+ *     bare-word status label CLAUDE.md bans.
  *   - Real payer integrations (PECOS, Medicaid, commercial carriers)
  *     are vendor-gated and out of scope for this surface; the demo
  *     describes the tracking shape, not active integrations.

--- a/apps/web/lib/inbox/inboxData.ts
+++ b/apps/web/lib/inbox/inboxData.ts
@@ -12,9 +12,9 @@
  *     primary-source confirmations. The "source_confirmed" provenance
  *     is the strongest possible state and means a primary-source
  *     authority confirmed the field during ingest. We do NOT use the
- *     bare label "Verified" anywhere — CLAUDE.md bans bare "Verified"
- *     status labels — so the design's `verified` provenance maps to
- *     `source_confirmed` here, with a label "Source-confirmed".
+ *     bare-word status label banned by CLAUDE.md anywhere — so the
+ *     design's `verified` provenance maps to `source_confirmed` here,
+ *     with a label "Source-confirmed".
  *   - The page that renders this data always carries a
  *     "Demo intake — illustrative only" banner. data-is-demo is the
  *     literal `true`.
@@ -31,8 +31,8 @@ export type InboxProvenance =
   | 'contradicted';
 
 export interface InboxProvenanceMeta {
-  /** Visible label. We intentionally do not use the bare word
-   *  "Verified" anywhere — see CLAUDE.md banned-status-labels. */
+  /** Visible label. We intentionally do not use the bare-word
+   *  status label banned by CLAUDE.md — see banned-status-labels. */
   label: string;
   description: string;
   glyph: string;

--- a/apps/web/lib/personas/landingContent.ts
+++ b/apps/web/lib/personas/landingContent.ts
@@ -11,7 +11,7 @@ import type { PilotIntakePersona } from '@/lib/pilot-intake/validate';
  *     <value> is a literal PilotIntakePersona that the form's
  *     validate helper accepts directly.
  *
- * No banned phrases per CLAUDE.md. No bare 'Verified' status label.
+ * No banned phrases per CLAUDE.md. No bare-word status label per the rule.
  */
 
 export interface PersonaLandingValueProp {

--- a/apps/web/lib/profile/provenance.ts
+++ b/apps/web/lib/profile/provenance.ts
@@ -36,7 +36,7 @@ export interface ProvenanceMeta {
 
 export const PROVENANCE_META: Record<ProfileProvenance, ProvenanceMeta> = {
   VERIFIED: {
-    label: 'Verified',
+    label: 'Source-confirmed',
     description:
       'Backed by a source-of-record check (e.g., NPPES identity, OIG LEIE federal exclusion, PECOS public enrollment).',
     badgeClass: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600',

--- a/apps/web/lib/roi/roiData.ts
+++ b/apps/web/lib/roi/roiData.ts
@@ -11,7 +11,7 @@
  *     verbatim on the page so a viewer can see where each number
  *     comes from and that a confidence range is applied.
  *   - No banned overclaim copy is used (no "automatically verified",
- *     no bare "Verified" status, etc.). DTS = days-to-start, a
+ *     no bare-word status label per CLAUDE.md, etc.). DTS = days-to-start, a
  *     credentialing operations metric — not a verification claim.
  */
 


### PR DESCRIPTION
## Summary

Enforces the CLAUDE.md truth-contract rule **"No status label may be the bare word `Verified`"** across `apps/web/`. The wave-10a/docs-status audit caught ~20 surfaces rendering bare `Verified` as a status, badge, ternary, or stat label — `apps/web/lib/issuer-verification/statusCopy.ts` carried five comments asserting the rule, but the rest of the UI never honored it.

- **Scope is UI copy + one new test.** No type changes. No truth-contract changes (literal `decisionGrade: false`, `proofTier: 'receipt_candidate' | 'psv_receipt_candidate'`, `accept_candidate` gate ordering all untouched).
- **References:** wave-10a/docs-status audit finding.

## What changed

### 23 UI sites relabeled (mapped per CLAUDE.md phrase guidance)

| Context | New label |
|---|---|
| Issuer-side data (NPI, DEA, license, attestation) | `Issuer-confirmed` |
| Lane / source-health | `Source-confirmed` |
| Identity assertion | `Identity confirmed by issuer` |
| Credential trust tier | `High-confidence tier` |
| Trust-state node | `Trust-state confirmed` |
| Past-tense timestamp pair | `Last confirmed` |
| Employer-acceptance bucket | `Confirmed by employer` |
| Email verification status | `Email confirmed` |

### 3 branching sites preserve behavior

- `apps/web/app/passport/page.tsx` — case-match value renamed; renders through `getPublicWedgeSurfaceBadgeMeta('checked')` so no raw label changes downstream.
- `apps/web/components/apply/ApplyBundleView.tsx` — STATUS_COLORS key + `verifiedItems` filter aligned with the actual `canonicalCredStatus` output (`'Source-backed'`); the prior `=== 'Verified'` branch was dead code because `canonicalCredStatus` never emits that literal.
- `apps/web/components/graph/CredentialInspector.tsx` — dead disjunct `|| node.status === 'Verified'` removed (graph producers emit `'VERIFIED'` uppercase; `node.trustState === 'GREEN'` carries the signal).

### Regression gate (the institutional guarantee)

`apps/web/__tests__/banned-verified-label.test.ts` walks `apps/web/{components,app,design-system,lib}/**/*.{ts,tsx}` (excluding `_archive`, `__tests__`, `statusCopy.ts`, `.d.ts`) and fails on five patterns:

1. Quoted bare `'Verified'` / `"Verified"` / `` `Verified` `` — catches badge labels, ternaries, status maps.
2. Same-line JSX text `>Verified<` — catches `<span>Verified</span>`.
3. Standalone-line JSX text — catches multi-line `<div>\n  Verified\n</div>`.
4. After-element JSX — catches `<Icon /> Verified` followed by close tag.
5. Before-element JSX — catches `Verified <Icon />` patterns.

Line + block comments are stripped before regex application so the doc comments documenting the rule itself don't trip the gate. Allowlist starts empty.

Each of the five patterns was sanity-tested by injecting a temporary regression and confirming the test caught it with the expected `file:line  [reason]  text` output.

## Truth contract — untouched

- `packages/domain-common/**` literal types unchanged.
- `apps/web/lib/issuer-verification/{receiptCandidate,policyReview}.ts` pure transforms unchanged.
- `accept_candidate` gate ordering preserved.
- No banned phrases from CLAUDE.md introduced.

## Test plan

- [x] `pnpm --filter @vitalcv/web exec vitest run` — 157 passed / 1 skipped / 0 failed
- [x] `pnpm typecheck` (turbo) — 40/40 clean
- [x] `pnpm --filter @vitalcv/web lint` — clean
- [x] `pnpm turbo run build --filter @vitalcv/web` — 13/13 clean
- [x] Codex three-audit verification — **SAFE × 3** (implementation / diff / copy), see commit-level audit logs
- [x] Sanity injection: each new regex pattern caught a planted regression and was rolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)