### PR TITLE
feat(demo): add OpenEvidence market-pain demo spine and ROI calculator

### DIFF
--- a/apps/web/__tests__/openevidence-demo-spine.test.ts
+++ b/apps/web/__tests__/openevidence-demo-spine.test.ts
@@ -1,0 +1,245 @@
+/**
+ * openevidence-demo-spine.test.ts
+ *
+ * Per TASK 8: verifies that the demo-spine routes render, the ROI math
+ * is correct, no banned phrases appear in the new files, no bare
+ * "Verified" labels are present, all synthetic demo data is labeled
+ * illustrative/demo, and the founder/demo scripts reference the
+ * correct repo path.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  CBP_CREDENTIALING_DAYS,
+  DAILY_DELAY_COST_HIGH,
+  DAILY_DELAY_COST_LOW,
+  DAYS_SAVED,
+  RESEARCH_SIGNALS,
+  SINGLE_PHYSICIAN_DELAY_COST_HIGH,
+  SINGLE_PHYSICIAN_DELAY_COST_LOW,
+  SPECIALTY_OPTIONS,
+  TRADITIONAL_CREDENTIALING_DAYS,
+  computeRoiRange,
+  formatUsdCompact,
+} from '../app/demo/_marketData';
+import { DEMO_PERSONAS, DEMO_EMPLOYER_APPLICATIONS, DEMO_ISSUER_REQUESTS } from '../app/demo/_seed';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const BANNED_PHRASES = [
+  /automatically verified/i,
+  /guaranteed verification/i,
+  /\bcomplete credentialing\b/i,
+  /instant credentialing/i,
+  /legally accepted/i,
+  /risk transferred/i,
+  /HIPAA compliant/i,
+  /SOC2 certified/i,
+  /certified compliant/i,
+  /NCQA certified/i,
+  /final verification without review/i,
+  /source confirmed before response/i,
+];
+
+const REPO_ROOT = join(__dirname, '../..', '..');
+
+function readRepoFile(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), 'utf8');
+}
+
+// ── ROI math ───────────────────────────────────────────────────────────────
+
+describe('marketData — ROI math', () => {
+  it('TRADITIONAL_CREDENTIALING_DAYS - CBP_CREDENTIALING_DAYS = DAYS_SAVED (103 - 36 = 67)', () => {
+    expect(TRADITIONAL_CREDENTIALING_DAYS).toBe(103);
+    expect(CBP_CREDENTIALING_DAYS).toBe(36);
+    expect(DAYS_SAVED).toBe(67);
+    expect(TRADITIONAL_CREDENTIALING_DAYS - CBP_CREDENTIALING_DAYS).toBe(DAYS_SAVED);
+  });
+
+  it('daily delay cost bounds match the published benchmark range', () => {
+    expect(DAILY_DELAY_COST_LOW).toBe(2700);
+    expect(DAILY_DELAY_COST_HIGH).toBe(5400);
+  });
+
+  it('single-physician 67-day exposure = $180,900–$361,800', () => {
+    expect(DAYS_SAVED * DAILY_DELAY_COST_LOW).toBe(180_900);
+    expect(DAYS_SAVED * DAILY_DELAY_COST_HIGH).toBe(361_800);
+    expect(SINGLE_PHYSICIAN_DELAY_COST_LOW).toBe(180_900);
+    expect(SINGLE_PHYSICIAN_DELAY_COST_HIGH).toBe(361_800);
+  });
+
+  it('computeRoiRange scales linearly with provider count', () => {
+    expect(computeRoiRange({ providerCount: 1 })).toEqual({ totalLow: 180_900, totalHigh: 361_800 });
+    expect(computeRoiRange({ providerCount: 5 })).toEqual({ totalLow: 904_500, totalHigh: 1_809_000 });
+    expect(computeRoiRange({ providerCount: 10 })).toEqual({ totalLow: 1_809_000, totalHigh: 3_618_000 });
+    expect(computeRoiRange({ providerCount: 25 })).toEqual({ totalLow: 4_522_500, totalHigh: 9_045_000 });
+  });
+
+  it('formatUsdCompact produces compact $k / $M strings', () => {
+    expect(formatUsdCompact(900)).toBe('$900');
+    expect(formatUsdCompact(180_900)).toBe('$181k');
+    expect(formatUsdCompact(1_809_000)).toMatch(/^\$1\.81M$/);
+  });
+
+  it('exposes all 9 specialty options for the calculator', () => {
+    expect(SPECIALTY_OPTIONS).toHaveLength(9);
+  });
+});
+
+// ── Route renderability ────────────────────────────────────────────────────
+
+describe('demo spine — pages render', () => {
+  async function renderPage(modulePath: string): Promise<string> {
+    const mod = await import(modulePath);
+    const Page = mod.default;
+    return renderToStaticMarkup(Page());
+  }
+
+  it('/launch renders and contains the primary message', async () => {
+    const html = await renderPage('../app/launch/page');
+    expect(html).toContain('Reusable, source-backed clinician readiness');
+    expect(html).toContain('See the employer view');
+  });
+
+  it('/demo renders and links to all three sub-flows', async () => {
+    const html = await renderPage('../app/demo/page');
+    expect(html).toContain('/demo/clinician');
+    expect(html).toContain('/demo/employer');
+    expect(html).toContain('/demo/issuer');
+  });
+
+  it('/demo/clinician renders all 6 personas', async () => {
+    const html = await renderPage('../app/demo/clinician/page');
+    for (const p of DEMO_PERSONAS) {
+      expect(html).toContain(p.displayName);
+    }
+  });
+
+  it('/demo/employer renders all 3 employer applications', async () => {
+    const html = await renderPage('../app/demo/employer/page');
+    for (const a of DEMO_EMPLOYER_APPLICATIONS) {
+      expect(html).toContain(a.candidate.displayName);
+    }
+  });
+
+  it('/demo/issuer renders all 3 issuer requests', async () => {
+    const html = await renderPage('../app/demo/issuer/page');
+    for (const r of DEMO_ISSUER_REQUESTS) {
+      expect(html).toContain(r.requestId);
+    }
+  });
+});
+
+// ── Truth contract: banned phrases ─────────────────────────────────────────
+
+describe('truth contract — banned phrases', () => {
+  const newFiles = [
+    'apps/web/app/launch/page.tsx',
+    'apps/web/app/demo/page.tsx',
+    'apps/web/app/demo/_seed.ts',
+    'apps/web/app/demo/_marketData.ts',
+    'apps/web/app/demo/clinician/page.tsx',
+    'apps/web/app/demo/employer/page.tsx',
+    'apps/web/app/demo/issuer/page.tsx',
+    'apps/web/components/demo/RoiCalculator.tsx',
+    'apps/web/components/demo/EquityRetentionBlock.tsx',
+  ];
+
+  for (const f of newFiles) {
+    it(`${f} contains no banned phrases`, () => {
+      const src = readRepoFile(f);
+      for (const re of BANNED_PHRASES) {
+        expect(src, `${f} contains banned phrase ${re}`).not.toMatch(re);
+      }
+    });
+  }
+});
+
+// ── Truth contract: no bare "Verified" labels ──────────────────────────────
+
+describe('truth contract — no bare Verified labels', () => {
+  const newFiles = [
+    'apps/web/app/launch/page.tsx',
+    'apps/web/app/demo/page.tsx',
+    'apps/web/app/demo/clinician/page.tsx',
+    'apps/web/app/demo/employer/page.tsx',
+    'apps/web/app/demo/issuer/page.tsx',
+    'apps/web/components/demo/RoiCalculator.tsx',
+    'apps/web/components/demo/EquityRetentionBlock.tsx',
+  ];
+  // Bare-Verified violation patterns:
+  //   - label="Verified" / label='Verified'
+  //   - >Verified</  (rendered between tags)
+  const BARE_VERIFIED = [
+    /label\s*[:=]\s*["']Verified["']/,
+    />\s*Verified\s*</,
+  ];
+
+  for (const f of newFiles) {
+    it(`${f} contains no bare-Verified label`, () => {
+      const src = readRepoFile(f);
+      for (const re of BARE_VERIFIED) {
+        expect(src, `${f} matches bare-Verified pattern ${re}`).not.toMatch(re);
+      }
+    });
+  }
+});
+
+// ── Synthetic demo data labeled ───────────────────────────────────────────
+
+describe('truth contract — synthetic demo data labeled illustrative', () => {
+  it('every DEMO_PERSONAS entry has isSyntheticNpi: true', () => {
+    for (const p of DEMO_PERSONAS) {
+      expect(p.isSyntheticNpi).toBe(true);
+    }
+  });
+
+  it('every persona displayName carries a "DEMO" marker', () => {
+    for (const p of DEMO_PERSONAS) {
+      expect(p.displayName).toMatch(/\bDEMO\b/i);
+    }
+  });
+
+  it('every employer-application organization carries a "DEMO" marker', () => {
+    for (const a of DEMO_EMPLOYER_APPLICATIONS) {
+      expect(a.organization).toMatch(/\bDEMO\b/i);
+    }
+  });
+
+  it('every issuer-request issuerOrg or claimSummary carries a "DEMO" marker', () => {
+    for (const r of DEMO_ISSUER_REQUESTS) {
+      const combined = `${r.issuerOrg} ${r.claimSummary}`;
+      expect(combined).toMatch(/\bDEMO\b/i);
+    }
+  });
+});
+
+// ── Research signal posture (no overclaim) ─────────────────────────────────
+
+describe('research signals — posture', () => {
+  it('every research signal has a citation hint', () => {
+    for (const key of Object.keys(RESEARCH_SIGNALS) as Array<keyof typeof RESEARCH_SIGNALS>) {
+      const s = RESEARCH_SIGNALS[key];
+      expect(s.cite, `${key} missing cite`).toBeTruthy();
+      expect(s.label).toBeTruthy();
+      expect(s.value).toBeTruthy();
+      expect(s.context).toBeTruthy();
+    }
+  });
+});
+
+// ── Script paths ──────────────────────────────────────────────────────────
+
+describe('scripts — repo-path references', () => {
+  const scripts = ['scripts/public-demo.sh', 'scripts/founder-mode.sh'];
+  for (const s of scripts) {
+    it(`${s} does not reference the stale ~/vitalcv-omega4f-trigger path`, () => {
+      const src = readRepoFile(s);
+      expect(src, `${s} contains stale omega path`).not.toContain('vitalcv-omega4f-trigger');
+    });
+  }
+});

--- a/apps/web/app/demo/_marketData.ts
+++ b/apps/web/app/demo/_marketData.ts
@@ -1,0 +1,162 @@
+/**
+ * _marketData.ts — OpenEvidence-backed market signals for the
+ * /launch + /demo surfaces.
+ *
+ * IMPORTANT — truth contract:
+ *   - Every value here is an ILLUSTRATIVE MARKET BENCHMARK from
+ *     published research and is not a measured VitalCV outcome.
+ *   - Consumers must render these as "research signal" or
+ *     "illustrative market benchmark", not as VitalCV-owned results.
+ *   - Citation labels are included so the rendered UI can disclose
+ *     the benchmark origin.
+ */
+
+// ── Credentialing cycle ────────────────────────────────────────────────────
+
+export const TRADITIONAL_CREDENTIALING_DAYS = 103;
+export const CBP_CREDENTIALING_DAYS = 36;
+export const DAYS_SAVED = TRADITIONAL_CREDENTIALING_DAYS - CBP_CREDENTIALING_DAYS;
+
+export const DAILY_DELAY_COST_LOW = 2700;
+export const DAILY_DELAY_COST_HIGH = 5400;
+
+export const SINGLE_PHYSICIAN_DELAY_COST_LOW = DAYS_SAVED * DAILY_DELAY_COST_LOW;
+export const SINGLE_PHYSICIAN_DELAY_COST_HIGH = DAYS_SAVED * DAILY_DELAY_COST_HIGH;
+
+// ── Workforce / equity research signals ────────────────────────────────────
+
+export interface ResearchSignal {
+  /** Short label used as the column / row heading. */
+  label: string;
+  /** Display value (string so percentage / range formatting is explicit). */
+  value: string;
+  /** One-sentence context for the value. */
+  context: string;
+  /** Citation hint — research origin, not a hyperlink. */
+  cite: string;
+}
+
+export const RESEARCH_SIGNALS = {
+  femalePhysicianAttritionHazard: {
+    label: 'Female physician attrition hazard',
+    value: '+43% higher',
+    context: 'Female physicians exit clinical practice at a 43% higher hazard than male counterparts in cited workforce research.',
+    cite: 'Published workforce attrition research; sized at hazard-ratio level.',
+  },
+  femaleMedianExitAge: {
+    label: 'Female vs male median exit age',
+    value: '49 vs 64',
+    context: 'Median age at exit from clinical practice for female vs male physicians.',
+    cite: 'Same workforce-attrition research; median across studied cohorts.',
+  },
+  blackSurgicalResidentAttrition: {
+    label: 'Black surgical resident attrition',
+    value: '10.6% total · 5.2% unintended',
+    context: 'Black/African American surgical residents recorded the highest attrition in the cited surgical-resident attrition study.',
+    cite: 'Surgical resident attrition study.',
+  },
+  ruralInternationalBornPhysicianShare: {
+    label: 'Rural physicians born internationally',
+    value: '28.0%',
+    context: 'Share of rural physicians born outside the United States; rural workforce depends materially on international medical graduates.',
+    cite: 'Rural physician workforce composition research.',
+  },
+  psychiatryAdminBurden: {
+    label: 'Psychiatry administrative burden',
+    value: '20.3% of working time',
+    context: 'Share of working time psychiatrists spend on administration in cited time-use research.',
+    cite: 'Time-use survey of practicing physicians.',
+  },
+  primaryCareExitRate: {
+    label: 'Primary care annual exit rate',
+    value: '4.41%',
+    context: 'Annual rate at which primary care physicians exit the active workforce.',
+    cite: 'Primary care workforce exit research.',
+  },
+  ruralPhysicianShortageProjection: {
+    label: 'Nonmetropolitan shortage projection (2036)',
+    value: '~56% shortage',
+    context: 'Projected nonmetropolitan physician workforce shortfall by 2036.',
+    cite: 'HHS / HRSA workforce projection.',
+  },
+  nonmetroPsychiatryAdequacy: {
+    label: 'Nonmetro psychiatry adequacy',
+    value: '34.8%',
+    context: 'Projected workforce adequacy for psychiatry in nonmetropolitan areas (2037).',
+    cite: 'HHS / HRSA workforce projection.',
+  },
+  nonmetroInternalMedicineAdequacy: {
+    label: 'Nonmetro internal medicine adequacy (2037)',
+    value: '41.8%',
+    context: 'Projected workforce adequacy for internal medicine in nonmetropolitan areas (2037).',
+    cite: 'HHS / HRSA workforce projection.',
+  },
+} as const satisfies Record<string, ResearchSignal>;
+
+// ── Specialty options (used by the RoiCalculator + employer demo) ──────────
+
+export type Specialty =
+  | 'primary_care'
+  | 'psychiatry'
+  | 'emergency_medicine'
+  | 'obgyn'
+  | 'cardiothoracic_surgery'
+  | 'orthopedic_surgery'
+  | 'hospitalist'
+  | 'nurse_practitioner'
+  | 'img_rural_primary_care';
+
+export const SPECIALTY_LABEL: Record<Specialty, string> = {
+  primary_care: 'Primary Care',
+  psychiatry: 'Psychiatry',
+  emergency_medicine: 'Emergency Medicine',
+  obgyn: 'OB/GYN',
+  cardiothoracic_surgery: 'Cardiothoracic Surgery',
+  orthopedic_surgery: 'Orthopedic Surgery',
+  hospitalist: 'Hospitalist',
+  nurse_practitioner: 'Nurse Practitioner',
+  img_rural_primary_care: 'IMG / Rural Primary Care',
+};
+
+export const SPECIALTY_OPTIONS: ReadonlyArray<Specialty> = [
+  'primary_care',
+  'psychiatry',
+  'emergency_medicine',
+  'obgyn',
+  'cardiothoracic_surgery',
+  'orthopedic_surgery',
+  'hospitalist',
+  'nurse_practitioner',
+  'img_rural_primary_care',
+];
+
+// ── Required disclaimers / labels (centralized) ────────────────────────────
+
+export const MARKET_BENCHMARK_LABELS = {
+  illustrative: 'Illustrative market benchmark',
+  notGuaranteed: 'Not a guaranteed VitalCV outcome',
+  methodology: 'Based on published credentialing-by-proxy and physician vacancy/revenue assumptions.',
+  researchSignal: 'Research signal',
+} as const;
+
+// ── Pure ROI math helpers (tested in __tests__/marketData.test.ts) ─────────
+
+export function computeRoiRange(args: {
+  providerCount: number;
+  daysSaved?: number;
+  dailyLow?: number;
+  dailyHigh?: number;
+}): { totalLow: number; totalHigh: number } {
+  const d = args.daysSaved ?? DAYS_SAVED;
+  const lo = args.dailyLow ?? DAILY_DELAY_COST_LOW;
+  const hi = args.dailyHigh ?? DAILY_DELAY_COST_HIGH;
+  const totalLow = args.providerCount * d * lo;
+  const totalHigh = args.providerCount * d * hi;
+  return { totalLow, totalHigh };
+}
+
+export function formatUsdCompact(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n >= 10_000_000 ? 1 : 2)}M`;
+  if (n >= 1_000) return `$${Math.round(n / 1_000)}k`;
+  return `$${n}`;
+}

--- a/apps/web/app/demo/_seed.ts
+++ b/apps/web/app/demo/_seed.ts
@@ -1,0 +1,400 @@
+/**
+ * /demo seed data — single source of truth for the demo flows.
+ *
+ * No backend dependency. No DB query. All values are deterministic
+ * fixtures so the demo renders identically on every load, on any
+ * environment, with or without env vars.
+ *
+ * IMPORTANT — truth contract:
+ *   - All NPIs in this file are SYNTHETIC. They are NOT live-source-
+ *     backed; the rendered source statuses are fixture-only. Demo
+ *     surfaces must label this clearly (see the eyebrow + footer
+ *     copy on each /demo/* page).
+ *   - The labels and tiers reflect the SAME vocabulary the live product
+ *     uses (T1-T4 authority ladder, "Source-backed", "Access required",
+ *     "Foundation preview"). Foundation-honest framing is preserved.
+ *   - The full list of phrases this file MUST NOT emit lives in
+ *     CLAUDE.md (the project truth contract). Demo content honors
+ *     that contract by construction; no compliance claims, no
+ *     credentialing-completion claims, no risk-transfer claims.
+ */
+
+export type SourceTier = 'T1' | 'T2' | 'T3' | 'T4';
+export type SourceStatus =
+  | 'source_backed'
+  | 'access_required'
+  | 'pending'
+  | 'not_yet';
+
+export interface DemoSource {
+  id: string;
+  name: string;
+  shortName: string;
+  status: SourceStatus;
+  tier: SourceTier;
+  detail: string;
+  checkedAt: string; // ISO
+}
+
+export interface DemoCredential {
+  name: string;
+  issuer: string;
+  issuedOn: string;
+  expiresOn?: string;
+  freshness: 'current' | 'expiring_soon' | 'expired' | 'no_expiry';
+  tier: SourceTier;
+}
+
+export interface DemoClinician {
+  personaKey: string;
+  npi: string;
+  /** Always true on /demo/* — every NPI here is synthetic. */
+  isSyntheticNpi: true;
+  displayName: string;
+  specialty: string;
+  state: string;
+  /** Role / setting context shown adjacent to the persona name. */
+  setting: string;
+  /** One-liner that names the operational pain VitalCV touches for this persona. */
+  delayPain: string;
+  /** What an employer reviewer should do next given the readiness shape. */
+  employerNextAction: string;
+  lastCheckedAt: string;
+  readinessLevel: 'High' | 'Moderate' | 'Low' | 'Unknown';
+  readinessScore: number; // 0-100
+  sources: ReadonlyArray<DemoSource>;
+  credentials: ReadonlyArray<DemoCredential>;
+}
+
+const NOW = '2026-05-16T15:00:00.000Z';
+
+// ── Six demo personas. NPIs are synthetic; labeled per the truth contract. ──
+
+export const DEMO_PERSONAS: ReadonlyArray<DemoClinician> = [
+  // 1. Rural / FQHC family medicine
+  {
+    personaKey: 'rural-fqhc-family-medicine',
+    npi: '1700100001',
+    isSyntheticNpi: true,
+    displayName: 'Dr. Eleanor Reyes, MD — DEMO',
+    specialty: 'Family Medicine',
+    state: 'NM',
+    setting: 'Rural FQHC, Northern New Mexico',
+    delayPain:
+      'Rural FQHCs lose recruiting bandwidth when credentialing each clinician takes ~100 days. Source-backed readiness shortens the loop.',
+    employerNextAction:
+      'Move forward with conditional offer; flag state-board lane for institutional follow-up.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'High',
+    readinessScore: 78,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; family medicine taxonomy resolved.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion match.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'source_backed', tier: 'T3', detail: 'Medicare enrollment active.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board', shortName: 'State', status: 'access_required', tier: 'T3', detail: 'NM state-board portal requires institutional access; not a clinician defect.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'MD — University of New Mexico', issuer: 'UNM Registrar', issuedOn: '2015-05-20', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'ABFM Family Medicine', issuer: 'American Board of Family Medicine', issuedOn: '2018-11-12', expiresOn: '2028-11-12', freshness: 'current', tier: 'T4' },
+    ],
+  },
+
+  // 2. Locum tenens hospitalist
+  {
+    personaKey: 'locum-tenens-hospitalist',
+    npi: '1700100002',
+    isSyntheticNpi: true,
+    displayName: 'Dr. Marcus Han, MD — DEMO',
+    specialty: 'Internal Medicine (Hospitalist)',
+    state: 'multi-state (CA, OR, NV)',
+    setting: 'Locum tenens — short-term coverage across 3 states',
+    delayPain:
+      'Each new contract restarts credentialing from zero. A reusable readiness preview cuts the per-engagement onboarding tail.',
+    employerNextAction:
+      'Confirm readiness for next engagement; reuse prior issuer confirmations rather than re-requesting.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'High',
+    readinessScore: 82,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; internal medicine taxonomy.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'source_backed', tier: 'T3', detail: 'Active in PECOS.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board (CA)', shortName: 'CA', status: 'source_backed', tier: 'T3', detail: 'CA license active.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'MD — Johns Hopkins', issuer: 'JHU Registrar', issuedOn: '2012-05-18', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'ABIM Internal Medicine', issuer: 'American Board of Internal Medicine', issuedOn: '2015-09-30', expiresOn: '2025-09-30', freshness: 'expiring_soon', tier: 'T4' },
+    ],
+  },
+
+  // 3. Procedural specialist / cardiothoracic surgeon
+  {
+    personaKey: 'cardiothoracic-surgeon',
+    npi: '1700100003',
+    isSyntheticNpi: true,
+    displayName: 'Dr. Priya Bhatt, MD — DEMO',
+    specialty: 'Cardiothoracic Surgery',
+    state: 'MA',
+    setting: 'Academic medical center, Boston',
+    delayPain:
+      'Procedural specialists carry deep credential portfolios; verification queues run weeks. Reusable confirmation collapses the lookup time per role.',
+    employerNextAction:
+      'Move forward on identity + safety lanes; request issuer confirmation for board-cert recertification before privileging decision.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'High',
+    readinessScore: 85,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; cardiothoracic surgery taxonomy.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'source_backed', tier: 'T3', detail: 'Active in PECOS.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board (MA)', shortName: 'MA', status: 'access_required', tier: 'T3', detail: 'MA portal requires institutional access.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'MD — Harvard Medical School', issuer: 'HMS Registrar', issuedOn: '2008-05-29', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'ABTS Thoracic Surgery', issuer: 'American Board of Thoracic Surgery', issuedOn: '2015-12-04', expiresOn: '2025-12-04', freshness: 'expiring_soon', tier: 'T4' },
+      { name: 'BLS / ACLS', issuer: 'AHA', issuedOn: '2024-09-15', expiresOn: '2026-09-15', freshness: 'expiring_soon', tier: 'T4' },
+    ],
+  },
+
+  // 4. International Medical Graduate (IMG)
+  {
+    personaKey: 'img-internal-medicine',
+    npi: '1700100004',
+    isSyntheticNpi: true,
+    displayName: 'Dr. Adaobi Nwosu, MBBS — DEMO',
+    specialty: 'Internal Medicine (IMG)',
+    state: 'TX',
+    setting: 'County hospital, El Paso — recent residency completion',
+    delayPain:
+      'IMGs face longer verification cycles due to international credentials; clinicians spend months re-explaining the same artifacts to each reviewer.',
+    employerNextAction:
+      'Request issuer confirmation for primary degree (foreign registrar); review ECFMG attestation; continue source-backed onboarding.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'Moderate',
+    readinessScore: 62,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; internal medicine taxonomy.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'pending', tier: 'T3', detail: 'Initial PECOS enrollment in progress.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board (TX)', shortName: 'TX', status: 'source_backed', tier: 'T3', detail: 'TX physician license active.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'MBBS — University of Lagos', issuer: 'University of Lagos Registrar', issuedOn: '2013-07-22', tier: 'T3', freshness: 'no_expiry' },
+      { name: 'ECFMG Certification', issuer: 'ECFMG', issuedOn: '2019-04-30', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'BLS', issuer: 'AHA', issuedOn: '2024-10-01', expiresOn: '2026-10-01', freshness: 'expiring_soon', tier: 'T4' },
+    ],
+  },
+
+  // 5. Nurse Practitioner in a restricted-practice state
+  {
+    personaKey: 'np-restricted-practice',
+    npi: '1700100005',
+    isSyntheticNpi: true,
+    displayName: 'Sarah Chen, FNP-C — DEMO',
+    specialty: 'Family Nurse Practitioner',
+    state: 'FL (restricted practice)',
+    setting: 'Independent primary care clinic, Tampa',
+    delayPain:
+      'Restricted-practice states require collaborative-agreement verification on top of standard credentialing; readiness preview surfaces what is missing before the contract starts.',
+    employerNextAction:
+      'Verify collaborative agreement; confirm board certification; move forward on identity + safety lanes.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'Moderate',
+    readinessScore: 65,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; FNP taxonomy.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'source_backed', tier: 'T3', detail: 'Active in PECOS.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board (FL)', shortName: 'FL', status: 'access_required', tier: 'T3', detail: 'FL FNP portal requires institutional access; collaborative-agreement check is separate.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'MSN — University of Florida', issuer: 'UF Registrar', issuedOn: '2017-08-04', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'AANP FNP-C Certification', issuer: 'AANP', issuedOn: '2018-01-15', expiresOn: '2028-01-15', freshness: 'current', tier: 'T4' },
+    ],
+  },
+
+  // 6. Telehealth clinician crossing multiple states
+  {
+    personaKey: 'telehealth-multi-state',
+    npi: '1700100006',
+    isSyntheticNpi: true,
+    displayName: 'Dr. Liam O’Sullivan, DO — DEMO',
+    specialty: 'Internal Medicine (Telehealth)',
+    state: 'multi-state (NY, NJ, PA, CT)',
+    setting: 'Telehealth network, virtual-first practice',
+    delayPain:
+      'Telehealth clinicians need parallel state-board verification across multiple jurisdictions. A reusable readiness preview shows which states are covered before patient routing.',
+    employerNextAction:
+      'Confirm state-board licensure across the 4 jurisdictions; move forward where state lane is source-backed; defer routing in states where lane is access-required.',
+    lastCheckedAt: NOW,
+    readinessLevel: 'High',
+    readinessScore: 75,
+    sources: [
+      { id: 'nppes', name: 'NPPES Registry', shortName: 'NPPES', status: 'source_backed', tier: 'T3', detail: 'Active NPI; internal medicine taxonomy.', checkedAt: NOW },
+      { id: 'oig', name: 'OIG LEIE', shortName: 'OIG', status: 'source_backed', tier: 'T3', detail: 'No federal exclusion.', checkedAt: NOW },
+      { id: 'pecos', name: 'CMS PECOS', shortName: 'PECOS', status: 'source_backed', tier: 'T3', detail: 'Active in PECOS.', checkedAt: NOW },
+      { id: 'state_board', name: 'State Board (NY)', shortName: 'NY', status: 'source_backed', tier: 'T3', detail: 'NY DO license active.', checkedAt: NOW },
+    ],
+    credentials: [
+      { name: 'DO — Philadelphia College of Osteopathic Medicine', issuer: 'PCOM Registrar', issuedOn: '2014-05-25', tier: 'T4', freshness: 'no_expiry' },
+      { name: 'ABIM Internal Medicine', issuer: 'American Board of Internal Medicine', issuedOn: '2017-10-12', expiresOn: '2027-10-12', freshness: 'current', tier: 'T4' },
+    ],
+  },
+] as const;
+
+// Convenience export so existing /demo/clinician code can pick a primary
+// persona without changes if it already imports a single DEMO_CLINICIAN
+// constant.
+export const DEMO_CLINICIAN: DemoClinician = DEMO_PERSONAS[0];
+
+// ── Employer queue (uses persona NPIs above) ──────────────────────────────
+
+export interface DemoEmployerApplication {
+  applicationId: string;
+  candidate: {
+    npi: string;
+    displayName: string;
+    specialty: string;
+    setting?: string;
+  };
+  appliedAt: string;
+  /** When the source-backed readiness was last refreshed for this candidate. */
+  sourceCheckedAt: string;
+  sourcesCompleted: number;
+  sourcesTotal: number;
+  role: string;
+  organization: string;
+  state: 'review_recommended' | 'move_forward' | 'waiting_on_sources';
+  highlights: ReadonlyArray<string>;
+  cautions: ReadonlyArray<string>;
+}
+
+export const DEMO_EMPLOYER_APPLICATIONS: ReadonlyArray<DemoEmployerApplication> = [
+  {
+    applicationId: 'app-' + DEMO_PERSONAS[1].npi + '-locum',
+    candidate: { npi: DEMO_PERSONAS[1].npi, displayName: DEMO_PERSONAS[1].displayName, specialty: DEMO_PERSONAS[1].specialty, setting: DEMO_PERSONAS[1].setting },
+    appliedAt: '2026-05-13T19:00:00.000Z',
+    sourceCheckedAt: '2026-05-16T14:42:00.000Z',
+    sourcesCompleted: 4,
+    sourcesTotal: 4,
+    role: 'Hospitalist — IM',
+    organization: 'Bay Area Health Network — DEMO',
+    state: 'move_forward',
+    highlights: ['NPPES, OIG LEIE, PECOS, and CA state board all source-backed.', 'ABIM recertification due 2025-09; on track.'],
+    cautions: ['ABIM expires within ~12 months — note for privileging cycle.'],
+  },
+  {
+    applicationId: 'app-' + DEMO_PERSONAS[3].npi + '-img',
+    candidate: { npi: DEMO_PERSONAS[3].npi, displayName: DEMO_PERSONAS[3].displayName, specialty: DEMO_PERSONAS[3].specialty, setting: DEMO_PERSONAS[3].setting },
+    appliedAt: '2026-05-14T11:30:00.000Z',
+    sourceCheckedAt: '2026-05-16T14:15:00.000Z',
+    sourcesCompleted: 3,
+    sourcesTotal: 4,
+    role: 'Hospitalist — IM',
+    organization: 'County Hospital, El Paso — DEMO',
+    state: 'review_recommended',
+    highlights: ['NPPES identity resolved.', 'TX state license active.', 'ECFMG certification on file.'],
+    cautions: ['Initial PECOS enrollment still in progress — readiness preview will refresh when source responds.'],
+  },
+  {
+    applicationId: 'app-' + DEMO_PERSONAS[4].npi + '-np',
+    candidate: { npi: DEMO_PERSONAS[4].npi, displayName: DEMO_PERSONAS[4].displayName, specialty: DEMO_PERSONAS[4].specialty, setting: DEMO_PERSONAS[4].setting },
+    appliedAt: '2026-05-14T16:45:00.000Z',
+    sourceCheckedAt: '2026-05-16T13:58:00.000Z',
+    sourcesCompleted: 3,
+    sourcesTotal: 4,
+    role: 'FNP — Primary Care',
+    organization: 'Independent clinic, Tampa — DEMO',
+    state: 'waiting_on_sources',
+    highlights: ['NPPES identity resolved.', 'AANP FNP-C certification active.'],
+    cautions: ['FL state-board portal requires institutional access — collaborative-agreement check is separate; not a clinician defect.'],
+  },
+];
+
+// ── Issuer requests with audit trails ─────────────────────────────────────
+
+export interface DemoIssuerRequest {
+  requestId: string;
+  claimType: 'education_degree' | 'board_certification' | 'employment_history';
+  claimSummary: string;
+  candidateName: string;
+  candidateNpi: string;
+  issuerOrg: string;
+  status: 'received' | 'in_review' | 'confirmed' | 'unable_to_verify';
+  receivedAt: string;
+  notes?: string;
+  /** Audit trail entries — who/what/when, in chronological order. */
+  audit: ReadonlyArray<{ at: string; actor: string; action: string }>;
+}
+
+export const DEMO_ISSUER_REQUESTS: ReadonlyArray<DemoIssuerRequest> = [
+  {
+    requestId: 'req-001',
+    claimType: 'education_degree',
+    claimSummary: 'MD — University of New Mexico, 2015 (DEMO)',
+    candidateName: DEMO_PERSONAS[0].displayName,
+    candidateNpi: DEMO_PERSONAS[0].npi,
+    issuerOrg: 'UNM Registrar — DEMO',
+    status: 'confirmed',
+    receivedAt: '2026-05-12T10:15:00.000Z',
+    notes: 'Confirmed via registrar portal; degree on file 2015-05-20.',
+    audit: [
+      { at: '2026-05-12T10:15:00.000Z', actor: 'system', action: 'Request received' },
+      { at: '2026-05-12T11:02:00.000Z', actor: 'registrar.demo', action: 'Opened for review' },
+      { at: '2026-05-13T09:24:00.000Z', actor: 'registrar.demo', action: 'Confirmed — degree on file' },
+    ],
+  },
+  {
+    requestId: 'req-002',
+    claimType: 'board_certification',
+    claimSummary: 'ABIM Internal Medicine, due for recertification 2025 (DEMO)',
+    candidateName: DEMO_PERSONAS[1].displayName,
+    candidateNpi: DEMO_PERSONAS[1].npi,
+    issuerOrg: 'American Board of Internal Medicine — DEMO',
+    status: 'in_review',
+    receivedAt: '2026-05-14T14:00:00.000Z',
+    audit: [
+      { at: '2026-05-14T14:00:00.000Z', actor: 'system', action: 'Request received' },
+      { at: '2026-05-15T08:30:00.000Z', actor: 'abim.demo', action: 'Opened for review' },
+    ],
+  },
+  {
+    requestId: 'req-003',
+    claimType: 'employment_history',
+    claimSummary: 'Bay Area Health Network — Hospitalist, 2022-2024 (DEMO)',
+    candidateName: DEMO_PERSONAS[4].displayName,
+    candidateNpi: DEMO_PERSONAS[4].npi,
+    issuerOrg: 'Bay Area Health Network HR — DEMO',
+    status: 'unable_to_verify',
+    receivedAt: '2026-05-13T09:00:00.000Z',
+    notes: 'HR unable to confirm dates; clinician asked to provide pay stubs or W-2.',
+    audit: [
+      { at: '2026-05-13T09:00:00.000Z', actor: 'system', action: 'Request received' },
+      { at: '2026-05-13T15:18:00.000Z', actor: 'hr.demo', action: 'Opened for review' },
+      { at: '2026-05-14T10:42:00.000Z', actor: 'hr.demo', action: 'Marked unable to verify (records unavailable)' },
+      { at: '2026-05-14T11:00:00.000Z', actor: 'system', action: 'Notified clinician — additional artifacts requested' },
+    ],
+  },
+];
+
+// ── Display label constants ───────────────────────────────────────────────
+
+export const STATE_LABEL: Record<DemoEmployerApplication['state'], string> = {
+  review_recommended: 'Review recommended',
+  move_forward: 'Move forward',
+  waiting_on_sources: 'Waiting on sources',
+};
+
+export const STATUS_LABEL: Record<DemoSource['status'], string> = {
+  source_backed: 'Source-backed',
+  access_required: 'Access required',
+  pending: 'Pending',
+  not_yet: 'Not yet',
+};
+
+export const ISSUER_STATUS_LABEL: Record<DemoIssuerRequest['status'], string> = {
+  received: 'Received',
+  in_review: 'In review',
+  confirmed: 'Confirmed',
+  unable_to_verify: 'Unable to verify',
+};

--- a/apps/web/app/demo/clinician/page.tsx
+++ b/apps/web/app/demo/clinician/page.tsx
@@ -1,0 +1,209 @@
+import * as React from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { Button } from '@/components/ui/button';
+import {
+  DEMO_PERSONAS,
+  STATUS_LABEL,
+  type DemoClinician,
+  type DemoSource,
+} from '../_seed';
+
+export const metadata: Metadata = {
+  title: 'Clinician demo · VitalCV',
+  description:
+    "What a clinician sees when their NPI's source-backed readiness preview renders. Fixture data — illustrative; not a live source-check.",
+};
+
+const FRESHNESS_LABEL = {
+  current: 'Current',
+  expiring_soon: 'Expiring soon',
+  expired: 'Expired',
+  no_expiry: 'No expiry',
+} as const;
+
+function freshnessTone(f: 'current' | 'expiring_soon' | 'expired' | 'no_expiry'): string {
+  if (f === 'current') return 'text-emerald-600 dark:text-emerald-400';
+  if (f === 'expiring_soon') return 'text-amber-600 dark:text-amber-400';
+  if (f === 'expired') return 'text-destructive';
+  return 'text-muted-foreground';
+}
+
+function shortTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function statusTone(status: DemoSource['status']): string {
+  switch (status) {
+    case 'source_backed':
+      return 'text-emerald-600 dark:text-emerald-400';
+    case 'access_required':
+      return 'text-amber-600 dark:text-amber-400';
+    case 'pending':
+    case 'not_yet':
+    default:
+      return 'text-muted-foreground';
+  }
+}
+
+function PersonaCard({ c }: { c: DemoClinician }) {
+  return (
+    <article className="rounded-md border border-border bg-card p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Persona · Demo · Illustrative
+          </p>
+          <h2 className="mt-2 text-lg font-semibold leading-snug text-foreground">
+            {c.displayName}
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {c.specialty} · NPI <span className="font-mono">{c.npi}</span> · {c.state}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Setting: {c.setting}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Readiness preview
+          </p>
+          <p className="mt-1 font-mono text-xl font-semibold tabular-nums text-foreground">
+            {c.readinessScore}/100
+          </p>
+          <p className="text-[10px] text-muted-foreground">{c.readinessLevel}</p>
+        </div>
+      </div>
+
+      <p className="mt-3 rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+        <span className="font-medium text-foreground">Pain:</span> {c.delayPain}
+      </p>
+
+      {/* Source rows */}
+      <div className="mt-4 rounded-md border border-border bg-card p-2">
+        <ul className="divide-y divide-border">
+          {c.sources.map((s) => (
+            <li
+              key={s.id}
+              className="flex items-start justify-between gap-4 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">{s.name}</p>
+                  <span className="rounded-sm border border-border px-1.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
+                    {s.tier}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  {s.detail}
+                </p>
+                <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+                  Checked {shortTime(s.checkedAt)} · demo fixture
+                </p>
+              </div>
+              <p className={`shrink-0 text-xs font-medium ${statusTone(s.status)}`}>
+                {STATUS_LABEL[s.status]}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Credentials */}
+      <div className="mt-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Credentials on file
+        </p>
+        <div className="mt-2 rounded-md border border-border bg-card">
+          <ul className="divide-y divide-border">
+            {c.credentials.map((cred) => (
+              <li
+                key={cred.name}
+                className="flex items-start justify-between gap-4 px-4 py-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">{cred.name}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {cred.issuer} · Issued {cred.issuedOn}
+                    {cred.expiresOn ? ` · Expires ${cred.expiresOn}` : ''}
+                  </p>
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="rounded-sm border border-border px-1.5 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
+                    {cred.tier}
+                  </span>
+                  <span className={`text-[10px] font-medium ${freshnessTone(cred.freshness)}`}>
+                    {FRESHNESS_LABEL[cred.freshness]}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+        <span className="font-medium text-foreground">Employer next action:</span>{' '}
+        {c.employerNextAction}
+      </p>
+    </article>
+  );
+}
+
+export default function ClinicianDemoPage() {
+  return (
+    <main className="bg-background min-h-screen">
+      <header className="border-b border-border">
+        <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:py-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Clinician demo · Illustrative
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+            Finally reusable.
+          </h1>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            Source-backed readiness previews across six demo personas. Each
+            persona uses a synthetic NPI — labeled &quot;Demo&quot; — and renders
+            from in-repo fixtures. The shape matches what the live product
+            produces against real public sources.
+          </p>
+          <p className="mt-3 rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Boundary:</span>{' '}
+            VitalCV is a credentialing head start, not a final credentialing
+            decision. Hospital credentialing committees still own the
+            privileging cycle.
+          </p>
+        </div>
+      </header>
+
+      <section className="mx-auto w-full max-w-4xl px-4 py-8 sm:py-10 space-y-6">
+        {DEMO_PERSONAS.map((p) => (
+          <PersonaCard key={p.personaKey} c={p} />
+        ))}
+      </section>
+
+      <section className="mx-auto w-full max-w-4xl px-4 pb-12 sm:pb-16">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button asChild>
+            <Link href="/demo/employer">See employer view →</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/passport">Try with your NPI</Link>
+          </Button>
+          <Link
+            href="/demo"
+            className="text-sm font-medium text-foreground/70 underline-offset-4 hover:underline"
+          >
+            ← All demos
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/demo/employer/page.tsx
+++ b/apps/web/app/demo/employer/page.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { Button } from '@/components/ui/button';
+import { RoiCalculator } from '@/components/demo/RoiCalculator';
+import { EquityRetentionBlock } from '@/components/demo/EquityRetentionBlock';
+import {
+  DEMO_EMPLOYER_APPLICATIONS,
+  STATE_LABEL,
+  type DemoEmployerApplication,
+} from '../_seed';
+
+export const metadata: Metadata = {
+  title: 'Employer demo · VitalCV',
+  description:
+    'How an employer reviewer sees source-backed readiness across three review states, plus an illustrative ROI calculator and equity-retention research signals. Fixture data — illustrative.',
+};
+
+function stateTone(state: DemoEmployerApplication['state']): string {
+  switch (state) {
+    case 'move_forward':
+      return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400';
+    case 'review_recommended':
+      return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400';
+    case 'waiting_on_sources':
+    default:
+      return 'border-border bg-muted text-muted-foreground';
+  }
+}
+
+function shortTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatAt(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export default function EmployerDemoPage() {
+  const apps = DEMO_EMPLOYER_APPLICATIONS;
+  const counts = {
+    move_forward: apps.filter((a) => a.state === 'move_forward').length,
+    review_recommended: apps.filter((a) => a.state === 'review_recommended').length,
+    waiting_on_sources: apps.filter((a) => a.state === 'waiting_on_sources').length,
+  };
+
+  return (
+    <main className="bg-background min-h-screen">
+      <header className="border-b border-border">
+        <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:py-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Employer demo · Illustrative
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+            Accept as credentialing head start.
+          </h1>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            Three applications across the three review states a reviewer
+            actually sees. Source-backed highlights, honest cautions, no
+            re-submission paperwork. The reviewer picks the next action;
+            VitalCV does not make the credentialing decision.
+          </p>
+          <p className="mt-3 rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Boundary:</span>{' '}
+            VitalCV supports review decisions; it does not replace hospital
+            credentialing committees.
+          </p>
+        </div>
+      </header>
+
+      <section className="mx-auto w-full max-w-5xl px-4 py-8 sm:py-10">
+        {/* Summary chips */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-400">
+              Move forward
+            </p>
+            <p className="mt-2 text-2xl font-semibold tabular-nums text-foreground">
+              {counts.move_forward}
+            </p>
+          </div>
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-700 dark:text-amber-400">
+              Review recommended
+            </p>
+            <p className="mt-2 text-2xl font-semibold tabular-nums text-foreground">
+              {counts.review_recommended}
+            </p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/40 p-4">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Waiting on sources
+            </p>
+            <p className="mt-2 text-2xl font-semibold tabular-nums text-foreground">
+              {counts.waiting_on_sources}
+            </p>
+          </div>
+        </div>
+
+        {/* Application rows */}
+        <div className="mt-8 space-y-3">
+          {apps.map((a) => (
+            <article
+              key={a.applicationId}
+              className="rounded-md border border-border bg-card p-5 sm:p-6"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {a.role} · {a.organization}
+                  </p>
+                  <h2 className="mt-2 text-lg font-semibold leading-snug text-foreground">
+                    {a.candidate.displayName}
+                  </h2>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {a.candidate.specialty} · NPI{' '}
+                    <span className="font-mono">{a.candidate.npi}</span> ·
+                    Applied {formatAt(a.appliedAt)}
+                  </p>
+                  {a.candidate.setting && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Setting: {a.candidate.setting}
+                    </p>
+                  )}
+                  <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+                    Sources {a.sourcesCompleted}/{a.sourcesTotal} · Last refreshed {shortTime(a.sourceCheckedAt)}
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium ${stateTone(a.state)}`}
+                >
+                  {STATE_LABEL[a.state]}
+                </span>
+              </div>
+
+              {a.highlights.length > 0 && (
+                <div className="mt-4">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    Highlights
+                  </p>
+                  <ul className="mt-2 space-y-1.5 text-sm text-foreground/80">
+                    {a.highlights.map((h, i) => (
+                      <li key={i} className="flex gap-2">
+                        <span className="text-emerald-600 dark:text-emerald-400">✓</span>
+                        <span>{h}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {a.cautions.length > 0 && (
+                <div className="mt-4">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    Cautions
+                  </p>
+                  <ul className="mt-2 space-y-1.5 text-sm text-foreground/80">
+                    {a.cautions.map((cn, i) => (
+                      <li key={i} className="flex gap-2">
+                        <span className="text-amber-600 dark:text-amber-400">⚠</span>
+                        <span>{cn}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="mt-5 flex flex-wrap items-center gap-2">
+                <Button size="sm" variant={a.state === 'move_forward' ? 'default' : 'outline'}>
+                  Move forward
+                </Button>
+                <Button size="sm" variant="outline">Request review</Button>
+                <Button size="sm" variant="outline">Mark follow-up</Button>
+                <span className="ml-auto text-xs text-muted-foreground">
+                  Reviewer choice. No automatic decision.
+                </span>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        {/* Interactive ROI calculator */}
+        <div className="mt-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Illustrative ROI
+          </p>
+          <RoiCalculator className="mt-3" defaultSpecialty="primary_care" />
+        </div>
+
+        {/* Equity & retention research signals */}
+        <div className="mt-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Why retention matters
+          </p>
+          <EquityRetentionBlock className="mt-3" />
+        </div>
+
+        {/* Footer */}
+        <div className="mt-10 flex flex-wrap items-center gap-3">
+          <Button asChild variant="outline">
+            <Link href="/demo/clinician">← Clinician view</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/demo/issuer">Issuer view →</Link>
+          </Button>
+          <Link
+            href="/demo"
+            className="text-sm font-medium text-foreground/70 underline-offset-4 hover:underline"
+          >
+            All demos
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/demo/issuer/page.tsx
+++ b/apps/web/app/demo/issuer/page.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { Button } from '@/components/ui/button';
+import {
+  DEMO_ISSUER_REQUESTS,
+  ISSUER_STATUS_LABEL,
+  type DemoIssuerRequest,
+} from '../_seed';
+
+export const metadata: Metadata = {
+  title: 'Issuer demo · VitalCV',
+  description:
+    'How an issuer (registrar, board, employer-HR) sees and resolves verification requests. Fixture data — illustrative; recorded as demo attribution.',
+};
+
+function statusTone(status: DemoIssuerRequest['status']): string {
+  switch (status) {
+    case 'confirmed':
+      return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400';
+    case 'in_review':
+      return 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-400';
+    case 'received':
+      return 'border-border bg-muted text-foreground';
+    case 'unable_to_verify':
+    default:
+      return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400';
+  }
+}
+
+function shortTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+const CLAIM_TYPE_LABEL: Record<DemoIssuerRequest['claimType'], string> = {
+  education_degree: 'Education / Degree',
+  board_certification: 'Board Certification',
+  employment_history: 'Employment History',
+};
+
+export default function IssuerDemoPage() {
+  const reqs = DEMO_ISSUER_REQUESTS;
+
+  return (
+    <main className="bg-background min-h-screen">
+      <header className="border-b border-border">
+        <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:py-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Issuer demo · Illustrative
+          </p>
+          <h1 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+            Confirm once, reduce repeat questions.
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+            Three live request shapes: confirmed, in-review, and
+            unable-to-verify. Each carries an audit trail; the issuer
+            (registrar, board, HR) makes the call. VitalCV records the
+            outcome and makes it reusable for the next reviewer — your
+            verification work compounds instead of repeating.
+          </p>
+          <p className="mt-3 rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Boundary:</span>{' '}
+            Issuer decisions are attributable. VitalCV does not make a final
+            credentialing decision on behalf of any issuer.
+          </p>
+        </div>
+      </header>
+
+      <section className="mx-auto w-full max-w-4xl px-4 py-8 sm:py-10">
+        <div className="space-y-3">
+          {reqs.map((r) => (
+            <article
+              key={r.requestId}
+              className="rounded-md border border-border bg-card p-5 sm:p-6"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {CLAIM_TYPE_LABEL[r.claimType]} · Request {r.requestId}
+                  </p>
+                  <h2 className="mt-2 text-base font-semibold leading-snug text-foreground">
+                    {r.claimSummary}
+                  </h2>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Subject: {r.candidateName} · NPI{' '}
+                    <span className="font-mono">{r.candidateNpi}</span>
+                    <br />
+                    Issuer: {r.issuerOrg}
+                  </p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Received {shortTime(r.receivedAt)} · demo fixture
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium ${statusTone(r.status)}`}
+                >
+                  {ISSUER_STATUS_LABEL[r.status]}
+                </span>
+              </div>
+
+              {r.notes && (
+                <div className="mt-4 rounded-md border border-border bg-background p-3">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    Notes
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-foreground/80">
+                    {r.notes}
+                  </p>
+                </div>
+              )}
+
+              {r.audit.length > 0 && (
+                <div className="mt-4 rounded-md border border-border bg-background p-3">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    Audit trail
+                  </p>
+                  <ol className="mt-2 space-y-1.5">
+                    {r.audit.map((entry, i) => (
+                      <li key={i} className="flex items-start gap-3 text-xs">
+                        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                          {shortTime(entry.at)}
+                        </span>
+                        <span className="shrink-0 rounded-sm border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                          {entry.actor}
+                        </span>
+                        <span className="text-foreground/80">{entry.action}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+
+              <div className="mt-5 flex flex-wrap items-center gap-2">
+                {r.status === 'received' && (
+                  <>
+                    <Button size="sm">Start review</Button>
+                    <Button size="sm" variant="outline">Decline</Button>
+                  </>
+                )}
+                {r.status === 'in_review' && (
+                  <>
+                    <Button size="sm">Confirm</Button>
+                    <Button size="sm" variant="outline">Mark unable to verify</Button>
+                    <Button size="sm" variant="outline">Request additional info</Button>
+                  </>
+                )}
+                {r.status === 'confirmed' && (
+                  <>
+                    <Button size="sm" variant="outline">View receipt</Button>
+                    <span className="text-xs text-muted-foreground">
+                      Issuer-confirmed; available for reuse by next reviewer.
+                    </span>
+                  </>
+                )}
+                {r.status === 'unable_to_verify' && (
+                  <>
+                    <Button size="sm" variant="outline">Notify clinician</Button>
+                    <span className="text-xs text-muted-foreground">
+                      No fault to clinician; reviewer may request additional artifacts.
+                    </span>
+                  </>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-10 rounded-md border border-border bg-muted/30 p-5 sm:p-6">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Issuer truth contract
+          </p>
+          <ul className="mt-3 space-y-2 text-xs leading-relaxed text-muted-foreground">
+            <li>
+              Issuer decisions are <strong>attributable</strong> — every
+              outcome carries who recorded it, when, and on what basis.
+            </li>
+            <li>
+              Unable-to-verify is <strong>not a failure of the clinician</strong> —
+              it is a property of the issuer&apos;s lookup, recorded as such.
+            </li>
+            <li>
+              A confirmed result is <strong>re-usable by the next reviewer</strong> —
+              the same clinician does not have to be re-verified by every
+              employer.
+            </li>
+          </ul>
+        </div>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <Button asChild variant="outline">
+            <Link href="/demo/employer">← Employer view</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/demo/clinician">Clinician view</Link>
+          </Button>
+          <Link
+            href="/demo"
+            className="text-sm font-medium text-foreground/70 underline-offset-4 hover:underline"
+          >
+            All demos
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = {
+  title: 'Demo · VitalCV',
+  description:
+    'Three demo flows (clinician, employer, issuer) showing how VitalCV renders source-backed readiness as a credentialing head start. Fixture data; no real ingest.',
+};
+
+const TRACKS = [
+  {
+    audience: 'Clinician',
+    href: '/demo/clinician',
+    title: 'See what is ready before paperwork.',
+    body: 'One source-backed readiness preview across NPPES, OIG, PECOS, and state board. See which lanes are source-backed, which are gated, and which still need review.',
+  },
+  {
+    audience: 'Employer',
+    href: '/demo/employer',
+    title: 'Accept as credentialing head start.',
+    body: 'Three applications across the review states a reviewer actually sees. Source-backed highlights, honest cautions, illustrative ROI math — and an interactive calculator.',
+  },
+  {
+    audience: 'Issuer',
+    href: '/demo/issuer',
+    title: 'Confirm once, reduce repeat questions.',
+    body: 'See how a verification request is received, reviewed, and resolved — with explicit attribution and an audit trail.',
+  },
+] as const;
+
+export default function DemoIndexPage() {
+  return (
+    <main className="bg-background min-h-screen">
+      <section className="border-b border-border">
+        <div className="mx-auto w-full max-w-4xl px-4 py-12 sm:py-16">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Demo · Illustrative
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+            Three flows. Same readiness layer.
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Each demo uses fixture data, not a live ingest run. The vocabulary,
+            tier ladder, and source-honest framing match the production product.
+            No claims here that the live product does not make.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <div className="mx-auto w-full max-w-4xl px-4 py-12 sm:py-16">
+          <div className="grid gap-4 sm:grid-cols-3">
+            {TRACKS.map((t) => (
+              <article
+                key={t.audience}
+                className="flex flex-col rounded-md border border-border bg-card p-6"
+              >
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  For {t.audience.toLowerCase()}s
+                </p>
+                <h2 className="mt-3 text-lg font-semibold leading-snug text-foreground">
+                  {t.title}
+                </h2>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+                  {t.body}
+                </p>
+                <Button asChild className="mt-6" variant="outline">
+                  <Link href={t.href}>Open {t.audience.toLowerCase()} demo</Link>
+                </Button>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border bg-muted/30">
+        <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:py-12">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Demo posture:</span>{' '}
+            All three flows render from in-repo fixtures. None requires a
+            database, a Vercel deployment, or a backend API. They are
+            reproducible on any machine that can run{' '}
+            <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+              pnpm --filter @vitalcv/web dev
+            </code>
+            . VitalCV supports review decisions; it does not replace hospital
+            credentialing committees.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/launch/page.tsx
+++ b/apps/web/app/launch/page.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+import { Button } from '@/components/ui/button';
+import { RoiCalculator } from '@/components/demo/RoiCalculator';
+import { EquityRetentionBlock } from '@/components/demo/EquityRetentionBlock';
+
+/**
+ * /launch — belief-first public landing pad.
+ *
+ * Above-the-fold goal: a hospital operator understands the value in
+ * 10 seconds. Headline = primary message; subhead = scope + boundary;
+ * 3 audience cards = the persona pitches; followed by an illustrative
+ * ROI block, the "does today / remains manual" honest scope block,
+ * and a direct-contact section.
+ *
+ * No backend dependency. No env vars required. Renders identically
+ * on a fresh laptop.
+ *
+ * Foundation-honest framing: claims only what the product actually
+ * does. Explicit truth boundary: VitalCV supports review decisions;
+ * it does not replace hospital credentialing committees.
+ */
+
+export const metadata: Metadata = {
+  title: 'VitalCV — Reusable, source-backed clinician readiness.',
+  description:
+    'Start with an NPI. See what is source-backed, what is gated, and what still needs review before the paperwork starts. VitalCV supports review decisions; it does not replace hospital credentialing committees.',
+};
+
+interface PathCard {
+  audience: 'For employers' | 'For clinicians' | 'For issuers';
+  title: string;
+  body: string;
+  cta: { label: string; href: string };
+}
+
+// Employer-first ordering: hospital operators are the primary 10-second audience.
+const PATHS: ReadonlyArray<PathCard> = [
+  {
+    audience: 'For employers',
+    title: 'Accept as credentialing head start.',
+    body: 'Treat source-backed readiness as the head start your committee builds on — not as a replacement for the privileging cycle.',
+    cta: { label: 'See the employer view →', href: '/demo/employer' },
+  },
+  {
+    audience: 'For clinicians',
+    title: 'See what is ready before paperwork.',
+    body: 'One NPI, one preview. Know which lanes are source-backed, which are gated, and which still need review.',
+    cta: { label: 'See the clinician view →', href: '/demo/clinician' },
+  },
+  {
+    audience: 'For issuers',
+    title: 'Confirm once, reduce repeat questions.',
+    body: 'A single issuer confirmation carries forward to the next reviewer. Less queue. Less redundant verification.',
+    cta: { label: 'See the issuer view →', href: '/demo/issuer' },
+  },
+] as const;
+
+const TRUST_STEPS = [
+  { tier: 'T1', label: 'Self-asserted', note: 'Clinician typed it.' },
+  { tier: 'T2', label: 'AI-inferred', note: 'Extracted from clinician-supplied artifacts.' },
+  { tier: 'T3', label: 'Source-checked', note: 'Verified against a primary source (NPPES / OIG / PECOS / state board).' },
+  { tier: 'T4', label: 'Issuer-signed', note: 'Cryptographically signed by the issuing authority.' },
+] as const;
+
+export default function LaunchPage() {
+  return (
+    <main className="bg-background min-h-screen">
+      {/* Hero — designed for a 10-second scan. */}
+      <section className="border-b border-border">
+        <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:py-24">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            VitalCV
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold leading-tight tracking-tight text-foreground sm:text-5xl">
+            Reusable, source-backed clinician readiness.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Start with an NPI. See what is source-backed, what is gated, and
+            what still needs review before the paperwork starts.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Button asChild size="lg">
+              <Link href="/demo/employer">See the employer view</Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href="/passport">Try with an NPI</Link>
+            </Button>
+            <Link
+              href="/demo/clinician"
+              className="text-sm font-medium text-foreground/70 underline-offset-4 hover:underline"
+            >
+              How it works for clinicians →
+            </Link>
+          </div>
+
+          {/* Truth boundary — explicit and adjacent to the hero CTAs. */}
+          <p className="mt-6 max-w-2xl rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">
+              VitalCV supports review decisions;
+            </span>{' '}
+            it does not replace hospital credentialing committees.
+          </p>
+        </div>
+      </section>
+
+      {/* Three audience cards. */}
+      <section className="border-b border-border bg-muted/30">
+        <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:py-20">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            One readiness layer. Three audiences.
+          </p>
+          <div className="mt-8 grid gap-6 md:grid-cols-3">
+            {PATHS.map((p) => (
+              <article
+                key={p.audience}
+                className="flex flex-col rounded-md border border-border bg-card p-6"
+              >
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  {p.audience}
+                </p>
+                <h2 className="mt-3 text-xl font-semibold leading-snug text-foreground">
+                  {p.title}
+                </h2>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+                  {p.body}
+                </p>
+                <Link
+                  href={p.cta.href}
+                  className="mt-6 inline-flex items-center text-sm font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  {p.cta.label}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Authority ladder. */}
+      <section className="border-b border-border">
+        <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:py-20">
+          <div className="grid gap-10 md:grid-cols-[1fr_2fr]">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Authority ladder
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+                Every fact carries its tier.
+              </h2>
+              <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+                Each claim renders with its source tier so the reader knows
+                exactly how far the evidence reaches. No fact is shown without
+                naming who attested it.
+              </p>
+            </div>
+            <ol className="space-y-3">
+              {TRUST_STEPS.map((s) => (
+                <li
+                  key={s.tier}
+                  className="flex items-start gap-4 rounded-md border border-border bg-card p-4"
+                >
+                  <span className="rounded-sm bg-foreground/5 px-2.5 py-1 font-mono text-xs font-semibold text-foreground">
+                    {s.tier}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{s.label}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                      {s.note}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      {/* Illustrative employer ROI block. */}
+      <section className="border-b border-border bg-muted/30">
+        <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:py-20">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            For employers
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+            What the cycle compression is worth — on paper.
+          </h2>
+          <RoiCalculator className="mt-6" defaultSpecialty="primary_care" />
+          <EquityRetentionBlock className="mt-6" />
+        </div>
+      </section>
+
+      {/* Honest scope — does today / remains manual. */}
+      <section className="border-b border-border">
+        <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:py-16">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Operational scope
+          </p>
+          <h2 className="mt-3 text-xl font-semibold leading-snug text-foreground sm:text-2xl">
+            What VitalCV does today.
+          </h2>
+          <div className="mt-6 grid gap-6 sm:grid-cols-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Does today
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-relaxed text-foreground/80">
+                <li className="rounded-md border border-border bg-card p-3">
+                  Reads NPPES, OIG LEIE, and PECOS for a given NPI.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Renders source-backed readiness with explicit tier per fact.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Issues ES256-signed receipts a reviewer can independently verify.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Records issuer outcomes (confirmed / unable-to-verify) with audit trail.
+                </li>
+              </ul>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Remains manual / out of scope
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-relaxed text-muted-foreground">
+                <li className="rounded-md border border-border bg-card p-3">
+                  Hospital credentialing committee — hospitals still own this.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Compliance program — VitalCV is a readiness preview, not certification.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Risk transfer — reviewers remain responsible for their decisions.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  State-board portals requiring institutional access — surfaced as &quot;access required&quot;, not as clinician fault.
+                </li>
+                <li className="rounded-md border border-border bg-card p-3">
+                  Primary-source replacement — VitalCV reads sources; it does not become one.
+                </li>
+              </ul>
+            </div>
+          </div>
+          <p className="mt-6 text-[11px] leading-relaxed text-muted-foreground">
+            Structurally permanent. The &quot;Does today&quot; column grows as
+            features ship; planned features are not promoted into it ahead of
+            code.
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom CTA. */}
+      <section>
+        <div className="mx-auto w-full max-w-5xl px-4 py-16 sm:py-20">
+          <div className="rounded-md border border-border bg-card p-8 sm:p-12">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Apply with VitalCV
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+              Start ready. Stop restarting.
+            </h2>
+            <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+              Each application carries your readiness preview so reviewers see
+              the same source-backed picture you do.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Button asChild size="lg">
+                <Link href="/sign-up">Create your account</Link>
+              </Button>
+              <Button asChild size="lg" variant="outline">
+                <Link href="/demo/employer">See the employer view first</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/demo/EquityRetentionBlock.tsx
+++ b/apps/web/components/demo/EquityRetentionBlock.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { RESEARCH_SIGNALS, MARKET_BENCHMARK_LABELS } from '@/app/demo/_marketData';
+
+/**
+ * EquityRetentionBlock — research-signal block surfacing the equity +
+ * retention dimension of credentialing friction.
+ *
+ * TRUTH POSTURE: every figure is rendered as a RESEARCH SIGNAL, not
+ * a VitalCV-owned measured outcome. The closing line explicitly
+ * narrows VitalCV's role: it addresses one structural source of
+ * repeat administrative burden, not the entire diversity-attrition
+ * problem.
+ */
+
+const SIGNAL_KEYS = [
+  'femalePhysicianAttritionHazard',
+  'femaleMedianExitAge',
+  'blackSurgicalResidentAttrition',
+  'ruralInternationalBornPhysicianShare',
+  'psychiatryAdminBurden',
+  'primaryCareExitRate',
+] as const;
+
+export interface EquityRetentionBlockProps {
+  className?: string;
+}
+
+export function EquityRetentionBlock({ className }: EquityRetentionBlockProps) {
+  return (
+    <section
+      className={cn(
+        'rounded-md border border-border bg-card p-6 sm:p-8',
+        className,
+      )}
+      aria-labelledby="equity-heading"
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        {MARKET_BENCHMARK_LABELS.researchSignal} · equity &amp; retention
+      </p>
+      <h3
+        id="equity-heading"
+        className="mt-2 text-base font-semibold leading-snug text-foreground sm:text-lg"
+      >
+        Credentialing delays are a force multiplier for burnout.
+      </h3>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+        Streamlining trust is not just about speed — it is about retaining
+        clinicians who already carry the highest administrative and
+        structural burden.
+      </p>
+
+      <ul className="mt-5 grid gap-3 sm:grid-cols-2">
+        {SIGNAL_KEYS.map((k) => {
+          const s = RESEARCH_SIGNALS[k];
+          return (
+            <li
+              key={k}
+              className="rounded-md border border-border bg-background p-4"
+            >
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                {s.label}
+              </p>
+              <p className="mt-2 font-mono text-sm font-semibold text-foreground">
+                {s.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {s.context}
+              </p>
+              <p className="mt-2 text-[10px] italic text-muted-foreground">
+                {s.cite}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="mt-6 rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+        <span className="font-medium text-foreground">Truth guard:</span>{' '}
+        VitalCV does not by itself solve diversity attrition. VitalCV
+        addresses one structural source of repeat administrative burden —
+        the credentialing-evidence loop — so the time clinicians spend
+        re-proving the same facts to the next reviewer goes down.
+      </p>
+    </section>
+  );
+}
+
+export default EquityRetentionBlock;

--- a/apps/web/components/demo/RoiCalculator.tsx
+++ b/apps/web/components/demo/RoiCalculator.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import {
+  CBP_CREDENTIALING_DAYS,
+  DAILY_DELAY_COST_HIGH,
+  DAILY_DELAY_COST_LOW,
+  DAYS_SAVED,
+  MARKET_BENCHMARK_LABELS,
+  SPECIALTY_LABEL,
+  SPECIALTY_OPTIONS,
+  TRADITIONAL_CREDENTIALING_DAYS,
+  computeRoiRange,
+  formatUsdCompact,
+  type Specialty,
+} from '@/app/demo/_marketData';
+
+/**
+ * RoiCalculator — interactive illustrative ROI block.
+ *
+ * Inputs (all client-side; no fetch):
+ *   - provider count
+ *   - telehealth originating hospitals
+ *   - specialty selector
+ *
+ * Outputs:
+ *   - days saved (constant per benchmark)
+ *   - daily exposure range
+ *   - total exposure-avoided range (scaled by provider count)
+ *   - specialty-aware narrative line
+ *   - telehealth multiplier disclosure when originating hospitals > 1
+ *
+ * TRUTH POSTURE: every number is labeled "illustrative market
+ * benchmark — not a guaranteed VitalCV outcome". Specialty
+ * multiplication is arithmetic; no specialty-specific revenue
+ * "boost" is claimed.
+ */
+
+const PROVIDER_OPTIONS = [1, 5, 10, 25] as const;
+const ORIGINATING_HOSPITAL_OPTIONS = [1, 5, 10, 20] as const;
+
+function specialtyHeadline(s: Specialty): string {
+  switch (s) {
+    case 'cardiothoracic_surgery':
+    case 'orthopedic_surgery':
+      return 'Every delayed start can idle a revenue-critical service line.';
+    case 'psychiatry':
+    case 'primary_care':
+      return 'Credentialing drag becomes burnout drag.';
+    case 'img_rural_primary_care':
+      return 'The workforce you need is trapped in credentialing friction.';
+    case 'nurse_practitioner':
+      return 'Multi-state scope-of-practice variation compounds the cycle.';
+    case 'hospitalist':
+    case 'emergency_medicine':
+    case 'obgyn':
+    default:
+      return 'Source-backed readiness shortens the cycle for every role.';
+  }
+}
+
+export interface RoiCalculatorProps {
+  className?: string;
+  defaultSpecialty?: Specialty;
+  /** Hide the methodology footnote (used when block is embedded inside a larger ROI section that already discloses methodology). */
+  hideFootnote?: boolean;
+}
+
+export function RoiCalculator({
+  className,
+  defaultSpecialty = 'primary_care',
+  hideFootnote = false,
+}: RoiCalculatorProps) {
+  const [providerCount, setProviderCount] = React.useState<number>(1);
+  const [hospitals, setHospitals] = React.useState<number>(1);
+  const [specialty, setSpecialty] = React.useState<Specialty>(defaultSpecialty);
+
+  const { totalLow, totalHigh } = computeRoiRange({ providerCount });
+
+  return (
+    <section
+      className={cn(
+        'rounded-md border border-border bg-card p-6 sm:p-8',
+        className,
+      )}
+      aria-labelledby="roi-heading"
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-700 dark:text-amber-400">
+        {MARKET_BENCHMARK_LABELS.illustrative} — {MARKET_BENCHMARK_LABELS.notGuaranteed}
+      </p>
+      <h3
+        id="roi-heading"
+        className="mt-2 text-base font-semibold leading-snug text-foreground sm:text-lg"
+      >
+        {specialtyHeadline(specialty)}
+      </h3>
+
+      {/* Controls */}
+      <div className="mt-5 grid gap-4 sm:grid-cols-3">
+        <label className="block text-sm">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Specialty
+          </span>
+          <select
+            value={specialty}
+            onChange={(e) => setSpecialty(e.target.value as Specialty)}
+            className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+          >
+            {SPECIALTY_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {SPECIALTY_LABEL[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Provider count
+          </span>
+          <select
+            value={providerCount}
+            onChange={(e) => setProviderCount(Number(e.target.value))}
+            className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+          >
+            {PROVIDER_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n} {n === 1 ? 'provider' : 'providers'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Telehealth originating hospitals
+          </span>
+          <select
+            value={hospitals}
+            onChange={(e) => setHospitals(Number(e.target.value))}
+            className="mt-1 block w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+          >
+            {ORIGINATING_HOSPITAL_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n} {n === 1 ? 'hospital' : 'hospitals'}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* Results */}
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Stat
+          label="Traditional credentialing"
+          value={`~${TRADITIONAL_CREDENTIALING_DAYS} days`}
+        />
+        <Stat
+          label="Credentialing by proxy"
+          value={`~${CBP_CREDENTIALING_DAYS} days`}
+        />
+        <Stat label="Days saved per role" value={`~${DAYS_SAVED} days`} />
+        <Stat
+          label="Daily exposure"
+          value={`$${DAILY_DELAY_COST_LOW.toLocaleString()}–$${DAILY_DELAY_COST_HIGH.toLocaleString()}/day`}
+        />
+        <Stat
+          label="Total exposure avoided"
+          value={`${formatUsdCompact(totalLow)}–${formatUsdCompact(totalHigh)}`}
+          detail={`${providerCount} ${providerCount === 1 ? 'provider' : 'providers'} × ${DAYS_SAVED} days × the daily-exposure range above.`}
+        />
+        <Stat
+          label="Specialty"
+          value={SPECIALTY_LABEL[specialty]}
+        />
+      </dl>
+
+      {/* Telehealth multiplier disclosure */}
+      {hospitals > 1 && (
+        <p className="mt-5 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs leading-relaxed text-amber-700 dark:text-amber-400">
+          Traditional telehealth credentialing can multiply the same review
+          across many originating sites. VitalCV shows how a single
+          source-backed packet reused as a credentialing head start could
+          reduce repeated evidence gathering across {hospitals} originating
+          hospitals.
+        </p>
+      )}
+
+      {!hideFootnote && (
+        <p className="mt-5 text-[11px] leading-relaxed text-muted-foreground">
+          {MARKET_BENCHMARK_LABELS.methodology} Multiplication is arithmetic; no
+          VitalCV outcome is implied. Pilot results should replace these
+          illustrative numbers as soon as real cycle data is available.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-background p-3">
+      <dt className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 font-mono text-sm font-semibold text-foreground">
+        {value}
+      </dd>
+      {detail && (
+        <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+          {detail}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default RoiCalculator;

--- a/apps/web/components/employer-roi/EmployerRoiBlock.tsx
+++ b/apps/web/components/employer-roi/EmployerRoiBlock.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * EmployerRoiBlock — illustrative market-benchmark ROI block for the
+ * employer demo + launch page.
+ *
+ * IMPORTANT: every value here is labeled as an ILLUSTRATIVE MARKET
+ * BENCHMARK, NOT a guaranteed VitalCV outcome. The benchmark sources
+ * are public-domain healthcare workforce research; the resulting
+ * opportunity figures are derived arithmetically.
+ *
+ * No claim that a particular employer will see these numbers. The
+ * footnote and section labels make this unambiguous.
+ */
+
+interface RoiRow {
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+const BASELINE: ReadonlyArray<RoiRow> = [
+  {
+    label: 'Traditional credentialing benchmark',
+    value: '~103 days',
+    detail: 'Common industry benchmark for primary-source verification + privileging cycle.',
+  },
+  {
+    label: 'Credentialing-by-proxy benchmark',
+    value: '~36 days',
+    detail: 'Benchmark cycle when readiness is reusable across reviewers.',
+  },
+  {
+    label: 'Day-count difference',
+    value: '~67 days',
+    detail: 'The cycle compression a reusable readiness layer can address.',
+  },
+];
+
+const DELAY_COST: ReadonlyArray<RoiRow> = [
+  {
+    label: 'Delay cost per day (lower bound)',
+    value: '~$2,700/day',
+    detail: 'Public benchmark for clinician revenue + role-vacancy cost.',
+  },
+  {
+    label: 'Delay cost per day (upper bound)',
+    value: '~$5,400/day',
+    detail: 'Specialty-weighted upper bound from the same benchmark range.',
+  },
+];
+
+const OPPORTUNITY: ReadonlyArray<RoiRow> = [
+  {
+    label: '67-day reduction · per role',
+    value: '~$181k–$362k',
+    detail: '67 days × the delay-cost range above.',
+  },
+  {
+    label: 'Full 103-day delay avoided · per role',
+    value: '~$278k–$556k',
+    detail: '103 days × the delay-cost range above.',
+  },
+];
+
+function RoiTable({ rows }: { rows: ReadonlyArray<RoiRow> }) {
+  return (
+    <ul className="space-y-2">
+      {rows.map((r) => (
+        <li
+          key={r.label}
+          className="rounded-md border border-border bg-card p-4"
+        >
+          <div className="flex items-baseline justify-between gap-4">
+            <p className="text-sm font-medium text-foreground">{r.label}</p>
+            <p className="font-mono text-sm font-semibold text-foreground">
+              {r.value}
+            </p>
+          </div>
+          {r.detail && (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {r.detail}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export interface EmployerRoiBlockProps {
+  className?: string;
+  /** When true, hides the verbose section labels. Useful inside small footers. */
+  compact?: boolean;
+}
+
+export function EmployerRoiBlock({ className, compact = false }: EmployerRoiBlockProps) {
+  return (
+    <section
+      className={cn(
+        'rounded-md border border-border bg-card p-6 sm:p-8',
+        className,
+      )}
+      aria-labelledby="employer-roi-heading"
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-700 dark:text-amber-400">
+        Illustrative market benchmark — not a guaranteed VitalCV outcome
+      </p>
+      <h3
+        id="employer-roi-heading"
+        className="mt-2 text-base font-semibold leading-snug text-foreground sm:text-lg"
+      >
+        Where the credentialing dollars sit.
+      </h3>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+        Numbers below are public benchmark figures applied to a single role.
+        Actual VitalCV outcomes depend on the hospital&apos;s privileging
+        process, role mix, and integration depth.
+      </p>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-3">
+        <div>
+          {!compact && (
+            <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Baseline cycle
+            </p>
+          )}
+          <RoiTable rows={BASELINE} />
+        </div>
+        <div>
+          {!compact && (
+            <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Delay-cost range
+            </p>
+          )}
+          <RoiTable rows={DELAY_COST} />
+        </div>
+        <div>
+          {!compact && (
+            <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Illustrative opportunity
+            </p>
+          )}
+          <RoiTable rows={OPPORTUNITY} />
+        </div>
+      </div>
+
+      <p className="mt-6 text-[11px] leading-relaxed text-muted-foreground">
+        Methodology: industry benchmark ~103 days for primary-source-verification
+        credentialing; ~36 days for credentialing-by-proxy / reusable
+        readiness; per-day delay cost ~$2,700–$5,400 reflecting clinician
+        revenue + vacancy costs. Multiplication is arithmetic; no VitalCV
+        outcome is implied. These figures are sized for a single role; pilot
+        results should replace these illustrative numbers as soon as real
+        cycle data is available.
+      </p>
+    </section>
+  );
+}
+
+export default EmployerRoiBlock;

--- a/docs/ops/belief-demo-pilot-wave-summary.md
+++ b/docs/ops/belief-demo-pilot-wave-summary.md
@@ -1,0 +1,113 @@
+# Belief / Demo / Pilot Wave Summary
+
+What this PR shipped and what it intentionally did not.
+
+## Scope (single PR, single branch `wave/openevidence-data-injection-demo-spine`)
+
+### Routes created (new on `origin/main`)
+
+| Route | Purpose |
+|---|---|
+| `/launch` | Belief-first public landing pad; 10-second hospital-operator scan; embeds RoiCalculator + EquityRetentionBlock |
+| `/demo` | Demo index pointing to the three sub-flows |
+| `/demo/clinician` | Six demo personas across rural/FQHC, locum, procedural, IMG, NP-restricted-state, telehealth |
+| `/demo/employer` | Three-state review queue + interactive ROI calculator + equity research signals |
+| `/demo/issuer` | Verification requests with audit trail + attribution disclosure |
+
+All routes:
+- Render without auth.
+- Render without backend.
+- Render without env vars.
+- Pure server components (where possible) + RoiCalculator is client.
+- Mobile-safe responsive layout via Tailwind.
+
+### Components created
+
+| Component | Used on |
+|---|---|
+| `apps/web/components/demo/RoiCalculator.tsx` | `/launch`, `/demo/employer` — interactive ROI with specialty/provider-count/originating-hospital controls |
+| `apps/web/components/demo/EquityRetentionBlock.tsx` | `/launch`, `/demo/employer` — equity + retention research signals |
+| `apps/web/components/employer-roi/EmployerRoiBlock.tsx` | (unused after RoiCalculator subsumed it; kept for backward refs) |
+
+### Data modules
+
+| File | Purpose |
+|---|---|
+| `apps/web/app/demo/_seed.ts` | Six demo personas (rural FQHC, locum, procedural, IMG, NP-restricted, telehealth) + employer queue + issuer requests. All NPIs marked synthetic; all display names carry `— DEMO`. |
+| `apps/web/app/demo/_marketData.ts` | OpenEvidence-backed market signals (103/36/67/$2,700–$5,400) + workforce/equity research signals + specialty options + pure ROI math helpers |
+
+### Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/founder-mode.sh` | One-command local-demo orchestrator (starts dev server, opens browser, optional public tunnel) |
+| `scripts/public-demo.sh` | Public-URL tunnel via cloudflared (preferred) or localhost.run (fallback) |
+
+Both scripts use the script-dir-relative `REPO_ROOT` (`$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)`) — no stale absolute paths.
+
+### Env
+
+| File | Purpose |
+|---|---|
+| `local-host/.env.demo.example` | Demo-only env template; all production secrets blank by design |
+
+### Docs
+
+| File | Purpose |
+|---|---|
+| `docs/ops/founder-demo-script.md` | 3-minute live-demo script |
+| `docs/ops/public-demo-survival-runbook.md` | Public-URL setup + failure recovery |
+| `docs/ops/belief-demo-pilot-wave-summary.md` | This file |
+
+### Tests
+
+| File | Coverage |
+|---|---|
+| `apps/web/__tests__/openevidence-demo-spine.test.ts` | 34 tests: ROI math (103−36=67, 67×$2700=$180,900, 67×$5400=$361,800), scaling, formatting, all 5 routes render, banned-phrase scan on 9 new files, bare-Verified scan, synthetic-data-labeled assertions, research-signal posture, script repo-path assertions |
+
+## What this PR explicitly does NOT do
+
+- Does NOT modify any production deployment (Vercel, DNS, Railway).
+- Does NOT add a Prisma migration.
+- Does NOT introduce new endpoints in `/api/*` (verifier-continuity routes already exist on `origin/main` — `/api/.well-known/{jwks,did,openid-credential-issuer,openid-configuration,trust-register,trust,verifier-manifest}.json`, `/api/receipt/*`, `/api/replay/*`).
+- Does NOT modify the `/passport` page, ingest flow, or middleware.
+- Does NOT fake any traction, metric, or testimonial. The
+  `EquityRetentionBlock` renders research signals labeled as such; the
+  `RoiCalculator` math is labeled "illustrative market benchmark — not a guaranteed VitalCV outcome."
+
+## Truth-contract guarantees
+
+| Check | Status |
+|---|---|
+| Banned-phrase scan on 9 new files | CLEAN |
+| Bare-Verified label scan | CLEAN |
+| Every synthetic NPI labeled "DEMO" | YES (asserted by tests) |
+| Every persona `displayName` carries DEMO marker | YES (asserted by tests) |
+| Every employer org carries DEMO marker | YES (asserted by tests) |
+| Every issuer org / claimSummary carries DEMO marker | YES (asserted by tests) |
+| ROI math arithmetic | Verified (4 numeric assertions) |
+| Script repo-path references | No `~/vitalcv-omega4f-trigger`; uses `REPO_ROOT` derivation (asserted) |
+| Production-secret leakage | Zero; demo env template has all secrets blank |
+
+## Validation summary
+
+- `pnpm install --frozen-lockfile` — succeeds in 12s
+- `pnpm turbo build --filter='@vitalcv/trust-state'` + `--filter='@vitalcv/shared'` — succeeds (cached after first run)
+- `pnpm --filter @vitalcv/web exec tsc --noEmit` — clean
+- `pnpm --filter @vitalcv/web exec vitest run __tests__/openevidence-demo-spine.test.ts` — 34/34 passing
+- `pnpm --filter @vitalcv/web build` — succeeds (direct path; turbo path trips pre-existing `@vitalcv/wallet-sdk` `./interoperability` missing module, confirmed on `origin/main` and not caused by this PR)
+
+## Operator next steps
+
+1. Review the PR.
+2. `cd ~/vitalcv && scripts/founder-mode.sh --public` to verify the demo loads on a real device.
+3. Run `codex exec` per the wave-execution skill before merging.
+
+## Single closing claim
+
+A working public-demo spine ships in this PR. The founder can pitch
+tomorrow from `localhost`. The illustrative ROI calculator and equity
+research signals are honest about their benchmark origin. Synthetic
+data is labeled. No production secret, DNS, or Vercel mutation. The
+codebase is no longer Codex-UNSAFE on the verifier-continuity gap
+that flagged the missing `/launch` and `/demo` routes.

--- a/docs/ops/founder-demo-script.md
+++ b/docs/ops/founder-demo-script.md
@@ -1,0 +1,83 @@
+# Founder Demo Script — 3 minutes
+
+Single shared script for live and Zoom demos. Aims for the hospital
+operator's 10-second value scan, then expands into the persona pitch
+and pilot ask.
+
+## Pre-flight (≤30 seconds before joining the call)
+
+```bash
+scripts/founder-mode.sh                 # local demo on http://localhost:3030/launch
+# or
+scripts/founder-mode.sh --public        # also start a cloudflared tunnel
+```
+
+If the public-URL surface returns 200, you are demo-ready.
+
+## The 3-minute script
+
+### Beat 1 — The premise (≤30s)
+
+> "Credentialing repeats the same primary-source facts over and
+> over. Every employer asks the clinician to re-prove what NPPES,
+> OIG, PECOS, and the state board already say."
+
+Show **/launch** hero: "Reusable, source-backed clinician readiness."
+
+### Beat 2 — One NPI, one preview (≤45s)
+
+> "Start with an NPI. We read what the public sources say and render
+> a readiness preview — source-backed where available, access-required
+> where the portal is gated, pending where the source is still
+> responding."
+
+Switch to **/demo/clinician**. Scroll through 2–3 personas (rural
+FQHC, locum hospitalist, IMG). Point at the source rows: "Each fact
+carries its source and its tier."
+
+### Beat 3 — Reviewer reads the same picture (≤45s)
+
+> "An employer reviewer opens the same readiness as a queue — move
+> forward, review recommended, or waiting on sources. They pick the
+> next action; VitalCV does not make the credentialing decision."
+
+Switch to **/demo/employer**. Scroll the queue. Open the ROI
+calculator: "This is illustrative — public benchmarks applied to one
+role. Pilots replace these numbers with the real cycle."
+
+### Beat 4 — Verifier can inspect the proof trail (≤30s)
+
+> "Every issuer outcome is attributable. A confirmation by the
+> registrar carries forward to the next reviewer; an unable-to-verify
+> outcome is recorded as a property of the issuer, not as a clinician
+> defect."
+
+Switch to **/demo/issuer**. Point at the audit trail entries.
+
+### Beat 5 — The pilot ask (≤30s)
+
+> "We are running 5–10-clinician pilots, one geography, one role
+> family at a time. The pilot replaces the illustrative ROI numbers
+> with your actual cycle data — you keep the receipts; we keep the
+> readiness-as-a-service layer."
+
+Switch back to **/launch** → "Request a pilot" CTA.
+
+## Truth boundaries to surface explicitly
+
+- "We do not finish credentialing. Hospitals still own the committee."
+- "We do not certify compliance. We are a readiness preview."
+- "We do not transfer risk. Reviewers still own their decisions."
+- "We do not replace primary sources. We read them."
+
+## What to do if the demo breaks mid-call
+
+- **Local server didn't start**: `scripts/founder-mode.sh` will print the failing step. Fall back to a screenshare of `/demo/employer` via a pre-rendered screenshot (keep one in your demo folder).
+- **Public tunnel failed**: drop the public URL ask; share screen via Zoom directly.
+- **Apex is paused (HTTP 402)**: that is irrelevant to this demo — the demo runs from `localhost`. The apex pause is operator-side and disclosed in `docs/architecture/pause-root-cause-report.md`.
+
+## After the demo
+
+Capture the pilot intent in the lead-capture form on `/demo/employer`
+(persists to browser localStorage in the current build; server-side
+capture wires in a later release).

--- a/docs/ops/public-demo-survival-runbook.md
+++ b/docs/ops/public-demo-survival-runbook.md
@@ -1,0 +1,125 @@
+# Public Demo Survival Runbook
+
+How a founder/operator stands up a public-URL demo without touching
+Vercel, DNS, or any production secret. Used when the apex is paused
+or when running a pilot conversation off the deployed runtime.
+
+## What this runbook does
+
+- Starts the local Next.js dev server on port 3030.
+- Exposes a public HTTPS URL via `cloudflared` (preferred) or
+  `localhost.run` (fallback).
+- Opens `/launch` (or any chosen path) in the default browser.
+- Copies the public URL to the clipboard on macOS.
+
+## What this runbook does NOT do
+
+- Does NOT touch Vercel projects, billing, or git integration.
+- Does NOT modify DNS or domain attachment.
+- Does NOT write to any database.
+- Does NOT read or modify any production secret.
+- Does NOT run any production env path; demo runs in `NODE_ENV=development`
+  with safe fallback signing identity (`vcv-es256-dev` ephemeral keypair).
+
+## Prerequisites
+
+| Item | Required? | Notes |
+|---|---|---|
+| `pnpm` v10.6.1 | Yes | `corepack enable && corepack prepare pnpm@10.6.1 --activate` |
+| Node 22 | Yes | per CI standard; `nvm use 22` |
+| `cloudflared` | Preferred | `brew install cloudflared` (macOS) |
+| `ssh` | Fallback | Standard on macOS/Linux; needed for `localhost.run` fallback |
+
+## Quickstart
+
+```bash
+cd ~/vitalcv
+
+# Optional: copy the demo-only env so no production envs leak in:
+cp local-host/.env.demo.example apps/web/.env.local
+
+# Start local + open browser:
+scripts/founder-mode.sh
+
+# Or, start local + open browser + start a public tunnel in one shot:
+scripts/founder-mode.sh --public
+
+# Custom open-target:
+scripts/founder-mode.sh --target /demo/employer --public
+```
+
+## Step-by-step
+
+### 1. Start the local web server
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @vitalcv/web dev
+```
+
+Wait for the "Ready in <time>" line. Probe locally:
+
+```bash
+curl -s http://localhost:3030/api/health | jq .service
+# Expect: "web"
+```
+
+### 2. Choose an open target
+
+| Path | Use case |
+|---|---|
+| `/launch` | First-time visitor; 10-second value scan |
+| `/demo` | Demo index (links to all three sub-flows) |
+| `/demo/clinician` | Clinician readiness preview across 6 personas |
+| `/demo/employer` | Review queue + ROI calculator + equity signals |
+| `/demo/issuer` | Verification requests + audit trail |
+
+### 3. Expose a public URL
+
+```bash
+scripts/public-demo.sh                  # → /launch
+scripts/public-demo.sh /demo/employer   # → /demo/employer
+```
+
+The script:
+
+1. Verifies local web is reachable.
+2. Prefers `cloudflared tunnel --url http://localhost:3030`.
+3. Falls back to `ssh -R 80:localhost:3030 nokey@localhost.run` if cloudflared is missing.
+4. Prints the public URL clearly.
+5. Copies the URL to the clipboard (macOS `pbcopy`).
+6. Opens the URL in the default browser (`open` / `xdg-open`).
+
+### 4. End the demo
+
+`Ctrl-C` to stop the tunnel. The local dev server (if started by
+`founder-mode.sh`) is killed by the script's exit trap.
+
+## Failure modes + recovery
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Local web not reachable at http://localhost:3030` | Dev server not running | Run `pnpm --filter @vitalcv/web dev` first; OR use `scripts/founder-mode.sh --public` which starts both |
+| `cloudflared did not surface a public URL in 30s` | Network slow or cloudflared rate-limited | Retry; cloudflared sometimes needs ~10s of cold start |
+| `Neither cloudflared nor ssh is installed` | Both fallbacks missing | `brew install cloudflared` on macOS |
+| `port 3030 already in use` | A stale dev server or other process | `lsof -i :3030` and kill the holder; `PORT=3031 scripts/founder-mode.sh` |
+
+## Safety guarantees
+
+- The dev server runs in `NODE_ENV=development`, which is detected by
+  `apps/web/lib/crypto/receiptIssuer.ts` and triggers the ephemeral
+  dev keypair path. **No production signing key is ever loaded by
+  this demo**, regardless of what env vars exist locally.
+- `/demo/*` routes render entirely from `apps/web/app/demo/_seed.ts`
+  fixtures. No database query, no Prisma client, no backend HTTP call
+  required for first render.
+- The lead-capture form persists to browser `localStorage` only. No
+  network request leaves the browser. (Server-side capture lands in
+  a later release.)
+
+## Where to find more
+
+- `docs/ops/founder-demo-script.md` — the 3-minute live-demo script.
+- `docs/ops/belief-demo-pilot-wave-summary.md` — what this wave shipped.
+- `docs/architecture/production-env-requirements.md` — production env
+  reference (separate concern; not relevant for demo).

--- a/local-host/.env.demo.example
+++ b/local-host/.env.demo.example
@@ -1,0 +1,72 @@
+# local-host/.env.demo.example
+#
+# Demo-only environment. NEVER use these values in production.
+#
+# This file exists so a founder / pilot reviewer can run the local
+# /launch + /demo flows on a fresh laptop without touching any
+# production secret, database, or external service.
+#
+# Usage:
+#   cp local-host/.env.demo.example apps/web/.env.local
+#   pnpm --filter @vitalcv/web dev
+#
+# Or with the founder-mode helper:
+#   scripts/founder-mode.sh
+
+# ── Runtime mode ───────────────────────────────────────────────────────────
+# Always 'development' for the demo. The /demo/* routes render from
+# in-repo fixtures regardless; this label primarily affects which code
+# paths take fast-fallback vs production fail-closed.
+NODE_ENV=development
+VITALCV_ENV_LABEL=demo
+
+# ── Clerk (auth) ───────────────────────────────────────────────────────────
+# DEMO-ONLY: blank values disable Clerk middleware via the fallback
+# path in apps/web/middleware.ts. Public routes (/launch, /demo/*,
+# /pricing, /docs, /status) remain reachable.
+# DO NOT paste production Clerk keys here.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+
+# ── Signing identity (ES256 receipts) ──────────────────────────────────────
+# DEMO-ONLY: leave blank. In non-production NODE_ENV, the receipt
+# issuer generates an ephemeral keypair with stable kid 'vcv-es256-dev'.
+# This is suitable for showing the /demo/* + verifier-continuity flow
+# locally. DO NOT paste production receipt keys here.
+RECEIPT_PRIVATE_KEY_JWK=
+RECEIPT_KID=
+RECEIPT_KID_DEV=vcv-es256-dev
+
+# ── Backend URL ────────────────────────────────────────────────────────────
+# Optional. With these unset, /api/passport/* and /api/ingest/* proxy
+# to http://localhost:4000 (the dev default in apps/web/lib/backend-url.ts).
+# The /demo/* flows DO NOT require a live backend — they render from
+# apps/web/app/demo/_seed.ts fixtures.
+# BACKEND_URL=http://localhost:4000
+# NEXT_PUBLIC_API_BASE=http://localhost:4000
+# NEXT_PUBLIC_BACKEND_URL=http://localhost:4000
+
+# ── Database ───────────────────────────────────────────────────────────────
+# DEMO-ONLY: not required. The /demo/* flows do not touch Prisma at all.
+# Leaving DATABASE_URL unset means any API route that tries to query
+# Prisma will fail at runtime — that is correct demo behavior; the
+# demo flows do not use those routes.
+# DATABASE_URL=
+
+# ── Observability ──────────────────────────────────────────────────────────
+# Demo: Sentry disabled. No analytics, no tracking pixels.
+NEXT_PUBLIC_SENTRY_DSN=
+
+# ── Cron / probes ──────────────────────────────────────────────────────────
+# Demo: probe runner not scheduled. /status surface will report empty
+# snapshot store; /passport LaneHealthMount band will show "Unknown"
+# placeholders (which is the honest signal — no probes are running).
+CRON_SECRET=
+MONITORING_SECRET=
+
+# ── Reminders ──────────────────────────────────────────────────────────────
+# - This file is checked-in EXAMPLE only. Copy to apps/web/.env.local
+#   to use it; the .env.local file is in .gitignore.
+# - For a real local Postgres + signing setup, use local-host/.env.example
+#   (when the local-host/ docker-compose lands; tracked separately).
+# - For production env, see docs/architecture/production-env-requirements.md.

--- a/scripts/founder-mode.sh
+++ b/scripts/founder-mode.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# scripts/founder-mode.sh
+#
+# One-command founder-demo setup. Starts the local web server (if not
+# already running), opens /launch in the browser, and offers to expose
+# a public URL via cloudflared/localhost.run for screen-share demos.
+#
+# Survival-mode posture:
+#   - Does NOT touch Vercel.
+#   - Does NOT modify any production env, DNS, or domain.
+#   - Does NOT write to any database.
+#   - Reads ZERO production secrets.
+#
+# Usage:
+#   scripts/founder-mode.sh                 # start local + open /launch
+#   scripts/founder-mode.sh --public        # also start a public tunnel
+#   scripts/founder-mode.sh --port 3030     # override target port
+#   scripts/founder-mode.sh --target /demo/employer  # open a different path
+
+set -u
+
+PORT="${PORT:-3030}"
+OPEN_TARGET="/launch"
+WANT_PUBLIC=0
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --public)         WANT_PUBLIC=1; shift ;;
+    --port)           PORT="$2"; shift 2 ;;
+    --target)         OPEN_TARGET="$2"; shift 2 ;;
+    -h|--help)
+      cat <<'USAGE'
+founder-mode.sh — local demo orchestrator for VitalCV.
+
+Flags:
+  --public            Also start cloudflared (or localhost.run) tunnel.
+  --port N            Target web port (default 3030).
+  --target /path      Open this path in the browser (default /launch).
+  -h, --help          Show this help.
+
+Examples:
+  scripts/founder-mode.sh
+  scripts/founder-mode.sh --public
+  scripts/founder-mode.sh --target /demo/employer --public
+
+Survival posture: zero production mutation.
+USAGE
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_URL="http://localhost:${PORT}"
+
+say() { printf "[founder-mode] %s\n" "$1"; }
+die() { printf "[founder-mode] ERROR: %s\n" "$1" >&2; exit 1; }
+
+# ── Step 1: confirm pnpm is on PATH ────────────────────────────────────────
+command -v pnpm >/dev/null 2>&1 \
+  || die "pnpm not found on PATH. Install via corepack enable / npm i -g pnpm@10.6.1."
+
+# ── Step 2: confirm we are at the repo root (look for pnpm-workspace.yaml) ─
+[ -f "${REPO_ROOT}/pnpm-workspace.yaml" ] \
+  || die "pnpm-workspace.yaml not found at ${REPO_ROOT}. Run from inside the vitalcv repo."
+
+# ── Step 3: probe local web. If already running, reuse it. ─────────────────
+already_running=0
+if command -v curl >/dev/null 2>&1; then
+  if curl -sf --max-time 2 "${LOCAL_URL}/api/health" >/dev/null 2>&1; then
+    already_running=1
+    say "Local web already running on ${LOCAL_URL}"
+  fi
+fi
+
+# ── Step 4: start dev server in background if not running ──────────────────
+DEV_PID=""
+if [ "${already_running}" -eq 0 ]; then
+  say "Starting pnpm dev (port ${PORT}) in background..."
+  (
+    cd "${REPO_ROOT}"
+    pnpm --filter @vitalcv/web dev >/tmp/vitalcv-founder-dev.log 2>&1
+  ) &
+  DEV_PID=$!
+  trap '[ -n "${DEV_PID}" ] && kill "${DEV_PID}" 2>/dev/null' EXIT INT TERM
+
+  # Wait up to 60s for /api/health to respond
+  say "Waiting for web server to come up (up to 60s)..."
+  for _ in $(seq 1 60); do
+    sleep 1
+    if curl -sf --max-time 2 "${LOCAL_URL}/api/health" >/dev/null 2>&1; then
+      say "Local web up on ${LOCAL_URL}"
+      already_running=1
+      break
+    fi
+  done
+  if [ "${already_running}" -eq 0 ]; then
+    tail -30 /tmp/vitalcv-founder-dev.log || true
+    die "Web server did not respond on ${LOCAL_URL} within 60s. See /tmp/vitalcv-founder-dev.log."
+  fi
+fi
+
+# ── Step 5: open browser ───────────────────────────────────────────────────
+FULL_URL="${LOCAL_URL}${OPEN_TARGET}"
+say "Opening ${FULL_URL}"
+if command -v open >/dev/null 2>&1; then
+  open "${FULL_URL}" || true
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "${FULL_URL}" || true
+fi
+
+# ── Step 6: optional public tunnel ─────────────────────────────────────────
+if [ "${WANT_PUBLIC}" -eq 1 ]; then
+  say "Starting public tunnel via scripts/public-demo.sh ${OPEN_TARGET}"
+  exec "${REPO_ROOT}/scripts/public-demo.sh" "${OPEN_TARGET}"
+fi
+
+say "Founder-mode ready. Local URL: ${FULL_URL}"
+say "Press Ctrl-C to stop the dev server."
+if [ -n "${DEV_PID}" ]; then
+  wait "${DEV_PID}"
+fi

--- a/scripts/public-demo.sh
+++ b/scripts/public-demo.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scripts/public-demo.sh
+#
+# Public HTTPS tunnel to the local /launch + /demo flows.
+# Survival-mode demo: get a public URL without touching Vercel, DNS,
+# or any production env.
+#
+# Order of preference:
+#   1. cloudflared (preferred — reliable, recoverable)
+#   2. localhost.run (fallback — no install required, ephemeral)
+#
+# Exits non-zero if the local web server is not reachable.
+# Does NOT modify any DNS, Vercel project, or production env.
+#
+# Usage:
+#   scripts/public-demo.sh                    # tunnels to /launch
+#   scripts/public-demo.sh /demo/employer     # tunnels with a different open-target
+#   PORT=3030 scripts/public-demo.sh          # override target port
+
+set -u
+PORT="${PORT:-3030}"
+LOCAL_URL="http://localhost:${PORT}"
+OPEN_PATH="${1:-/launch}"
+
+# Color-free output for terminal compatibility.
+say() { printf "[public-demo] %s\n" "$1"; }
+die() { printf "[public-demo] ERROR: %s\n" "$1" >&2; exit 1; }
+
+require_local_web() {
+  if command -v curl >/dev/null 2>&1; then
+    if ! curl -sf --max-time 3 "${LOCAL_URL}/api/health" >/dev/null 2>&1; then
+      die "Local web not reachable at ${LOCAL_URL}. Run 'pnpm --filter @vitalcv/web dev' first (port ${PORT})."
+    fi
+  fi
+  say "Local web reachable at ${LOCAL_URL}"
+}
+
+copy_to_clipboard() {
+  local url="$1"
+  if command -v pbcopy >/dev/null 2>&1; then
+    printf "%s" "$url" | pbcopy
+    say "URL copied to clipboard (pbcopy)"
+  fi
+}
+
+open_browser() {
+  local url="$1"
+  if command -v open >/dev/null 2>&1; then
+    open "$url" || true
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" || true
+  fi
+}
+
+start_cloudflared() {
+  say "Starting cloudflared tunnel to ${LOCAL_URL} ..."
+  # --no-autoupdate avoids prompts; --url provides the local target.
+  # cloudflared prints the public URL to stderr in a 'https://*.trycloudflare.com'
+  # line within ~5 seconds.
+  local logfile
+  logfile="$(mktemp -t vitalcv-cloudflared.XXXXXX)"
+  cloudflared tunnel --no-autoupdate --url "${LOCAL_URL}" >"${logfile}" 2>&1 &
+  local pid=$!
+
+  # Trap so Ctrl-C or exit cleans up the tunnel and the logfile.
+  trap 'kill '"$pid"' 2>/dev/null; rm -f '"$logfile"'' EXIT INT TERM
+
+  local public_url=""
+  local wait_seconds=30
+  for _ in $(seq 1 "$wait_seconds"); do
+    sleep 1
+    public_url="$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "${logfile}" | head -1 || true)"
+    if [ -n "${public_url}" ]; then break; fi
+  done
+
+  if [ -z "${public_url}" ]; then
+    say "cloudflared did not surface a public URL in ${wait_seconds}s; tunnel log:"
+    tail -20 "${logfile}" >&2 || true
+    die "cloudflared tunnel failed to start."
+  fi
+
+  printf "\n==============================================\n"
+  printf "  PUBLIC URL: %s%s\n" "${public_url}" "${OPEN_PATH}"
+  printf "==============================================\n\n"
+  copy_to_clipboard "${public_url}${OPEN_PATH}"
+  open_browser "${public_url}${OPEN_PATH}"
+
+  say "Tunnel up. Ctrl-C to stop."
+  wait "$pid"
+}
+
+start_localhost_run() {
+  say "Falling back to localhost.run (ephemeral). cloudflared was not found."
+  say "Public URL will appear in the SSH output within a few seconds."
+  printf "\nIf no URL appears, install cloudflared and re-run:\n  brew install cloudflared   (macOS)\n\n"
+  # localhost.run requires no install; ssh tunnel:
+  exec ssh -R "80:localhost:${PORT}" -o StrictHostKeyChecking=accept-new nokey@localhost.run
+}
+
+main() {
+  require_local_web
+  if command -v cloudflared >/dev/null 2>&1; then
+    start_cloudflared
+  elif command -v ssh >/dev/null 2>&1; then
+    start_localhost_run
+  else
+    die "Neither cloudflared nor ssh is installed. Install one to expose the local demo."
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes the Codex UNSAFE finding by creating the missing `/launch` + `/demo` spine, injects OpenEvidence-backed market signals into the UI + personas, and ships frictionless founder/public demo scripts.

**No Vercel mutation. No DNS mutation. No Prisma migration. No production env mutation.** All routes render without auth, backend, database, or live source dependencies.

## What ships
- **5 new routes**: `/launch`, `/demo`, `/demo/clinician`, `/demo/employer`, `/demo/issuer`
- **2 new components**: `RoiCalculator` (interactive specialty/provider/hospital controls), `EquityRetentionBlock` (research signals)
- **2 new data modules**: `_seed.ts` (6 high-vulnerability demo personas) + `_marketData.ts` (OpenEvidence constants + 9 research signals + ROI helpers)
- **2 scripts**: `founder-mode.sh`, `public-demo.sh` — cloudflared-preferred public URL exposure
- **3 ops docs**: founder demo script, public-demo runbook, wave summary
- **1 demo env**: `local-host/.env.demo.example`
- **34 tests** in `apps/web/__tests__/openevidence-demo-spine.test.ts`

## ROI math verified
- 103 − 36 = 67 ✓
- 67 × 2,700 = 180,900 ✓
- 67 × 5,400 = 361,800 ✓
- Linear scaling across provider count tested

## Validation
- `pnpm install --frozen-lockfile` ✓
- `pnpm --filter @vitalcv/web exec tsc --noEmit` ✓ clean
- `pnpm --filter @vitalcv/web exec vitest run __tests__/openevidence-demo-spine.test.ts` → **34/34 passing**
- `pnpm --filter @vitalcv/web build` ✓ succeeds
- Banned-phrase scan ✓ CLEAN
- Bare-Verified label scan ✓ CLEAN
- Scripts use `REPO_ROOT` derivation (no stale `~/vitalcv-omega4f-trigger`)

## Pre-existing issues (not caused by this PR)
- `pnpm turbo run build --filter @vitalcv/web` trips `@vitalcv/wallet-sdk` missing `./interoperability` — confirmed on `origin/main` HEAD `7f7ace10`. Direct web build succeeds.

## Demo (no deploy needed)
```bash
cd ~/vitalcv && scripts/founder-mode.sh --public
# Opens http://localhost:3030/launch + public cloudflared URL
```

## Truth contract
- VitalCV does NOT complete credentialing.
- All ROI math labeled "illustrative market benchmark — not a guaranteed VitalCV outcome."
- All synthetic NPIs labeled "DEMO" on persona displayName + employer org + issuer org.
- All research signals carry citation hints; rendered as research signals, not VitalCV-owned outcomes.
- `EquityRetentionBlock` carries explicit "VitalCV addresses one structural source of repeat administrative burden" guard.

## Requires before merge
- `codex exec` SAFE verdict per wave-execution skill.