### PR TITLE
docs(ops): Vercel exit emergency plan + Cloudflare tunnel runbook

### DIFF
--- a/docs/ops/cloudflare-production-cutover-plan.md
+++ b/docs/ops/cloudflare-production-cutover-plan.md
@@ -1,0 +1,208 @@
+# Cloudflare production cutover plan
+
+Track B of the [Vercel exit plan](./vercel-exit-emergency-plan.md).
+This document is the **plan**, not the runbook. Nothing here is
+executed without explicit founder approval at each gated step.
+
+The goal: put a working VitalCV web surface on Cloudflare Pages
+(or Workers, if Pages can't host it), then — only after manual
+QA on a `*.pages.dev` URL — cut vitalcv.com DNS over to it.
+
+## Hard constraints (carried from the exit plan)
+
+- No money spent. Cloudflare free tier only.
+- No DNS mutation without **founder explicit approval** at the
+  cutover step.
+- Vercel projects stay in place (do not delete) until at least
+  30 days post-cutover.
+- No Prisma migration. No database changes. No production env
+  secret rotation as part of this wave.
+- No Apply-with-VitalCV iframe revival.
+
+## Assumptions
+
+| # | Assumption | Validation step |
+|---|-----------|-----------------|
+| 1 | The founder will create (or already has) a free Cloudflare account. | Founder confirms; document the account email in 1Password / similar. **Do not commit it to the repo.** |
+| 2 | The `vitalcv.com` domain is registered with a registrar the founder controls. | `dig vitalcv.com NS` from the founder's laptop. Record current nameservers before any change. |
+| 3 | The repo builds `apps/web` with no Vercel-specific runtime calls. | `pnpm --filter @vitalcv/web build` succeeds locally on `origin/main` (verified after PR #375 lands). |
+| 4 | The truth-contract banned-strings gate (PR #370) does not regress on Cloudflare's build environment. | Re-run the gate as a CI step against the new platform. |
+
+## DNS inventory needed (before founder approves cutover)
+
+The cutover step must not surprise anyone. Before approval, the
+following must be captured to a private operator note (NOT to the
+repo):
+
+1. Current registrar for `vitalcv.com`.
+2. Current nameservers (NS records). Most likely Vercel's
+   nameservers or the registrar's own (`ns1.<registrar>.com` etc.).
+3. Current `A` / `AAAA` / `CNAME` records on `vitalcv.com` and
+   `www.vitalcv.com`.
+4. Current `MX` / `TXT` records (especially SPF, DKIM, DMARC) —
+   these must survive the cutover or email delivery breaks.
+5. Any other production subdomains under `vitalcv.com`
+   (e.g. `app.`, `api.`, `status.`) and where they currently
+   point.
+
+Capture this into a local file under `~/vitalcv-ops/dns-snapshot-YYYY-MM-DD.txt`
+(operator-only path, never commit). The cutover step uses this
+snapshot as the rollback artifact.
+
+## Cloudflare Pages — build feasibility
+
+`apps/web` is a Next.js 15 App Router app with several server
+components, route handlers under `apps/web/app/api/*`, and the
+JSONL-append `/api/leads` route that uses Node's `fs`/`os`/`path`
+modules.
+
+Cloudflare Pages supports Next.js via the
+`@cloudflare/next-on-pages` adapter, which compiles server
+routes to Cloudflare Workers (V8 runtime, no Node built-ins by
+default). The `/api/leads` route uses `node:fs`, which the
+Workers runtime exposes only behind the `nodejs_compat`
+compatibility flag.
+
+Decision matrix:
+
+| Surface | Cloudflare Pages compatibility | Action |
+|---------|--------------------------------|--------|
+| Static / RSC pages (`/launch`, `/demo/*`, `/passport/*`) | ✅ direct | adapter handles them |
+| Route handlers that touch `fetch`, `Headers`, `Response` only | ✅ direct | adapter handles them |
+| `/api/leads` (uses `node:fs/promises`) | ⚠️ needs `nodejs_compat` | enable compat flag; or persist via Cloudflare KV / D1 instead |
+| `/api/employer-review/*` proxy (forwards to backend) | ✅ direct | depends only on backend availability, not local file IO |
+| WebAssembly / Worker-only APIs | ✅ direct | not used |
+
+Recommendation: **enable `nodejs_compat` for the first deploy**.
+Replacing the JSONL append with KV / D1 is a follow-up that
+shouldn't block the public surface coming back up. The truth-
+contract guardrails on `/api/leads` are runtime invariants, not
+filesystem invariants — they survive a backend swap.
+
+## Build command discovery
+
+The canonical build chain on this repo is:
+
+```bash
+# Prebuild workspace deps (required — @vitalcv/trust-state ships from dist/)
+pnpm install --frozen-lockfile
+pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'
+
+# Build apps/web (direct path, bypasses the wallet-sdk failure once PR #375 lands)
+pnpm --filter @vitalcv/web build
+```
+
+For Cloudflare Pages, the project setup will likely be:
+
+| Field | Value |
+|-------|-------|
+| Framework preset | Next.js (Cloudflare Pages preset) |
+| Build command | `pnpm install --frozen-lockfile && pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared' && pnpm --filter @vitalcv/web exec npx @cloudflare/next-on-pages` |
+| Build output directory | `apps/web/.vercel/output/static` (the adapter writes here) |
+| Root directory | repo root (the monorepo entry; Cloudflare reads the workspace from `pnpm-workspace.yaml`) |
+| Node version | 20.x (matches the dev server runtime assertion) |
+| Compatibility flags | `nodejs_compat` |
+
+The first build on a `*.pages.dev` preview will validate every
+assumption above. **Do not enter any env vars yet** — the first
+build is meant to surface compile-time failures, not runtime
+behavior.
+
+## Env var inventory (per the truth contract — names only, no values)
+
+The web app reads, in rough order of demo necessity:
+
+| Env var | Required for | Source |
+|---------|--------------|--------|
+| `LEAD_LOG_PATH` | `/api/leads` persistence override (optional) | `apps/web/lib/leads/persistLead.ts` |
+| `SLACK_LEAD_CAPTURE_WEBHOOK_URL` | Slack lead delivery (optional, best-effort) | `apps/web/lib/leads/slack.ts` |
+| `SLACK_PILOT_INTAKE_WEBHOOK_URL` | Slack pilot-intake delivery (optional) | `apps/web/lib/pilot-intake/slack.ts` |
+| `RECEIPT_PRIVATE_KEY_JWK` | ES256 receipt signing (production fail-closed) | `apps/web/lib/crypto/receiptIssuer.ts` |
+| `RECEIPT_KID` | ES256 receipt kid (production fail-closed) | same |
+| `APP_ORIGIN` / `NEXT_PUBLIC_APP_URL` | share-link origin resolution | `apps/api/backend/src/routes/employerActions.ts` |
+| `DATABASE_URL` | Prisma (backend only; the apps/web surface mostly proxies) | `apps/api/backend/prisma/schema.prisma` |
+| `BACKEND_URL` | apps/web proxy target | `apps/web/lib/backend-url.ts` |
+| `CLERK_*` | auth (only on routes that require sign-in) | `@clerk/nextjs/server` consumers |
+
+For the **first** Pages deploy, do not set any of these. The
+`/launch` and `/demo/*` surfaces work without them. After the
+first deploy lands on a `*.pages.dev` URL, the founder approves
+each key one at a time, pasted into Cloudflare's dashboard.
+
+## QA checklist on `*.pages.dev` (before any DNS change)
+
+Run `scripts/check-public-surface.sh` with
+`BASE_URL=https://<project>.pages.dev`. Expected:
+
+| Route | Expected status |
+|-------|-----------------|
+| `/` | 200 or a deliberate redirect to `/launch` |
+| `/launch` | 200, renders the foundation message |
+| `/demo` | 200, lists the three sub-flows |
+| `/demo/employer` | 200, ROI calculator interactive |
+| `/demo/clinician` | 200, persona list |
+| `/api/health` | 200 if implemented (WARN otherwise) |
+
+If any of these fail on Cloudflare Pages but pass on
+`localhost:3030`, the adapter or compatibility flag is the
+culprit. Do not advance to DNS cutover until the `*.pages.dev` URL
+passes the surface check end-to-end.
+
+## DNS cutover (founder approval gate)
+
+When the founder approves the cutover, the operator steps are:
+
+1. **Snapshot current DNS.** Use the `dig` outputs captured in
+   the inventory step. Save them to
+   `~/vitalcv-ops/dns-snapshot-YYYY-MM-DD-pre-cutover.txt`.
+2. **Add the apex CNAME flattening** (or A/AAAA records for
+   Cloudflare's IPs) per Cloudflare Pages' "Custom domain"
+   instructions in their dashboard. Cloudflare provides the
+   exact target.
+3. **Lower TTL first.** 24 hours before cutover, drop the
+   existing record TTL to 300s so rollback is fast.
+4. **Verify propagation on a non-production DNS resolver**
+   (e.g. `dig @1.1.1.1 vitalcv.com` and `dig @8.8.8.8 vitalcv.com`)
+   before announcing.
+5. **Send the launch announcement only after** the surface check
+   from step "QA checklist" above passes against `https://vitalcv.com`
+   itself.
+
+## Rollback (if anything breaks)
+
+| Scenario | Rollback |
+|----------|----------|
+| Cloudflare Pages build fails | nothing to roll back — vitalcv.com is still 402 on Vercel; no traffic was migrated |
+| Cloudflare Pages deploys but a route 500s | leave DNS unchanged; debug on `*.pages.dev`; do not cut over |
+| DNS cuts over but a route 500s | revert the DNS record to its pre-cutover value (snapshot in step 1) |
+| DNS cuts over and Cloudflare goes down | revert the DNS record; while vitalcv.com is down, restart the Track A tunnel for live demos |
+
+The Vercel project is intentionally left in place so a worst-case
+rollback is "point DNS back at Vercel and pay the bill" — but
+that path is only used if everything else fails AND a paying
+customer is on the line. Approval gate still applies.
+
+## What this plan explicitly does NOT promise
+
+- Same performance characteristics as Vercel's edge.
+- Same Next.js feature coverage (some App Router features ship
+  on Cloudflare Pages later than on Vercel; the adapter's release
+  notes are the source of truth).
+- Email survival. SPF / DKIM / DMARC must be reviewed in the DNS
+  snapshot step; the cutover is for the web surface only.
+- Zero-touch CI. Cloudflare's GitHub integration handles
+  per-commit builds, but the truth-contract gate (PR #370) needs
+  to be wired into Pages' build pipeline (env var or a custom
+  build step) before merge protection on `main` matters again.
+
+## Status
+
+| Step | State |
+|------|-------|
+| Track A tunnel runbook | ✅ shipped — see sibling doc |
+| Track B plan (this doc) | ✅ shipped |
+| Cloudflare account creation | pending founder action |
+| Pages `*.pages.dev` first deploy | pending founder action |
+| Env var paste | pending per-key founder approval |
+| DNS cutover | pending founder explicit approval |
+| Vercel project deletion | hold ≥30 days post-cutover |

--- a/docs/ops/cloudflare-tunnel-founder-demo-runbook.md
+++ b/docs/ops/cloudflare-tunnel-founder-demo-runbook.md
@@ -1,0 +1,173 @@
+# Cloudflare Tunnel — founder demo runbook
+
+A 5-minute runbook for shipping a public URL onto
+`http://localhost:3030` while vitalcv.com remains down. This is
+Track A of the [Vercel exit plan](./vercel-exit-emergency-plan.md).
+
+This runbook is for the founder running a live walkthrough from
+their laptop. It is NOT a production hosting plan. For permanent
+hosting see
+[cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md).
+
+## Prerequisites
+
+- macOS or Linux laptop with the VitalCV repo cloned.
+- `pnpm` 10.6.1 installed (matches the repo lockfile).
+- Internet connection.
+- **No Cloudflare account required.** The `try.cloudflare.com`
+  trycloudflare URL is free, anonymous, and ephemeral.
+- **No DNS access required.** This runbook never touches the
+  vitalcv.com record.
+
+## One-time setup (under 60 seconds)
+
+### Install `cloudflared`
+
+macOS (Homebrew):
+
+```bash
+brew install cloudflared
+```
+
+macOS (no Homebrew) or Linux (any distro), download the official
+binary:
+
+```bash
+# Pick the right URL for your arch from
+# https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+curl -L --output ~/bin/cloudflared \
+  https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-arm64
+chmod +x ~/bin/cloudflared
+```
+
+Verify:
+
+```bash
+cloudflared --version
+```
+
+You should see a version string. No login is required for the
+`--url` (quick tunnel) mode this runbook uses.
+
+## Demo session — 4 commands
+
+Open three terminal tabs in `~/vitalcv`. The tabs hold the dev
+server, the tunnel, and an optional smoke-checker.
+
+### Tab 1 — start the local app
+
+```bash
+cd ~/vitalcv
+pnpm install --frozen-lockfile          # only on first run / after lockfile bump
+pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'
+pnpm --filter @vitalcv/web dev
+```
+
+Wait for `▲ Next.js …` `- Local: http://localhost:3030`. The
+dev server is now listening on `:3030`.
+
+### Tab 2 — start the tunnel
+
+```bash
+cloudflared tunnel --url http://localhost:3030
+```
+
+Within 5–10 seconds you'll see a block that looks like:
+
+```
++--------------------------------------------------------------------------------------------+
+|  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |
+|  https://<random-three-words>.trycloudflare.com                                            |
++--------------------------------------------------------------------------------------------+
+```
+
+That `https://<random>.trycloudflare.com` URL is the public
+address. Copy it. Hand it to the buyer / investor / pilot lead.
+
+### Tab 3 — verify the public surface (optional)
+
+From the repo root, with the tunnel URL in your clipboard:
+
+```bash
+BASE_URL=https://<random>.trycloudflare.com bash scripts/check-public-surface.sh
+```
+
+You should see a PASS/WARN/FAIL table covering `/`, `/launch`,
+`/demo`, `/demo/employer`, `/demo/clinician`, and `/api/health`.
+A PASS on `/launch` is the minimum a founder demo needs.
+
+### Stop everything
+
+| Tab | How |
+|-----|-----|
+| Tab 2 — tunnel | `Ctrl-C`. The URL stops resolving within a few seconds. |
+| Tab 1 — dev server | `Ctrl-C` in the dev server tab. |
+
+You may also use the wrapper script that does Tab 1 + Tab 2 in
+one process:
+
+```bash
+bash scripts/public-demo-cloudflare.sh
+```
+
+It checks for `cloudflared`, verifies that something is listening
+on `:3030` (and prints a clear hint if not), starts a quick
+tunnel, and prints the public URL when it appears. `Ctrl-C` once
+to stop the tunnel.
+
+## Routes worth testing on the public URL
+
+Before handing the URL to a buyer:
+
+| Path | Expected |
+|------|----------|
+| `/launch` | foundation-tier readiness preview lands without auth |
+| `/demo` | demo index linking to clinician / employer / issuer |
+| `/demo/clinician` | persona-driven readiness preview |
+| `/demo/employer` | ROI calculator + EquityRetentionBlock |
+| `/passport/<entity>` | source-backed readiness preview for one entity |
+| `/api/leads` | POST a test lead and confirm the JSONL row appears in `~/.vitalcv-logs/leads.jsonl` |
+
+These are the surfaces the founder narrative depends on. If any
+of them 500s on the tunnel URL but works on
+`http://localhost:3030`, the issue is your local NEXT build, not
+the tunnel.
+
+## Limitations
+
+- **Ephemeral URL.** Each `cloudflared tunnel --url …` invocation
+  yields a new subdomain. Do not paste the URL into anything you
+  expect to live longer than the session.
+- **No CDN, no edge caching.** Latency is laptop-to-edge-to-viewer.
+  Fine for a 1-on-1 demo; not appropriate for sustained traffic.
+- **No IP allow-list.** Anyone with the URL can hit it. Treat the
+  URL as effectively public. The demo surface is already
+  designed for anonymous reach (no PHI, no credentials), so this
+  is fine — but do **not** point the tunnel at a backend
+  configured with production database creds.
+- **Laptop must stay awake** for the tunnel to stay up. Disable
+  sleep on the active machine if the demo session is meant to
+  span hours.
+- **Not a substitute for production.** A live tunnel does not
+  satisfy any pilot deliverable that requires vitalcv.com or a
+  persistent SLA. For that, you need Track B (Cloudflare Pages /
+  Workers) — see the cutover plan.
+
+## When the tunnel is the right tool
+
+- The founder is on a call and needs to show the demo "live, on
+  the internet, not on my laptop."
+- An investor asks "what does it look like?" and the founder
+  wants a URL to drop in a thread.
+- A pilot lead asks for a 5-minute walkthrough before signing
+  paperwork.
+
+## When the tunnel is NOT the right tool
+
+- A pilot customer expects the surface to be reachable when the
+  founder is asleep.
+- A press / launch announcement needs vitalcv.com to work.
+- Any path that needs production secrets, production database
+  rows, or persistent audit / receipt storage.
+
+For all of those, accelerate Track B (production cutover plan).

--- a/docs/ops/pilot-funnel-merge-board.md
+++ b/docs/ops/pilot-funnel-merge-board.md
@@ -1,0 +1,91 @@
+# Pilot funnel merge board
+
+Single page tracking the PRs and hosting state that gate VitalCV's
+public pilot funnel. Updated only on merged evidence; in-flight PRs
+are listed but do not move the completion percentages.
+
+Last updated: 2026-05-17.
+
+## Hosting status
+
+| Surface | Provider | State | Notes |
+|---------|----------|-------|-------|
+| `https://vitalcv.com` | Vercel | **down — HTTP 402 `DEPLOYMENT_DISABLED`** | abandoned as a dependency; do not pay |
+| Vercel project (`vitalcv`, `vcv-web`) | Vercel | hold | do not delete until ≥30 days post-cutover |
+| Founder live-demo URL | Cloudflare Tunnel (`trycloudflare.com`) | **immediate demo path** | runbook: [cloudflare-tunnel-founder-demo-runbook.md](./cloudflare-tunnel-founder-demo-runbook.md) |
+| Permanent web hosting | Cloudflare Pages / Workers | **production replacement candidate** | plan: [cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md) |
+| vitalcv.com DNS | unchanged at registrar | hold | cutover only behind explicit founder approval |
+| Database | local / dev only | unchanged | out of scope for this exit wave |
+
+See [vercel-exit-emergency-plan.md](./vercel-exit-emergency-plan.md)
+for the umbrella plan.
+
+## Open PRs in the pilot funnel
+
+| # | Title | Branch | State | Blocks pilot? |
+|---|-------|--------|-------|---------------|
+| 369 | feat(leads): persist pilot and walkthrough requests from launch demo | feat/lead-capture-wire | open, UNSTABLE | yes — `/launch` and `/demo/employer` need lead capture |
+| 370 | ci(copy): block banned truth-contract phrases in public surfaces | ci/banned-strings-guard | open, UNSTABLE | no (CI gate; merges independently) |
+| 371 | feat(review): show audit event id after employer acceptance | feat/employer-accept-audit-event-visibility | open, UNSTABLE | yes — buyer wants to see the audit proof line |
+| 372 | feat(ops): add source-health remediation hints for gated and degraded lanes | feat/source-health-remediation-hints | open, UNSTABLE | indirectly — ops-panel honesty supports the pilot |
+| 373 | fix(profile): make clinician profile preview state explicit | fix/clinician-profile-honest-state | open, UNSTABLE | yes — public route currently misleading |
+| 374 | docs(demo): add founder smoke checklist for pilot walkthrough | docs/founder-demo-smoke-checklist | open, UNSTABLE | no (docs only) |
+| 375 | fix(wallet-sdk): restore interoperability export for monorepo build | fix/wallet-sdk-interoperability-export | open, UNSTABLE | **unblocker** — Web Quality CI failure across the entire open fleet |
+
+All seven PRs show `UNSTABLE` for the same reasons: (a) the
+wallet-sdk DTS failure that PR #375 fixes, and (b) Vercel
+deployment checks failing because the Vercel account is disabled.
+Vercel check failures are no longer load-bearing — see the exit
+plan. Once #375 merges, the Web Quality lane should go green on
+the remaining six PRs.
+
+## Recommended merge order (operator decision)
+
+1. **#375** — unblocks Web Quality across the fleet.
+2. **#370** — banned-strings gate becomes enforceable on every
+   subsequent PR.
+3. **#371** — audit-entry UI line lights up the buyer's "where's
+   my proof?" moment.
+4. **#369** — `/api/leads` persists pilot inquiries from the
+   public demo route.
+5. **#373** — `/clinician/profile` stops implying it's editable.
+6. **#372** — source-health panel ships with honest copy and
+   operator-action hints; CI tests already cover the contract.
+7. **#374** — founder-demo smoke checklist becomes runnable
+   end-to-end once the prerequisite PRs above land.
+
+Numbers here are merge order, not completion order — the PRs are
+independent and can land in any sequence as long as the merge gate
+is satisfied per PR.
+
+## Pilot-funnel completion board
+
+These percentages move only on merged evidence per the canonical
+completion-board schema. In-flight PRs are tracked separately
+above.
+
+| Area | Current % | After this wave merges % | Detail / next action |
+|------|-----------|--------------------------|----------------------|
+| Public reachability (vitalcv.com) | 0% | 0% until Track B cutover | Vercel disabled; tunnel is for live demos only, not vitalcv.com |
+| Founder live-demo URL (tunnel) | 0% | 100% once `cloudflared` installed and the runbook is followed | runbook + script shipped this wave |
+| Production replacement plan | 0% | 50% once #375 merges and Cloudflare account exists | plan shipped this wave; first `*.pages.dev` build is the next gate |
+| Banned-strings CI gate | 0% | 100% once #370 merges | gate scans default scope + PR diffs |
+| Source-backed readiness preview (`/launch`) | 60% | 60% (depends on demo-spine PRs separate from this wave) | does not regress with the exit |
+| Lead capture (`/api/leads`) | 0% | 90% once #369 merges | last 10% is wiring into `/launch` once the demo spine lands |
+| Audit-entry visibility | 0% | 100% once #371 merges | UI line + proxy contract shipped |
+| Clinician profile honesty | 0% | 100% once #373 merges | input chrome removed; preview banner present |
+| Source-health remediation hints | 0% | 100% once #372 merges | 55/55 vitest passing |
+| Founder smoke checklist | 0% | 100% once #374 merges | 15-step doc + non-mutating smoke script |
+
+## Status emoji (derived from %)
+
+| Range | Emoji |
+|-------|-------|
+| 0% | ⛔ blocker |
+| 1–49% | 🟥 critical |
+| 50–74% | 🟧 partial |
+| 75–94% | 🟨 near complete |
+| 95–100% | 🟩 done |
+
+Apply to the percentages above only on merge — never independently
+of the percentage.

--- a/docs/ops/vercel-exit-emergency-plan.md
+++ b/docs/ops/vercel-exit-emergency-plan.md
@@ -1,0 +1,128 @@
+# Vercel exit — emergency plan
+
+**Status: production is down. Vercel is no longer a viable hosting
+dependency for VitalCV.**
+
+Last verified:
+
+```
+$ curl -sI https://vitalcv.com
+HTTP/2 402
+server: Vercel
+x-vercel-error: DEPLOYMENT_DISABLED
+```
+
+Founder decision: **no more Vercel dependency**. No paid path. No
+support-ticket wait. No DNS mutation until founder explicitly
+approves. The vitalcv.com domain stays parked at Vercel for now;
+nothing about the domain registrar configuration changes until the
+production cutover plan is approved.
+
+This document is the umbrella plan. The operational runbook and the
+production cutover plan live in two sibling docs:
+
+- [cloudflare-tunnel-founder-demo-runbook.md](./cloudflare-tunnel-founder-demo-runbook.md)
+- [cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md)
+
+## Posture
+
+| Item | State |
+|------|-------|
+| Vercel as primary hosting | **abandoned as a dependency** |
+| Vercel account | left in place; do not delete projects yet |
+| vitalcv.com DNS | unchanged; pointing at Vercel; still returning 402 |
+| Founder demo path | local app + Cloudflare Tunnel (Track A) |
+| Permanent hosting candidate | Cloudflare Pages / Workers (Track B) |
+| Database / Prisma | untouched; out of scope for this wave |
+| Spend allowed for this wave | **$0** |
+
+## Two-track strategy
+
+### Track A — Cloudflare Tunnel (today)
+
+A free `cloudflared` tunnel maps a public URL onto
+`http://localhost:3030`. The founder runs `next dev` on their
+laptop, starts the tunnel, and hands the resulting URL to anyone
+who needs to see the demo.
+
+- **Cost:** $0. `cloudflared` is a binary, no Cloudflare account
+  required for the temporary `try.cloudflare.com` subdomain.
+- **Audience:** founder-driven walkthroughs and recorded demos.
+  Not a production surface.
+- **Lifetime of URL:** for as long as the founder's laptop is on
+  and the tunnel process is running. Each restart yields a new
+  URL.
+- **Limitations:** no SLA, no caching, no CDN, no IP allow-listing.
+  Latency is laptop-to-Cloudflare-edge-to-viewer.
+- **What it lets the founder do today:** ship a working live demo
+  to a buyer / investor / pilot lead inside 5 minutes without
+  paying anyone.
+
+Operational details: see
+[cloudflare-tunnel-founder-demo-runbook.md](./cloudflare-tunnel-founder-demo-runbook.md).
+
+### Track B — Cloudflare Pages / Workers (this week)
+
+The permanent replacement. Cloudflare Pages can build a Next.js
+app for free (100k requests/day, 500 builds/month on the free
+tier). Workers can host the same app via OpenNext adapter if
+the routing is more dynamic than Pages handles directly.
+
+- **Cost:** $0 on the free tier for the expected demo / pilot
+  traffic volume.
+- **Audience:** vitalcv.com once the founder approves DNS
+  cutover.
+- **Build approach:** prebuild `@vitalcv/trust-state` +
+  `@vitalcv/shared`, then `next build`, then deploy the static +
+  serverless output. Adapter choice (Pages direct vs.
+  `@cloudflare/next-on-pages` vs. Workers via OpenNext) is
+  determined in the cutover plan.
+- **Limitations vs. Vercel:** the Next.js App Router on Cloudflare
+  needs an adapter step (`@cloudflare/next-on-pages`) — not a
+  one-click deploy. Some Node-specific APIs require an
+  `export const runtime = 'nodejs'` review. Already documented in
+  the cutover plan.
+
+Operational details: see
+[cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md).
+
+## Approval gates
+
+| Action | Approval required | Default |
+|--------|-------------------|---------|
+| Run Track A tunnel from founder laptop | none — founder executes | go |
+| Create Cloudflare account | none — founder executes | go |
+| Cloudflare Pages / Workers first deploy on a `*.pages.dev` subdomain | none | go |
+| Production env vars set in Cloudflare | **founder approval per-key** | hold |
+| Point vitalcv.com DNS at Cloudflare | **founder explicit approval** | hold |
+| Delete Vercel projects | **founder explicit approval** | hold (keep for forensic / rollback) |
+| Pay any vendor | **forbidden this wave** | hard stop |
+
+## Rollback posture
+
+Because vitalcv.com DNS is unchanged, the rollback for Track A is
+"close the laptop." The rollback for the Track B `*.pages.dev`
+URL is "stop sending traffic to it." The rollback for the eventual
+DNS cutover is "revert the DNS record to the prior Vercel target."
+The Vercel project is intentionally left in place until at least
+30 days after Cloudflare cutover succeeds, so the rollback is
+literally a DNS edit.
+
+## What is explicitly NOT in this plan
+
+- No database migration. Prisma schema untouched. The demo flows
+  on Track A run against the local sqlite / in-memory state that
+  the dev server already uses; the cutover plan defers the
+  question of where production Prisma lives.
+- No payment integration changes.
+- No mobile app changes.
+- No new Vercel project on a free account ("just create another
+  free Vercel account") — this loop ends today.
+- No Apply-with-VitalCV iframe / widget revival. The founder
+  retired that surface in a prior wave; this exit plan keeps it
+  retired.
+
+## Owner
+
+Chris Toler (founder). This document is the canonical reference
+for the next person who asks "why isn't vitalcv.com up?"

--- a/scripts/check-public-surface.sh
+++ b/scripts/check-public-surface.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# check-public-surface.sh — probe the public VitalCV surface
+# without mutating anything. Use against the Track-A tunnel URL
+# (https://*.trycloudflare.com), the Track-B preview URL
+# (https://<project>.pages.dev), or eventually https://vitalcv.com.
+#
+# Reports PASS/WARN/FAIL per route. Never mutates production,
+# never reads secrets, never touches DNS.
+#
+# Exit codes:
+#   0  all required routes PASS or WARN
+#   1  at least one required route FAIL
+#   2  configuration error (BASE_URL missing, curl not on PATH)
+#
+# Usage:
+#   BASE_URL=https://round-banana-tree.trycloudflare.com bash scripts/check-public-surface.sh
+#   BASE_URL=https://vitalcv-web.pages.dev               bash scripts/check-public-surface.sh
+#   BASE_URL=https://vitalcv.com                         bash scripts/check-public-surface.sh
+#
+#   bash scripts/check-public-surface.sh --base https://example.com
+#   bash scripts/check-public-surface.sh --quiet
+
+set -uo pipefail
+
+BASE="${BASE_URL:-}"
+QUIET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --help|-h)
+      sed -n '2,/^set/p' "$0" | sed -n 's/^# \{0,1\}//p'
+      exit 0
+      ;;
+    *)
+      echo "check-public-surface: unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${BASE}" ]]; then
+  echo "check-public-surface: BASE_URL is required (env var or --base)." >&2
+  exit 2
+fi
+# Strip any trailing slash so we can always concat "${BASE}${path}".
+BASE="${BASE%/}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "check-public-surface: curl not on PATH." >&2
+  exit 2
+fi
+
+# Each entry is "path|kind". `kind` is one of:
+#   required  — must PASS (2xx or deliberate 3xx) or it's FAIL
+#   informational — 404 / 405 produces WARN, not FAIL
+ROUTES=(
+  "/|required"
+  "/launch|required"
+  "/demo|required"
+  "/demo/employer|required"
+  "/demo/clinician|required"
+  "/api/health|informational"
+)
+
+PASS=0
+WARN=0
+FAIL=0
+declare -a SUMMARY
+
+color_for() {
+  case "$1" in
+    PASS) printf '\033[32m';;
+    WARN) printf '\033[33m';;
+    FAIL) printf '\033[31m';;
+    *)    printf '';;
+  esac
+}
+reset() { printf '\033[0m'; }
+
+emit() {
+  local status="$1"
+  local path="$2"
+  local detail="$3"
+  case "$status" in
+    PASS) PASS=$((PASS + 1));;
+    WARN) WARN=$((WARN + 1));;
+    FAIL) FAIL=$((FAIL + 1));;
+  esac
+  local line
+  line="$(printf '%s%-4s%s  %-22s  %s' "$(color_for "$status")" "$status" "$(reset)" "$path" "$detail")"
+  SUMMARY+=("$line")
+  if [[ $QUIET -eq 0 ]]; then
+    printf '%s\n' "$line"
+  fi
+}
+
+probe() {
+  local path="$1"
+  local kind="$2"
+  local url="${BASE}${path}"
+  # `--max-time 10` keeps a hung tunnel from blocking the whole run.
+  # `--retry 1` smooths a single hiccup on Cloudflare's edge.
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 --retry 1 \
+    -L --connect-timeout 5 -H 'Accept: text/html, application/json' "$url" 2>/dev/null \
+    || echo "000")"
+
+  case "$code" in
+    200|201|202|203|204|205|206)
+      emit PASS "$path" "HTTP $code"
+      ;;
+    301|302|303|307|308)
+      emit PASS "$path" "HTTP $code (followed)"
+      ;;
+    404|405)
+      if [[ "$kind" == "informational" ]]; then
+        emit WARN "$path" "HTTP $code (route not implemented yet)"
+      else
+        emit FAIL "$path" "HTTP $code"
+      fi
+      ;;
+    000)
+      emit FAIL "$path" "no response (timeout or connection refused)"
+      ;;
+    *)
+      if [[ "$kind" == "informational" ]]; then
+        emit WARN "$path" "HTTP $code"
+      else
+        emit FAIL "$path" "HTTP $code"
+      fi
+      ;;
+  esac
+}
+
+echo "check-public-surface: probing ${BASE}"
+echo ""
+for entry in "${ROUTES[@]}"; do
+  path="${entry%%|*}"
+  kind="${entry##*|}"
+  probe "$path" "$kind"
+done
+
+echo ""
+printf 'check-public-surface: %d pass, %d warn, %d fail (target: %s)\n' \
+  "$PASS" "$WARN" "$FAIL" "$BASE"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/public-demo-cloudflare.sh
+++ b/scripts/public-demo-cloudflare.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# public-demo-cloudflare.sh — start a Cloudflare quick-tunnel onto
+# the local VitalCV dev server.
+#
+# Track A of the Vercel exit plan
+# (docs/ops/vercel-exit-emergency-plan.md). Non-mutating: this script
+# never touches DNS, never touches Vercel, never reads or writes any
+# repo secret, and never starts a server itself. It only:
+#
+#   1. Verifies the `cloudflared` binary is on PATH.
+#   2. Probes http://localhost:3030 to confirm the founder's dev
+#      server is already running. If not, prints the exact
+#      command to start it and exits without starting a tunnel
+#      (so a tunnel to nothing is never published).
+#   3. Starts a quick tunnel (`cloudflared tunnel --url …`),
+#      tees the output to the terminal, and highlights the public
+#      URL when cloudflared emits it.
+#
+# Stop with Ctrl-C. The tunnel URL stops resolving immediately.
+#
+# Usage:
+#   bash scripts/public-demo-cloudflare.sh
+#   bash scripts/public-demo-cloudflare.sh --port 3030
+#   bash scripts/public-demo-cloudflare.sh --quiet
+#   bash scripts/public-demo-cloudflare.sh --help
+
+set -uo pipefail
+
+PORT="3030"
+QUIET=0
+
+usage() {
+  cat <<'EOF'
+public-demo-cloudflare.sh — start a Cloudflare quick-tunnel onto
+the local VitalCV dev server.
+
+Flags:
+  --port <n>   Local port to tunnel (default: 3030).
+  --quiet      Suppress cloudflared's own log noise; still prints
+               the resolved public URL.
+  --help       Show this help.
+
+Prereqs:
+  cloudflared on PATH and a dev server already listening on
+  http://localhost:<port>.
+
+This script never touches DNS, never touches Vercel, never reads
+or writes secrets. Stop with Ctrl-C.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "public-demo-cloudflare: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ── 1. cloudflared must be installed ───────────────────────────
+if ! command -v cloudflared >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+public-demo-cloudflare: `cloudflared` not found on PATH.
+
+Install:
+  macOS:    brew install cloudflared
+  Linux:    https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+
+This is a free anonymous tunnel — no Cloudflare account login
+needed for the trycloudflare.com URL.
+EOF
+  exit 2
+fi
+
+# ── 2. Local dev server must already be listening ──────────────
+if ! curl -sf --max-time 3 "http://localhost:${PORT}/" >/dev/null 2>&1 \
+   && ! curl -sf --max-time 3 "http://localhost:${PORT}/launch" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+public-demo-cloudflare: nothing is listening on http://localhost:${PORT}.
+
+Start the dev server in another terminal first:
+  cd ~/vitalcv
+  pnpm install --frozen-lockfile
+  pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'
+  pnpm --filter @vitalcv/web dev
+
+Then re-run this script. Refusing to start a tunnel pointed at
+nothing.
+EOF
+  exit 2
+fi
+
+# ── 3. Start the quick tunnel ─────────────────────────────────
+echo "public-demo-cloudflare: starting trycloudflare quick tunnel onto localhost:${PORT} …"
+echo "public-demo-cloudflare: Ctrl-C to stop. URL appears below as soon as Cloudflare assigns it."
+echo ""
+
+# Wrap cloudflared so we can highlight the public URL when it
+# appears. The binary writes the assigned URL to stderr; we tee
+# it through `awk` to flag the line clearly.
+if [[ $QUIET -eq 1 ]]; then
+  # Suppress noisy "connection established" lines but keep the URL.
+  cloudflared tunnel --url "http://localhost:${PORT}" 2>&1 \
+    | awk '
+        /trycloudflare\.com/ {
+          print "\n→ PUBLIC URL: " $0 "\n";
+          fflush();
+          next;
+        }
+        # drop the rest in quiet mode
+      '
+else
+  cloudflared tunnel --url "http://localhost:${PORT}" 2>&1 \
+    | awk '
+        {
+          print $0;
+          fflush();
+        }
+        /trycloudflare\.com/ {
+          print "\n→ PUBLIC URL (above) — copy and share.\n";
+          fflush();
+        }
+      '
+fi


### PR DESCRIPTION
## Summary
- Production is **down**: `https://vitalcv.com` returns HTTP 402 with `x-vercel-error: DEPLOYMENT_DISABLED`.
- Founder decision: **no more Vercel dependency. Zero spend. No DNS mutation without explicit founder approval.**
- This PR ships the operational doctrine and the two scripts the founder needs to get a public demo URL today — and the cutover plan for moving vitalcv.com to Cloudflare Pages later, behind an explicit approval gate.

## Files
- `docs/ops/vercel-exit-emergency-plan.md` — umbrella plan. Two tracks (A: Cloudflare Tunnel today; B: Cloudflare Pages later), approval gates per action, rollback posture, explicit non-goals.
- `docs/ops/cloudflare-tunnel-founder-demo-runbook.md` — install cloudflared, start `next dev` on :3030, start `cloudflared tunnel --url …`, share the `*.trycloudflare.com` URL. Limitations + stop commands explicit.
- `docs/ops/cloudflare-production-cutover-plan.md` — DNS inventory checklist, Pages build feasibility (incl. `nodejs_compat` for `/api/leads`), env var inventory (names only, per truth contract), QA gate on `*.pages.dev` before DNS, rollback matrix.
- `docs/ops/pilot-funnel-merge-board.md` — single-page status board: hosting state, open PRs (#369-#375), recommended merge order, completion percentages that move only on merged evidence.
- `scripts/public-demo-cloudflare.sh` — non-mutating tunnel wrapper. Refuses to start if :3030 isn't already serving. Never touches DNS, never reads secrets.
- `scripts/check-public-surface.sh` — `BASE_URL`-driven probe of /, /launch, /demo, /demo/employer, /demo/clinician, /api/health. PASS/WARN/FAIL table. Works against the tunnel URL, a `*.pages.dev` preview, or eventually vitalcv.com.

## Hard constraints honoured
- No money spent.
- No DNS mutation in this PR.
- No Vercel project deleted (left in place for rollback ≥30 days).
- No Prisma / database / production env / secret mutation.
- No new product surface; docs + scripts only.
- No banned phrases / no bare `Verified` (verified by grep).
- No Apply-with-VitalCV iframe revival.

## Recommended next action for the founder
1. `brew install cloudflared`
2. `cd ~/vitalcv && pnpm --filter @vitalcv/web dev` (in one terminal)
3. `bash scripts/public-demo-cloudflare.sh` (in another) — get a public URL inside 5 minutes
4. Track B follows once #375 lands and a Cloudflare account exists; nothing in this PR forces that decision.

## Test plan
- [ ] Founder runs the Track-A runbook end-to-end on their own laptop, gets a `*.trycloudflare.com` URL that resolves `/launch`.
- [ ] `BASE_URL=<that URL> bash scripts/check-public-surface.sh` returns 0 FAILs.
- [ ] Codex SAFE verdict on implementation / diff / copy audits.