### PR TITLE
feat(trust): add Claude Design trust surfaces canon

### DIFF
--- a/apps/web/__tests__/trust-copy-safety.test.ts
+++ b/apps/web/__tests__/trust-copy-safety.test.ts
@@ -1,0 +1,213 @@
+/**
+ * trust-copy-safety.test.ts
+ *
+ * Source-level scan over every trust-surface file: forbids bare
+ * "Verified" labels, the standard truth-contract banned phrases,
+ * the customer-cohort placeholders the brief explicitly forbids,
+ * and unsupported security/compliance claims.
+ *
+ * The scan operates on the file content (not rendered HTML) so any
+ * banned phrase introduced as a string literal or JSX text is
+ * caught even if no test renders that route.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WEB_ROOT = join(__dirname, '..');
+
+// Files in scope — every trust-surface source file PR introduces.
+const FILES = [
+  'styles/trust.css',
+  'lib/trust/types.ts',
+  'lib/trust/format.ts',
+  'lib/trust/demoData.ts',
+  'components/trust/primitives.tsx',
+  'components/trust/SurfaceHeader.tsx',
+  'components/trust/LineageHeader.tsx',
+  'components/trust/SignaturePanel.tsx',
+  'components/trust/ChainStrip.tsx',
+  'components/trust/FailureBanner.tsx',
+  'components/trust/DegradedRow.tsx',
+  'app/trust-canon/layout.tsx',
+  'app/trust-canon/passport/[npi]/page.tsx',
+  'app/trust-canon/verify/[receipt]/page.tsx',
+  'app/trust-canon/replay/page.tsx',
+  'app/trust-canon/receipt/[id]/page.tsx',
+  'app/trust-canon/trust/page.tsx',
+];
+
+const BANNED_PHRASES: ReadonlyArray<RegExp> = [
+  /automatically verified/i,
+  /guaranteed verification/i,
+  /\bcomplete credentialing\b/i,
+  /instant credentialing/i,
+  /legally accepted/i,
+  /risk transferred/i,
+  /HIPAA compliant/i,
+  /SOC ?2 certified/i,
+  /NCQA certified/i,
+  /certified compliant/i,
+  /final verification without review/i,
+  /source confirmed before response/i,
+  /instantly verified/i,
+  /\bfully verified\b/i,
+  /real-time verification/i,
+  /real-time check/i,
+  /guaranteed compliant/i,
+  /eliminates credentialing/i,
+  /replaces credentialing/i,
+  /accepted everywhere/i,
+  /\balways up to date\b/i,
+  /solves burnout/i,
+  /solves diversity attrition/i,
+  /HITRUST certified/i,
+  /BAA not required/i,
+];
+
+// Bare-Verified markers (case-sensitive, capital-V only).
+const BARE_VERIFIED: ReadonlyArray<RegExp> = [
+  /(?:label|status)\s*[:=]\s*['"`]Verified['"`]/,
+  /['"`]Verified['"`]/,
+  />\s*Verified\s*</,
+  /\bVerified provider\b/,
+  /\bVerified source\b/,
+];
+
+// Customer-cohort placeholders the brief forbids.
+const FORBIDDEN_CUSTOMER_CLAIMS: ReadonlyArray<RegExp> = [
+  /Cedar Health/i,
+  /\bN ?= ?47\b/i,
+  /Q2 ?2026 pilot/i,
+];
+
+// Unsupported security / signature / SLA claims.
+const FORBIDDEN_SECURITY_CLAIMS: ReadonlyArray<RegExp> = [
+  /AES ?-? ?256/,
+  /\b72-?hour deletion\b/i,
+  /deletion receipt/i,
+  /\bSLA\b/,
+  /ed25519 fingerprint/i,
+  /offline re-?verifiable/i,
+];
+
+// Files that legitimately mention the forbidden literals as
+// NEGATIONS ("does not claim X") — allowed by the canon. Each entry
+// is a path suffix.
+const NEGATION_ALLOWLIST: ReadonlyArray<string> = [
+  'lib/trust/demoData.ts',
+  'app/trust-canon/trust/page.tsx',
+  '__tests__/trust-copy-safety.test.ts',
+];
+
+// Files where bare-Verified appears only inside a JSDoc negation
+// ("no bare Verified labels", "never bare Verified"). These are
+// contract documentation, not bare-label assertions in product copy.
+// The renderer guards (VerdictBar runtime check, no JSX text-node
+// "Verified" anywhere) remain enforced by the routing/render tests.
+const BARE_VERIFIED_NEGATION_ALLOWLIST: ReadonlyArray<string> = [
+  'lib/trust/demoData.ts',
+  'components/trust/LineageHeader.tsx',
+  'components/trust/primitives.tsx',
+  'app/trust-canon/verify/[receipt]/page.tsx',
+];
+
+function isNegationAllowlisted(rel: string): boolean {
+  return NEGATION_ALLOWLIST.some((s) => rel.endsWith(s));
+}
+
+function isBareVerifiedNegationAllowlisted(rel: string): boolean {
+  return BARE_VERIFIED_NEGATION_ALLOWLIST.some((s) => rel.endsWith(s));
+}
+
+function read(rel: string): string {
+  const full = join(WEB_ROOT, rel);
+  if (!existsSync(full)) return '';
+  return readFileSync(full, 'utf8');
+}
+
+describe('trust-surface copy safety', () => {
+  for (const rel of FILES) {
+    describe(rel, () => {
+      const src = read(rel);
+
+      it('file exists', () => {
+        expect(src.length, `${rel} is empty`).toBeGreaterThan(0);
+      });
+
+      it('contains no banned phrases', () => {
+        for (const re of BANNED_PHRASES) {
+          expect(src, `${rel} contains banned phrase ${re}`).not.toMatch(re);
+        }
+      });
+
+      it('contains no bare "Verified" label', () => {
+        if (isBareVerifiedNegationAllowlisted(rel)) {
+          // The runtime guards in VerdictBar + the routing tests
+          // enforce no bare Verified in rendered DOM. This file's
+          // hits are JSDoc negations documenting the contract.
+          return;
+        }
+        for (const re of BARE_VERIFIED) {
+          expect(src, `${rel} contains bare-Verified pattern ${re}`).not.toMatch(re);
+        }
+      });
+
+      it('contains no Cedar Health / N=47 / Q2 2026 cohort claim', () => {
+        for (const re of FORBIDDEN_CUSTOMER_CLAIMS) {
+          expect(src, `${rel} contains forbidden customer claim ${re}`).not.toMatch(re);
+        }
+      });
+
+      it('contains no unsupported security claim (AES-256, deletion receipt, SLA, ed25519 fingerprint)', () => {
+        if (isNegationAllowlisted(rel)) {
+          // The doctrine page lists these as NON-claims ("does not
+          // assert AES-256, deletion receipt, SLA…"). The negation
+          // form is allowed because the surface explicitly disclaims
+          // each pattern.
+          return;
+        }
+        for (const re of FORBIDDEN_SECURITY_CLAIMS) {
+          expect(src, `${rel} contains unsupported security claim ${re}`).not.toMatch(re);
+        }
+      });
+    });
+  }
+});
+
+describe('trust.css scoping', () => {
+  it('every top-level selector either anchors on .trust-scope or uses the .t- class-prefix namespace', () => {
+    const src = read('styles/trust.css');
+    expect(src.length).toBeGreaterThan(0);
+
+    // Strip comment blocks before testing.
+    const noComments = src.replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // The canon uses two scoping disciplines together:
+    //   1. The root `.trust-scope` rule sets variables / typography.
+    //   2. All component rules use `.t-…` class names that are only
+    //      emitted by components rendered INSIDE the layout's
+    //      `<div class="trust-scope">` wrapper.
+    // Either prefix is sufficient — anything else would leak.
+    const blocks = noComments.split('}');
+    for (const block of blocks) {
+      const trimmed = block.trim();
+      if (!trimmed) continue;
+      if (!trimmed.includes('{')) continue;
+      const selectorPart = trimmed.split('{')[0].trim();
+      if (!selectorPart) continue;
+
+      const ok =
+        selectorPart.startsWith('.trust-scope') ||
+        selectorPart.startsWith('.t-') ||
+        selectorPart.startsWith('@keyframes') ||
+        selectorPart.startsWith('@media') ||
+        selectorPart.startsWith('@supports') ||
+        // Nested rule inside @media / @keyframes / @supports
+        // (selector starts with `from`, `to`, or a percentage).
+        /^(from\b|to\b|\d+%)/.test(selectorPart);
+      expect(ok, `Unscoped CSS selector in trust.css: ${selectorPart}`).toBe(true);
+    }
+  });
+});

--- a/apps/web/__tests__/trust-demo-disclaimers.test.tsx
+++ b/apps/web/__tests__/trust-demo-disclaimers.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * trust-demo-disclaimers.test.tsx
+ *
+ * Every trust-surface route must render the canonical demo
+ * disclaimer ("Demo data — not a real credentialing decision.") AND
+ * a controlled-document classification flagged DEMO / FIXTURE.
+ *
+ * The test renders each route page via Next.js's async page contract
+ * and inspects the SSR markup.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const ROUTES: Array<{
+  label: string;
+  importer: () => Promise<{ default: (props: unknown) => Promise<React.ReactElement> | React.ReactElement }>;
+  params?: Record<string, string>;
+}> = [
+  {
+    label: '/passport/[npi]',
+    importer: () => import('../app/trust-canon/passport/[npi]/page'),
+    params: { npi: '1346053246' },
+  },
+  {
+    label: '/verify/[receipt]',
+    importer: () => import('../app/trust-canon/verify/[receipt]/page'),
+    params: { receipt: 'rcpt_demo_004' },
+  },
+  {
+    label: '/replay',
+    importer: () => import('../app/trust-canon/replay/page'),
+  },
+  {
+    label: '/receipt/[id]',
+    importer: () => import('../app/trust-canon/receipt/[id]/page'),
+    params: { id: 'rcpt_demo_004' },
+  },
+  {
+    label: '/trust',
+    importer: () => import('../app/trust-canon/trust/page'),
+  },
+];
+
+async function renderRoute(
+  importer: () => Promise<{ default: (props: unknown) => Promise<React.ReactElement> | React.ReactElement }>,
+  params: Record<string, string> | undefined,
+): Promise<string> {
+  const mod = await importer();
+  const props = params ? { params: Promise.resolve(params) } : {};
+  const element = await mod.default(props);
+  return renderToStaticMarkup(element);
+}
+
+describe('trust surfaces — demo disclaimers', () => {
+  for (const route of ROUTES) {
+    it(`${route.label} renders the canonical demo banner`, async () => {
+      const html = await renderRoute(route.importer, route.params);
+      expect(html).toMatch(
+        /Demo data — not a real credentialing decision\./,
+      );
+      expect(html).toContain('data-testid="trust-demo-banner"');
+    });
+
+    it(`${route.label} carries a controlled-document footer`, async () => {
+      const html = await renderRoute(route.importer, route.params);
+      expect(html).toContain('data-testid="trust-control-footer"');
+    });
+
+    it(`${route.label} classification stripe includes "DEMO" or "FIXTURE"`, async () => {
+      const html = await renderRoute(route.importer, route.params);
+      expect(html).toMatch(/DEMO|FIXTURE/);
+    });
+  }
+});

--- a/apps/web/__tests__/trust-lineage-order.test.tsx
+++ b/apps/web/__tests__/trust-lineage-order.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * trust-lineage-order.test.tsx
+ *
+ * Asserts the binding reading order from the design canon:
+ *
+ *   Object → Ownership → checked_at → Channel → Replay → run_id
+ *
+ * Two layers of guarantee:
+ *   1. The exported LINEAGE_READING_ORDER constant matches the
+ *      expected literal — so renderers that iterate it can't drift.
+ *   2. The LineageHeader renders cells in that exact DOM order —
+ *      verified via the `data-cell` attribute the component emits.
+ *
+ * Also confirms OwnershipBadge renders subject / delegated / unbound
+ * distinctly.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { LineageHeader } from '@/components/trust/LineageHeader';
+import { OwnershipBadge } from '@/components/trust/primitives';
+import {
+  LINEAGE_READING_ORDER,
+  type Lineage,
+} from '@/lib/trust/types';
+
+const FIXTURE: Lineage = {
+  state: 'snapshot',
+  object: 'Demo · trust-lineage-order test (DEMO)',
+  objectSub: 'fixture only',
+  ownership: 'delegated',
+  checkedAtIso: '2026-05-18T13:59:30.000Z',
+  checkedAgo: '30 seconds ago',
+  channel: 'test.local.demo',
+  replay: 'anchored',
+  runId: 'run_v1_test-abc123',
+};
+
+describe('LINEAGE_READING_ORDER constant', () => {
+  it('is the canonical reading order', () => {
+    expect([...LINEAGE_READING_ORDER]).toEqual([
+      'object',
+      'ownership',
+      'checkedAt',
+      'channel',
+      'replay',
+      'runId',
+    ]);
+  });
+});
+
+describe('LineageHeader DOM order', () => {
+  it('renders lineage cells in Object → Ownership → checked_at → Channel → Replay → run_id', () => {
+    const html = renderToStaticMarkup(<LineageHeader lineage={FIXTURE} />);
+
+    // Extract every data-cell value in the order they appear in markup.
+    const re = /data-cell="([a-zA-Z]+)"/g;
+    const seen: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(html)) !== null) {
+      seen.push(match[1]);
+    }
+
+    expect(seen).toEqual([
+      'object',
+      'ownership',
+      'checkedAt',
+      'channel',
+      'replay',
+      'runId',
+    ]);
+  });
+
+  it('emits per-cell data-testid for each lineage cell', () => {
+    const html = renderToStaticMarkup(<LineageHeader lineage={FIXTURE} />);
+    for (const id of LINEAGE_READING_ORDER) {
+      expect(html).toContain(`data-testid="trust-lineage-cell-${id}"`);
+    }
+  });
+});
+
+describe('OwnershipBadge distinct rendering', () => {
+  it('renders subject / delegated / unbound with distinct data-ownership values', () => {
+    const subject = renderToStaticMarkup(<OwnershipBadge state="subject" />);
+    const delegated = renderToStaticMarkup(<OwnershipBadge state="delegated" />);
+    const unbound = renderToStaticMarkup(<OwnershipBadge state="unbound" />);
+
+    expect(subject).toContain('data-ownership="subject"');
+    expect(delegated).toContain('data-ownership="delegated"');
+    expect(unbound).toContain('data-ownership="unbound"');
+
+    // The three renderings must be distinct strings.
+    expect(new Set([subject, delegated, unbound]).size).toBe(3);
+  });
+
+  it('never renders the bare word "Verified" — not in this scope', () => {
+    const subject = renderToStaticMarkup(<OwnershipBadge state="subject" />);
+    expect(subject).not.toMatch(/['"`]Verified['"`]/);
+    expect(subject).not.toMatch(/>\s*Verified\s*</);
+  });
+});

--- a/apps/web/__tests__/trust-surfaces-routing.test.tsx
+++ b/apps/web/__tests__/trust-surfaces-routing.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * trust-surfaces-routing.test.tsx
+ *
+ * Verifies each trust route renders end-to-end:
+ *   - the controlled-document SurfaceHeader is present,
+ *   - the lineage cells render in the canonical reading order,
+ *   - the SurfaceControlFooter closes the artifact,
+ *   - degraded rows use the dashed-border contract
+ *     (data-degraded), NOT opacity-based disabled styling.
+ *
+ * Also verifies the .trust-scope wrapper is the root of every
+ * surface so trust.css containment is preserved.
+ */
+
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import TrustGroupLayout from '../app/trust-canon/layout';
+import PassportPage from '../app/trust-canon/passport/[npi]/page';
+import VerifyPage from '../app/trust-canon/verify/[receipt]/page';
+import ReplayPage from '../app/trust-canon/replay/page';
+import ReceiptPage from '../app/trust-canon/receipt/[id]/page';
+import TrustRegisterPage from '../app/trust-canon/trust/page';
+
+async function renderInsideLayout(node: React.ReactElement): Promise<string> {
+  return renderToStaticMarkup(<TrustGroupLayout>{node}</TrustGroupLayout>);
+}
+
+describe('trust route group — layout scoping', () => {
+  it('layout wraps children in a .trust-scope container', () => {
+    const html = renderToStaticMarkup(
+      <TrustGroupLayout>
+        <span data-testid="trust-test-child">x</span>
+      </TrustGroupLayout>,
+    );
+    expect(html).toContain('class="trust-scope"');
+    expect(html).toContain('data-testid="trust-scope-root"');
+    expect(html).toContain('data-testid="trust-test-child"');
+  });
+});
+
+describe('/passport/[npi]', () => {
+  it('renders SurfaceHeader, LineageHeader cells in order, and the degraded list', async () => {
+    const page = await PassportPage({ params: Promise.resolve({ npi: '1346053246' }) });
+    const html = await renderInsideLayout(page);
+
+    expect(html).toContain('data-testid="trust-surface-header"');
+    expect(html).toContain('data-testid="trust-lineage-header"');
+    expect(html).toContain('data-testid="trust-degraded-list"');
+    expect(html).toContain('data-testid="trust-control-footer"');
+  });
+
+  it('every degraded row carries data-degraded and never inline opacity below 1', async () => {
+    const page = await PassportPage({ params: Promise.resolve({ npi: '1346053246' }) });
+    const html = await renderInsideLayout(page);
+
+    expect(html).toMatch(/data-degraded="(stale|access_required|review_required|gated|unavailable)"/);
+
+    // No `opacity:` rule below 1 in any inline style.
+    expect(html).not.toMatch(/style="[^"]*opacity:\s*0\./);
+  });
+});
+
+describe('/verify/[receipt]', () => {
+  it('renders verifier reading mode with verdict bar (not bare Verified)', async () => {
+    const page = await VerifyPage({ params: Promise.resolve({ receipt: 'rcpt_demo_004' }) });
+    const html = await renderInsideLayout(page);
+
+    expect(html).toContain('data-testid="trust-surface-header"');
+    expect(html).toContain('data-testid="trust-verdict-bar"');
+
+    // Safe verdict only.
+    expect(html).toMatch(/Source-backed preview|Replay-ready|Signed fixture|Receipt-shaped artifact/);
+    // Never the bare word.
+    expect(html).not.toMatch(/['"`]Verified['"`]/);
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+});
+
+describe('/replay', () => {
+  it('renders chain strip + chronological nodes', async () => {
+    const page = await ReplayPage({});
+    const html = await renderInsideLayout(page);
+
+    expect(html).toContain('data-testid="trust-chain-strip"');
+    expect(html).toContain('data-testid="trust-replay-nodes"');
+  });
+});
+
+describe('/receipt/[id]', () => {
+  it('renders SignaturePanel (inverted cryptographic plane) with fixture signer', async () => {
+    const page = await ReceiptPage({ params: Promise.resolve({ id: 'rcpt_demo_004' }) });
+    const html = await renderInsideLayout(page);
+
+    expect(html).toContain('data-testid="trust-signature-panel"');
+    expect(html).toContain('fixture:demo-signer-a-not-a-real-key');
+    // The signature panel emits data-fixture="true" only when the
+    // fingerprint announces itself as a fixture.
+    expect(html).toContain('data-fixture="true"');
+  });
+
+  it('renders the chain strip with all fixture nodes', async () => {
+    const page = await ReceiptPage({ params: Promise.resolve({ id: 'rcpt_demo_004' }) });
+    const html = await renderInsideLayout(page);
+    expect(html).toContain('data-testid="trust-chain-strip"');
+    // We have four fixture nodes including the head id.
+    const matches = html.match(/data-testid="trust-chain-node"/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('/trust (visual register)', () => {
+  it('renders the three-state stage, the reading-order list, and the failure grid', async () => {
+    const page = await TrustRegisterPage({});
+    const html = await renderInsideLayout(page);
+
+    expect(html).toContain('data-testid="trust-register-stage"');
+    expect(html).toContain('data-testid="trust-reading-order"');
+    expect(html).toContain('data-testid="trust-failure-grid"');
+    expect(html).toContain('data-testid="trust-ownership-list"');
+  });
+
+  it('renders failure modes A through E', async () => {
+    const page = await TrustRegisterPage({});
+    const html = await renderInsideLayout(page);
+    for (const mode of ['A', 'B', 'C', 'D', 'E']) {
+      expect(html).toMatch(new RegExp(`data-mode="${mode}"`));
+    }
+  });
+});

--- a/apps/web/app/trust-canon/layout.tsx
+++ b/apps/web/app/trust-canon/layout.tsx
@@ -1,0 +1,35 @@
+/**
+ * VitalCV · Trust Surfaces · Route group layout
+ *
+ * The (trust) route group is the only place in apps/web that imports
+ * trust.css. The CSS lives entirely under the `.trust-scope`
+ * selector so it does not leak into the rest of the app.
+ *
+ * Every child route renders inside the .trust-scope wrapper. The
+ * required demo banner is the route's own responsibility; the
+ * layout intentionally does NOT inject it globally so a future
+ * non-fixture page (when it ever ships) can choose its own
+ * disclaimer.
+ */
+
+import * as React from 'react';
+
+import '@/styles/trust.css';
+
+export const metadata = {
+  title: 'VitalCV · Trust Surfaces (demo fixtures)',
+  description:
+    'Demo trust surfaces — canonical reading order, controlled-document headers, signed receipt fixtures. Not a real credentialing decision.',
+};
+
+export default function TrustGroupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="trust-scope" data-testid="trust-scope-root">
+      <div className="t-page">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/app/trust-canon/passport/[npi]/page.tsx
+++ b/apps/web/app/trust-canon/passport/[npi]/page.tsx
@@ -1,0 +1,77 @@
+/**
+ * VitalCV · Trust Surfaces · /passport/[npi]
+ *
+ * Holder passport / readiness surface. Demo fixture only — no live
+ * source resolution, no Prisma read. The page composes the canonical
+ * primitives and renders a labelled fixture.
+ */
+
+import * as React from 'react';
+
+import {
+  SurfaceHeader,
+  SurfaceControlFooter,
+  type SurfaceControl,
+} from '@/components/trust/SurfaceHeader';
+import { DegradedRow } from '@/components/trust/DegradedRow';
+import { SectionHeader, DemoBanner, Mono } from '@/components/trust/primitives';
+import { DEGRADED_ROWS, passportFixture } from '@/lib/trust/demoData';
+
+interface PageProps {
+  params: Promise<{ npi: string }>;
+}
+
+export default async function PassportPage({ params }: PageProps) {
+  const { npi } = await params;
+  const lineage = passportFixture(npi);
+
+  const control: SurfaceControl = {
+    form: 'VC-PASSPORT-v1',
+    title: 'Clinician readiness preview',
+    classification: 'DEMO · FIXTURE',
+    effective: lineage.checkedAtIso,
+    revision: 'rev 1 · 2026-05-18',
+    controlledBy: 'design fixture · not a live registry',
+    state: lineage.state,
+  };
+
+  return (
+    <>
+      <SurfaceHeader control={control} lineage={lineage} />
+      <DemoBanner extra="Pilot intake is designed to reject PHI; do not submit patient data." />
+
+      <main className="t-main">
+        <SectionHeader
+          n="01"
+          title="Readiness lanes (preview)"
+          ey="source-backed preview · no live decision"
+        />
+        <ul className="t-degraded-list" data-testid="trust-degraded-list">
+          {DEGRADED_ROWS.map((entry) => (
+            <DegradedRow key={`${entry.reason}-${entry.laneLabel}`} entry={entry} />
+          ))}
+        </ul>
+
+        <SectionHeader
+          n="02"
+          title="Receipt-shaped artifact (preview)"
+          ey="how the holder sees their own packet"
+        />
+        <div className="t-receipt-preview">
+          <p className="t-receipt-preview-copy">
+            This passport renders the readiness packet shape only. No
+            real receipt has been signed for{' '}
+            <Mono>{npi}</Mono>. The brief explicitly forbids live
+            signature verification claims in this surface.
+          </p>
+        </div>
+      </main>
+
+      <SurfaceControlFooter
+        control={control}
+        runId={lineage.runId}
+        page="01 / 01"
+      />
+    </>
+  );
+}

--- a/apps/web/app/trust-canon/receipt/[id]/page.tsx
+++ b/apps/web/app/trust-canon/receipt/[id]/page.tsx
@@ -1,0 +1,90 @@
+/**
+ * VitalCV · Trust Surfaces · /receipt/[id]
+ *
+ * Signed-receipt artifact layout. Uses the inverted-dark SignaturePanel
+ * for the cryptographic plane (signer + fingerprint fixture +
+ * payload-hash fixture) and the ChainStrip for the receipt chain.
+ * The page is a fixture — no live signature verification is performed.
+ */
+
+import * as React from 'react';
+
+import {
+  SurfaceHeader,
+  SurfaceControlFooter,
+  type SurfaceControl,
+} from '@/components/trust/SurfaceHeader';
+import { SignaturePanel } from '@/components/trust/SignaturePanel';
+import { ChainStrip } from '@/components/trust/ChainStrip';
+import { LineageHeader, VerdictBar } from '@/components/trust/LineageHeader';
+import { SectionHeader, DemoBanner } from '@/components/trust/primitives';
+import { receiptFixture } from '@/lib/trust/demoData';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ReceiptPage({ params }: PageProps) {
+  const { id } = await params;
+  const receipt = receiptFixture(id);
+
+  const control: SurfaceControl = {
+    form: 'VC-RECEIPT-v1',
+    title: 'Signed receipt · fixture',
+    classification: 'DEMO · FIXTURE',
+    effective: receipt.lineage.checkedAtIso,
+    revision: 'rev 1 · 2026-05-18',
+    controlledBy: 'design fixture · not a live registry',
+    state: receipt.lineage.state,
+  };
+
+  return (
+    <>
+      <SurfaceHeader control={control} lineage={receipt.lineage} />
+      <DemoBanner extra="No live key, no live registry, no live continuity claim." />
+
+      <main className="t-main">
+        <SectionHeader
+          n="01"
+          title="Receipt lineage"
+          ey="reading order is binding"
+          right={
+            <VerdictBar
+              status="Signed fixture"
+              sub="design fixture · not a live artifact"
+              tone="neutral"
+            />
+          }
+        />
+        <LineageHeader lineage={receipt.lineage} />
+
+        <SectionHeader
+          n="02"
+          title="Cryptographic plane (fixture)"
+          ey="inverted surface · reserved for signed planes"
+        />
+        <SignaturePanel
+          signer={receipt.signer}
+          payloadHashFixture="fixture:demo-payload-hash-not-a-real-digest"
+          caption="The signer label and fingerprint above are fixture-only. The CSS reserves this dark register for the cryptographic plane and no other surface should adopt it."
+        />
+
+        <SectionHeader
+          n="03"
+          title="Receipt chain"
+          ey="oldest → newest"
+        />
+        <ChainStrip
+          chain={receipt.chain}
+          highlightIndex={receipt.chain.length - 1}
+          caption="Demo chain — no node has been signed against a live key."
+        />
+      </main>
+
+      <SurfaceControlFooter
+        control={control}
+        runId={receipt.lineage.runId}
+      />
+    </>
+  );
+}

--- a/apps/web/app/trust-canon/replay/page.tsx
+++ b/apps/web/app/trust-canon/replay/page.tsx
@@ -1,0 +1,92 @@
+/**
+ * VitalCV · Trust Surfaces · /replay
+ *
+ * Replay memory / chronology — chain strip plus chronological receipt
+ * nodes. No marketing copy. Every node is a fixture.
+ */
+
+import * as React from 'react';
+
+import {
+  SurfaceHeader,
+  SurfaceControlFooter,
+  type SurfaceControl,
+} from '@/components/trust/SurfaceHeader';
+import { ChainStrip } from '@/components/trust/ChainStrip';
+import { SectionHeader, DemoBanner, Mono } from '@/components/trust/primitives';
+import { replayFixture } from '@/lib/trust/demoData';
+import { lineageWhen } from '@/lib/trust/format';
+
+export default async function ReplayPage() {
+  const receipts = replayFixture();
+  const newest = receipts[receipts.length - 1];
+  const now = new Date();
+  const when = lineageWhen(newest.lineage.checkedAtIso, now);
+
+  const control: SurfaceControl = {
+    form: 'VC-REPLAY-v1',
+    title: 'Replay memory · chronology',
+    classification: 'DEMO · FIXTURE',
+    effective: when.checkedAtIso,
+    revision: 'rev 1 · 2026-05-18',
+    controlledBy: 'design fixture · not a live registry',
+    state: 'snapshot',
+  };
+
+  const chain = receipts.map((r) => r.id);
+
+  return (
+    <>
+      <SurfaceHeader control={control} lineage={newest.lineage} />
+      <DemoBanner extra="No live continuity claim is made by this surface." />
+
+      <main className="t-main">
+        <SectionHeader
+          n="01"
+          title="Chain strip"
+          ey="oldest → newest · all nodes are fixtures"
+        />
+        <ChainStrip
+          chain={chain}
+          highlightIndex={chain.length - 1}
+          caption="Each node is a design-fixture receipt id; no node has been signed against a live key."
+        />
+
+        <SectionHeader
+          n="02"
+          title="Chronological nodes"
+          ey="receipt-shaped artifacts · in order"
+        />
+        <ol className="t-replay-nodes" data-testid="trust-replay-nodes">
+          {receipts.map((r, i) => (
+            <li
+              key={r.id}
+              className="t-replay-node"
+              data-testid="trust-replay-node"
+              data-index={i}
+            >
+              <div className="t-replay-node-l">
+                <span className="t-replay-node-idx mono">
+                  {i.toString().padStart(2, '0')}
+                </span>
+                <span className="t-replay-node-id">
+                  <Mono>{r.id}</Mono>
+                </span>
+              </div>
+              <div className="t-replay-node-r">
+                <span className="t-replay-node-when mono">
+                  {r.lineage.checkedAgo}
+                </span>
+                <span className="t-replay-node-channel mono">
+                  {r.lineage.channel}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </main>
+
+      <SurfaceControlFooter control={control} runId={newest.lineage.runId} />
+    </>
+  );
+}

--- a/apps/web/app/trust-canon/trust/page.tsx
+++ b/apps/web/app/trust-canon/trust/page.tsx
@@ -1,0 +1,189 @@
+/**
+ * VitalCV · Trust Surfaces · /trust
+ *
+ * The trust state register — the doctrinal surface that documents
+ * the three states (preview / snapshot / signed), the binding
+ * reading order, the ownership taxonomy, the five failure modes,
+ * and the degraded-row semantics. The register is itself a
+ * controlled document; it wears the same SurfaceHeader as every
+ * other trust surface.
+ */
+
+import * as React from 'react';
+
+import {
+  SurfaceHeader,
+  SurfaceControlFooter,
+  type SurfaceControl,
+} from '@/components/trust/SurfaceHeader';
+import { LineageHeader } from '@/components/trust/LineageHeader';
+import { DegradedRow } from '@/components/trust/DegradedRow';
+import { FailureBanner } from '@/components/trust/FailureBanner';
+import {
+  SectionHeader,
+  DemoBanner,
+  StateStamp,
+  OwnershipBadge,
+  Mono,
+} from '@/components/trust/primitives';
+import {
+  DEGRADED_ROWS,
+  FAILURE_MODES,
+  trustRegisterFixture,
+} from '@/lib/trust/demoData';
+import { LINEAGE_READING_ORDER } from '@/lib/trust/types';
+
+export default async function TrustRegisterPage() {
+  const { preview, snapshot, signed } = trustRegisterFixture();
+
+  const control: SurfaceControl = {
+    form: 'VC-TRUST-STATE-v1',
+    title: 'Trust state · visual register',
+    classification: 'PUBLIC · DOCTRINE (demo fixture)',
+    effective: signed.checkedAtIso,
+    revision: 'rev 1 · 2026-05-18',
+    controlledBy: 'design fixture · not a live registry',
+    state: 'signed',
+  };
+
+  return (
+    <>
+      <SurfaceHeader control={control} lineage={signed} />
+      <DemoBanner extra="No live signature, no live key, no live customer." />
+
+      <main className="t-main">
+        {/* ── 01 · Three states at the same scale ────────────────── */}
+        <SectionHeader
+          n="01"
+          title="Three states · at the same scale"
+          ey="same content · different register"
+        />
+        <div className="t-register-stage" data-testid="trust-register-stage">
+          <article className="t-register-card" data-state="preview">
+            <StateStamp state="preview" caption="A" />
+            <LineageHeader lineage={preview} />
+          </article>
+          <article className="t-register-card" data-state="snapshot">
+            <StateStamp state="snapshot" caption="B" />
+            <LineageHeader lineage={snapshot} />
+          </article>
+          <article className="t-register-card" data-state="signed">
+            <StateStamp state="signed" caption="C" />
+            <LineageHeader lineage={signed} />
+          </article>
+        </div>
+
+        {/* ── 02 · Reading order is binding ─────────────────────── */}
+        <SectionHeader
+          n="02"
+          title="Reading order is binding"
+          ey="Object → Ownership → checked_at → Channel → Replay → run_id"
+        />
+        <ol className="t-reading-order" data-testid="trust-reading-order">
+          {LINEAGE_READING_ORDER.map((id, i) => (
+            <li
+              key={id}
+              data-order-index={i}
+              data-cell={id}
+              className="t-reading-order-item"
+            >
+              <span className="t-reading-order-n mono">
+                {(i + 1).toString().padStart(2, '0')}
+              </span>
+              <span className="t-reading-order-id mono">{id}</span>
+            </li>
+          ))}
+        </ol>
+
+        {/* ── 03 · Ownership taxonomy ─────────────────────────── */}
+        <SectionHeader
+          n="03"
+          title="Ownership taxonomy"
+          ey="three values · no implicit ownership"
+        />
+        <ul className="t-ownership-list" data-testid="trust-ownership-list">
+          <li>
+            <OwnershipBadge state="subject" />
+            <span className="t-ownership-copy">
+              The asserting party IS the subject.
+            </span>
+          </li>
+          <li>
+            <OwnershipBadge state="delegated" />
+            <span className="t-ownership-copy">
+              An operator is reading on behalf of the subject under a
+              documented delegation.
+            </span>
+          </li>
+          <li>
+            <OwnershipBadge state="unbound" />
+            <span className="t-ownership-copy">
+              No subject binding has been established yet.
+            </span>
+          </li>
+        </ul>
+
+        {/* ── 04 · Failure modes A–E ──────────────────────────── */}
+        <SectionHeader
+          n="04"
+          title="Failure modes · A through E"
+          ey="documented refusals · never system errors"
+        />
+        <div
+          className="t-failure-grid"
+          data-testid="trust-failure-grid"
+        >
+          {FAILURE_MODES.map((descriptor) => (
+            <FailureBanner key={descriptor.mode} descriptor={descriptor} />
+          ))}
+        </div>
+
+        {/* ── 05 · Degraded row semantics ─────────────────────── */}
+        <SectionHeader
+          n="05"
+          title="Degraded row semantics"
+          ey="dashed border · never opacity"
+        />
+        <ul className="t-degraded-list" data-testid="trust-register-degraded-list">
+          {DEGRADED_ROWS.map((entry) => (
+            <DegradedRow
+              key={`${entry.reason}-${entry.laneLabel}`}
+              entry={entry}
+            />
+          ))}
+        </ul>
+
+        {/* ── 06 · What this register does NOT claim ─────────── */}
+        <SectionHeader
+          n="06"
+          title="What this register does not claim"
+          ey="explicit non-claims"
+        />
+        <ul className="t-nonclaims" data-testid="trust-nonclaims">
+          <li>
+            No live signature verification is performed by any surface
+            in this group.
+          </li>
+          <li>
+            No live <Mono>did:web:vitalcv.health</Mono> registry is
+            queried; the controlled-by field is a fixture string.
+          </li>
+          <li>
+            No customer cohort, no SLA, no AES claim, no deletion
+            receipt is asserted.
+          </li>
+          <li>
+            No HIPAA, SOC 2, NCQA, HITRUST, or BAA claim is implied by
+            this surface.
+          </li>
+        </ul>
+      </main>
+
+      <SurfaceControlFooter
+        control={control}
+        runId={signed.runId}
+        page="01 / 01"
+      />
+    </>
+  );
+}

--- a/apps/web/app/trust-canon/verify/[receipt]/page.tsx
+++ b/apps/web/app/trust-canon/verify/[receipt]/page.tsx
@@ -1,0 +1,105 @@
+/**
+ * VitalCV · Trust Surfaces · /verify/[receipt]
+ *
+ * Verifier reading mode. The page's 30-second answer is:
+ *
+ *   who asserted · what source · when checked · ownership · replay ·
+ *   run_id · receipt status
+ *
+ * All of which the LineageHeader already renders in the canonical
+ * reading order. The verdict bar adds the receipt-status line —
+ * "Replay-ready" / "Signed fixture" / "Source-backed preview" /
+ * "Receipt-shaped artifact" — never bare "Verified".
+ */
+
+import * as React from 'react';
+
+import {
+  SurfaceHeader,
+  SurfaceControlFooter,
+  type SurfaceControl,
+} from '@/components/trust/SurfaceHeader';
+import { LineageHeader, VerdictBar } from '@/components/trust/LineageHeader';
+import {
+  SectionHeader,
+  DemoBanner,
+  Mono,
+} from '@/components/trust/primitives';
+import { verifyFixture } from '@/lib/trust/demoData';
+
+interface PageProps {
+  params: Promise<{ receipt: string }>;
+}
+
+export default async function VerifyPage({ params }: PageProps) {
+  const { receipt } = await params;
+  const lineage = verifyFixture(receipt);
+
+  const control: SurfaceControl = {
+    form: 'VC-VERIFY-v1',
+    title: 'Verifier reading mode',
+    classification: 'DEMO · FIXTURE',
+    effective: lineage.checkedAtIso,
+    revision: 'rev 1 · 2026-05-18',
+    controlledBy: 'design fixture · not a live registry',
+    state: lineage.state,
+  };
+
+  return (
+    <>
+      <SurfaceHeader control={control} lineage={lineage} />
+      <DemoBanner extra="No live signature verification is performed by this surface." />
+
+      <main className="t-main">
+        <SectionHeader
+          n="01"
+          title="Verdict (fixture)"
+          ey="receipt-shaped artifact · not a live verification"
+          right={
+            <VerdictBar
+              status="Source-backed preview"
+              sub="receipt is a fixture · no continuity claim"
+              tone="neutral"
+            />
+          }
+        />
+        <div className="t-verify-summary">
+          <LineageHeader lineage={lineage} />
+        </div>
+
+        <SectionHeader
+          n="02"
+          title="What the verifier answers in 30 seconds"
+          ey="binding reading order"
+        />
+        <ul className="t-verify-list">
+          <li>
+            <span className="mono">who_asserted</span> · the
+            controlled-document header above (see <Mono>controlled_by</Mono>).
+          </li>
+          <li>
+            <span className="mono">what_source</span> · channel cell{' '}
+            <Mono>{lineage.channel}</Mono>.
+          </li>
+          <li>
+            <span className="mono">when_checked</span> ·{' '}
+            <Mono>{lineage.checkedAgo}</Mono>{' '}
+            (<Mono>{lineage.checkedAtIso}</Mono>).
+          </li>
+          <li>
+            <span className="mono">ownership</span> · explicit{' '}
+            <Mono>{lineage.ownership}</Mono> — never implicit.
+          </li>
+          <li>
+            <span className="mono">replay</span> · <Mono>{lineage.replay}</Mono>.
+          </li>
+          <li>
+            <span className="mono">run_id</span> · <Mono>{lineage.runId}</Mono>.
+          </li>
+        </ul>
+      </main>
+
+      <SurfaceControlFooter control={control} runId={lineage.runId} />
+    </>
+  );
+}

--- a/apps/web/components/trust/ChainStrip.tsx
+++ b/apps/web/components/trust/ChainStrip.tsx
@@ -1,0 +1,74 @@
+/**
+ * VitalCV · Trust Surfaces · ChainStrip v1
+ *
+ * Renders the chain of receipt nodes oldest → newest in a horizontal
+ * strip. Used on /receipt/[id] and /replay. Mono / tabular numerals
+ * for every id. Inverted-dark surface inherits from the parent
+ * SignaturePanel when nested; on /replay it sits on the light plane
+ * (CSS uses the `.t-chain` class only — no global override).
+ *
+ * The chain is fixture data. The component does not verify lineage,
+ * does not call any network, and does not assert continuity.
+ */
+
+import * as React from 'react';
+
+import { Mono, cn } from './primitives';
+import { truncateId } from '@/lib/trust/format';
+
+export interface ChainStripProps {
+  /** Receipt ids oldest first. */
+  chain: ReadonlyArray<string>;
+  /** Index of the currently-highlighted node (defaults to last). */
+  highlightIndex?: number;
+  /** Optional caption shown below the strip. */
+  caption?: string;
+}
+
+export function ChainStrip({
+  chain,
+  highlightIndex,
+  caption,
+}: ChainStripProps) {
+  const last = chain.length - 1;
+  const highlight = highlightIndex ?? last;
+  return (
+    <section
+      className="t-chain"
+      data-testid="trust-chain-strip"
+      aria-label="Receipt chain (oldest first)"
+    >
+      <header className="t-chain-head">
+        <span className="t-chain-eye mono">chain · oldest → newest</span>
+        <span className="t-chain-count mono">{chain.length} nodes</span>
+      </header>
+
+      <ol className="t-chain-nodes" role="list">
+        {chain.map((id, i) => {
+          const isHead = i === highlight;
+          return (
+            <li
+              key={id}
+              className={cn('t-chain-node', isHead && 't-chain-node--head')}
+              data-testid="trust-chain-node"
+              data-index={i}
+              data-head={String(isHead)}
+            >
+              <span className="t-chain-node-idx mono">{i.toString().padStart(2, '0')}</span>
+              <span className="t-chain-node-id">
+                <Mono>{truncateId(id, 8, 4)}</Mono>
+              </span>
+              {i < chain.length - 1 && (
+                <span className="t-chain-node-arrow" aria-hidden>
+                  →
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {caption && <p className="t-chain-caption">{caption}</p>}
+    </section>
+  );
+}

--- a/apps/web/components/trust/DegradedRow.tsx
+++ b/apps/web/components/trust/DegradedRow.tsx
@@ -1,0 +1,55 @@
+/**
+ * VitalCV · Trust Surfaces · DegradedRow v1
+ *
+ * Renders a non-decision-grade lane row. Doctrine:
+ *
+ *   - Dashed border, NEVER opacity-based disabled styling.
+ *   - The row exposes data-degraded={reason} so tests can assert the
+ *     dashed-not-opacity contract directly.
+ *   - The hint is operator-action copy ("Refresh source probe …",
+ *     "Route to operator review …"). Never blame the clinician.
+ *   - Gated / accessRequired / unavailable lanes MUST NOT look
+ *     positive — the CSS class is amber-warn for gated/accessRequired,
+ *     amber-warn for stale/reviewRequired, critical for unavailable.
+ */
+
+import * as React from 'react';
+
+import type { DegradedReason, DegradedRowEntry } from '@/lib/trust/types';
+
+const REASON_LABEL: Record<DegradedReason, string> = {
+  stale: 'STALE',
+  access_required: 'ACCESS REQUIRED',
+  review_required: 'REVIEW REQUIRED',
+  unavailable: 'UNAVAILABLE',
+  gated: 'GATED',
+};
+
+export interface DegradedRowProps {
+  entry: DegradedRowEntry;
+}
+
+export function DegradedRow({ entry }: DegradedRowProps) {
+  return (
+    <li
+      className="t-degraded-row"
+      data-testid="trust-degraded-row"
+      data-degraded={entry.reason}
+      // Defensive: any inline opacity here would violate the canon.
+      // Browsers ignore explicit opacity:1 styling — but writing it
+      // out makes the intent unmistakable.
+      style={{ opacity: 1 }}
+    >
+      <div className="t-degraded-l">
+        <span
+          className="t-degraded-badge mono"
+          data-tone={entry.reason === 'unavailable' ? 'critical' : 'warn'}
+        >
+          {REASON_LABEL[entry.reason]}
+        </span>
+        <span className="t-degraded-lane">{entry.laneLabel}</span>
+      </div>
+      <p className="t-degraded-hint">→ {entry.hint}</p>
+    </li>
+  );
+}

--- a/apps/web/components/trust/FailureBanner.tsx
+++ b/apps/web/components/trust/FailureBanner.tsx
@@ -1,0 +1,40 @@
+/**
+ * VitalCV · Trust Surfaces · FailureBanner v1
+ *
+ * Renders one of the five canonical failure modes (A–E) as a
+ * documented refusal — never as a "system error" toast. The banner
+ * has two halves: the failure copy (what happened) and the refusal
+ * copy (what MUST NOT happen as a consequence). The refusal is the
+ * operator-action contract; without it the banner is just noise.
+ */
+
+import * as React from 'react';
+
+import type { FailureModeDescriptor } from '@/lib/trust/types';
+
+export interface FailureBannerProps {
+  descriptor: FailureModeDescriptor;
+}
+
+export function FailureBanner({ descriptor }: FailureBannerProps) {
+  return (
+    <aside
+      className="t-failure"
+      data-testid="trust-failure-banner"
+      data-mode={descriptor.mode}
+      role="status"
+    >
+      <header className="t-failure-head">
+        <span className="t-failure-mode mono">
+          mode {descriptor.mode}
+        </span>
+        <h3 className="t-failure-title">{descriptor.title}</h3>
+      </header>
+      <p className="t-failure-copy">{descriptor.copy}</p>
+      <p className="t-failure-refusal">
+        <span className="t-failure-refusal-label mono">refusal · </span>
+        {descriptor.refusalCopy}
+      </p>
+    </aside>
+  );
+}

--- a/apps/web/components/trust/LineageHeader.tsx
+++ b/apps/web/components/trust/LineageHeader.tsx
@@ -1,0 +1,114 @@
+/**
+ * VitalCV · Trust Surfaces · LineageHeader v1
+ *
+ * Renders the six lineage cells in the binding canonical reading
+ * order:
+ *
+ *   Object → Ownership → checked_at → Channel → Replay → run_id
+ *
+ * The renderer iterates `lineageCells()` from lib/trust/format so the
+ * order is asserted by a single source of truth. Each rendered cell
+ * carries `data-cell={id}` so trust-lineage-order.test.tsx can
+ * inspect the DOM order directly.
+ */
+
+import * as React from 'react';
+
+import type { Lineage } from '@/lib/trust/types';
+import { lineageCells } from '@/lib/trust/format';
+import { OwnershipBadge, Mono } from './primitives';
+
+export interface LineageHeaderProps {
+  lineage: Lineage;
+  /** Optional verdict bar slot (rendered to the right). */
+  verdict?: React.ReactNode;
+}
+
+export function LineageHeader({ lineage, verdict }: LineageHeaderProps) {
+  const cells = lineageCells(lineage);
+  return (
+    <div
+      className="t-lineage"
+      data-testid="trust-lineage-header"
+      data-state={lineage.state}
+    >
+      <div className="t-lineage-in">
+        {cells.map((cell) => (
+          <div
+            key={cell.id}
+            className="t-lineage-cell"
+            data-cell={cell.id}
+            data-testid={`trust-lineage-cell-${cell.id}`}
+          >
+            <div className="t-lineage-k mono">{cell.label}</div>
+            <div className="t-lineage-v">
+              {cell.id === 'ownership' ? (
+                <OwnershipBadge state={lineage.ownership} />
+              ) : (
+                <Mono>{cell.value}</Mono>
+              )}
+              {cell.subValue && (
+                <span className="t-lineage-sub mono">{cell.subValue}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {verdict && <div className="t-lineage-verdict">{verdict}</div>}
+    </div>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * VerdictBar — short stripe to the right of the lineage cells.
+ * Used by /verify and /receipt to surface the receipt status without
+ * making any live verification claim.
+ *
+ * The brief replaces "Verifiable" with safer copy. This component
+ * accepts a free-text status string so the caller can choose the
+ * safe wording from:
+ *   - "Replay-ready"
+ *   - "Signed fixture"
+ *   - "Source-backed preview"
+ *   - "Receipt-shaped artifact"
+ * No bare "Verified".
+ * ─────────────────────────────────────────────────────────────────── */
+export interface VerdictBarProps {
+  status: string;
+  /** Optional sub-line — short. */
+  sub?: string;
+  /** Tone signal: "ok" / "warn" / "critical" / "neutral". */
+  tone?: 'ok' | 'warn' | 'critical' | 'neutral';
+}
+
+const FORBIDDEN_VERDICT = /^['"`]?Verified['"`]?$/;
+
+export function VerdictBar({ status, sub, tone = 'neutral' }: VerdictBarProps) {
+  if (FORBIDDEN_VERDICT.test(status.trim())) {
+    // The CSS still renders, but we surface an obvious typo / contract
+    // violation so a tester sees it immediately. Components must
+    // pass one of the safe verdict strings instead.
+    return (
+      <span
+        className="t-verdict"
+        data-tone="critical"
+        data-testid="trust-verdict-bar"
+      >
+        <span className="t-verdict-status">verdict missing</span>
+        <span className="t-verdict-sub">
+          replace bare &quot;Verified&quot; with a compound verdict
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span
+      className="t-verdict"
+      data-tone={tone}
+      data-testid="trust-verdict-bar"
+    >
+      <span className="t-verdict-status">{status}</span>
+      {sub && <span className="t-verdict-sub">{sub}</span>}
+    </span>
+  );
+}

--- a/apps/web/components/trust/SignaturePanel.tsx
+++ b/apps/web/components/trust/SignaturePanel.tsx
@@ -1,0 +1,94 @@
+/**
+ * VitalCV · Trust Surfaces · SignaturePanel v1
+ *
+ * Inverted dark surface reserved for the cryptographic plane:
+ * signer display, fingerprint fixture, chain context. The canon
+ * rule: inverted/dark surfaces are ONLY used for signature / chain /
+ * signed-receipt areas. The CSS class `t-sig` is the only carrier of
+ * that visual register.
+ *
+ * Hard safety contract:
+ *   - No real ed25519 / RSA / EC key bytes ever rendered.
+ *   - The signer fingerprint MUST be prefixed `fixture:` so it can't
+ *     be mistaken for a live key.
+ *   - The signer label MUST be one of {"design fixture",
+ *     "demo signer fixture"} (typed in lib/trust/types.ts).
+ *   - No "live signature verification" copy.
+ */
+
+import * as React from 'react';
+
+import type { SignerFixture } from '@/lib/trust/types';
+import { Mono } from './primitives';
+
+export interface SignaturePanelProps {
+  signer: SignerFixture;
+  /** Optional canonical-payload short hash (fixture). */
+  payloadHashFixture?: string;
+  /** Optional "what this signs" caption. */
+  caption?: string;
+}
+
+export function SignaturePanel({
+  signer,
+  payloadHashFixture,
+  caption,
+}: SignaturePanelProps) {
+  // Defensive: refuse to render real-looking fingerprints.
+  // A real ed25519 key is 64 hex chars; a fixture must announce itself.
+  const fingerprintLooksFixture =
+    typeof signer.fingerprintFixture === 'string' &&
+    signer.fingerprintFixture.startsWith('fixture:');
+
+  return (
+    <section
+      className="t-sig"
+      data-testid="trust-signature-panel"
+      data-fixture={String(fingerprintLooksFixture)}
+      aria-label="Signature fixture (cryptographic plane)"
+    >
+      <header className="t-sig-head">
+        <span className="t-sig-eye mono">cryptographic plane · fixture only</span>
+        <span className="t-sig-tag mono">{signer.label}</span>
+      </header>
+
+      <div className="t-sig-grid">
+        <div className="t-sig-row">
+          <div className="t-sig-k mono">signer</div>
+          <div className="t-sig-v">
+            <Mono>{signer.displayName}</Mono>
+          </div>
+        </div>
+        <div className="t-sig-row">
+          <div className="t-sig-k mono">fingerprint</div>
+          <div className="t-sig-v">
+            {fingerprintLooksFixture ? (
+              <Mono>{signer.fingerprintFixture}</Mono>
+            ) : (
+              <Mono>fixture:placeholder-not-a-real-key</Mono>
+            )}
+          </div>
+        </div>
+        {payloadHashFixture && (
+          <div className="t-sig-row">
+            <div className="t-sig-k mono">payload_hash</div>
+            <div className="t-sig-v">
+              <Mono>{payloadHashFixture}</Mono>
+              <span className="t-sig-sub">fixture digest — not a live hash</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {caption && <p className="t-sig-caption">{caption}</p>}
+
+      <footer className="t-sig-foot">
+        <span className="t-sig-foot-copy">
+          This panel renders a design fixture. It does not assert live
+          signature verification, key continuity, or attribution to any
+          live registry.
+        </span>
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/trust/SurfaceHeader.tsx
+++ b/apps/web/components/trust/SurfaceHeader.tsx
@@ -1,0 +1,156 @@
+/**
+ * VitalCV · Trust Surfaces · SurfaceHeader + SurfaceControlFooter
+ *
+ * The controlled-document header that sits above every trust surface,
+ * and the matching footer that closes it. Both render as audit
+ * artifacts — form number, classification, effective date, revision,
+ * controlled-by — never as marketing chrome.
+ *
+ * The header is paired with a LineageHeader (separate component) so
+ * the binding reading order (Object → Ownership → checked_at →
+ * Channel → Replay → run_id) is asserted by a single source of
+ * truth (`lineageCells()` in lib/trust/format.ts).
+ */
+
+import * as React from 'react';
+
+import type { Lineage, TrustState } from '@/lib/trust/types';
+import { LineageHeader } from './LineageHeader';
+import { StateStamp, Mono } from './primitives';
+
+/** Controlled-document header metadata. */
+export interface SurfaceControl {
+  /** Form number — e.g. "VC-PASSPORT-v1". Monospace. */
+  form: string;
+  /** Human-readable title shown next to the form glyph. */
+  title: string;
+  /** Classification stripe — e.g. "PUBLIC · DOCTRINE", "DEMO · FIXTURE". */
+  classification: string;
+  /** Effective ISO timestamp (mono). */
+  effective: string;
+  /** Revision string — e.g. "rev 1 · 2026-05-18". */
+  revision: string;
+  /** Authority — e.g. "did:web:vitalcv.health (design fixture)". */
+  controlledBy: string;
+  /** Stage stamp — preview / snapshot / signed. */
+  state: TrustState;
+}
+
+export interface SurfaceHeaderProps {
+  control: SurfaceControl;
+  lineage: Lineage;
+}
+
+/**
+ * Two-row controlled-document header:
+ *   Row 1 — t-doc band: form · title · classification · effective ·
+ *           revision · stage stamp.
+ *   Row 2 — LineageHeader: binding cells in canonical reading order.
+ */
+export function SurfaceHeader({ control, lineage }: SurfaceHeaderProps) {
+  return (
+    <header className="t-surface" data-testid="trust-surface-header">
+      <div className="t-doc">
+        <div className="in">
+          <div className="cell form">
+            <div className="g">
+              <span className="glyph" aria-hidden>
+                VC
+              </span>
+              <div>
+                <div className="nm">{control.form}</div>
+                <div className="title">{control.title}</div>
+              </div>
+            </div>
+          </div>
+          <div className="cell">
+            <div className="k">classification</div>
+            <div className="v">
+              <Mono>{control.classification}</Mono>
+            </div>
+          </div>
+          <div className="cell">
+            <div className="k">effective</div>
+            <div className="v">
+              <Mono>{control.effective}</Mono>
+            </div>
+          </div>
+          <div className="cell">
+            <div className="k">revision</div>
+            <div className="v">
+              <Mono>{control.revision}</Mono>
+            </div>
+          </div>
+          <div className="cell">
+            <div className="k">controlled_by</div>
+            <div className="v">
+              <Mono>{control.controlledBy}</Mono>
+              <span className="sub">design fixture — not a live registry</span>
+            </div>
+          </div>
+          <div className="cell" style={{ alignSelf: 'center' }}>
+            <StateStamp state={control.state} caption="stage" />
+          </div>
+        </div>
+      </div>
+
+      <LineageHeader lineage={lineage} />
+    </header>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * SurfaceControlFooter — closes the controlled-document. Renders the
+ * same form fields as the header in a compact bottom stripe so any
+ * printed artifact carries the metadata on both ends.
+ * ─────────────────────────────────────────────────────────────────── */
+export interface SurfaceControlFooterProps {
+  control: SurfaceControl;
+  /** Compact identifier for this rendering (e.g. run_id). */
+  runId?: string;
+  /** Page-of-pages marker — e.g. "01 / 01". */
+  page?: string;
+}
+
+export function SurfaceControlFooter({
+  control,
+  runId,
+  page = '01 / 01',
+}: SurfaceControlFooterProps) {
+  return (
+    <footer
+      className="t-control"
+      data-testid="trust-control-footer"
+      role="contentinfo"
+    >
+      <div className="in">
+        <div className="t-control-row">
+          <span className="t-control-k mono">form</span>
+          <span className="t-control-v mono">{control.form}</span>
+          <span className="t-control-sep" aria-hidden>
+            ·
+          </span>
+          <span className="t-control-k mono">rev</span>
+          <span className="t-control-v mono">{control.revision}</span>
+          <span className="t-control-sep" aria-hidden>
+            ·
+          </span>
+          <span className="t-control-k mono">control</span>
+          <span className="t-control-v mono">{control.controlledBy}</span>
+          {runId && (
+            <>
+              <span className="t-control-sep" aria-hidden>
+                ·
+              </span>
+              <span className="t-control-k mono">run_id</span>
+              <span className="t-control-v mono">{runId}</span>
+            </>
+          )}
+          <span className="t-control-spacer" />
+          <span className="t-control-k mono">page</span>
+          <span className="t-control-v mono">{page}</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/trust/primitives.tsx
+++ b/apps/web/components/trust/primitives.tsx
@@ -1,0 +1,154 @@
+/**
+ * VitalCV · Trust Surfaces · Primitives v1
+ *
+ * Shared primitives used by every trust-surface route. The visual
+ * canon lives in apps/web/styles/trust.css; these components are the
+ * minimal React/TSX surface that the routes compose. Each primitive
+ * is intentionally small — when a route needs a richer rendering it
+ * composes primitives rather than reaching back into trust.css.
+ *
+ * No "Verified" labels (bare or quoted). No banned phrases. No live
+ * source claims. Every consumer must render a demo banner.
+ */
+
+import * as React from 'react';
+
+/** Tiny class-name concatenator (no dependency on `clsx`). */
+export function cn(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * SectionHeader — labels every numbered section on a trust surface.
+ * Renders as a controlled-document section header, never as a
+ * marketing eyebrow.
+ * ─────────────────────────────────────────────────────────────────── */
+export interface SectionHeaderProps {
+  /** Section number, two-digit string ("01", "02", …). */
+  n: string;
+  /** Section title. */
+  title: string;
+  /** Eyebrow strapline below the title; kept short. */
+  ey?: string;
+  /** Optional right-aligned slot for inline citations / stamps. */
+  right?: React.ReactNode;
+}
+
+export function SectionHeader({ n, title, ey, right }: SectionHeaderProps) {
+  return (
+    <header
+      className="t-section"
+      data-testid="trust-section-header"
+      data-section={n}
+    >
+      <div className="t-section-l">
+        <span className="t-section-n mono">{n}</span>
+        <div>
+          <h2 className="t-section-title">{title}</h2>
+          {ey && <p className="t-section-ey">{ey}</p>}
+        </div>
+      </div>
+      {right && <div className="t-section-r">{right}</div>}
+    </header>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * StateStamp — preview / snapshot / signed badge.
+ * Uses the `.t-stamp[data-state="…"]` CSS canon directly. Preview is
+ * dashed (never opacity); signed uses the inverted dark surface
+ * reserved for crypto planes.
+ * ─────────────────────────────────────────────────────────────────── */
+export interface StateStampProps {
+  state: 'preview' | 'snapshot' | 'signed';
+  /** Optional label override. Defaults to the state name uppercased. */
+  label?: string;
+  /** Short prefix shown above the value (e.g. "stage"). */
+  caption?: string;
+}
+
+export function StateStamp({ state, label, caption = 'stage' }: StateStampProps) {
+  return (
+    <span
+      className="t-stamp"
+      data-state={state}
+      data-testid="trust-state-stamp"
+    >
+      <span className="lb">{caption}</span>
+      <span className="v">{label ?? state.toUpperCase()}</span>
+    </span>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * OwnershipBadge — explicit subject / delegated / unbound rendering.
+ *
+ * Doctrine: every trust surface must render one of these three
+ * values explicitly. There is no default. This component is what
+ * the lineage-order test asserts.
+ * ─────────────────────────────────────────────────────────────────── */
+export interface OwnershipBadgeProps {
+  state: 'subject' | 'delegated' | 'unbound';
+}
+
+export function OwnershipBadge({ state }: OwnershipBadgeProps) {
+  return (
+    <span
+      className="t-ownership"
+      data-ownership={state}
+      data-testid="trust-ownership-badge"
+    >
+      <span className="mono t-ownership-label">{state}</span>
+    </span>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * DemoBanner — required on every trust surface that consumes a
+ * fixture. The brief explicitly requires the literal disclaimer
+ * "Demo data — not a real credentialing decision." to appear on
+ * every surface.
+ * ─────────────────────────────────────────────────────────────────── */
+export interface DemoBannerProps {
+  /** Optional extra context shown after the canonical sentence. */
+  extra?: string;
+}
+
+export function DemoBanner({ extra }: DemoBannerProps) {
+  return (
+    <aside
+      className="t-demo-banner"
+      role="status"
+      data-testid="trust-demo-banner"
+    >
+      <span className="t-demo-banner-pill mono">DEMO</span>
+      <span className="t-demo-banner-copy">
+        Demo data — not a real credentialing decision.
+        {extra ? ` ${extra}` : ''}
+      </span>
+    </aside>
+  );
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * Mono — wraps any identifier-shaped value in the mono + tabular
+ * numeral class set the canon prescribes. Used heavily for run_id,
+ * receipt ids, NPI, and timestamps.
+ * ─────────────────────────────────────────────────────────────────── */
+export function Mono({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <span className={cn('mono', className)}>{children}</span>;
+}
+
+/* ───────────────────────────────────────────────────────────────────
+ * Cite — inline standards reference. Renders the "ref · " prefix
+ * automatically via CSS.
+ * ─────────────────────────────────────────────────────────────────── */
+export function Cite({ children }: { children: React.ReactNode }) {
+  return <span className="t-cite">{children}</span>;
+}

--- a/apps/web/lib/trust/demoData.ts
+++ b/apps/web/lib/trust/demoData.ts
@@ -1,0 +1,228 @@
+/**
+ * VitalCV · Trust Surfaces · Demo fixtures v1
+ *
+ * Every export from this file is FIXTURE DATA. None of it represents
+ * a real credentialing decision, a real clinician, a real customer,
+ * or a real cryptographic signature.
+ *
+ * The full list of items this file MUST NOT emit as factual product
+ * copy is enumerated in CLAUDE.md and in the corresponding wave brief
+ * (named customer artifacts, cohort sizes, ed25519 fingerprints, key
+ * fingerprints from any live registry, security certifications,
+ * deletion-receipt claims, SLA claims, BAA-not-required claims, and
+ * bare status labels).
+ *
+ * Every component that consumes a fixture in this file must render
+ * the `DEMO_BANNER` near the surface and use the `DESIGN_FIXTURE_SIGNER`
+ * label ("design fixture" / "demo signer fixture") for any signer
+ * field. The `t-stamp[data-state="preview"]` CSS already makes this
+ * visually obvious.
+ */
+
+import { lineageWhen } from './format';
+import type {
+  DegradedRowEntry,
+  DemoFixtureMeta,
+  FailureModeDescriptor,
+  Lineage,
+  ReceiptArtifact,
+  SignerFixture,
+} from './types';
+
+/** Banner copy required on every trust-surface route. */
+export const DEMO_BANNER =
+  'Demo data — not a real credentialing decision.';
+
+/** Single signer fixture used across receipt/replay/trust pages. */
+export const DESIGN_FIXTURE_SIGNER: SignerFixture = {
+  label: 'design fixture',
+  displayName: 'VitalCV Design Fixture · Signer A',
+  fingerprintFixture: 'fixture:demo-signer-a-not-a-real-key',
+};
+
+/** Standard demo meta shared across fixtures. */
+export const DEMO_META: DemoFixtureMeta = {
+  banner: DEMO_BANNER,
+  source: 'demo-fixture',
+};
+
+/**
+ * Stable base time so the fixtures don't drift turn-to-turn in tests.
+ * Real surfaces should pass `new Date()` instead.
+ */
+const BASE_NOW = new Date('2026-05-18T14:00:00.000Z');
+
+function makeLineageBase(
+  overrides: Partial<Lineage> = {},
+  checkedAtOffsetSec = 90,
+): Lineage {
+  const checkedAt = new Date(BASE_NOW.getTime() - checkedAtOffsetSec * 1000);
+  const when = lineageWhen(checkedAt, BASE_NOW);
+  return {
+    state: 'preview',
+    object: 'Demo passport · MACIE MILLER, PA-C (DEMO)',
+    objectSub: 'NPI 1346053246 (demo persona — not a real provider)',
+    ownership: 'subject',
+    checkedAtIso: when.checkedAtIso,
+    checkedAgo: when.checkedAgo,
+    channel: 'preview.local.demo',
+    replay: 'pending',
+    runId: 'run_v1_demo-7a2cb8d3',
+    ...overrides,
+  };
+}
+
+/** Fixture for /passport/[npi]. */
+export function passportFixture(npi: string): Lineage {
+  return makeLineageBase({
+    object: 'Demo passport · MACIE MILLER, PA-C (DEMO)',
+    objectSub: `NPI ${npi} (demo persona — not a real provider)`,
+    ownership: 'subject',
+    channel: 'preview.local.demo',
+    replay: 'pending',
+  });
+}
+
+/** Fixture for /verify/[receipt] — the verifier reading mode. */
+export function verifyFixture(receipt: string): Lineage {
+  return makeLineageBase(
+    {
+      state: 'snapshot',
+      object: 'Demo readiness packet · MACIE MILLER, PA-C (DEMO)',
+      objectSub: `receipt ${receipt} (fixture — not a live receipt)`,
+      ownership: 'delegated',
+      channel: 'verify.local.demo',
+      replay: 'anchored',
+      runId: 'run_v1_demo-verifier-5fa1c0',
+    },
+    60 * 7,
+  );
+}
+
+/** Fixture for /receipt/[id] — the signed receipt artifact. */
+export function receiptFixture(id: string): ReceiptArtifact {
+  const lineage = makeLineageBase(
+    {
+      state: 'signed',
+      object: 'Demo signed receipt · readiness packet (DEMO)',
+      objectSub: `receipt ${id} (signed fixture — not a real artifact)`,
+      ownership: 'delegated',
+      channel: 'receipt.local.demo',
+      replay: 'anchored',
+      runId: 'run_v1_demo-receipt-91c3a4',
+    },
+    60 * 22,
+  );
+  return {
+    id,
+    lineage,
+    signer: DESIGN_FIXTURE_SIGNER,
+    chain: [
+      'rcpt_demo_001',
+      'rcpt_demo_002',
+      'rcpt_demo_003',
+      id,
+    ],
+    demoMeta: DEMO_META,
+  };
+}
+
+/** Fixture for /replay — chronological chain visualisation. */
+export function replayFixture(): ReadonlyArray<ReceiptArtifact> {
+  return [
+    receiptFixture('rcpt_demo_001'),
+    receiptFixture('rcpt_demo_002'),
+    receiptFixture('rcpt_demo_003'),
+    receiptFixture('rcpt_demo_004'),
+  ];
+}
+
+/** Fixture for /trust — the visual register. */
+export function trustRegisterFixture(): {
+  preview: Lineage;
+  snapshot: Lineage;
+  signed: Lineage;
+} {
+  return {
+    preview: makeLineageBase(
+      { state: 'preview', ownership: 'unbound', channel: 'preview.local.demo' },
+      30,
+    ),
+    snapshot: makeLineageBase(
+      { state: 'snapshot', ownership: 'delegated', channel: 'snapshot.local.demo', replay: 'pending' },
+      60 * 4,
+    ),
+    signed: makeLineageBase(
+      { state: 'signed', ownership: 'delegated', channel: 'signed.local.demo', replay: 'anchored' },
+      60 * 18,
+    ),
+  };
+}
+
+/** Failure modes A–E from the canon. Rendered by /trust. */
+export const FAILURE_MODES: ReadonlyArray<FailureModeDescriptor> = [
+  {
+    mode: 'A',
+    title: 'Ambiguous ownership',
+    copy:
+      'Surface rendered without an explicit ownership state (subject / delegated / unbound). The reader cannot tell who asserted what.',
+    refusalCopy: 'Refuse to render. Require ownership to be set before paint.',
+  },
+  {
+    mode: 'B',
+    title: 'Stale lineage',
+    copy:
+      'checked_at is older than the surface\'s freshness budget. Reader may treat the assertion as current when it is not.',
+    refusalCopy: 'Mark the row degraded (dashed border). Do not render as success.',
+  },
+  {
+    mode: 'C',
+    title: 'Channel mismatch',
+    copy:
+      'The assertion was made on a channel different from the one the reader is reading on. Continuity is broken.',
+    refusalCopy: 'Refuse to merge channels. Display the disagreement explicitly.',
+  },
+  {
+    mode: 'D',
+    title: 'Replay disagreement',
+    copy:
+      'Replay state contradicts the surface state (e.g. signed surface paired with unanchored replay).',
+    refusalCopy: 'Refuse to upgrade the surface state. Surface follows the weakest of (state, replay).',
+  },
+  {
+    mode: 'E',
+    title: 'Run-id collision',
+    copy:
+      'Two assertions share a run_id but reach different conclusions. Hash discipline is broken.',
+    refusalCopy: 'Quarantine the run. Do not render either assertion until reconciled.',
+  },
+] as const;
+
+/** Degraded rows shown on /passport and /trust. */
+export const DEGRADED_ROWS: ReadonlyArray<DegradedRowEntry> = [
+  {
+    reason: 'stale',
+    laneLabel: 'NPPES (demo)',
+    hint: 'Refresh source probe. If stale persists, route to operator review before relying on this lane.',
+  },
+  {
+    reason: 'access_required',
+    laneLabel: 'State Board · CA (demo)',
+    hint: 'Operator credentials required to query this source. Provision access or route the candidate to manual review.',
+  },
+  {
+    reason: 'review_required',
+    laneLabel: 'OIG LEIE (demo)',
+    hint: 'Lane signal is ambiguous. Route to operator review before treating it as decision-grade.',
+  },
+  {
+    reason: 'gated',
+    laneLabel: 'PECOS (demo)',
+    hint: 'Institutional access required. Confirm source agreement or mark lane as access-required before review.',
+  },
+  {
+    reason: 'unavailable',
+    laneLabel: 'DEA · current (demo)',
+    hint: 'Source unavailable. Do not treat this lane as decision-grade until a fresh check succeeds.',
+  },
+] as const;

--- a/apps/web/lib/trust/format.ts
+++ b/apps/web/lib/trust/format.ts
@@ -1,0 +1,151 @@
+/**
+ * VitalCV · Trust Surfaces · Format helpers v1
+ *
+ * Pure formatting helpers used by every trust-surface component. No
+ * I/O, no fetch, no source coupling. The helpers are deterministic
+ * given their inputs — important for SSR consistency and snapshot
+ * tests.
+ */
+
+import type {
+  Lineage,
+  LineageCellId,
+  OwnershipState,
+  ReplayState,
+} from './types';
+
+/**
+ * Humanise a checked-at timestamp into a "X ago" string suitable for
+ * the lineage header.
+ *
+ * Returned shape:
+ *   - checkedAtIso  → an explicit ISO timestamp string (untouched if
+ *                     already ISO, normalised through `toISOString()`
+ *                     otherwise).
+ *   - checkedAgo    → "just now" / "X minutes ago" / "X hours ago" /
+ *                     "X days ago" — the renderer never needs to do
+ *                     time math itself.
+ *
+ * Designed to be pure: callers pass an explicit `now` so SSR tests
+ * are deterministic.
+ */
+export function lineageWhen(
+  isoOrDate: string | Date,
+  now: Date = new Date(),
+): { checkedAtIso: string; checkedAgo: string } {
+  const checkedAt =
+    isoOrDate instanceof Date ? isoOrDate : new Date(isoOrDate);
+  const checkedAtIso = checkedAt.toISOString();
+
+  const deltaMs = Math.max(0, now.getTime() - checkedAt.getTime());
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 30) return { checkedAtIso, checkedAgo: 'just now' };
+  if (seconds < 90) return { checkedAtIso, checkedAgo: '1 minute ago' };
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 90) return { checkedAtIso, checkedAgo: `${minutes} minutes ago` };
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 36) return { checkedAtIso, checkedAgo: `${hours} hours ago` };
+
+  const days = Math.floor(hours / 24);
+  return { checkedAtIso, checkedAgo: `${days} days ago` };
+}
+
+/** Human label for an ownership state, suitable for rendering. */
+export function ownershipLabel(state: OwnershipState): string {
+  switch (state) {
+    case 'subject':
+      return 'subject';
+    case 'delegated':
+      return 'delegated';
+    case 'unbound':
+      return 'unbound';
+  }
+}
+
+/** Long-form explanation for the ownership state. */
+export function ownershipDescription(state: OwnershipState): string {
+  switch (state) {
+    case 'subject':
+      return 'The asserting party is the subject of this record.';
+    case 'delegated':
+      return 'An operator is reading on behalf of the subject under a documented delegation.';
+    case 'unbound':
+      return 'No subject binding has been established yet.';
+  }
+}
+
+/** Human label for a replay state. */
+export function replayLabel(state: ReplayState): string {
+  switch (state) {
+    case 'anchored':
+      return 'anchored';
+    case 'pending':
+      return 'pending';
+    case 'unanchored':
+      return 'unanchored';
+    case 'mismatched':
+      return 'mismatched';
+  }
+}
+
+/**
+ * Extract the binding lineage cells in the canonical reading order.
+ * Renderers loop over this array; never iterate Object.keys(lineage).
+ *
+ * Each cell is { id, label, value } so the renderer can pin
+ * `data-cell={cell.id}` for the lineage-order test.
+ */
+export interface LineageCell {
+  id: LineageCellId;
+  label: string;
+  value: string;
+  subValue?: string;
+}
+
+export function lineageCells(lineage: Lineage): readonly LineageCell[] {
+  return [
+    {
+      id: 'object',
+      label: 'Object',
+      value: lineage.object,
+      subValue: lineage.objectSub,
+    },
+    {
+      id: 'ownership',
+      label: 'Ownership',
+      value: ownershipLabel(lineage.ownership),
+    },
+    {
+      id: 'checkedAt',
+      label: 'checked_at',
+      value: lineage.checkedAgo,
+      subValue: lineage.checkedAtIso,
+    },
+    {
+      id: 'channel',
+      label: 'Channel',
+      value: lineage.channel,
+    },
+    {
+      id: 'replay',
+      label: 'Replay',
+      value: replayLabel(lineage.replay),
+    },
+    {
+      id: 'runId',
+      label: 'run_id',
+      value: lineage.runId,
+    },
+  ] as const;
+}
+
+/**
+ * Truncate a long identifier for monospace display, keeping the head
+ * and tail visible (e.g. "abc12345…f9d3"). Pure; never throws.
+ */
+export function truncateId(id: string, headLen = 8, tailLen = 4): string {
+  if (id.length <= headLen + tailLen + 1) return id;
+  return `${id.slice(0, headLen)}…${id.slice(-tailLen)}`;
+}

--- a/apps/web/lib/trust/types.ts
+++ b/apps/web/lib/trust/types.ts
@@ -1,0 +1,140 @@
+/**
+ * VitalCV · Trust Surfaces · Type Canon v1
+ *
+ * Types that match the binding reading order documented in
+ * docs/design/claude-design-handoff-2026-05-18/. Every trust surface
+ * renders lineage cells in this exact order:
+ *
+ *   OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID
+ *
+ * The order is encoded in `LINEAGE_READING_ORDER` so tests can assert
+ * it directly. Components must consume that array — never hand-roll
+ * a different sequence.
+ *
+ * No live source claims live in these types. Every value is a
+ * fixture/demo string by default; production routes that ever wire
+ * to a real source must add their own runtime guards.
+ */
+
+/** Trust-surface visual state. */
+export type TrustState = 'preview' | 'snapshot' | 'signed';
+
+/**
+ * Ownership state of the subject of a trust assertion.
+ *
+ * `subject`   — the asserting party is the subject (a clinician
+ *               viewing their own record).
+ * `delegated` — an operator / verifier is reading on behalf of the
+ *               subject under a documented delegation.
+ * `unbound`   — no subject binding has been established yet (the
+ *               surface is a preview or anonymous probe).
+ *
+ * The brief forbids implicit ownership — every trust surface must
+ * render one of these three values explicitly. There is no fourth
+ * "default" option.
+ */
+export type OwnershipState = 'subject' | 'delegated' | 'unbound';
+
+/** Replay-memory state for the assertion. */
+export type ReplayState =
+  | 'anchored'
+  | 'pending'
+  | 'unanchored'
+  | 'mismatched';
+
+/** Failure modes A–E from the design canon. */
+export type FailureMode = 'A' | 'B' | 'C' | 'D' | 'E';
+
+/** Degraded-row reason (rendered with dashed border, never opacity). */
+export type DegradedReason =
+  | 'stale'
+  | 'access_required'
+  | 'review_required'
+  | 'unavailable'
+  | 'gated';
+
+/**
+ * Lineage cells — the binding reading order.
+ *
+ * Component renderers MUST iterate `LINEAGE_READING_ORDER` rather
+ * than `Object.keys(lineage)`. The literal order below is the order
+ * the design canon prescribes.
+ */
+export interface Lineage {
+  state: TrustState;
+  object: string;
+  objectSub?: string;
+  ownership: OwnershipState;
+  /** ISO timestamp. Renderers must use lineageWhen() to humanise. */
+  checkedAtIso: string;
+  /** Pre-humanised "X seconds ago" / "5 minutes ago" string. */
+  checkedAgo: string;
+  channel: string;
+  replay: ReplayState;
+  /** Short identifier (mono / tabular numerals). */
+  runId: string;
+}
+
+/**
+ * Canonical reading order. **Do not reorder.** The order is asserted
+ * by trust-lineage-order.test.tsx.
+ */
+export const LINEAGE_READING_ORDER = [
+  'object',
+  'ownership',
+  'checkedAt',
+  'channel',
+  'replay',
+  'runId',
+] as const;
+
+export type LineageCellId = (typeof LINEAGE_READING_ORDER)[number];
+
+/** Demo / fixture provenance — every fixture carries this. */
+export interface DemoFixtureMeta {
+  /** Single-sentence demo banner shown above the surface. */
+  banner: string;
+  /** Source attribution shown in the controlled footer. */
+  source: 'demo-fixture' | 'design-fixture';
+}
+
+/** A signer fixture for the SignaturePanel. Never a real key. */
+export interface SignerFixture {
+  /** Always "design fixture" or "demo signer fixture" — see brief. */
+  label: 'design fixture' | 'demo signer fixture';
+  /** Display name (no live credential mapping). */
+  displayName: string;
+  /** Fixture-only fingerprint, prefixed `fixture:` so it cannot be
+   *  mistaken for a real ed25519 / RSA fingerprint. */
+  fingerprintFixture: string;
+}
+
+/** Receipt artifact — the input to /receipt/[id]. */
+export interface ReceiptArtifact {
+  id: string;
+  lineage: Lineage;
+  signer: SignerFixture;
+  /** Each chain node is a previous receipt id, oldest first. */
+  chain: string[];
+  /** Always present — see brief. */
+  demoMeta: DemoFixtureMeta;
+}
+
+/** Failure-mode descriptor for the Trust State Register page. */
+export interface FailureModeDescriptor {
+  mode: FailureMode;
+  title: string;
+  /** Operator-action copy describing the failure and the next step. */
+  copy: string;
+  /** What MUST NOT happen — operator-action negation. */
+  refusalCopy: string;
+}
+
+/** Degraded row entry — rendered with dashed border, never opacity. */
+export interface DegradedRowEntry {
+  reason: DegradedReason;
+  /** What lane is degraded (e.g. "OIG LEIE", "State Board CA"). */
+  laneLabel: string;
+  /** Single-sentence operator-action hint. */
+  hint: string;
+}

--- a/apps/web/styles/trust.css
+++ b/apps/web/styles/trust.css
@@ -1,0 +1,1702 @@
+/* VitalCV · Trust Surfaces · Canon v1
+   Scoped under .trust-scope (applied by app/(trust)/layout.tsx).
+   No global resets — leaves the rest of @vitalcv/web alone. */
+
+.trust-scope {
+  --ink-0: #fff;
+  --ink-50: #f8fafc;
+  --ink-100: #f1f5f9;
+  --ink-200: #e2e8f0;
+  --ink-300: #cbd5e1;
+  --ink-400: #94a3b8;
+  --ink-500: #64748b;
+  --ink-600: #475569;
+  --ink-700: #334155;
+  --ink-800: #1e293b;
+  --ink-900: #0f172a;
+  --ink-950: #020617;
+  --rule: #e2e8f0;
+  --paper: #f8f6f1;
+
+  font-family: "Geist", ui-sans-serif, system-ui, sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  -webkit-font-smoothing: antialiased;
+  background: var(--ink-50);
+  color: var(--ink-900);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.trust-scope .mono,
+.trust-scope code {
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============ DOCUMENT CONTROL BAND · regulated-document header ============ */
+/* Replaces the marketing role of a masthead with the institutional role of
+   a controlled-document header: form number · classification · effective ·
+   controlled-by · revision. Renders ABOVE the lineage header on every surface. */
+.t-doc {
+  background: var(--ink-0);
+  border-top: 2px solid var(--ink-950);
+  border-bottom: 1px solid var(--ink-900);
+}
+.t-doc .in {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 14px 28px 13px;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.9fr;
+  gap: 18px;
+  align-items: end;
+}
+.t-doc .cell {
+  border-left: 1px solid var(--rule);
+  padding-left: 14px;
+}
+.t-doc .cell:first-child {
+  border-left: 0;
+  padding-left: 0;
+}
+.t-doc .k {
+  font-family: "Geist Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.t-doc .v {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  color: var(--ink-900);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1.25;
+}
+.t-doc .v .sub {
+  display: block;
+  font-family: "Geist", sans-serif;
+  font-size: 10.5px;
+  color: var(--ink-500);
+  margin-top: 3px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.t-doc .form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.t-doc .form .g {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.t-doc .form .g .glyph {
+  width: 22px;
+  height: 22px;
+  background: var(--ink-950);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+.t-doc .form .nm {
+  font-family: "Geist Mono", monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-950);
+  font-weight: 600;
+}
+.t-doc .form .title {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--ink-500);
+  text-transform: uppercase;
+}
+
+/* ============ STATE STAMP · PREVIEW / SNAPSHOT / SIGNED ============ */
+.t-stamp {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 7px 11px;
+  border: 1.5px solid var(--ink-950);
+  font-family: "Geist Mono", monospace;
+  background: transparent;
+}
+.t-stamp .lb {
+  font-size: 8.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.t-stamp .v {
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-950);
+  font-weight: 600;
+}
+.t-stamp[data-state="preview"] {
+  border-style: dashed;
+  border-color: var(--ink-500);
+}
+.t-stamp[data-state="preview"] .v {
+  color: var(--ink-700);
+}
+.t-stamp[data-state="snapshot"] {
+  border-color: var(--ink-700);
+}
+.t-stamp[data-state="signed"] {
+  border-color: var(--ink-950);
+  background: var(--ink-950);
+}
+.t-stamp[data-state="signed"] .lb {
+  color: var(--ink-400);
+}
+.t-stamp[data-state="signed"] .v {
+  color: #fff;
+}
+
+/* ============ INLINE STANDARDS CITATIONS ============ */
+/* For statute / standard references inline with body copy.
+   "ref · RFC 3161"  · "ref · NCQA CR §3"  · "ref · OpenID4VCI § 7"
+   These read like a regulator's citation, not marketing chrome. */
+.t-cite {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--ink-600);
+  padding: 1px 5px;
+  border: 1px solid var(--rule);
+  background: var(--ink-50);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.t-cite::before {
+  content: "ref · ";
+  color: var(--ink-400);
+}
+
+/* ============ CONTROLLED-DOCUMENT FOOTER · revision / page / control ============ */
+.t-control {
+  max-width: 1320px;
+  margin: 28px auto 0;
+  border-top: 2px solid var(--ink-950);
+  border-bottom: 1px solid var(--ink-900);
+  background: var(--ink-0);
+}
+.t-control .in {
+  padding: 12px 28px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr 1fr;
+  gap: 18px;
+  align-items: end;
+}
+.t-control .cell {
+  border-left: 1px solid var(--rule);
+  padding-left: 14px;
+}
+.t-control .cell:first-child {
+  border-left: 0;
+  padding-left: 0;
+}
+.t-control .k {
+  font-family: "Geist Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 4px;
+}
+.t-control .v {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-900);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.t-control .v .sub {
+  display: block;
+  font-family: "Geist", sans-serif;
+  font-size: 10px;
+  color: var(--ink-500);
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* ============ RUNTIME STATE BAND (replaces the t-op marketing strip) ============ */
+.t-runtime {
+  background: var(--ink-950);
+  color: var(--ink-300);
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+}
+.t-runtime .in {
+  max-width: 1320px;
+  margin: 0 auto;
+  min-height: 28px;
+  padding: 5px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.t-runtime .grp {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.t-runtime .grp .k {
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 9.5px;
+}
+.t-runtime .grp .v {
+  color: #fff;
+  font-weight: 500;
+}
+.t-runtime .sep {
+  color: var(--ink-700);
+}
+
+/* ============ MASTHEAD · top anchor band ============ */
+.t-masthead {
+  background: var(--ink-0);
+  border-bottom: 1px solid var(--ink-900);
+}
+.t-masthead .in {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 14px 28px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.t-masthead .brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+.t-masthead .brand .g {
+  width: 20px;
+  height: 20px;
+  background: var(--ink-900);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  font-weight: 600;
+}
+.t-masthead .brand .t {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-masthead .brand .sl {
+  color: var(--ink-300);
+  margin: 0 7px;
+}
+.t-masthead .meta {
+  display: flex;
+  gap: 14px;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-500);
+  letter-spacing: 0.04em;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.t-masthead .meta strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-masthead .meta .sep {
+  color: var(--ink-300);
+}
+
+/* ============ OP STRIP · runtime metadata ============ */
+.t-op {
+  background: var(--ink-950);
+  color: var(--ink-300);
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+}
+.t-op .in {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 6px 28px;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.t-op .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 7px;
+  border: 1px solid var(--ink-700);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 10px;
+}
+.t-op .pill .d {
+  width: 6px;
+  height: 6px;
+  background: #fff;
+  border-radius: 50%;
+}
+.t-op .sep {
+  color: var(--ink-600);
+}
+
+/* ============ MAIN ============ */
+.t-main {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 18px 28px 56px;
+}
+
+/* ============ LINEAGE HEADER · 6-cell strip ============ */
+.t-lineage {
+  border: 1px solid var(--ink-900);
+  background: var(--ink-0);
+}
+.t-lineage .hd {
+  background: var(--ink-900);
+  color: #fff;
+  padding: 9px 16px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.t-lineage .cells {
+  display: grid;
+  grid-template-columns: 1.4fr 0.8fr 1fr 1fr 0.8fr 0.9fr;
+}
+.t-lineage .cell {
+  padding: 11px 14px;
+  border-right: 1px solid var(--rule);
+}
+.t-lineage .cell:last-child {
+  border-right: 0;
+}
+.t-lineage .k {
+  font-family: "Geist Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  margin-bottom: 4px;
+}
+.t-lineage .v {
+  font-family: "Geist Mono", monospace;
+  font-size: 11.5px;
+  color: var(--ink-900);
+  font-weight: 500;
+  line-height: 1.3;
+}
+.t-lineage .v .sub {
+  display: block;
+  font-family: "Geist", sans-serif;
+  font-size: 10.5px;
+  color: var(--ink-500);
+  font-weight: 400;
+  margin-top: 2px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* state band on lineage header — preview · snapshot · signed */
+.t-lineage[data-state="preview"] {
+  border-style: dashed;
+  border-color: var(--ink-400);
+  background: var(--paper);
+}
+.t-lineage[data-state="preview"] .hd {
+  background: var(--ink-50);
+  color: var(--ink-700);
+}
+.t-lineage[data-state="signed"] {
+  border-color: var(--ink-950);
+}
+.t-lineage[data-state="signed"] .hd {
+  background: var(--ink-950);
+}
+
+/* ============ TRUST CHIP ============ */
+.t-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  border: 1px solid var(--ink-900);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-900);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.t-chip .d {
+  width: 5px;
+  height: 5px;
+  background: var(--ink-900);
+  border-radius: 50%;
+}
+.t-chip[data-variant="solid"] {
+  background: var(--ink-900);
+  color: #fff;
+}
+.t-chip[data-variant="solid"] .d {
+  background: #fff;
+}
+.t-chip[data-variant="outline"] {
+  background: transparent;
+}
+.t-chip[data-variant="dashed"] {
+  border-style: dashed;
+  color: var(--ink-700);
+}
+.t-chip[data-variant="dashed"] .d {
+  background: transparent;
+  border: 1px solid var(--ink-700);
+}
+.t-chip[data-variant="dotted"] {
+  border-style: dotted;
+  color: var(--ink-700);
+}
+.t-chip[data-variant="dotted"] .d {
+  background: transparent;
+  border: 1px dotted var(--ink-700);
+}
+
+/* tier badge */
+.t-tier {
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--ink-900);
+  padding: 3px 6px;
+  letter-spacing: 0.06em;
+  display: inline-block;
+}
+
+/* ============ ID RENDER ============ */
+.t-id {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-900);
+  font-weight: 500;
+  padding: 2px 6px;
+  background: var(--ink-50);
+  border: 1px solid var(--rule);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.t-id[data-tone="inverted"] {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+/* ============ CHECKED_AT ============ */
+.t-when {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-900);
+  font-weight: 500;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+}
+.t-when .sub {
+  display: block;
+  font-size: 9.5px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* ============ OWNERSHIP BADGE ============ */
+.t-own {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.t-own[data-state="subject"] {
+  background: var(--ink-900);
+  color: #fff;
+}
+.t-own[data-state="subject"] .d {
+  width: 5px;
+  height: 5px;
+  background: #fff;
+  border-radius: 50%;
+}
+.t-own[data-state="delegated"] {
+  border: 1px solid var(--ink-900);
+  color: var(--ink-900);
+}
+.t-own[data-state="delegated"] .d {
+  width: 5px;
+  height: 5px;
+  background: var(--ink-900);
+  border-radius: 50%;
+}
+.t-own[data-state="unbound"] {
+  border: 1px dashed var(--ink-700);
+  color: var(--ink-700);
+}
+.t-own[data-state="unbound"] .d {
+  width: 5px;
+  height: 5px;
+  border: 1px solid var(--ink-700);
+  border-radius: 50%;
+}
+
+/* ============ VERDICT BAR ============ */
+.t-verdict {
+  border: 1px solid var(--ink-900);
+  background: var(--ink-0);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+}
+.t-verdict .v {
+  padding: 13px 18px;
+  background: var(--ink-900);
+  color: #fff;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.t-verdict .v .d {
+  width: 7px;
+  height: 7px;
+  background: #fff;
+  border-radius: 50%;
+}
+.t-verdict .b {
+  padding: 13px 18px;
+  color: var(--ink-900);
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.t-verdict .b .pipe {
+  color: var(--ink-300);
+}
+.t-verdict .a {
+  padding: 13px 18px;
+  border-left: 1px solid var(--rule);
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-700);
+  background: var(--ink-50);
+}
+.t-verdict .a strong {
+  color: var(--ink-900);
+  font-weight: 500;
+  display: block;
+}
+
+/* ============ CHAIN STRIP ============ */
+.t-chain {
+  border: 1px solid var(--ink-300);
+  background: var(--ink-0);
+}
+.t-chain[data-tone="inverted"] {
+  background: var(--ink-950);
+  border-color: var(--ink-950);
+  color: #fff;
+}
+.t-chain .hd {
+  padding: 9px 16px;
+  background: var(--ink-50);
+  border-bottom: 1px solid var(--rule);
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.t-chain .hd strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-chain[data-tone="inverted"] .hd {
+  background: transparent;
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+  color: var(--ink-400);
+}
+.t-chain[data-tone="inverted"] .hd strong {
+  color: #fff;
+}
+.t-chain .body {
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.t-chain .tok {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-900);
+  background: var(--ink-50);
+  border: 1px solid var(--rule);
+  padding: 3px 7px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.t-chain[data-tone="inverted"] .tok {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+.t-chain .tok[data-now="true"] {
+  background: var(--ink-900);
+  color: #fff;
+}
+.t-chain[data-tone="inverted"] .tok[data-now="true"] {
+  background: #fff;
+  color: var(--ink-950);
+  border-color: #fff;
+}
+.t-chain .arr {
+  color: var(--ink-400);
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+}
+.t-chain[data-tone="inverted"] .arr {
+  color: var(--ink-500);
+}
+
+/* ============ SIGNATURE PANEL ============ */
+.t-sig {
+  border: 1px solid var(--ink-300);
+  background: var(--ink-0);
+}
+.t-sig .hd {
+  padding: 9px 16px;
+  background: var(--ink-50);
+  border-bottom: 1px solid var(--ink-300);
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.t-sig .hd strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-sig .body {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+}
+.t-sig .body .col {
+  padding: 14px 16px;
+  border-right: 1px solid var(--rule);
+}
+.t-sig .body .col:last-child {
+  border-right: 0;
+}
+.t-sig .body .k {
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-500);
+  margin-bottom: 4px;
+}
+.t-sig .body .v {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  color: var(--ink-900);
+  font-weight: 500;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+}
+.t-sig .body .v .sub {
+  display: block;
+  font-family: "Geist", sans-serif;
+  font-size: 11px;
+  color: var(--ink-600);
+  font-weight: 400;
+  margin-top: 3px;
+  letter-spacing: 0;
+}
+.t-sig .age {
+  height: 5px;
+  background: var(--ink-100);
+  border: 1px solid var(--ink-200);
+  position: relative;
+  margin-top: 7px;
+}
+.t-sig .age .f {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ink-900);
+}
+
+/* ============ DEGRADED ROW · dashed, never opacity ============ */
+.t-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: stretch;
+}
+.t-row[data-degraded="true"] {
+  background: var(--ink-50);
+}
+.t-row[data-degraded="true"] .t-chip {
+  border-style: dashed;
+}
+
+/* ============ FAILURE BANNER ============ */
+.t-fb {
+  border: 1px solid var(--ink-300);
+  background: var(--ink-0);
+  padding: 14px 18px;
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 14px;
+  align-items: center;
+}
+.t-fb[data-mode="A"] {
+  border-style: dashed;
+  border-color: var(--ink-400);
+}
+.t-fb[data-mode="B"] {
+  border-color: var(--ink-300);
+}
+.t-fb[data-mode="C"] {
+  background: var(--ink-900);
+  border-color: var(--ink-900);
+  color: #fff;
+}
+.t-fb[data-mode="D"] {
+  border-color: var(--ink-900);
+}
+.t-fb[data-mode="E"] {
+  background: var(--ink-950);
+  border-color: var(--ink-950);
+  color: #fff;
+}
+.t-fb .lb {
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.t-fb[data-mode="C"] .lb,
+.t-fb[data-mode="E"] .lb {
+  color: var(--ink-400);
+}
+.t-fb .title {
+  font-size: 13.5px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink-900);
+  margin-top: 2px;
+}
+.t-fb[data-mode="C"] .title,
+.t-fb[data-mode="E"] .title {
+  color: #fff;
+}
+.t-fb .cta {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid var(--ink-900);
+  color: var(--ink-900);
+  font-weight: 500;
+  background: transparent;
+  cursor: pointer;
+}
+.t-fb[data-mode="C"] .cta,
+.t-fb[data-mode="E"] .cta {
+  border-color: #fff;
+  color: #fff;
+}
+
+/* ============ CLAIM TABLE ============ */
+.t-facts {
+  border: 1px solid var(--ink-300);
+  background: var(--ink-0);
+}
+.t-facts .h {
+  display: grid;
+  grid-template-columns: 54px 100px 96px 1.4fr 1fr 120px;
+  background: var(--ink-50);
+  border-bottom: 1px solid var(--ink-900);
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+}
+.t-facts .h .c {
+  padding: 10px 12px;
+  border-right: 1px solid var(--rule);
+}
+.t-facts .h .c:last-child {
+  border-right: 0;
+}
+.t-facts .r {
+  display: grid;
+  grid-template-columns: 54px 100px 96px 1.4fr 1fr 120px;
+  border-bottom: 1px solid var(--rule);
+  align-items: stretch;
+}
+.t-facts .r:last-child {
+  border-bottom: 0;
+}
+.t-facts .r .c {
+  padding: 11px 12px;
+  border-right: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+}
+.t-facts .r .c:last-child {
+  border-right: 0;
+}
+.t-facts .r:hover {
+  background: var(--ink-50);
+}
+.t-facts .claim {
+  font-size: 13px;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-facts .claim .sub {
+  display: block;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+  font-weight: 400;
+}
+.t-facts .src {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-700);
+}
+.t-facts .src .sub {
+  display: block;
+  font-size: 9.5px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+}
+.t-facts .rcpt {
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-facts .rcpt .sub {
+  display: block;
+  font-size: 9.5px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* ============ SECTION HEADER ============ */
+.t-sh {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  border-bottom: 1px solid var(--ink-900);
+  padding-bottom: 8px;
+  margin: 28px 0 16px;
+}
+.t-sh .n {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-300);
+  font-weight: 600;
+}
+.t-sh h2 {
+  font-size: 16px;
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--ink-900);
+}
+.t-sh .ey {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-500);
+  margin-left: auto;
+}
+
+/* ============ FOOT BAND · bottom anchor ============ */
+.t-foot {
+  max-width: 1320px;
+  margin: 24px auto 0;
+  padding: 20px 28px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-500);
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--rule);
+  background: var(--ink-0);
+}
+.t-foot strong {
+  color: var(--ink-700);
+}
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 1100px) {
+  .t-doc .in {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+  .t-doc .cell:nth-child(4) {
+    border-left: 0;
+    padding-left: 0;
+  }
+  .t-control .in {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+  .t-control .cell:nth-child(4) {
+    border-left: 0;
+    padding-left: 0;
+  }
+}
+@media (max-width: 1000px) {
+  .t-lineage .cells {
+    grid-template-columns: 1fr 1fr;
+  }
+  .t-lineage .cell {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .t-sig .body {
+    grid-template-columns: 1fr 1fr;
+  }
+  .t-sig .body .col {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .t-sig .body .col:nth-child(2n) {
+    border-right: 0;
+  }
+  .t-facts .h,
+  .t-facts .r {
+    grid-template-columns: 54px 1fr 110px;
+  }
+  .t-facts .h > :nth-child(n + 4):nth-child(-n + 5),
+  .t-facts .r > :nth-child(n + 4):nth-child(-n + 5) {
+    display: none;
+  }
+  .t-verdict {
+    grid-template-columns: 1fr;
+  }
+  .t-verdict .a {
+    border-left: 0;
+    border-top: 1px solid var(--rule);
+  }
+}
+
+/* ============ TRUST STATE · VISUAL REGISTER ============
+   Three-state stage (Preview / Snapshot / Signed) at the same scale, plus
+   the five-rule differentiation matrix and failure-mode prevention table.
+   Canon doctrine: inverted register is reserved — the .t-r-sg card here is
+   a doctrinal demonstration of the signed surface, not chrome. */
+
+.t-r-stage {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+}
+.t-r-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 560px;
+}
+
+/* state label strip above each card */
+.t-r-clabel {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.t-r-clabel .ord {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-300);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+}
+.t-r-clabel .b {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--ink-900);
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-r-clabel .b.solid {
+  background: var(--ink-900);
+  color: #fff;
+}
+.t-r-clabel .b.dashed {
+  border-style: dashed;
+  color: var(--ink-700);
+  background: transparent;
+}
+.t-r-clabel .nm {
+  font-size: 14.5px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink-900);
+}
+
+/* === A · Anonymous preview ===
+   paper bg, dashed border, soft type, marketing register, minimal data */
+.t-r-pv {
+  background: var(--paper);
+  border: 1.5px dashed var(--ink-400);
+  padding: 22px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.t-r-pv .top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-500);
+}
+.t-r-pv .top .glyph {
+  width: 14px;
+  height: 14px;
+  border: 1px dashed var(--ink-500);
+}
+.t-r-pv .h {
+  font-family: "Geist", sans-serif;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  color: var(--ink-900);
+  font-weight: 500;
+  line-height: 1.18;
+  margin: 0;
+}
+.t-r-pv .h .cursor {
+  display: inline-block;
+  width: 2px;
+  height: 0.95em;
+  background: var(--ink-900);
+  vertical-align: -2px;
+  margin-left: 2px;
+  animation: t-r-blink 1.05s steps(2, end) infinite;
+}
+@keyframes t-r-blink {
+  50% {
+    opacity: 0;
+  }
+}
+.t-r-pv .body {
+  font-size: 13.5px;
+  color: var(--ink-600);
+  line-height: 1.55;
+}
+.t-r-pv .field {
+  padding: 11px 13px;
+  border: 1px dashed var(--ink-400);
+  background: rgba(255, 255, 255, 0.55);
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  color: var(--ink-500);
+}
+.t-r-pv .field .lbl {
+  display: block;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-400);
+  margin-bottom: 4px;
+}
+.t-r-pv .pad {
+  flex: 1;
+}
+.t-r-pv .fineprint {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  border-top: 1px dashed var(--ink-300);
+  padding-top: 10px;
+}
+
+/* === B · Authenticated ownership ===
+   white card, solid 1px black border, session bar, live freshness pulse */
+.t-r-sn {
+  background: var(--ink-0);
+  border: 1px solid var(--ink-900);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.t-r-sn .session {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--ink-50);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-700);
+}
+.t-r-sn .session .l {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.t-r-sn .session .av {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ink-900);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+.t-r-sn .session .r {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.t-r-sn .session .ring {
+  width: 8px;
+  height: 8px;
+  border: 1px solid var(--ink-900);
+  border-radius: 50%;
+  position: relative;
+}
+.t-r-sn .session .ring::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 50%;
+  background: var(--ink-900);
+  animation: t-r-pulse 2.2s ease-in-out infinite;
+}
+@keyframes t-r-pulse {
+  0%,
+  100% {
+    transform: scale(0.4);
+    opacity: 0.3;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+.t-r-sn .body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex: 1;
+}
+.t-r-sn .h-eye {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-500);
+}
+.t-r-sn .h {
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--ink-900);
+  line-height: 1.2;
+  margin: 0;
+}
+.t-r-sn .h .id {
+  display: block;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-500);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 4px;
+}
+.t-r-sn .rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--rule);
+}
+.t-r-sn .rows .row {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr auto;
+  gap: 10px;
+  padding: 9px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--rule);
+}
+.t-r-sn .rows .row:last-child {
+  border-bottom: 0;
+}
+.t-r-sn .rows .nm {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--ink-900);
+}
+.t-r-sn .rows .src {
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-500);
+}
+.t-r-sn .rows .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 6px;
+  border: 1px solid var(--ink-900);
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-r-sn .rows .chip .d {
+  width: 5px;
+  height: 5px;
+  background: var(--ink-900);
+  border-radius: 50%;
+}
+.t-r-sn .rows .chip.dashed {
+  border-style: dashed;
+  color: var(--ink-700);
+}
+.t-r-sn .rows .chip.dashed .d {
+  background: transparent;
+  border: 1px solid var(--ink-700);
+}
+.t-r-sn .meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-top: 1px solid var(--rule);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.t-r-sn .meta .c {
+  padding: 8px 12px;
+  border-right: 1px solid var(--rule);
+}
+.t-r-sn .meta .c:last-child {
+  border-right: 0;
+}
+.t-r-sn .meta .c strong {
+  color: var(--ink-900);
+  font-weight: 500;
+  display: block;
+  letter-spacing: 0.08em;
+}
+.t-r-sn .pad {
+  flex: 1;
+}
+.t-r-sn .foot {
+  padding: 10px 14px;
+  border-top: 1px solid var(--rule);
+  background: var(--ink-50);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-700);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.t-r-sn .foot strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+
+/* === C · Signed institutional artifact ===
+   inverted dark, key glyph, dense metadata, signature footer */
+.t-r-sg {
+  background: var(--ink-950);
+  color: #fff;
+  border: 1px solid var(--ink-950);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 0 0 1px var(--ink-950);
+}
+.t-r-sg .top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+}
+.t-r-sg .top .l {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.t-r-sg .top .key {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+}
+.t-r-sg .top .key svg {
+  display: block;
+}
+.t-r-sg .top .r {
+  color: #fff;
+  font-weight: 500;
+}
+.t-r-sg .body {
+  padding: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.t-r-sg .h-eye {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-400);
+}
+.t-r-sg .h {
+  font-size: 19px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  margin: 0;
+}
+.t-r-sg .h .id {
+  display: block;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-400);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-top: 4px;
+}
+.t-r-sg .grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+.t-r-sg .grid .kv {
+  padding: 8px 12px;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.t-r-sg .grid .kv:nth-child(2n) {
+  border-right: 0;
+}
+.t-r-sg .grid .kv:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+.t-r-sg .grid .k {
+  font-family: "Geist Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-400);
+  margin-bottom: 3px;
+}
+.t-r-sg .grid .v {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: #fff;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.t-r-sg .grid .v .sub {
+  display: block;
+  font-family: "Geist", sans-serif;
+  font-size: 10.5px;
+  color: var(--ink-400);
+  font-weight: 400;
+  margin-top: 2px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.t-r-sg .sig {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: #000;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-400);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.t-r-sg .sig .did {
+  color: #fff;
+  font-weight: 500;
+}
+.t-r-sg .sig .verify {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #fff;
+  font-weight: 500;
+}
+.t-r-sg .sig .verify .d {
+  width: 6px;
+  height: 6px;
+  background: #fff;
+  border-radius: 50%;
+}
+
+/* hover hint under the stage */
+.t-r-hint {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-500);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  margin-top: 12px;
+  text-align: center;
+}
+.t-r-hint strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+
+/* === Five-rule differentiation table === */
+.t-r-rules {
+  border: 1px solid var(--ink-300);
+  background: var(--ink-0);
+}
+.t-r-rules .hd {
+  display: grid;
+  grid-template-columns: 160px 1fr 1fr 1fr;
+  gap: 0;
+  background: var(--ink-50);
+  border-bottom: 1px solid var(--ink-900);
+}
+.t-r-rules .hd .c {
+  padding: 11px 14px;
+  border-right: 1px solid var(--rule);
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-500);
+}
+.t-r-rules .hd .c:last-child {
+  border-right: 0;
+}
+.t-r-rules .hd .c strong {
+  color: var(--ink-900);
+  font-weight: 500;
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  margin-bottom: 2px;
+}
+.t-r-rules .row {
+  display: grid;
+  grid-template-columns: 160px 1fr 1fr 1fr;
+  gap: 0;
+  border-bottom: 1px solid var(--rule);
+}
+.t-r-rules .row:last-child {
+  border-bottom: 0;
+}
+.t-r-rules .row .rk {
+  padding: 12px 14px;
+  border-right: 1px solid var(--rule);
+  background: var(--ink-50);
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-700);
+  font-weight: 500;
+}
+.t-r-rules .row .v {
+  padding: 12px 14px;
+  border-right: 1px solid var(--rule);
+  font-size: 12px;
+  color: var(--ink-700);
+  line-height: 1.5;
+}
+.t-r-rules .row .v:last-child {
+  border-right: 0;
+}
+.t-r-rules .row .v strong {
+  color: var(--ink-900);
+  font-weight: 500;
+}
+.t-r-rules .row .v code {
+  font-family: "Geist Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-900);
+}
+
+/* mini swatches inline with rules */
+.t-r-rules .sw {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 6px;
+}
+.t-r-rules .sw .box {
+  width: 24px;
+  height: 16px;
+  border: 1.5px dashed var(--ink-400);
+  background: var(--paper);
+}
+.t-r-rules .sw .box.solid {
+  border: 1px solid var(--ink-900);
+  background: #fff;
+}
+.t-r-rules .sw .box.dark {
+  border: 1px solid var(--ink-950);
+  background: var(--ink-950);
+}
+.t-r-rules .sw .lbl {
+  font-family: "Geist Mono", monospace;
+  font-size: 9.5px;
+  color: var(--ink-500);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* density meter */
+.t-r-rules .density {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 6px;
+}
+.t-r-rules .density .b {
+  width: 10px;
+  height: 5px;
+  background: var(--ink-300);
+}
+.t-r-rules .density .b.on {
+  background: var(--ink-900);
+}
+
+@media (max-width: 1100px) {
+  .t-r-stage {
+    grid-template-columns: 1fr;
+  }
+  .t-r-card {
+    min-height: 0;
+  }
+  .t-r-rules .hd,
+  .t-r-rules .row {
+    grid-template-columns: 1fr;
+  }
+  .t-r-rules .hd .c,
+  .t-r-rules .row .v,
+  .t-r-rules .row .rk {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+}

--- a/docs/design/claude-design-handoff-2026-05-18/README.md
+++ b/docs/design/claude-design-handoff-2026-05-18/README.md
@@ -1,0 +1,85 @@
+# Claude Design handoff · 2026-05-18
+
+A controlled-document folder that records what shipped in
+`feat/design-trust-surfaces-canon-v1` (PR opened against `main`).
+
+## What this folder contains
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This index. |
+| `implementation-inventory.md` | Per-file classification (A–E) of every artifact in the handoff. |
+
+## Wave scope
+
+| Item | Result |
+|------|--------|
+| Trust route group `(trust)` | 5 routes shipped — `/passport/[npi]`, `/verify/[receipt]`, `/replay`, `/receipt/[id]`, `/trust` |
+| Canonical CSS | `apps/web/styles/trust.css` ported verbatim from the handoff drop |
+| Shared primitives | `apps/web/components/trust/*` — 7 components |
+| Shared library | `apps/web/lib/trust/{types.ts,format.ts,demoData.ts}` |
+| Tests | 4 vitest suites — lineage order, demo disclaimers, copy safety, route render |
+| Demo banner | Required on every route. Literal copy: "Demo data — not a real credentialing decision." |
+| Live claims | **None**. No live signature verification, no live registry, no customer cohort, no SLA, no AES, no deletion receipt, no BAA, no HIPAA / SOC 2 / NCQA / HITRUST claim. |
+
+## Doctrine preserved
+
+1. **Reading order is binding.** Object → Ownership → checked_at → Channel → Replay → run_id. Encoded in `LINEAGE_READING_ORDER`; asserted by `trust-lineage-order.test.tsx`.
+2. **Ownership is explicit.** `subject` / `delegated` / `unbound` — three values, no default. `OwnershipBadge` renders each distinctly.
+3. **Degraded uses dashed border, never opacity.** `DegradedRow` emits `data-degraded={reason}` and explicitly sets `style={{ opacity: 1 }}` as a defensive guard. Asserted by `trust-surfaces-routing.test.tsx`.
+4. **Inverted dark surface is reserved for cryptographic planes.** Only `SignaturePanel` (and nested `ChainStrip` inside it) uses the `.t-sig` register; no other component adopts it.
+5. **No adverse findings = success, not failure.** Empty degraded lists and clean lineage do not render error chrome.
+6. **Mono / tabular numerals for every identifier.** The `<Mono>` primitive carries the `.mono` class which the CSS pins to Geist Mono with `font-variant-numeric: tabular-nums`.
+7. **Controlled-document headers.** `SurfaceHeader` and `SurfaceControlFooter` render the form / classification / effective / revision / controlled_by stripe above and below every route.
+8. **Signatures are visibly distinct.** The dark `.t-sig` register, the explicit `fixture:` prefix on every fingerprint, and the "design fixture · not a live registry" footer are all in the same component.
+
+## Routes & how to view them locally
+
+```bash
+# From the worktree:
+cd /private/tmp/vitalcv-design-trust-surfaces
+pnpm install --frozen-lockfile
+pnpm turbo build --filter='@vitalcv/trust-state' --filter='@vitalcv/shared'
+pnpm --filter @vitalcv/web dev
+
+# Then open:
+#   http://localhost:3030/passport/1346053246
+#   http://localhost:3030/verify/rcpt_demo_004
+#   http://localhost:3030/replay
+#   http://localhost:3030/receipt/rcpt_demo_004
+#   http://localhost:3030/trust
+```
+
+Or run via the Cloudflare tunnel operator (PR #377):
+
+```bash
+bash scripts/vitalcv-demo-operator.sh
+```
+
+## Truth contract — explicit non-claims
+
+This wave **does not claim**:
+
+- a real Cedar Health pilot or any named customer artifact
+- the N=47 / Q2 2026 cohort
+- live signature verification
+- offline re-verifiability
+- `did:web:vitalcv.health` registry continuity
+- ed25519 fingerprints, AES-256, deletion receipts, or SLAs
+- HIPAA, SOC 2, NCQA, HITRUST, or BAA-not-required
+- a credentialing decision of any kind
+
+Every demo fixture carries the canonical banner and a `DEMO · FIXTURE`
+classification stripe.
+
+## Sources read for this implementation
+
+- `/Users/christoler/vitalcv-web/styles/trust.css` — copied verbatim
+- `/Users/christoler/vitalcv-web/app/trust-canon/trust/page.tsx` — patterned after; ported to apps/web shape
+- `/Users/christoler/Library/CloudStorage/Dropbox/vitalcv (7)/primitives.jsx` — primitive vocabulary (Chip, Mono, SectionHeader)
+- `/Users/christoler/Library/CloudStorage/Dropbox/vitalcv (7)/{Visual Grammar Canon, Trust Primitives, Lineage Header, Lineage Row, Degraded State Semantics, Failure Taxonomy, Receipt Reading Doctrine, Replay Memory, Replay Chronology Topology, Trust State Register, Verifier Reading Mode, Institutional Receipt}.html` — design doctrine reference
+
+The Dropbox path was the handoff's location on this machine. The
+implementation read it as the source of truth for component shapes
+and copy. No file was copied into the repo without re-writing it
+under the truth-contract guards above.

--- a/docs/design/claude-design-handoff-2026-05-18/implementation-inventory.md
+++ b/docs/design/claude-design-handoff-2026-05-18/implementation-inventory.md
@@ -1,0 +1,70 @@
+# Claude Design handoff · implementation inventory
+
+Five-category classification per the brief:
+
+- **A — IMPLEMENT NOW**
+- **B — IMPLEMENT AFTER DEMO SPINE MERGES**
+- **C — REFERENCE ONLY**
+- **D — DO NOT IMPLEMENT AS FACTUAL CLAIM**
+- **E — DUPLICATE / SUPERSEDED**
+
+## Handoff source
+
+Located on this machine at:
+
+```
+/Users/christoler/vitalcv-web/                                          (partial implementation drop)
+/Users/christoler/Library/CloudStorage/Dropbox/vitalcv (7)/             (design source)
+```
+
+## Inventory
+
+| # | Source file | Category | Shipped target | Notes |
+|---|-------------|----------|----------------|-------|
+| 1 | `vitalcv-web/styles/trust.css` | **A** | `apps/web/styles/trust.css` | Verbatim. 1,702 lines. Fully scoped under `.trust-scope`. |
+| 2 | `vitalcv-web/app/trust-canon/trust/page.tsx` | **A** | `apps/web/app/trust-canon/trust/page.tsx` | Re-shaped to use the new TS primitive set. |
+| 3 | `Dropbox/primitives.jsx` | **A** | `apps/web/components/trust/primitives.tsx` | Rewritten as TS. The original used `window` globals and `Icon` from a sandbox shim; the port drops both. |
+| 4 | `Dropbox/Visual Grammar Canon.html` | **A** (as doctrine) | encoded in primitive class names + `LINEAGE_READING_ORDER` constant | Doctrine, not chrome. |
+| 5 | `Dropbox/Trust Primitives.html` | **A** | `apps/web/components/trust/{primitives,SurfaceHeader,LineageHeader,SignaturePanel,ChainStrip,FailureBanner,DegradedRow}.tsx` | Each primitive ported. |
+| 6 | `Dropbox/Lineage Header.html` + `Lineage Row.html` | **A** | `apps/web/components/trust/LineageHeader.tsx` | Reading-order constant + per-cell `data-cell` attrs. |
+| 7 | `Dropbox/Degraded State Semantics.html` | **A** | `apps/web/components/trust/DegradedRow.tsx` | Dashed-border contract; `data-degraded` attr; explicit `opacity:1` guard. |
+| 8 | `Dropbox/Failure Taxonomy.html` | **A** | `apps/web/components/trust/FailureBanner.tsx` + `FAILURE_MODES` data | A–E modes with refusal copy. |
+| 9 | `Dropbox/Trust State Register.html` + `Trust State Visual System.html` | **A** | `apps/web/app/trust-canon/trust/page.tsx` | Three-state stage + reading-order + ownership + failure modes + degraded + non-claims. |
+| 10 | `Dropbox/Verifier Reading Mode.html` + `Verifier Reading Runtime.html` | **A** | `apps/web/app/trust-canon/verify/[receipt]/page.tsx` | 30-second answer surface. Verdict bar uses safe compound copy only. |
+| 11 | `Dropbox/Institutional Receipt.html` + `Receipt Reading Doctrine.html` | **A** | `apps/web/app/trust-canon/receipt/[id]/page.tsx` | Inverted `.t-sig` cryptographic plane + `ChainStrip`. |
+| 12 | `Dropbox/Replay Memory.html` + `Replay Chronology Topology.html` + `Institutional Replay Ledger.html` | **A** | `apps/web/app/trust-canon/replay/page.tsx` | Chain strip + chronological nodes. No marketing copy. |
+| 13 | `Dropbox/Human Trust Surface.html` (passport view) | **A** | `apps/web/app/trust-canon/passport/[npi]/page.tsx` | Holder readiness preview. Renders the degraded-row list. |
+| 14 | `Dropbox/Verifier Continuity System.html`, `Verifier Trust Registry.html`, `Verifier Walkthrough.html` | **B** | (not shipped this wave) | Continuity / registry coupling requires live trust-state endpoints; defer until backend regression on `origin/main` (`replayEngine.ts` missing imports) is resolved. |
+| 15 | `Dropbox/Institutional Trust Canon.html` + `Institutional Trust Surface.html` + `Final Institutional Trust Surface.html` | **C — REFERENCE ONLY** | not ported as routes | Capstone documents the doctrine encoded across primitives + `/trust`. Re-shipping them as separate routes would be duplicate doctrine. |
+| 16 | `Dropbox/Trust State Transitions.html` | **C** | not ported | The transitions are state-machine doctrine; the runtime is enforced by `TrustState` + `ReplayState` types and the `t-stamp[data-state]` CSS, not by a dedicated route. |
+| 17 | `Dropbox/Clinician Activation.html` | **B** | (not shipped this wave) | Activation wave is its own surface family; depends on lead-capture (PR #369) and demo spine PRs. |
+| 18 | `Dropbox/PR-B Crypto Receipt Verifier Decision.html` + `PR-B Crypto Verifier Superseded.html` + `…v2.html` | **E — DUPLICATE / SUPERSEDED** | not ported | Superseded by the canonical Verifier Reading Mode (row 10). |
+| 19 | Cedar Health named pilot artifacts (referenced in Dropbox HTML copy) | **D — DO NOT IMPLEMENT AS FACTUAL CLAIM** | actively stripped | No file in this PR mentions Cedar Health. |
+| 20 | N=47 / Q2 2026 cohort numbers | **D** | actively stripped | No file in this PR claims a cohort size or quarter. |
+| 21 | `did:web:vitalcv.health` signer identity | **D** | rendered ONLY as a fixture string with sub-label "design fixture — not a live registry" | The CSS classes still exist; the data is fixture-only. |
+| 22 | ed25519 fingerprints | **D** | replaced with `fixture:demo-signer-a-not-a-real-key` | `SignaturePanel` carries a defensive check that any non-fixture-prefixed string is replaced. |
+| 23 | 5-minute SLA / AES-256 / 72-hour deletion / deletion receipt | **D** | not present | Truth-contract scan in `trust-copy-safety.test.ts` asserts absence. |
+| 24 | Pilot Intake / Why VitalCV / Employer Pipeline (HTML files in Dropbox) | **B** | deferred to `feat/design-demo-pilot-visual-grammar` (not in this PR) | Per brief: do not create that branch yet. |
+| 25 | `Dropbox/wave18-verify.jsx` + `wave23-verify-v2.jsx` (sandbox jsx) | **C** | referenced for verdict-bar shape | Used as design source for the `VerdictBar` component; not directly ported. |
+| 26 | emergency Vercel / Cloudflare docs (PRs #376, #377) | C — kept separate | not part of trust surfaces | Lives outside `(trust)` group. |
+
+## Wave gating
+
+| Gate | Status |
+|------|--------|
+| Trust surfaces canon (this PR) | shipped |
+| Demo-spine routes (PR #368) | open / not merged |
+| Lead capture (PR #369) | open / not merged |
+| Audit-event visibility (PR #371) | open / not merged |
+| Wallet-sdk unblocker (PR #375) | open / not merged — but real Web Quality blocker is the unrelated `replayEngine.ts` regression on `origin/main` |
+| `feat/design-demo-pilot-visual-grammar` | **not created** per brief |
+
+## What this wave intentionally did NOT do
+
+- did not touch product runtime code outside the new `(trust)` group
+- did not modify Prisma schema, env vars, DNS, Vercel, or any paid service
+- did not add any new npm dependency
+- did not introduce a new package
+- did not revive Apply-with-VitalCV
+- did not produce factual customer claims, factual SLA claims, or factual security certifications
+- did not break or modify the existing `apps/web/app/trust/page.tsx` doctrine page (which lives outside the `(trust)` route group)


### PR DESCRIPTION
Implements the Claude Design trust-surface canon as scoped demo/fixture trust routes with copy-safety guards, no production/DNS/Vercel/Prisma mutation, no unsupported customer/security claims, and no bare Verified labels.