### PR TITLE
fix(discovery): resolve .well-known issuer host per-request (WAVE C60)

### DIFF
--- a/apps/web/__tests__/well-known-dynamic-host.test.ts
+++ b/apps/web/__tests__/well-known-dynamic-host.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  resolveIssuerHost,
+  resolveIssuerOrigin,
+  resolveIssuerDid,
+} from '@/lib/discovery/issuerHost';
+
+const ORIGINAL_ENV = process.env.VCV_ISSUER_HOST;
+
+beforeEach(() => {
+  delete process.env.VCV_ISSUER_HOST;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.VCV_ISSUER_HOST;
+  } else {
+    process.env.VCV_ISSUER_HOST = ORIGINAL_ENV;
+  }
+});
+
+function buildHeaders(init: Record<string, string> = {}): Headers {
+  return new Headers(init);
+}
+
+describe('resolveIssuerHost · precedence order', () => {
+  it('returns the env override when set', () => {
+    process.env.VCV_ISSUER_HOST = 'demo-tunnel.trycloudflare.com';
+    const host = resolveIssuerHost(
+      buildHeaders({
+        host: 'localhost:3000',
+        'x-forwarded-host': 'wrong.example.com',
+      }),
+    );
+    expect(host).toBe('demo-tunnel.trycloudflare.com');
+  });
+
+  it('falls back to x-forwarded-host when env is unset', () => {
+    expect(
+      resolveIssuerHost(
+        buildHeaders({
+          host: 'localhost:3000',
+          'x-forwarded-host': 'demo-tunnel.trycloudflare.com',
+        }),
+      ),
+    ).toBe('demo-tunnel.trycloudflare.com');
+  });
+
+  it('uses the first value when x-forwarded-host is comma-separated', () => {
+    expect(
+      resolveIssuerHost(
+        buildHeaders({
+          'x-forwarded-host':
+            'demo-tunnel.trycloudflare.com, internal.example.com',
+        }),
+      ),
+    ).toBe('demo-tunnel.trycloudflare.com');
+  });
+
+  it('falls back to host header when env and x-forwarded-host are unset', () => {
+    expect(
+      resolveIssuerHost(buildHeaders({ host: 'preview-1234.vercel.app' })),
+    ).toBe('preview-1234.vercel.app');
+  });
+
+  it('falls back to vitalcv.com when no header is present', () => {
+    expect(resolveIssuerHost(buildHeaders())).toBe('vitalcv.com');
+  });
+});
+
+describe('resolveIssuerHost · injection resistance', () => {
+  it.each([
+    'evil.com/.well-known',
+    'evil.com://attack',
+    '   ',
+    'with whitespace',
+    '',
+    'a'.repeat(254),
+  ])('rejects malformed candidate "%s" and falls through', (bad) => {
+    process.env.VCV_ISSUER_HOST = bad;
+    expect(resolveIssuerHost(buildHeaders())).toBe('vitalcv.com');
+  });
+
+  it('strips the env override path-injection attempt', () => {
+    process.env.VCV_ISSUER_HOST = 'good.com';
+    expect(
+      resolveIssuerHost(
+        buildHeaders({ 'x-forwarded-host': 'attacker.com/evil' }),
+      ),
+    ).toBe('good.com');
+  });
+});
+
+describe('resolveIssuerOrigin / resolveIssuerDid composition', () => {
+  it('builds https origin from resolved host', () => {
+    process.env.VCV_ISSUER_HOST = 'demo-tunnel.trycloudflare.com';
+    expect(resolveIssuerOrigin(buildHeaders())).toBe(
+      'https://demo-tunnel.trycloudflare.com',
+    );
+  });
+
+  it('builds did:web from resolved host', () => {
+    process.env.VCV_ISSUER_HOST = 'demo-tunnel.trycloudflare.com';
+    expect(resolveIssuerDid(buildHeaders())).toBe(
+      'did:web:demo-tunnel.trycloudflare.com',
+    );
+  });
+
+  it('production default remains did:web:vitalcv.com', () => {
+    expect(resolveIssuerDid(buildHeaders())).toBe('did:web:vitalcv.com');
+    expect(resolveIssuerOrigin(buildHeaders())).toBe('https://vitalcv.com');
+  });
+});

--- a/apps/web/app/api/.well-known/did.json/route.ts
+++ b/apps/web/app/api/.well-known/did.json/route.ts
@@ -1,8 +1,10 @@
 /**
  * GET /.well-known/did.json
  *
- * W3C DID document for did:web:vitalcv.com.
- * Enables decentralized identifier resolution and verifiable credential trust.
+ * W3C DID document for the resolved issuer host. The controller is
+ * derived per-request from `lib/discovery/issuerHost.ts` so the same
+ * codebase serves the production identity at vitalcv.com and a tunnel
+ * identity at <name>.trycloudflare.com without a domain swap.
  *
  * Spec: https://w3c.github.io/did-core/
  * did:web method: https://w3c-ccg.github.io/did-method-web/
@@ -10,44 +12,51 @@
 
 import { NextResponse } from 'next/server';
 import { getPublicKeyJwk } from '@/lib/crypto/receiptIssuer';
+import {
+  resolveIssuerDid,
+  resolveIssuerOrigin,
+} from '@/lib/discovery/issuerHost';
 
 export const runtime = 'nodejs';
 
 // Force runtime evaluation — same rationale as the sibling JWKS route.
 // Prerendering would invoke the production-only signing guard at build
-// time and fail with no env vars present.
+// time and fail with no env vars present. Force-dynamic also lets us
+// read request headers to derive the issuer host.
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(request: Request) {
   const publicKeyJwk = await getPublicKeyJwk();
+  const issuerDid = resolveIssuerDid(request.headers);
+  const issuerOrigin = resolveIssuerOrigin(request.headers);
 
   const didDocument = {
     '@context': 'https://www.w3.org/ns/did/v1',
-    id: 'did:web:vitalcv.com',
+    id: issuerDid,
     verificationMethod: [
       {
-        id: 'did:web:vitalcv.com#vcv-signing-key-1',
+        id: `${issuerDid}#vcv-signing-key-1`,
         type: 'JsonWebKey2020',
-        controller: 'did:web:vitalcv.com',
+        controller: issuerDid,
         publicKeyJwk,
       },
     ],
-    authentication: ['did:web:vitalcv.com#vcv-signing-key-1'],
+    authentication: [`${issuerDid}#vcv-signing-key-1`],
     service: [
       {
-        id: 'did:web:vitalcv.com#credential-issuer',
+        id: `${issuerDid}#credential-issuer`,
         type: 'CredentialIssuer',
-        serviceEndpoint: 'https://vitalcv.com/api/credentials/issue',
+        serviceEndpoint: `${issuerOrigin}/api/credentials/issue`,
       },
       {
-        id: 'did:web:vitalcv.com#receipt-verifier',
+        id: `${issuerDid}#receipt-verifier`,
         type: 'ReceiptVerifier',
-        serviceEndpoint: 'https://vitalcv.com/api/receipts/verify',
+        serviceEndpoint: `${issuerOrigin}/api/receipts/verify`,
       },
       {
-        id: 'did:web:vitalcv.com#openid-credential-issuer',
+        id: `${issuerDid}#openid-credential-issuer`,
         type: 'OID4VCIIssuer',
-        serviceEndpoint: 'https://vitalcv.com/.well-known/openid-credential-issuer',
+        serviceEndpoint: `${issuerOrigin}/.well-known/openid-credential-issuer`,
       },
     ],
   };

--- a/apps/web/app/api/.well-known/openid-credential-issuer/route.ts
+++ b/apps/web/app/api/.well-known/openid-credential-issuer/route.ts
@@ -2,23 +2,30 @@
  * GET /.well-known/openid-credential-issuer
  *
  * OID4VCI (OpenID for Verifiable Credential Issuance) issuer metadata.
- * Enables wallets and verifiers to discover credential capabilities.
+ * The issuer host is resolved per-request via
+ * `lib/discovery/issuerHost.ts` so the same handler serves vitalcv.com
+ * and tunnel hosts (e.g. trycloudflare) without a domain swap.
  *
  * Spec: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
  */
 
 import { NextResponse } from 'next/server';
+import { resolveIssuerOrigin } from '@/lib/discovery/issuerHost';
 
 export const runtime = 'nodejs';
 
-export const revalidate = 3600;
+// force-dynamic so we can read request headers; revalidate cannot be
+// used together with header-derived responses.
+export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(request: Request) {
+  const origin = resolveIssuerOrigin(request.headers);
+
   const metadata = {
-    issuer: 'https://vitalcv.com',
-    credential_issuer: 'https://vitalcv.com',
-    credential_endpoint: 'https://vitalcv.com/api/credentials/issue',
-    jwks_uri: 'https://vitalcv.com/.well-known/jwks.json',
+    issuer: origin,
+    credential_issuer: origin,
+    credential_endpoint: `${origin}/api/credentials/issue`,
+    jwks_uri: `${origin}/.well-known/jwks.json`,
     credentials_supported: [
       {
         format: 'jwt_vc_json',

--- a/apps/web/lib/discovery/issuerHost.ts
+++ b/apps/web/lib/discovery/issuerHost.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolves the issuer host for `.well-known` discovery endpoints.
+ *
+ * Production deployments default to `vitalcv.com`. Demo / preview /
+ * trycloudflare-tunnel deployments need the discovery documents to
+ * report the live tunnel host so that:
+ *
+ *   curl https://<tunnel>/.well-known/did.json
+ *
+ * returns a `did:web:<tunnel>` document whose service endpoints resolve
+ * back to the same tunnel — the requirement for the OpenMythos verifier
+ * probe to pass without a domain swap.
+ *
+ * Resolution order (first match wins):
+ *   1. `VCV_ISSUER_HOST` env var — operator override (set this on the
+ *      tunnel process)
+ *   2. `X-Forwarded-Host` header — set by the trycloudflare proxy
+ *   3. `Host` header — direct requests
+ *   4. fallback to `vitalcv.com`
+ *
+ * The returned host is the bare authority (no scheme, no path).
+ */
+
+const DEFAULT_ISSUER_HOST = 'vitalcv.com';
+
+/**
+ * Validates that a candidate host is a bare authority (no scheme, no
+ * path, no whitespace). Rejects empty strings and obviously malformed
+ * values so injected request headers cannot widen the discovery
+ * document's controller field.
+ */
+function isValidHost(candidate: string | null | undefined): candidate is string {
+  if (!candidate) return false;
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > 253) return false;
+  if (/\s/.test(trimmed)) return false;
+  if (trimmed.includes('/')) return false;
+  if (trimmed.includes('://')) return false;
+  return /^[A-Za-z0-9.\-:_]+$/.test(trimmed);
+}
+
+export function resolveIssuerHost(headers: Headers): string {
+  const envHost = process.env.VCV_ISSUER_HOST;
+  if (isValidHost(envHost)) return envHost.trim();
+
+  const fwdHost = headers.get('x-forwarded-host');
+  if (fwdHost) {
+    // x-forwarded-host may carry multiple values comma-separated; take the first.
+    const first = fwdHost.split(',')[0]?.trim();
+    if (isValidHost(first)) return first;
+  }
+
+  const host = headers.get('host');
+  if (isValidHost(host)) return host.trim();
+
+  return DEFAULT_ISSUER_HOST;
+}
+
+/**
+ * Returns `https://<host>` — the canonical scheme for did:web and
+ * OID4VCI metadata. The discovery spec mandates HTTPS; even on
+ * localhost we render `https://` because the document is a contract,
+ * not a fetchable URL.
+ */
+export function resolveIssuerOrigin(headers: Headers): string {
+  return `https://${resolveIssuerHost(headers)}`;
+}
+
+/**
+ * Renders the `did:web` identifier for the resolved host.
+ * Per did-method-web, percent-encoded colons in ports and slashes in
+ * paths are required, but VitalCV's discovery never uses ports/paths.
+ */
+export function resolveIssuerDid(headers: Headers): string {
+  return `did:web:${resolveIssuerHost(headers)}`;
+}


### PR DESCRIPTION
## Mission

WAVE C60 — Verifier Continuity Probe Resolution. Wire the standard cryptographic discovery routes so external agents (and the Replay UI) can independently verify the issuer posture from any deployment host — production at vitalcv.com **and** trycloudflare tunnels during demos.

## Finding (forensic)

The `.well-known/` endpoints already exist:

```
apps/web/app/api/.well-known/
  did.json/route.ts
  jwks.json/route.ts
  openid-credential-issuer/route.ts
  openid-configuration/route.ts
  trust.json/route.ts
  trust-register/route.ts
  verifier-manifest.json/route.ts
```

`next.config.mjs` rewrites every standard discovery path:

```
/.well-known/did.json                 → /api/.well-known/did.json
/.well-known/jwks.json                → /api/.well-known/jwks.json
/.well-known/openid-credential-issuer → /api/.well-known/openid-credential-issuer
/.well-known/openid-configuration     → /api/.well-known/openid-credential-issuer
/.well-known/trust.json               → /api/.well-known/trust.json
/.well-known/trust-register           → /api/.well-known/trust-register
/.well-known/verifier-manifest.json   → /api/.well-known/verifier-manifest.json
```

The 404 in the "Verifier Continuity Probe" verdict is not actually a missing-route problem — it is an **identity mismatch**: the handlers hardcode `did:web:vitalcv.com` and `https://vitalcv.com/...`, so a probe at `https://demo-tunnel.trycloudflare.com/.well-known/did.json` receives a document whose `id` points to a different host. Verifiers reject this as non-conforming.

## Fix

New: `apps/web/lib/discovery/issuerHost.ts`

```ts
resolveIssuerHost(headers)   // VCV_ISSUER_HOST env > x-forwarded-host > host > vitalcv.com
resolveIssuerOrigin(headers) // https://<resolved-host>
resolveIssuerDid(headers)    // did:web:<resolved-host>
```

Strict host-string validation rejects path-injection (`evil.com/.well-known`), scheme-injection (`evil.com://attack`), whitespace, empty, oversized (>253 char DNS limit). Tests cover every rejection path.

Updated endpoints to use the helper:

- `apps/web/app/api/.well-known/did.json/route.ts` — `id`, `verificationMethod`/`authentication`/`service` ids and endpoints all carry the resolved did:web. Cache-Control unchanged.
- `apps/web/app/api/.well-known/openid-credential-issuer/route.ts` — `issuer`, `credential_issuer`, `credential_endpoint`, `jwks_uri` all carry the resolved origin. Switched from `revalidate = 3600` (incompatible with header reads) to `dynamic = 'force-dynamic'`.
- `jwks.json` — **unchanged**. It only renders the public JWK and has no host references; no fix needed.

## Resolution precedence (defensible)

| Source | When | Why this order |
|---|---|---|
| 1. `VCV_ISSUER_HOST` env | operator override | explicit > implicit; tunnel processes can pin the host |
| 2. `X-Forwarded-Host` | proxy/CDN/tunnel | trycloudflare and Vercel inject this; first value used |
| 3. `Host` header | direct requests | localhost dev |
| 4. `vitalcv.com` default | build prerender, no headers | preserves production identity when nothing is set |

Production deployments served at vitalcv.com see `Host: vitalcv.com` and continue to render the existing canonical identity — **no behavior change for the production case**.

## Tests added — 15 passing

`apps/web/__tests__/well-known-dynamic-host.test.ts`:

| Group | Tests | What it asserts |
|---|---|---|
| Precedence order | 5 | env > x-forwarded-host > host > default; first-of-CSV for x-forwarded-host |
| Injection resistance | 7 | rejects path, scheme, whitespace, empty, oversized; env override survives malformed forwarded header |
| Origin / DID composition | 3 | https-prefixed origin; did:web: prefixed identifier; production default preserved |

## Validation

```
pnpm install --frozen-lockfile                                 → clean
pnpm --filter @vitalcv/web exec vitest run well-known-dynamic-host  → 15/15
pnpm --filter @vitalcv/web exec tsc --noEmit
  → 2 pre-existing errors in components/clinician/intake-types.ts (unrelated)
  → 0 introduced
pnpm --filter @vitalcv/web lint                                → clean
```

## Operator instructions (demo)

```
# In the terminal that runs `pnpm dev` or the tunnel sidecar:
export VCV_ISSUER_HOST=$(echo $TUNNEL_URL | sed 's|https://||;s|/.*||')

# Probe:
curl https://${VCV_ISSUER_HOST}/.well-known/did.json | jq .id
# → "did:web:demo-tunnel.trycloudflare.com"

curl https://${VCV_ISSUER_HOST}/.well-known/openid-credential-issuer | jq .issuer
# → "https://demo-tunnel.trycloudflare.com"
```

Setting `VCV_ISSUER_HOST` is optional; if unset, the X-Forwarded-Host injected by trycloudflare's proxy already resolves correctly.

## Truth-contract audit

No banned phrases, no new compliance claims, no new crypto semantics — this is a host-resolution fix, not an identity-rotation change. The active signing key, JWK, and key fingerprint are unchanged.

## Test plan
- [ ] `pnpm --filter @vitalcv/web exec vitest run well-known-dynamic-host` passes (15 tests)
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 2 pre-existing `intake-types.ts` errors
- [ ] `pnpm --filter @vitalcv/web lint` clean
- [ ] In a tunnel session: `curl https://<tunnel>/.well-known/did.json | jq .id` returns `did:web:<tunnel-host>`
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)