### PR TITLE
docs(demo): add founder smoke checklist for pilot walkthrough

### DIFF
--- a/docs/ops/founder-demo-smoke-checklist.md
+++ b/docs/ops/founder-demo-smoke-checklist.md
@@ -1,0 +1,229 @@
+# Founder demo smoke checklist
+
+A 15-step pre-flight to run **after** the lead-capture, banned-strings,
+and audit-event-visibility PRs land on `main`. Each step is a
+verifiable check; the checklist intentionally avoids any production
+mutation. Pair it with `scripts/smoke-founder-demo.sh` for the
+fast-machine checks.
+
+The checklist is for the founder running a live demo from their
+laptop — it does **not** validate apex / Vercel state. The Vercel /
+DNS / apex deployment is a separate concern (see the operator
+runbook).
+
+## Pre-flight assumptions
+
+- The repo is on `origin/main` HEAD with the three feature PRs merged
+  (lead-capture, banned-strings gate, audit-event-visibility).
+- `pnpm install --frozen-lockfile` has completed without errors.
+- `pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'`
+  has been run at least once (workspace dep prebuild).
+
+## 1. Start local app on port 3030
+
+```bash
+pnpm --filter @vitalcv/web dev -- --port 3030
+```
+
+✅ Pass when: server logs `Ready in <Xs>` and `http://localhost:3030`
+is reachable.
+
+## 2. Open `/launch`
+
+Visit `http://localhost:3030/launch`.
+
+✅ Pass when: page renders the primary message
+("Reusable, source-backed clinician readiness…") without auth, and
+the lead-capture block is visible.
+
+## 3. Confirm `/launch` renders without backend dependency
+
+Stop the backend (if running). Reload `http://localhost:3030/launch`.
+
+✅ Pass when: the page still renders. No 5xx errors. The ROI
+calculator + research signals still display. The lead-capture form
+still posts (it has no backend dependency — it persists locally via
+JSONL).
+
+## 4. Open `/demo`
+
+Visit `http://localhost:3030/demo`.
+
+✅ Pass when: index page lists all three sub-flows
+(`/demo/clinician`, `/demo/employer`, `/demo/issuer`) and clicking
+each navigates without auth.
+
+## 5. Open `/demo/employer`
+
+Visit `http://localhost:3030/demo/employer`.
+
+✅ Pass when: three demo employer applications render, the ROI
+calculator is interactive, and the Equity / Retention block shows
+research signals labelled as research signals (not as VitalCV
+outcomes).
+
+## 6. Submit lead-capture form with a test email
+
+In the lead-capture form on `/launch` or `/demo/employer`:
+
+- Email: `founder-smoke+test@example.com`
+- Intent: `pilot`
+
+Submit.
+
+✅ Pass when: the success state renders ("Received. We've received
+your request and will follow up with the next useful step.
+Reference: `<uuid>`") and no banner / promise of a response window
+appears.
+
+## 7. Confirm `/api/leads` writes JSONL
+
+```bash
+# Default path:
+tail -n 1 ~/.vitalcv-logs/leads.jsonl
+
+# Or, if LEAD_LOG_PATH is set:
+tail -n 1 "$LEAD_LOG_PATH"
+```
+
+✅ Pass when: the last JSONL row matches the submission (email,
+intent, source, hashed IP, sampleNpis array if applicable). The raw
+caller IP must **not** appear in the row.
+
+## 8. Confirm Slack optional failure does not break lead persistence
+
+```bash
+# Set an obviously-bad Slack webhook so the delivery fails.
+SLACK_LEAD_CAPTURE_WEBHOOK_URL=https://hooks.slack.com/services/INVALID \
+  pnpm --filter @vitalcv/web dev -- --port 3030
+```
+
+Submit a lead again. Inspect the API response.
+
+✅ Pass when: response is `200 { ok: true, slackDelivered: false,
+slackReason: 'http_error' | 'fetch_failed' }` AND the JSONL row was
+still appended (lead is persisted even when Slack fails).
+
+## 9. Confirm no banned-string gate failures in public demo routes
+
+```bash
+bash scripts/check-banned-strings.sh apps/web/app/launch \
+                                     apps/web/app/demo \
+                                     apps/web/components/lead-capture
+```
+
+✅ Pass when: the scanner exits `0` and reports `CLEAN`.
+
+If the gate fails on a route the founder is about to show, **stop
+the demo prep** and fix the copy first. See
+`docs/ops/banned-strings-gate.md` for the rewrite patterns.
+
+## 10. Walk the employer review accept flow
+
+Visit `/review/<entity-id>` (via the demo seed) or
+`/demo/employer/<id>`. Trigger the **Accept** action.
+
+✅ Pass when: the action transitions to the success state without
+500s.
+
+## 11. Confirm `auditEventId` appears after accept
+
+After the accept call completes, look for the audit-entry line:
+
+```
+Audit entry: <uuid> · <ISO-8601 timestamp>
+```
+
+✅ Pass when: the line is present, the UUID is monospace, and the
+timestamp is recent. The line must appear **only** after the accept
+succeeds — never before, never as persistent dashboard chrome.
+
+## 12. Confirm no route claims a final credentialing decision
+
+Walk `/launch`, `/demo`, `/demo/employer`, `/review`, `/passport`.
+Visually scan for any text that implies credentialing is "complete",
+"verified" (bare), "guaranteed", or "automatic".
+
+✅ Pass when: none of these phrases appear. Status labels use
+compound forms (`Source-verified`, `Source-backed`) and the
+audit-entry line carries no compliance overclaim.
+
+The banned-strings gate covers this mechanically, but the founder
+should still scan once before the demo — copy in `<span>{variable}</span>`
+shapes is not caught by the regex gate.
+
+## 13. Confirm local tunnel script opens `/launch`
+
+If `scripts/public-demo.sh` is present (lands with PR #366 / #367 /
+#368), run:
+
+```bash
+scripts/public-demo.sh
+```
+
+✅ Pass when: the script prints a tunnel URL (cloudflared or
+localhost.run) that resolves to `http://localhost:3030/launch`.
+
+If the tunnel script is **absent** (the PRs haven't merged yet),
+this step is **SKIP** — the smoke check still passes.
+
+## 14. Confirm the founder can explain — in this order
+
+The founder narrative for a 3-minute pitch:
+
+1. **Pain** — credentialing takes 103 days (CBP benchmark); each
+   day of delay costs the hospital $2,700–$5,400 per role.
+2. **Source-backed readiness preview** — VitalCV runs a probe set
+   against NPPES / OIG-LEIE / PECOS / the state board and surfaces
+   what's checked, stale, gated, or unavailable. It is not final
+   credentialing.
+3. **Employer review head start** — given the readiness preview,
+   an employer can record an acceptance and a start date. The
+   recognition → acceptance → start ladder writes an AuditEvent
+   row before any 2xx response.
+4. **Lead capture** — `/launch` and `/demo/employer` collect
+   email + intent into a JSONL row. Optional Slack delivery if
+   `SLACK_LEAD_CAPTURE_WEBHOOK_URL` is set.
+5. **Audit entry proof** — after acceptance, the UI surfaces the
+   `auditEventId` + `auditRecordedAt` so the buyer can see the
+   non-repudiation receipt their action created.
+
+✅ Pass when: the founder can recite each beat without notes in
+under 30 seconds.
+
+## 15. Record known limitations — in this order
+
+The founder must lead with these, not bury them:
+
+- **Not final credentialing.** Acceptance is a *head start*, not a
+  credentialing decision. Real credentialing remains the customer's
+  responsibility.
+- **Gated sources are access-required.** Any lane in
+  `accessRequired` / `gated` is not decision-grade; the source-
+  health panel surfaces the next operator step.
+- **ROI is an illustrative benchmark.** The $2,700–$5,400/day figure
+  is an OpenEvidence market benchmark, not a guaranteed VitalCV
+  outcome.
+- **Vercel / apex status is separate from the founder tunnel.** A
+  failing apex / Vercel preview does not invalidate the local demo;
+  treat the tunnel URL as the source of truth for the live walk.
+
+✅ Pass when: each limitation is on the founder's lips before the
+buyer raises it.
+
+## Smoke script
+
+`scripts/smoke-founder-demo.sh` automates the fast-machine portion of
+this checklist:
+
+- Verifies the required files exist (script, JSONL handler, banned-
+  strings gate, audit-event UI line).
+- Optionally curls `http://localhost:3030/launch` and
+  `http://localhost:3030/demo` if the local server is running.
+- Runs the banned-strings scanner against the public demo route
+  scope.
+- Prints a `PASS/FAIL/SKIP` summary table.
+
+The script is non-mutating — it never writes to production, never
+runs migrations, and never calls Slack. See its header comment for
+exact behavior.

--- a/scripts/smoke-founder-demo.sh
+++ b/scripts/smoke-founder-demo.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# smoke-founder-demo.sh — non-mutating pre-flight checks for the
+# founder demo walk.
+#
+# What this script DOES:
+#   - Inspects local files / routes / scripts that the demo depends
+#     on and reports PASS / FAIL / SKIP for each.
+#   - Optionally curls http://localhost:3030/launch and /demo if a
+#     local server is already running.
+#   - Runs the banned-strings gate against the public demo route
+#     scope (read-only).
+#
+# What this script DOES NOT do:
+#   - Mutate production state of any kind.
+#   - Start a server. (The /launch curl check is a probe — if no
+#     server is listening, it reports SKIP, not FAIL.)
+#   - Call Slack. The Slack delivery surface is tested via
+#     /api/leads behaviour at demo time, not here.
+#   - Write to LEAD_LOG_PATH or ~/.vitalcv-logs/leads.jsonl.
+#   - Run pnpm install, build, or any migration.
+#
+# Exit codes:
+#   0  all checks PASS or SKIP
+#   1  one or more checks FAIL (the demo prep should stop and the
+#      failing check should be addressed before going live)
+#   2  configuration error (run from outside a repo, missing tools)
+#
+# Usage:
+#   bash scripts/smoke-founder-demo.sh          # default full run
+#   bash scripts/smoke-founder-demo.sh --quiet  # PASS/FAIL only
+#   bash scripts/smoke-founder-demo.sh --port 4000   # curl probe target
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="3030"
+QUIET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    -h|--help)
+      head -30 "$0" | sed -n 's/^# \{0,1\}//p'
+      exit 0
+      ;;
+    *)
+      echo "smoke-founder-demo: unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+PASS=0
+FAIL=0
+SKIP=0
+declare -a SUMMARY
+
+emit() {
+  local status="$1"
+  local label="$2"
+  local detail="${3:-}"
+  case "$status" in
+    PASS) PASS=$((PASS + 1)); color=$'\033[32m' ;;
+    FAIL) FAIL=$((FAIL + 1)); color=$'\033[31m' ;;
+    SKIP) SKIP=$((SKIP + 1)); color=$'\033[33m' ;;
+    *) color="" ;;
+  esac
+  local reset=$'\033[0m'
+  SUMMARY+=("$(printf '%s%-4s%s  %-50s  %s' "$color" "$status" "$reset" "$label" "$detail")")
+  if [[ $QUIET -eq 0 ]]; then
+    printf '%s%-4s%s  %-50s  %s\n' "$color" "$status" "$reset" "$label" "$detail"
+  fi
+}
+
+# ─── Check 1: scripts/check-banned-strings.sh exists ───
+if [[ -x "${REPO_ROOT}/scripts/check-banned-strings.sh" ]]; then
+  emit PASS "banned-strings scanner present"
+else
+  emit FAIL "banned-strings scanner present" "expected scripts/check-banned-strings.sh"
+fi
+
+# ─── Check 2: /api/leads handler present ───
+if [[ -f "${REPO_ROOT}/apps/web/app/api/leads/route.ts" ]]; then
+  emit PASS "/api/leads route present"
+else
+  emit FAIL "/api/leads route present" "apps/web/app/api/leads/route.ts not found"
+fi
+
+# ─── Check 3: persistLead helper present ───
+if [[ -f "${REPO_ROOT}/apps/web/lib/leads/persistLead.ts" ]]; then
+  emit PASS "lead persistLead helper present"
+else
+  emit FAIL "lead persistLead helper present" "apps/web/lib/leads/persistLead.ts not found"
+fi
+
+# ─── Check 4: founder-mode script present (optional) ───
+if [[ -f "${REPO_ROOT}/scripts/founder-mode.sh" ]]; then
+  emit PASS "founder-mode script present"
+else
+  emit SKIP "founder-mode script present" "scripts/founder-mode.sh not on this branch yet"
+fi
+
+# ─── Check 5: public-demo tunnel script present (optional) ───
+if [[ -f "${REPO_ROOT}/scripts/public-demo.sh" ]]; then
+  emit PASS "public-demo tunnel script present"
+else
+  emit SKIP "public-demo tunnel script present" "scripts/public-demo.sh not on this branch yet"
+fi
+
+# ─── Check 6: /launch route source present (optional) ───
+if [[ -f "${REPO_ROOT}/apps/web/app/launch/page.tsx" ]]; then
+  emit PASS "/launch page source present"
+else
+  emit SKIP "/launch page source present" "apps/web/app/launch/page.tsx not on this branch yet"
+fi
+
+# ─── Check 7: /demo route source present (optional) ───
+if [[ -f "${REPO_ROOT}/apps/web/app/demo/page.tsx" ]]; then
+  emit PASS "/demo page source present"
+else
+  emit SKIP "/demo page source present" "apps/web/app/demo/page.tsx not on this branch yet"
+fi
+
+# ─── Check 8: LeadCaptureBlock component present (optional) ───
+if [[ -f "${REPO_ROOT}/apps/web/components/lead-capture/LeadCaptureBlock.tsx" ]]; then
+  emit PASS "LeadCaptureBlock component present"
+else
+  emit SKIP "LeadCaptureBlock component present" "lead-capture component not on this branch yet"
+fi
+
+# ─── Check 9: ReviewClient renders audit-entry line ───
+if [[ -f "${REPO_ROOT}/apps/web/components/review/ReviewClient.tsx" ]]; then
+  if grep -q 'Audit entry:' "${REPO_ROOT}/apps/web/components/review/ReviewClient.tsx"; then
+    emit PASS "ReviewClient renders Audit entry: line"
+  else
+    emit SKIP "ReviewClient renders Audit entry: line" "audit-entry UI line not yet wired on this branch"
+  fi
+else
+  emit FAIL "ReviewClient renders Audit entry: line" "apps/web/components/review/ReviewClient.tsx not found"
+fi
+
+# ─── Check 10: backend accept route present ───
+if [[ -f "${REPO_ROOT}/apps/api/backend/src/routes/employerActions.ts" ]]; then
+  emit PASS "backend employer accept route present"
+else
+  emit FAIL "backend employer accept route present" "employerActions.ts not found"
+fi
+
+# ─── Check 11: banned-strings list present ───
+if [[ -f "${REPO_ROOT}/scripts/banned-strings.list" ]]; then
+  emit PASS "banned-strings list present"
+else
+  emit FAIL "banned-strings list present" "scripts/banned-strings.list not found"
+fi
+
+# ─── Check 12: banned-strings scan on public demo routes ───
+SCAN_PATHS=()
+for p in apps/web/app/launch apps/web/app/demo apps/web/components/lead-capture; do
+  if [[ -d "${REPO_ROOT}/${p}" ]]; then
+    SCAN_PATHS+=("${REPO_ROOT}/${p}")
+  fi
+done
+if [[ ${#SCAN_PATHS[@]} -eq 0 ]]; then
+  emit SKIP "banned-strings scan on demo routes" "no demo route directories present yet"
+elif [[ -x "${REPO_ROOT}/scripts/check-banned-strings.sh" ]]; then
+  if bash "${REPO_ROOT}/scripts/check-banned-strings.sh" "${SCAN_PATHS[@]}" >/dev/null 2>&1; then
+    emit PASS "banned-strings scan on demo routes" "${#SCAN_PATHS[@]} path(s) clean"
+  else
+    emit FAIL "banned-strings scan on demo routes" "scanner reported hits — run scripts/check-banned-strings.sh ${SCAN_PATHS[*]#${REPO_ROOT}/}"
+  fi
+else
+  emit SKIP "banned-strings scan on demo routes" "scanner not executable"
+fi
+
+# ─── Check 13: optional live HTTP probes ───
+if command -v curl >/dev/null 2>&1; then
+  if curl -sf --max-time 2 "http://localhost:${PORT}/launch" >/dev/null 2>&1; then
+    emit PASS "GET http://localhost:${PORT}/launch"
+  else
+    emit SKIP "GET http://localhost:${PORT}/launch" "no local server listening on :${PORT}"
+  fi
+  if curl -sf --max-time 2 "http://localhost:${PORT}/demo" >/dev/null 2>&1; then
+    emit PASS "GET http://localhost:${PORT}/demo"
+  else
+    emit SKIP "GET http://localhost:${PORT}/demo" "no local server listening on :${PORT}"
+  fi
+else
+  emit SKIP "live HTTP probes" "curl not on PATH"
+fi
+
+# ─── Summary ───
+echo ""
+printf 'smoke-founder-demo: %d pass, %d skip, %d fail\n' "$PASS" "$SKIP" "$FAIL"
+echo "See docs/ops/founder-demo-smoke-checklist.md for the full 15-step checklist."
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- New `docs/ops/founder-demo-smoke-checklist.md` — 15-step pre-flight the founder runs BEFORE a live demo, covering local app start, route renders, lead capture, JSONL persistence, Slack-failure-doesn't-break-persistence, banned-strings gate clean, employer accept walk, `auditEventId` visibility, no final-credentialing claim, local tunnel, founder narrative beats, and known limitations.
- New `scripts/smoke-founder-demo.sh` — bash-only, non-mutating script that checks 13 local files/routes/scripts and emits a PASS/FAIL/SKIP table. Optional `curl` probes against `http://localhost:${PORT}/launch` and `/demo` when a server is already listening (no server is started).

## Hard constraints honoured
- Does **not** mutate production. Never writes to JSONL, never calls Slack, never starts a server, never runs migrations.
- No product code modified. No Prisma migration. No env / DNS / Vercel mutation.
- The checklist explicitly names its prerequisites — the lead-capture, banned-strings, and audit-event-visibility PRs must merge before the checklist becomes useful.

## Smoke script behaviour
- Reports `PASS` when a required file is present.
- Reports `FAIL` when a hard-required prereq is missing (banned-strings scanner, `/api/leads`, `persistLead`, `ReviewClient`).
- Reports `SKIP` when an optional / known-on-unmerged-branch artefact is missing (`/launch`, `/demo`, tunnel scripts).
- Exit `0` if all checks `PASS`/`SKIP`, `1` if any `FAIL`, `2` on config error.
- Supports `--port <n>`, `--quiet`, `-h/--help`.

## Validation
- `bash scripts/smoke-founder-demo.sh` runs cleanly on origin/main HEAD and reports the expected mix of FAIL (on prereq PRs not yet merged) and SKIP (on optional artefacts on unmerged branches).
- `pnpm --filter @vitalcv/web exec tsc --noEmit` → clean.
- `pnpm lint` → clean.

## Test plan
- [ ] Once lead-capture / banned-strings / audit-event-visibility PRs merge to main, run `bash scripts/smoke-founder-demo.sh` and confirm 0 FAILs.
- [ ] With a local server running on port 3030, run the script and confirm the two `curl` probes report `PASS`.
- [ ] Codex SAFE verdict on implementation / diff / copy audits.