### PR TITLE
fix(wallet-sdk): restore interoperability export for monorepo build

### DIFF
--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,3 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';


### PR DESCRIPTION
## Summary
- One-line removal of a stale forward re-export in `packages/wallet-sdk/src/index.ts:351`. The line declared `export * from './interoperability';` but the underlying file was never created — the `src/` tree contains only `index.ts`, `version.ts`, `diagnostics.ts`.
- This is the root cause of the repo-wide `Web Quality` CI failure visible on every open PR (#369–#374). tsup's DTS compilation fails on `Cannot find module './interoperability'`, breaking the wallet-sdk dist, which breaks every downstream filter chain.

## Root cause
- Stale export added in the "Wave 133: version + diagnostics" block. The companion module never landed.
- `rg -n "interoperability"` across the monorepo confirms zero consumers for a `@vitalcv/wallet-sdk/interoperability` import or any symbol that would have transited this barrel.
- `packages/wallet-sdk/package.json` `exports` only publishes `"."`, so no subpath consumer can exist.

## Why removal rather than a stub
The spec offered two paths: create a conservative stub OR remove the export if rg confirms no consumers. rg confirms no consumers. Creating a stub would add a public surface with no implementation behind it — exactly the kind of "live interoperability" overclaim the truth contract forbids. A real OID4VCI / OID4VP / HAIP interoperability surface can ship in a separate PR when the runtime behavior actually exists.

## Files changed
- `packages/wallet-sdk/src/index.ts` — one line removed.

## Validation
- `pnpm --filter @vitalcv/wallet-sdk build` → **succeeds** (CJS / ESM / DTS green)
- `pnpm turbo run build --filter @vitalcv/web` → **13/13 tasks green** (previously 11/12 with wallet-sdk failing)
- `pnpm --filter @vitalcv/web exec tsc --noEmit` → clean
- `pnpm --filter @vitalcv/wallet-sdk exec tsc --noEmit` → clean
- `pnpm lint` → clean (only pre-existing marketing `NpiInput.tsx` warning, unrelated)
- Banned-phrase / bare-`Verified` rg on `packages/wallet-sdk/src` → clean

## Hard constraints honoured
- Tiny fix (1 line removed).
- No broad refactor.
- No Prisma migration.
- No production env / DNS / Vercel mutation.
- No product copy changes.
- No new runtime behavior.
- No public API removed without checking consumers.
- No fake implementation claiming live interoperability.

## Test plan
- [ ] CI `Web Quality` passes on this PR (the blocker is the wallet-sdk DTS failure this PR removes).
- [ ] Codex SAFE verdict on implementation / diff / copy audits.