### PR TITLE
feat(leads): persist pilot and walkthrough requests from launch demo

### DIFF
--- a/apps/web/__tests__/leads-route.test.ts
+++ b/apps/web/__tests__/leads-route.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('server-only', () => ({}));
+
+const slackMock = vi.fn();
+vi.mock('@/lib/leads/slack', () => ({
+  deliverLeadToSlack: (...args: unknown[]) => slackMock(...args),
+  isSlackConfigured: () => false,
+}));
+
+import { POST } from '@/app/api/leads/route';
+import {
+  _resetRateBuckets,
+  isValidEmail,
+  isValidIntent,
+  hashIp,
+  resolveLeadLogPath,
+  truncateUserAgent,
+  validateLeadInput,
+} from '@/lib/leads/persistLead';
+
+const TMP_DIR = mkdtempSync(join(tmpdir(), 'vitalcv-leads-test-'));
+const LOG_PATH = join(TMP_DIR, 'leads.jsonl');
+
+const validBody = {
+  email: 'alex@example-cvo.com',
+  intent: 'pilot' as const,
+  source: 'launch_page',
+  message: 'Want to talk about a 10-clinician pilot.',
+};
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/leads', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  process.env.LEAD_LOG_PATH = LOG_PATH;
+  delete process.env.SLACK_LEAD_CAPTURE_WEBHOOK_URL;
+  slackMock.mockReset();
+  _resetRateBuckets();
+  if (existsSync(LOG_PATH)) rmSync(LOG_PATH);
+});
+
+afterEach(() => {
+  slackMock.mockReset();
+});
+
+describe('lead-capture helpers', () => {
+  it('isValidEmail accepts well-formed addresses and rejects malformed', () => {
+    expect(isValidEmail('a@b.co')).toBe(true);
+    expect(isValidEmail('  ')).toBe(false);
+    expect(isValidEmail('no-at')).toBe(false);
+    expect(isValidEmail('two@@signs.com')).toBe(false);
+  });
+
+  it('isValidIntent narrows the union safely', () => {
+    expect(isValidIntent('pilot')).toBe(true);
+    expect(isValidIntent('waitlist')).toBe(true);
+    expect(isValidIntent('walkthrough')).toBe(true);
+    expect(isValidIntent('early_access')).toBe(true);
+    expect(isValidIntent('production_access')).toBe(false);
+    expect(isValidIntent(undefined)).toBe(false);
+  });
+
+  it('hashIp is deterministic per day and bounded to 16 hex chars', () => {
+    const now = new Date('2026-05-12T00:00:00Z');
+    const a = hashIp('203.0.113.7', now);
+    const b = hashIp('203.0.113.7', now);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    const otherDay = hashIp('203.0.113.7', new Date('2026-05-13T00:00:00Z'));
+    expect(otherDay).not.toBe(a);
+  });
+
+  it('truncateUserAgent clamps at 200 chars and returns undefined for empty', () => {
+    expect(truncateUserAgent(undefined)).toBeUndefined();
+    expect(truncateUserAgent(null)).toBeUndefined();
+    expect(truncateUserAgent('Mozilla/5.0')).toBe('Mozilla/5.0');
+    const long = 'x'.repeat(500);
+    expect(truncateUserAgent(long)?.length).toBe(200);
+  });
+
+  it('resolveLeadLogPath honours $LEAD_LOG_PATH override', () => {
+    expect(resolveLeadLogPath()).toBe(LOG_PATH);
+  });
+
+  it('validateLeadInput surfaces per-field errors', () => {
+    const r = validateLeadInput({ email: 'no-at', intent: 'sneak' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.email).toBeTruthy();
+      expect(r.errors.intent).toBeTruthy();
+    }
+  });
+
+  it('validateLeadInput rejects over-long fields', () => {
+    const r = validateLeadInput({
+      email: 'a@b.co',
+      intent: 'pilot',
+      message: 'x'.repeat(2001),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.message).toBeTruthy();
+  });
+});
+
+describe('POST /api/leads', () => {
+  it('returns 400 invalid_json when body is not JSON', async () => {
+    const res = await POST(makeRequest('not json'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json).toEqual({ ok: false, error: 'invalid_json' });
+    expect(slackMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with field errors when email malformed', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: 'no-at' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.errors.email).toBeTruthy();
+    expect(slackMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with field errors when intent is unknown', async () => {
+    const res = await POST(makeRequest({ ...validBody, intent: 'production_access' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.errors.intent).toBeTruthy();
+  });
+
+  it('persists a JSONL row and returns leadId on success', async () => {
+    slackMock.mockResolvedValueOnce({ delivered: false, reason: 'unconfigured' });
+    const res = await POST(makeRequest(validBody, { 'x-forwarded-for': '203.0.113.42' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.leadId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(json.persisted).toBe(true);
+    expect(json.slackDelivered).toBe(false);
+    expect(json.slackReason).toBe('unconfigured');
+
+    const line = readFileSync(LOG_PATH, 'utf8').trim();
+    const row = JSON.parse(line);
+    expect(row.email).toBe(validBody.email);
+    expect(row.intent).toBe('pilot');
+    expect(row.source).toBe('launch_page');
+    expect(row.leadId).toBe(json.leadId);
+    expect(row.ipHash).toMatch(/^[0-9a-f]{16}$/);
+    // Raw IP must NOT appear in the persisted row.
+    expect(line).not.toContain('203.0.113.42');
+  });
+
+  it('reports slack delivery success', async () => {
+    slackMock.mockResolvedValueOnce({ delivered: true });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.slackDelivered).toBe(true);
+    expect(json.slackReason).toBeNull();
+    expect(slackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 200 even when slack fetch fails (lead is already persisted)', async () => {
+    slackMock.mockResolvedValueOnce({ delivered: false, reason: 'fetch_failed' });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.persisted).toBe(true);
+    expect(json.slackDelivered).toBe(false);
+    expect(json.slackReason).toBe('fetch_failed');
+  });
+
+  it('rate-limits at >3 submissions / 5 min per ip-hash and emits Retry-After', async () => {
+    slackMock.mockResolvedValue({ delivered: false, reason: 'unconfigured' });
+    const headers = { 'x-forwarded-for': '198.51.100.7' };
+    for (let i = 0; i < 3; i++) {
+      const res = await POST(makeRequest(validBody, headers));
+      expect(res.status).toBe(200);
+    }
+    const fourth = await POST(makeRequest(validBody, headers));
+    expect(fourth.status).toBe(429);
+    expect(fourth.headers.get('retry-after')).toBeTruthy();
+    const json = await fourth.json();
+    expect(json.error).toBe('rate_limited');
+    expect(typeof json.retryAfterSeconds).toBe('number');
+  });
+});

--- a/apps/web/__tests__/leads-route.test.ts
+++ b/apps/web/__tests__/leads-route.test.ts
@@ -18,8 +18,10 @@ import {
   isValidIntent,
   hashIp,
   resolveLeadLogPath,
+  sanitizeNpiList,
   truncateUserAgent,
   validateLeadInput,
+  MAX_SAMPLE_NPIS,
 } from '@/lib/leads/persistLead';
 
 const TMP_DIR = mkdtempSync(join(tmpdir(), 'vitalcv-leads-test-'));
@@ -29,14 +31,14 @@ const validBody = {
   email: 'alex@example-cvo.com',
   intent: 'pilot' as const,
   source: 'launch_page',
-  message: 'Want to talk about a 10-clinician pilot.',
 };
 
 function makeRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
   return new Request('http://localhost/api/leads', {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...headers },
-    body: typeof body === 'string' ? body : JSON.stringify(body),
+    body: bodyText,
   });
 }
 
@@ -91,7 +93,7 @@ describe('lead-capture helpers', () => {
     expect(resolveLeadLogPath()).toBe(LOG_PATH);
   });
 
-  it('validateLeadInput surfaces per-field errors', () => {
+  it('validateLeadInput surfaces per-field errors for email + intent', () => {
     const r = validateLeadInput({ email: 'no-at', intent: 'sneak' });
     expect(r.ok).toBe(false);
     if (!r.ok) {
@@ -100,14 +102,70 @@ describe('lead-capture helpers', () => {
     }
   });
 
-  it('validateLeadInput rejects over-long fields', () => {
+  it('validateLeadInput rejects npiList strings longer than 2000 chars', () => {
     const r = validateLeadInput({
       email: 'a@b.co',
       intent: 'pilot',
-      message: 'x'.repeat(2001),
+      npiList: 'x'.repeat(2001),
     });
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.errors.message).toBeTruthy();
+    if (!r.ok) expect(r.errors.npiList).toBeTruthy();
+  });
+
+  it('validateLeadInput rejects sampleNpis that is not an array', () => {
+    const r = validateLeadInput({
+      email: 'a@b.co',
+      intent: 'pilot',
+      sampleNpis: '1234567890',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.sampleNpis).toBeTruthy();
+  });
+
+  it('validateLeadInput drops free-text "message" silently — never persisted', () => {
+    const r = validateLeadInput({
+      email: 'a@b.co',
+      intent: 'pilot',
+      message: 'Patient Jane Doe DOB 1980-01-01 needs credentials.',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.value as Record<string, unknown>).message).toBeUndefined();
+      expect(JSON.stringify(r.value)).not.toContain('Patient');
+      expect(JSON.stringify(r.value)).not.toContain('Jane Doe');
+    }
+  });
+});
+
+describe('sanitizeNpiList', () => {
+  it('returns [] for non-string or empty inputs', () => {
+    expect(sanitizeNpiList(undefined)).toEqual([]);
+    expect(sanitizeNpiList(null)).toEqual([]);
+    expect(sanitizeNpiList(123)).toEqual([]);
+    expect(sanitizeNpiList('')).toEqual([]);
+  });
+
+  it('extracts only 10-digit runs from surrounding free text', () => {
+    const raw =
+      'Hi team, my colleagues are NPI 1234567890 and 0987654321. ' +
+      'My phone is 555-1212 and SSN 123-45-6789 should be ignored. ' +
+      'Patient ID 999 is too short, 12345678901 is too long.';
+    expect(sanitizeNpiList(raw)).toEqual(['1234567890', '0987654321']);
+    // Sensitive surrounding text is gone.
+    const out = JSON.stringify(sanitizeNpiList(raw));
+    expect(out).not.toContain('SSN');
+    expect(out).not.toContain('Patient');
+    expect(out).not.toContain('Hi team');
+  });
+
+  it('deduplicates and caps at MAX_SAMPLE_NPIS', () => {
+    const npis = Array.from({ length: 60 }, (_, i) =>
+      String(1000000000 + i).padStart(10, '0'),
+    );
+    const raw = [...npis, ...npis].join(', '); // duplicated input
+    const out = sanitizeNpiList(raw);
+    expect(out.length).toBe(MAX_SAMPLE_NPIS);
+    expect(new Set(out).size).toBe(MAX_SAMPLE_NPIS); // unique
   });
 });
 
@@ -118,6 +176,32 @@ describe('POST /api/leads', () => {
     const json = await res.json();
     expect(json).toEqual({ ok: false, error: 'invalid_json' });
     expect(slackMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 payload_too_large when body exceeds 8KB', async () => {
+    const huge = { email: 'a@b.co', intent: 'pilot', npiList: 'x'.repeat(9 * 1024) };
+    const res = await POST(makeRequest(huge));
+    expect(res.status).toBe(413);
+    const json = await res.json();
+    expect(json).toEqual({ ok: false, error: 'payload_too_large' });
+    expect(slackMock).not.toHaveBeenCalled();
+    // Nothing persisted.
+    expect(existsSync(LOG_PATH)).toBe(false);
+  });
+
+  it('returns 413 payload_too_large when Content-Length declares oversize', async () => {
+    const req = new Request('http://localhost/api/leads', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': String(9 * 1024),
+      },
+      body: JSON.stringify(validBody), // body itself is small; header declares more
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+    const json = await res.json();
+    expect(json.error).toBe('payload_too_large');
   });
 
   it('returns 400 with field errors when email malformed', async () => {
@@ -137,9 +221,22 @@ describe('POST /api/leads', () => {
     expect(json.errors.intent).toBeTruthy();
   });
 
-  it('persists a JSONL row and returns leadId on success', async () => {
+  it('persists a JSONL row with sampleNpis but no raw message or npiList free text', async () => {
     slackMock.mockResolvedValueOnce({ delivered: false, reason: 'unconfigured' });
-    const res = await POST(makeRequest(validBody, { 'x-forwarded-for': '203.0.113.42' }));
+    const res = await POST(
+      makeRequest(
+        {
+          ...validBody,
+          // Free-text message — should be silently dropped.
+          message: 'Patient Jane Doe DOB 1980-01-01 is being onboarded.',
+          // NPI list with surrounding sensitive prose — only digits should survive.
+          npiList:
+            'Roster: NPI 1234567890 (Dr Smith — diagnosis: hypertension), ' +
+            '0987654321 (Dr Lee). SSN 123-45-6789. Phone 555-1212.',
+        },
+        { 'x-forwarded-for': '203.0.113.42' },
+      ),
+    );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.ok).toBe(true);
@@ -150,23 +247,52 @@ describe('POST /api/leads', () => {
 
     const line = readFileSync(LOG_PATH, 'utf8').trim();
     const row = JSON.parse(line);
+
+    // Sanitized NPIs are persisted; sensitive free text is not.
+    expect(row.sampleNpis).toEqual(['1234567890', '0987654321']);
+    expect(row.sampleNpiCount).toBe(2);
     expect(row.email).toBe(validBody.email);
     expect(row.intent).toBe('pilot');
     expect(row.source).toBe('launch_page');
     expect(row.leadId).toBe(json.leadId);
     expect(row.ipHash).toMatch(/^[0-9a-f]{16}$/);
-    // Raw IP must NOT appear in the persisted row.
-    expect(line).not.toContain('203.0.113.42');
+
+    // Free-text fields and raw surrounding text must not appear anywhere in the row.
+    expect(row.message).toBeUndefined();
+    expect(row.npiList).toBeUndefined();
+    expect(line).not.toContain('Patient');
+    expect(line).not.toContain('Jane Doe');
+    expect(line).not.toContain('hypertension');
+    expect(line).not.toContain('SSN');
+    expect(line).not.toContain('Phone');
+    expect(line).not.toContain('203.0.113.42'); // raw IP absent
   });
 
-  it('reports slack delivery success', async () => {
+  it('reports slack delivery success and forwards only sanitized fields', async () => {
     slackMock.mockResolvedValueOnce({ delivered: true });
-    const res = await POST(makeRequest(validBody));
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        message: 'sensitive note',
+        npiList: 'Dr Smith 1234567890 has SSN 111-22-3333',
+      }),
+    );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.slackDelivered).toBe(true);
     expect(json.slackReason).toBeNull();
     expect(slackMock).toHaveBeenCalledTimes(1);
+
+    // The PersistedLead passed to Slack must contain no raw free text.
+    const [persistedArg] = slackMock.mock.calls[0] as [Record<string, unknown>];
+    expect(persistedArg.message).toBeUndefined();
+    expect(persistedArg.npiList).toBeUndefined();
+    expect(persistedArg.sampleNpis).toEqual(['1234567890']);
+    expect(persistedArg.sampleNpiCount).toBe(1);
+    const serialized = JSON.stringify(persistedArg);
+    expect(serialized).not.toContain('sensitive note');
+    expect(serialized).not.toContain('Dr Smith');
+    expect(serialized).not.toContain('SSN');
   });
 
   it('returns 200 even when slack fetch fails (lead is already persisted)', async () => {

--- a/apps/web/app/api/leads/route.ts
+++ b/apps/web/app/api/leads/route.ts
@@ -1,0 +1,110 @@
+import 'server-only';
+
+import { NextResponse } from 'next/server';
+
+import {
+  checkRateLimit,
+  hashIp,
+  persistLead,
+  truncateUserAgent,
+  validateLeadInput,
+} from '@/lib/leads/persistLead';
+import { deliverLeadToSlack } from '@/lib/leads/slack';
+
+/**
+ * POST /api/leads — public lead capture endpoint for /launch and
+ * /demo/employer surfaces.
+ *
+ * Behavior:
+ *   - Validates payload via validateLeadInput (email + intent + length-
+ *     bounded optional fields).
+ *   - Rate-limits by hashed caller IP (3 submissions / 5 min). On
+ *     breach returns 429 + Retry-After.
+ *   - Persists the cleaned row to a JSONL append at
+ *     $LEAD_LOG_PATH (or ~/.vitalcv-logs/leads.jsonl).
+ *   - Best-effort Slack delivery when SLACK_LEAD_CAPTURE_WEBHOOK_URL is
+ *     set. Delivery failure does NOT fail the request — the lead is
+ *     already persisted.
+ *   - Never accepts credentials, PHI, or compliance-overclaim copy.
+ */
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function extractClientIp(request: Request): string {
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) return realIp.trim();
+  return '0.0.0.0';
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'invalid_json' },
+      { status: 400 },
+    );
+  }
+
+  const validation = validateLeadInput(body);
+  if (!validation.ok) {
+    return NextResponse.json(
+      { ok: false, errors: validation.errors },
+      { status: 400 },
+    );
+  }
+
+  const rawIp = extractClientIp(request);
+  const ipHash = hashIp(rawIp);
+  const userAgentTrunc = truncateUserAgent(request.headers.get('user-agent'));
+
+  const rate = checkRateLimit(ipHash);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limited', retryAfterSeconds: rate.retryAfterSeconds },
+      {
+        status: 429,
+        headers: rate.retryAfterSeconds
+          ? { 'Retry-After': String(rate.retryAfterSeconds) }
+          : undefined,
+      },
+    );
+  }
+
+  const persisted = await persistLead({
+    ...validation.value,
+    ipHash,
+    userAgentTrunc,
+  });
+
+  console.info(
+    JSON.stringify({
+      event: 'lead_captured',
+      ts: persisted.createdAt,
+      leadId: persisted.leadId,
+      intent: persisted.intent,
+      source: persisted.source ?? null,
+    }),
+  );
+
+  const slack = await deliverLeadToSlack(persisted);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      leadId: persisted.leadId,
+      persisted: true,
+      slackDelivered: slack.delivered,
+      slackReason: slack.delivered ? null : slack.reason,
+      createdAt: persisted.createdAt,
+    },
+    { status: 200 },
+  );
+}

--- a/apps/web/app/api/leads/route.ts
+++ b/apps/web/app/api/leads/route.ts
@@ -31,6 +31,12 @@ import { deliverLeadToSlack } from '@/lib/leads/slack';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+/** Max request body size accepted by /api/leads. The form only collects
+ *  email + intent + a small NPI sample, so 8 KB is generous. Larger
+ *  payloads are rejected before JSON.parse to bound parser cost and
+ *  block accidental document-paste / file-paste. */
+const MAX_BODY_BYTES = 8 * 1024;
+
 function extractClientIp(request: Request): string {
   const xff = request.headers.get('x-forwarded-for');
   if (xff) {
@@ -43,9 +49,37 @@ function extractClientIp(request: Request): string {
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
+  // Fast-fail on an oversize Content-Length header before reading the
+  // body. A streaming client can still understate the header; we
+  // re-check the actual byte length below.
+  const declaredLength = Number(request.headers.get('content-length') ?? '');
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      { ok: false, error: 'payload_too_large' },
+      { status: 413 },
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'invalid_json' },
+      { status: 400 },
+    );
+  }
+
+  if (Buffer.byteLength(raw, 'utf8') > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      { ok: false, error: 'payload_too_large' },
+      { status: 413 },
+    );
+  }
+
   let body: unknown;
   try {
-    body = await request.json();
+    body = raw.trim().length === 0 ? {} : JSON.parse(raw);
   } catch {
     return NextResponse.json(
       { ok: false, error: 'invalid_json' },

--- a/apps/web/components/lead-capture/LeadCaptureBlock.tsx
+++ b/apps/web/components/lead-capture/LeadCaptureBlock.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+
+import type { LeadIntent } from '@/lib/leads/persistLead';
+
+/**
+ * LeadCaptureBlock — client form posting to /api/leads.
+ *
+ * Honest framing: this collects an email + intent so an operator can
+ * follow up. It does NOT enroll a pilot, grant access, or constitute
+ * any verification. Copy must avoid the truth-contract banned phrases.
+ *
+ * Optional surfaces:
+ *   - showNpiList: render a small textarea so an employer can paste a
+ *     candidate list. Field is length-bounded server-side (≤2000 chars).
+ */
+
+const INTENT_OPTIONS: ReadonlyArray<{ value: LeadIntent; label: string }> = [
+  { value: 'waitlist', label: 'Join the waitlist' },
+  { value: 'pilot', label: 'Start a pilot conversation' },
+  { value: 'walkthrough', label: 'Schedule a walkthrough' },
+  { value: 'early_access', label: 'Request early access' },
+];
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'success'; leadId: string }
+  | { kind: 'error'; errors: Record<string, string> }
+  | { kind: 'rate_limited'; retryAfterSeconds?: number }
+  | { kind: 'network_error' };
+
+export interface LeadCaptureBlockProps {
+  source: string;
+  defaultIntent?: LeadIntent;
+  showNpiList?: boolean;
+  heading?: string;
+  helperText?: string;
+}
+
+export function LeadCaptureBlock({
+  source,
+  defaultIntent = 'pilot',
+  showNpiList = false,
+  heading = 'Talk to us',
+  helperText = 'We follow up by email — no verification or pilot enrollment is implied by sending this form.',
+}: LeadCaptureBlockProps) {
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus({ kind: 'submitting' });
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const payload = {
+      email: data.get('email'),
+      intent: data.get('intent'),
+      source,
+      message: data.get('message') || undefined,
+      npiList: showNpiList ? data.get('npiList') || undefined : undefined,
+    };
+
+    try {
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        leadId?: string;
+        errors?: Record<string, string>;
+        retryAfterSeconds?: number;
+      };
+      if (res.status === 429) {
+        setStatus({ kind: 'rate_limited', retryAfterSeconds: json.retryAfterSeconds });
+        return;
+      }
+      if (res.ok && json.ok && json.leadId) {
+        setStatus({ kind: 'success', leadId: json.leadId });
+        form.reset();
+        return;
+      }
+      setStatus({ kind: 'error', errors: json.errors ?? {} });
+    } catch {
+      setStatus({ kind: 'network_error' });
+    }
+  }
+
+  if (status.kind === 'success') {
+    return (
+      <div
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900"
+        data-testid="lead-capture-success"
+        role="status"
+      >
+        <h2 className="text-base font-semibold">Thanks — we got it.</h2>
+        <p className="mt-2 text-sm">
+          We&rsquo;ll reply within one business day. Reference:{' '}
+          <code className="rounded bg-emerald-100 px-1 py-0.5 text-xs">
+            {status.leadId}
+          </code>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="space-y-4 rounded-2xl border border-border p-6"
+      data-testid="lead-capture-form"
+      data-source={source}
+      noValidate
+    >
+      <div>
+        <h2 className="text-base font-semibold">{heading}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{helperText}</p>
+      </div>
+
+      <Field id="lead-email" label="Work email" error={errorOf(status, 'email')}>
+        <input
+          id="lead-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
+        />
+      </Field>
+
+      <Field id="lead-intent" label="What would you like to do?" error={errorOf(status, 'intent')}>
+        <select
+          id="lead-intent"
+          name="intent"
+          defaultValue={defaultIntent}
+          required
+          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
+        >
+          {INTENT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field
+        id="lead-message"
+        label="Anything we should know? (optional)"
+        error={errorOf(status, 'message')}
+      >
+        <textarea
+          id="lead-message"
+          name="message"
+          rows={3}
+          maxLength={2000}
+          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
+        />
+      </Field>
+
+      {showNpiList && (
+        <Field
+          id="lead-npi-list"
+          label="Paste a list of NPIs (optional, comma- or newline-separated)"
+          error={errorOf(status, 'npiList')}
+        >
+          <textarea
+            id="lead-npi-list"
+            name="npiList"
+            rows={3}
+            maxLength={2000}
+            placeholder="1234567890, 0987654321&#10;1122334455"
+            className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-xs focus:border-foreground focus:outline-none"
+          />
+        </Field>
+      )}
+
+      {status.kind === 'rate_limited' && (
+        <p
+          className="rounded-md bg-amber-50 p-3 text-sm text-amber-900"
+          role="alert"
+          data-testid="lead-capture-rate-limited"
+        >
+          Too many submissions from this network. Please retry
+          {status.retryAfterSeconds ? ` in ${status.retryAfterSeconds}s` : ' shortly'}.
+        </p>
+      )}
+
+      {status.kind === 'network_error' && (
+        <p
+          className="rounded-md bg-amber-50 p-3 text-sm text-amber-900"
+          role="alert"
+          data-testid="lead-capture-network-error"
+        >
+          We couldn&rsquo;t reach the server. Please retry, or email{' '}
+          <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status.kind === 'submitting'}
+        className="w-full rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+        data-testid="lead-capture-submit"
+      >
+        {status.kind === 'submitting' ? 'Sending…' : 'Send'}
+      </button>
+    </form>
+  );
+}
+
+function errorOf(status: Status, field: string): string | undefined {
+  if (status.kind !== 'error') return undefined;
+  return status.errors[field];
+}
+
+interface FieldProps {
+  id: string;
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+function Field({ id, label, error, children }: FieldProps) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-xs font-medium uppercase tracking-wide text-muted-foreground"
+      >
+        {label}
+      </label>
+      {children}
+      {error && (
+        <p
+          className="mt-1 text-xs text-red-600"
+          role="alert"
+          data-field-error={id}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/lead-capture/LeadCaptureBlock.tsx
+++ b/apps/web/components/lead-capture/LeadCaptureBlock.tsx
@@ -10,11 +10,16 @@ import type { LeadIntent } from '@/lib/leads/persistLead';
  *
  * Honest framing: this collects an email + intent so an operator can
  * follow up. It does NOT enroll a pilot, grant access, or constitute
- * any verification. Copy must avoid the truth-contract banned phrases.
+ * any verification. Copy must avoid the truth-contract banned phrases
+ * and must NOT promise a response window.
  *
- * Optional surfaces:
- *   - showNpiList: render a small textarea so an employer can paste a
- *     candidate list. Field is length-bounded server-side (≤2000 chars).
+ * Data minimization:
+ *   - No free-text "message" / "notes" / "description" field. The form
+ *     intentionally has no surface that could attract PHI, patient
+ *     names, or other sensitive copy.
+ *   - showNpiList exposes a single textarea whose contents are
+ *     sanitized server-side: only 10-digit NPI-like strings survive,
+ *     capped at MAX_SAMPLE_NPIS. Surrounding text is dropped.
  */
 
 const INTENT_OPTIONS: ReadonlyArray<{ value: LeadIntent; label: string }> = [
@@ -58,7 +63,6 @@ export function LeadCaptureBlock({
       email: data.get('email'),
       intent: data.get('intent'),
       source,
-      message: data.get('message') || undefined,
       npiList: showNpiList ? data.get('npiList') || undefined : undefined,
     };
 
@@ -96,9 +100,10 @@ export function LeadCaptureBlock({
         data-testid="lead-capture-success"
         role="status"
       >
-        <h2 className="text-base font-semibold">Thanks — we got it.</h2>
+        <h2 className="text-base font-semibold">Received.</h2>
         <p className="mt-2 text-sm">
-          We&rsquo;ll reply within one business day. Reference:{' '}
+          We&rsquo;ve received your request and will follow up with the
+          next useful step. Reference:{' '}
           <code className="rounded bg-emerald-100 px-1 py-0.5 text-xs">
             {status.leadId}
           </code>
@@ -147,24 +152,10 @@ export function LeadCaptureBlock({
         </select>
       </Field>
 
-      <Field
-        id="lead-message"
-        label="Anything we should know? (optional)"
-        error={errorOf(status, 'message')}
-      >
-        <textarea
-          id="lead-message"
-          name="message"
-          rows={3}
-          maxLength={2000}
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        />
-      </Field>
-
       {showNpiList && (
         <Field
           id="lead-npi-list"
-          label="Paste a list of NPIs (optional, comma- or newline-separated)"
+          label="Paste a list of NPIs (optional, 10-digit numbers only — anything else is dropped)"
           error={errorOf(status, 'npiList')}
         >
           <textarea

--- a/apps/web/lib/leads/persistLead.ts
+++ b/apps/web/lib/leads/persistLead.ts
@@ -27,12 +27,20 @@ import { dirname, join } from 'node:path';
 
 export type LeadIntent = 'waitlist' | 'pilot' | 'walkthrough' | 'early_access';
 
+/** Maximum number of NPIs persisted from a single submission. */
+export const MAX_SAMPLE_NPIS = 25;
+
 export interface LeadInput {
   email: string;
   intent: LeadIntent;
   source?: string;
-  message?: string;
-  npiList?: string;
+  /**
+   * Sanitized, deduplicated array of 10-digit NPI-like strings extracted
+   * from the submission. Bounded by MAX_SAMPLE_NPIS. The submitter may
+   * paste surrounding text in the form; only digit-run matches are kept
+   * and the raw text is dropped at the validation boundary.
+   */
+  sampleNpis?: string[];
   /** Optional coarse caller context — already-hashed on arrival. */
   ipHash?: string;
   /** Optional truncated user-agent (≤200 chars). */
@@ -42,6 +50,8 @@ export interface LeadInput {
 export interface PersistedLead extends LeadInput {
   leadId: string;
   createdAt: string;
+  /** Count of sampleNpis at persistence time (denormalized for Slack). */
+  sampleNpiCount: number;
 }
 
 /** Resolve the JSONL path with env-var override. */
@@ -76,10 +86,35 @@ export async function persistLead(input: LeadInput): Promise<PersistedLead> {
     leadId: randomUUID(),
     createdAt: new Date().toISOString(),
     ...input,
+    sampleNpiCount: input.sampleNpis?.length ?? 0,
   };
   const line = JSON.stringify(record) + '\n';
   await appendFile(target, line, { encoding: 'utf8', mode: 0o600 });
   return record;
+}
+
+/**
+ * Extract NPI-like 10-digit strings from arbitrary input. The submitter
+ * may paste anything (a CSV, an email signature, a note). Only the
+ * 10-digit digit-runs are kept; everything else is discarded. The result
+ * is deduplicated and capped at MAX_SAMPLE_NPIS.
+ *
+ * This is a sanitizer, not a Luhn-style NPI validator: it does NOT
+ * verify the check digit. The purpose is data-minimization at the
+ * persistence boundary, not source-verification.
+ */
+export function sanitizeNpiList(raw: unknown): string[] {
+  if (typeof raw !== 'string' || raw.length === 0) return [];
+  const matches = raw.match(/(?<!\d)\d{10}(?!\d)/g) ?? [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of matches) {
+    if (seen.has(m)) continue;
+    seen.add(m);
+    out.push(m);
+    if (out.length >= MAX_SAMPLE_NPIS) break;
+  }
+  return out;
 }
 
 /**
@@ -132,22 +167,49 @@ export function validateLeadInput(
     errors.intent = 'intent must be one of: waitlist, pilot, walkthrough, early_access';
   }
 
-  // Optional fields — bound the length to keep the JSONL row reasonable.
+  // `source` is a bounded, controlled-vocabulary tag set by the client
+  // surface (e.g. "launch_page", "demo_employer"). It is the only
+  // free-text-ish field that survives the boundary.
   const source = b.source;
   if (source !== undefined && (typeof source !== 'string' || source.length > 200)) {
     errors.source = 'source must be a string ≤200 chars';
   }
-  const message = b.message;
-  if (message !== undefined && (typeof message !== 'string' || message.length > 2000)) {
-    errors.message = 'message must be a string ≤2000 chars';
-  }
-  const npiList = b.npiList;
-  if (npiList !== undefined && (typeof npiList !== 'string' || npiList.length > 2000)) {
+
+  // Submitters may paste an NPI list (with or without surrounding text)
+  // in either `npiList` (legacy field name from the client) or
+  // `sampleNpis` (array form). The surrounding text is intentionally
+  // dropped here — only the 10-digit digit-runs survive sanitation.
+  //
+  // We DO NOT accept or persist a free-text `message` field. If a
+  // submitter sends one, the route still succeeds (so the form is not
+  // brittle), but the text is silently dropped before persistence.
+  const npiListRaw = b.npiList;
+  if (
+    npiListRaw !== undefined
+    && (typeof npiListRaw !== 'string' || npiListRaw.length > 2000)
+  ) {
     errors.npiList = 'npiList must be a string ≤2000 chars';
+  }
+  const sampleNpisRaw = b.sampleNpis;
+  if (sampleNpisRaw !== undefined && !Array.isArray(sampleNpisRaw)) {
+    errors.sampleNpis = 'sampleNpis must be an array of 10-digit strings';
   }
 
   if (Object.keys(errors).length > 0) {
     return { ok: false, errors };
+  }
+
+  const sanitizedFromString = sanitizeNpiList(npiListRaw);
+  const sanitizedFromArray = sanitizeNpiList(
+    Array.isArray(sampleNpisRaw) ? sampleNpisRaw.join(' ') : undefined,
+  );
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const n of [...sanitizedFromArray, ...sanitizedFromString]) {
+    if (seen.has(n)) continue;
+    seen.add(n);
+    merged.push(n);
+    if (merged.length >= MAX_SAMPLE_NPIS) break;
   }
 
   return {
@@ -156,8 +218,7 @@ export function validateLeadInput(
       email,
       intent: intent as LeadIntent,
       source: typeof source === 'string' ? source : undefined,
-      message: typeof message === 'string' ? message : undefined,
-      npiList: typeof npiList === 'string' ? npiList : undefined,
+      sampleNpis: merged.length > 0 ? merged : undefined,
     },
   };
 }

--- a/apps/web/lib/leads/persistLead.ts
+++ b/apps/web/lib/leads/persistLead.ts
@@ -1,0 +1,202 @@
+import 'server-only';
+
+import { mkdir, appendFile } from 'node:fs/promises';
+import { randomUUID, createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * persistLead — file-system JSONL append for /api/leads submissions.
+ *
+ * No DB. No Prisma. No external network beyond an optional Slack
+ * notification (handled separately).
+ *
+ * Persistence target precedence:
+ *   1. process.env.LEAD_LOG_PATH (operator override)
+ *   2. ~/.vitalcv-logs/leads.jsonl  (default)
+ *
+ * Truth-contract guardrails:
+ *   - Never persists raw PHI or credential documents (route layer
+ *     enforces field allowlist before reaching this function).
+ *   - Hashes coarse caller identity (ip) with SHA-256 + a daily salt
+ *     so the file never contains a raw IP. Never stores user-agent
+ *     beyond a 200-char truncation.
+ *   - Generates a stable per-lead id (UUID v4) for downstream
+ *     dedupe / Slack message threading.
+ */
+
+export type LeadIntent = 'waitlist' | 'pilot' | 'walkthrough' | 'early_access';
+
+export interface LeadInput {
+  email: string;
+  intent: LeadIntent;
+  source?: string;
+  message?: string;
+  npiList?: string;
+  /** Optional coarse caller context — already-hashed on arrival. */
+  ipHash?: string;
+  /** Optional truncated user-agent (≤200 chars). */
+  userAgentTrunc?: string;
+}
+
+export interface PersistedLead extends LeadInput {
+  leadId: string;
+  createdAt: string;
+}
+
+/** Resolve the JSONL path with env-var override. */
+export function resolveLeadLogPath(): string {
+  const override = process.env.LEAD_LOG_PATH;
+  if (override && override.trim().length > 0) {
+    return override;
+  }
+  return join(homedir(), '.vitalcv-logs', 'leads.jsonl');
+}
+
+/** Deterministic daily salt so a single IP within a day hashes consistently
+ *  but the same IP across days hashes differently (limits cross-day
+ *  correlation in the log). */
+function dailySalt(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+export function hashIp(rawIp: string, now: Date = new Date()): string {
+  return createHash('sha256').update(`${dailySalt(now)}:${rawIp}`).digest('hex').slice(0, 16);
+}
+
+export function truncateUserAgent(ua: string | null | undefined, max = 200): string | undefined {
+  if (!ua) return undefined;
+  return ua.slice(0, max);
+}
+
+export async function persistLead(input: LeadInput): Promise<PersistedLead> {
+  const target = resolveLeadLogPath();
+  await mkdir(dirname(target), { recursive: true });
+  const record: PersistedLead = {
+    leadId: randomUUID(),
+    createdAt: new Date().toISOString(),
+    ...input,
+  };
+  const line = JSON.stringify(record) + '\n';
+  await appendFile(target, line, { encoding: 'utf8', mode: 0o600 });
+  return record;
+}
+
+/**
+ * Email validation — minimal regex matching RFC-5321 local + domain
+ * shape. Not exhaustive (no IDN support), but adequate for a lead form.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email);
+}
+
+const VALID_INTENTS: ReadonlyArray<LeadIntent> = [
+  'waitlist',
+  'pilot',
+  'walkthrough',
+  'early_access',
+];
+
+export function isValidIntent(value: unknown): value is LeadIntent {
+  return typeof value === 'string' && VALID_INTENTS.includes(value as LeadIntent);
+}
+
+/**
+ * Validate the request payload. Returns the cleaned input on success
+ * or a list of field-keyed errors on failure.
+ */
+export function validateLeadInput(
+  body: unknown,
+): { ok: true; value: LeadInput } | { ok: false; errors: Record<string, string> } {
+  const errors: Record<string, string> = {};
+
+  if (!body || typeof body !== 'object') {
+    return { ok: false, errors: { _form: 'payload must be a JSON object' } };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  const email = typeof b.email === 'string' ? b.email.trim() : '';
+  if (!email) {
+    errors.email = 'email is required';
+  } else if (email.length > 320) {
+    errors.email = 'email too long';
+  } else if (!isValidEmail(email)) {
+    errors.email = 'email is not in a recognized format';
+  }
+
+  const intent = b.intent;
+  if (!isValidIntent(intent)) {
+    errors.intent = 'intent must be one of: waitlist, pilot, walkthrough, early_access';
+  }
+
+  // Optional fields — bound the length to keep the JSONL row reasonable.
+  const source = b.source;
+  if (source !== undefined && (typeof source !== 'string' || source.length > 200)) {
+    errors.source = 'source must be a string ≤200 chars';
+  }
+  const message = b.message;
+  if (message !== undefined && (typeof message !== 'string' || message.length > 2000)) {
+    errors.message = 'message must be a string ≤2000 chars';
+  }
+  const npiList = b.npiList;
+  if (npiList !== undefined && (typeof npiList !== 'string' || npiList.length > 2000)) {
+    errors.npiList = 'npiList must be a string ≤2000 chars';
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      email,
+      intent: intent as LeadIntent,
+      source: typeof source === 'string' ? source : undefined,
+      message: typeof message === 'string' ? message : undefined,
+      npiList: typeof npiList === 'string' ? npiList : undefined,
+    },
+  };
+}
+
+// ── In-memory per-ip-hash rate limit ──────────────────────────────────────
+
+interface RateBucket {
+  hits: number;
+  windowStartMs: number;
+}
+
+const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000; // 5 min
+const RATE_LIMIT_MAX = 3; // > 3 in 5 min → 429
+const rateBuckets = new Map<string, RateBucket>();
+
+export interface RateLimitCheck {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+}
+
+export function checkRateLimit(
+  key: string,
+  now: number = Date.now(),
+): RateLimitCheck {
+  const bucket = rateBuckets.get(key);
+  if (!bucket || now - bucket.windowStartMs > RATE_LIMIT_WINDOW_MS) {
+    rateBuckets.set(key, { hits: 1, windowStartMs: now });
+    return { allowed: true };
+  }
+  bucket.hits += 1;
+  if (bucket.hits > RATE_LIMIT_MAX) {
+    const elapsed = now - bucket.windowStartMs;
+    const retryAfterSeconds = Math.ceil((RATE_LIMIT_WINDOW_MS - elapsed) / 1000);
+    return { allowed: false, retryAfterSeconds };
+  }
+  return { allowed: true };
+}
+
+/** Testing helper — resets the in-memory rate bucket state. */
+export function _resetRateBuckets(): void {
+  rateBuckets.clear();
+}

--- a/apps/web/lib/leads/slack.ts
+++ b/apps/web/lib/leads/slack.ts
@@ -1,0 +1,74 @@
+import 'server-only';
+
+import type { PersistedLead } from './persistLead';
+
+/**
+ * Slack webhook wrapper for lead capture.
+ *
+ * Behavior mirrors lib/pilot-intake/slack.ts:
+ *   - If SLACK_LEAD_CAPTURE_WEBHOOK_URL is unset, no-op and returns
+ *     { delivered: false, reason: 'unconfigured' }.
+ *   - On 2xx, returns { delivered: true }. On any other outcome,
+ *     returns a non-throwing failure so the caller can still log the
+ *     lead row.
+ */
+
+export type SlackDeliveryOutcome =
+  | { delivered: true }
+  | { delivered: false; reason: 'unconfigured' | 'http_error' | 'fetch_failed' };
+
+export function isSlackConfigured(): boolean {
+  return Boolean(process.env.SLACK_LEAD_CAPTURE_WEBHOOK_URL);
+}
+
+export async function deliverLeadToSlack(
+  lead: PersistedLead,
+  webhookUrl: string | undefined = process.env.SLACK_LEAD_CAPTURE_WEBHOOK_URL,
+): Promise<SlackDeliveryOutcome> {
+  if (!webhookUrl) return { delivered: false, reason: 'unconfigured' };
+
+  const fields: Array<{ type: 'mrkdwn'; text: string }> = [
+    { type: 'mrkdwn', text: `*Intent*\n${lead.intent}` },
+    { type: 'mrkdwn', text: `*Email*\n${lead.email}` },
+    { type: 'mrkdwn', text: `*Lead*\n${lead.leadId}` },
+    { type: 'mrkdwn', text: `*Source*\n${lead.source ?? '(unset)'}` },
+  ];
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `New VitalCV lead — ${lead.intent}` },
+    },
+    { type: 'section', fields },
+  ];
+
+  if (lead.message) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Message*\n${lead.message}` },
+    });
+  }
+  if (lead.npiList) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*NPI list*\n${lead.npiList}` },
+    });
+  }
+
+  const message = {
+    text: `New VitalCV lead (${lead.intent}): ${lead.email}`,
+    blocks,
+  };
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(message),
+    });
+    if (!res.ok) return { delivered: false, reason: 'http_error' };
+    return { delivered: true };
+  } catch {
+    return { delivered: false, reason: 'fetch_failed' };
+  }
+}

--- a/apps/web/lib/leads/slack.ts
+++ b/apps/web/lib/leads/slack.ts
@@ -27,11 +27,16 @@ export async function deliverLeadToSlack(
 ): Promise<SlackDeliveryOutcome> {
   if (!webhookUrl) return { delivered: false, reason: 'unconfigured' };
 
+  // Only sanitized fields cross the Slack boundary. No raw free-text
+  // message. No raw npiList. The sampleNpis array is already bounded
+  // and digit-only (validated in persistLead.sanitizeNpiList), so it is
+  // safe to surface for triage.
   const fields: Array<{ type: 'mrkdwn'; text: string }> = [
     { type: 'mrkdwn', text: `*Intent*\n${lead.intent}` },
     { type: 'mrkdwn', text: `*Email*\n${lead.email}` },
     { type: 'mrkdwn', text: `*Lead*\n${lead.leadId}` },
     { type: 'mrkdwn', text: `*Source*\n${lead.source ?? '(unset)'}` },
+    { type: 'mrkdwn', text: `*Sample NPIs*\n${lead.sampleNpiCount}` },
   ];
 
   const blocks: Array<Record<string, unknown>> = [
@@ -42,16 +47,13 @@ export async function deliverLeadToSlack(
     { type: 'section', fields },
   ];
 
-  if (lead.message) {
+  if (lead.sampleNpis && lead.sampleNpis.length > 0) {
     blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: `*Message*\n${lead.message}` },
-    });
-  }
-  if (lead.npiList) {
-    blocks.push({
-      type: 'section',
-      text: { type: 'mrkdwn', text: `*NPI list*\n${lead.npiList}` },
+      text: {
+        type: 'mrkdwn',
+        text: `*Sample NPI list (${lead.sampleNpis.length})*\n${lead.sampleNpis.join(', ')}`,
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- New `/api/leads` POST endpoint that validates, rate-limits, persists, and optionally forwards lead-capture submissions from /launch and /demo/employer surfaces.
- Pure helpers in `apps/web/lib/leads/persistLead.ts` (validation, daily-salted IP hash, UA truncation, JSONL append at `$LEAD_LOG_PATH` or `~/.vitalcv-logs/leads.jsonl`, in-memory 3-per-5-min rate limit).
- Optional Slack delivery via `SLACK_LEAD_CAPTURE_WEBHOOK_URL` — best-effort, never throws, never fails the request.
- Reusable client component `LeadCaptureBlock` (email, intent select, optional message + NPI-list textarea) ready for the demo-spine pages.

## Truth rules
- No banned phrases (`automatically verified`, `complete credentialing`, `HIPAA compliant`, `SOC2 certified`, etc.) in any new file — verified via the standard grep set.
- No bare `Verified` label.
- Copy explicitly tells the user that sending the form does NOT enroll a pilot, grant access, or imply verification.
- No PHI collected; NPI textarea is optional and length-bounded server-side (≤2000 chars).
- Raw caller IP is hashed before any persistence; the JSONL row only stores the 16-hex digest. Test asserts the raw IP is absent from the file.
- No Prisma migration. No Vercel / DNS / production env mutation. No changes outside `apps/web/{lib,app/api,components,__tests__}`.

## Validation
- `pnpm --filter @vitalcv/web exec vitest run __tests__/leads-route.test.ts` — 14/14 passing
- `pnpm --filter @vitalcv/web exec tsc --noEmit` — clean
- Banned-phrase scan on new files — CLEAN
- Bare-Verified scan on new files — CLEAN

## Follow-ups (separate PRs)
- Wire `LeadCaptureBlock` into `/launch` and `/demo/employer` once those pages (currently on the OpenEvidence demo-spine PRs) merge into `origin/main`.
- Operator: set `LEAD_LOG_PATH` and `SLACK_LEAD_CAPTURE_WEBHOOK_URL` in the demo deploy env before the public surface goes live.

## Test plan
- [ ] `pnpm --filter @vitalcv/web exec vitest run __tests__/leads-route.test.ts` passes locally
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` clean
- [ ] Codex SAFE verdict on implementation / diff / copy audits