### PR TITLE
feat(review): show audit event id after employer acceptance

### DIFF
--- a/apps/web/__tests__/employer-review-proxy.test.ts
+++ b/apps/web/__tests__/employer-review-proxy.test.ts
@@ -271,6 +271,32 @@ describe('/api/employer-review/[entityId]/[action] proxy', () => {
     });
   });
 
+  it('preserves auditEventId and timestamp on accept so the UI can render the audit-entry line', async () => {
+    authMock.mockResolvedValue({ userId: 'clerk-user-1' });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(buildActionResponse('accept'), 201));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../app/api/employer-review/[entityId]/[action]/route');
+    const response = await POST(new NextRequest('http://localhost/api/employer-review/entity-1/accept', {
+      method: 'POST',
+      body: JSON.stringify({ acceptanceScope: 'pilot' }),
+      headers: { 'Content-Type': 'application/json' },
+    }) as never, {
+      params: Promise.resolve({ entityId: 'entity-1', action: 'accept' }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      ok: boolean;
+      state: { auditEventId: string; timestamp: string; action: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.state.action).toBe('accept');
+    // The two fields the ReviewClient renders as the audit-entry line.
+    expect(body.state.auditEventId).toBe('audit-accept-1');
+    expect(body.state.timestamp).toBe('2026-03-23T19:00:00.000Z');
+  });
+
   it('forwards share-packet generation and validates the share-token response', async () => {
     authMock.mockResolvedValue({ userId: 'clerk-user-1' });
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({

--- a/apps/web/components/review/ReviewClient.tsx
+++ b/apps/web/components/review/ReviewClient.tsx
@@ -1562,10 +1562,15 @@ function ReviewClientLoaded({
                 <span className="text-[var(--vt-success)] text-sm">✔</span>
                 <p className="text-foreground/70 text-sm font-medium">Audit-boundary entry captured</p>
               </div>
-              <div className="rounded-lg border border-white/8 bg-card px-3 py-2 mt-1 space-y-1.5">
-                <p className="text-muted-foreground/40 text-[10px] uppercase tracking-widest">Audit record</p>
-                <p className="text-foreground text-[10px] font-mono break-all">{actionState.state.auditEventId}</p>
-                <p className="text-muted-foreground/40 text-[10px]">{new Date(actionState.state.timestamp).toLocaleString()}</p>
+              <div className="rounded-lg border border-white/8 bg-card px-3 py-2 mt-1">
+                <p
+                  className="text-foreground text-[10px] font-mono break-all"
+                  data-testid="employer-accept-audit-entry"
+                  data-audit-event-id={actionState.state.auditEventId}
+                  data-audit-recorded-at={actionState.state.timestamp}
+                >
+                  {`Audit entry: ${actionState.state.auditEventId} · ${new Date(actionState.state.timestamp).toLocaleString()}`}
+                </p>
               </div>
 
             </TrustStateCard>


### PR DESCRIPTION
## Summary
- After every employer action (accept, request-refresh, route-to-review), the review surface now shows a single monospace line that surfaces the non-repudiable receipt the action generated:

      Audit entry: {auditEventId} · {auditRecordedAt}

- Adds \`data-testid=\"employer-accept-audit-entry\"\` and structured \`data-audit-event-id\` / \`data-audit-recorded-at\` attributes so downstream tests and observability tooling can scrape the IDs without parsing copy.

## What this PR does NOT change
- **Backend** (\`apps/api/backend/src/routes/employerActions.ts\`): already creates the AuditEvent before returning 201 and already returns \`{ ok: true, state: { auditEventId, timestamp, ... } }\` where \`state.timestamp\` is the AuditEvent row's \`createdAt\` (see \`services/entity/employerReviewActions.ts:938\`). No change.
- **Proxy** (\`apps/web/app/api/employer-review/[entityId]/[action]/route.ts\`): already passes \`auditEventId\` and \`timestamp\` through via \`normalizeEmployerReviewActionResponse\`. No change.
- AuditEvent-before-2xx invariant: preserved by existing backend code; no contract change.
- No Prisma migration. No env / Vercel / Railway / DNS change. No new endpoints.

## Truth rules
- No banned phrases introduced (verified on the diff scope).
- No bare "Verified" label (the new line begins with "Audit entry:").
- The audit-entry line renders only when the action proxy returns a normalized state with a real auditEventId — the existing error branch is untouched, so no fabricated ID is ever shown.

## Validation
- \`pnpm --filter @vitalcv/web exec vitest run __tests__/employer-review-proxy.test.ts\` → 16/16 passing (15 pre-existing + 1 new "preserves auditEventId and timestamp on accept")
- \`pnpm --filter @vitalcv/web exec tsc --noEmit\` → clean
- Banned-phrase scan on diff scope → CLEAN
- Bare-Verified scan on diff scope → CLEAN

## Test plan
- [ ] Targeted vitest passes on CI
- [ ] Type check clean
- [ ] Codex SAFE verdict on implementation / diff / copy audits