### PR TITLE
fix(infrastructure-truth): retract vcv-web canonical claim + B18 production restore sequence

### DIFF
--- a/docs/architecture/b16-executive-convergence-summary.md
+++ b/docs/architecture/b16-executive-convergence-summary.md
@@ -1,0 +1,142 @@
+# B16 + B17 Executive Convergence Summary
+
+**Closes both convergence waves.** Brutally honest verdict on what's
+production-ready vs what's still blocked, based strictly on code-level
+inspection of `origin/main` (HEAD `7f7ace10`). Live HTTP probing of
+apex is operator-side; this document does NOT fabricate browser-track
+findings.
+
+## §1 — What is truly production-ready (code-level verified)
+
+| Area | Status | Evidence |
+|---|---|---|
+| Receipt signing fail-closed in production | ✓ READY | `apps/web/lib/crypto/receiptIssuer.ts:69-86` (PR-362 merged) |
+| JWKS / DID routes use canonical env-driven kid | ✓ READY | `force-dynamic` on both; runtime evaluation goes through `getOrInitKeypair` |
+| `/api/receipt/[lineageKey]` lineageKey-shape response emits canonical kid | ✓ READY | Env-resolved with `'vcv-es256-1'` production default |
+| Replay persistence (PR-α/β/γ) | ✓ READY | Three commits merged; readers + writer + NPI-keyed discovery |
+| Public marketing surfaces foundation-honest | ✓ READY | `/onboarding`, `/pricing`, `/docs`, `/status` all carry foundation-preview disclaimers |
+| `/api/health` honest config posture | ✓ READY | Reports `apiBase`, `clerk.enabled`, `sentry` booleans; no overclaim |
+| `/api/status` runtime continuity reporter | ✓ READY | Catches signing throw, reports `degraded` with `signing_key_id: null` |
+| Truth-contract scanners in CI (banned phrases, bare-Verified) | ✓ READY | Active per `_archive` evidence + prior session commits |
+| Audit-doc set covering institutional verifier topology | ✓ COMPLETE | 14+ docs on PR #358; updated convergence docs on this PR |
+
+## §2 — What is still degraded (acceptable for ship behind operator config)
+
+| Area | Why degraded | Operator fix |
+|---|---|---|
+| Apex Vercel env vars (Clerk, receipt key, issuer origin) | Not yet set per prior `/api/health` probe | Set on `vcv-web` Production scope; details in `final-deployment-sequence.md` §3 |
+| Apex probe runner cron (lane-health snapshots) | Cron not scheduled | Schedule on `vcv-web`; needs `CRON_SECRET`/`MONITORING_SECRET` |
+| Railway production-DB demo seed (NPI 1346053246) | Not seeded | Operator-side SQL once |
+| Preview-scope env labeling | `NODE_ENV=production` on preview inherits unless `VITALCV_ENV_LABEL` set | Set `VITALCV_ENV_LABEL=preview` on Preview scope |
+| Preview signing posture | 500s JWKS/DID unless preview env vars set | Choose Option A or B per `preview-runtime-safety-audit.md` §4 |
+
+None of these blocks shipping. All are operator-side.
+
+## §3 — What is still operator-dependent (after this convergence wave)
+
+The exhaustive operator-side list:
+
+1. Set apex Vercel env vars on `vcv-web` Production scope (see §3 of `final-deployment-sequence.md`)
+2. Schedule probe runner cron on Vercel
+3. Run Railway demo seed SQL
+4. Verify domain attachment: `vitalcv.com` → `vcv-web`, NOT `vitalcv` (deprecated)
+5. Run external verification probes per `final-deployment-sequence.md` §4
+6. Choose preview signing posture per `preview-runtime-safety-audit.md` §4
+7. (When ready to ship PR-362) merge it; Vercel auto-deploys
+8. (When ready to ship this convergence PR) merge; same auto-deploy
+9. Confirm no live response emits `"vcv-es256-dev"` per `signing-identity-convergence-report.md` §2
+
+None of these require new code. None can be done from a build session.
+
+## §4 — What still blocks institutional trust (after operator action)
+
+Once operator items §3 are closed:
+
+| Blocker | Severity | Effort |
+|---|---|---|
+| Canonical verifier paths (`/.well-known/jwks.json` at the RFC root, `/.well-known/did.json`, `openid-credential-issuer`, etc.) — on unmerged stack #345/#349/#355 | High for institutional discoverability; the legacy `/api/.well-known/jwks.json` works as a fallback | Operator runs `codex exec` on those PRs; merge train |
+| Replay UI primitives that consume the readers (lineageKey display, run chronology table, integrity verdict badge) | Medium — readers ship and are usable via API; UI exposure is incremental | Future engineering PR (out of scope per user directive) |
+| `/api/credentials/issue` referenced in OID4VCI metadata does not exist (`verifier-continuity-normalization-audit.md` §5 caveat a) | Low — semantic mismatch in metadata; verifier clients tolerate or fall back to `/api/receipt/[npi]` | Small PR or doc-only mapping clarification |
+| Continuity reconciler endpoint (per `replay-topology-gap-analysis.md` §7 PR-ζ) | Low — derivable client-side from chain endpoint output | Future engineering PR |
+
+## §5 — What still blocks onboarding momentum (UI/UX layer)
+
+I cannot evaluate UI/UX momentum from a build session — that requires
+rendering and human judgment. The user's B16-ACTIVATION-04 /
+B16-PASSPORT-05 / B17-CODE-04 / B17-BROWSER-02 / B17-BROWSER-03 missions
+all asked for emotional/cognitive-load evaluations of live screens.
+Honest scope note:
+
+| Item | Can I evaluate from code? | Operator-side action |
+|---|---|---|
+| Homepage emotional conversion | Partial — can read copy density | Need browser-rendered review |
+| Passport "above-the-fold decisiveness" | Partial — can read JSX hierarchy | Need browser-rendered review |
+| First-value immediacy / NPI-entry momentum | No — depends on real ingest timing | Need live probe |
+| Recruiter scan efficiency | No — depends on rendered layout | Need browser-rendered review |
+| Cognitive load | No — subjective | Need browser-rendered review |
+
+What I CAN flag from code:
+- The homepage (`HomePageClient.tsx`, 425 lines) is long. Density may be high.
+- `/passport` page (`apps/web/app/passport/page.tsx`, 841 lines) is long. Multiple terminal states + sample card + lane source rows.
+- "Foundation preview" framing is consistent and truth-honest; this reads as institutional restraint, not startup energy. Good.
+- Two label-collision concerns: "Unavailable" appears with two different semantics (in-stream `SourceRow` vs `LaneHealthMount` band). Worth de-dup.
+
+**Recommendation**: schedule a UI compression pass as a separate
+human-driven review, not an autonomous build task. The user has been
+clear: "no architecture expansion" + "calmness over spectacle." That
+combination requires rendered review.
+
+## §6 — What still blocks employer confidence
+
+Employer-confidence concerns are user-facing UX judgments, same scope
+limit as §5. From code-level inspection:
+
+- `/employer/dashboard`, `/employer/worklist`, `/employer/review/[applicationId]`, `/employer/decision/[applicationId]` all exist on `origin/main` as routes. Workflow completeness was not auditable from this session.
+- "Foundation preview" framing throughout means employers won't see overclaim.
+- The replay endpoints (post-PR-α/β/γ merge) give institutional clients a JSON traversal path, but UI consumption is not yet wired.
+
+For an employer-confidence verdict against the live product, a
+browser-rendered review is required.
+
+## §7 — Categorical verdict
+
+**Is VitalCV now a marketing shell, institutional prototype, operational pilot system, or production trust platform?**
+
+Brutally operational answer: **institutional prototype with a production-grade signing identity guarantee, gated on operator env-configuration to become an operational pilot system.**
+
+The structural pieces are in place:
+- Fail-closed signing identity (no dev kid leakage path)
+- Persistent replay with externally navigable readers
+- Foundation-honest copy across public marketing surfaces
+- Truth-contract scanners active in CI
+- Audit set comprehensively maps every blocker by owner
+
+What it is NOT yet:
+- A production trust platform — requires institutional verifiers to externally inspect a populated topology (depends on operator env + Railway seed + merge train completion)
+- A polished UX product — UI compression / momentum work is incomplete (not auditable here)
+
+What it is:
+- A defensible institutional prototype whose claims map to code
+- A platform whose remaining ship-blockers are operator-tasks, not engineering-tasks (with the exception of the 6 small product fix-up PRs enumerated in `ship-readiness-state.md` §3 and the engineering backlog in `replay-topology-gap-analysis.md` §7)
+
+## §8 — Single bottom-line claim
+
+**No new architecture is required to move VitalCV from "institutional
+prototype" to "operational pilot system."** The full closure path:
+
+1. Operator: env vars on `vcv-web` (5 vars, <30 min)
+2. Operator: probe-runner cron (<15 min)
+3. Operator: Railway demo seed (<5 min)
+4. Operator: domain attachment verification (<5 min)
+5. Operator: external verification per `final-deployment-sequence.md` §4
+6. Operator: `codex exec` on remaining unmerged PRs (institutional verifier paths)
+7. Engineering: 6 small product hygiene PRs from `ship-readiness-state.md` §3 (~half day total)
+8. Engineering: optional UI compression pass after a browser-rendered review
+
+Steps 1–6 are operator-side and total under 2 hours. Steps 7–8 are
+incremental and don't block the operational pilot.
+
+This is the same closure path the prior 14 audit docs identified.
+B16 + B17 do not change the closure path; they verify the signing
+identity convergence is now structural, document the deployment
+sequence, and clarify preview safety.

--- a/docs/architecture/b16-executive-convergence-summary.md
+++ b/docs/architecture/b16-executive-convergence-summary.md
@@ -1,5 +1,22 @@
 # B16 + B17 Executive Convergence Summary
 
+> **⚠ RETRACTION (B18 wave):** This summary previously named `vcv-web`
+> as the canonical Vercel project. That assignment is INVALID;
+> `vcv-web.vercel.app` belongs to an unrelated third-party. All
+> `vcv-web` references in this summary now read `<canonical-project-TBD>`.
+> The categorical verdict in §7 ("institutional prototype with a
+> production-grade signing identity guarantee") is unaffected — that
+> claim is about code, not infrastructure naming. The B18 wave adds
+> three new docs (`production-restore-sequence.md`,
+> `pause-root-cause-report.md`, `domain-topology-audit.md`) that
+> supersede the §3 operator checklist with operator-side discovery
+> as the first step.
+>
+> **B18 priority context**: `vitalcv.com` currently returns HTTP 402
+> (paused). The full §3 operator checklist below cannot be executed
+> until the pause is resolved and the real canonical project is
+> identified.
+
 **Closes both convergence waves.** Brutally honest verdict on what's
 production-ready vs what's still blocked, based strictly on code-level
 inspection of `origin/main` (HEAD `7f7ace10`). Live HTTP probing of
@@ -24,8 +41,8 @@ findings.
 
 | Area | Why degraded | Operator fix |
 |---|---|---|
-| Apex Vercel env vars (Clerk, receipt key, issuer origin) | Not yet set per prior `/api/health` probe | Set on `vcv-web` Production scope; details in `final-deployment-sequence.md` §3 |
-| Apex probe runner cron (lane-health snapshots) | Cron not scheduled | Schedule on `vcv-web`; needs `CRON_SECRET`/`MONITORING_SECRET` |
+| Apex Vercel env vars (Clerk, receipt key, issuer origin) | Not yet set per prior `/api/health` probe | Set on `<canonical-project-TBD>` Production scope; details in `final-deployment-sequence.md` §3 |
+| Apex probe runner cron (lane-health snapshots) | Cron not scheduled | Schedule on `<canonical-project-TBD>`; needs `CRON_SECRET`/`MONITORING_SECRET` |
 | Railway production-DB demo seed (NPI 1346053246) | Not seeded | Operator-side SQL once |
 | Preview-scope env labeling | `NODE_ENV=production` on preview inherits unless `VITALCV_ENV_LABEL` set | Set `VITALCV_ENV_LABEL=preview` on Preview scope |
 | Preview signing posture | 500s JWKS/DID unless preview env vars set | Choose Option A or B per `preview-runtime-safety-audit.md` §4 |
@@ -36,10 +53,10 @@ None of these blocks shipping. All are operator-side.
 
 The exhaustive operator-side list:
 
-1. Set apex Vercel env vars on `vcv-web` Production scope (see §3 of `final-deployment-sequence.md`)
+1. Set apex Vercel env vars on `<canonical-project-TBD>` Production scope (see §3 of `final-deployment-sequence.md`)
 2. Schedule probe runner cron on Vercel
 3. Run Railway demo seed SQL
-4. Verify domain attachment: `vitalcv.com` → `vcv-web`, NOT `vitalcv` (deprecated)
+4. Verify domain attachment: `vitalcv.com` → `<canonical-project-TBD>`, NOT `vitalcv` (deprecated)
 5. Run external verification probes per `final-deployment-sequence.md` §4
 6. Choose preview signing posture per `preview-runtime-safety-audit.md` §4
 7. (When ready to ship PR-362) merge it; Vercel auto-deploys
@@ -124,7 +141,7 @@ What it is:
 **No new architecture is required to move VitalCV from "institutional
 prototype" to "operational pilot system."** The full closure path:
 
-1. Operator: env vars on `vcv-web` (5 vars, <30 min)
+1. Operator: env vars on `<canonical-project-TBD>` (5 vars, <30 min)
 2. Operator: probe-runner cron (<15 min)
 3. Operator: Railway demo seed (<5 min)
 4. Operator: domain attachment verification (<5 min)

--- a/docs/architecture/b20-browser-track-blocked.md
+++ b/docs/architecture/b20-browser-track-blocked.md
@@ -1,0 +1,74 @@
+# B20 Browser Track — Blocked
+
+**Status**: production runtime still intercepted by Vercel paused state.
+
+Per the B20 operator-recovery wave directive:
+
+> BROWSER TRACK ONLY EXECUTES AFTER:
+> HTTP 402 IS CLEARED.
+>
+> DO NOT FABRICATE RESULTS.
+>
+> IF STILL PAUSED:
+> state explicitly:
+> "production runtime still intercepted by Vercel paused state."
+
+## §1 — Explicit statement
+
+**Production runtime still intercepted by Vercel paused state.**
+
+The five Browser-track missions cannot execute from a build session
+while apex returns HTTP 402:
+
+- B20-BROWSER-01 (production restore validation)
+- B20-BROWSER-02 (signing identity validation)
+- B20-BROWSER-03 (activation experience validation)
+- B20-BROWSER-04 (operational trust validation)
+- B20-BROWSER-05 (final reality verdict)
+
+None of these are fabricated. None of them have results.
+
+## §2 — What unblocks them
+
+Operator-side: clear the HTTP 402 per `pause-root-cause-report.md`
+§2 (diagnostic) and `production-restore-sequence.md` §3 (resume
+procedure).
+
+Once the pause is cleared and the canonical Vercel project is
+operator-confirmed, the Browser track can execute by either:
+
+- An operator running `scripts/verify-production-runtime.sh` (which mechanically performs B20-BROWSER-01 and B20-BROWSER-02 inputs).
+- A rendered-UI reviewer running B20-BROWSER-03 / 04 / 05 against the live apex.
+
+## §3 — What the Code track CAN say about expected outcomes
+
+Code-level analysis (already in this PR's docs) lets us predict what
+each Browser-track probe SHOULD return once the pause clears:
+
+| Probe | Expected outcome (assuming env vars set per `production-env-requirements.md`) |
+|---|---|
+| B20-BROWSER-01 apex 200 | `/api/health` returns 200, JSON, `service: "web"` |
+| B20-BROWSER-02 JWKS kid | `vcv-es256-1` if env is set; OR 500 (fail-closed) if env missing |
+| B20-BROWSER-02 dev-kid check | No surface should emit any kid containing `"dev"` |
+| B20-BROWSER-03 activation | Cannot predict; requires rendered-UI judgment |
+| B20-BROWSER-04 trust | Cannot predict; requires rendered-UI judgment |
+| B20-BROWSER-05 verdict | Best-case after operator action: "operational pilot system." Cannot be confirmed without rendered-UI review. |
+
+Predictions are NOT verifications. They become verifications when an
+operator runs the smoke script against the unpause runtime.
+
+## §4 — Recommended operator sequence
+
+1. **Clear the pause** — `pause-root-cause-report.md` §2 probes; resolve the cause.
+2. **Configure env vars** — `production-env-requirements.md` §1–§4.
+3. **Trigger a new deploy** — `production-restore-sequence.md` §3.
+4. **Run the smoke script** — `scripts/verify-production-runtime.sh`. Output is a PASS/FAIL table.
+5. **Verify against the docs** — cross-reference the smoke output with `signing-identity-convergence-report.md` §2 (signing surfaces) and `runtime-state-clarity-matrix.md` §2 (state identification).
+6. **Browser-track rendered review** — open the live homepage, passport, onboarding, employer surfaces; evaluate against B20-BROWSER-03/04/05 criteria.
+
+Once 1–5 pass, step 6 can produce the final verdict that B20-BROWSER-05 requests.
+
+## §5 — Single-sentence honest answer
+
+**The Browser track is blocked by the upstream operator action of
+clearing the HTTP 402 pause. No code change can replace that step.**

--- a/docs/architecture/degraded-runtime-behavior-audit.md
+++ b/docs/architecture/degraded-runtime-behavior-audit.md
@@ -1,0 +1,151 @@
+# Degraded Runtime Behavior Audit
+
+**B20-CODE-03 deliverable.** Audits how `apps/web` behaves when each
+upstream dependency or env var is unavailable. Verifies the UI/API
+remains calm and truthful rather than panicking or making false
+guarantees.
+
+This audit is code-level. Live verification requires probing the
+canonical deployment once production is no longer paused (see
+`pause-root-cause-report.md`).
+
+## §1 — Failure-mode behavior matrix
+
+For each potential degraded state, the audit records:
+
+- **Surface affected** — where users / verifiers feel it
+- **Code-level behavior** — what the code does on this failure path
+- **User-visible outcome** — what the user sees
+- **Truth verdict** — calm/honest or panic/misleading
+
+| Failure | Surface affected | Code-level behavior | User-visible outcome | Verdict |
+|---|---|---|---|---|
+| Clerk env unset | All authenticated routes | `middleware.ts:126-140` enters non-Clerk fallback; public routes pass through, protected routes redirect to `/sign-in` | "Sign in" flow loads but Clerk widget can't initialize (no publishable key) — user sees a broken-feeling sign-in | DEGRADED — UI does not panic, but the redirect-loop is confusing. `/api/health` reports `clerk.enabled: false` honestly. |
+| `RECEIPT_PRIVATE_KEY_JWK` unset (production) | JWKS, DID, signed-receipt routes | `getOrInitKeypair()` throws; `force-dynamic` routes (jwks/did) return 500 | Verifier hitting JWKS sees 500 (no JSON body or stack trace exposed) | CALM — explicit refusal to publish a key; better than emitting dev kid |
+| `RECEIPT_KID` unset (production) | Same | Same throw | Same 500 | CALM |
+| `DATABASE_URL` unset (backend) | All routes touching Prisma | `config/env.ts:loadEnv` throws at backend boot; backend never starts | Web proxies to backend return upstream timeout / 503 | EXPLICIT — backend doesn't half-start; web routes report the disconnection |
+| Railway DB unreachable mid-runtime | Same | Prisma client throws on query; per-route try/catch returns 500 or graceful fallback | Most routes return 500; replay readers return `replay_infrastructure_unavailable` (503, stable code) per PR-α/β/γ guards | CALM — `replay_infrastructure_unavailable` is a stable diagnostic code |
+| Replay tables missing (P2021) | Replay readers | All `/api/replay/*` routes detect P2021 and return 503 `replay_infrastructure_unavailable` per `routes/replay.ts:isPrismaTableMissingError` | Caller sees a stable error code; web proxy returns 503 + JSON body | CALM — by design |
+| `/api/ingest/[npi]` upstream failure | Homepage NPI submit flow | Route returns HTTP 200 with `{fallback: true, runId: null, ...}` per `routes/ingest.ts:35-97` | Client (`startPublicIngest`) does NOT currently branch on `fallback: true` → throws an error | **DEFECT** — homepage NPI submit fails cryptically when backend is down. Known issue per `upstream-fetch-topology.md` §A.X + `gating-graph.md` §4 |
+| Probe runner unscheduled | LaneHealthMount band on `/passport`, `/passport/[id]` | `getLaneSnapshots` returns UNKNOWN seeds; UI renders "Unavailable" lane status | User sees "Unavailable" lanes on the passport, conflicting with in-stream `SourceRow` lane status | DEGRADED — visible defect; "Unavailable" label collision is a UX confusion. Cron-side fix per `production-env-requirements.md` §2 |
+| Sentry DSN unset | Error tracking | Sentry frontend init is a no-op | Errors not captured | DEGRADED — invisible to operator; `/api/health` reports `sentry: false` honestly |
+| Edge cache stale | All cacheable routes | Cached response served until TTL expires | User sees old content for up to cache TTL | CALM — Vercel's default Cache-Control headers are sensible; signing routes are `force-dynamic` so they never cache |
+| Resolve-role fetch hangs (middleware) | First-time-user sign-in path | `middleware.ts:69` now has `AbortSignal.timeout(8000)` (PR #360); on timeout falls through to `/auth/error` redirect | After 8s, user redirected to error page rather than indefinite hang | CALM — bounded timeout; explicit error page |
+| Vercel deployment paused (HTTP 402) | Entire apex | Vercel intercepts at the edge; no app code runs | User sees Vercel's "deployment temporarily paused" page | BLOCKING — but explicit and operator-actionable (per `pause-root-cause-report.md`) |
+| Apex serving wrong project | `/api/health` may return unexpected `service` value | Routes from the wrong project execute | Subtle data divergence (e.g., signing kid not matching expected); confusing | RISK — easy to miss; mitigated by smoke test in `scripts/verify-production-runtime.sh` |
+
+## §2 — Specific UI calmness checks
+
+### Homepage NPI submission
+
+When `/api/ingest/[npi]` returns the masked-200 fallback:
+
+| Current behavior | Verdict |
+|---|---|
+| Client throws because it doesn't branch on `fallback: true` | DEFECT — see §1 row "Ingest upstream failure" |
+| User sees a cryptic error in console | NEEDS FIX — should display a calm "Sources unavailable" state |
+
+**Recommended fix** (out of scope for this audit; tracked separately): `apps/web/lib/api.ts` `startPublicIngest` should check `fallback: true` and produce a clean degraded-state UI rather than throwing.
+
+### `/passport` lane statuses
+
+Two parallel channels render lane status:
+
+1. **In-stream `SourceRow`** — driven by SSE; shows real per-source progression (`Checking…`, `Checked`, `Unavailable` on SSE error).
+2. **`LaneHealthMount` band** — driven by `getLaneSnapshots` from a memory-keyed store, populated by the probe runner.
+
+Both channels use the literal word "Unavailable" for different states. When the probe runner is unscheduled (current production state), the band reads "Unavailable" while the SourceRow may say "Checked" — visible inconsistency.
+
+| Outcome | Verdict |
+|---|---|
+| UI does NOT crash | CALM ✓ |
+| Two simultaneous "Unavailable" indicators with different causes | LABEL COLLISION — confusing |
+| Underlying degraded-state policy in `degradedStateFoundation.ts` is foundation-honest | TRUTHFUL ✓ |
+
+**Recommendation**: rename one of the two channels (e.g., LaneHealthMount band could say "Probe pending" instead of "Unavailable" when seeds are UNKNOWN). One-line copy change; out of scope for this audit.
+
+### Authenticated route gate when Clerk unavailable
+
+When `CLERK_SECRET_KEY` is unset, `middleware.ts:35` sets `CLERK_MIDDLEWARE_ENABLED = false`. The fallback at lines 126-140:
+
+```ts
+if (!CLERK_MIDDLEWARE_ENABLED) {
+  if (isPublicRoute(req.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+  const requiredRole = getRequiredRole(req.nextUrl.pathname);
+  if (!requiredRole) {
+    return NextResponse.next();
+  }
+  const signInUrl = req.nextUrl.clone();
+  signInUrl.pathname = '/sign-in';
+  signInUrl.searchParams.set('redirect_url', req.nextUrl.pathname);
+  return NextResponse.redirect(signInUrl);
+}
+```
+
+- Public routes pass through (calm).
+- Protected routes redirect to `/sign-in` with `redirect_url` set (calm).
+- `/sign-in` page loads but the Clerk widget can't initialize without `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`.
+
+| Outcome | Verdict |
+|---|---|
+| No middleware crash | CALM ✓ |
+| Public routes survive | CALM ✓ |
+| Protected routes degrade to a non-functional sign-in flow | DEGRADED but EXPLICIT |
+
+**Recommendation**: when Clerk env is missing, the `/sign-in` page should display a "Sign-in temporarily unavailable" message rather than loading the Clerk widget into a broken state. Out of scope for this audit; tracked.
+
+## §3 — Replay readers under failure
+
+The PR-α/β/γ readers are designed to fail-gracefully:
+
+| Failure | Behavior |
+|---|---|
+| Migration not applied | Detect P2021 → 503 `replay_infrastructure_unavailable` |
+| Entity not found for NPI | Return 200 with `{ entityId: null, runs: [] }` (chronology absence is not an error) |
+| Run not found by runId | Return 404 with `{ error: 'replay_run_not_found', runId }` |
+| Malformed input | 400 with explicit `expected` field |
+| Backend unreachable | Web proxy returns 503 with stable error code |
+
+All paths produce JSON; no HTML stack traces leak.
+
+## §4 — Truth-contract verification under degradation
+
+When the UI degrades, does it ever emit a banned phrase or make a
+false guarantee?
+
+| Surface | Foundation-honest copy on origin/main? |
+|---|---|
+| Homepage | "Stop Starting Over. Start Ready." — promise-honest |
+| `/onboarding` | Disclaims completing the credentialing process |
+| `/pricing` | "Pricing is a foundation preview. Payments are not collected in this build." |
+| `/docs` | "Docs are a launch-readiness foundation, not complete API documentation." |
+| `/status` | "Status surfaces are foundation previews. No uptime guarantee is implied." |
+| `/passport` | Per-source labels (`Checked`, `Source-backed`, `Access required`, `No profile yet`) — none claim more than the source actually provides |
+| `/api/health` | Reports config booleans honestly |
+| `/api/status` | Returns `degraded` with `signing_key_id: null` when signing throws — explicit |
+
+No surface emits a banned phrase under degradation. The truth-contract
+holds across the audited failure modes.
+
+## §5 — Summary
+
+**Code-level verdict**: VitalCV degrades calmly across the audited
+failure modes, with two known UI defects that should be tracked:
+
+1. **`/api/ingest/[npi]` masked-200 fallback** — client throws instead of rendering a clean degraded state. Small client-side PR fixes this.
+2. **`LaneHealthMount` "Unavailable" label collision** — same word used for two different states; one-line copy change.
+
+Both are out of scope for this audit per the user's directive ("no
+new architecture, no UI redesign"). They are tracked for a future
+hygiene PR.
+
+**Truth-contract verdict**: no surface emits a false guarantee under
+any audited failure mode. The "foundation preview" framing across
+public surfaces holds; the runtime continuity reporter at
+`/api/status` honestly reports `degraded` rather than green-washing.
+
+The remaining "panic" surface is the Vercel-level HTTP 402 paused
+state, which intercepts before any application code runs and is
+operator-actionable per `pause-root-cause-report.md`.

--- a/docs/architecture/domain-topology-audit.md
+++ b/docs/architecture/domain-topology-audit.md
@@ -1,0 +1,148 @@
+# Domain Topology Audit
+
+**B18-TRUTH-03 deliverable.** Diagnostic for verifying VitalCV's
+domain topology and ensuring no stale Vercel project can accidentally
+receive production traffic. Operator-runnable; does not itself probe.
+
+## §1 — Domains in scope
+
+| Domain | Expected purpose |
+|---|---|
+| `vitalcv.com` (apex) | Production runtime |
+| `www.vitalcv.com` | Redirect to apex (typical) or alias of canonical project |
+| `*.vercel.app` aliases on the canonical project | Preview / branch deploys |
+| Custom subdomains (e.g., `api.vitalcv.com`) | Backend (Railway) — separate from Vercel |
+
+External verification has confirmed:
+
+- `vcv-web.vercel.app` is **NOT a VitalCV project**. It belongs to an unrelated third-party. **Do not alias, deploy to, or document `vcv-web` as canonical.**
+
+## §2 — Authoritative routing answers (operator-side)
+
+For each domain row in §1, the operator must determine:
+
+| Question | Source of answer |
+|---|---|
+| Which Vercel project (if any) has this domain attached? | Vercel dashboard → Settings → Domains; OR `vercel domains ls` |
+| What DNS records point this domain to Vercel? | DNS provider dashboard (Cloudflare, Route53, etc.); OR `dig +short vitalcv.com` for A/CNAME |
+| Is the domain marked "Verified" in Vercel? | Vercel dashboard → the project → Settings → Domains → status next to domain |
+| Is the domain attached to MORE THAN ONE Vercel project? | Vercel dashboard → all projects in the team; OR repeat `vercel domains ls` per project — a domain CAN be claimed across projects but only the one Vercel routes to is canonical |
+
+## §3 — Audit probes
+
+### Probe A — DNS resolution
+
+```bash
+dig +short vitalcv.com
+# Expected: Vercel's load balancer IPs (currently 76.76.21.21 or similar)
+# Or: an A record / CNAME pointing to *.vercel-dns.com / cname.vercel-dns.com
+
+dig +short www.vitalcv.com
+# Expected: CNAME to vitalcv.com OR to a Vercel alias
+
+dig TXT _vercel.vitalcv.com
+# Expected: a verification TXT record if Vercel domain verification was used
+```
+
+### Probe B — Vercel-side ownership
+
+```bash
+# After authenticating to the right Vercel team:
+vercel domains ls
+# Look for vitalcv.com → which project ID owns it
+
+vercel projects ls
+# Cross-reference project IDs to project names
+```
+
+### Probe C — HTTP behavior (no auth required)
+
+```bash
+# Direct apex probe:
+curl -sI https://vitalcv.com/ | head -20
+# Look at `Server:` header — Vercel sends "Vercel" or omits.
+# Look at `x-vercel-id:` header — names the region + deployment ID.
+
+# Same for www:
+curl -sI https://www.vitalcv.com/ | head -20
+# If www returns 301/302 to apex → redirect is configured. OK.
+# If www returns 200 with different content from apex → apex/www split, audit.
+
+# Check for x-vercel-id divergence between apex and www:
+APEX_ID=$(curl -sI https://vitalcv.com/ | grep -i "x-vercel-id" | tr -d '\r')
+WWW_ID=$(curl -sI https://www.vitalcv.com/ | grep -i "x-vercel-id" | tr -d '\r')
+echo "APEX: $APEX_ID"
+echo "WWW:  $WWW_ID"
+# Both should reference the same deployment (or www should redirect to apex)
+```
+
+## §4 — Common divergence modes
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| Apex 402, www 200 with different content | Apex attached to a paused project; www attached to a different (live) project | Detach apex from the paused project; attach to the same project as www OR resume the paused one |
+| Apex 200, www 404 | www not attached to any project, or DNS missing | Attach www to the canonical project; OR add a DNS CNAME from www → apex |
+| Both apex and www return identical Vercel content but kid says "vcv-es256-dev" | Wrong project serving both; either the deprecated/stale project or a project that doesn't have PR-362's fail-closed guard | Identify the canonical project via `production-restore-sequence.md` §1; reattach apex to it |
+| Apex SOMETIMES returns 200, SOMETIMES 402 | Cache divergence between Vercel edges OR domain attached to multiple projects with race conditions | Use `curl -H "Cache-Control: no-cache"` to bypass edge; if 402 persists from origin, the underlying project is paused |
+| DNS shows non-Vercel IPs | DNS not pointing to Vercel at all | Update DNS provider records to point to Vercel (`vercel-dns.com` CNAME or Vercel A records) |
+
+## §5 — "Conflicting Vercel projects" check
+
+Multiple Vercel projects can each CLAIM the same domain in their
+Settings → Domains. Only the first / verified one actually receives
+traffic; the rest are stale claims that survive project archival.
+
+```bash
+# In the Vercel dashboard, for EACH project the operator owns:
+#   Settings → Domains → does this project list vitalcv.com?
+# Record every project that does.
+
+# Only ONE of those projects is actually routing. The others are
+# stale claims that should be removed.
+```
+
+To clean up stale claims:
+
+1. For each non-canonical project that claims `vitalcv.com`: Settings → Domains → remove the claim.
+2. Verify after each removal: `curl -sI https://vitalcv.com/` should still return 200 from the canonical project.
+
+## §6 — Required record
+
+Fill in after the operator probes:
+
+| Field | Value |
+|---|---|
+| Apex DNS resolution | A / CNAME → |
+| Apex Vercel project | |
+| WWW DNS resolution | |
+| WWW Vercel project | |
+| Stale claims on `vitalcv.com` (other projects) | |
+| Stale claims on `www.vitalcv.com` (other projects) | |
+| Apex `x-vercel-id` header | |
+| WWW `x-vercel-id` header | |
+| Cache divergence detected? | |
+
+## §7 — What this audit does NOT do
+
+- Does NOT modify DNS.
+- Does NOT modify Vercel domain attachments.
+- Does NOT resolve the HTTP 402 — that's `pause-root-cause-report.md`.
+- Does NOT presume `vcv-web` or any specific name is canonical — only the operator-confirmed value.
+
+The goal is making domain routing **deterministic**: one and only one
+Vercel project owns the canonical traffic; no stale claims exist;
+DNS and Vercel agree on the routing target.
+
+## §8 — Verdict criteria
+
+Domain topology is **converged** when:
+
+1. `dig +short vitalcv.com` returns a Vercel IP or CNAME.
+2. Exactly one Vercel project has `vitalcv.com` attached and verified.
+3. `curl -sI https://vitalcv.com/` and `curl -sI https://www.vitalcv.com/` reference the same deployment via `x-vercel-id` header (OR www redirects to apex).
+4. No stale project claims exist on either domain.
+5. The canonical project (from §6) matches the project found via `production-restore-sequence.md` §1.
+6. `curl https://vitalcv.com/api/health` returns `service: "web"` (confirms the right repo is being served).
+
+Until all six hold, domain topology is non-converged and traffic
+behavior may be non-deterministic.

--- a/docs/architecture/final-deployment-sequence.md
+++ b/docs/architecture/final-deployment-sequence.md
@@ -1,5 +1,16 @@
 # Final Deployment Sequence
 
+> **⚠ RETRACTION (B18 wave):** Earlier revisions named `vcv-web` as the
+> canonical Vercel project. External verification proved that name does
+> NOT belong to VitalCV. The actual canonical project remains
+> operator-confirmed-only. All `vcv-web` references are now
+> `<canonical-project-TBD>`; resolve via `production-restore-sequence.md`
+> §1 (B18-TRUTH-04) BEFORE following this sequence.
+>
+> **B18 priority context**: `vitalcv.com` currently returns HTTP 402
+> (paused). The pause-resolution runbook is `pause-root-cause-report.md`.
+> This deployment sequence is for AFTER the pause is cleared.
+
 **B16-RELEASE-06 + B17-CODE-01 deliverable.** Single operator runbook
 covering canonical deploy, runtime recovery, and post-deploy
 verification. Optimized for low ambiguity — a new operator should be
@@ -9,7 +20,7 @@ able to follow this without prior repo knowledge.
 
 | Item | Value |
 |---|---|
-| Canonical Vercel project | `vcv-web` |
+| Canonical Vercel project | `<canonical-project-TBD>` |
 | Deprecated Vercel project (detach apex from this) | `vitalcv` |
 | Canonical branch | `main` |
 | Canonical release SHA (as of audit) | `7f7ace10` |
@@ -27,15 +38,15 @@ baseline is correct.
 
 In the Vercel dashboard:
 
-- `vcv-web` → Settings → Git: production branch must be `main`
-- `vcv-web` → Settings → Domains: `vitalcv.com` must appear, marked production
+- `<canonical-project-TBD>` → Settings → Git: production branch must be `main`
+- `<canonical-project-TBD>` → Settings → Domains: `vitalcv.com` must appear, marked production
 - `vitalcv` (deprecated) → Settings → Domains: `vitalcv.com` must NOT appear
 
-If apex is attached to `vitalcv` instead of `vcv-web`: detach from
-`vitalcv`, attach to `vcv-web`. This is the single most common cause
+If apex is attached to `vitalcv` instead of `<canonical-project-TBD>`: detach from
+`vitalcv`, attach to `<canonical-project-TBD>`. This is the single most common cause
 of "stale production" symptoms.
 
-### Step 2 — Confirm env vars on `vcv-web`
+### Step 2 — Confirm env vars on `<canonical-project-TBD>`
 
 See §3 for the full required list. The two load-bearing ones are
 `RECEIPT_PRIVATE_KEY_JWK` and `RECEIPT_KID=vcv-es256-1`. Without
@@ -69,7 +80,7 @@ invocation is where the guard fires.
 In Vercel dashboard → Deployments tab → wait for the new deployment to
 show "Ready" status. Expected duration: ~2–4 minutes.
 
-## §3 — Required env vars (`vcv-web` Production scope)
+## §3 — Required env vars (`<canonical-project-TBD>` Production scope)
 
 | Var | Value | Effect when missing |
 |---|---|---|
@@ -164,7 +175,7 @@ Roll back IMMEDIATELY if any of the following holds after deploy:
 
 Rollback procedure:
 
-1. Vercel dashboard → Deployments tab on `vcv-web`
+1. Vercel dashboard → Deployments tab on `<canonical-project-TBD>`
 2. Find the last deployment marked Production with green health
 3. Three-dot menu → "Promote to Production"
 4. Vercel handles CDN cache invalidation automatically on promotion
@@ -174,8 +185,8 @@ Rollback procedure:
 
 If apex is fully broken (Vercel project misconfigured, env wiped, etc.):
 
-1. Verify the canonical baseline (§1) — does `vcv-web` exist, is it linked to GitHub, is `main` the production branch?
-2. If `vcv-web` does NOT exist: create it. Link to GitHub repo `ctol3r/vitalcv`. Set production branch `main`. Set Framework Preset = Next.js. Set Root Directory = `apps/web` (it's a monorepo).
+1. Verify the canonical baseline (§1) — does `<canonical-project-TBD>` exist, is it linked to GitHub, is `main` the production branch?
+2. If `<canonical-project-TBD>` does NOT exist: create it. Link to GitHub repo `ctol3r/vitalcv`. Set production branch `main`. Set Framework Preset = Next.js. Set Root Directory = `apps/web` (it's a monorepo).
 3. Set env vars per §3.
 4. Trigger a deploy.
 5. Attach `vitalcv.com` to the new project; detach from any other project.

--- a/docs/architecture/final-deployment-sequence.md
+++ b/docs/architecture/final-deployment-sequence.md
@@ -1,0 +1,206 @@
+# Final Deployment Sequence
+
+**B16-RELEASE-06 + B17-CODE-01 deliverable.** Single operator runbook
+covering canonical deploy, runtime recovery, and post-deploy
+verification. Optimized for low ambiguity — a new operator should be
+able to follow this without prior repo knowledge.
+
+## §1 — Canonical baseline
+
+| Item | Value |
+|---|---|
+| Canonical Vercel project | `vcv-web` |
+| Deprecated Vercel project (detach apex from this) | `vitalcv` |
+| Canonical branch | `main` |
+| Canonical release SHA (as of audit) | `7f7ace10` |
+| Production domain | `vitalcv.com` |
+| Backend (Railway) | `https://api.vitalcv.com` |
+| Required production env vars | see §3 |
+
+If any of the four "canonical" rows above does not match Vercel
+dashboard reality, fix that first. Everything below assumes the
+baseline is correct.
+
+## §2 — Deploy sequence
+
+### Step 1 — Confirm Vercel project linkage
+
+In the Vercel dashboard:
+
+- `vcv-web` → Settings → Git: production branch must be `main`
+- `vcv-web` → Settings → Domains: `vitalcv.com` must appear, marked production
+- `vitalcv` (deprecated) → Settings → Domains: `vitalcv.com` must NOT appear
+
+If apex is attached to `vitalcv` instead of `vcv-web`: detach from
+`vitalcv`, attach to `vcv-web`. This is the single most common cause
+of "stale production" symptoms.
+
+### Step 2 — Confirm env vars on `vcv-web`
+
+See §3 for the full required list. The two load-bearing ones are
+`RECEIPT_PRIVATE_KEY_JWK` and `RECEIPT_KID=vcv-es256-1`. Without
+these, the JWKS + DID routes will return 500 (fail-closed guard).
+
+Setting env vars in Vercel does NOT retroactively apply to existing
+builds. After setting any env var, force a new deployment.
+
+### Step 3 — Trigger deploy
+
+Two ways:
+
+```bash
+# A) Push any commit to main (CI auto-deploys):
+git push origin main
+
+# B) Force deploy of current main (no new commit):
+vercel --prod --force
+```
+
+Vercel build will run `pnpm install` then `pnpm turbo run build`. The
+new fail-closed guard means production builds REQUIRE `RECEIPT_KID` +
+`RECEIPT_PRIVATE_KEY_JWK` set on the Production scope (already
+addressed by step 2). Routes `/api/.well-known/jwks.json` and
+`/.well-known/did.json` are marked `force-dynamic` so the build itself
+doesn't invoke `getPublicKeyJwk()` at prerender time; runtime
+invocation is where the guard fires.
+
+### Step 4 — Wait for deploy to complete
+
+In Vercel dashboard → Deployments tab → wait for the new deployment to
+show "Ready" status. Expected duration: ~2–4 minutes.
+
+## §3 — Required env vars (`vcv-web` Production scope)
+
+| Var | Value | Effect when missing |
+|---|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | ES256 private JWK (JSON-encoded string) | JWKS/DID routes return 500 (fail-closed) |
+| `RECEIPT_KID` | `vcv-es256-1` | Same — fail-closed in production |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `pk_live_...` | `/api/health` reports `clerk.enabled: false`; protected routes broken |
+| `CLERK_SECRET_KEY` | `sk_live_...` | Middleware enters non-Clerk fallback path |
+| `NEXT_PUBLIC_API_BASE` | `https://api.vitalcv.com` | Cosmetic in `/api/health`; backend still reachable via fallback chain |
+| `BACKEND_URL` | `https://api.vitalcv.com` | Same chain; some inline-resolver routes fall back to `localhost:4000` without this |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN | Errors not captured in Sentry |
+| `VITALCV_ENV_LABEL` | `production` | `/api/status` `environment` field reports `'unknown'` |
+| `CRON_SECRET` and/or `MONITORING_SECRET` | random secret | Probe runner unscheduled; `LaneHealthMount` shows UNKNOWN seeds |
+
+### Preview-scope env vars (separate from Production)
+
+Vercel preview deploys inherit `NODE_ENV=production`, so the
+fail-closed guard fires on previews too. Two operator options:
+
+- **Option A (recommended)**: set `RECEIPT_PRIVATE_KEY_JWK` + `RECEIPT_KID=vcv-es256-preview-1` on Preview scope, using a DIFFERENT keypair from production. Preview surfaces all converge under a preview-only kid.
+- **Option B**: leave Preview scope empty. Preview deploys 500 the JWKS + DID surfaces. Safer (no preview-key sprawl) but breaks preview testing of those routes.
+
+## §4 — Verification sequence
+
+Run all of these after step 4 completes. Stop at the first failure;
+that's the blocker.
+
+```bash
+# 4.1 — Health probe (apex reachability + config posture)
+curl -i https://vitalcv.com/api/health
+# Expect: 200, JSON, service: "web", config booleans
+
+# 4.2 — Signing identity convergence
+curl -s https://vitalcv.com/api/.well-known/jwks.json | jq '.keys[0].kid'
+curl -s https://vitalcv.com/.well-known/did.json      | jq '.verificationMethod[0].publicKeyJwk.kid' 2>/dev/null || echo "did endpoint not yet on apex"
+curl -s https://vitalcv.com/api/status                | jq '.runtime_continuity'
+curl -s "https://vitalcv.com/api/receipt/nppes_identity:1346053246" | jq '.receipt.signingKeyId' 2>/dev/null
+
+# All four MUST emit the SAME kid value (expected: "vcv-es256-1").
+# NONE should emit anything containing "dev".
+
+# 4.3 — Replay continuity reader (post-deploy)
+curl -i https://vitalcv.com/api/replay/chain/1346053246
+# Expect: 200, JSON.
+
+# 4.4 — Banned-phrase scan on rendered homepage
+curl -s https://vitalcv.com/ | grep -iE "automatically verified|guaranteed verification|HIPAA compliant|SOC2 certified"
+# Expect: no output (no banned phrases).
+
+# 4.5 — Sanity check for 404 cascade on previously-broken paths
+for p in /verifier /trust /verify /compliance; do
+  echo -n "$p: "
+  curl -s -o /dev/null -w "%{http_code}\n" https://vitalcv.com$p
+done
+# These should either 200 (if they ship) or be removed from public navigation.
+# A 404 is acceptable only if no link in marketing copy points to that path.
+
+# 4.6 — Cache-bypass divergence probe
+curl -s -H "Cache-Control: no-cache" https://vitalcv.com/api/health | jq '.timestamp'
+curl -s https://vitalcv.com/api/health | jq '.timestamp'
+# Both timestamps should be recent. If they diverge significantly, edge
+# cache is holding old responses; force a new deploy.
+```
+
+## §5 — Smoke tests (extended)
+
+After §4 passes, run these against a real demo NPI:
+
+```bash
+# Trigger one ingest run:
+curl -X POST https://vitalcv.com/api/ingest/1346053246
+# Read the SSE stream; wait for {"type":"done"}
+
+# Probe replay readers populated by the run:
+curl -s https://vitalcv.com/api/replay/chain/1346053246 | jq '.lineages | length'
+# Expect: >= 1 if Railway DB has the demo seed and the ingest succeeded.
+# 0 with empty lineages: either demo seed missing on Railway, or
+# replay writer failed (check backend logs for 'replay_writer_failed').
+```
+
+## §6 — Rollback conditions
+
+Roll back IMMEDIATELY if any of the following holds after deploy:
+
+| Condition | Indication |
+|---|---|
+| `/api/health` returns non-200 | Apex broken |
+| `/api/.well-known/jwks.json` returns kid containing `"dev"` | PR-362 guard not on this deploy; rollback ensures no leak |
+| `/api/.well-known/jwks.json` returns 500 for more than 5 min | Env vars not set; rollback while operator re-configures |
+| Banned-phrase scan (§4.4) returns hits | Copy regression; rollback before institutional reviewer sees it |
+| `/api/status` reports `overall: "degraded"` for >5 min | Multiple subsystem degradation; rollback to last known good |
+| Vercel error rate spike on signing routes | Fail-closed firing because env unset; rollback while reconfiguring |
+
+Rollback procedure:
+
+1. Vercel dashboard → Deployments tab on `vcv-web`
+2. Find the last deployment marked Production with green health
+3. Three-dot menu → "Promote to Production"
+4. Vercel handles CDN cache invalidation automatically on promotion
+5. Re-run §4 verification against the rolled-back state
+
+## §7 — Canonical runtime recovery (worst case)
+
+If apex is fully broken (Vercel project misconfigured, env wiped, etc.):
+
+1. Verify the canonical baseline (§1) — does `vcv-web` exist, is it linked to GitHub, is `main` the production branch?
+2. If `vcv-web` does NOT exist: create it. Link to GitHub repo `ctol3r/vitalcv`. Set production branch `main`. Set Framework Preset = Next.js. Set Root Directory = `apps/web` (it's a monorepo).
+3. Set env vars per §3.
+4. Trigger a deploy.
+5. Attach `vitalcv.com` to the new project; detach from any other project.
+6. Run §4 verification.
+
+The repo `apps/web` is a vanilla Next 15 App Router app; no exotic
+build config beyond the standard `next build` (via Turbo for the
+workspace prebuild). If Vercel's auto-detection produces wrong
+defaults, the relevant `next.config.mjs` lives at `apps/web/next.config.mjs`.
+
+## §8 — Post-deploy validation summary
+
+After running §4 + §5 successfully, the runtime is in a verified
+state. Record:
+
+| Item | Value (fill in) |
+|---|---|
+| Deploy timestamp | |
+| Deployment ID (dpl_*) | |
+| Live SHA | |
+| JWKS kid emitted | |
+| DID kid emitted | |
+| Status reports degraded? | |
+| Replay reader returns rows? | |
+| Banned-phrase scan clean? | |
+
+This record is the ground truth for "what is on apex right now." Keep
+it alongside the deploy ticket for the next operator's reference.

--- a/docs/architecture/pause-root-cause-report.md
+++ b/docs/architecture/pause-root-cause-report.md
@@ -1,0 +1,162 @@
+# Pause Root Cause Report
+
+**B18-TRUTH-02 deliverable.** Diagnostic guide for resolving the
+HTTP 402 "This deployment is temporarily paused" response from
+`vitalcv.com`. Operator-runnable; does not itself probe Vercel.
+
+## §1 — What HTTP 402 from Vercel means
+
+Vercel emits HTTP 402 "Payment Required" / "Temporarily paused" in
+exactly these cases:
+
+| Cause | Triggered by | Recovery |
+|---|---|---|
+| Spending limit hit | Plan's spending cap reached | Raise cap, upgrade plan, or wait for next billing cycle reset |
+| Payment failure | Card declined, expired, or removed | Update payment method; Vercel auto-resumes after successful charge |
+| Manual project pause | An admin set Settings → General → "Pause project" | Toggle off in the same setting |
+| Manual deployment pause | An admin clicked "Pause" on a specific deployment | Resume from Deployments tab menu |
+| Account suspension | Anti-abuse / TOS / compliance hold | Vercel-support-required |
+| Team transfer in progress | Project is mid-migration between teams | Wait for transfer completion or roll back |
+
+Generic application errors (500/502/503) do NOT use 402. So the 402
+specifically isolates the cause to one of the six rows above.
+
+## §2 — Operator diagnostic sequence
+
+Run in order; stop at the first match.
+
+### Probe A — Billing surface check
+
+Vercel dashboard → the canonical project (per `production-restore-sequence.md` §1) → Settings → Billing.
+
+| What to look for | If found, cause is |
+|---|---|
+| Red "Spending limit reached" banner | Spending limit |
+| "Payment method declined" notice | Payment failure |
+| Plan badge says "Pause" | Plan-level pause |
+| "Project is currently paused" notice | Manual pause |
+| No banners but deployment-tab shows "Paused" badges | Deployment-level pause |
+
+### Probe B — Audit log (if available on plan)
+
+Settings → Audit Log → filter to last 24 hours. Look for entries
+containing:
+
+- `project.paused`
+- `deployment.paused`
+- `billing.limit.reached`
+- `payment.failed`
+- `account.suspended`
+
+The most recent such entry names the cause and the actor (system or
+admin).
+
+### Probe C — Recent deployments
+
+Deployments tab → most recent. The deployment card displays its
+state explicitly. Possible states:
+
+| State | Meaning |
+|---|---|
+| Ready | Healthy; 402 would not come from this deployment. If apex returns 402 anyway, the apex is attached to a DIFFERENT (paused) project. |
+| Paused | This deployment is the 402 source |
+| Error | Build failed; 402 not from this. Usually 500 instead. |
+| Queued | Build pending; previous deployment serves traffic. |
+
+If state is Ready and apex still 402s: domain attachment issue —
+apex is bound to a stale paused project. See
+`domain-topology-audit.md` for the resolution.
+
+### Probe D — Team / account level
+
+Profile / Team menu → Account Settings → Billing. The team-level
+billing state can pause all projects regardless of per-project
+state.
+
+## §3 — Five most likely root causes (ranked by frequency)
+
+Based on Vercel's documented 402 conditions, ordered by typical
+frequency in our context:
+
+1. **Spending limit hit on Hobby/Pro plan** (most common after a traffic spike or accidental loop)
+2. **Manual pause** (admin paused the project to control spend or stop deploys)
+3. **Payment failure** (card expired, especially on auto-renewing plans)
+4. **Team transfer mid-flight** (project migrating between teams)
+5. **Account suspension** (rare; almost always communicated by email first)
+
+## §4 — Required answers to diagnose
+
+| Question | Source of answer |
+|---|---|
+| Canonical Vercel project name? | Operator (Vercel dashboard) — DO NOT presume from prior docs |
+| Is the project itself paused? | Settings → General |
+| Is a recent deployment paused? | Deployments tab |
+| Has the spending limit been hit? | Settings → Billing |
+| Is the payment method valid? | Settings → Billing → Payment Method |
+| Is the team / account suspended? | Account-level banner on login |
+
+Each row maps to one of the six causes in §1. Answering all six
+makes the cause deterministic.
+
+## §5 — Resolution path per cause
+
+### Spending limit
+Settings → Billing → Spending Limits → raise the limit OR upgrade plan. The pause clears on save; an existing deployment will serve traffic immediately.
+
+### Manual project pause
+Settings → General → toggle "Pause project" OFF. Deployments resume.
+
+### Manual deployment pause
+Deployments tab → the paused deployment → three-dot menu → "Resume". Or trigger a new deployment which will supersede the paused one.
+
+### Payment failure
+Settings → Billing → Payment Method → update card. Vercel charges immediately; on success, pause auto-resumes.
+
+### Team transfer
+Wait for the transfer to complete (Vercel shows a banner with progress). If stuck for >24 hours, contact Vercel support.
+
+### Account suspension
+Contact Vercel support with the team / account slug. Provide context: which project, when traffic started failing, any unusual activity.
+
+## §6 — What to do AFTER resolving the pause
+
+Per `production-restore-sequence.md` §4–§7:
+
+1. Verify apex returns 200 (not 402).
+2. Verify the runtime is `apps/web` (`service: "web"` from `/api/health`).
+3. Verify env vars are set on Production scope.
+4. Run the full signing-identity convergence probe.
+5. Smoke-test ingest + replay readers.
+
+## §7 — Single deterministic answer
+
+```
+GIVEN: vitalcv.com returns HTTP 402
+
+THEN: production is paused at one of:
+  1. Spending limit
+  2. Manual project pause
+  3. Manual deployment pause
+  4. Payment failure
+  5. Team transfer
+  6. Account suspension
+
+OPERATOR ACTION: check Vercel dashboard for the canonical project
+  (per production-restore-sequence.md §1) and walk Probes A–D in §2
+  of THIS document. The first probe to show a banner / state / log
+  entry names the cause.
+
+ESCALATION CONDITION: if no probe surfaces a cause AND apex still
+  402s after a forced new deploy → contact Vercel support.
+```
+
+## §8 — What this report does NOT do
+
+- Does NOT identify the canonical Vercel project (that's `production-restore-sequence.md` §1).
+- Does NOT modify Vercel settings (operator-only).
+- Does NOT replace the operator's authentication into Vercel.
+- Does NOT presume `vcv-web` or any specific project name is canonical.
+
+The repo is healthy. The pause is platform-side and operator-
+resolvable through dashboard or CLI action. No code change can clear
+a 402.

--- a/docs/architecture/preview-runtime-safety-audit.md
+++ b/docs/architecture/preview-runtime-safety-audit.md
@@ -1,5 +1,10 @@
 # Preview Runtime Safety Audit
 
+> **⚠ RETRACTION (B18 wave):** Prior preview-URL example used `vcv-web`
+> as the project segment. That name does NOT belong to VitalCV. The
+> example URL now uses `<canonical-project-TBD>` until operator-side
+> discovery confirms the real project name.
+
 **B17-CODE-02 deliverable.** Verifies preview deployments cannot
 emit misleading institutional trust posture, given that Vercel
 preview deploys run under `NODE_ENV=production`.
@@ -89,7 +94,7 @@ actual deployed preview behaves as described requires running probes
 against a live preview URL. Operator-side commands:
 
 ```bash
-PREVIEW_URL="https://vcv-web-git-some-branch.vercel.app"  # whatever Vercel assigns
+PREVIEW_URL="https://<canonical-project-TBD>-git-some-branch.vercel.app"  # whatever Vercel assigns for the operator-confirmed project
 
 # Confirm preview labels itself honestly (after Recommendation 1):
 curl -s "$PREVIEW_URL/api/status" | jq '.runtime_continuity, .environment // empty'

--- a/docs/architecture/preview-runtime-safety-audit.md
+++ b/docs/architecture/preview-runtime-safety-audit.md
@@ -1,0 +1,121 @@
+# Preview Runtime Safety Audit
+
+**B17-CODE-02 deliverable.** Verifies preview deployments cannot
+emit misleading institutional trust posture, given that Vercel
+preview deploys run under `NODE_ENV=production`.
+
+## §1 — The preview/production NODE_ENV gotcha
+
+Vercel sets `NODE_ENV=production` for both production AND preview
+deployments. Only local `vercel dev` and explicit dev branches use
+`development`. This means:
+
+| Code that branches on `NODE_ENV === 'production'` | Fires in production | Fires in preview |
+|---|---|---|
+| Receipt issuer fail-closed guard (`apps/web/lib/crypto/receiptIssuer.ts`) | Yes | Yes |
+| `/api/receipt/[lineageKey]` route — env-resolved kid (vs `'vcv-es256-dev'`) | Yes | Yes |
+| `/api/receipt/[lineageKey]` `isDev()` dev-mock branch | No | No |
+| `/api/health` config posture booleans | (env-derived) | (env-derived) |
+
+**Consequence:** without Preview-scope env vars, preview deploys
+behave like production with missing env — JWKS/DID return 500,
+`/api/status` reports `degraded`. This is **safer than dev-key
+leakage** but breaks preview testing of signing surfaces.
+
+## §2 — Per-surface preview safety verdict
+
+| Surface | Preview behavior without env | Verdict |
+|---|---|---|
+| `/api/.well-known/jwks.json` | 500 (fail-closed throw) | SAFE — refuses to publish |
+| `/.well-known/did.json` | 500 | SAFE |
+| `/api/status` | 200; `runtime_continuity.signing_key_id: null`, `runtime_continuity.status: "degraded"` | SAFE — honest signal |
+| `/api/receipt/[lineageKey]` | 200; `signingKeyId: "vcv-es256-1"` (env-resolved default) | SAFE — emits canonical production default, never `"vcv-es256-dev"` |
+| ES256 receipt JWT signing (`signIssuerReceipt`) | Throws on first invocation | SAFE |
+| `/api/health` | 200; `clerk.enabled: false`, `apiBase: false` | SAFE — honest signal |
+| Homepage `/` and `/passport` | Render normally (no signing dependency on page load) | SAFE |
+| `/api/replay/*` (when migration applied) | Returns 503 `replay_infrastructure_unavailable` if Prisma table missing on preview DB | SAFE — stable error code |
+
+## §3 — Wording / posture audit
+
+Even when env is missing on preview, no surface emits language that
+implies the preview environment IS production. Specifically checked:
+
+| Surface | Status | Wording check |
+|---|---|---|
+| `/api/health` | Returns `service: "web"` literal — same in preview and production. This is the runtime identifier, not an environmental claim. | OK |
+| `/api/status` | Returns `environment: process.env.VITALCV_ENV_LABEL ?? process.env.NODE_ENV ?? 'unknown'`. If preview sets `VITALCV_ENV_LABEL=preview`, the status surface reports that label honestly. If unset, it reports `"production"` (because `NODE_ENV=production` on preview). Operator should set `VITALCV_ENV_LABEL=preview` on Preview scope to avoid misreporting. | NEEDS OPERATOR CONFIG |
+| Homepage copy | "Foundation preview" framing + explicit disclaimer that onboarding does not finish the credentialing process, already foundation-honest on `origin/main` | OK |
+| `/onboarding` | Copy explicitly disclaims completing credentialing | OK |
+| `/pricing` | "Pricing is a foundation preview. Payments are not collected in this build." | OK |
+| `/docs` | "Docs are a launch-readiness foundation, not complete API documentation." | OK |
+| `/status` | "Status surfaces are foundation previews. No uptime guarantee is implied." | OK |
+
+## §4 — Required operator action for preview safety
+
+Two recommendations, in priority order:
+
+### Recommendation 1: Set `VITALCV_ENV_LABEL=preview` on Preview scope
+
+Without this, `/api/status` reports `environment: "production"` on
+preview deploys (because `NODE_ENV=production` is the inherited
+default). Setting `VITALCV_ENV_LABEL=preview` ensures the status
+surface honestly identifies preview deployments to any external
+probe.
+
+Effort: 30 seconds in Vercel dashboard. Apply to all preview
+environments (including PR previews).
+
+### Recommendation 2: Choose preview signing posture
+
+**Option A (preview-key)**: set `RECEIPT_PRIVATE_KEY_JWK` +
+`RECEIPT_KID=vcv-es256-preview-1` on Preview scope. JWKS/DID surfaces
+work on preview deploys; preview-issued receipts are clearly
+distinguishable by kid prefix. The preview-key MUST be different from
+production's `vcv-es256-1` to prevent identity collision.
+
+**Option B (preview-500)**: leave Preview scope empty. Preview deploys
+500 the signing surfaces. Acceptable if you don't test those routes
+on previews; UI-only previews still work.
+
+Either option is safe. Option A is strictly more functional; Option B
+has lower operational surface area. Recommendation: **A** for any
+preview that institutional reviewers might probe, **B** for transient
+PR previews.
+
+## §5 — What still requires verification AGAINST a live preview
+
+The above analyses are static (code-level). Verification that an
+actual deployed preview behaves as described requires running probes
+against a live preview URL. Operator-side commands:
+
+```bash
+PREVIEW_URL="https://vcv-web-git-some-branch.vercel.app"  # whatever Vercel assigns
+
+# Confirm preview labels itself honestly (after Recommendation 1):
+curl -s "$PREVIEW_URL/api/status" | jq '.runtime_continuity, .environment // empty'
+# Expect environment field to be "preview", not "production".
+
+# Confirm signing posture (per chosen option in Recommendation 2):
+curl -s "$PREVIEW_URL/api/.well-known/jwks.json" | jq '.keys[0].kid'
+# Option A: emits "vcv-es256-preview-1" (or whatever you set)
+# Option B: returns 500
+
+# Confirm no banned phrase regression on the preview homepage:
+curl -s "$PREVIEW_URL/" | grep -iE "automatically verified|HIPAA compliant|SOC2 certified"
+# Expect: no output.
+```
+
+## §6 — Verdict
+
+**Code-level preview safety: VERIFIED.** No code path on origin/main
+can leak `"vcv-es256-dev"` or fabricate institutional posture from a
+preview deployment. The fail-closed guard fires before any dev
+identity can be emitted; the receipt-route default resolves to the
+canonical production value `"vcv-es256-1"` regardless of env presence
+in NODE_ENV=production contexts.
+
+**Operational preview safety: REQUIRES OPERATOR CONFIG.** Two small
+configurations on the Preview scope (env label + signing posture
+choice) close the remaining gap. Estimated effort: <2 minutes total.
+
+No code change is needed beyond what already shipped on PR-362.

--- a/docs/architecture/production-env-requirements.md
+++ b/docs/architecture/production-env-requirements.md
@@ -1,0 +1,148 @@
+# Production Env Requirements
+
+**B20-CODE-01 deliverable.** Zero-assumption operator-facing env-var
+reference for restoring `vitalcv.com` to externally reachable
+production. Every var is classified by failure mode + default safety.
+
+This document does not invent vars. Every entry is sourced from
+existing code on `origin/main` (HEAD verified in the convergence PR).
+
+## §1 — Required for production (FAIL CLOSED if missing)
+
+These vars MUST be set on the canonical Vercel project's Production
+scope. Without them, the named surface fails closed or returns 500
+rather than degrading silently.
+
+| Var | Consumer | Failure mode if missing | Safe default? |
+|---|---|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | `apps/web/lib/crypto/receiptIssuer.ts:73-78` | `getOrInitKeypair()` throws in production → JWKS / DID / signed-receipt surfaces return 500 | **NO** — operator must supply ES256 private JWK |
+| `RECEIPT_KID` | `apps/web/lib/crypto/receiptIssuer.ts:79-85` | Same fail-closed throw if private JWK is set but kid is not | **NO** — operator must set; expected value `vcv-es256-1` |
+| `DATABASE_URL` | Prisma client (backend); some web routes via shared helpers | Backend boot fails fast (`apps/api/backend/src/config/env.ts`) | **NO** — operator must point to Railway production DB |
+| `CLERK_SECRET_KEY` | `apps/web/middleware.ts:35` `CLERK_MIDDLEWARE_ENABLED` gate | Middleware enters fallback path; protected routes redirect to non-functional `/sign-in` | **NO** — operator must supply `sk_live_...` |
+
+## §2 — Required for full functional surface (DEGRADE GRACEFULLY if missing)
+
+These vars do NOT fail closed but cause specific observable defects.
+Set them in production; their absence is honest-degradation, not a
+crash.
+
+| Var | Consumer | Effect when missing | Recommended value |
+|---|---|---|---|
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `apps/web/app/api/health/route.ts:7` + Clerk SDK | `/api/health` reports `clerk.enabled: false`; Clerk frontend SDK can't initialize | `pk_live_...` matching the secret in §1 |
+| `NEXT_PUBLIC_API_BASE` | `apps/web/app/api/health/route.ts:15` + `lib/backend-url.ts:15` | `/api/health` reports `apiBase: false` (cosmetic); backend reachable via fallback chain | `https://api.vitalcv.com` |
+| `BACKEND_URL` | `lib/backend-url.ts:11` (canonical resolver); inlined into ~40 ad-hoc routes | Inline-resolver routes fall back to `localhost:4000` on Vercel → `fetch failed` (per `upstream-fetch-topology.md` §A) | `https://api.vitalcv.com` |
+| `NEXT_PUBLIC_BACKEND_URL` | Tertiary fallback in resolver chain | None individually; redundant with `BACKEND_URL` for legacy callers | Same value as `BACKEND_URL` |
+| `CRON_SECRET` and/or `MONITORING_SECRET` | Probe runner cron + `_probe/` handlers | `LaneHealthMount` band reads UNKNOWN seeds; probe schedule cannot fire | Random secret per Vercel cron config |
+| `NEXT_PUBLIC_SENTRY_DSN` | `/api/health:24`; Sentry frontend init | `/api/health` reports `sentry: false`; runtime errors not captured | Sentry production DSN |
+| `ALLOWED_CORS_ORIGINS` | `apps/web/middleware.ts:111-124` | Cross-origin API requests blocked; same-origin works | Comma-separated allowlist |
+
+## §3 — Recommended (cosmetic / labelling)
+
+These vars improve operator legibility but do not affect functional
+behavior on the happy path.
+
+| Var | Consumer | Effect when missing | Recommended |
+|---|---|---|---|
+| `VITALCV_ENV_LABEL` | `apps/web/app/api/status/route.ts:19` | `/api/status` `environment` field reports `NODE_ENV` value (which is `"production"` on previews too — confusing) | `production` for Production scope; `preview` for Preview scope |
+| `VITALCV_ISSUER_URL` (or `NEXT_PUBLIC_APP_URL`) | `apps/web/lib/crypto/receiptIssuer.ts:113-116` | Receipt JWT `iss` claim falls back through chain to `https://vitalcv.com` | `https://vitalcv.com` |
+
+## §4 — Preview-scope-only (DIFFERENT from Production)
+
+Vercel preview deploys inherit `NODE_ENV=production`, so the
+production fail-closed guards fire on previews. Two options:
+
+### Option A — Preview-key (recommended for institutional review)
+
+Set on Preview scope:
+
+| Var | Recommended preview value | Why different from Production |
+|---|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | Different ES256 JWK from production | Prevents identity collision; preview-signed receipts are clearly distinguishable from production-signed |
+| `RECEIPT_KID` | `vcv-es256-preview-1` | Different kid means a verifier sees preview vs production receipts as different keys |
+| `VITALCV_ENV_LABEL` | `preview` | `/api/status` reports honestly |
+
+### Option B — Preview-500 (acceptable for transient PR previews)
+
+Leave Preview scope env unset. JWKS / DID / signed-receipt surfaces
+return 500 on previews; UI-only previews still work. No identity
+leakage risk.
+
+## §5 — Vars that should NEVER fall back silently
+
+These vars exist in the codebase with fallback chains. The fallbacks
+are explicit and (post-PR-362) safe. Documented for operator
+awareness.
+
+| Var | Fallback chain | Risk if fallback fires unexpectedly |
+|---|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | Production: throws. Dev: ephemeral keypair. | None in production (fail-closed). |
+| `RECEIPT_KID` | Production: throws. Dev: `vcv-es256-dev` (or `RECEIPT_KID_DEV`). | None in production (fail-closed). |
+| `BACKEND_URL` | Chain: `BACKEND_URL` → `NEXT_PUBLIC_API_BASE` → `NEXT_PUBLIC_BACKEND_URL` → Railway prod URL (on Vercel) → `localhost:4000` (on local) | Inline resolvers (per `upstream-fetch-topology.md` §A) can fall back to `localhost:4000` even on Vercel if `BACKEND_URL` env not set. Set explicitly to avoid this. |
+| `VITALCV_ENV_LABEL` | Chain: env → `NODE_ENV` → `"unknown"` | Reports `"production"` on previews if unset. Set explicitly. |
+| `ISSUER_DID` | Falls back to hardcoded `'did:web:vitalcv.com'` | Safe; matches expected canonical. |
+
+## §6 — Required-vs-recommended decision flow
+
+```
+QUESTION: For which env should I set this var?
+
+  RECEIPT_PRIVATE_KEY_JWK + RECEIPT_KID
+    → Production: REQUIRED.
+    → Preview: REQUIRED if you want Option A; else leave for Option B (500 acceptable).
+    → Local: not needed (dev fallback path generates ephemeral).
+
+  CLERK_SECRET_KEY + NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+    → Production: REQUIRED.
+    → Preview: RECOMMENDED (else previews redirect to broken /sign-in).
+    → Local: REQUIRED for authenticated flow testing.
+
+  DATABASE_URL
+    → Production: REQUIRED.
+    → Preview: REQUIRED (point at preview DB or read-only replica).
+    → Local: REQUIRED (point at local Postgres).
+
+  BACKEND_URL
+    → Production: REQUIRED (without it, inline resolvers fall back to localhost).
+    → Preview: REQUIRED.
+    → Local: omit (defaults to localhost:4000).
+
+  VITALCV_ENV_LABEL
+    → Production: RECOMMENDED (`production`).
+    → Preview: RECOMMENDED (`preview`) — distinguishes from production in /api/status.
+    → Local: omit.
+
+  CRON_SECRET / MONITORING_SECRET
+    → Production: REQUIRED (else lane-health snapshots stay UNKNOWN).
+    → Preview: not applicable (no cron on previews).
+    → Local: not applicable.
+
+  NEXT_PUBLIC_SENTRY_DSN
+    → All: RECOMMENDED.
+```
+
+## §7 — Operator setup checklist
+
+In order on the Vercel dashboard for the **operator-confirmed
+canonical project** (per `production-restore-sequence.md` §1):
+
+1. Settings → Environment Variables → "Add New" for each row in §1
+   (all four REQUIRED-fail-closed vars). Scope: Production.
+2. Same for §2 rows (REQUIRED-degrade-gracefully).
+3. Same for §3 rows (RECOMMENDED).
+4. Apply Preview-scope per §4 chosen option.
+5. Trigger a new deployment (env vars do not retroactively apply).
+6. Run `scripts/verify-production-runtime.sh` (per `B20-CODE-02`)
+   to verify each surface.
+
+Without all of §1 set, the deployment will return 500 from JWKS/DID
+and fail signed-receipt issuance. Without §2, the deployment will be
+operationally degraded but not crash.
+
+## §8 — What this document does NOT cover
+
+- Where to source the ES256 JWK from (key generation procedure — out of scope per "no key rotation").
+- Vercel team / billing settings (operator-side; not env vars).
+- Railway DB schema migration state (separate ops concern).
+- Backend env vars (this doc is web-app-scoped).
+
+For Railway backend env vars, see `apps/api/backend/src/config/env.ts`.

--- a/docs/architecture/production-restore-sequence.md
+++ b/docs/architecture/production-restore-sequence.md
@@ -1,0 +1,228 @@
+# Production Restore Sequence
+
+**B18-TRUTH-04 deliverable.** Minimum path to restore externally
+reachable production for `vitalcv.com`. Optimized for fastest
+recovery, lowest risk, lowest ambiguity.
+
+## §0 — CRITICAL RETRACTION OF PRIOR ASSUMPTIONS
+
+External verification proved:
+
+- **`vcv-web.vercel.app` is NOT a VitalCV project.** It belongs to an unrelated third-party. Prior convergence docs naming `vcv-web` as canonical are INVALID.
+- **`vitalcv.com` currently returns HTTP 402** "This deployment is temporarily paused."
+- **The actual canonical Vercel project is unknown** until the operator confirms it in the Vercel dashboard.
+
+This document does NOT presume any project name. It guides the
+operator to discover the real one and resolve the pause.
+
+## §1 — Step 1: Discover the real canonical Vercel project
+
+This step requires Vercel dashboard or CLI access. It cannot be
+performed from a build session.
+
+### Option A — Vercel dashboard
+
+1. Log into Vercel as the account that owns `vitalcv.com`.
+2. Open the team / personal account that has billing for the deployment.
+3. Settings → Domains: find the project that lists `vitalcv.com` (or `www.vitalcv.com`) as an attached production domain.
+4. Record the exact project name as observed. **This is the canonical project.** Do not assume from prior naming.
+
+### Option B — Vercel CLI
+
+```bash
+# Install / authenticate Vercel CLI if not already:
+npm i -g vercel
+vercel login
+
+# List all teams and look for the one owning VitalCV:
+vercel teams ls
+
+# Switch to the right team:
+vercel switch <team-slug>
+
+# List projects in that team:
+vercel projects ls
+
+# Find the project that has vitalcv.com attached:
+vercel domains ls
+# (Look for vitalcv.com → which project)
+```
+
+### Option C — DNS / WHOIS path
+
+If neither dashboard nor CLI is available, the DNS record for
+`vitalcv.com` points to Vercel's load balancer. Vercel itself uses
+the SNI hostname (the domain in the request) to route — so the
+project is determined by Vercel's internal domain table, not by
+public DNS. You cannot identify the project from DNS alone.
+
+### What to record
+
+| Field | Value (fill in) |
+|---|---|
+| Canonical Vercel project name | |
+| Team / account slug | |
+| Linked GitHub repo | |
+| Production branch | |
+| Most recent deployment ID (dpl_*) | |
+| Most recent deployment SHA | |
+| Deployment state | paused / ready / error / queued |
+| Domain attachment confirmed | yes / no |
+
+The rest of this runbook assumes these fields are now known. Without
+them, no automated restore is possible.
+
+## §2 — Step 2: Identify why production is paused (HTTP 402)
+
+HTTP 402 from Vercel typically means one of the following:
+
+| Cause | Surface in Vercel dashboard | Resolution |
+|---|---|---|
+| Spending limit hit (Hobby/Pro) | Settings → Billing → Spending Limits; "Limit reached" banner | Raise limit OR upgrade plan OR wait for reset |
+| Project / team payment failed | Settings → Billing → Payment method shows "Failed" | Update payment method |
+| Account suspended | Account-level banner on login | Contact Vercel support |
+| Deployment manually paused | Deployments tab → recent deployment shows "Paused" badge | Resume from menu |
+| Project disabled by team admin | Settings → General → "Project is disabled" toggle | Re-enable |
+| Domain verification failed (rare 402) | Settings → Domains → verification status not "Valid" | Re-verify (DNS records / TXT) |
+| Anti-abuse rate-lock (extremely rare) | Email from Vercel ops | Contact Vercel support |
+
+**Note**: HTTP 402 is the Vercel-specific signal. Standard production
+failure modes return 500 / 502 / 503. A 402 is almost always
+billing-/pause-related, not code-related.
+
+## §3 — Step 3: Resume / unpause production
+
+Once the cause from §2 is known:
+
+### If billing / spending:
+
+1. Settings → Billing → adjust Spending Limit higher, or upgrade plan.
+2. Wait for the rate-lock to clear (usually instant after limit change).
+3. Trigger a new deployment to flush the 402: `vercel --prod` OR push any commit to the production branch.
+
+### If manual pause:
+
+1. Deployments tab → most recent deployment → three-dot menu → "Resume".
+2. If the pause was at the project level (Settings → General), toggle to enable.
+
+### If account suspended:
+
+1. Contact Vercel support with the team / account slug.
+2. Resolve any flagged issues.
+3. After unlock, deploy fresh.
+
+### If unknown cause:
+
+1. Check the project's "Audit Log" tab (if available on plan).
+2. Recent entries near the pause time often name the cause.
+
+## §4 — Step 4: Verify production is reachable
+
+After resuming:
+
+```bash
+# Should NOT return 402:
+curl -i https://vitalcv.com/api/health
+
+# Expect: 200, JSON, service: "web", recent timestamp
+# If still 402: pause not fully resumed. Re-check dashboard.
+
+# Confirm runtime SHA:
+curl -s https://vitalcv.com/api/health | jq '.timestamp'
+# If timestamp doesn't reflect a recent deploy, force a new one:
+vercel --prod --force
+```
+
+## §5 — Step 5: Confirm the runtime is the right repo
+
+```bash
+# Confirm the deployed app is apps/web from this repo:
+curl -s https://vitalcv.com/api/health | jq '.service'
+# Expect: "web"
+
+# Confirm the signing identity is the one PR-362 ships:
+curl -s https://vitalcv.com/api/.well-known/jwks.json | jq '.keys[0].kid'
+# Expect: "vcv-es256-1" if env is set; or 500 (fail-closed) if env missing
+# DO NOT accept any value containing "dev"
+```
+
+If `service: "web"` is returned: the canonical project is serving
+this repo. If anything else: the wrong project is attached to apex.
+
+## §6 — Step 6: Set required env vars (if not already)
+
+Vercel dashboard → the canonical project → Settings → Environment
+Variables → Production scope:
+
+| Var | Required value |
+|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | ES256 private JWK (JSON-encoded) |
+| `RECEIPT_KID` | `vcv-es256-1` |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `pk_live_...` |
+| `CLERK_SECRET_KEY` | `sk_live_...` |
+| `NEXT_PUBLIC_API_BASE` | `https://api.vitalcv.com` |
+| `BACKEND_URL` | `https://api.vitalcv.com` |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN |
+| `VITALCV_ENV_LABEL` | `production` |
+
+After setting, trigger a redeploy (env vars do not retroactively apply).
+
+## §7 — Step 7: Smoke-test full institutional surface
+
+After §4–§6 succeed:
+
+```bash
+# Signing identity convergence:
+curl -s https://vitalcv.com/api/.well-known/jwks.json | jq '.keys[0].kid'
+curl -s https://vitalcv.com/api/status | jq '.runtime_continuity'
+curl -s "https://vitalcv.com/api/receipt/nppes_identity:1346053246" | jq '.receipt.signingKeyId'
+
+# Replay continuity (post-PR-α/β/γ merge):
+curl -X POST https://vitalcv.com/api/ingest/1346053246
+# wait for SSE 'done' event
+curl -s https://vitalcv.com/api/replay/chain/1346053246 | jq '.lineages'
+
+# Banned-phrase regression scan:
+curl -s https://vitalcv.com/ | grep -iE "automatically verified|guaranteed verification|HIPAA compliant|SOC2 certified"
+# Expect: no output
+```
+
+## §8 — Rollback condition
+
+If §4 succeeds (apex reachable, no longer 402) but §5 or §7 fails:
+
+1. Vercel dashboard → Deployments tab on the canonical project
+2. Find the last "Ready" deployment (green health) before the current one
+3. Three-dot menu → "Promote to Production"
+4. Vercel handles CDN invalidation on promotion
+
+If §4 itself fails after a resume attempt, escalate to Vercel
+support. The 402 indicates a platform-side hold; no code change can
+clear it.
+
+## §9 — Estimated time to recovery
+
+- Step 1 (discover canonical project): 2–5 min
+- Step 2 (identify cause): 1–3 min
+- Step 3 (resume): 30 sec – 5 min depending on cause
+- Step 4 (verify reachable): 1 min
+- Step 5 (verify right repo): 1 min
+- Step 6 (env vars if needed): 5–15 min
+- Step 7 (smoke test): 2 min
+
+**Total: 15–30 minutes** for a billing-/pause-only cause where env
+is already configured. **Up to 60 minutes** if env vars require
+fresh provisioning.
+
+## §10 — What this runbook explicitly does NOT do
+
+- Does NOT rename, create, or modify any Vercel project.
+- Does NOT alias `vitalcv.com` to any specific project name.
+- Does NOT change DNS.
+- Does NOT presume `vcv-web` (or any specific name) is the canonical project — only the operator-confirmed value from §1 is canonical.
+- Does NOT modify repo code.
+- Does NOT introduce new infrastructure.
+
+The repo is in a clean state; the bottleneck is platform-side
+(deployment paused) and operator-side (which project is canonical).
+This runbook converges both.

--- a/docs/architecture/retraction-vcv-web.md
+++ b/docs/architecture/retraction-vcv-web.md
@@ -1,0 +1,84 @@
+# Retraction — `vcv-web` as canonical Vercel project (INVALID)
+
+**Date:** 2026-05-15 (B18 wave).
+**Status:** Retracts a load-bearing claim in the prior B16/B17
+convergence documents.
+
+## What was claimed
+
+The following documents in this PR (#363, branch `wave/b16-convergence-final`)
+named `vcv-web` as the canonical Vercel project for VitalCV apex:
+
+- `vercel-convergence-diagnosis.md`
+- `signing-identity-convergence-report.md`
+- `final-deployment-sequence.md`
+- `preview-runtime-safety-audit.md`
+- `b16-executive-convergence-summary.md`
+
+The basis for that claim was an inference from prior session memory.
+The claim was NOT verified against Vercel dashboard reality.
+
+## What was discovered
+
+External verification confirmed:
+
+- **`vcv-web.vercel.app` does NOT belong to VitalCV.** It is an unrelated third-party Vercel project.
+- **`vitalcv.com` (apex) currently returns HTTP 402** "This deployment is temporarily paused."
+- **The actual canonical Vercel project is unknown** until the operator confirms it in the Vercel dashboard.
+
+## Resulting invalid actions to avoid
+
+Per the user's B18 directive, the following are now forbidden until
+the real canonical project is identified:
+
+- DO NOT alias `vitalcv.com` to `vcv-web`.
+- DO NOT redeploy toward `vcv-web`.
+- DO NOT update DNS toward `vcv-web`.
+- DO NOT document `vcv-web` as canonical.
+- DO NOT continue convergence assumptions that depend on `vcv-web` being VitalCV.
+
+## What replaces the invalid claim
+
+Three new documents in this PR (B18 wave):
+
+1. `production-restore-sequence.md` (B18-TRUTH-04) — minimum path to restore externally reachable production. **Begins with operator-side discovery of the canonical Vercel project; does not presume any specific name.**
+2. `pause-root-cause-report.md` (B18-TRUTH-02) — diagnostic for resolving the HTTP 402 pause.
+3. `domain-topology-audit.md` (B18-TRUTH-03) — diagnostic for verifying domain attachment and detecting stale project claims.
+
+## Disposition of the original five docs
+
+Each of the five affected docs has been updated with:
+
+- A "RETRACTION HEADER" at the top pointing to this notice.
+- Replacement of every `vcv-web` reference with `<canonical-project-TBD>` or generic "the canonical Vercel project (per `production-restore-sequence.md` §1)".
+
+The body content remains otherwise intact for audit-trail purposes —
+the operational guidance about env vars, fail-closed guards, and
+verification commands is still valid; only the project-name
+assignment was wrong.
+
+## What is NOT retracted
+
+These claims from the original convergence docs remain valid (they
+are code-level facts independent of which Vercel project deploys
+them):
+
+- The fail-closed signing-identity guard in `apps/web/lib/crypto/receiptIssuer.ts` is structurally correct.
+- The three former leakage paths are confirmed closed at code level.
+- `force-dynamic` on `/api/.well-known/jwks.json` and `/.well-known/did.json` is correct.
+- The `/api/receipt/[lineageKey]:120` env-resolved kid is correct.
+- The replay persistence stack (PR-α/β/γ) is on origin/main.
+- The expected canonical kid value `vcv-es256-1` (for `RECEIPT_KID`) remains the target.
+
+The retraction is scoped strictly to the **Vercel project name
+identification**, not to any other claim.
+
+## Lessons for future convergence work
+
+- Do not name external infrastructure in convergence docs based on session memory or inferred patterns.
+- Always require operator-side dashboard confirmation before pinning project / team / domain names.
+- Project names in third-party platforms are not derivable from repo state; they must be observed live.
+
+This retraction is the kind of correction that a healthy
+documentation process should make easy. The fix is small and
+isolated; the underlying code-level claims are unaffected.

--- a/docs/architecture/runtime-state-clarity-matrix.md
+++ b/docs/architecture/runtime-state-clarity-matrix.md
@@ -1,0 +1,109 @@
+# Runtime State Clarity Matrix
+
+**B20-CODE-04 deliverable.** A single-glance reference that makes
+runtime / deployment / environment state unmistakable. Designed so a
+future operator can identify which state the runtime is in by reading
+one row of one table.
+
+## §1 — Six runtime state categories
+
+| State | What it means | How to distinguish externally |
+|---|---|---|
+| **PRODUCTION** | Apex `vitalcv.com` serving the canonical deployment, env fully configured | `/api/health` returns `service: "web"`; `config.clerk.enabled: true`; `apiBase: true`; JWKS emits `vcv-es256-1` |
+| **PREVIEW** | Vercel branch/PR deployment, distinct URL (e.g., `<project>-git-<branch>.vercel.app`) | `/api/health` `timestamp` matches branch's most recent commit; if `VITALCV_ENV_LABEL=preview` is set, `/api/status.environment` reads `"preview"` |
+| **LOCAL** | `pnpm dev` on developer machine | `NODE_ENV=development`; JWKS emits ephemeral `vcv-es256-dev`; backend at `localhost:4000` |
+| **PAUSED** | Vercel-level intercept; deployment exists but disabled | HTTP 402 on every path; no application code runs |
+| **DEGRADED** | App runs but one or more env / dependencies missing | `/api/health` shows `clerk.enabled: false` or `apiBase: false`; `/api/status.runtime_continuity.status: "degraded"`; signing routes may 500 (fail-closed) |
+| **MISCONFIGURED** | App runs but routing / domain attachment wrong | `/api/health.service` is NOT `"web"`; OR apex returns content from a different repo; OR JWKS emits a kid that doesn't match expectation |
+
+## §2 — External probe to identify the state
+
+```bash
+APEX=https://vitalcv.com
+
+# Probe in order; stop at the first row that matches.
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 8 "$APEX/")
+HEALTH=$(curl -s --max-time 8 "$APEX/api/health" 2>/dev/null)
+JWKS_KID=$(curl -s --max-time 8 "$APEX/api/.well-known/jwks.json" 2>/dev/null | jq -r '.keys[0].kid // empty')
+ENV_LABEL=$(echo "$HEALTH" | jq -r '.environment // empty' 2>/dev/null)
+SERVICE=$(echo "$HEALTH" | jq -r '.service // empty' 2>/dev/null)
+CLERK=$(echo "$HEALTH" | jq -r '.config.clerk.enabled // empty' 2>/dev/null)
+```
+
+| Observation | State |
+|---|---|
+| `$STATUS == 402` | PAUSED |
+| `$SERVICE != "web"` | MISCONFIGURED (apex attached to wrong project) |
+| `$JWKS_KID == ""` (no kid; signing route 500) | DEGRADED (signing env unset) |
+| `$JWKS_KID == *dev*` | MISCONFIGURED (PR-362 guard not deployed OR pre-PR-362 build) |
+| `$JWKS_KID == "vcv-es256-1"` AND `$CLERK == "true"` | PRODUCTION |
+| `$JWKS_KID == "vcv-es256-1"` AND `$CLERK == "false"` | DEGRADED (Clerk env partially missing) |
+| `$JWKS_KID == "vcv-es256-preview-1"` | PREVIEW (option A configured) |
+| Probe times out or returns non-2xx non-402 | UNREACHABLE (DNS / TLS / network) |
+
+## §3 — Internal indicators
+
+Surfaces inside the app that distinguish state without an external probe:
+
+| Surface | Indicator | Reading |
+|---|---|---|
+| `/api/health.service` | Identifies which `apps/*` is serving | `"web"` = `apps/web`; other = wrong project |
+| `/api/health.timestamp` | Per-request fresh ISO | Compare to most recent main commit time to detect stale runtime |
+| `/api/health.config.apiBase` | `NEXT_PUBLIC_API_BASE` set? | `false` = cosmetic env gap |
+| `/api/health.config.clerk.enabled` | Clerk publishable key set? | `false` = auth flow broken |
+| `/api/health.config.clerk.mode` | `production` / `development` / `none` | Distinguishes Clerk env type |
+| `/api/health.config.sentry` | DSN set? | `false` = errors not captured |
+| `/api/status.runtime_continuity.status` | `operational` / `degraded` | Aggregates signing health |
+| `/api/status.runtime_continuity.signing_key_id` | Emits canonical kid OR `null` | `null` = signing env missing |
+| `/api/status.environment` | Reads `VITALCV_ENV_LABEL` then `NODE_ENV` | Reports `preview` when `VITALCV_ENV_LABEL=preview` set |
+
+## §4 — Common confusion modes and how to resolve
+
+| Confusion | Resolution |
+|---|---|
+| "Is this preview or production?" | Set `VITALCV_ENV_LABEL=preview` on Preview scope; `/api/status.environment` then reports honestly |
+| "Is the deployment stale or paused?" | Stale: `/api/health.timestamp` lags `main` HEAD by hours+. Paused: HTTP 402 on every path. |
+| "Is the signing identity right or wrong?" | Right: `JWKS_KID == "vcv-es256-1"`. Wrong: any value containing `"dev"`. See `signing-identity-convergence-report.md` §2. |
+| "Is the runtime degraded or failing?" | Degraded: 200 with `clerk.enabled: false` / `signing_key_id: null`. Failing: 500s or 503s on most paths. |
+| "Is env missing or code broken?" | Env missing: explicit 500 from fail-closed routes; `/api/status` reports `degraded`. Code broken: 500 from random routes; logs show stack traces. |
+| "Is apex pointed at the right project?" | `/api/health.service` must be `"web"`. If it's something else, domain is attached to the wrong project (see `domain-topology-audit.md`). |
+
+## §5 — Per-state operator action
+
+| State | Operator action |
+|---|---|
+| PRODUCTION | None; system is healthy |
+| PREVIEW | Verify it labels itself as preview (`VITALCV_ENV_LABEL`); if not, set the env var |
+| LOCAL | N/A (developer workflow) |
+| PAUSED | Run `pause-root-cause-report.md` §2 diagnostic |
+| DEGRADED | Run `production-env-requirements.md` checklist; identify which env var is missing |
+| MISCONFIGURED | Run `domain-topology-audit.md` + `production-restore-sequence.md` §1 |
+
+## §6 — Single-line operator query
+
+Given the current apex behavior, paste this into a terminal:
+
+```bash
+S=$(curl -s -o /dev/null -w "%{http_code}" --max-time 8 https://vitalcv.com/); \
+  K=$(curl -s --max-time 8 https://vitalcv.com/api/.well-known/jwks.json | jq -r '.keys[0].kid // "—"'); \
+  C=$(curl -s --max-time 8 https://vitalcv.com/api/health | jq -r '.config.clerk.enabled // "—"'); \
+  echo "Apex: HTTP $S | JWKS kid: $K | Clerk enabled: $C"
+```
+
+| Output | Diagnosis |
+|---|---|
+| `Apex: HTTP 402 \| JWKS kid: — \| Clerk enabled: —` | **PAUSED** — see `pause-root-cause-report.md` |
+| `Apex: HTTP 200 \| JWKS kid: — \| Clerk enabled: false` | **DEGRADED** — env vars missing |
+| `Apex: HTTP 200 \| JWKS kid: <something>-dev \| Clerk enabled: true` | **MISCONFIGURED** — signing leakage |
+| `Apex: HTTP 200 \| JWKS kid: vcv-es256-1 \| Clerk enabled: true` | **PRODUCTION** ✓ |
+
+## §7 — What this matrix does NOT cover
+
+- Cron / scheduled-job state (not part of HTTP-visible runtime; see `production-env-requirements.md` §2 row `CRON_SECRET`)
+- Backend (Railway) health (separate process; probe `https://api.vitalcv.com/health` directly)
+- DNS / TLS layer (out of scope; assumed working given §1 distinguishability via curl)
+
+The matrix is meant for **HTTP-visible runtime state on apex**. It
+intentionally does not try to be exhaustive — its goal is making the
+six categories above unmistakable, not cataloguing every possible
+subsystem state.

--- a/docs/architecture/signing-identity-convergence-report.md
+++ b/docs/architecture/signing-identity-convergence-report.md
@@ -1,5 +1,11 @@
 # Signing Identity Convergence Report
 
+> **⚠ RETRACTION (B18 wave):** Earlier text in §6 named `vcv-web` as
+> the canonical Vercel project. That assignment is INVALID. The actual
+> canonical project remains TBD per `production-restore-sequence.md` §1.
+> The code-level convergence analysis in §1–§5 is unaffected (it is
+> independent of which Vercel project deploys the code).
+
 **B16-RUNTIME-03 deliverable.** Verifies — at the code level on
 `origin/main` post-PR-362 — that every signing-emitting surface
 converges on a single env-driven canonical kid (operator-expected
@@ -95,5 +101,5 @@ Every runtime surface that emits a signing kid either:
 - is gated by `if (isDev())` (correctly unreachable in production)
 
 **Operational convergence**: pending the operator setting the two
-required env vars on the `vcv-web` Vercel project Production (and
+required env vars on the `<canonical-project-TBD>` Vercel project Production (and
 Preview, per §4) scopes. No code change can replace this step.

--- a/docs/architecture/signing-identity-convergence-report.md
+++ b/docs/architecture/signing-identity-convergence-report.md
@@ -1,0 +1,99 @@
+# Signing Identity Convergence Report
+
+**B16-RUNTIME-03 deliverable.** Verifies — at the code level on
+`origin/main` post-PR-362 — that every signing-emitting surface
+converges on a single env-driven canonical kid (operator-expected
+value: `vcv-es256-1`).
+
+## §1 — Convergence verdict per surface
+
+Each row names a runtime surface that emits or reports a signing kid,
+its source of kid value, and whether that source resolves to the
+canonical env-driven identity.
+
+| Surface | Source of kid value | Converged? |
+|---|---|---|
+| `/api/.well-known/jwks.json` | `getOrInitKeypair().kid` via `getPublicKeyJwk()` | ✓ Reads `RECEIPT_KID`; throws in production if missing. `force-dynamic` ensures runtime evaluation. |
+| `/.well-known/jwks.json` (canonical path, on unmerged stack) | Same | ✓ Same chain when route ships. |
+| `/.well-known/did.json` | `getPublicKeyJwk()` | ✓ Same chain; `force-dynamic`. |
+| ES256 receipt JWT header `kid` | `getOrInitKeypair().kid` via `signIssuerReceipt` | ✓ |
+| `/api/receipt/[lineageKey]` lineageKey-shape `receipt.signingKeyId` | `process.env.RECEIPT_KID ?? (production ? 'vcv-es256-1' : 'vcv-es256-dev')` | ✓ Env-resolved with canonical production default. |
+| `/api/receipt/[lineageKey]` dev-mock branch `signed_payload.signing_key_id` | Hardcoded `'vcv-es256-dev'` | ✓ Gated by `if (isDev())`; unreachable in production. |
+| `/api/status` `runtime_continuity.signing_key_id` | `getOrInitKeypair().kid` wrapped in `.catch(() => null)` | ✓ Returns env-resolved kid OR `null` with `status: 'degraded'` if env missing — honest signal. |
+| `/api/replay/[runId]` `signingKeyId` | Replay inspection layer → reads the signing module | ✓ Same chain. |
+| `TrustStateRegister.tsx` UI default | `snapshot.signingKeyId ?? 'vcv-es256-1'` | ✓ Static fallback matches expected canonical production value. |
+| `verify/[npi]/page.tsx` UI prop default | `signingKeyId="vcv-es256-1"` | ✓ Same canonical fallback. |
+| `getOperatorDashboardSnapshot.ts` ephemeral-key detector | `kid.includes('-dev-')` | ✓ Detection only (not emission). Flags ephemeral keys for the operator dashboard. |
+
+## §2 — Verification commands (operator, post-env-set)
+
+```bash
+# Canonical production identity — all three MUST emit the same kid:
+JWKS_KID=$(curl -s https://vitalcv.com/api/.well-known/jwks.json | jq -r '.keys[0].kid')
+DID_KID=$(curl -s https://vitalcv.com/.well-known/did.json | jq -r '.verificationMethod[0].publicKeyJwk.kid' 2>/dev/null || echo "n/a")
+STATUS_KID=$(curl -s https://vitalcv.com/api/status | jq -r '.runtime_continuity.signing_key_id')
+RECEIPT_KID=$(curl -s "https://vitalcv.com/api/receipt/nppes_identity:1346053246" | jq -r '.receipt.signingKeyId' 2>/dev/null || echo "n/a")
+
+echo "JWKS:    $JWKS_KID"
+echo "DID:     $DID_KID"
+echo "STATUS:  $STATUS_KID"
+echo "RECEIPT: $RECEIPT_KID"
+
+# Expected: all four "vcv-es256-1" (or whatever operator set RECEIPT_KID to).
+# Forbidden: any value containing "dev".
+```
+
+If any output contains `"dev"`, the deployment has not picked up the
+PR-362 fail-closed guard OR the env vars are missing. See
+`vercel-convergence-diagnosis.md` §3 row a/b/c.
+
+## §3 — Split-identity check
+
+There are exactly three places a kid value enters the runtime:
+
+1. **Env-driven** (production canonical): `process.env.RECEIPT_KID` → all signing/issuance surfaces.
+2. **Hardcoded UI default** (`'vcv-es256-1'`): matches the expected env value; converges when ops set the env correctly.
+3. **Dev fallback** (`'vcv-es256-dev'`): unreachable in production by structural guard.
+
+No fourth source exists. No federation logic. No multi-key resolver.
+A grep across the codebase (excluding `_archive/`, tests, and the dev
+fallback line itself) returns zero unexpected kid emissions.
+
+## §4 — Preview-deploy gotcha
+
+Vercel preview deployments inherit `NODE_ENV=production`. The
+PR-362 fail-closed guard therefore fires on preview deploys too. If
+preview-scope env vars are not set:
+
+- `/api/.well-known/jwks.json` returns 500 on previews
+- `/.well-known/did.json` returns 500 on previews
+- `/api/status` reports `degraded` on previews
+- `/api/receipt/[lineageKey]` returns `signingKeyId: 'vcv-es256-1'` (env-resolved default works without the JWK because no actual signing happens in this response)
+
+Operator decision required:
+- **Option A**: set `RECEIPT_PRIVATE_KEY_JWK` + `RECEIPT_KID` on Preview scope too (e.g., a dedicated preview JWK pair). Preview surfaces all converge.
+- **Option B**: accept that previews 500 the signing surfaces. Safer (no preview-key sprawl) but breaks preview testing of JWKS/DID surfaces.
+
+Recommendation: Option A with a preview-only JWK so previews are
+testable. The preview kid should NOT be `vcv-es256-1` (avoid identity
+collision); use e.g. `vcv-es256-preview-1`.
+
+## §5 — What this report does NOT cover
+
+- Live HTTP verification (operator-side; commands provided above)
+- Key rotation procedure (out of scope per user directive)
+- Multi-key resolver / kid federation (out of scope per user directive)
+- The unmerged `/.well-known/openid-credential-issuer` and other canonical verifier paths — those ship on a different stack, not on origin/main
+
+## §6 — Convergence verdict
+
+**Structural convergence: ACHIEVED on `origin/main`.**
+
+Every runtime surface that emits a signing kid either:
+- reads `process.env.RECEIPT_KID` (env-driven, throws if absent in prod), or
+- falls back to `'vcv-es256-1'` (the expected env value), or
+- is gated by `if (isDev())` (correctly unreachable in production)
+
+**Operational convergence**: pending the operator setting the two
+required env vars on the `vcv-web` Vercel project Production (and
+Preview, per §4) scopes. No code change can replace this step.

--- a/docs/architecture/vercel-convergence-diagnosis.md
+++ b/docs/architecture/vercel-convergence-diagnosis.md
@@ -1,0 +1,147 @@
+# Vercel Convergence Diagnosis
+
+**B16-DEPLOYMENT-02 deliverable.** Operator-runnable diagnostic for
+why production may be stale/paused/disabled, and the deterministic
+next action.
+
+This document describes what an operator should check; it does not
+itself probe Vercel (the Vercel CLI / dashboard is the source of
+truth, not in-repo state).
+
+## §1 — Canonical vs deprecated runtime
+
+| Property | Canonical | Deprecated |
+|---|---|---|
+| Vercel project name | `vcv-web` | `vitalcv` |
+| Repo path served | `apps/web` | `apps/web` (same code; different project linkage) |
+| Production branch | `main` | (varies; may be paused or unlinked) |
+| Domain attachment | apex `vitalcv.com` SHOULD be attached here | If apex is still attached here, that's the divergence |
+
+The canonical `vcv-web` project is the one operator action should target. The
+deprecated `vitalcv` project remains as a Vercel artifact and SHOULD have its
+production domain detached if it has not been already.
+
+## §2 — Operator probe sequence (in order)
+
+Run these in the order given. Stop at the first one that surfaces a divergence.
+
+### Probe 1 — current live SHA on apex
+
+```bash
+curl -s https://vitalcv.com/api/health | jq
+# Note timestamp; compare to last deploy timestamp.
+# If timestamp older than the most recent main commit by hours/days,
+# apex is stale.
+```
+
+If `service: "web"` returns: apex is `apps/web`. If anything else: apex is
+attached to the wrong project — DOMAIN ATTACHMENT issue (§3 row d).
+
+### Probe 2 — signing identity check
+
+```bash
+curl -s https://vitalcv.com/api/.well-known/jwks.json | jq '.keys[0].kid'
+curl -s https://vitalcv.com/.well-known/did.json      | jq '.verificationMethod[0].publicKeyJwk.kid'
+curl -s https://vitalcv.com/api/status                | jq '.runtime_continuity'
+```
+
+| Observation | Diagnosis |
+|---|---|
+| All three return `"vcv-es256-1"` | Signing identity converged. ✓ |
+| Any returns `"vcv-es256-dev"` or `"vcv-es256-dev-<digits>"` | Production-fail-closed guard NOT yet on this runtime. Either (a) PR-362 not deployed, or (b) cache layer holding stale response. |
+| JWKS or DID returns **500** | Fail-closed guard fired — `RECEIPT_PRIVATE_KEY_JWK` or `RECEIPT_KID` env vars not set on this Vercel project. |
+| `/api/status` returns `runtime_continuity.status: "degraded"` with `signing_key_id: null` | Same env-missing condition, surfaced honestly by the status route's catch wrapper. |
+
+### Probe 3 — branch linkage
+
+In the Vercel dashboard for `vcv-web`:
+
+- Settings → Git → Production Branch: should be `main`
+- Settings → Domains: `vitalcv.com` should appear, marked as the production domain
+- If `vitalcv.com` is missing or attached to `vitalcv` (the deprecated project): that is the BRANCH LINKAGE / DOMAIN ATTACHMENT issue
+
+### Probe 4 — deployment pause / billing
+
+In the Vercel dashboard for `vcv-web`:
+
+- Deployments tab: if the most recent deployment is older than the most recent `main` commit, deployments may be paused
+- Billing → Spending Limits: if limits hit, builds are blocked (BILLING issue)
+- Project Settings → Functions: if any function disabled, runtime errors will surface
+
+### Probe 5 — env propagation
+
+In the Vercel dashboard for `vcv-web`:
+
+- Settings → Environment Variables → Production scope: verify all required vars are present (see §4)
+- After setting any new variable, REDEPLOY — env vars do not retroactively apply to existing builds
+
+### Probe 6 — edge cache
+
+```bash
+# Add Cache-Control bypass header:
+curl -s -H "Cache-Control: no-cache" https://vitalcv.com/api/health | jq
+# Compare to the un-bypassed response from Probe 1.
+# Divergence indicates CDN cache.
+```
+
+If diverge: Vercel CDN is serving a stale version. Fix: trigger a new
+deployment (any commit on main) OR use Vercel CLI: `vercel deploy --prod
+--force`.
+
+## §3 — Likely root causes ordered by frequency
+
+| # | Cause | Symptom | Fix |
+|---|---|---|---|
+| a | Env propagation incomplete (`RECEIPT_PRIVATE_KEY_JWK` / `RECEIPT_KID` not set on Production scope) | JWKS/DID return 500; `/api/status` reports `degraded` | Set env vars, redeploy |
+| b | Wrong project receiving traffic — apex attached to `vitalcv` (deprecated) instead of `vcv-web` (canonical) | `/api/health` may still return `service: "web"` (same code) but config differs; signing kid different from operator expectation | Detach apex from deprecated project; verify only `vcv-web` has the apex domain |
+| c | Stale runtime — deployment older than current `main` | `/api/health` timestamp behind current commit time | Force new deploy; if blocked, check billing/pause |
+| d | Edge cache holding old responses | `Cache-Control: no-cache` returns different content from cached request | Force deploy (cache invalidates on new deployment); confirm via probe 6 |
+| e | Vercel project paused | Deployments tab shows pause marker | Resume in dashboard |
+| f | Billing limit hit | Builds queued but never run | Adjust spending limit |
+| g | Preview/Production env divergence | Preview shows `vcv-es256-1`, production shows `vcv-es256-dev` (or vice-versa) | Ensure env vars set on BOTH Production AND Preview scopes in `vcv-web` |
+| h | Vercel preview NODE_ENV=production gotcha | Preview deploys return 500 on JWKS unless preview-scope env vars are set | Set the env vars on Preview scope too, or accept previews 500-ing on signing surfaces |
+
+## §4 — Required env vars on `vcv-web` (Production scope)
+
+| Var | Required value | Effect if missing |
+|---|---|---|
+| `RECEIPT_PRIVATE_KEY_JWK` | ES256 private JWK (JSON-encoded) | JWKS/DID routes throw → 500 (fail-closed); status reports degraded |
+| `RECEIPT_KID` | `vcv-es256-1` | JWKS/DID routes throw → 500 (fail-closed); receipt[lineageKey] route falls back to `vcv-es256-1` literal anyway |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `pk_live_...` | `/api/health` reports `clerk.enabled: false`; protected routes redirect to `/sign-in` that has no functional backing |
+| `CLERK_SECRET_KEY` | `sk_live_...` | Same — middleware enters fallback path |
+| `NEXT_PUBLIC_API_BASE` (recommended) | `https://api.vitalcv.com` | `/api/health` reports `apiBase: false` (cosmetic); backend reachability still works via fallback |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN | Errors not captured in Sentry |
+| `VITALCV_ENV_LABEL` (optional) | `production` | `/api/status` `environment` field reports `'unknown'` |
+
+## §5 — Single deterministic answer to "what blocks production"
+
+```
+IF curl https://vitalcv.com/api/.well-known/jwks.json returns 500:
+  → BLOCKER: RECEIPT_PRIVATE_KEY_JWK and/or RECEIPT_KID not set on vcv-web Production scope.
+  → ACTION: set both, redeploy.
+
+ELIF curl returns kid containing "dev":
+  → BLOCKER: PR-362 deploy has not propagated, OR apex attached to deprecated project.
+  → ACTION: verify domain attachment in Vercel dashboard; if correct, force new deploy.
+
+ELIF curl returns kid "vcv-es256-1":
+  → NO BLOCKER. Signing identity converged. ✓
+
+ELSE:
+  → CACHE LAYER suspected. Run probe 6.
+```
+
+## §6 — Rollback condition
+
+If post-deploy any of the following holds, roll back to the prior
+deployment:
+
+- `/api/health` returns non-200
+- `/api/.well-known/jwks.json` returns 500 (env vars not set; safer to roll back than serve a degraded JWKS until env is fixed)
+- Apex `/passport` page renders the bare-Verified label or any banned phrase
+- `/api/status` reports `overall: "degraded"` for more than 5 minutes after deploy
+- A spike in 500s from the signing routes (any caller hit by fail-closed)
+
+Rollback in Vercel: Deployments tab → previous deployment → Promote
+to Production. Vercel handles cache invalidation automatically on
+promotion.

--- a/docs/architecture/vercel-convergence-diagnosis.md
+++ b/docs/architecture/vercel-convergence-diagnosis.md
@@ -1,5 +1,17 @@
 # Vercel Convergence Diagnosis
 
+> **⚠ RETRACTION (B18 wave):** Earlier revisions of this document named
+> `vcv-web` as the canonical Vercel project. External verification proved
+> `vcv-web.vercel.app` is unrelated to VitalCV. The actual canonical project
+> is unknown until operator-side discovery in the Vercel dashboard. All
+> `vcv-web` references in this document have been replaced with
+> `<canonical-project-TBD>`. The remaining diagnostic logic is unaffected.
+> See `retraction-vcv-web.md` and `production-restore-sequence.md` §1.
+
+**B18 priority context**: `vitalcv.com` currently returns HTTP 402 (paused).
+The pause-resolution runbook is `pause-root-cause-report.md`; run it
+BEFORE the diagnostic flow below.
+
 **B16-DEPLOYMENT-02 deliverable.** Operator-runnable diagnostic for
 why production may be stale/paused/disabled, and the deterministic
 next action.
@@ -12,12 +24,12 @@ truth, not in-repo state).
 
 | Property | Canonical | Deprecated |
 |---|---|---|
-| Vercel project name | `vcv-web` | `vitalcv` |
+| Vercel project name | `<canonical-project-TBD>` | `vitalcv` |
 | Repo path served | `apps/web` | `apps/web` (same code; different project linkage) |
 | Production branch | `main` | (varies; may be paused or unlinked) |
 | Domain attachment | apex `vitalcv.com` SHOULD be attached here | If apex is still attached here, that's the divergence |
 
-The canonical `vcv-web` project is the one operator action should target. The
+The canonical `<canonical-project-TBD>` project is the one operator action should target. The
 deprecated `vitalcv` project remains as a Vercel artifact and SHOULD have its
 production domain detached if it has not been already.
 
@@ -54,7 +66,7 @@ curl -s https://vitalcv.com/api/status                | jq '.runtime_continuity'
 
 ### Probe 3 — branch linkage
 
-In the Vercel dashboard for `vcv-web`:
+In the Vercel dashboard for `<canonical-project-TBD>`:
 
 - Settings → Git → Production Branch: should be `main`
 - Settings → Domains: `vitalcv.com` should appear, marked as the production domain
@@ -62,7 +74,7 @@ In the Vercel dashboard for `vcv-web`:
 
 ### Probe 4 — deployment pause / billing
 
-In the Vercel dashboard for `vcv-web`:
+In the Vercel dashboard for `<canonical-project-TBD>`:
 
 - Deployments tab: if the most recent deployment is older than the most recent `main` commit, deployments may be paused
 - Billing → Spending Limits: if limits hit, builds are blocked (BILLING issue)
@@ -70,7 +82,7 @@ In the Vercel dashboard for `vcv-web`:
 
 ### Probe 5 — env propagation
 
-In the Vercel dashboard for `vcv-web`:
+In the Vercel dashboard for `<canonical-project-TBD>`:
 
 - Settings → Environment Variables → Production scope: verify all required vars are present (see §4)
 - After setting any new variable, REDEPLOY — env vars do not retroactively apply to existing builds
@@ -93,15 +105,15 @@ deployment (any commit on main) OR use Vercel CLI: `vercel deploy --prod
 | # | Cause | Symptom | Fix |
 |---|---|---|---|
 | a | Env propagation incomplete (`RECEIPT_PRIVATE_KEY_JWK` / `RECEIPT_KID` not set on Production scope) | JWKS/DID return 500; `/api/status` reports `degraded` | Set env vars, redeploy |
-| b | Wrong project receiving traffic — apex attached to `vitalcv` (deprecated) instead of `vcv-web` (canonical) | `/api/health` may still return `service: "web"` (same code) but config differs; signing kid different from operator expectation | Detach apex from deprecated project; verify only `vcv-web` has the apex domain |
+| b | Wrong project receiving traffic — apex attached to `vitalcv` (deprecated) instead of `<canonical-project-TBD>` (canonical) | `/api/health` may still return `service: "web"` (same code) but config differs; signing kid different from operator expectation | Detach apex from deprecated project; verify only `<canonical-project-TBD>` has the apex domain |
 | c | Stale runtime — deployment older than current `main` | `/api/health` timestamp behind current commit time | Force new deploy; if blocked, check billing/pause |
 | d | Edge cache holding old responses | `Cache-Control: no-cache` returns different content from cached request | Force deploy (cache invalidates on new deployment); confirm via probe 6 |
 | e | Vercel project paused | Deployments tab shows pause marker | Resume in dashboard |
 | f | Billing limit hit | Builds queued but never run | Adjust spending limit |
-| g | Preview/Production env divergence | Preview shows `vcv-es256-1`, production shows `vcv-es256-dev` (or vice-versa) | Ensure env vars set on BOTH Production AND Preview scopes in `vcv-web` |
+| g | Preview/Production env divergence | Preview shows `vcv-es256-1`, production shows `vcv-es256-dev` (or vice-versa) | Ensure env vars set on BOTH Production AND Preview scopes in `<canonical-project-TBD>` |
 | h | Vercel preview NODE_ENV=production gotcha | Preview deploys return 500 on JWKS unless preview-scope env vars are set | Set the env vars on Preview scope too, or accept previews 500-ing on signing surfaces |
 
-## §4 — Required env vars on `vcv-web` (Production scope)
+## §4 — Required env vars on `<canonical-project-TBD>` (Production scope)
 
 | Var | Required value | Effect if missing |
 |---|---|---|
@@ -117,7 +129,7 @@ deployment (any commit on main) OR use Vercel CLI: `vercel deploy --prod
 
 ```
 IF curl https://vitalcv.com/api/.well-known/jwks.json returns 500:
-  → BLOCKER: RECEIPT_PRIVATE_KEY_JWK and/or RECEIPT_KID not set on vcv-web Production scope.
+  → BLOCKER: RECEIPT_PRIVATE_KEY_JWK and/or RECEIPT_KID not set on <canonical-project-TBD> Production scope.
   → ACTION: set both, redeploy.
 
 ELIF curl returns kid containing "dev":

--- a/docs/architecture/vitalcv-project-structure-map.md
+++ b/docs/architecture/vitalcv-project-structure-map.md
@@ -44,9 +44,16 @@
   * **Status:** Canonical.
 
 ### Vercel Deployment Map
-* `vcv-web`
+
+> **⚠ RETRACTION (B18 wave, 2026-05-15):** Earlier text named `vcv-web`
+> as the canonical Vercel project. External verification proved
+> `vcv-web.vercel.app` is unrelated to VitalCV. The actual canonical
+> project remains operator-confirmed-only. Resolve via
+> `production-restore-sequence.md` §1.
+
+* `<canonical-project-TBD>` (operator-confirmed via Vercel dashboard)
   * **Purpose:** The production frontend Vercel project serving `vitalcv.com`. Maps directly to `apps/web`.
-  * **Status:** Canonical.
-* `vitalcv-marketing` / `staging`
+  * **Status:** Operator-confirmed pending; see `production-restore-sequence.md` §1.
+* `vitalcv-marketing` / `staging` / other historical projects
   * **Status:** Legacy / Tangled projects.
-  * **Action:** Route all production traffic through `vcv-web`.
+  * **Action:** Route all production traffic through the operator-confirmed canonical project. Detach `vitalcv.com` from any non-canonical project.

--- a/scripts/verify-production-runtime.sh
+++ b/scripts/verify-production-runtime.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# B20-CODE-02 — Production runtime smoke-test verifier.
+#
+# Usage:
+#   scripts/verify-production-runtime.sh             # probes https://vitalcv.com
+#   APEX=https://staging.example.com scripts/verify-production-runtime.sh
+#
+# Exit code: 0 if every check passes, 1 if any fails.
+# Output: PASS/FAIL table to stdout.
+#
+# Required tools: curl, jq.
+
+set -u
+APEX="${APEX:-https://vitalcv.com}"
+EXPECTED_KID="${EXPECTED_KID:-vcv-es256-1}"
+TIMEOUT="${TIMEOUT:-10}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: curl not installed" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq not installed (brew install jq)" >&2
+  exit 1
+fi
+
+FAIL=0
+PASS_COUNT=0
+FAIL_COUNT=0
+
+result() {
+  local name="$1"
+  local outcome="$2"
+  local detail="$3"
+  if [[ "$outcome" == "PASS" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    printf "  %-46s  ✓ PASS  %s\n" "$name" "$detail"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAIL=1
+    printf "  %-46s  ✗ FAIL  %s\n" "$name" "$detail"
+  fi
+}
+
+# Capture HTTP status only.
+http_status() {
+  curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$1" 2>/dev/null || echo "000"
+}
+
+# Capture full response with status.
+http_body_and_status() {
+  curl -s -w "\n__HTTP_STATUS__:%{http_code}" --max-time "$TIMEOUT" "$1" 2>/dev/null
+}
+
+echo
+echo "================================================================"
+echo " VitalCV production runtime smoke test"
+echo " Target apex: $APEX"
+echo " Expected kid: $EXPECTED_KID"
+echo "================================================================"
+echo
+
+# ─── 1. Reachability ─────────────────────────────────────────────────────────
+echo "[1] Reachability"
+
+S=$(http_status "$APEX/")
+if [[ "$S" == "200" ]]; then result "homepage GET /" "PASS" "(200)"; \
+elif [[ "$S" == "402" ]]; then result "homepage GET /" "FAIL" "(402 — deployment paused; see pause-root-cause-report.md)"; \
+else result "homepage GET /" "FAIL" "(HTTP $S)"; fi
+
+S=$(http_status "$APEX/api/health")
+if [[ "$S" == "200" ]]; then result "api GET /api/health" "PASS" "(200)"; \
+else result "api GET /api/health" "FAIL" "(HTTP $S)"; fi
+
+S=$(http_status "$APEX/passport")
+if [[ "$S" == "200" ]]; then result "page GET /passport" "PASS" "(200)"; \
+else result "page GET /passport" "FAIL" "(HTTP $S)"; fi
+
+S=$(http_status "$APEX/onboarding")
+if [[ "$S" == "200" ]]; then result "page GET /onboarding" "PASS" "(200)"; \
+else result "page GET /onboarding" "FAIL" "(HTTP $S)"; fi
+
+echo
+
+# ─── 2. /api/health config posture ───────────────────────────────────────────
+echo "[2] /api/health config posture"
+
+HEALTH=$(curl -s --max-time "$TIMEOUT" "$APEX/api/health" 2>/dev/null || echo "")
+if [[ -z "$HEALTH" ]]; then
+  result "/api/health JSON" "FAIL" "(no response)"
+else
+  SERVICE=$(echo "$HEALTH" | jq -r '.service // "?"' 2>/dev/null)
+  if [[ "$SERVICE" == "web" ]]; then result "service = web" "PASS" "(apex serves apps/web)"; \
+  else result "service = web" "FAIL" "(got '$SERVICE'; apex may be attached to wrong project)"; fi
+
+  CLERK=$(echo "$HEALTH" | jq -r '.config.clerk.enabled' 2>/dev/null)
+  if [[ "$CLERK" == "true" ]]; then result "clerk.enabled" "PASS" "(true)"; \
+  else result "clerk.enabled" "FAIL" "(false — NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY / CLERK_SECRET_KEY unset)"; fi
+
+  API_BASE=$(echo "$HEALTH" | jq -r '.config.apiBase' 2>/dev/null)
+  if [[ "$API_BASE" == "true" ]]; then result "apiBase" "PASS" "(true)"; \
+  else result "apiBase" "FAIL" "(false — NEXT_PUBLIC_API_BASE unset; cosmetic but recommended)"; fi
+
+  SENTRY=$(echo "$HEALTH" | jq -r '.config.sentry' 2>/dev/null)
+  if [[ "$SENTRY" == "true" ]]; then result "sentry" "PASS" "(true)"; \
+  else result "sentry" "FAIL" "(false — NEXT_PUBLIC_SENTRY_DSN unset; errors not captured)"; fi
+fi
+
+echo
+
+# ─── 3. Signing identity ─────────────────────────────────────────────────────
+echo "[3] Signing identity convergence"
+
+JWKS=$(curl -s --max-time "$TIMEOUT" "$APEX/api/.well-known/jwks.json" 2>/dev/null || echo "")
+if [[ -z "$JWKS" ]]; then
+  result "JWKS legacy path" "FAIL" "(no response)"
+else
+  JWKS_KID=$(echo "$JWKS" | jq -r '.keys[0].kid // empty' 2>/dev/null)
+  if [[ -z "$JWKS_KID" ]]; then
+    result "JWKS legacy path" "FAIL" "(no kid in response — possibly 500 fail-closed)"
+  elif [[ "$JWKS_KID" == *dev* ]]; then
+    result "JWKS legacy kid" "FAIL" "(emits '$JWKS_KID' — DEV KID LEAKAGE on production)"
+  elif [[ "$JWKS_KID" == "$EXPECTED_KID" ]]; then
+    result "JWKS legacy kid" "PASS" "($JWKS_KID)"
+  else
+    result "JWKS legacy kid" "FAIL" "(emits '$JWKS_KID', expected '$EXPECTED_KID')"
+  fi
+fi
+
+# Canonical path (may or may not ship depending on unmerged stack)
+S=$(http_status "$APEX/.well-known/jwks.json")
+if [[ "$S" == "200" ]]; then
+  CANONICAL_KID=$(curl -s --max-time "$TIMEOUT" "$APEX/.well-known/jwks.json" | jq -r '.keys[0].kid // empty' 2>/dev/null)
+  if [[ "$CANONICAL_KID" == *dev* ]]; then
+    result "JWKS canonical path" "FAIL" "(emits '$CANONICAL_KID' — DEV KID LEAKAGE)"
+  elif [[ "$CANONICAL_KID" == "$EXPECTED_KID" ]]; then
+    result "JWKS canonical path" "PASS" "($CANONICAL_KID)"
+  else
+    result "JWKS canonical path" "FAIL" "(emits '$CANONICAL_KID')"
+  fi
+elif [[ "$S" == "404" ]]; then
+  result "JWKS canonical path" "PASS" "(404 — route not yet on main; legacy mirror is canonical)"
+else
+  result "JWKS canonical path" "FAIL" "(HTTP $S)"
+fi
+
+# Status route signing-key check
+STATUS_KID=$(curl -s --max-time "$TIMEOUT" "$APEX/api/status" 2>/dev/null | jq -r '.runtime_continuity.signing_key_id // empty' 2>/dev/null)
+if [[ -z "$STATUS_KID" || "$STATUS_KID" == "null" ]]; then
+  result "/api/status signing_key_id" "FAIL" "(null — env missing; runtime_continuity reports degraded)"
+elif [[ "$STATUS_KID" == *dev* ]]; then
+  result "/api/status signing_key_id" "FAIL" "(emits '$STATUS_KID' — DEV KID LEAKAGE)"
+elif [[ "$STATUS_KID" == "$EXPECTED_KID" ]]; then
+  result "/api/status signing_key_id" "PASS" "($STATUS_KID)"
+else
+  result "/api/status signing_key_id" "FAIL" "(emits '$STATUS_KID')"
+fi
+
+echo
+
+# ─── 4. Replay continuity readers ────────────────────────────────────────────
+echo "[4] Replay continuity readers"
+
+S=$(http_status "$APEX/api/replay/chain/1346053246")
+if [[ "$S" == "200" ]]; then result "replay chain reader" "PASS" "(200)"; \
+elif [[ "$S" == "503" ]]; then result "replay chain reader" "FAIL" "(503 — replay_infrastructure_unavailable; migration not applied)"; \
+else result "replay chain reader" "FAIL" "(HTTP $S)"; fi
+
+S=$(http_status "$APEX/api/replay/chain/not-a-valid-npi")
+if [[ "$S" == "400" ]]; then result "replay chain invalid NPI" "PASS" "(400 — input validation correct)"; \
+else result "replay chain invalid NPI" "FAIL" "(HTTP $S; expected 400)"; fi
+
+echo
+
+# ─── 5. Banned-phrase regression scan ────────────────────────────────────────
+echo "[5] Banned-phrase regression scan"
+
+HOME=$(curl -s --max-time "$TIMEOUT" "$APEX/" 2>/dev/null || echo "")
+# Banned-phrase scan against the rendered homepage. Any hit (including
+# negated forms in surrounding text) must be inspected by hand against
+# the CLAUDE.md truth contract; not every match is necessarily a defect
+# (safety/negation text is allowed) — the script flags for human review.
+if [[ -z "$HOME" ]]; then
+  result "banned phrase scan" "FAIL" "(no homepage response to scan)"
+else
+  HITS=$(echo "$HOME" | grep -iE "automatically verified|guaranteed verification|complete credentialing|instant credentialing|legally accepted|risk transferred|HIPAA compliant|SOC2 certified|certified compliant" | head -5)
+  if [[ -z "$HITS" ]]; then
+    result "banned phrase scan" "PASS" "(no hits)"
+  else
+    result "banned phrase scan" "FAIL" "(hits — see CLAUDE.md truth contract; inspect by hand: $HITS)"
+  fi
+fi
+
+echo
+
+# ─── 6. Cache-bypass divergence ──────────────────────────────────────────────
+echo "[6] Cache-bypass divergence"
+
+T1=$(curl -s --max-time "$TIMEOUT" "$APEX/api/health" | jq -r '.timestamp // empty' 2>/dev/null)
+T2=$(curl -s --max-time "$TIMEOUT" -H "Cache-Control: no-cache" "$APEX/api/health" | jq -r '.timestamp // empty' 2>/dev/null)
+if [[ -z "$T1" || -z "$T2" ]]; then
+  result "cache-bypass divergence" "FAIL" "(could not read timestamps)"
+elif [[ "$T1" == "$T2" ]]; then
+  result "cache-bypass divergence" "PASS" "(both timestamps fresh)"
+else
+  # Different timestamps is fine — /api/health is force-dynamic and computes per request.
+  # But we still PASS because the responses came through and are recent.
+  result "cache-bypass divergence" "PASS" "(both responses recent; /api/health is dynamic)"
+fi
+
+echo
+
+# ─── 7. Deployment-paused interception ───────────────────────────────────────
+echo "[7] No deployment-paused interception"
+
+HOME_STATUS=$(http_status "$APEX/")
+if [[ "$HOME_STATUS" == "402" ]]; then
+  result "no 402 paused-runtime" "FAIL" "(apex returns 402 — Vercel pause active; see pause-root-cause-report.md)"
+else
+  result "no 402 paused-runtime" "PASS" "(homepage not paused)"
+fi
+
+# Look for paused-runtime interstitial keyword in response body
+if [[ -n "$HOME" ]] && echo "$HOME" | grep -iqE "temporarily paused|deployment is paused|This deployment is currently paused"; then
+  result "no paused interstitial" "FAIL" "(homepage contains paused-state language)"
+else
+  result "no paused interstitial" "PASS" "(no paused-state language detected)"
+fi
+
+echo
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo "================================================================"
+echo " Summary"
+echo "================================================================"
+echo "  Passed: $PASS_COUNT"
+echo "  Failed: $FAIL_COUNT"
+echo
+if [[ "$FAIL" == "0" ]]; then
+  echo "  ✓ Production runtime smoke test PASSED."
+  exit 0
+else
+  echo "  ✗ Production runtime smoke test FAILED."
+  echo "  Diagnostic refs:"
+  echo "    - pause-root-cause-report.md       (if HTTP 402)"
+  echo "    - production-env-requirements.md   (if env vars / config posture failures)"
+  echo "    - signing-identity-convergence-report.md  (if dev kid leakage)"
+  echo "    - domain-topology-audit.md         (if wrong service / 404 cascade)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

**B18 retraction wave.** External verification proved `vcv-web.vercel.app` is unrelated to VitalCV. Prior B16/B17 convergence docs in this PR naming `vcv-web` as canonical are now retracted. Adds the B18 infrastructure-truth-recovery sequence.

## What's in this PR

**3 new B18 docs (operator restore runbooks)**:
- `production-restore-sequence.md` — minimum path to restore `vitalcv.com`; begins with operator-side discovery of the canonical Vercel project (DOES NOT presume any name). 15–30 min recovery for billing/pause causes.
- `pause-root-cause-report.md` — diagnostic for the current HTTP 402 "deployment temporarily paused" response on `vitalcv.com`. Six possible causes; deterministic resolution.
- `domain-topology-audit.md` — verifies domain attachment + detects stale Vercel project claims. Convergence criteria.

**1 retraction notice**:
- `retraction-vcv-web.md` — explicit retraction of the invalid claim, the docs that propagated it, and forbidden actions per B18 directive.

**6 affected docs retracted in-place** (header + every `vcv-web` reference replaced with `<canonical-project-TBD>`):
- `vercel-convergence-diagnosis.md`
- `signing-identity-convergence-report.md`
- `final-deployment-sequence.md`
- `preview-runtime-safety-audit.md`
- `b16-executive-convergence-summary.md`
- `vitalcv-project-structure-map.md`

## Truth rules
- All docs scan CLEAN (only banned-phrase hits are grep verification literals; allowable).
- Remaining `vcv-web` mentions are in retraction/negation contexts only — no positive assignments.
- Code-level claims (signing fail-closed, force-dynamic, `'vcv-es256-1'` as the expected env value) are UNAFFECTED — they're about code, not infrastructure naming.

## Honest scope note

B18-BROWSER-05 (post-recovery external revalidation) is operator-side. I cannot probe `vitalcv.com` from a build session, especially when it's returning 402. The verification commands an operator needs are in `production-restore-sequence.md` §4–§7 and `signing-identity-convergence-report.md` §2.

## What still blocks production
1. Operator identifies the real canonical Vercel project (per `production-restore-sequence.md` §1)
2. Operator resolves the HTTP 402 pause (per `pause-root-cause-report.md`)
3. Operator verifies domain attachment (per `domain-topology-audit.md`)
4. Operator sets the required env vars on the confirmed-canonical project
5. Operator runs the smoke tests

No code change can replace any of these steps.