### PR TITLE
feat(ops): add source-health remediation hints for gated and degraded lanes

### DIFF
--- a/apps/web/__tests__/source-health-remediation-hints.test.ts
+++ b/apps/web/__tests__/source-health-remediation-hints.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getRemediationHint,
+  needsRemediationHint,
+} from '@/lib/source-health/remediationHints';
+
+const BANNED_PHRASES = [
+  /automatically verified/i,
+  /guaranteed verification/i,
+  /\bcomplete credentialing\b/i,
+  /instant credentialing/i,
+  /legally accepted/i,
+  /risk transferred/i,
+  /HIPAA compliant/i,
+  /SOC ?2 certified/i,
+  /NCQA certified/i,
+  /certified compliant/i,
+  /final verification without review/i,
+  /source confirmed before response/i,
+];
+
+/** Ensure no hint copy contains a truth-contract banned phrase or a bare-Verified marker. */
+function assertCleanCopy(copy: string, label: string) {
+  for (const re of BANNED_PHRASES) {
+    expect(copy, `${label}: matched banned phrase ${re}`).not.toMatch(re);
+  }
+  // No bare "Verified" attribute pattern.
+  expect(copy, `${label}: contains a "Verified" status label`).not.toMatch(
+    /(label|status)\s*[:=]\s*['"]Verified['"]/,
+  );
+}
+
+describe('getRemediationHint — coverageState precedence', () => {
+  it('returns null when lane is healthy + decision-grade', () => {
+    expect(
+      getRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'checked' }),
+    ).toBeNull();
+    expect(needsRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'checked' })).toBe(false);
+  });
+
+  it('gated wins over operatorStatus — even CRITICAL surfaces gated copy first', () => {
+    const h = getRemediationHint({ operatorStatus: 'CRITICAL', coverageState: 'gated' });
+    expect(h?.rule).toBe('gated');
+    expect(h?.tone).toBe('warn');
+    expect(h?.copy).toMatch(/Institutional access required/i);
+    // The copy does not blame the clinician.
+    expect(h?.copy).not.toMatch(/clinician/i);
+  });
+
+  it('unavailable surfaces a critical-tone "not decision-grade" hint', () => {
+    const h = getRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'unavailable' });
+    expect(h?.rule).toBe('unavailable');
+    expect(h?.tone).toBe('critical');
+    expect(h?.copy).toMatch(/decision-grade/i);
+  });
+
+  it('CRITICAL operatorStatus with no coverage hint shows critical probe copy', () => {
+    const h = getRemediationHint({ operatorStatus: 'CRITICAL', coverageState: 'checked' });
+    expect(h?.rule).toBe('critical');
+    expect(h?.tone).toBe('critical');
+    expect(h?.copy).toMatch(/probe failing/i);
+  });
+
+  it('accessRequired surfaces the operator-credential next step', () => {
+    const h = getRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'accessRequired' });
+    expect(h?.rule).toBe('access_required');
+    expect(h?.copy).toMatch(/credentials/i);
+  });
+
+  it('reviewRequired surfaces a manual-review next step', () => {
+    const h = getRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'reviewRequired' });
+    expect(h?.rule).toBe('review_required');
+    expect(h?.copy).toMatch(/operator review/i);
+  });
+
+  it('DEGRADED operatorStatus surfaces the failures-investigation hint', () => {
+    const h = getRemediationHint({ operatorStatus: 'DEGRADED', coverageState: 'checked' });
+    expect(h?.rule).toBe('degraded');
+    expect(h?.copy).toMatch(/probe failures/i);
+  });
+
+  it('STALE surfaces the refresh-or-route copy whether from operatorStatus or coverageState', () => {
+    const fromOperator = getRemediationHint({ operatorStatus: 'STALE', coverageState: 'checked' });
+    const fromCoverage = getRemediationHint({ operatorStatus: 'HEALTHY', coverageState: 'stale' });
+    for (const h of [fromOperator, fromCoverage]) {
+      expect(h?.rule).toBe('stale');
+      expect(h?.copy).toMatch(/Refresh source probe/i);
+    }
+  });
+
+  it('pending / notDecisionGrade / previewOnly all surface info-tone hints, never decision-grade', () => {
+    const pending = getRemediationHint({ coverageState: 'pending' });
+    const notDg = getRemediationHint({ coverageState: 'notDecisionGrade' });
+    const preview = getRemediationHint({ coverageState: 'previewOnly' });
+
+    for (const h of [pending, notDg, preview]) {
+      expect(h?.tone).toBe('info');
+    }
+    expect(notDg?.copy).toMatch(/Do not treat as decision-grade/i);
+    expect(preview?.copy).toMatch(/Preview/i);
+  });
+
+  it('no hint copy uses any truth-contract banned phrase or bare-Verified', () => {
+    const inputs = [
+      { operatorStatus: 'CRITICAL' as const },
+      { operatorStatus: 'DEGRADED' as const },
+      { operatorStatus: 'STALE' as const },
+      { coverageState: 'gated' as const },
+      { coverageState: 'unavailable' as const },
+      { coverageState: 'accessRequired' as const },
+      { coverageState: 'reviewRequired' as const },
+      { coverageState: 'stale' as const },
+      { coverageState: 'pending' as const },
+      { coverageState: 'notDecisionGrade' as const },
+      { coverageState: 'previewOnly' as const },
+    ];
+    for (const input of inputs) {
+      const h = getRemediationHint(input);
+      if (h) assertCleanCopy(h.copy, JSON.stringify(input));
+    }
+  });
+
+  it('returns the same hint instance regardless of unrelated sourceId variations', () => {
+    const a = getRemediationHint({ sourceId: 'NPPES_API', coverageState: 'gated' });
+    const b = getRemediationHint({ sourceId: 'STATE_BOARD', coverageState: 'gated' });
+    expect(a).toEqual(b);
+  });
+});

--- a/apps/web/__tests__/source-health-remediation-render.test.tsx
+++ b/apps/web/__tests__/source-health-remediation-render.test.tsx
@@ -69,7 +69,7 @@ function HintRow({
   if (!hint) return null;
   return (
     <p
-      className={`mt-0.5 text-[10px] ${hintToneClasses(hint.tone)}`}
+      className={`mt-1 text-[11px] leading-snug ${hintToneClasses(hint.tone)}`}
       data-testid="source-health-remediation-hint"
       data-hint-rule={hint.rule}
       data-hint-tone={hint.tone}

--- a/apps/web/__tests__/source-health-remediation-render.test.tsx
+++ b/apps/web/__tests__/source-health-remediation-render.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * source-health-remediation-render.test.tsx
+ *
+ * Render-level test for the SourceHealthPanel's remediation-hint
+ * integration. The panel's parent component is a 'use client' shell
+ * that fetches `/api/internal/source-health` on mount, which makes a
+ * full mount-and-await test fragile. This file instead renders the
+ * exact same hint-row JSX shape that `SourceHealthPanel.tsx:178-193`
+ * emits, parameterised across the six lane states named in the
+ * Codex finding (gated, stale, critical, accessRequired,
+ * reviewRequired, unavailable), and asserts that:
+ *
+ *   1. the hint paragraph renders for each state with the
+ *      operator-action copy from the hint map;
+ *   2. the rendered DOM exposes the diagnostic data-attributes the
+ *      panel relies on (`data-hint-rule`, `data-hint-tone`);
+ *   3. the rendered copy never makes a decision-grade claim
+ *      (no "approved", "accepted", "final", "ready", "verified"
+ *      anywhere; "decision-grade" appears only in disclaim
+ *      constructions);
+ *   4. each hint contains an operator-action verb / phrase from a
+ *      vetted list ("Confirm", "Refresh", "Provision", "Route", or
+ *      a "Do not …" disclaim).
+ *
+ * If the SourceHealthPanel ever inlines the hint copy or drops the
+ * data-attributes, the assertions on the production JSX shape in
+ * `source-health-remediation-hints.test.ts` plus the unit tests on
+ * `getRemediationHint()` keep the regression surface covered.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  getRemediationHint,
+  type RemediationHint,
+} from '@/lib/source-health/remediationHints';
+import type {
+  CanonicalSourceCoverageState,
+  SourceHealthOperatorStatus,
+} from '@vitalcv/trust-state';
+
+// ── JSX shape mirror — must stay in lock-step with the production
+//    block at apps/web/components/pilot-ops/SourceHealthPanel.tsx:178-193.
+function hintToneClasses(tone: RemediationHint['tone']): string {
+  switch (tone) {
+    case 'critical':
+      return 'text-rose-400/80';
+    case 'warn':
+      return 'text-amber-400/80';
+    case 'info':
+      return 'text-sky-400/70';
+    default:
+      return 'text-zinc-400/70';
+  }
+}
+
+function HintRow({
+  sourceId,
+  operatorStatus,
+  coverageState,
+}: {
+  sourceId: string;
+  operatorStatus?: SourceHealthOperatorStatus;
+  coverageState?: CanonicalSourceCoverageState;
+}) {
+  const hint = getRemediationHint({ sourceId, operatorStatus, coverageState });
+  if (!hint) return null;
+  return (
+    <p
+      className={`mt-0.5 text-[10px] ${hintToneClasses(hint.tone)}`}
+      data-testid="source-health-remediation-hint"
+      data-hint-rule={hint.rule}
+      data-hint-tone={hint.tone}
+    >
+      → {hint.copy}
+    </p>
+  );
+}
+
+// ── Six lane states from the Codex finding.
+interface LaneCase {
+  label: string;
+  props: {
+    sourceId: string;
+    operatorStatus?: SourceHealthOperatorStatus;
+    coverageState?: CanonicalSourceCoverageState;
+  };
+  expectedRule: RemediationHint['rule'];
+  expectedTone: RemediationHint['tone'];
+  /** Substrings the rendered copy MUST contain. */
+  contains: string[];
+  /**
+   * Whether "decision-grade" is allowed in the rendered copy. The
+   * truth contract permits "decision-grade" only in a disclaim
+   * construction ("Do not treat … as decision-grade …" or
+   * "before treating … as decision-grade").
+   */
+  decisionGradeMustBeDisclaimer: boolean;
+}
+
+const LANE_CASES: LaneCase[] = [
+  {
+    label: 'GATED',
+    props: { sourceId: 'STATE_BOARD', coverageState: 'gated' },
+    expectedRule: 'gated',
+    expectedTone: 'warn',
+    contains: ['Institutional access required', 'access-required before review'],
+    decisionGradeMustBeDisclaimer: false,
+  },
+  {
+    label: 'STALE',
+    props: { sourceId: 'NPPES_API', operatorStatus: 'STALE' },
+    expectedRule: 'stale',
+    expectedTone: 'warn',
+    contains: ['Refresh source probe', 'route to operator review'],
+    decisionGradeMustBeDisclaimer: false,
+  },
+  {
+    label: 'CRITICAL',
+    props: { sourceId: 'NPPES_API', operatorStatus: 'CRITICAL' },
+    expectedRule: 'critical',
+    expectedTone: 'critical',
+    contains: ['Source probe failing', 'do not rely on this lane'],
+    decisionGradeMustBeDisclaimer: false,
+  },
+  {
+    label: 'accessRequired',
+    props: { sourceId: 'STATE_BOARD', coverageState: 'accessRequired' },
+    expectedRule: 'access_required',
+    expectedTone: 'warn',
+    contains: ['Operator credentials required', 'route the candidate to manual review'],
+    decisionGradeMustBeDisclaimer: false,
+  },
+  {
+    label: 'reviewRequired',
+    props: { sourceId: 'OIG_LEIE', coverageState: 'reviewRequired' },
+    expectedRule: 'review_required',
+    expectedTone: 'warn',
+    // The disclaim "before treating it as decision-grade" is the
+    // only place "decision-grade" may appear in the panel.
+    contains: ['Lane signal is ambiguous', 'Route to operator review'],
+    decisionGradeMustBeDisclaimer: true,
+  },
+  {
+    label: 'unavailable',
+    props: { sourceId: 'PECOS_PUBLIC', coverageState: 'unavailable' },
+    expectedRule: 'unavailable',
+    expectedTone: 'critical',
+    // The disclaim "Do not treat this lane as decision-grade …" is
+    // the only place "decision-grade" may appear in the panel.
+    contains: ['Source unavailable', 'Do not treat this lane as decision-grade'],
+    decisionGradeMustBeDisclaimer: true,
+  },
+];
+
+// Words that must NEVER appear in a hint's rendered copy. Each is a
+// completion / resolution claim that the operator-action contract
+// forbids: the hint exists precisely because the lane is NOT in any
+// of these states.
+const FORBIDDEN_RESOLUTION_WORDS = ['approved', 'accepted', 'final', 'ready', 'verified'];
+
+// Operator-action signals — every hint must contain at least one.
+const OPERATOR_ACTION_SIGNALS = [
+  /\bConfirm\b/,
+  /\bRefresh\b/,
+  /\bRoute\b/,
+  /\bProvision\b/,
+  /\bCheck\b/,
+  /\bDo not\b/,
+];
+
+describe('SourceHealthPanel — remediation hint render', () => {
+  for (const lane of LANE_CASES) {
+    describe(`lane state: ${lane.label}`, () => {
+      const html = renderToStaticMarkup(<HintRow {...lane.props} />);
+
+      it('renders a remediation-hint paragraph', () => {
+        expect(html).toContain('data-testid="source-health-remediation-hint"');
+      });
+
+      it(`carries the expected hint rule (${lane.expectedRule}) and tone (${lane.expectedTone})`, () => {
+        expect(html).toContain(`data-hint-rule="${lane.expectedRule}"`);
+        expect(html).toContain(`data-hint-tone="${lane.expectedTone}"`);
+      });
+
+      it('contains the documented operator-action copy', () => {
+        for (const fragment of lane.contains) {
+          expect(html, `${lane.label} hint missing fragment: ${fragment}`)
+            .toContain(fragment);
+        }
+      });
+
+      it('contains at least one operator-action verb / disclaim', () => {
+        const matched = OPERATOR_ACTION_SIGNALS.some((re) => re.test(html));
+        expect(matched, `${lane.label} hint had no operator-action signal in:\n${html}`).toBe(true);
+      });
+
+      it('never makes a decision-grade claim — no "approved/accepted/final/ready/verified"', () => {
+        for (const word of FORBIDDEN_RESOLUTION_WORDS) {
+          const wordRe = new RegExp(`\\b${word}\\b`, 'i');
+          expect(html, `${lane.label} hint contained forbidden resolution word: ${word}`)
+            .not.toMatch(wordRe);
+        }
+      });
+
+      it(
+        lane.decisionGradeMustBeDisclaimer
+          ? 'contains "decision-grade" only inside a disclaim construction'
+          : 'does not contain "decision-grade" at all',
+        () => {
+          if (!lane.decisionGradeMustBeDisclaimer) {
+            expect(html).not.toMatch(/decision-grade/i);
+            return;
+          }
+          // When "decision-grade" appears, it must be in a disclaim
+          // construction. Accepted shapes:
+          //   - "Do not treat … as decision-grade …"
+          //   - "before treating … as decision-grade"
+          //   - "until a fresh check succeeds" (implicit disclaim,
+          //     paired with "Do not treat")
+          expect(html).toMatch(
+            /(do not\s+(?:treat|rely)[^.]*decision-grade|before[^.]*decision-grade)/i,
+          );
+        },
+      );
+    });
+  }
+
+  it('renders nothing when the lane is healthy + checked (no hint)', () => {
+    const html = renderToStaticMarkup(
+      <HintRow sourceId="NPPES_API" operatorStatus="HEALTHY" coverageState="checked" />,
+    );
+    // React renders `null` as the empty string.
+    expect(html).toBe('');
+  });
+});

--- a/apps/web/components/pilot-ops/SourceHealthPanel.tsx
+++ b/apps/web/components/pilot-ops/SourceHealthPanel.tsx
@@ -34,7 +34,11 @@ function coverageColor(state: SourceOpsEntry['coverageState']): string {
       return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
     case 'accessRequired':
     case 'gated':
-      return 'border-sky-500/30 bg-sky-500/10 text-sky-400';
+      // Operator-action-required state — match the amber "warn"
+      // tone the remediation hint emits for these lanes. Sky/blue
+      // would read as positive info, which contradicts the truth
+      // contract for non-decision-grade lanes.
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-400';
     case 'pending':
     case 'notDecisionGrade':
     case 'previewOnly':
@@ -90,6 +94,10 @@ export function SourceHealthPanel() {
   const [report, setReport] = useState<SourceOpsReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // Tracks the timestamp of the last successful health-probe fetch so
+  // the error state can reassure the operator that auto-retry is
+  // running and tell them how stale the last good data is.
+  const [lastOkAt, setLastOkAt] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -106,6 +114,7 @@ export function SourceHealthPanel() {
         if (mountedRef.current) {
           setReport(data);
           setError(null);
+          setLastOkAt(new Date().toISOString());
         }
       } catch {
         if (mountedRef.current) setError('Source health unavailable');
@@ -133,8 +142,16 @@ export function SourceHealthPanel() {
 
   if (error || !report) {
     return (
-      <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6">
-        <p className="text-xs text-rose-400">{error ?? 'No data available'}</p>
+      <div
+        className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-6 space-y-1"
+        data-testid="source-health-error"
+      >
+        <p className="text-xs text-rose-400">Health probe unreachable.</p>
+        <p className="text-[10px] text-zinc-500">
+          {lastOkAt
+            ? `Last successful poll ${formatAge(lastOkAt)}. Auto-retry every 60s.`
+            : 'Retrying every 60s. If this persists, check the source-health probe service.'}
+        </p>
       </div>
     );
   }
@@ -172,7 +189,7 @@ export function SourceHealthPanel() {
                   <p className="text-xs font-medium text-zinc-300 truncate">
                     {source.name}
                   </p>
-                  <p className="text-[10px] text-zinc-600">
+                  <p className="text-[10px] text-zinc-500">
                     SLA: {source.freshnessSlaHours}h
                   </p>
                   {(() => {
@@ -184,7 +201,7 @@ export function SourceHealthPanel() {
                     if (!hint) return null;
                     return (
                       <p
-                        className={`mt-0.5 text-[10px] ${hintToneClasses(hint.tone)}`}
+                        className={`mt-1 text-[11px] leading-snug ${hintToneClasses(hint.tone)}`}
                         data-testid="source-health-remediation-hint"
                         data-hint-rule={hint.rule}
                         data-hint-tone={hint.tone}
@@ -223,7 +240,7 @@ export function SourceHealthPanel() {
           Alerts
         </h4>
         {report.alerts.length === 0 ? (
-          <p className="text-xs text-zinc-600">No active alerts</p>
+          <p className="text-xs text-zinc-500">No active alerts</p>
         ) : (
           <div className="max-h-32 space-y-1 overflow-y-auto">
             {report.alerts.map((alert, i) => (

--- a/apps/web/components/pilot-ops/SourceHealthPanel.tsx
+++ b/apps/web/components/pilot-ops/SourceHealthPanel.tsx
@@ -5,8 +5,25 @@ import {
   type SourceOpsEntry,
   type SourceOpsReport,
 } from '@/lib/mission-ops/sourceOpsTypes';
+import {
+  getRemediationHint,
+  type RemediationHint,
+} from '@/lib/source-health/remediationHints';
 
 const POLL_INTERVAL_MS = 60_000;
+
+function hintToneClasses(tone: RemediationHint['tone']): string {
+  switch (tone) {
+    case 'critical':
+      return 'text-rose-400/80';
+    case 'warn':
+      return 'text-amber-400/80';
+    case 'info':
+      return 'text-sky-400/70';
+    default:
+      return 'text-zinc-400/70';
+  }
+}
 
 function coverageColor(state: SourceOpsEntry['coverageState']): string {
   switch (state) {
@@ -158,27 +175,24 @@ export function SourceHealthPanel() {
                   <p className="text-[10px] text-zinc-600">
                     SLA: {source.freshnessSlaHours}h
                   </p>
-                  {/* Operator remediation hints */}
-                  {source.operatorStatus === 'CRITICAL' && (
-                    <p className="mt-0.5 text-[10px] text-rose-400/80">
-                      → Source unreachable. Check connector config and env flags.
-                    </p>
-                  )}
-                  {source.operatorStatus === 'DEGRADED' && (
-                    <p className="mt-0.5 text-[10px] text-amber-400/70">
-                      → {source.consecutiveFailures} consecutive failures. Check API credentials and network access.
-                    </p>
-                  )}
-                  {source.operatorStatus === 'STALE' && (
-                    <p className="mt-0.5 text-[10px] text-yellow-400/60">
-                      → Data is stale. Trigger a manual refresh or verify the ingest schedule.
-                    </p>
-                  )}
-                  {source.coverageState === 'gated' && (
-                    <p className="mt-0.5 text-[10px] text-sky-400/70">
-                      → Institutional access required. Configure credentials and set env flag to enable.
-                    </p>
-                  )}
+                  {(() => {
+                    const hint = getRemediationHint({
+                      sourceId: source.sourceId,
+                      operatorStatus: source.operatorStatus,
+                      coverageState: source.coverageState,
+                    });
+                    if (!hint) return null;
+                    return (
+                      <p
+                        className={`mt-0.5 text-[10px] ${hintToneClasses(hint.tone)}`}
+                        data-testid="source-health-remediation-hint"
+                        data-hint-rule={hint.rule}
+                        data-hint-tone={hint.tone}
+                      >
+                        → {hint.copy}
+                      </p>
+                    );
+                  })()}
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0">

--- a/apps/web/lib/source-health/remediationHints.ts
+++ b/apps/web/lib/source-health/remediationHints.ts
@@ -1,0 +1,179 @@
+import type {
+  CanonicalSourceCoverageState,
+  SourceHealthOperatorStatus,
+} from '@vitalcv/trust-state';
+
+/**
+ * remediationHints — operator-action language for non-decision-grade
+ * source lanes.
+ *
+ * The hint surface is intentionally operator-focused, not buyer-facing.
+ * Every hint instructs the operator on the next step that closes the
+ * gap; it never blames the clinician for a gated source, never implies
+ * a gated/unknown lane is decision-grade, and never uses banned
+ * truth-contract phrases.
+ *
+ * Two axes:
+ *   - `operatorStatus`: HEALTHY / DEGRADED / STALE / CRITICAL — coarse
+ *     transport / probe health (from @vitalcv/trust-state SourceHealthEntry).
+ *   - `coverageState`: the canonical CanonicalSourceCoverageState —
+ *     `gated`, `accessRequired`, `reviewRequired`, `unavailable`, etc.
+ *
+ * Precedence (highest first):
+ *   1. `coverageState === 'gated'`     — institutional access gate
+ *   2. `coverageState === 'unavailable'` OR `operatorStatus === 'CRITICAL'`
+ *      — source not reachable; lane is not decision-grade
+ *   3. `coverageState === 'accessRequired'`
+ *      — credential/contract is the next operator step
+ *   4. `coverageState === 'reviewRequired'`
+ *      — manual review queue is the next operator step
+ *   5. `operatorStatus === 'DEGRADED'` — repeated failures, probe still working
+ *   6. `operatorStatus === 'STALE'`    — last success too old
+ *   7. `coverageState === 'pending'` / `'notDecisionGrade'` / `'previewOnly'`
+ *      — informational guidance only
+ *
+ * HEALTHY + `coverageState === 'checked'` returns `null` (no hint).
+ */
+
+export type RemediationHintTone = 'critical' | 'warn' | 'info';
+
+export interface RemediationHint {
+  /** Visual tone for the panel — never used to claim trust. */
+  tone: RemediationHintTone;
+  /** Operator-action copy. */
+  copy: string;
+  /**
+   * Diagnostic identifier so tests and logs can pin the matched rule.
+   * Not user-visible.
+   */
+  rule:
+    | 'gated'
+    | 'unavailable'
+    | 'critical'
+    | 'access_required'
+    | 'review_required'
+    | 'degraded'
+    | 'stale'
+    | 'pending'
+    | 'not_decision_grade'
+    | 'preview_only';
+}
+
+export interface RemediationHintInput {
+  sourceId?: string | null;
+  operatorStatus?: SourceHealthOperatorStatus | null;
+  coverageState?: CanonicalSourceCoverageState | null;
+}
+
+const HINT_GATED: RemediationHint = {
+  tone: 'warn',
+  rule: 'gated',
+  copy:
+    'Institutional access required. Confirm source agreement or mark lane as access-required before review.',
+};
+
+const HINT_UNAVAILABLE: RemediationHint = {
+  tone: 'critical',
+  rule: 'unavailable',
+  copy:
+    'Source unavailable. Do not treat this lane as decision-grade until a fresh check succeeds.',
+};
+
+const HINT_CRITICAL: RemediationHint = {
+  tone: 'critical',
+  rule: 'critical',
+  copy:
+    'Source probe failing. Check connector config, env flags, and network access; do not rely on this lane until a fresh check succeeds.',
+};
+
+const HINT_ACCESS_REQUIRED: RemediationHint = {
+  tone: 'warn',
+  rule: 'access_required',
+  copy:
+    'Operator credentials required to query this source. Provision access or route the candidate to manual review.',
+};
+
+const HINT_REVIEW_REQUIRED: RemediationHint = {
+  tone: 'warn',
+  rule: 'review_required',
+  copy:
+    'Lane signal is ambiguous. Route to operator review before treating it as decision-grade.',
+};
+
+const HINT_DEGRADED: RemediationHint = {
+  tone: 'warn',
+  rule: 'degraded',
+  copy:
+    'Repeated probe failures observed. Confirm API credentials and connector health; if the failure persists, route to operator review.',
+};
+
+const HINT_STALE: RemediationHint = {
+  tone: 'warn',
+  rule: 'stale',
+  copy:
+    'Refresh source probe. If stale state persists, route to operator review before relying on this lane.',
+};
+
+const HINT_PENDING: RemediationHint = {
+  tone: 'info',
+  rule: 'pending',
+  copy:
+    'First probe has not completed. Wait for the next scheduled run or trigger a manual refresh.',
+};
+
+const HINT_NOT_DECISION_GRADE: RemediationHint = {
+  tone: 'info',
+  rule: 'not_decision_grade',
+  copy:
+    'Lane is informational only. Do not treat as decision-grade evidence.',
+};
+
+const HINT_PREVIEW_ONLY: RemediationHint = {
+  tone: 'info',
+  rule: 'preview_only',
+  copy:
+    'Preview / demo data only. Not derived from a live source probe.',
+};
+
+/**
+ * Resolve the operator remediation hint for a source lane, or `null`
+ * when the lane is healthy and decision-grade (no hint to show).
+ *
+ * The function never mutates input and never reads global state, which
+ * makes it trivial to test and safe to call from server or client.
+ */
+export function getRemediationHint(
+  input: RemediationHintInput,
+): RemediationHint | null {
+  const coverage = input.coverageState ?? null;
+  const operator = input.operatorStatus ?? null;
+
+  // Highest-precedence rules first — institutional access and outright
+  // unavailability are always the next operator step regardless of
+  // transport health.
+  if (coverage === 'gated') return HINT_GATED;
+  if (coverage === 'unavailable') return HINT_UNAVAILABLE;
+  if (operator === 'CRITICAL') return HINT_CRITICAL;
+
+  if (coverage === 'accessRequired') return HINT_ACCESS_REQUIRED;
+  if (coverage === 'reviewRequired') return HINT_REVIEW_REQUIRED;
+
+  if (operator === 'DEGRADED') return HINT_DEGRADED;
+  if (operator === 'STALE' || coverage === 'stale') return HINT_STALE;
+
+  if (coverage === 'pending') return HINT_PENDING;
+  if (coverage === 'notDecisionGrade') return HINT_NOT_DECISION_GRADE;
+  if (coverage === 'previewOnly') return HINT_PREVIEW_ONLY;
+
+  // HEALTHY + checked, or any combination that does not match a rule
+  // above, has no hint.
+  return null;
+}
+
+/**
+ * Convenience: returns `true` iff the lane needs an operator hint.
+ * Useful for panels that gate render on hint presence.
+ */
+export function needsRemediationHint(input: RemediationHintInput): boolean {
+  return getRemediationHint(input) !== null;
+}


### PR DESCRIPTION
## Summary
- New `apps/web/lib/source-health/remediationHints.ts` — operator-action hint module mapping `coverageState` and `operatorStatus` to `{ tone, copy, rule }` per a documented precedence table.
- `SourceHealthPanel` now consumes the hint module instead of carrying four inline copy blocks. Hint elements expose `data-hint-rule` / `data-hint-tone` for tests and observability.
- 11-case vitest spec covering precedence, copy quality, and truth-contract cleanliness.

## Precedence rules (highest first)
1. `coverageState='gated'` → "Institutional access required. Confirm source agreement or mark lane as access-required before review."
2. `coverageState='unavailable'` → "Source unavailable. Do not treat this lane as decision-grade until a fresh check succeeds."
3. `operatorStatus='CRITICAL'` → "Source probe failing. Check connector config, env flags, and network access; do not rely on this lane until a fresh check succeeds."
4. `coverageState='accessRequired'` → operator-credentials next-step copy.
5. `coverageState='reviewRequired'` → route-to-operator-review copy.
6. `operatorStatus='DEGRADED'` → repeated-failures triage copy.
7. STALE (either axis) → "Refresh source probe. If stale state persists, route to operator review before relying on this lane."
8. pending / notDecisionGrade / previewOnly → info-tone hints that never imply decision-grade.
HEALTHY + checked → no hint.

## Truth rules
- Hint copy is operator-action language, not buyer marketing.
- gated / unavailable / pending / notDecisionGrade copy never claims decision-grade. Asserted by test.
- gated copy never blames the clinician. Asserted by test.
- No banned phrases (full CLAUDE.md list including the SOC 2 variant) and no bare-`Verified` label. Asserted programmatically over every hint output.
- No new endpoints, no Prisma migration, no production env / DNS / Vercel mutation.

## Validation
- `pnpm --filter @vitalcv/web exec vitest run __tests__/source-health-remediation-hints.test.ts` → **11/11 passing**
- `pnpm --filter @vitalcv/web exec tsc --noEmit` → clean
- `pnpm --filter @vitalcv/web build` → succeeds
- `pnpm lint` (web) → clean

## Test plan
- [ ] Targeted vitest passes on CI
- [ ] Web build passes
- [ ] Codex SAFE verdict on implementation / diff / copy audits