### PR TITLE
fix(prisma): normalize backend namespace contracts

### DIFF
--- a/apps/api/backend/prisma/identityWaveSeedFixtures.ts
+++ b/apps/api/backend/prisma/identityWaveSeedFixtures.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import type { Prisma } from '@prisma/client'
 import prisma from '../src/graphql/prisma_client'
 import type { NormalizedClaim, VerificationReceipt } from '../src/services/identity/evidenceModel'
 import { buildIdentitySummary } from '../src/services/identity/evidenceModel'
@@ -216,7 +217,7 @@ export async function seedIdentityWaveFixtures(): Promise<{ seededRunCount: numb
         fixture: true,
         _claims: [identityClaim, specialtyClaim],
         _receipts: [receipts[0]],
-      },
+      } as unknown as Prisma.InputJsonValue,
       checksum: nppesChecksum,
       verifiedAt: new Date(observedAt),
     },
@@ -244,7 +245,7 @@ export async function seedIdentityWaveFixtures(): Promise<{ seededRunCount: numb
         fixture: true,
         _claims: [exclusionClaim],
         _receipts: [receipts[1]],
-      },
+      } as unknown as Prisma.InputJsonValue,
       checksum: oigChecksum,
       verifiedAt: new Date(observedAt),
     },
@@ -259,7 +260,7 @@ export async function seedIdentityWaveFixtures(): Promise<{ seededRunCount: numb
         verificationArtifactId: claim.artifactId,
         subjectNpi: claim.subjectNpi,
         claimType: claim.claimType,
-        value: claim.value,
+        value: claim.value as unknown as Prisma.InputJsonValue,
         trustTier: claim.tier,
         confidenceLabel: claim.confidence,
         confidenceScore: claim.confidenceScore,
@@ -290,7 +291,7 @@ export async function seedIdentityWaveFixtures(): Promise<{ seededRunCount: numb
         subjectNpi: '1992992991',
         entityId: receipt.entity_id,
         field: receipt.field,
-        value: receipt.value,
+        value: receipt.value as Prisma.InputJsonValue,
         trustTier: receipt.tier,
         confidence: receipt.confidence,
         sourceArtifactId: receipt.source_artifact_id,
@@ -323,7 +324,7 @@ export async function seedIdentityWaveFixtures(): Promise<{ seededRunCount: numb
         claimRefs: claims.map((claim) => claim.claimId),
         sourceRecordIds: [sourceRecord.id],
         summary,
-      },
+      } as unknown as Prisma.InputJsonValue,
       checksum: hex({ summary, claims: claims.map((claim) => claim.claimId) }),
       verifiedAt: new Date(observedAt),
       observedAt: new Date(observedAt),


### PR DESCRIPTION
## Mission

Prisma substrate-hardening stabilization wave. Eliminate canonical Prisma namespace/type fragmentation in the backend without schema redesign, refactor, or surface-area sweep.

## Forensic baseline

Backend production `tsc --noEmit` (apps/api/backend/tsconfig.json):

| Category | Count | Notes |
|---|---|---|
| TS2694 (cannot use namespace as value) | **0** | |
| TS2305 (no exported member) | **0** | |
| TS2339 (property does not exist) | **0** | |
| TS2307 (module not found) | 6 | Non-Prisma; owned by `fix/replay-engine-ci-regression` |
| TS7006 (implicit any) | 1 | Non-Prisma |
| **Total** | **7** | None Prisma-related |

Backend seed `tsc --noEmit` (apps/api/backend/tsconfig.seed.json):

| Category | Before | After | Delta |
|---|---|---|---|
| TS2322 (Prisma.InputJsonValue assignability) | 5 | **0** | -5 |
| TS6059 (rootDir violation, non-Prisma) | 19 | 19 | 0 |
| **Total** | **24** | **19** | **-5** |

Full unscoped backend scan: 36 → 31 errors. All 5 collapsed errors are Prisma JSON assignability sites; no new errors introduced.

## Import landscape (136 files)

```
  28  import { PrismaClient } from '@prisma/client'
  27  import type { Prisma } from '@prisma/client'
  20  import { Prisma } from '@prisma/client'
  17  import { Prisma, type PrismaClient } from '@prisma/client'
  14  import type { PrismaClient } from '@prisma/client'
  ... long tail of model-name imports
```

Audit of all 33 type-only Prisma imports: **0** files reference Prisma runtime values (`DbNull`/`JsonNull`/`skip`/`validator`/`raw`/`sql`). No erased-namespace foot-guns.

## Canonical import convention (decision)

- `import type { Prisma } from '@prisma/client'` when only Prisma types are referenced (preferred — `isolatedModules`-safe, fully erased at compile time).
- `import { Prisma } from '@prisma/client'` only when a runtime member (`DbNull`, `JsonNull`, `skip`, `validator`, `raw`, `sql`) is used.
- `PrismaClient` is type-imported (`import type`) unless the file constructs the client.

This convention matches the dominant existing pattern (44 of 136 files already conform). No mass-rewrite — existing files are correct as-is; new code follows the rule.

## Duplicate / stale generated clients

Three Prisma schemas exist, one per app, with distinct generator outputs and disjoint runtime scope:

| App | Output | Notes |
|---|---|---|
| `apps/api/backend` | default (node_modules) | Backend runtime |
| `apps/web` | `apps/web/lib/generated/prisma` | Server components |
| `apps/marketing` | `apps/marketing/generated/prisma` | Marketing CMS |

No duplicate output dirs. No nested generated clients. No package-boundary leakage — `find packages/ -name package.json | xargs grep '@prisma/client'` returns **zero** packages depending on Prisma. Backend is the sole consumer of its generator output. The `scripts/prisma-generate-locked.sh` advisory lock prevents concurrent-generate corruption across worktrees.

## Stabilization layer

**None required.** No barrel, no adapter, no compat aliases. The substrate is structurally sound; the fragmentation premise is not borne out by the forensic baseline. A barrel would be speculative architecture for a problem that does not exist.

## Files changed

- `apps/api/backend/prisma/identityWaveSeedFixtures.ts` (+6 / -5)
  - Add `import type { Prisma } from '@prisma/client'` (canonical type-only)
  - 3× `rawPayload: { ... } as unknown as Prisma.InputJsonValue` casts
  - 1× `value: claim.value as unknown as Prisma.InputJsonValue`
  - 1× `value: receipt.value as Prisma.InputJsonValue`

Cast rationale: the seed fixture builds JSON-column payloads from domain structural types (`NormalizedClaim`, `VerificationReceipt`, `ClaimValue`, `CanonicalIdentitySummary`). At the persistence boundary these are JSON-serializable by construction, but TypeScript cannot prove `JsonSerializable` from a closed nominal type. The cast is the documented Prisma pattern for this exact situation (see https://github.com/prisma/prisma/issues/9247).

## Error reduction metrics

| Surface | Before | After | Delta |
|---|---|---|---|
| Backend production tsc | 7 | 7 | 0 (no regression; all pre-existing TS2307 owned elsewhere) |
| Backend seed tsc | 24 | 19 | **-5** |
| Backend full unscoped scan | 36 | 31 | **-5** |
| Prisma-namespace errors anywhere | 5 | **0** | **-5** |

## Remaining instability classes (not in scope)

1. **TS2307 missing modules in backend production tsc** (6 errors): owned by `fix/replay-engine-ci-regression` — `runtimeTrustCohesion`, `loadDotenv`, `replayCorruptionContainment`, `confidenceCalibration`, `tenantIsolation`. That branch's diff already creates the missing files.
2. **TS6059 rootDir violations in seed tsc** (19): seed pulls `src/*` which transitively imports `core/*` and `@vitalcv/trust-state` (outside seed rootDir). Architectural — not a Prisma contract issue.
3. **Other TS2322/2353/2551 in unscoped scan** (~20): all in `exclude`-listed files (`employerActions.ts`, `passportService.ts`, etc.) — known excluded surface, owned by their respective feature waves.

## CI fleet impact

Combined with `fix/replay-engine-ci-regression`:

- Backend production `tsc --noEmit` will compile cleanly (7 TS2307s resolved by replay-engine branch, 0 Prisma errors blocking).
- `pnpm seed` workflow type-checks the Prisma-contract portion of `identityWaveSeedFixtures.ts` (5 TS2322 → 0). Remaining 19 TS6059 are pre-existing rootDir hygiene, unblocking when seed tsconfig is hardened.
- Deterministic backend CI is restored modulo replay-engine merge.

## Scope discipline

Why not normalize all 136 import sites? The mission explicitly forbids "while I'm here" cleanup and refactor sweeps. Audit confirmed every existing `import type { Prisma }` site is structurally correct (no runtime-value misuse). Mass-rewriting cosmetic style differences would:
- Touch 100+ files for zero error-reduction
- Generate large diff noise blocking review
- Risk regressing files whose existing imports are intentional

Convention is documented for new code. Existing code is correct.

## Truth-contract grep

```
git diff apps/api/backend/prisma/identityWaveSeedFixtures.ts | grep -E "automatically verified|guaranteed verification|complete credentialing|instant credentialing|legally accepted|risk transferred|final verification without review|source confirmed before response|certified compliant|HIPAA compliant|SOC2 certified"
# → no matches
```

No banned strings introduced. No new compliance claims, crypto semantics, or guarantee language.

## Test plan
- [ ] Confirm backend `pnpm exec tsc --noEmit` baseline unchanged (7 errors, all TS2307/TS7006).
- [ ] Confirm seed tsconfig drops 5 Prisma TS2322 errors.
- [ ] Confirm `pnpm install --frozen-lockfile` + `prisma generate` succeeds.
- [ ] Confirm `pnpm lint` passes (FULL TURBO cache hit).
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)