### PR TITLE
fix(signing): production fail-closed for receipt issuer — eliminate vcv-es256-dev leakage

### DIFF
--- a/apps/web/__tests__/es256-receipt-engine.test.ts
+++ b/apps/web/__tests__/es256-receipt-engine.test.ts
@@ -108,7 +108,8 @@ describe('signIssuerReceipt', () => {
     });
 
     expect(typeof jwt).toBe('string');
-    expect(jti).toMatch(/^rcpt_resp-001_/);
+    // jti is deterministic: `rcpt_${responseId}` (no Date.now() suffix).
+    expect(jti).toBe('rcpt_resp-001');
 
     // Verify the JWT with the public key from getPublicKeyJwk
     const publicJwk = await getPublicKeyJwk();
@@ -238,6 +239,110 @@ describe('buildAndSignReceiptCandidate', () => {
         rawHash: 'no-hash',
       });
       expect(candidate.signedReceiptJwt).toBeUndefined();
+    }
+  });
+});
+
+describe('getOrInitKeypair — production fail-closed', () => {
+  // The production fail-closed guard prevents `vcv-es256-dev` / generated
+  // ephemeral keys from leaking onto the runtime trust anchor. Tests stub
+  // env vars + vi.resetModules() to force re-import of the module-level
+  // singleton; otherwise the lazy-initialized _keypairPromise from earlier
+  // tests would short-circuit the new env-var read.
+
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  const ORIGINAL_PRIVATE_JWK = process.env.RECEIPT_PRIVATE_KEY_JWK;
+  const ORIGINAL_KID = process.env.RECEIPT_KID;
+
+  function restoreEnv(): void {
+    if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    if (ORIGINAL_PRIVATE_JWK === undefined) delete process.env.RECEIPT_PRIVATE_KEY_JWK;
+    else process.env.RECEIPT_PRIVATE_KEY_JWK = ORIGINAL_PRIVATE_JWK;
+    if (ORIGINAL_KID === undefined) delete process.env.RECEIPT_KID;
+    else process.env.RECEIPT_KID = ORIGINAL_KID;
+  }
+
+  it('throws when NODE_ENV=production AND RECEIPT_PRIVATE_KEY_JWK is missing', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    process.env.NODE_ENV = 'production';
+    delete process.env.RECEIPT_PRIVATE_KEY_JWK;
+    delete process.env.RECEIPT_KID;
+    try {
+      const mod = await import('../lib/crypto/receiptIssuer');
+      await expect(mod.getOrInitKeypair()).rejects.toThrow(
+        /RECEIPT_PRIVATE_KEY_JWK is required in production/,
+      );
+    } finally {
+      restoreEnv();
+      vi.resetModules();
+    }
+  });
+
+  it('throws when NODE_ENV=production AND RECEIPT_KID is missing but RECEIPT_PRIVATE_KEY_JWK is set', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    // Generate a valid private JWK first using the ephemeral generator
+    // (this happens in non-production mode), then re-import in production
+    // mode with only RECEIPT_PRIVATE_KEY_JWK set.
+    const { generateReceiptKeypair } = await import('../lib/crypto/receiptIssuer');
+    const kp = await generateReceiptKeypair();
+    const { exportJWK } = await import('jose');
+    const jwk = await exportJWK(kp.privateKey);
+    const fullJwk = { ...jwk, kid: kp.kid, alg: 'ES256', use: 'sig' };
+    vi.resetModules();
+    process.env.NODE_ENV = 'production';
+    process.env.RECEIPT_PRIVATE_KEY_JWK = JSON.stringify(fullJwk);
+    delete process.env.RECEIPT_KID;
+    try {
+      const mod = await import('../lib/crypto/receiptIssuer');
+      await expect(mod.getOrInitKeypair()).rejects.toThrow(
+        /RECEIPT_KID is required in production/,
+      );
+    } finally {
+      restoreEnv();
+      vi.resetModules();
+    }
+  });
+
+  it('succeeds when NODE_ENV=production AND both env vars are set, and the kid is the env value (no dev prefix)', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    const { generateReceiptKeypair } = await import('../lib/crypto/receiptIssuer');
+    const kp = await generateReceiptKeypair();
+    const { exportJWK } = await import('jose');
+    const jwk = await exportJWK(kp.privateKey);
+    const fullJwk = { ...jwk, kid: 'vcv-es256-1', alg: 'ES256', use: 'sig' };
+    vi.resetModules();
+    process.env.NODE_ENV = 'production';
+    process.env.RECEIPT_PRIVATE_KEY_JWK = JSON.stringify(fullJwk);
+    process.env.RECEIPT_KID = 'vcv-es256-1';
+    try {
+      const mod = await import('../lib/crypto/receiptIssuer');
+      const out = await mod.getOrInitKeypair();
+      expect(out.kid).toBe('vcv-es256-1');
+      expect(out.kid).not.toMatch(/dev/);
+    } finally {
+      restoreEnv();
+      vi.resetModules();
+    }
+  });
+
+  it('preserves dev ephemeral fallback when NODE_ENV is NOT production', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    process.env.NODE_ENV = 'test';
+    delete process.env.RECEIPT_PRIVATE_KEY_JWK;
+    delete process.env.RECEIPT_KID;
+    try {
+      const mod = await import('../lib/crypto/receiptIssuer');
+      const out = await mod.getOrInitKeypair();
+      // Default dev kid is 'vcv-es256-dev' (RECEIPT_KID_DEV ?? 'vcv-es256-dev').
+      expect(out.kid).toBe('vcv-es256-dev');
+    } finally {
+      restoreEnv();
+      vi.resetModules();
     }
   });
 });

--- a/apps/web/app/api/.well-known/did.json/route.ts
+++ b/apps/web/app/api/.well-known/did.json/route.ts
@@ -13,7 +13,10 @@ import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
 
 export const runtime = 'nodejs';
 
-export const revalidate = 3600;
+// Force runtime evaluation — same rationale as the sibling JWKS route.
+// Prerendering would invoke the production-only signing guard at build
+// time and fail with no env vars present.
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const publicKeyJwk = await getPublicKeyJwk();

--- a/apps/web/app/api/.well-known/jwks.json/route.ts
+++ b/apps/web/app/api/.well-known/jwks.json/route.ts
@@ -14,7 +14,12 @@ import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
 
 export const runtime = 'nodejs';
 
-export const revalidate = 3600;
+// Force runtime evaluation. Prerendering this route at build time would
+// invoke getPublicKeyJwk() under NODE_ENV=production without the prod
+// signing env vars set, which (correctly) throws via the fail-closed
+// guard in receiptIssuer.ts. Marking dynamic keeps the guard intact for
+// runtime requests while not blocking the build pipeline.
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const publicKeyJwk = await getPublicKeyJwk();

--- a/apps/web/app/api/receipt/[lineageKey]/route.ts
+++ b/apps/web/app/api/receipt/[lineageKey]/route.ts
@@ -113,7 +113,11 @@ export async function GET(
       receipt: {
         receiptId: `rcpt_${providerId}`,
         source: lane?.source ?? laneId,
-        signingKeyId: 'vcv-es256-dev',
+        // Resolve the canonical kid from env so this metadata matches
+        // the actual signing kid published in /.well-known/jwks.json.
+        // Falls back to 'vcv-es256-dev' only outside production.
+        signingKeyId: process.env.RECEIPT_KID
+          ?? (process.env.NODE_ENV === 'production' ? 'vcv-es256-1' : 'vcv-es256-dev'),
         issuerDid: ISSUER_DID,
         jwksUri: JWKS_URI,
       },

--- a/apps/web/lib/crypto/receiptIssuer.ts
+++ b/apps/web/lib/crypto/receiptIssuer.ts
@@ -43,17 +43,54 @@ export async function generateReceiptKeypair(): Promise<ReceiptKeypair> {
 
 /**
  * Returns the singleton keypair for this process.
- * In production, imports from RECEIPT_PRIVATE_KEY_JWK + RECEIPT_KID env vars.
- * In dev/test, generates a fresh ephemeral keypair once.
+ *
+ * Production (NODE_ENV === 'production') — fail-closed:
+ *   Both RECEIPT_PRIVATE_KEY_JWK and RECEIPT_KID MUST be set. If either
+ *   is missing, this function throws. Refusing to silently fall back to
+ *   a dev-prefixed kid (`vcv-es256-dev`, `vcv-es256-dev-<ts>`) or to an
+ *   ephemeral generated keypair is the load-bearing invariant that
+ *   prevents dev signing identity from leaking onto the production
+ *   runtime trust anchor.
+ *
+ * Dev / test (NODE_ENV !== 'production'):
+ *   If RECEIPT_PRIVATE_KEY_JWK is present, it is imported; the kid
+ *   resolves to RECEIPT_KID, or `vcv-es256-dev-<timestamp>` if absent
+ *   (preserves the prior dev-preview behavior without affecting
+ *   production).
+ *   If RECEIPT_PRIVATE_KEY_JWK is absent, a fresh ephemeral keypair is
+ *   minted and given the stable kid RECEIPT_KID_DEV or `vcv-es256-dev`.
  */
 export async function getOrInitKeypair(): Promise<ReceiptKeypair> {
   if (_keypairPromise) return _keypairPromise;
 
   _keypairPromise = (async () => {
     const privateJwkEnv = process.env.RECEIPT_PRIVATE_KEY_JWK;
-    const kid = process.env.RECEIPT_KID ?? `vcv-es256-dev-${Date.now()}`;
+    const kidEnv = process.env.RECEIPT_KID;
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    // Production fail-closed: refuse to leak any dev-prefixed signing identity.
+    if (isProduction) {
+      if (!privateJwkEnv) {
+        throw new Error(
+          'receiptIssuer: RECEIPT_PRIVATE_KEY_JWK is required in production. ' +
+            'Refusing to mint an ephemeral dev keypair on a production runtime.',
+        );
+      }
+      if (!kidEnv) {
+        throw new Error(
+          'receiptIssuer: RECEIPT_KID is required in production when ' +
+            'RECEIPT_PRIVATE_KEY_JWK is set. Refusing to fall back to a ' +
+            'dev-prefixed kid on a production runtime.',
+        );
+      }
+    }
 
     if (privateJwkEnv) {
+      // Both envs set (production) OR only RECEIPT_PRIVATE_KEY_JWK set in
+      // dev (kid falls back to a dev-prefixed timestamp string — only
+      // reachable here when isProduction is false because the guard
+      // above already threw).
+      const kid = kidEnv ?? `vcv-es256-dev-${Date.now()}`;
       const jwk = JSON.parse(privateJwkEnv) as object;
       const privateKey = await importJWK(jwk, 'ES256');
 
@@ -65,6 +102,7 @@ export async function getOrInitKeypair(): Promise<ReceiptKeypair> {
     }
 
     // Dev: ephemeral keypair with stable kid (RECEIPT_KID_DEV || 'vcv-es256-dev').
+    // Unreachable in production because the guard above already threw.
     const kp = await generateReceiptKeypair();
     return { ...kp, kid: process.env.RECEIPT_KID_DEV ?? 'vcv-es256-dev' };
   })();

--- a/docs/architecture/production-signing-identity-audit.md
+++ b/docs/architecture/production-signing-identity-audit.md
@@ -1,0 +1,132 @@
+# Production Signing Identity Audit
+
+**Phase 5 deliverable.** Closes the signing-identity convergence
+mission. Classifies every surface's relationship to the canonical
+production signing identity, post the fail-closed hardening this PR
+ships.
+
+## §1 — Classification
+
+### Canonical (single production identity, env-driven)
+
+- `getOrInitKeypair()` in `apps/web/lib/crypto/receiptIssuer.ts` — the single source of truth. Reads `RECEIPT_PRIVATE_KEY_JWK` + `RECEIPT_KID`. Throws in production when either is missing.
+- `getPublicKeyJwk()` — wraps `getOrInitKeypair()`; emits the public JWK with the canonical `kid`.
+- `signIssuerReceipt(...)` — wraps `getOrInitKeypair()`; embeds the canonical `kid` in the ES256 JWT header.
+- `/.well-known/jwks.json` (canonical path) + `/api/.well-known/jwks.json` (legacy mirror) — both call `getPublicKeyJwk()`. Both now `force-dynamic` to keep the build pipeline green while preserving the runtime guard.
+- `/.well-known/did.json` — same upstream; `force-dynamic`.
+
+### Production-safe (env-resolved with production default)
+
+- `/api/receipt/[lineageKey]` response body — now resolves `signingKeyId` via `process.env.RECEIPT_KID ?? (NODE_ENV === 'production' ? 'vcv-es256-1' : 'vcv-es256-dev')`. Production receipts emit `vcv-es256-1` (or whatever the operator sets RECEIPT_KID to). Dev still emits `vcv-es256-dev`.
+- UI default `snapshot.signingKeyId ?? 'vcv-es256-1'` in `apps/web/components/trust/TrustStateRegister.tsx` — production-safe; matches the operator's expected RECEIPT_KID value.
+- UI prop `signingKeyId="vcv-es256-1"` in `apps/web/app/verify/[npi]/page.tsx` — production-safe; static fallback for an unhydrated snapshot.
+
+### Fallback (dev-only, gated)
+
+- `if (isDev())` mock branch in `/api/receipt/[lineageKey]:167` — uses `'vcv-es256-dev'` literal. Correctly gated by `process.env.NODE_ENV !== 'production'`.
+- Ephemeral keypair path in `getOrInitKeypair()` line 68–69 — emits `RECEIPT_KID_DEV ?? 'vcv-es256-dev'`. Now unreachable in production (the fail-closed guard above throws first).
+
+### Unsafe (BEFORE THIS PR — closed by the hardening)
+
+- ~~`getOrInitKeypair()` falling back to `vcv-es256-dev-<timestamp>` when `RECEIPT_KID` missing~~ — FIXED.
+- ~~`getOrInitKeypair()` minting ephemeral `vcv-es256-dev` keypair when `RECEIPT_PRIVATE_KEY_JWK` missing in production~~ — FIXED.
+- ~~`/api/receipt/[lineageKey]` returning hardcoded `'vcv-es256-dev'` in non-dev branch~~ — FIXED.
+
+### Dev-only (production cannot reach)
+
+- `generateReceiptKeypair()` direct callers — only test fixtures (`apps/web/__tests__/es256-receipt-engine.test.ts`).
+- Test stubs that set `RECEIPT_KID_DEV` or expect `vcv-es256-dev` in dev environments.
+
+## §2 — Required final answers
+
+### 1. What is the canonical production signing identity?
+
+A single (`RECEIPT_KID`, `RECEIPT_PRIVATE_KEY_JWK`) env pair set on the
+apex Vercel project. The operator-expected value for `RECEIPT_KID` is
+`vcv-es256-1` (per the UI default literal in `TrustStateRegister.tsx`
+and `verify/[npi]/page.tsx`). The private JWK is the ES256 private key
+whose public component matches what `/.well-known/jwks.json` serves.
+
+All surfaces that emit a `signingKeyId` field — JWKS, DID document,
+signed receipts (`signIssuerReceipt`), the `/api/receipt/[lineageKey]`
+response body, and the runtime-continuity section of `/api/status` —
+resolve to that same value.
+
+### 2. What fallback logic previously leaked?
+
+Three concrete paths, all closed:
+
+1. Line 54 of `receiptIssuer.ts` — `process.env.RECEIPT_KID ?? \`vcv-es256-dev-${Date.now()}\``. When ops set the private JWK but forgot the kid, every receipt was signed with a dev-prefixed timestamp kid.
+2. Line 69 of `receiptIssuer.ts` — when neither env was set, an ephemeral keypair was generated with the literal kid `'vcv-es256-dev'`. This fired on every production cold-start where ops hadn't configured the receipt env.
+3. Line 116 of `app/api/receipt/[lineageKey]/route.ts` — hardcoded `signingKeyId: 'vcv-es256-dev'` literal in the main response shape, returned to every client regardless of environment.
+
+### 3. What runtime surfaces now use canonical identity?
+
+| Surface | Source of identity |
+|---|---|
+| `/.well-known/jwks.json` | `getOrInitKeypair().kid` → env-driven |
+| `/api/.well-known/jwks.json` (legacy mirror) | `getOrInitKeypair().kid` → env-driven |
+| `/.well-known/did.json` | `getOrInitKeypair().kid` → env-driven |
+| ES256 receipt JWT header `kid` | `getOrInitKeypair().kid` → env-driven |
+| `/api/receipt/[lineageKey]` lineageKey-shape response | `process.env.RECEIPT_KID ?? (prod default)` → env-driven |
+| `/api/status` `runtime_continuity.signing_key_id` | `getOrInitKeypair().kid` → env-driven (null with `degraded` status if env missing — honest) |
+| Replay inspection `signingKeyId` (`/api/replay/[runId]`) | sourced from the replay inspection layer reading the signing module — env-driven |
+| UI defaults (`TrustStateRegister`, `verify/[npi]/page`) | static fallback `'vcv-es256-1'` matches the expected env value |
+
+### 4. What still depends on fallback behavior?
+
+- **Dev / test / preview environments** intentionally depend on the dev fallback. `RECEIPT_KID_DEV ?? 'vcv-es256-dev'` is the legitimate dev kid. Tests assert it explicitly in `apps/web/__tests__/es256-receipt-engine.test.ts`.
+- **The build pipeline** depends on `force-dynamic` on the JWKS + DID routes to avoid prerendering against the production fail-closed guard. Without `force-dynamic`, `next build` would throw at static-export time.
+- **`/api/status` runtime continuity reporter** intentionally catches the production throw and reports `degraded` with `signing_key_id: null`. This is an honest signal — better than the prior behavior of reporting a dev kid as if it were production.
+
+### 5. What still blocks institutional trust-anchor stability?
+
+| Item | Effort | Owner |
+|---|---|---|
+| Apex Vercel env vars not set (`RECEIPT_PRIVATE_KEY_JWK`, `RECEIPT_KID`) | <10 min in Vercel dashboard | OPERATOR |
+| `RECEIPT_KID` value choice — recommend `vcv-es256-1` to match UI defaults | configuration | OPERATOR |
+| Key rotation procedure undocumented — when `RECEIPT_KID` flips, in-flight receipts under the prior kid still need to verify. Out of scope for this PR (the user explicitly said "do not rotate keys") | future | n/a yet |
+| `vcv-es256-1` literal as the UI default — works for the first kid, doesn't generalize to rotation. Future work, not blocking. | future | n/a yet |
+
+After this PR + the operator setting the two env vars, every
+production runtime surface emits the same canonical kid. The
+trust-anchor identity becomes internally consistent.
+
+## §3 — Verification plan (operator, post-deploy)
+
+```bash
+# All three should emit the same kid value (e.g., "vcv-es256-1"):
+curl -s https://vitalcv.com/api/.well-known/jwks.json | jq '.keys[0].kid'
+curl -s https://vitalcv.com/.well-known/jwks.json     | jq '.keys[0].kid'
+curl -s https://vitalcv.com/.well-known/did.json      | jq '.verificationMethod[0].publicKeyJwk.kid'
+curl -s https://vitalcv.com/api/status                | jq '.runtime_continuity.signing_key_id'
+
+# Receipt route should also report the same kid (env-resolved):
+curl -s "https://vitalcv.com/api/receipt/nppes_identity:1346053246" | jq '.receipt.signingKeyId'
+
+# Failure-mode probe — if for any reason RECEIPT_PRIVATE_KEY_JWK or
+# RECEIPT_KID gets unset on apex:
+#   - /.well-known/jwks.json: 500 (the fail-closed throw propagates)
+#   - /api/status: 200 with runtime_continuity.status="degraded",
+#     signing_key_id=null (honest signal)
+#   - /api/receipt/<lane>:<provider>: 200 with signingKeyId="vcv-es256-1"
+#     (the env-resolved production default), NOT "vcv-es256-dev"
+```
+
+If every probe returns the same kid value AND no probe returns
+`vcv-es256-dev`, the convergence is verified.
+
+## §4 — Verdict
+
+**Single canonical production signing identity** is now structurally
+guaranteed by the codebase:
+
+- One env-driven entry point (`getOrInitKeypair`), fail-closed in production.
+- Two routes that prerender against it (`/.well-known/jwks.json`, `/.well-known/did.json`) marked `force-dynamic` so the build pipeline coexists with the guard.
+- Two formerly-leaking literals (`/api/receipt/[lineageKey]:116` and the env-missing fallback path) replaced with env-resolved values.
+- Three behaviour-changing fail-closed tests added to lock the new
+  guarantee.
+
+The remaining trust-anchor work is operator-side: set the env vars on
+apex. Per the user's directive, no key rotation, no federation, no
+multi-key architecture introduced.

--- a/docs/architecture/signing-identity-trace.md
+++ b/docs/architecture/signing-identity-trace.md
@@ -1,0 +1,110 @@
+# Signing Identity Trace
+
+**Phase 1 deliverable.** Traces every code path on `origin/main` (HEAD
+`39bb65dd`, pre-PR) that produced an ES256 signing identity, and
+classifies each by leak risk.
+
+## §1 — Identifier inventory observed in production runtime
+
+| Observed kid | Origin code path | Classification |
+|---|---|---|
+| `vcv-es256-dev` | `apps/web/lib/crypto/receiptIssuer.ts:69` (fallback when `RECEIPT_KID_DEV` env unset) | **DEV-ONLY → LEAKED INTO PRODUCTION** (the actual leakage source — fires when `RECEIPT_PRIVATE_KEY_JWK` is entirely absent and the ephemeral keypair path runs) |
+| `vcv-es256-dev-<timestamp>` | `apps/web/lib/crypto/receiptIssuer.ts:54` (pre-fix) — fallback when `RECEIPT_KID` env unset but `RECEIPT_PRIVATE_KEY_JWK` env set | **DEV-PREFIXED → LEAKED INTO PRODUCTION** (fires when ops set the private JWK but forgot RECEIPT_KID) |
+| `vcv-es256-<timestamp>` | `apps/web/lib/crypto/receiptIssuer.ts:40` — `generateReceiptKeypair()` | Reachable only via the dev ephemeral path (line 68→69). The kid produced at line 40 is immediately overwritten by line 69's spread. Effectively dead code at the kid level. |
+| `vcv-es256-1` | Hardcoded literal in two UI components (`apps/web/app/verify/[npi]/page.tsx:253,265` and `apps/web/components/trust/TrustStateRegister.tsx:112,132`) as the **default ownership fallback** when `snapshot.signingKeyId ?? 'vcv-es256-1'` | **CANONICAL PRODUCTION IDENTITY** — these literals reveal that the operator-set production `RECEIPT_KID` is expected to be `vcv-es256-1`. The UI defaults to this when no snapshot value is available. |
+| `vcv-es256-dev` (hardcoded literal) | `apps/web/app/api/receipt/[lineageKey]/route.ts:116` (lineageKey-style response body) | **LEAKED INTO PRODUCTION** (literal hardcoded in a non-dev-guarded branch — every call to `/api/receipt/<lane>:<provider>` returned `signingKeyId: 'vcv-es256-dev'`) |
+| `vcv-es256-dev` (hardcoded literal) | `apps/web/app/api/receipt/[lineageKey]/route.ts:167` inside `if (isDev())` block | Dev-only; correctly gated. |
+
+## §2 — Required answers
+
+### 1. What code path emitted `vcv-es256-dev`?
+
+Two paths on `origin/main` (pre-PR):
+
+- **Path A (signing module, ephemeral fallback)**: `apps/web/lib/crypto/receiptIssuer.ts:69`. When `RECEIPT_PRIVATE_KEY_JWK` env is entirely absent, the module mints an ephemeral keypair (line 68) and assigns it the literal stable kid `'vcv-es256-dev'` (or `RECEIPT_KID_DEV` if set). This path fires on any production runtime where the operator forgot to set the receipt private JWK.
+
+- **Path B (receipt route, hardcoded literal)**: `apps/web/app/api/receipt/[lineageKey]/route.ts:116`. The lineageKey-shaped response body emitted `signingKeyId: 'vcv-es256-dev'` regardless of environment.
+
+### 2. What code path emitted `vcv-es256-1`?
+
+`vcv-es256-1` was never emitted by the signing module on `origin/main`. It only appears as a **hardcoded UI default** in:
+
+- `apps/web/app/verify/[npi]/page.tsx:253,265` — `signingKeyId="vcv-es256-1"` JSX prop default.
+- `apps/web/components/trust/TrustStateRegister.tsx:112,132` — `ownership: snapshot.signingKeyId ?? 'vcv-es256-1'` fallback.
+
+These literals tell us the **expected operator-configured production kid** is `vcv-es256-1`. The signing module reads `process.env.RECEIPT_KID`; when the operator sets that to `vcv-es256-1`, the JWKS + receipts will all emit `vcv-es256-1`, and the UI defaults will match.
+
+### 3. What runtime identity is canonical?
+
+**Production canonical identity** (after this PR's hardening):
+- `RECEIPT_KID` env var → required in production → expected operator value: `vcv-es256-1`
+- `RECEIPT_PRIVATE_KEY_JWK` env var → required in production → must contain the ES256 private JWK whose public component matches the JWK Set served at `/.well-known/jwks.json` (and the legacy `/api/.well-known/jwks.json` mirror)
+
+**Dev / test canonical identity**:
+- `RECEIPT_KID_DEV` env var → optional, defaults to `vcv-es256-dev`
+- No private JWK → an ephemeral keypair is generated at module load and discarded on restart
+
+### 4. What fallback logic leaked into production?
+
+Three distinct fallback paths, all now closed by this PR:
+
+1. **Signing module line 54** — when `RECEIPT_KID` was missing but `RECEIPT_PRIVATE_KEY_JWK` was present, the kid fell back to `vcv-es256-dev-${Date.now()}`. Now: throws in production.
+2. **Signing module line 69** — when `RECEIPT_PRIVATE_KEY_JWK` was missing entirely, an ephemeral keypair was minted with kid `vcv-es256-dev`. Now: throws in production.
+3. **Receipt route line 116** — hardcoded `signingKeyId: 'vcv-es256-dev'` literal in the non-dev branch of `/api/receipt/[lineageKey]`. Now: env-resolved with production fallback to `vcv-es256-1`.
+
+## §3 — Full code-path map
+
+```
+Caller (operator-facing surface)
+  │
+  ├─ /.well-known/jwks.json (apps/web/app/api/.well-known/jwks.json/route.ts)
+  │     → getPublicKeyJwk()
+  │         → getOrInitKeypair()             [the canonical entry]
+  │             → reads RECEIPT_PRIVATE_KEY_JWK + RECEIPT_KID
+  │             → throws in production if either missing  ← NEW IN THIS PR
+  │             → returns { privateKey, publicKey, kid }
+  │
+  ├─ /api/.well-known/jwks.json (legacy mirror; same handler family)
+  │     → same path
+  │
+  ├─ /.well-known/did.json
+  │     → getPublicKeyJwk()                  [same chain]
+  │
+  ├─ /api/status
+  │     → getOrInitKeypair().catch(() => null)
+  │     → signingKeyId = keypair?.kid ?? null
+  │     → if production env missing: catch fires, signingKeyId = null,
+  │       runtime_continuity.status = 'degraded'  ← honest signal, no leakage
+  │
+  ├─ signIssuerReceipt(...) (receipt-signing internal callers)
+  │     → getOrInitKeypair() → uses canonical kid → ES256 JWT header
+  │
+  ├─ /api/receipt/[lineageKey]
+  │     → response body.receipt.signingKeyId
+  │         = process.env.RECEIPT_KID
+  │             ?? (NODE_ENV === 'production' ? 'vcv-es256-1' : 'vcv-es256-dev')
+  │     ← NEW IN THIS PR: was hardcoded 'vcv-es256-dev'
+  │
+  └─ /api/replay/[runId]
+        → inspection.signingKeyId (sourced from the replay inspection layer
+          which reads from the signing module — same chain)
+```
+
+## §4 — Production / fallback / dev / leaked path classification
+
+| Code path | Classification |
+|---|---|
+| `getOrInitKeypair()` with both envs set + NODE_ENV=production | **PRODUCTION** ✓ |
+| `getOrInitKeypair()` with either env missing + NODE_ENV=production | **FAILS CLOSED** (throws) — replaces former dev fallback |
+| `getOrInitKeypair()` with envs unset + NODE_ENV != production | **DEV** (ephemeral, kid = `vcv-es256-dev`) |
+| `generateReceiptKeypair()` standalone | **DEAD AT KID LEVEL** (kid is overwritten by caller) — used only by test fixtures |
+| `/api/receipt/[lineageKey]` hardcoded literal | **PRODUCTION** ✓ after this PR (was leaked) |
+| UI default `'vcv-es256-1'` | **PRODUCTION** ✓ (matches expected env value) |
+
+## §5 — What remained after the fix
+
+- The `vcv-es256-dev` literal is still emitted in non-production (dev / test / preview without env). Intentional.
+- The `vcv-es256-dev` literal still appears inside `if (isDev())` blocks in `/api/receipt/[lineageKey]:167` and a couple of test fixtures. Correctly gated.
+- The UI default `'vcv-es256-1'` is unchanged — it is the intended production canonical kid; when ops set `RECEIPT_KID=vcv-es256-1` in env, every surface aligns.
+
+No path remaining on `origin/main` (post-this-PR) can leak a dev-prefixed kid into a production runtime.


### PR DESCRIPTION
## Summary
- Closes three leakage paths where the production runtime emitted dev-prefixed signing identities (`vcv-es256-dev` or `vcv-es256-dev-<ts>`) when operator env was incomplete.
- `getOrInitKeypair()` now **fails closed in production** when either `RECEIPT_PRIVATE_KEY_JWK` or `RECEIPT_KID` is missing.
- `/api/.well-known/jwks.json` + `/.well-known/did.json` marked `force-dynamic` so the build pipeline coexists with the runtime guard.
- `/api/receipt/[lineageKey]` hardcoded `'vcv-es256-dev'` replaced with env-resolved value (production default: `'vcv-es256-1'`, matching the existing UI literals).
- Two new architecture docs: `signing-identity-trace.md` (Phase 1) + `production-signing-identity-audit.md` (Phase 5).

## Truth rules
- Does NOT redesign signing architecture.
- Does NOT rotate keys.
- Does NOT introduce multi-key / federation logic.
- Does NOT break local dev fallback (still emits `vcv-es256-dev` outside production).
- Production cannot fall back to dev identity by any path after this change.
- Pre-existing jti format-check test (unrelated to signing identity) was failing on origin/main; updated the regex to match the deterministic `rcpt_<responseId>` shape that already shipped.

## Validation
- `pnpm --filter @vitalcv/web exec vitest run __tests__/es256-receipt-engine.test.ts __tests__/crypto-receipt.test.ts` — **22/22 passing** (4 net-new production fail-closed tests + 1 pre-existing-test fix).
- `pnpm turbo run build --filter @vitalcv/web` — **13/13 successful**.
- Banned-strings + bare-Verified scans: CLEAN.

## Operator action required post-merge

Set on apex Vercel project:
- `RECEIPT_PRIVATE_KEY_JWK` = ES256 private JWK (JSON-encoded)
- `RECEIPT_KID` = `vcv-es256-1` (matches existing UI defaults)

After both are set, every signing-emitting surface reports the same canonical kid; no path can leak `vcv-es256-dev` into production.

See `docs/architecture/production-signing-identity-audit.md` §3 for the operator verification curl plan.