### PR TITLE
feat(trust): canonicalize institutional trust primitives

### DIFF
--- a/apps/web/__tests__/institutional-trust-primitives.test.tsx
+++ b/apps/web/__tests__/institutional-trust-primitives.test.tsx
@@ -1,0 +1,415 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  LINEAGE_SLOT_ORDER,
+  composeLineage,
+  READING_ORDER_CAPTION,
+  type LineageSlots,
+} from '@/lib/trust/replay-grammar';
+import {
+  describeFailureMode,
+  describeDegradation,
+  visualForDegradation,
+  allFailureModes,
+  type DegradationState,
+  type FailureMode,
+} from '@/lib/trust/degradation';
+import {
+  BANNED_INSTITUTIONAL_PHRASES,
+  INSTITUTIONAL_PHRASES,
+  OWNERSHIP_LABELS,
+  TIER_LABELS,
+  findBannedInstitutionalPhrases,
+  READING_ORDER_LABELS,
+} from '@/lib/trust/institutional-language';
+import {
+  LineageHeader,
+  LineageRow,
+  ReplayTimeline,
+  DegradedStatePanel,
+  FailureTaxonomyBadge,
+  OwnershipStateBadge,
+  TierBadge,
+  CheckedAtStamp,
+  HumanReviewLane,
+  RevocationStateBanner,
+} from '@/components/trust/primitives';
+
+function buildSampleLineage(): LineageSlots {
+  return composeLineage({
+    object: { label: 'Object', value: 'Provider passport · NPI 1356428912' },
+    ownership: { label: 'Ownership', value: 'Subject' },
+    checkedAt: {
+      label: 'checked_at',
+      value: '2026-05-12T14:31:58Z',
+      subLabel: '10 s ago',
+    },
+    channel: { label: 'Channel', value: 'verify.vitalcv.health' },
+    replay: { label: 'Replay', value: 'anchored' },
+    runId: { label: 'run_id', value: '7a2c…b8d3', subLabel: 'batch · committed' },
+  });
+}
+
+describe('replay grammar · reading-order contract', () => {
+  it('binds OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID', () => {
+    expect(LINEAGE_SLOT_ORDER).toEqual([
+      'object',
+      'ownership',
+      'checkedAt',
+      'channel',
+      'replay',
+      'runId',
+    ]);
+  });
+
+  it('composes a lineage in canonical order regardless of input order', () => {
+    const slots = composeLineage({
+      runId: { label: 'run_id', value: 'r' },
+      replay: { label: 'Replay', value: 'r' },
+      channel: { label: 'Channel', value: 'c' },
+      checkedAt: { label: 'checked_at', value: 't' },
+      ownership: { label: 'Ownership', value: 'o' },
+      object: { label: 'Object', value: 'x' },
+    });
+    expect(slots.map((s) => s.key)).toEqual([
+      'object',
+      'ownership',
+      'checkedAt',
+      'channel',
+      'replay',
+      'runId',
+    ]);
+  });
+
+  it('caption rail uses the binding string', () => {
+    expect(READING_ORDER_CAPTION).toBe(
+      'object → ownership → checked_at → channel → replay → run_id',
+    );
+  });
+});
+
+describe('failure taxonomy · five non-confusable modes', () => {
+  it.each<FailureMode>(['A', 'B', 'C', 'D', 'E'])(
+    'mode %s has owner + cause + action + plane + severity',
+    (mode) => {
+      const d = describeFailureMode(mode);
+      expect(d.mode).toBe(mode);
+      expect(d.owner.length).toBeGreaterThan(0);
+      expect(d.cause.length).toBeGreaterThan(0);
+      expect(d.action.length).toBeGreaterThan(0);
+      expect(d.plane).toMatch(/^(upstream|policy|verifier|subject|issuer)$/);
+      expect(d.severity).toMatch(/^S[0-4]$/);
+    },
+  );
+
+  it('mode D is the only success', () => {
+    expect(describeFailureMode('D').isSuccess).toBe(true);
+    expect(describeFailureMode('A').isSuccess).toBe(false);
+    expect(describeFailureMode('B').isSuccess).toBe(false);
+    expect(describeFailureMode('C').isSuccess).toBe(false);
+    expect(describeFailureMode('E').isSuccess).toBe(false);
+  });
+
+  it('mode D copy is "no adverse findings", never bare "no findings"', () => {
+    const d = describeFailureMode('D');
+    expect(d.title.toLowerCase()).toBe('no adverse findings');
+  });
+
+  it('every plane is owned by exactly one mode for S1–S4 distinctness', () => {
+    const planes = allFailureModes().map((d) => d.plane);
+    expect(new Set(planes).size).toBe(planes.length);
+  });
+});
+
+describe('degradation grammar · visual non-alarmist semantics', () => {
+  const states: DegradationState[] = [
+    'fresh',
+    'degraded',
+    'stale',
+    'revoked',
+    'interrupted',
+    'pending_human_review',
+    'unverifiable',
+    'continuity_mismatch',
+  ];
+
+  it.each(states)('state %s renders non-alarmist copy', (state) => {
+    const copy = describeDegradation(state);
+    expect(copy.alarmist).toBe(false);
+    expect(copy.headline.length).toBeGreaterThan(0);
+    expect(copy.detail.length).toBeGreaterThan(0);
+  });
+
+  it('maps each state to a visual-grammar token', () => {
+    expect(visualForDegradation('fresh')).toBe('continuous');
+    expect(visualForDegradation('degraded')).toBe('dashed');
+    expect(visualForDegradation('stale')).toBe('dashed');
+    expect(visualForDegradation('revoked')).toBe('hard_interruption');
+    expect(visualForDegradation('interrupted')).toBe('hard_interruption');
+    expect(visualForDegradation('pending_human_review')).toBe('manual_lane');
+    expect(visualForDegradation('unverifiable')).toBe('dashed');
+    expect(visualForDegradation('continuity_mismatch')).toBe(
+      'hard_interruption',
+    );
+  });
+});
+
+describe('canonical operational language', () => {
+  it('exposes phrase constants', () => {
+    expect(INSTITUTIONAL_PHRASES.institutionOwned).toBe(
+      'Institution-owned workflow',
+    );
+    expect(INSTITUTIONAL_PHRASES.affirmativeNegative).toBe(
+      'No adverse findings',
+    );
+  });
+
+  it('reading-order labels match the canonical primitives §00 spec', () => {
+    expect(READING_ORDER_LABELS).toEqual({
+      object: 'Object',
+      ownership: 'Ownership',
+      checkedAt: 'checked_at',
+      channel: 'Channel',
+      replay: 'Replay',
+      runId: 'run_id',
+    });
+  });
+
+  it('ownership labels are the three fixed values; "anonymous" and "guest" are absent', () => {
+    expect(Object.keys(OWNERSHIP_LABELS).sort()).toEqual([
+      'delegated',
+      'subject',
+      'unbound',
+    ]);
+    expect(Object.values(OWNERSHIP_LABELS).join(' ').toLowerCase()).not.toMatch(
+      /anonymous|guest/,
+    );
+  });
+
+  it('tier labels are the four fixed values; T5 is absent', () => {
+    expect(Object.keys(TIER_LABELS).sort()).toEqual(['T1', 'T2', 'T3', 'T4']);
+  });
+
+  it('clean copy passes the banned-phrase guard', () => {
+    expect(
+      findBannedInstitutionalPhrases('Source-confirmed at checked_at.'),
+    ).toEqual([]);
+  });
+
+  it('banned phrase guard flags every banned token', () => {
+    for (const token of BANNED_INSTITUTIONAL_PHRASES) {
+      const hits = findBannedInstitutionalPhrases(
+        `prefix ${token} suffix · institutional`,
+      );
+      expect(hits).toContain(token);
+    }
+  });
+});
+
+describe('primitive render isolation · server-renderable, no globals', () => {
+  it('LineageHeader renders the six-cell reading order', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(LineageHeader, {
+        slots: buildSampleLineage(),
+        state: 'signed',
+      }),
+    );
+    expect(html).toContain('data-slot="lineage-header"');
+    expect(html).toContain('data-state="signed"');
+    for (const slotKey of LINEAGE_SLOT_ORDER) {
+      expect(html).toContain(READING_ORDER_LABELS[slotKey]);
+    }
+  });
+
+  it('LineageRow encodes all six row primitives + tier + signed', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(LineageRow, {
+        claim: 'CA medical license',
+        subject: 'subj · npi 1356428912',
+        source: 'CA Medical Board',
+        sourceState: 'live · ca-pa registry',
+        checkedAtIso: '2026-05-12T14:31:58Z',
+        checkedAtRelative: '10 s ago',
+        ownership: 'subject',
+        replay: 'Anchored',
+        tier: 'T3',
+        signed: true,
+        runId: '7a2c…b8d3',
+        rowState: 'signed',
+      }),
+    );
+    expect(html).toContain('CA medical license');
+    expect(html).toContain('data-slot="lineage-row"');
+    expect(html).toContain('data-slot="ownership-badge"');
+    expect(html).toContain('data-slot="tier-badge"');
+    expect(html).toContain('data-tier="T3"');
+    expect(html).toContain('Signed · ed25519');
+  });
+
+  it('DegradedStatePanel renders mode + plane + owner + action', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DegradedStatePanel, {
+        mode: 'A',
+        incidentId: 'pecos-p95-5.8s',
+      }),
+    );
+    expect(html).toContain('data-slot="degraded-state-panel"');
+    expect(html).toContain('data-mode="A"');
+    expect(html).toContain('Source unreachable');
+    expect(html).toContain('Upstream registry');
+  });
+
+  it('Mode D panel marks itself as success', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DegradedStatePanel, { mode: 'D' }),
+    );
+    expect(html).toContain('data-success="true"');
+    expect(html).toContain('No adverse findings');
+  });
+
+  it('FailureTaxonomyBadge renders Mode + plane', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(FailureTaxonomyBadge, { mode: 'C' }),
+    );
+    expect(html).toContain('Mode C');
+    expect(html).toContain('verifier');
+  });
+
+  it('OwnershipStateBadge renders only the three fixed values', () => {
+    for (const state of ['subject', 'delegated', 'unbound'] as const) {
+      const html = renderToStaticMarkup(
+        React.createElement(OwnershipStateBadge, { state }),
+      );
+      expect(html).toContain(`data-ownership="${state}"`);
+    }
+  });
+
+  it('TierBadge renders T1–T4', () => {
+    for (const tier of ['T1', 'T2', 'T3', 'T4'] as const) {
+      const html = renderToStaticMarkup(
+        React.createElement(TierBadge, { tier }),
+      );
+      expect(html).toContain(`data-tier="${tier}"`);
+      expect(html).toContain(tier);
+    }
+  });
+
+  it('CheckedAtStamp renders ISO + relative; degraded adds dashed border', () => {
+    const fresh = renderToStaticMarkup(
+      React.createElement(CheckedAtStamp, {
+        iso: '2026-05-12T14:31:58Z',
+        relative: '10 s ago',
+      }),
+    );
+    expect(fresh).toContain('2026-05-12T14:31:58Z');
+    expect(fresh).toContain('10 s ago');
+    expect(fresh).not.toContain('data-degraded');
+    const degraded = renderToStaticMarkup(
+      React.createElement(CheckedAtStamp, {
+        iso: '2026-05-12T14:29:14Z',
+        relative: '2 m 54 s ago · upstream degraded',
+        degraded: true,
+      }),
+    );
+    expect(degraded).toContain('data-degraded="true"');
+    expect(degraded).toContain('border-dashed');
+  });
+
+  it('ReplayTimeline renders nodes head-first with arrows', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ReplayTimeline, {
+        nodes: [
+          { hash: '7a2c…b8d3', caption: 'head' },
+          { hash: '9d11…3e4a' },
+          { gap: true, hash: '' },
+          { hash: '4b00…f1c2' },
+        ],
+        tone: 'inverted',
+      }),
+    );
+    expect(html).toContain('data-slot="replay-timeline"');
+    expect(html).toContain('data-tone="inverted"');
+    expect(html).toContain('— gap —');
+    expect(html).toContain('7a2c…b8d3');
+  });
+
+  it('HumanReviewLane labels operator + reviewedAt', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        HumanReviewLane,
+        {
+          operator: 'VitalCV CVO desk · M. Patel',
+          reviewedAtIso: '2026-05-12T14:31:58Z',
+          caseRef: 'case-481',
+        },
+        React.createElement('p', null, 'body'),
+      ),
+    );
+    expect(html).toContain('Human-reviewed');
+    expect(html).toContain('M. Patel');
+    expect(html).toContain('case-481');
+    expect(html).toContain('body');
+  });
+
+  it('RevocationStateBanner is a hard interruption, not soft stale', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(RevocationStateBanner, {
+        statusListIndex: 481,
+        revokedAtIso: '2026-05-12T14:31:58Z',
+        reason: 'issuer rotation · key 4f2a retired',
+      }),
+    );
+    expect(html).toContain('Credential revoked');
+    expect(html).toContain('StatusList2021');
+    expect(html).toContain('idx 481');
+    expect(html).toContain('issuer rotation · key 4f2a retired');
+    expect(html).toContain('role="alert"');
+  });
+});
+
+describe('truth-contract · touched files do not introduce banned phrases', () => {
+  const TOUCHED_FILES = [
+    'apps/web/lib/trust/replay-grammar.ts',
+    'apps/web/lib/trust/degradation.ts',
+    'apps/web/lib/trust/institutional-language.ts',
+    'apps/web/components/trust/primitives/LineageHeader.tsx',
+    'apps/web/components/trust/primitives/LineageRow.tsx',
+    'apps/web/components/trust/primitives/TrustReceipt.tsx',
+    'apps/web/components/trust/primitives/ReplayTimeline.tsx',
+    'apps/web/components/trust/primitives/DegradedStatePanel.tsx',
+    'apps/web/components/trust/primitives/FailureTaxonomyBadge.tsx',
+    'apps/web/components/trust/primitives/OwnershipStateBadge.tsx',
+    'apps/web/components/trust/primitives/TierBadge.tsx',
+    'apps/web/components/trust/primitives/CheckedAtStamp.tsx',
+    'apps/web/components/trust/primitives/HumanReviewLane.tsx',
+    'apps/web/components/trust/primitives/RevocationStateBanner.tsx',
+    'apps/web/components/trust/primitives/index.ts',
+  ];
+
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+  // Strip block comments, line comments, and the canonical banned-list
+  // declaration before scanning. References to banned phrases inside
+  // JSDoc or rule-documentation comments are not usage sites — they are
+  // the canon declaring what is banned.
+  function stripDeclarativeMatter(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '')
+      .replace(
+        /BANNED_INSTITUTIONAL_PHRASES[\s\S]*?\] as const;/,
+        'BANNED_INSTITUTIONAL_PHRASES_REDACTED_FOR_TEST',
+      );
+  }
+
+  it.each(TOUCHED_FILES)('%s contains no banned institutional phrases', (rel) => {
+    const abs = path.join(repoRoot, rel);
+    const src = fs.readFileSync(abs, 'utf8');
+    const hits = findBannedInstitutionalPhrases(stripDeclarativeMatter(src));
+    expect(hits).toEqual([]);
+  });
+});

--- a/apps/web/components/trust/primitives/CheckedAtStamp.tsx
+++ b/apps/web/components/trust/primitives/CheckedAtStamp.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * checked_at — when the source-of-record was consulted.
+ *
+ * Source: Trust Primitives.html §07. Always ISO 8601 UTC plus relative
+ * age — never one without the other. Stale facts remain equally legible:
+ * degradation marks the border, not the text. The relative line uses
+ * institutional verbs (ago, last refresh, since rotate); never "just now".
+ */
+export interface CheckedAtStampProps {
+  /** ISO 8601 timestamp (UTC). Use `null` for unconsulted preview state. */
+  iso: string | null;
+  /** Relative age string ("10 s ago", "2 m 54 s ago", etc). */
+  relative: string;
+  /** When true, renders a dashed left border (mode-A defer pattern). */
+  degraded?: boolean;
+  className?: string;
+}
+
+export function CheckedAtStamp({
+  iso,
+  relative,
+  degraded = false,
+  className,
+}: CheckedAtStampProps) {
+  return (
+    <div
+      data-slot="checked-at"
+      data-degraded={degraded ? 'true' : undefined}
+      className={cn(
+        'pl-2 font-mono text-xs tabular-nums',
+        degraded && 'border-l-2 border-dashed border-amber-400',
+        className,
+      )}
+    >
+      <div className="text-slate-900">{iso ?? '—'}</div>
+      <div className="text-slate-600">{relative}</div>
+    </div>
+  );
+}

--- a/apps/web/components/trust/primitives/DegradedStatePanel.tsx
+++ b/apps/web/components/trust/primitives/DegradedStatePanel.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  describeFailureMode,
+  type FailureMode,
+} from '@/lib/trust/degradation';
+import { FailureTaxonomyBadge } from './FailureTaxonomyBadge';
+
+/**
+ * Surfaces a single failure mode at surface or claim level.
+ *
+ * Source: Trust Primitives.html §05 · Failure Taxonomy.html ·
+ * Degraded State Semantics.html. Mode D is success — solid border.
+ * Modes C and E reserve the dark fill for VitalCV-side and signing-plane
+ * respectively.
+ */
+export interface DegradedStatePanelProps {
+  mode: FailureMode;
+  /** Optional incident or evidence id rendered into the panel rail. */
+  incidentId?: string;
+  /** Optional CTA element rendered in the action slot. */
+  action?: React.ReactNode;
+  className?: string;
+}
+
+const PANEL_FRAME: Record<FailureMode, string> = {
+  A: 'border border-dashed border-slate-400 bg-amber-50/30 text-slate-900',
+  B: 'border border-solid border-slate-400 bg-slate-50 text-slate-800',
+  C: 'border border-solid border-slate-900 bg-slate-900 text-slate-50',
+  D: 'border-2 border-solid border-slate-900 bg-white text-slate-900',
+  E: 'border border-solid border-slate-950 bg-slate-950 text-slate-50',
+};
+
+export function DegradedStatePanel({
+  mode,
+  incidentId,
+  action,
+  className,
+}: DegradedStatePanelProps) {
+  const descriptor = describeFailureMode(mode);
+  return (
+    <section
+      data-slot="degraded-state-panel"
+      data-mode={mode}
+      data-success={descriptor.isSuccess ? 'true' : undefined}
+      className={cn('rounded-2xl p-4 text-sm', PANEL_FRAME[mode], className)}
+    >
+      <header className="flex items-center justify-between gap-3">
+        <FailureTaxonomyBadge mode={mode} />
+        <div className="font-mono text-[10px] uppercase tracking-wider opacity-70">
+          {descriptor.severity} · {descriptor.sigmaState}
+        </div>
+      </header>
+      <h3 className="mt-3 text-base font-semibold">{descriptor.title}</h3>
+      <p className="mt-1 text-sm opacity-90">{descriptor.cause}</p>
+      <dl className="mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+        <div>
+          <dt className="font-mono uppercase tracking-wider opacity-70">
+            Owner
+          </dt>
+          <dd>{descriptor.owner}</dd>
+        </div>
+        <div>
+          <dt className="font-mono uppercase tracking-wider opacity-70">
+            User sees
+          </dt>
+          <dd>{descriptor.userSees}</dd>
+        </div>
+        <div>
+          <dt className="font-mono uppercase tracking-wider opacity-70">
+            Action
+          </dt>
+          <dd>{descriptor.action}</dd>
+        </div>
+        <div>
+          <dt className="font-mono uppercase tracking-wider opacity-70">
+            Recovers
+          </dt>
+          <dd>{descriptor.recovers}</dd>
+        </div>
+      </dl>
+      {(incidentId || action) && (
+        <footer className="mt-3 flex items-center justify-between gap-3 border-t border-current/20 pt-3 font-mono text-xs">
+          <span className="opacity-70">
+            {incidentId ? `incident · ${incidentId}` : ''}
+          </span>
+          {action}
+        </footer>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/trust/primitives/FailureTaxonomyBadge.tsx
+++ b/apps/web/components/trust/primitives/FailureTaxonomyBadge.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  describeFailureMode,
+  type FailureMode,
+} from '@/lib/trust/degradation';
+
+/**
+ * Five-letter failure-mode chip.
+ *
+ * Source: Trust Primitives.html §05 · Failure Taxonomy.html. Five
+ * non-confusable modes; never yellow/orange/red; never collapsed to
+ * "error". Mode D is success, not failure.
+ */
+export interface FailureTaxonomyBadgeProps {
+  mode: FailureMode;
+  className?: string;
+}
+
+const MODE_FILL: Record<FailureMode, string> = {
+  A: 'border-dashed border-slate-400 bg-amber-50 text-slate-800',
+  B: 'border-solid border-slate-400 bg-slate-50 text-slate-700',
+  C: 'border-solid border-slate-900 bg-slate-900 text-slate-50',
+  D: 'border-solid border-slate-900 bg-white text-slate-900',
+  E: 'border-solid border-slate-950 bg-slate-950 text-slate-50',
+};
+
+export function FailureTaxonomyBadge({
+  mode,
+  className,
+}: FailureTaxonomyBadgeProps) {
+  const descriptor = describeFailureMode(mode);
+  return (
+    <span
+      data-slot="failure-mode-badge"
+      data-mode={mode}
+      data-plane={descriptor.plane}
+      title={`${descriptor.title} · ${descriptor.plane}`}
+      className={cn(
+        'inline-flex items-center gap-1 border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider',
+        MODE_FILL[mode],
+        className,
+      )}
+    >
+      <span>Mode {mode}</span>
+      <span className="opacity-70">· {descriptor.plane}</span>
+    </span>
+  );
+}

--- a/apps/web/components/trust/primitives/HumanReviewLane.tsx
+++ b/apps/web/components/trust/primitives/HumanReviewLane.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Manual-operator lane wrapper.
+ *
+ * Source: Human Trust Surface.html. A human review lane is institutional
+ * chrome wrapped around content that an operator co-signed. The lane
+ * visibly names the operator and the time they signed; the chrome makes
+ * it impossible to confuse with an automatic source-check.
+ */
+export interface HumanReviewLaneProps {
+  /** Operator name or DID (e.g. "VitalCV CVO desk · M. Patel"). */
+  operator: string;
+  /** ISO 8601 timestamp the operator co-signed. */
+  reviewedAtIso: string;
+  /** Optional case / ticket reference. */
+  caseRef?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function HumanReviewLane({
+  operator,
+  reviewedAtIso,
+  caseRef,
+  children,
+  className,
+}: HumanReviewLaneProps) {
+  return (
+    <section
+      data-slot="human-review-lane"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-800 bg-white',
+        className,
+      )}
+    >
+      <header className="flex flex-wrap items-baseline justify-between gap-3 border-b border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[11px] uppercase tracking-wider text-slate-700">
+        <span>Human-reviewed · operator lane</span>
+        <span>
+          {operator} · {reviewedAtIso}
+          {caseRef ? ` · ${caseRef}` : ''}
+        </span>
+      </header>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/components/trust/primitives/LineageHeader.tsx
+++ b/apps/web/components/trust/primitives/LineageHeader.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  READING_ORDER_CAPTION,
+  type LineageSlots,
+  type LineageTrustState,
+} from '@/lib/trust/replay-grammar';
+import { READING_ORDER_LABELS } from '@/lib/trust/institutional-language';
+
+/**
+ * Canonical six-cell trust header.
+ *
+ * Source: Lineage Header.html · Trust Primitives.html §01.
+ * Renders the mandatory reading order:
+ *   OBJECT → OWNERSHIP → checked_at → CHANNEL → REPLAY → run_id
+ *
+ * The caption rail is institutional, not decorative — it names the
+ * contract the cells satisfy.
+ */
+export interface LineageHeaderProps {
+  slots: LineageSlots;
+  state: LineageTrustState;
+  className?: string;
+}
+
+const STATE_FRAME: Record<LineageTrustState, string> = {
+  preview: 'border-dashed border-slate-400 bg-amber-50/40',
+  snapshot: 'border-solid border-slate-700 bg-white',
+  signed: 'border-solid border-slate-950 bg-slate-950 text-slate-100',
+};
+
+const STATE_CAP: Record<LineageTrustState, string> = {
+  preview: 'bg-amber-50 text-slate-700 border-slate-300',
+  snapshot: 'bg-slate-50 text-slate-800 border-slate-700',
+  signed: 'bg-slate-900 text-slate-100 border-slate-700',
+};
+
+export function LineageHeader({ slots, state, className }: LineageHeaderProps) {
+  return (
+    <section
+      data-slot="lineage-header"
+      data-state={state}
+      className={cn(
+        'rounded-2xl border text-sm',
+        STATE_FRAME[state],
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          'flex items-center justify-between gap-3 border-b px-4 py-2 font-mono text-xs uppercase tracking-wider',
+          STATE_CAP[state],
+        )}
+      >
+        <span>Lineage · {READING_ORDER_CAPTION}</span>
+        <span>state · {state}</span>
+      </div>
+      <ol
+        className="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0 lg:grid-cols-6"
+      >
+        {slots.map((slot) => (
+          <li
+            key={slot.key}
+            data-degraded={slot.degraded ? 'true' : undefined}
+            className={cn(
+              'px-4 py-3',
+              slot.degraded && 'border-l-2 border-dashed border-amber-400',
+            )}
+          >
+            <div className="font-mono text-[10px] uppercase tracking-wider opacity-70">
+              {READING_ORDER_LABELS[slot.key]}
+            </div>
+            <div className="mt-1 font-mono text-sm break-words">
+              {slot.value}
+            </div>
+            {slot.subLabel ? (
+              <div className="mt-0.5 text-[11px] opacity-70">
+                {slot.subLabel}
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/components/trust/primitives/LineageRow.tsx
+++ b/apps/web/components/trust/primitives/LineageRow.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { LineageTrustState } from '@/lib/trust/replay-grammar';
+import type {
+  OwnershipState,
+  TrustTier,
+} from '@/lib/trust/institutional-language';
+import { OwnershipStateBadge } from './OwnershipStateBadge';
+import { TierBadge } from './TierBadge';
+import { CheckedAtStamp } from './CheckedAtStamp';
+
+/**
+ * One claim · six labeled primitives.
+ *
+ * Source: Lineage Row.html · "Anatomy of one row · six primitives".
+ * Every claim carries six things you can name. If a primitive isn't
+ * present, the row doesn't assert it. Missing primitive reads as a gap,
+ * not as silence.
+ */
+export interface LineageRowProps {
+  /** What the claim names (e.g. "CA medical license"). */
+  claim: string;
+  /** Subject label (e.g. "subj · npi 1356428912 · dr. mira chen, md"). */
+  subject: string;
+  /** Named source registry. */
+  source: string;
+  /** Source state caption (e.g. "live · ca-pa registry"). */
+  sourceState: string;
+  /** checked_at ISO + relative. */
+  checkedAtIso: string | null;
+  checkedAtRelative: string;
+  ownership: OwnershipState;
+  /** Replay state label: "Anchored" · "Logged · pending anchor" · "Not written". */
+  replay: string;
+  tier: TrustTier;
+  /** Issuer-signed state for this row's receipt. */
+  signed: boolean;
+  /** Verification-run fingerprint. */
+  runId: string;
+  rowState: LineageTrustState;
+  degraded?: boolean;
+  className?: string;
+}
+
+const ROW_FRAME: Record<LineageTrustState, string> = {
+  preview: 'border-dashed border-slate-400 bg-amber-50/30',
+  snapshot: 'border-solid border-slate-300 bg-white',
+  signed: 'border-solid border-slate-900 bg-white',
+};
+
+export function LineageRow(props: LineageRowProps) {
+  const {
+    claim,
+    subject,
+    source,
+    sourceState,
+    checkedAtIso,
+    checkedAtRelative,
+    ownership,
+    replay,
+    tier,
+    signed,
+    runId,
+    rowState,
+    degraded = false,
+    className,
+  } = props;
+
+  return (
+    <article
+      data-slot="lineage-row"
+      data-state={rowState}
+      data-degraded={degraded ? 'true' : undefined}
+      className={cn(
+        'rounded-2xl border p-4 text-sm',
+        ROW_FRAME[rowState],
+        degraded && 'border-l-4 border-l-amber-400',
+        className,
+      )}
+    >
+      <header className="flex items-baseline justify-between gap-2">
+        <h4 className="text-base font-semibold">{claim}</h4>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          {subject}
+        </span>
+      </header>
+      <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <Cell label="Source · checked">
+          <div className="font-medium">{source}</div>
+          <div className="font-mono text-[11px] text-slate-600">
+            {sourceState}
+          </div>
+        </Cell>
+        <Cell label="checked_at">
+          <CheckedAtStamp
+            iso={checkedAtIso}
+            relative={checkedAtRelative}
+            degraded={degraded}
+          />
+        </Cell>
+        <Cell label="Ownership">
+          <OwnershipStateBadge state={ownership} />
+        </Cell>
+        <Cell label="Replay">
+          <span className="font-mono text-xs">{replay}</span>
+        </Cell>
+        <Cell label="Tier">
+          <TierBadge tier={tier} />
+        </Cell>
+        <Cell label="Receipt">
+          <span
+            className={cn(
+              'inline-flex items-center font-mono text-xs',
+              signed ? 'text-slate-900' : 'text-slate-500',
+            )}
+          >
+            {signed ? 'Signed · ed25519' : 'Unsigned'}
+          </span>
+        </Cell>
+      </dl>
+      <footer className="mt-3 flex items-center justify-between border-t border-slate-200 pt-2 font-mono text-[11px] text-slate-600">
+        <span>run · {runId}</span>
+      </footer>
+    </article>
+  );
+}
+
+function Cell({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-1">{children}</dd>
+    </div>
+  );
+}

--- a/apps/web/components/trust/primitives/OwnershipStateBadge.tsx
+++ b/apps/web/components/trust/primitives/OwnershipStateBadge.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  OWNERSHIP_LABELS,
+  type OwnershipState,
+} from '@/lib/trust/institutional-language';
+
+/**
+ * Who asserted · 3 fixed values · subject · delegated · unbound.
+ *
+ * Source: Trust Primitives.html §04. "anonymous" and "guest" are banned
+ * by the spec; this component cannot render them.
+ */
+export interface OwnershipStateBadgeProps {
+  state: OwnershipState;
+  className?: string;
+}
+
+const OWNERSHIP_DOT: Record<OwnershipState, string> = {
+  subject: 'bg-slate-900',
+  delegated: 'border border-slate-700 bg-transparent',
+  unbound: 'border border-dashed border-slate-400 bg-transparent',
+};
+
+export function OwnershipStateBadge({
+  state,
+  className,
+}: OwnershipStateBadgeProps) {
+  return (
+    <span
+      data-slot="ownership-badge"
+      data-ownership={state}
+      className={cn(
+        'inline-flex items-center gap-1.5 font-mono text-xs',
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn('inline-block h-2 w-2 rounded-full', OWNERSHIP_DOT[state])}
+      />
+      <span>{OWNERSHIP_LABELS[state]}</span>
+    </span>
+  );
+}

--- a/apps/web/components/trust/primitives/ReplayTimeline.tsx
+++ b/apps/web/components/trust/primitives/ReplayTimeline.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Chain-linked replay strip · head ← prev hashes · RFC 3161 anchored.
+ *
+ * Source: Trust Primitives.html §02 · Replay Chronology Topology.html.
+ * Arrow direction is fixed: head is leftmost; reading is right-to-left
+ * in time but left-to-right in causality. A gap renders as a dashed
+ * empty token — never elided. Never animate. Never recolor to indicate
+ * freshness.
+ */
+
+export interface ReplayNode {
+  /** Truncated hash, e.g. "7a2c…b8d3". */
+  hash: string;
+  /** Optional caption (e.g. "head", "#11 σ defer"). */
+  caption?: string;
+  /** Renders as a dashed empty gap token. */
+  gap?: boolean;
+}
+
+export interface ReplayTimelineProps {
+  /** Nodes in head-first order: [head, prev, prev-1, ...]. */
+  nodes: readonly ReplayNode[];
+  /** light = holder memory; inverted = signed plane. */
+  tone?: 'light' | 'inverted';
+  /** When true, surfaces the "pending re-anchor" sub-caption. */
+  pending?: boolean;
+  className?: string;
+}
+
+const TONE_FRAME: Record<'light' | 'inverted', string> = {
+  light: 'bg-white text-slate-900 border-slate-300',
+  inverted: 'bg-slate-950 text-slate-100 border-slate-700',
+};
+
+export function ReplayTimeline({
+  nodes,
+  tone = 'light',
+  pending = false,
+  className,
+}: ReplayTimelineProps) {
+  if (nodes.length === 0) {
+    return null;
+  }
+  return (
+    <section
+      data-slot="replay-timeline"
+      data-tone={tone}
+      data-pending={pending ? 'true' : undefined}
+      className={cn(
+        'rounded-2xl border p-4 font-mono text-xs',
+        TONE_FRAME[tone],
+        className,
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between uppercase tracking-wider opacity-70">
+        <span>Replay lineage · chain-linked</span>
+        <span>
+          {pending ? 'pending re-anchor' : `${nodes.length} receipts`}
+        </span>
+      </div>
+      <ol className="flex flex-wrap items-center gap-2">
+        {nodes.map((node, index) => (
+          <React.Fragment key={`${node.hash}:${index}`}>
+            <li
+              data-head={index === 0 ? 'true' : undefined}
+              data-gap={node.gap ? 'true' : undefined}
+              className={cn(
+                'inline-flex flex-col items-start border px-2 py-1',
+                node.gap
+                  ? 'border-dashed border-slate-400 opacity-70'
+                  : index === 0
+                    ? tone === 'inverted'
+                      ? 'border-slate-100 bg-slate-100 text-slate-950'
+                      : 'border-slate-900 bg-slate-900 text-slate-50'
+                    : 'border-current',
+              )}
+            >
+              <span>{node.gap ? '— gap —' : node.hash}</span>
+              {node.caption ? (
+                <span className="text-[10px] opacity-70">{node.caption}</span>
+              ) : null}
+            </li>
+            {index < nodes.length - 1 ? (
+              <span aria-hidden="true" className="opacity-60">
+                ←
+              </span>
+            ) : null}
+          </React.Fragment>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/components/trust/primitives/RevocationStateBanner.tsx
+++ b/apps/web/components/trust/primitives/RevocationStateBanner.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Hard interruption · revoked credential.
+ *
+ * Source: Trust State Transitions.html · StatusList2021. A revoked
+ * credential renders a red lineage break; this is a hard interruption,
+ * never a soft "stale" state. Verifiers must not honor.
+ */
+export interface RevocationStateBannerProps {
+  /** StatusList2021 index for this credential. */
+  statusListIndex: number;
+  /** ISO 8601 timestamp the issuer set the revocation bit. */
+  revokedAtIso: string;
+  /** Optional reason rendered as institutional sub-copy. */
+  reason?: string;
+  className?: string;
+}
+
+export function RevocationStateBanner({
+  statusListIndex,
+  revokedAtIso,
+  reason,
+  className,
+}: RevocationStateBannerProps) {
+  return (
+    <section
+      role="alert"
+      data-slot="revocation-banner"
+      className={cn(
+        'rounded-2xl border-2 border-rose-900 bg-rose-950 p-4 text-sm text-rose-50',
+        className,
+      )}
+    >
+      <header className="flex items-center justify-between gap-3 font-mono text-[10px] uppercase tracking-wider text-rose-200">
+        <span>StatusList2021 · bit 1</span>
+        <span>idx {statusListIndex}</span>
+      </header>
+      <h3 className="mt-2 text-base font-semibold">Credential revoked</h3>
+      <p className="mt-1 text-sm">
+        The issuer has revoked this credential. Verifiers must not honor it.
+      </p>
+      <dl className="mt-3 grid grid-cols-1 gap-2 font-mono text-xs sm:grid-cols-2">
+        <div>
+          <dt className="text-[10px] uppercase tracking-wider text-rose-200">
+            Revoked at
+          </dt>
+          <dd>{revokedAtIso}</dd>
+        </div>
+        {reason ? (
+          <div>
+            <dt className="text-[10px] uppercase tracking-wider text-rose-200">
+              Reason
+            </dt>
+            <dd className="break-words">{reason}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/components/trust/primitives/TierBadge.tsx
+++ b/apps/web/components/trust/primitives/TierBadge.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { TIER_LABELS, type TrustTier } from '@/lib/trust/institutional-language';
+
+/**
+ * Trust ontology · T1–T4 · four fixed values.
+ *
+ * Source: Trust Primitives.html §03. Darkening fill = closer to a
+ * signed VC. Always monospaced, never rounded. "T5" is banned.
+ */
+export interface TierBadgeProps {
+  tier: TrustTier;
+  className?: string;
+}
+
+const TIER_FILL: Record<TrustTier, string> = {
+  T1: 'bg-slate-50 text-slate-600 border-slate-300',
+  T2: 'bg-slate-200 text-slate-700 border-slate-400',
+  T3: 'bg-slate-700 text-slate-50 border-slate-800',
+  T4: 'bg-slate-950 text-slate-50 border-slate-950',
+};
+
+export function TierBadge({ tier, className }: TierBadgeProps) {
+  return (
+    <span
+      data-slot="tier-badge"
+      data-tier={tier}
+      title={TIER_LABELS[tier]}
+      className={cn(
+        'inline-flex items-center border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider',
+        TIER_FILL[tier],
+        className,
+      )}
+    >
+      {tier}
+    </span>
+  );
+}

--- a/apps/web/components/trust/primitives/TrustReceipt.tsx
+++ b/apps/web/components/trust/primitives/TrustReceipt.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { LineageHeader, type LineageHeaderProps } from './LineageHeader';
+
+/**
+ * Signed receipt · evidentiary register.
+ *
+ * Source: Institutional Receipt.html. A verifier trusts the receipt
+ * before reading the explanation. The artifact reads as a controlled
+ * document — visible permanence, no marketing flourish. The dark
+ * register is reserved for the cryptographic plane.
+ */
+export interface TrustReceiptProps {
+  receiptId: string;
+  /** Issuer DID (e.g. "did:web:vitalcv.health"). */
+  issuerDid: string;
+  /** Signing algorithm label (e.g. "Ed25519 · EdDSA"). */
+  algorithm: string;
+  /** Key id summary (e.g. "kid 6f0e 1d22"). */
+  keyId: string;
+  /** BLAKE3-256 head (e.g. "7a2c b8d3 9d11 3e4a"). */
+  receiptHash: string;
+  /** "0 = active" | "1 = revoked" — verbatim from StatusList2021. */
+  statusBit: '0 = active' | '1 = revoked';
+  /** Six-cell lineage header (composed via `composeLineage`). */
+  lineage: LineageHeaderProps['slots'];
+  /** Attested-claim paragraph rendered verbatim. */
+  attestedClaim: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function TrustReceipt({
+  receiptId,
+  issuerDid,
+  algorithm,
+  keyId,
+  receiptHash,
+  statusBit,
+  lineage,
+  attestedClaim,
+  children,
+  className,
+}: TrustReceiptProps) {
+  const revoked = statusBit === '1 = revoked';
+  return (
+    <article
+      data-slot="trust-receipt"
+      data-revoked={revoked ? 'true' : undefined}
+      className={cn(
+        'rounded-2xl border border-slate-950 bg-slate-950 text-slate-100',
+        className,
+      )}
+    >
+      <header className="flex flex-wrap items-baseline justify-between gap-3 border-b border-slate-800 px-5 py-3 font-mono text-xs uppercase tracking-wider text-slate-300">
+        <span>Signed receipt · evidentiary artifact</span>
+        <span>{receiptId}</span>
+      </header>
+      <div className="space-y-4 p-5 text-sm">
+        <LineageHeader slots={lineage} state="signed" />
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Cell label="Issuer · DID" value={issuerDid} />
+          <Cell label="Signing key" value={keyId} sub={algorithm} />
+          <Cell label="Receipt hash" value={receiptHash} sub="BLAKE3-256 head" />
+          <Cell
+            label="Status · revocation bit"
+            value={statusBit}
+            sub="StatusList2021"
+            emphasis={revoked ? 'alarm' : 'calm'}
+          />
+        </dl>
+        <section
+          data-slot="attested-claim"
+          className="rounded-xl border border-slate-800 bg-slate-900 p-4 text-sm text-slate-100"
+        >
+          <div className="mb-1 font-mono text-[10px] uppercase tracking-wider text-slate-400">
+            Attested claim · what the issuer signs
+          </div>
+          {attestedClaim}
+        </section>
+        {children}
+      </div>
+    </article>
+  );
+}
+
+function Cell({
+  label,
+  value,
+  sub,
+  emphasis = 'calm',
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  emphasis?: 'calm' | 'alarm';
+}) {
+  return (
+    <div>
+      <dt className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          'mt-1 font-mono text-sm break-words',
+          emphasis === 'alarm' ? 'text-amber-200' : 'text-slate-100',
+        )}
+      >
+        {value}
+      </dd>
+      {sub ? (
+        <div className="mt-0.5 text-[11px] text-slate-400">{sub}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/trust/primitives/index.ts
+++ b/apps/web/components/trust/primitives/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Canonical institutional trust primitives.
+ *
+ * Source archive: `Dropbox/vitalcv (7)/`. Forensic map:
+ * `docs/design/institutional-trust-primitive-map.md`.
+ *
+ * Reading order (binding):
+ *   OBJECT → OWNERSHIP → checked_at → CHANNEL → REPLAY → run_id
+ */
+
+export { LineageHeader } from './LineageHeader';
+export type { LineageHeaderProps } from './LineageHeader';
+
+export { LineageRow } from './LineageRow';
+export type { LineageRowProps } from './LineageRow';
+
+export { TrustReceipt } from './TrustReceipt';
+export type { TrustReceiptProps } from './TrustReceipt';
+
+export { ReplayTimeline } from './ReplayTimeline';
+export type { ReplayNode, ReplayTimelineProps } from './ReplayTimeline';
+
+export { DegradedStatePanel } from './DegradedStatePanel';
+export type { DegradedStatePanelProps } from './DegradedStatePanel';
+
+export { FailureTaxonomyBadge } from './FailureTaxonomyBadge';
+export type { FailureTaxonomyBadgeProps } from './FailureTaxonomyBadge';
+
+export { OwnershipStateBadge } from './OwnershipStateBadge';
+export type { OwnershipStateBadgeProps } from './OwnershipStateBadge';
+
+export { TierBadge } from './TierBadge';
+export type { TierBadgeProps } from './TierBadge';
+
+export { CheckedAtStamp } from './CheckedAtStamp';
+export type { CheckedAtStampProps } from './CheckedAtStamp';
+
+export { HumanReviewLane } from './HumanReviewLane';
+export type { HumanReviewLaneProps } from './HumanReviewLane';
+
+export { RevocationStateBanner } from './RevocationStateBanner';
+export type { RevocationStateBannerProps } from './RevocationStateBanner';

--- a/apps/web/lib/trust/degradation.ts
+++ b/apps/web/lib/trust/degradation.ts
@@ -1,0 +1,257 @@
+/**
+ * Canonical failure / degradation taxonomy.
+ *
+ * Source: `Failure Taxonomy.html` (VCV-DEG-001) and
+ * `Degraded State Semantics.html`. Five non-confusable modes across three
+ * planes; one success. The taxonomy is closed. Severity encodes plane
+ * ownership, not danger.
+ *
+ * Five things that look like "no result" — they are not the same. The
+ * system distinguishes them so a user never has to guess.
+ */
+
+export type FailureMode = 'A' | 'B' | 'C' | 'D' | 'E';
+
+export type FailurePlane =
+  | 'upstream'
+  | 'policy'
+  | 'verifier'
+  | 'subject'
+  | 'issuer';
+
+export type Severity = 'S0' | 'S1' | 'S2' | 'S3' | 'S4';
+
+export type SigmaState =
+  | 'sigma_ok'
+  | 'sigma_defer'
+  | 'sigma_halt'
+  | 'sigma_restricted'
+  | 'sigma_withheld';
+
+export type FrameStyle =
+  | 'dashed_paper'
+  | 'solid_ink_0'
+  | 'solid_ink_900_fill'
+  | 'solid_ink_0_thick'
+  | 'solid_ink_950_fill';
+
+export interface FailureModeDescriptor {
+  readonly mode: FailureMode;
+  readonly title: string;
+  readonly plane: FailurePlane;
+  readonly severity: Severity;
+  readonly sigmaState: SigmaState;
+  readonly frame: FrameStyle;
+  readonly owner: string;
+  readonly cause: string;
+  readonly userSees: string;
+  readonly action: string;
+  readonly recovers: string;
+  readonly isSuccess: boolean;
+}
+
+const FAILURE_MODES: Record<FailureMode, FailureModeDescriptor> = {
+  A: {
+    mode: 'A',
+    title: 'Source unreachable',
+    plane: 'upstream',
+    severity: 'S1',
+    sigmaState: 'sigma_defer',
+    frame: 'dashed_paper',
+    owner: 'Upstream registry',
+    cause:
+      "The source didn't answer in time. A specific registry is slow or unresponsive. The rest of the system continues; this lane is not fresh.",
+    userSees:
+      'Dashed lane chip · stale checked_at · honest age label · receipt records source.X.degraded=true inline.',
+    action:
+      'Wait or retry. Anything older than the source’s last confirmed value is treated as not yet checked, not as adverse.',
+    recovers: 'Recovers via upstream restoration.',
+    isSuccess: false,
+  },
+  B: {
+    mode: 'B',
+    title: 'Anonymous restriction',
+    plane: 'policy',
+    severity: 'S2',
+    sigmaState: 'sigma_restricted',
+    frame: 'solid_ink_0',
+    owner: 'VitalCV policy + holder',
+    cause:
+      'This lane requires sign-in. Some sources reveal protected fields only when the holder is authenticated. The check did not fail; it was not attempted under your identity.',
+    userSees:
+      'Lane greyed · sign-in affordance · no claim asserted; no findings denied.',
+    action:
+      'Sign in (or have the subject sign in). This is not an outage.',
+    recovers: 'Recovers via caller authentication.',
+    isSuccess: false,
+  },
+  C: {
+    mode: 'C',
+    title: 'Infrastructure outage',
+    plane: 'verifier',
+    severity: 'S4',
+    sigmaState: 'sigma_halt',
+    frame: 'solid_ink_900_fill',
+    owner: 'VitalCV (paged)',
+    cause:
+      'A VitalCV service cannot serve this request right now. Existing signed receipts remain valid; they verify offline against did:web:vitalcv.health and do not require our servers.',
+    userSees:
+      'Black status banner · incident id · link to status page · current SLO impact stated.',
+    action:
+      'If holding a signed receipt, verify it against the public verifier; no VitalCV server needed. Otherwise wait.',
+    recovers: 'Recovers via VitalCV restoration.',
+    isSuccess: false,
+  },
+  D: {
+    mode: 'D',
+    title: 'No adverse findings',
+    plane: 'subject',
+    severity: 'S0',
+    sigmaState: 'sigma_ok',
+    frame: 'solid_ink_0_thick',
+    owner: 'No one — the system worked.',
+    cause:
+      'The source answered. Zero records returned. This is an affirmative negative; it is materially different from "we could not check".',
+    userSees:
+      'Solid lane chip · no adverse findings · 0 records · fresh checked_at · receipt signed.',
+    action: 'None. This is the affirmative state; the receipt is re-verifiable.',
+    recovers: 'No recovery needed.',
+    isSuccess: true,
+  },
+  E: {
+    mode: 'E',
+    title: 'Issuer unavailable',
+    plane: 'issuer',
+    severity: 'S3',
+    sigmaState: 'sigma_withheld',
+    frame: 'solid_ink_950_fill',
+    owner: 'VitalCV keyholder quorum',
+    cause:
+      'The active signing key is unreachable, expired, or under rotation. New receipts cannot issue until the issuer continuity plane recovers. Existing signed receipts remain valid until and unless explicitly revoked via StatusList2021.',
+    userSees:
+      'Inverted black banner across signed surfaces · issuance paused · existing credentials unaffected unless revoked.',
+    action:
+      'Verifiers: continue to trust existing receipts. Operators: rotate to backup signer per runbook.',
+    recovers: 'Recovers via quorum activation.',
+    isSuccess: false,
+  },
+};
+
+export function describeFailureMode(mode: FailureMode): FailureModeDescriptor {
+  return FAILURE_MODES[mode];
+}
+
+export function allFailureModes(): readonly FailureModeDescriptor[] {
+  return ['A', 'B', 'C', 'D', 'E'].map((m) => FAILURE_MODES[m as FailureMode]);
+}
+
+/**
+ * Lifecycle states a single claim or surface can be in. Disjoint from
+ * `FailureMode`: a `signed` claim can carry a per-source mode-A defer
+ * without the whole surface degrading.
+ */
+export type DegradationState =
+  | 'fresh'
+  | 'degraded'
+  | 'stale'
+  | 'revoked'
+  | 'interrupted'
+  | 'pending_human_review'
+  | 'unverifiable'
+  | 'continuity_mismatch';
+
+export interface DegradationCopy {
+  readonly state: DegradationState;
+  readonly headline: string;
+  readonly detail: string;
+  readonly alarmist: false;
+}
+
+const DEGRADATION_COPY: Record<DegradationState, DegradationCopy> = {
+  fresh: {
+    state: 'fresh',
+    headline: 'Source-confirmed',
+    detail: 'Live authority consulted within freshness budget.',
+    alarmist: false,
+  },
+  degraded: {
+    state: 'degraded',
+    headline: 'Operational degradation',
+    detail: 'Upstream source slow; last-known value rendered with stale-flag.',
+    alarmist: false,
+  },
+  stale: {
+    state: 'stale',
+    headline: 'Stale-but-signed',
+    detail: 'Last confirmed value remains signed; freshness defers.',
+    alarmist: false,
+  },
+  revoked: {
+    state: 'revoked',
+    headline: 'Credential revoked',
+    detail:
+      'StatusList2021 bit set to 1. The issuer has revoked this credential; do not honor.',
+    alarmist: false,
+  },
+  interrupted: {
+    state: 'interrupted',
+    headline: 'Trust interruption',
+    detail: 'Replay chain has a recorded gap. Continuity not currently established.',
+    alarmist: false,
+  },
+  pending_human_review: {
+    state: 'pending_human_review',
+    headline: 'Pending human review',
+    detail: 'Routed to the human-reviewed lane; an operator signs before issuance.',
+    alarmist: false,
+  },
+  unverifiable: {
+    state: 'unverifiable',
+    headline: 'Unverifiable',
+    detail:
+      'No source-of-record was consulted under this identity. Evidence pending.',
+    alarmist: false,
+  },
+  continuity_mismatch: {
+    state: 'continuity_mismatch',
+    headline: 'Continuity mismatch',
+    detail:
+      'Replay head does not reconcile to the TSA anchor; chain requires re-anchor.',
+    alarmist: false,
+  },
+};
+
+export function describeDegradation(state: DegradationState): DegradationCopy {
+  return DEGRADATION_COPY[state];
+}
+
+/**
+ * Maps a degradation state to a stable visual-grammar token. Components
+ * read this so a state always renders with the same border / continuity
+ * treatment regardless of surface.
+ */
+export type DegradationVisual =
+  | 'continuous'
+  | 'dashed'
+  | 'hard_interruption'
+  | 'manual_lane'
+  | 'pending_anchor';
+
+export function visualForDegradation(
+  state: DegradationState,
+): DegradationVisual {
+  switch (state) {
+    case 'fresh':
+      return 'continuous';
+    case 'degraded':
+    case 'stale':
+    case 'unverifiable':
+      return 'dashed';
+    case 'revoked':
+    case 'interrupted':
+    case 'continuity_mismatch':
+      return 'hard_interruption';
+    case 'pending_human_review':
+      return 'manual_lane';
+  }
+}

--- a/apps/web/lib/trust/institutional-language.ts
+++ b/apps/web/lib/trust/institutional-language.ts
@@ -1,0 +1,123 @@
+/**
+ * Canonical operational language for institutional trust surfaces.
+ *
+ * Source: archive HTML files (Human Trust Surface, Failure Taxonomy,
+ * Institutional Receipt, Trust State Register). Phrases here are the
+ * exact, audited words that may appear on institutional surfaces.
+ *
+ * Companion to `apps/web/lib/trust/status-language.ts`, which governs
+ * status labels for the public passport. This module governs the
+ * operational copy on institutional surfaces (replay ledger, signed
+ * receipt, lineage row, degraded state panels).
+ */
+
+export const INSTITUTIONAL_PHRASES = {
+  /** Workflow ownership: "the institution, not the individual". */
+  institutionOwned: 'Institution-owned workflow',
+  /** Replay continuity: head ← prev chain, RFC 3161 anchored. */
+  replayableEvidence: 'Replayable evidence',
+  /** Live source-of-record was consulted at checked_at. */
+  sourceConfirmed: 'Source-confirmed',
+  /** An operator manually reviewed and co-signed. */
+  humanReviewed: 'Human-reviewed',
+  /** Authority via authenticated proxy (employer · admin). */
+  delegatedOwnership: 'Delegated ownership',
+  /** Chain has a recorded gap. */
+  trustInterruption: 'Trust interruption',
+  /** Upstream source is slow; receipt records degraded inline. */
+  operationalDegradation: 'Operational degradation',
+  /** Chain reconciled after a defer. */
+  continuityRestored: 'Continuity restored',
+  /** No source-of-record fetched yet. */
+  evidencePending: 'Evidence pending',
+  /** Mode D — affirmative negative. */
+  affirmativeNegative: 'No adverse findings',
+  /** Existing signed credential remains offline-verifiable. */
+  reVerifiableOffline: 'Re-verifiable offline',
+  /** σ chain is hash-linked end to end. */
+  hashLinkedEndToEnd: 'Hash-linked end to end',
+  /** TSA anchor reached. */
+  tsaAnchored: 'TSA-anchored',
+} as const;
+
+export type InstitutionalPhraseKey = keyof typeof INSTITUTIONAL_PHRASES;
+
+/**
+ * Reading-order labels for `LineageHeader`/`LineageRow`. The labels are
+ * the canonical names from `Trust Primitives.html` §00 and must never be
+ * reworded ("when generated" → "checked_at"; "what surface" → "channel").
+ */
+export const READING_ORDER_LABELS = {
+  object: 'Object',
+  ownership: 'Ownership',
+  checkedAt: 'checked_at',
+  channel: 'Channel',
+  replay: 'Replay',
+  runId: 'run_id',
+} as const;
+
+/**
+ * Phrases that are NEVER permitted on an institutional trust surface.
+ * Mirrors the project CLAUDE.md truth contract plus archive-specific
+ * rejections ("just now", bare "anonymous", "guest" for ownership).
+ *
+ * The token list is consumed by
+ * `apps/web/__tests__/institutional-trust-primitives.test.ts` to guard
+ * touched files at CI time. Keep entries lowercase and substring-style.
+ */
+export const BANNED_INSTITUTIONAL_PHRASES: readonly string[] = [
+  // CLAUDE.md truth contract — bans on these are project-wide.
+  'automatically verified',
+  'guaranteed verification',
+  'complete credentialing',
+  'instant credentialing',
+  'legally accepted',
+  'risk transferred',
+  'final verification without review',
+  'source confirmed before response',
+  'certified compliant',
+  'hipaa compliant',
+  'soc2 certified',
+  // Archive-specific rejections (Trust Primitives §04, §07).
+  'just now',
+  // Mode-D copy must say "no adverse findings", never "no findings".
+  // We do not ban "no findings" outright since compound forms exist,
+  // but tests check for "no findings" as a bare lane label.
+] as const;
+
+/**
+ * Returns the lowercased banned tokens that occur in the supplied text.
+ * Empty array means the text is clean.
+ *
+ * Intended for dev-only assertions and CI guards — not user-facing
+ * runtime validation.
+ */
+export function findBannedInstitutionalPhrases(text: string): readonly string[] {
+  const lower = text.toLowerCase();
+  return BANNED_INSTITUTIONAL_PHRASES.filter((token) => lower.includes(token));
+}
+
+/**
+ * Canonical ownership labels — Trust Primitives §04. The three fixed
+ * values; "anonymous" and "guest" are explicitly banned by the spec.
+ */
+export const OWNERSHIP_LABELS = {
+  subject: 'Subject',
+  delegated: 'Delegated',
+  unbound: 'Unbound',
+} as const;
+
+export type OwnershipState = keyof typeof OWNERSHIP_LABELS;
+
+/**
+ * Canonical tier labels — Trust Primitives §03. The four fixed values;
+ * "T5" is explicitly banned by the spec.
+ */
+export const TIER_LABELS = {
+  T1: 'T1 · self-attest',
+  T2: 'T2 · third-party',
+  T3: 'T3 · authoritative',
+  T4: 'T4 · issuer-signed',
+} as const;
+
+export type TrustTier = keyof typeof TIER_LABELS;

--- a/apps/web/lib/trust/replay-grammar.ts
+++ b/apps/web/lib/trust/replay-grammar.ts
@@ -1,0 +1,74 @@
+/**
+ * Canonical replay grammar — binding reading order.
+ *
+ * From `Trust Primitives.html` (canon spec VC-PRIM-v1):
+ *
+ *     OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID
+ *
+ * Every institutional trust surface composes these six primitives in this
+ * order. Surfaces compose; they never invent. This module encodes the
+ * contract at the type level so a missing or reordered slot fails the
+ * type-check.
+ */
+
+export const LINEAGE_SLOT_ORDER = [
+  'object',
+  'ownership',
+  'checkedAt',
+  'channel',
+  'replay',
+  'runId',
+] as const;
+
+export type LineageSlotKey = (typeof LINEAGE_SLOT_ORDER)[number];
+
+export type LineageTrustState = 'preview' | 'snapshot' | 'signed';
+
+export interface LineageSlot {
+  readonly key: LineageSlotKey;
+  readonly label: string;
+  readonly value: string;
+  readonly subLabel?: string;
+  readonly degraded?: boolean;
+}
+
+export type LineageSlots = readonly [
+  LineageSlot & { key: 'object' },
+  LineageSlot & { key: 'ownership' },
+  LineageSlot & { key: 'checkedAt' },
+  LineageSlot & { key: 'channel' },
+  LineageSlot & { key: 'replay' },
+  LineageSlot & { key: 'runId' },
+];
+
+export interface LineageSlotInput {
+  object: Omit<LineageSlot, 'key'>;
+  ownership: Omit<LineageSlot, 'key'>;
+  checkedAt: Omit<LineageSlot, 'key'>;
+  channel: Omit<LineageSlot, 'key'>;
+  replay: Omit<LineageSlot, 'key'>;
+  runId: Omit<LineageSlot, 'key'>;
+}
+
+/**
+ * Compose a canonical six-slot lineage. The return tuple is always in
+ * binding reading order. Construction is total over LineageSlotInput —
+ * a caller that omits a slot fails to compile.
+ */
+export function composeLineage(input: LineageSlotInput): LineageSlots {
+  return [
+    { key: 'object', ...input.object },
+    { key: 'ownership', ...input.ownership },
+    { key: 'checkedAt', ...input.checkedAt },
+    { key: 'channel', ...input.channel },
+    { key: 'replay', ...input.replay },
+    { key: 'runId', ...input.runId },
+  ] as const;
+}
+
+/**
+ * Human-readable caption for the canonical reading-order rail.
+ * Rendered by LineageHeader above the six cells.
+ */
+export const READING_ORDER_CAPTION =
+  'object → ownership → checked_at → channel → replay → run_id';

--- a/docs/design/institutional-trust-primitive-map.md
+++ b/docs/design/institutional-trust-primitive-map.md
@@ -1,0 +1,167 @@
+# Institutional Trust Primitive Map
+
+Forensic inventory of the design archive, mapping each surface to canonical
+reusable primitives or rejecting it as non-canonical. This document is the
+audit trail for the `feat/institutional-trust-primitives` wave.
+
+## Source archive
+
+```
+Dropbox/vitalcv (7)/
+  Trust Primitives.html                  # canonical visual grammar — primary source
+  Lineage Header.html                    # six-cell header anatomy
+  Lineage Row.html                       # row anatomy (six primitives per claim)
+  Failure Taxonomy.html                  # five failure modes A/B/C/D/E
+  Degraded State Semantics.html          # plane ownership + severity S0–S4
+  Replay Chronology Topology.html        # chain topology + chronology grammar
+  Institutional Replay Ledger.html       # operational-history surface
+  Institutional Receipt.html             # signed-receipt evidentiary register
+  Human Trust Surface.html               # plain-language verifier onboarding
+  Trust State Register.html              # three-state visual register
+  Trust State Transitions.html           # S0/S1/S2/S3 state machine
+  Visual Grammar Canon.html              # visual rules
+  Receipt Reading Doctrine.html          # how to read a receipt
+  Replay Memory.html                     # memory model for replay
+```
+
+## Reading-order contract (binding)
+
+Every trust surface composes the same six primitives in the same order:
+
+```
+OBJECT → OWNERSHIP → CHECKED_AT → CHANNEL → REPLAY → RUN_ID
+```
+
+Surfaces compose; they never invent. This contract is encoded in
+`apps/web/lib/trust/replay-grammar.ts` as a tuple type that fails the build
+if any consumer attempts to reorder or omit a slot.
+
+## Three trust states (binding)
+
+| State | Border | Authority | What it means |
+|---|---|---|---|
+| `preview` | dashed paper border | none | anonymous exploration; no claim asserted |
+| `snapshot` | solid ink-700 | internal | authenticated; ownership claimed; not yet signed |
+| `signed` | inverted ink-950 + dark cap | issuer-bound | issuer-signed; re-verifiable offline |
+
+## Five failure modes (binding)
+
+| Mode | Letter | Plane | Owner | UI state |
+|---|---|---|---|---|
+| Source unreachable | A | Upstream | upstream registry | dashed lane chip · stale checked_at |
+| Anonymous restriction | B | Policy | VitalCV policy + holder | greyed; sign in to verify |
+| Infrastructure outage | C | Verifier | VitalCV (paged) | black status banner |
+| No adverse findings | D | Subject (outcome) | nobody — system worked | solid lane chip · 0 records |
+| Issuer unavailable | E | Cryptographic | VitalCV keyholder quorum | inverted black banner |
+
+Severity hierarchy is **plane ownership, not danger**:
+`S0=D (success) · S1=A · S2=B · S3=E · S4=C`.
+
+Mode D is **success**, not failure. Mode D copy is "no adverse findings",
+**never** "no findings" or "no results".
+
+## Canonical primitives extracted
+
+Implemented under `apps/web/components/trust/primitives/`:
+
+| Primitive | Source | What it renders |
+|---|---|---|
+| `LineageHeader` | Lineage Header.html · Trust Primitives §01 | Six-cell mandatory-reading-order header |
+| `LineageRow` | Lineage Row.html · Trust Primitives | One claim row · six labeled primitives |
+| `TrustReceipt` | Institutional Receipt.html | Signed evidentiary register (dark plane) |
+| `ReplayTimeline` | Replay Chronology Topology.html · Trust Primitives §02 | Chain head ← prev hashes with σ defer notches |
+| `DegradedStatePanel` | Degraded State Semantics.html · Failure Taxonomy.html | Mode A/B/C/D/E surface with owner + action |
+| `FailureTaxonomyBadge` | Failure Taxonomy.html · Trust Primitives §05 | 5-mode chip (A/B/C/D/E + plane) |
+| `OwnershipStateBadge` | Trust Primitives §04 | subject · delegated · unbound (3 fixed values) |
+| `TierBadge` | Trust Primitives §03 | T1 self-attest · T2 third-party · T3 authoritative · T4 issuer-signed |
+| `CheckedAtStamp` | Trust Primitives §07 | ISO 8601 UTC + relative age; degraded = dashed left border |
+| `HumanReviewLane` | Human Trust Surface.html · Trust Primitives §08 (run_id) | Manual-operator lane wrapper |
+| `RevocationStateBanner` | Trust State Transitions.html · StatusList2021 cell | Hard interruption / revoked credential break |
+
+## Concepts rejected (non-canonical / not present in archive)
+
+The mission listing names several primitives that do not appear in the
+attached archive and have no operational semantics defined:
+
+| Concept | Status | Reason for rejection |
+|---|---|---|
+| `Audit Ledger D52` | **rejected** | "D52" is not present in any archive file; there is no D52-numbered audit ledger spec. Existing `Institutional Replay Ledger` covers operational history. |
+| `Operational Guardrails` (as named primitive) | **rejected as primitive** | Archive treats guardrails as *rules* on existing primitives (e.g. "never reorder cells", "never recolor on age", "never invent T5"), not as a renderable component. Encoded instead as type-level constraints and lint guards. |
+| `Executive Share` | **rejected** | Not present in the archive. "Executive summary" appears in `Human Trust Surface.html` as a plain-language summary block (rendered by existing `EvidenceDisclosureCard`/`TrustContainerPanel`), not as a separate share primitive. |
+| `Clinician Passport Revoked` (as bespoke primitive) | **collapsed** | Folded into `RevocationStateBanner` because revocation is a credential state (StatusList2021 bit), not a passport-specific surface. The existing `apps/web/app/passport/[id]` route renders the banner when the revocation bit is set. |
+
+Adding bespoke components for these would be cargo-culting — they have no
+defined semantics in the source archive.
+
+## Visual semantic system
+
+| Concept | Visual encoding (binding) |
+|---|---|
+| degraded | dashed border / interrupted continuity / honest age label |
+| revoked | hard interruption (red lineage break, status bit 1) |
+| human-reviewed | signed / manual / operator-lane chrome |
+| replayable | deterministic chronology with head ← prev arrows |
+| institutional | dense, quiet, high-signal (no gradients, no animation) |
+| receipt surfaces | dark cryptographic register **only** when issuer-signed |
+
+Explicit non-rules (binding):
+- never yellow/orange/red for failure modes (only mode-A dashed slate)
+- never animate state transitions
+- never recolor on age (border degrades; text stays legible)
+- never collapse states to "something went wrong"
+- never reorder reading-order slots
+- never invent a T5 tier
+- never use "anonymous" or "guest" for `OwnershipState` (only `subject` / `delegated` / `unbound`)
+
+## Replay grammar
+
+```
+Object → Ownership → checked_at → Channel → Replay → run_id
+```
+
+Encoded in `apps/web/lib/trust/replay-grammar.ts` as `LineageSlots` (typed
+tuple) and `composeLineage(...)` (returns slots in canonical order). Any
+attempt to render a lineage without all six slots fails the type-check.
+
+## Failure / degradation grammar
+
+Encoded in `apps/web/lib/trust/degradation.ts`:
+
+- `FailureMode` discriminated union (`'A' | 'B' | 'C' | 'D' | 'E'`)
+- `FailurePlane` (`'upstream' | 'policy' | 'verifier' | 'subject' | 'issuer'`)
+- `Severity` (`'S0' | 'S1' | 'S2' | 'S3' | 'S4'`)
+- `describeFailureMode(mode)` returns human-readable copy verbatim from the
+  archive: title, owner, user-sees, action, plane, severity.
+
+## Operational language
+
+Encoded in `apps/web/lib/trust/institutional-language.ts`:
+
+- Canonical phrase constants (`INSTITUTIONAL_PHRASES`)
+- `BANNED_INSTITUTIONAL_PHRASES` runtime guard for dev-only assertions
+
+## Integration boundaries
+
+This wave **introduces** the primitives. It does **not**:
+- create new routes
+- modify existing trust-canon routes
+- touch Prisma, env, or schema
+- introduce CSS globals
+- redesign existing trust-canon UI
+
+A follow-up wave will additively wire primitives into existing routes
+(`/passport/[id]`, `/verify/receipt/[receiptId]`, `/dossier/[receiptId]`,
+`/review/[entityId]`) only where the primitive replaces an ad-hoc renderer
+without changing surface behavior.
+
+## Truth-contract status
+
+No file in this wave introduces:
+- bare "Verified" status label
+- `automatically verified`, `guaranteed verification`, `complete credentialing`,
+  `instant credentialing`, `legally accepted`, `risk transferred`,
+  `final verification without review`, `source confirmed before response`,
+  `certified compliant`, `HIPAA compliant`, `SOC2 certified`
+
+Verified by `apps/web/__tests__/banned-verified-label.test.ts` and the
+new `apps/web/__tests__/institutional-trust-primitives.test.ts`.


### PR DESCRIPTION
## Mission

Convert the institutional design archive (`Dropbox/vitalcv (7)/`) into canonical, reusable, typed trust primitives + operational grammar inside the real VitalCV architecture. Canonicalization wave — not an HTML import, not a visual-polish pass.

Forensic inventory: [`docs/design/institutional-trust-primitive-map.md`](./docs/design/institutional-trust-primitive-map.md).

## Extracted primitives

Under `apps/web/components/trust/primitives/`. All server-renderable; semantic Tailwind only; no CSS globals; no client-only hooks.

| Primitive | Source HTML | What it renders |
|---|---|---|
| `LineageHeader` | Lineage Header · Trust Primitives §01 | 6-cell mandatory reading order |
| `LineageRow` | Lineage Row · Trust Primitives | 1 claim · 6 labeled primitives (source, checked_at, ownership, replay, tier, signed) + run_id |
| `TrustReceipt` | Institutional Receipt | Signed evidentiary register (dark cryptographic plane) |
| `ReplayTimeline` | Replay Chronology Topology · Trust Primitives §02 | Chain head ← prev with dashed gap tokens |
| `DegradedStatePanel` | Degraded State Semantics · Failure Taxonomy | Mode A/B/C/D/E surface with owner + action |
| `FailureTaxonomyBadge` | Failure Taxonomy · Trust Primitives §05 | 5-mode chip (A/B/C/D/E + plane) |
| `OwnershipStateBadge` | Trust Primitives §04 | subject · delegated · unbound (3 fixed) |
| `TierBadge` | Trust Primitives §03 | T1 · T2 · T3 · T4 (4 fixed) |
| `CheckedAtStamp` | Trust Primitives §07 | ISO 8601 UTC + relative age; degraded = dashed left border |
| `HumanReviewLane` | Human Trust Surface · Trust Primitives §08 | Manual-operator lane wrapper |
| `RevocationStateBanner` | Trust State Transitions · StatusList2021 | Hard credential interruption (red lineage break) |

## Concepts rejected (non-canonical)

| Concept | Reason for rejection |
|---|---|
| `Audit Ledger D52` | "D52" is not present anywhere in the attached archive; no spec defines its semantics. `Institutional Replay Ledger` already covers operational history. |
| `Operational Guardrails` (as named primitive) | Archive treats guardrails as **rules on existing primitives** (\"never reorder cells\", \"never recolor on age\", \"never invent T5\"), not as a renderable surface. Encoded as type constraints + the banned-phrase guard. |
| `Executive Share` | Not in the archive. \"Executive summary\" appears as plain-language copy on `Human Trust Surface.html` and is already covered by existing `EvidenceDisclosureCard` / `TrustContainerPanel`. |
| `Clinician Passport Revoked` (bespoke surface) | Collapsed into `RevocationStateBanner` because revocation is a credential state (StatusList2021 bit), not a passport-specific surface. The existing `app/passport/[id]` route renders the banner when the bit is set. |

Adding bespoke components for these would be cargo-culting — they have no operational semantics defined in the source archive.

## Operational semantic system

Encoded in `apps/web/lib/trust/`:

### `replay-grammar.ts` — reading-order contract (binding)

```ts
OBJECT → OWNERSHIP → checked_at → CHANNEL → REPLAY → run_id
```

`composeLineage(input: LineageSlotInput): LineageSlots` is **total** — a caller that omits a slot fails to compile.

### `degradation.ts` — five-mode failure taxonomy (binding)

| Mode | Plane | Severity | σ state | Frame | Success? |
|---|---|---|---|---|---|
| A · Source unreachable | upstream | S1 | σ defer | dashed paper | no |
| B · Anonymous restriction | policy | S2 | σ restricted | solid ink-0 | no |
| C · Infrastructure outage | verifier | S4 | σ halt | solid ink-900 fill | no |
| **D · No adverse findings** | **subject** | **S0** | **σ ok** | **solid ink-0 thick** | **yes** |
| E · Issuer unavailable | issuer | S3 | σ withheld | solid ink-950 fill | no |

Severity encodes plane ownership, **not** danger. Mode D is the only success.

Eight `DegradationState` values: `fresh · degraded · stale · revoked · interrupted · pending_human_review · unverifiable · continuity_mismatch`. Each maps to one of five `DegradationVisual` tokens: `continuous · dashed · hard_interruption · manual_lane · pending_anchor`.

### `institutional-language.ts` — canonical phrases + banned-phrase guard

- 13 phrase constants (`institutionOwned`, `replayableEvidence`, `sourceConfirmed`, `humanReviewed`, `delegatedOwnership`, `trustInterruption`, `operationalDegradation`, `continuityRestored`, `evidencePending`, `affirmativeNegative`, `reVerifiableOffline`, `hashLinkedEndToEnd`, `tsaAnchored`).
- `BANNED_INSTITUTIONAL_PHRASES` ⊇ the project CLAUDE.md truth-contract list + archive-specific bans (`just now`, `anonymous`/`guest` for ownership).
- `findBannedInstitutionalPhrases(text)` for runtime / CI guards.

## Visual semantic system

| Concept | Visual encoding (binding) |
|---|---|
| degraded | dashed border / interrupted continuity |
| revoked | hard interruption (red lineage break, status bit 1) |
| human-reviewed | signed / manual / operator-lane chrome |
| replayable | deterministic chronology (head ← prev arrows) |
| institutional | dense, quiet, high-signal — no gradients, no animation |
| receipt surfaces | dark cryptographic register **only** when issuer-signed |

Explicit non-rules enforced by the design and tests:
- never yellow/orange/red for failure modes
- never recolor on age (border degrades; text stays legible)
- never collapse to \"something went wrong\"
- never reorder reading-order slots
- never invent T5; never use \"anonymous\"/\"guest\" for `OwnershipState`

## Integration boundaries

This wave **introduces** the primitives. It does **not**:
- create new routes
- modify existing trust-canon routes (`/passport`, `/verify/receipt`, `/dossier`, `/review`)
- touch Prisma, env, or schema
- introduce CSS globals
- redesign existing UI

A follow-up wave will additively wire primitives into existing routes only where they cleanly replace an ad-hoc renderer.

## Tests added — 52 passing

`apps/web/__tests__/institutional-trust-primitives.test.tsx`:

| Group | Tests | What it asserts |
|---|---|---|
| Replay grammar · reading-order | 3 | Binding tuple order, total-construction, caption rail string |
| Failure taxonomy · 5 modes | 8 | Each mode has owner+cause+action+plane+severity; D is the only success; titles binding; planes disjoint |
| Degradation grammar · non-alarmist | 9 | Every state non-alarmist; correct visual mapping |
| Operational language | 5 | Reading-order labels; ownership 3-fixed; tier 4-fixed; banned-phrase guard catches every token |
| Primitive render isolation | 12 | Every primitive renders to static markup with stable `data-slot` / `data-state` attrs |
| Truth-contract per-file | 15 | Every touched file passes `findBannedInstitutionalPhrases` after stripping declarative matter |

## Validation

```
pnpm --filter @vitalcv/web exec tsc --noEmit
  → 2 pre-existing TS errors in components/clinician/intake-types.ts (unrelated)
  → 0 errors introduced by this wave

pnpm --filter @vitalcv/web lint
  → ✔ No ESLint warnings or errors

pnpm --filter @vitalcv/web exec vitest run institutional-trust-primitives.test.tsx
  → Test Files  1 passed (1)
  → Tests       52 passed (52)
```

## Truth-contract audit

No touched file introduces:
- bare \"Verified\" status label
- `automatically verified`, `guaranteed verification`, `complete credentialing`, `instant credentialing`, `legally accepted`, `risk transferred`, `final verification without review`, `source confirmed before response`, `certified compliant`, `hipaa compliant`, `soc2 certified`
- crypto/compliance claims unsupported by the underlying primitive

`institutional-trust-primitives.test.tsx > truth-contract` gates this at CI.

## Remaining gaps

1. **Existing trust-canon routes not yet wired** — additive integration into `/passport`, `/verify/receipt`, `/dossier`, `/review` is a follow-up wave (deliberately out of scope to avoid \"while I'm here\" expansion).
2. **`pending_anchor` visual token unused** — reserved for the follow-up replay-ledger surface; the timeline currently uses `dashed` for both stale and pending-anchor states.
3. **No Storybook / visual-regression** — the project has no Storybook harness; primitives are render-tested via `renderToStaticMarkup`. A visual-regression layer is a separate infrastructure wave.

## Test plan

- [ ] Pull branch and run `pnpm --filter @vitalcv/web exec vitest run institutional-trust-primitives.test.tsx`.
- [ ] Confirm `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 2 pre-existing `intake-types.ts` errors.
- [ ] Confirm `pnpm --filter @vitalcv/web lint` clean.
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)