### PR TITLE
ops(demo): add local Cloudflare demo operator

### DIFF
--- a/docs/ops/cloudflare-tunnel-founder-demo-runbook.md
+++ b/docs/ops/cloudflare-tunnel-founder-demo-runbook.md
@@ -1,0 +1,176 @@
+# Cloudflare Tunnel — founder demo runbook
+
+A manual walkthrough that ships a public URL onto
+`http://localhost:3030` while vitalcv.com remains down. This is
+the read-it-once explanation behind the one-command operator
+script — see
+[local-demo-operator-runbook.md](./local-demo-operator-runbook.md)
+if you want the fast path.
+
+For the umbrella context, see
+[vercel-exit-emergency-plan.md](./vercel-exit-emergency-plan.md).
+For permanent hosting, see
+[cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md).
+
+## Prerequisites
+
+- macOS or Linux laptop with the VitalCV repo cloned.
+- `pnpm` 10.6.1 installed (matches the repo lockfile).
+- Internet connection.
+- **No Cloudflare account required.** The `try.cloudflare.com`
+  trycloudflare URL is free, anonymous, and ephemeral.
+- **No DNS access required.** This runbook never touches the
+  vitalcv.com record.
+
+## One-time setup (under 60 seconds)
+
+### Install `cloudflared`
+
+macOS (Homebrew):
+
+```bash
+brew install cloudflared
+```
+
+macOS (no Homebrew) or Linux, download the official binary:
+
+```bash
+# Pick the right URL for your arch from
+# https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+curl -L --output ~/bin/cloudflared \
+  https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-arm64
+chmod +x ~/bin/cloudflared
+```
+
+Verify:
+
+```bash
+cloudflared --version
+```
+
+You should see a version string. No login is required for the
+`--url` quick-tunnel mode this runbook uses.
+
+## The fast path
+
+If you just want the URL:
+
+```bash
+cd ~/vitalcv
+bash scripts/vitalcv-demo-operator.sh
+```
+
+The operator script does everything below for you and prints the
+URL when it's ready. Read on if you want to understand what's
+happening, or if you need to run the steps individually because
+something's broken.
+
+## Manual demo session — 4 steps
+
+Open three terminal tabs in `~/vitalcv`.
+
+### Tab 1 — start the local app
+
+```bash
+cd ~/vitalcv
+pnpm install --frozen-lockfile          # only on first run / after lockfile bump
+pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'
+pnpm --filter @vitalcv/web dev
+```
+
+Wait for `▲ Next.js …  - Local: http://localhost:3030`.
+
+### Tab 2 — start the tunnel
+
+```bash
+cloudflared tunnel --url http://localhost:3030
+```
+
+Within 5–10 seconds:
+
+```
++--------------------------------------------------------------------------------------------+
+|  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |
+|  https://<random-three-words>.trycloudflare.com                                            |
++--------------------------------------------------------------------------------------------+
+```
+
+Copy that URL. Hand it to the buyer / investor / pilot lead.
+
+### Tab 3 — verify the public surface (optional)
+
+From the repo root, with the tunnel URL in your clipboard:
+
+```bash
+BASE_URL=https://<random>.trycloudflare.com bash scripts/check-public-surface.sh
+```
+
+Expect a PASS/WARN/FAIL table covering `/`, `/launch`, `/demo`,
+`/demo/employer`, `/demo/clinician`, and `/api/health`. A PASS on
+`/launch` is the minimum a founder demo needs. WARNs on
+`/launch` and `/demo/*` are expected if you're running `origin/main`
+without the demo-spine PRs merged.
+
+### Stop everything
+
+| Tab | How |
+|-----|-----|
+| Tab 2 — tunnel | `Ctrl-C`. The URL stops resolving within a few seconds. |
+| Tab 1 — dev server | `Ctrl-C`. |
+
+Or, if you used the operator script, **Ctrl-C in the operator
+terminal** cleans up both children automatically.
+
+## Routes worth testing on the public URL
+
+Before handing the URL to a buyer:
+
+| Path | Expected |
+|------|----------|
+| `/launch` | foundation-tier readiness preview lands without auth |
+| `/demo` | demo index linking to clinician / employer / issuer |
+| `/demo/clinician` | persona-driven readiness preview |
+| `/demo/employer` | ROI calculator + EquityRetentionBlock |
+| `/passport/<entity>` | source-backed readiness preview for one entity |
+| `/api/leads` | POST a test lead and confirm the JSONL row appears in `~/.vitalcv-logs/leads.jsonl` |
+
+If any of these 500 on the tunnel URL but works on
+`http://localhost:3030`, the issue is local — not the tunnel.
+
+## Limitations
+
+- **Ephemeral URL.** Each `cloudflared tunnel --url …` invocation
+  yields a new subdomain. Do not paste the URL into anything you
+  expect to live longer than the session.
+- **No CDN, no edge caching.** Latency is laptop-to-edge-to-viewer.
+  Fine for a 1-on-1 demo; not appropriate for sustained traffic.
+- **No IP allow-list.** Anyone with the URL can hit it. The demo
+  surface is designed for anonymous reach (no PHI, no credentials),
+  so this is fine — but do **not** point the tunnel at a backend
+  configured with production database creds.
+- **Laptop must stay awake** for the tunnel to stay up. Disable
+  sleep on the active machine during a long demo session.
+- **Not a substitute for production.** A live tunnel does not
+  satisfy any pilot deliverable that requires vitalcv.com or a
+  persistent SLA. For that, follow the Cloudflare production
+  cutover plan.
+
+## When the tunnel is the right tool
+
+- The founder is on a call and needs to show the demo "live, on
+  the internet, not on my laptop."
+- An investor asks "what does it look like?" and the founder
+  wants a URL to drop in a thread.
+- A pilot lead asks for a 5-minute walkthrough before signing
+  paperwork.
+
+## When the tunnel is NOT the right tool
+
+- A pilot customer expects the surface to be reachable when the
+  founder is asleep.
+- A press / launch announcement needs vitalcv.com to work.
+- Any path that needs production secrets, production database
+  rows, or persistent audit / receipt storage.
+
+For all of those, accelerate the Cloudflare production cutover
+plan.

--- a/docs/ops/local-demo-operator-runbook.md
+++ b/docs/ops/local-demo-operator-runbook.md
@@ -1,0 +1,190 @@
+# Local demo operator runbook
+
+One command brings the VitalCV demo back online without Vercel,
+without DNS changes, and without spend.
+
+For the umbrella context (why Vercel is gone, what comes next, the
+production cutover plan), see
+[vercel-exit-emergency-plan.md](./vercel-exit-emergency-plan.md).
+
+For the manual tunnel walkthrough (what the operator script does
+under the hood), see
+[cloudflare-tunnel-founder-demo-runbook.md](./cloudflare-tunnel-founder-demo-runbook.md).
+
+## Why Vercel is bypassed
+
+`https://vitalcv.com` currently returns:
+
+```
+HTTP/2 402
+server: Vercel
+x-vercel-error: DEPLOYMENT_DISABLED
+```
+
+The founder decision is final: no more Vercel dependency, no paid
+recovery path. The operator script in this doc gets a working
+public URL up via `cloudflared` quick-tunnel, fed by a local
+`pnpm dev` server.
+
+## The one command
+
+From any terminal:
+
+```bash
+cd ~/vitalcv         # or the canonical worktree
+bash scripts/vitalcv-demo-operator.sh
+```
+
+The script will:
+
+1. Repair `PATH` so Homebrew + npm-global binaries resolve in
+   stripped shells.
+2. Verify `pnpm`, `cloudflared`, `lsof`, and `curl` are present.
+3. Run `scripts/kill-shadow-vitalcv-runtimes.sh` to clean up any
+   left-over vitalcv-omega4f-trigger processes and stale pm2
+   services named `vitalcv-web` or `vitalcv-tunnel`. It does
+   **not** touch `ai.openclaw.gateway` or generic node
+   processes.
+4. Pick the best demo worktree it can find (`/tmp/vitalcv-demo-
+   spine-openevidence` → `/tmp/vitalcv-demo-spine` → any git
+   worktree matching `demo`/`openevidence`/`launch` → `~/vitalcv`).
+5. Print the worktree, branch, and short SHA so you can confirm
+   you're demoing the right code.
+6. Install dependencies only if `node_modules` is missing or if
+   you passed `--install`.
+7. Prebuild `@vitalcv/trust-state` and `@vitalcv/shared`.
+8. Start `pnpm --filter @vitalcv/web dev` in the background,
+   logging to `.vitalcv-demo-app.log`.
+9. Wait for `http://localhost:3030` to respond (max 120 s).
+10. Start `cloudflared tunnel --url http://localhost:3030`,
+    logging to `.vitalcv-demo-tunnel.log`.
+11. Extract the assigned `https://*.trycloudflare.com` URL,
+    write it to `.vitalcv-demo-url`, and print it.
+12. Run `scripts/check-public-surface.sh` against the public URL
+    and print the PASS / WARN / FAIL table.
+13. Sit and watch the two child processes until you press
+    Ctrl-C — at which point the `trap` cleans both of them up.
+
+## Expected route statuses
+
+Against `https://<random>.trycloudflare.com`:
+
+| Route | Expected | Notes |
+|-------|----------|-------|
+| `/` | PASS (2xx or redirect) | redirect to `/launch` is fine |
+| `/launch` | PASS on a demo branch · WARN on plain `main` | the OpenEvidence demo-spine PRs ship `/launch`; if you're on `origin/main` without those merges, a 404 here is reported as WARN, not FAIL |
+| `/demo` | PASS on a demo branch · WARN on plain `main` | same as above |
+| `/demo/employer` | PASS on a demo branch · WARN on plain `main` | same |
+| `/demo/clinician` | PASS on a demo branch · WARN on plain `main` | same |
+| `/api/health` | PASS or WARN | informational only — the route is not required for a founder walk |
+
+The script does not exit with a failure for WARN states. A FAIL
+only happens on 5xx, on unreachable, or on 4xx for a route that
+must work (e.g. `/`).
+
+## How to stop
+
+Three options, pick whichever is in front of you:
+
+1. Press **Ctrl-C** in the operator terminal. The `trap` kills
+   both child processes and exits.
+2. Run the explicit kill command printed at the bottom of the
+   operator output:
+   ```
+   kill <app_pid> <tunnel_pid>
+   ```
+3. From any terminal:
+   ```bash
+   bash scripts/kill-shadow-vitalcv-runtimes.sh
+   ```
+   This is the broader cleanup — it stops the named pm2 services
+   and any `vitalcv-omega4f-trigger` processes. It also prints
+   listeners on `:3000` and `:3030` but does NOT kill them
+   automatically.
+
+## How to switch to the demo branch
+
+If you're getting WARN on `/launch` and `/demo/*`, the demo
+spine isn't in your current worktree. Either:
+
+- check out one of the demo-spine PR branches into a new
+  worktree:
+  ```bash
+  git worktree add -B demo-preview /tmp/vitalcv-demo-spine \
+    origin/wave/demo-spine-openevidence-execution
+  cd /tmp/vitalcv-demo-spine
+  pnpm install --frozen-lockfile
+  ```
+  Re-run the operator from this tree; the auto-detection picks
+  it up first by name.
+
+- or merge the demo-spine PRs into `main` (per the pilot-funnel
+  merge board) and re-run the operator.
+
+## Recovery — I closed the terminal and lost the URL
+
+The operator writes the URL and PIDs to discoverable files in the
+chosen app directory:
+
+| File | Contents |
+|------|----------|
+| `.vitalcv-demo-url` | the active trycloudflare URL (single line) |
+| `.vitalcv-demo-operator.log` | every step the operator script ran, with timestamps |
+| `.vitalcv-demo-app.log` | raw `pnpm dev` output |
+| `.vitalcv-demo-tunnel.log` | raw `cloudflared` output |
+
+If the URL file is present and the PIDs in the operator log are
+still alive (`kill -0 <pid>`), the tunnel is still up. Just
+share the URL.
+
+If the PIDs are dead, the tunnel URL is dead too. Re-run the
+operator.
+
+## Known limitations
+
+- **The trycloudflare URL is temporary.** Each operator invocation
+  yields a fresh `https://<random>.trycloudflare.com` subdomain.
+  Don't paste it into anything that needs to outlive the
+  session.
+- **The script does not survive laptop sleep.** macOS will pause
+  the dev server when the lid closes, and the tunnel will drop
+  shortly after. Disable sleep on the active machine during a
+  long demo.
+- **No SLA, no IP allow-list, no CDN.** The latency is
+  laptop-to-Cloudflare-edge-to-viewer. Acceptable for a 1-on-1
+  walkthrough, not for sustained traffic. For a real production
+  surface, follow
+  [cloudflare-production-cutover-plan.md](./cloudflare-production-cutover-plan.md).
+- **No DNS mutation.** The script never touches `vitalcv.com`.
+  Pointing the production domain at Cloudflare Pages is a
+  separate, founder-approved action covered by the cutover
+  plan.
+- **No Vercel API calls.** The script is engineered to operate
+  while the Vercel account is disabled. Don't add Vercel CLI
+  calls to it.
+- **No secrets read or written.** The script does not look at
+  `.env*` files, does not paste tokens into Cloudflare, and does
+  not call the Slack webhooks. Slack delivery for `/api/leads`
+  still works at runtime if the env var is set in the shell that
+  launches `pnpm dev`, but the script never sets it for you.
+
+## Constraints the script will not violate
+
+- No sudo.
+- No DNS mutation.
+- No Vercel CLI / API calls.
+- No paid services.
+- No Prisma migration or database mutation.
+- No package dependency additions.
+- No killing of `ai.openclaw.gateway`.
+- No killing of unrelated `node` processes — only pm2 services
+  named `vitalcv-web` / `vitalcv-tunnel` and processes whose
+  command line contains the literal `vitalcv-omega4f-trigger`.
+- No automatic kill of `:3000` or `:3030` listeners. Those are
+  printed but the operator decides what to do with them.
+
+## Owner
+
+Chris Toler (founder). This runbook is the canonical reference
+for the operator script. Edits go through a PR; do not modify
+the script's safety contract section without a Codex review.

--- a/scripts/check-public-surface.sh
+++ b/scripts/check-public-surface.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# check-public-surface.sh — probe the public VitalCV surface
+# without mutating anything. Use against the local dev server
+# (http://localhost:3030), the Track-A tunnel URL
+# (https://*.trycloudflare.com), the Track-B preview URL
+# (https://<project>.pages.dev), or eventually https://vitalcv.com.
+#
+# Reports PASS / WARN / FAIL per route. Never mutates production,
+# never reads secrets, never touches DNS or Vercel.
+#
+# WARN cases (not failures):
+#   - 404 on /launch or /demo when running plain main without the
+#     OpenEvidence demo-spine PRs merged. The operator can see the
+#     gap without it being a hard error.
+#   - 404 / 405 on /api/health when the route isn't implemented.
+#
+# Exit codes:
+#   0  all required routes PASS or WARN
+#   1  at least one required route FAIL (5xx or unreachable)
+#   2  configuration error (BASE_URL missing, curl not on PATH)
+#
+# Usage:
+#   BASE_URL=http://localhost:3030                     bash scripts/check-public-surface.sh
+#   BASE_URL=https://round-banana-tree.trycloudflare.com bash scripts/check-public-surface.sh
+#   BASE_URL=https://vitalcv-web.pages.dev             bash scripts/check-public-surface.sh
+#   BASE_URL=https://vitalcv.com                       bash scripts/check-public-surface.sh
+#
+#   bash scripts/check-public-surface.sh --base https://example.com
+#   bash scripts/check-public-surface.sh --quiet
+
+set -uo pipefail
+
+# PATH repair so this runs cleanly when invoked from launchd,
+# pm2, or a stripped-down shell.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.npm-global/bin:${HOME}/.local/bin:${PATH:-}"
+
+# Prefer /usr/bin/curl when present (matches the system curl
+# expected by every macOS/Linux environment). Fall back to
+# PATH-resolved curl. If neither exists, exit 2.
+if [[ -x /usr/bin/curl ]]; then
+  CURL=/usr/bin/curl
+elif command -v curl >/dev/null 2>&1; then
+  CURL="$(command -v curl)"
+else
+  echo "check-public-surface: curl not found." >&2
+  exit 2
+fi
+
+BASE="${BASE_URL:-}"
+QUIET=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --help|-h)
+      sed -n '2,/^set/p' "$0" | sed -n 's/^# \{0,1\}//p'
+      exit 0
+      ;;
+    *)
+      echo "check-public-surface: unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${BASE}" ]]; then
+  echo "check-public-surface: BASE_URL is required (env var or --base)." >&2
+  exit 2
+fi
+# Strip any trailing slash so we can always concat "${BASE}${path}".
+BASE="${BASE%/}"
+
+# Each entry is "path|kind". `kind`:
+#   required        — must PASS (2xx / followed redirect) or FAIL
+#   demo-optional   — 404 is WARN (demo-spine PRs not merged yet),
+#                     5xx is FAIL
+#   informational   — any non-success is WARN
+ROUTES=(
+  "/|required"
+  "/launch|demo-optional"
+  "/demo|demo-optional"
+  "/demo/employer|demo-optional"
+  "/demo/clinician|demo-optional"
+  "/api/health|informational"
+)
+
+PASS=0
+WARN=0
+FAIL=0
+
+color_for() {
+  case "$1" in
+    PASS) printf '\033[32m';;
+    WARN) printf '\033[33m';;
+    FAIL) printf '\033[31m';;
+    *)    printf '';;
+  esac
+}
+reset_color() { printf '\033[0m'; }
+
+emit() {
+  local status="$1"
+  local path="$2"
+  local detail="$3"
+  case "$status" in
+    PASS) PASS=$((PASS + 1));;
+    WARN) WARN=$((WARN + 1));;
+    FAIL) FAIL=$((FAIL + 1));;
+  esac
+  if [[ $QUIET -eq 0 ]]; then
+    printf '%s%-4s%s  %-22s  %s\n' \
+      "$(color_for "$status")" "$status" "$(reset_color)" "$path" "$detail"
+  fi
+}
+
+probe() {
+  local path="$1"
+  local kind="$2"
+  local url="${BASE}${path}"
+
+  local code
+  code="$("$CURL" -sS -o /dev/null -w '%{http_code}' \
+    --max-time 10 --retry 1 -L --connect-timeout 5 \
+    -H 'Accept: text/html, application/json' \
+    "$url" 2>/dev/null || echo '000')"
+
+  case "$code" in
+    200|201|202|203|204|205|206)
+      emit PASS "$path" "HTTP $code"
+      ;;
+    301|302|303|307|308)
+      emit PASS "$path" "HTTP $code (followed)"
+      ;;
+    404|405)
+      if [[ "$kind" == "demo-optional" ]]; then
+        emit WARN "$path" "HTTP $code (demo route not on main yet — run from demo branch to see it)"
+      elif [[ "$kind" == "informational" ]]; then
+        emit WARN "$path" "HTTP $code (route not implemented yet)"
+      else
+        emit FAIL "$path" "HTTP $code"
+      fi
+      ;;
+    5*)
+      emit FAIL "$path" "HTTP $code"
+      ;;
+    000)
+      emit FAIL "$path" "no response (timeout or connection refused)"
+      ;;
+    *)
+      if [[ "$kind" == "informational" ]]; then
+        emit WARN "$path" "HTTP $code"
+      else
+        emit FAIL "$path" "HTTP $code"
+      fi
+      ;;
+  esac
+}
+
+echo "check-public-surface: probing ${BASE}"
+echo ""
+for entry in "${ROUTES[@]}"; do
+  path="${entry%%|*}"
+  kind="${entry##*|}"
+  probe "$path" "$kind"
+done
+
+echo ""
+printf 'check-public-surface: %d pass, %d warn, %d fail (target: %s)\n' \
+  "$PASS" "$WARN" "$FAIL" "$BASE"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/kill-shadow-vitalcv-runtimes.sh
+++ b/scripts/kill-shadow-vitalcv-runtimes.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# kill-shadow-vitalcv-runtimes.sh — clean up the small set of
+# vitalcv-specific processes that, when left running from a prior
+# operator session, will block a fresh `vitalcv-demo-operator.sh`
+# from starting cleanly.
+#
+# Safety contract (DO NOT WEAKEN):
+#   - Never kills `ai.openclaw.gateway` (operator infrastructure).
+#   - Never kills generic `node` processes. The script only kills:
+#       1. pm2 services whose names match the vitalcv-* allowlist
+#          below.
+#       2. processes whose full command line mentions the literal
+#          string `vitalcv-omega4f-trigger` (the historical local
+#          dev tree that is the most common shadow runtime source
+#          on Chris's laptop).
+#   - Sudo is never required and never invoked.
+#   - DNS, registrar, Vercel, and database state are out of scope.
+#   - Listeners on :3000 and :3030 are PRINTED but not killed. The
+#     operator decides whether to terminate them.
+#
+# Exit codes:
+#   0  cleanup completed (no targets found, or targets cleanly
+#      terminated)
+#   2  configuration error (lsof missing on a flow that needs it)
+
+set -uo pipefail
+
+# ── PATH repair — Homebrew on Apple Silicon paths, plus the
+#    operator's local install directories.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.npm-global/bin:${HOME}/.local/bin:${PATH:-}"
+
+OPENCLAW_NEVER_KILL='ai.openclaw.gateway'
+SHADOW_NEEDLE='vitalcv-omega4f-trigger'
+
+# pm2 service-name allowlist. The script only stops/deletes these
+# exact names. Adding a name here is the only way the script will
+# touch a pm2 service.
+PM2_KILL_TARGETS=(
+  "vitalcv-web"
+  "vitalcv-tunnel"
+)
+
+echo "kill-shadow-vitalcv-runtimes: starting (no sudo, no DNS, no Vercel)."
+
+# ── 1. pm2 cleanup — only the allowlisted service names ──────
+if command -v pm2 >/dev/null 2>&1; then
+  echo ""
+  echo "[pm2] inventory:"
+  pm2 list 2>/dev/null | tail -n +1 || true
+  for svc in "${PM2_KILL_TARGETS[@]}"; do
+    if pm2 list 2>/dev/null | awk '{print $2}' | grep -qx "$svc"; then
+      echo "[pm2] stopping + deleting service '$svc'"
+      pm2 stop  "$svc" >/dev/null 2>&1 || true
+      pm2 delete "$svc" >/dev/null 2>&1 || true
+    else
+      echo "[pm2] service '$svc' not running — skipping"
+    fi
+  done
+  pm2 save --force >/dev/null 2>&1 || true
+else
+  echo "[pm2] not installed — skipping"
+fi
+
+# ── 2. Kill processes whose command line mentions
+#    `vitalcv-omega4f-trigger`. We list every match first so the
+#    operator can see exactly what will die before any signal is
+#    sent.
+echo ""
+echo "[shadow] scanning for '${SHADOW_NEEDLE}' processes (excluding ${OPENCLAW_NEVER_KILL} and this script)…"
+
+shadow_pids=()
+# `ps` is portable across macOS + Linux. We grep the full command
+# line, then filter:
+#   - drop the grep process itself
+#   - drop anything mentioning the openclaw gateway
+#   - drop this script's own grep invocation
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if echo "$line" | grep -q "$OPENCLAW_NEVER_KILL"; then
+    continue
+  fi
+  pid="$(echo "$line" | awk '{print $1}')"
+  [[ -z "$pid" ]] && continue
+  echo "  → would kill PID $pid: $(echo "$line" | cut -c1-180)"
+  shadow_pids+=("$pid")
+done < <(ps -axo pid,command 2>/dev/null | grep -- "$SHADOW_NEEDLE" | grep -v 'grep --' | grep -v 'kill-shadow-vitalcv-runtimes' || true)
+
+if [[ ${#shadow_pids[@]} -gt 0 ]]; then
+  echo "[shadow] sending SIGTERM to ${#shadow_pids[@]} pid(s)…"
+  for pid in "${shadow_pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  # Anything that didn't exit, escalate to SIGKILL — but recheck
+  # the openclaw guard one more time defensively.
+  for pid in "${shadow_pids[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      if ps -o command= -p "$pid" 2>/dev/null | grep -q "$OPENCLAW_NEVER_KILL"; then
+        echo "  ! PID $pid morphed into ${OPENCLAW_NEVER_KILL}; leaving it alone"
+        continue
+      fi
+      echo "  → SIGKILL PID $pid"
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+else
+  echo "[shadow] no '${SHADOW_NEEDLE}' processes found"
+fi
+
+# ── 3. Print listeners on :3000 and :3030. Do NOT kill them —
+#    the operator script decides what to do with the port.
+echo ""
+echo "[ports] current listeners on :3000 and :3030 (informational only — NOT killed by this script):"
+if command -v lsof >/dev/null 2>&1; then
+  for port in 3000 3030; do
+    out="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+    if [[ -z "$out" ]]; then
+      echo "  :$port — no listener"
+    else
+      echo "  :$port —"
+      echo "$out" | sed 's/^/    /'
+    fi
+  done
+else
+  echo "  lsof not on PATH — cannot inspect port state (skipping, not failing)"
+fi
+
+echo ""
+echo "kill-shadow-vitalcv-runtimes: done."

--- a/scripts/vitalcv-demo-operator.sh
+++ b/scripts/vitalcv-demo-operator.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# vitalcv-demo-operator.sh — one command that brings the founder
+# demo back up via a Cloudflare quick-tunnel.
+#
+# Workflow:
+#   1. PATH repair (Homebrew + npm-global + local bin).
+#   2. Tool verification: pnpm, cloudflared, lsof, curl.
+#   3. Shadow-runtime cleanup via kill-shadow-vitalcv-runtimes.sh.
+#   4. App directory resolution (demo-spine paths first, then any
+#      worktree matching demo/openevidence/launch, then ~/vitalcv).
+#   5. Optional `pnpm install` (only if node_modules missing or
+#      --install is passed).
+#   6. Start `pnpm --filter @vitalcv/web dev` in the background.
+#   7. Wait for http://localhost:3030 to respond.
+#   8. Start `cloudflared tunnel --url http://localhost:3030`.
+#   9. Extract the trycloudflare URL from cloudflared output.
+#  10. Smoke-test the public URL via check-public-surface.sh.
+#  11. Print the route table, write the URL to .vitalcv-demo-url,
+#      mirror everything to .vitalcv-demo-operator.log.
+#  12. Hand back a single stop command.
+#
+# Hard safety contract (DO NOT WEAKEN):
+#   - No DNS mutation. No Vercel commands. No paid services. No
+#     sudo. No Prisma / database mutation.
+#   - Does not kill ai.openclaw.gateway or unrelated node procs.
+#     Shadow cleanup is delegated to kill-shadow-vitalcv-runtimes.sh,
+#     which has its own narrow allowlist.
+#   - Cleans up both child processes on Ctrl-C (SIGINT) and on
+#     normal exit.
+#
+# Flags:
+#   --install        force `pnpm install --frozen-lockfile` before dev
+#   --port <n>       override the local port (default: 3030)
+#   --skip-smoke     skip the check-public-surface.sh smoke test
+#   --skip-shadow    skip the shadow-runtime cleanup step
+#   --help
+
+set -uo pipefail
+# `set -e` is intentionally NOT enabled at the top level because we
+# need to handle subprocess exit codes manually (pnpm dev never
+# exits on its own; cloudflared writes the URL to stderr; etc.).
+# We use explicit `|| { … }` for every command that must fail loudly.
+
+# ── 1. PATH repair ─────────────────────────────────────────────
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.npm-global/bin:${HOME}/.local/bin:${PATH:-}"
+
+# Curl resolver (prefer the system binary for predictability).
+if [[ -x /usr/bin/curl ]]; then
+  CURL=/usr/bin/curl
+elif command -v curl >/dev/null 2>&1; then
+  CURL="$(command -v curl)"
+else
+  CURL=""
+fi
+
+# ── Flag parsing ───────────────────────────────────────────────
+DO_INSTALL=0
+PORT=3030
+SKIP_SMOKE=0
+SKIP_SHADOW=0
+
+usage() {
+  sed -n '2,/^set/p' "$0" | sed -n 's/^# \{0,1\}//p'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)     DO_INSTALL=1; shift ;;
+    --port)        PORT="$2"; shift 2 ;;
+    --skip-smoke)  SKIP_SMOKE=1; shift ;;
+    --skip-shadow) SKIP_SHADOW=1; shift ;;
+    --help|-h)     usage; exit 0 ;;
+    *) echo "vitalcv-demo-operator: unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ── Operator state — written to disk so an operator who lost the
+#    terminal session can recover the URL and the PIDs.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_HINT="$(cd "${SCRIPT_DIR}/.." 2>/dev/null && pwd || true)"
+URL_FILE_REL=".vitalcv-demo-url"
+LOG_FILE_REL=".vitalcv-demo-operator.log"
+
+APP_PID=""
+TUNNEL_PID=""
+TUNNEL_LOG=""
+PUBLIC_URL=""
+
+log() {
+  local line
+  line="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+  echo "$line"
+  if [[ -n "${LOG_FILE_ABS:-}" ]]; then
+    printf '%s\n' "$line" >>"$LOG_FILE_ABS"
+  fi
+}
+
+cleanup() {
+  local rc=$?
+  log "cleanup: terminating child processes…"
+  if [[ -n "$TUNNEL_PID" ]] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    kill "$TUNNEL_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+    kill "$APP_PID" 2>/dev/null || true
+  fi
+  # Give them a moment to exit gracefully.
+  sleep 1
+  for pid in "$TUNNEL_PID" "$APP_PID"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  if [[ -n "$TUNNEL_LOG" && -f "$TUNNEL_LOG" ]]; then
+    rm -f "$TUNNEL_LOG"
+  fi
+  exit "$rc"
+}
+trap cleanup INT TERM EXIT
+
+# ── 2. Tool verification ───────────────────────────────────────
+need() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "vitalcv-demo-operator: required tool not found on PATH: $tool" >&2
+    case "$tool" in
+      pnpm)        echo "  install: npm install -g pnpm@10.6.1" >&2 ;;
+      cloudflared) echo "  install: brew install cloudflared (macOS) or fetch the binary from Cloudflare's downloads page" >&2 ;;
+      lsof)        echo "  install: lsof is part of base macOS / most Linux distros — check PATH" >&2 ;;
+    esac
+    exit 2
+  fi
+}
+
+need pnpm
+need cloudflared
+need lsof
+if [[ -z "$CURL" ]]; then
+  echo "vitalcv-demo-operator: curl not found (checked /usr/bin/curl and PATH)." >&2
+  exit 2
+fi
+
+# ── 4. App directory resolution ───────────────────────────────
+# Search order is documented in the file header.
+APP_DIR=""
+for candidate in \
+  "/tmp/vitalcv-demo-spine-openevidence" \
+  "/tmp/vitalcv-demo-spine"
+do
+  if [[ -d "$candidate" ]] && [[ -f "$candidate/apps/web/package.json" ]]; then
+    APP_DIR="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$APP_DIR" ]] && command -v git >/dev/null 2>&1; then
+  # Look for any worktree path whose name contains demo / openevidence
+  # / launch. We use `git worktree list --porcelain` so the path is
+  # cleanly extractable.
+  while IFS= read -r line; do
+    [[ "$line" =~ ^worktree[[:space:]](.*)$ ]] || continue
+    wt_path="${BASH_REMATCH[1]}"
+    case "$wt_path" in
+      *demo*|*openevidence*|*launch*)
+        if [[ -f "$wt_path/apps/web/package.json" ]]; then
+          APP_DIR="$wt_path"
+          break
+        fi
+        ;;
+    esac
+  done < <(git -C "$REPO_HINT" worktree list --porcelain 2>/dev/null || true)
+fi
+
+if [[ -z "$APP_DIR" ]] && [[ -f "${HOME}/vitalcv/apps/web/package.json" ]]; then
+  APP_DIR="${HOME}/vitalcv"
+fi
+
+if [[ -z "$APP_DIR" ]]; then
+  echo "vitalcv-demo-operator: could not resolve an app directory." >&2
+  echo "  Tried /tmp/vitalcv-demo-spine-openevidence, /tmp/vitalcv-demo-spine," >&2
+  echo "  any git worktree matching demo/openevidence/launch, and ~/vitalcv." >&2
+  exit 2
+fi
+
+# Operator state files live in APP_DIR so they're discoverable
+# from the founder's primary working tree.
+URL_FILE_ABS="${APP_DIR}/${URL_FILE_REL}"
+LOG_FILE_ABS="${APP_DIR}/${LOG_FILE_REL}"
+: >"$LOG_FILE_ABS"
+
+log "vitalcv-demo-operator: starting."
+log "app dir:    ${APP_DIR}"
+
+BRANCH=""
+SHA=""
+if [[ -d "${APP_DIR}/.git" ]] || git -C "$APP_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BRANCH="$(git -C "$APP_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '<detached>')"
+  SHA="$(git -C "$APP_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo '<unknown>')"
+  log "branch:     ${BRANCH}"
+  log "sha:        ${SHA}"
+else
+  log "branch:     <not a git tree>"
+fi
+
+# ── 3. Shadow-runtime cleanup ────────────────────────────────
+if [[ $SKIP_SHADOW -eq 0 ]]; then
+  if [[ -x "${SCRIPT_DIR}/kill-shadow-vitalcv-runtimes.sh" ]]; then
+    log "running shadow cleanup…"
+    bash "${SCRIPT_DIR}/kill-shadow-vitalcv-runtimes.sh" 2>&1 | tee -a "$LOG_FILE_ABS"
+  else
+    log "kill-shadow-vitalcv-runtimes.sh not found — skipping cleanup."
+  fi
+else
+  log "shadow cleanup skipped (--skip-shadow)."
+fi
+
+# ── 5. Install dependencies if needed ────────────────────────
+if [[ $DO_INSTALL -eq 1 || ! -d "${APP_DIR}/node_modules" ]]; then
+  log "running pnpm install --frozen-lockfile (this can take a minute)…"
+  ( cd "$APP_DIR" && pnpm install --frozen-lockfile ) 2>&1 | tee -a "$LOG_FILE_ABS"
+else
+  log "node_modules present — skipping install (pass --install to force)."
+fi
+
+# Prebuild workspace deps — required for @vitalcv/trust-state's
+# dist/ entry to exist before `next dev` evaluates imports.
+log "prebuilding @vitalcv/trust-state and @vitalcv/shared…"
+( cd "$APP_DIR" && pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared' ) \
+  >>"$LOG_FILE_ABS" 2>&1 || {
+    log "prebuild failed (non-fatal for some demo branches). See ${LOG_FILE_ABS}."
+  }
+
+# ── 6. Start the dev server in the background ────────────────
+APP_LOG="${APP_DIR}/.vitalcv-demo-app.log"
+: >"$APP_LOG"
+log "starting pnpm --filter @vitalcv/web dev on :${PORT}…"
+(
+  cd "$APP_DIR"
+  # Inherit the operator's env but ensure PORT/NEXT_PORT are
+  # honoured by the web app's `dev` script (which already pins
+  # :3030 via the runtime-assert wrapper).
+  exec pnpm --filter @vitalcv/web dev
+) >"$APP_LOG" 2>&1 &
+APP_PID=$!
+log "app pid:    ${APP_PID}"
+
+# ── 7. Wait for localhost:PORT to respond ────────────────────
+log "waiting for http://localhost:${PORT} to respond (max 120s)…"
+ready=0
+for _ in $(seq 1 60); do
+  if "$CURL" -sf --max-time 2 "http://localhost:${PORT}/" >/dev/null 2>&1 \
+     || "$CURL" -sf --max-time 2 "http://localhost:${PORT}/launch" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    log "app process exited prematurely — see ${APP_LOG}."
+    tail -n 20 "$APP_LOG" || true
+    exit 1
+  fi
+  sleep 2
+done
+if [[ $ready -ne 1 ]]; then
+  log "app did not become ready within 120s — see ${APP_LOG}."
+  tail -n 40 "$APP_LOG" || true
+  exit 1
+fi
+log "app is ready."
+
+# ── 8. Start the cloudflared tunnel ──────────────────────────
+TUNNEL_LOG="${APP_DIR}/.vitalcv-demo-tunnel.log"
+: >"$TUNNEL_LOG"
+log "starting cloudflared tunnel onto :${PORT}…"
+(
+  cd "$APP_DIR"
+  exec cloudflared tunnel --url "http://localhost:${PORT}" --no-autoupdate
+) >"$TUNNEL_LOG" 2>&1 &
+TUNNEL_PID=$!
+log "tunnel pid: ${TUNNEL_PID}"
+
+# ── 9. Extract the trycloudflare URL ────────────────────────
+log "waiting for trycloudflare.com URL (max 60s)…"
+PUBLIC_URL=""
+for _ in $(seq 1 30); do
+  PUBLIC_URL="$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -1 || true)"
+  if [[ -n "$PUBLIC_URL" ]]; then
+    break
+  fi
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    log "cloudflared exited prematurely — see ${TUNNEL_LOG}."
+    tail -n 40 "$TUNNEL_LOG" || true
+    exit 1
+  fi
+  sleep 2
+done
+
+if [[ -z "$PUBLIC_URL" ]]; then
+  log "cloudflared did not emit a public URL within 60s — see ${TUNNEL_LOG}."
+  tail -n 40 "$TUNNEL_LOG" || true
+  exit 1
+fi
+
+log "PUBLIC URL: ${PUBLIC_URL}"
+printf '%s\n' "$PUBLIC_URL" >"$URL_FILE_ABS"
+log "wrote ${URL_FILE_ABS}"
+
+# ── 10. Smoke-test the surface ──────────────────────────────
+if [[ $SKIP_SMOKE -eq 0 ]] && [[ -x "${SCRIPT_DIR}/check-public-surface.sh" ]]; then
+  log "running check-public-surface against the tunnel URL…"
+  ( BASE_URL="$PUBLIC_URL" bash "${SCRIPT_DIR}/check-public-surface.sh" ) 2>&1 | tee -a "$LOG_FILE_ABS"
+elif [[ $SKIP_SMOKE -eq 0 ]]; then
+  log "check-public-surface.sh not found — skipping smoke test."
+else
+  log "smoke test skipped (--skip-smoke)."
+fi
+
+# ── 11. Final summary ───────────────────────────────────────
+cat <<EOF | tee -a "$LOG_FILE_ABS"
+
+──────────────────────────────────────────────────────────────
+VitalCV demo operator — live
+
+  Public URL: ${PUBLIC_URL}
+  App PID:    ${APP_PID}
+  Tunnel PID: ${TUNNEL_PID}
+  App log:    ${APP_LOG}
+  Tunnel log: ${TUNNEL_LOG}
+  URL file:   ${URL_FILE_ABS}
+  Operator log: ${LOG_FILE_ABS}
+
+Stop everything:
+  kill ${APP_PID} ${TUNNEL_PID}
+
+Or press Ctrl-C in this terminal — the script's trap will
+clean up both child processes.
+──────────────────────────────────────────────────────────────
+EOF
+
+# Block forever until Ctrl-C or one of the children dies; that
+# gives the operator a clean session boundary.
+while true; do
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    log "app process exited — shutting down tunnel and operator."
+    break
+  fi
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    log "tunnel process exited — shutting down app and operator."
+    break
+  fi
+  sleep 5
+done


### PR DESCRIPTION
## Summary
One command brings the VitalCV demo back online without Vercel, without DNS changes, and without spend.

`bash scripts/vitalcv-demo-operator.sh` runs the full recovery flow: PATH repair → tool verification → shadow-runtime cleanup → demo-worktree resolution → dev server start → readiness wait → Cloudflare quick-tunnel → URL extraction → surface smoke test → final PID + URL table → Ctrl-C cleanup.

## Files
- `scripts/vitalcv-demo-operator.sh` — the operator. ~350 lines of bash with explicit PATH repair, four required-tool checks, worktree auto-detection in the documented search order (`/tmp/vitalcv-demo-spine-openevidence` → `/tmp/vitalcv-demo-spine` → any git worktree matching `demo`/`openevidence`/`launch` → `~/vitalcv`), trap-based cleanup on Ctrl-C, and operator-state files (`.vitalcv-demo-url`, `.vitalcv-demo-operator.log`).
- `scripts/kill-shadow-vitalcv-runtimes.sh` — narrow shadow-cleanup. pm2 allowlist is exactly `vitalcv-web` + `vitalcv-tunnel`; process kills are scoped to commands mentioning `vitalcv-omega4f-trigger`. `ai.openclaw.gateway` is hard-allowlisted (never killed). Listeners on `:3000` and `:3030` are printed, not terminated.
- `scripts/check-public-surface.sh` — `BASE_URL`-driven probe of /, /launch, /demo, /demo/employer, /demo/clinician, /api/health. Treats `/launch` and `/demo/*` 404s as WARN (demo-spine PRs not merged yet), 5xx and unreachable as FAIL.
- `docs/ops/local-demo-operator-runbook.md` — one-command runbook with explicit recovery steps if the terminal is lost.
- `docs/ops/cloudflare-tunnel-founder-demo-runbook.md` — manual walkthrough behind the operator. Same content as PR #376 to keep the two PRs convergent.

## Hard constraints honoured
- No product runtime code modified.
- No Prisma / database mutation.
- No DNS mutation. No Vercel CLI / API calls. No paid services. No sudo.
- No new package dependencies.
- Does not kill `ai.openclaw.gateway`; never kills generic node processes; only kills pm2 services whose names match the explicit allowlist and processes whose command line contains `vitalcv-omega4f-trigger`.
- No banned phrases / no bare-`Verified` (verified by grep across all five files).

## Validation
- `bash -n scripts/vitalcv-demo-operator.sh` → OK
- `bash -n scripts/kill-shadow-vitalcv-runtimes.sh` → OK
- `bash -n scripts/check-public-surface.sh` → OK
- Truth-contract scan on all five files → CLEAN
- No long-running server was started during implementation, per the spec's instruction.

## Test plan
- [ ] Founder runs `bash scripts/vitalcv-demo-operator.sh` on their laptop, sees the `https://*.trycloudflare.com` URL printed, and confirms `/launch` loads.
- [ ] Ctrl-C cleanly stops both child processes.
- [ ] Codex SAFE verdict on implementation / diff / copy audits.