### PR TITLE
feat(trust): implement matuschak-style stacked provenance panes

### DIFF
--- a/apps/web/__tests__/stacked-provenance-panes.test.tsx
+++ b/apps/web/__tests__/stacked-provenance-panes.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  PANE_KINDS,
+  PANE_STACK_OFFSET_PX,
+  closePaneAt,
+  parsePanes,
+  paneToken,
+  pushPane,
+  serializePanes,
+  type PaneRef,
+} from '@/lib/trust/panes';
+
+// `LineageBacklinks` and `StackedPaneLayout` consume next/navigation
+// hooks via `usePaneStack`. In a static-render harness we mock them so
+// component output is rendered without an app-router context. The
+// mocks emulate a stable, empty search-param snapshot.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/trust/panes/rec-test',
+  useSearchParams: () => ({
+    get: () => null,
+    toString: () => '',
+  }),
+}));
+
+import {
+  LineageBacklinks,
+  type LineageBacklinkEntry,
+} from '@/components/trust/LineageBacklinks';
+
+// `StackedPaneLayout` uses `useSearchParams` and `useRouter`, which
+// require a Next.js navigation context. We test it indirectly via the
+// pure URL helpers and via static markup of the backlinks component
+// (which only mounts a `useStackedPanes()` hook for its onClick).
+
+describe('panes URL contract', () => {
+  it('exposes the five canonical pane kinds', () => {
+    expect([...PANE_KINDS]).toEqual([
+      'receipt',
+      'audit',
+      'claim',
+      'lineage',
+      'entity',
+    ]);
+  });
+
+  it('parses a well-formed panes string', () => {
+    const panes = parsePanes('receipt-7a2cb8d3,audit-evt_8821,lineage-nppes');
+    expect(panes).toEqual([
+      { kind: 'receipt', id: '7a2cb8d3' },
+      { kind: 'audit', id: 'evt_8821' },
+      { kind: 'lineage', id: 'nppes' },
+    ]);
+  });
+
+  it('round-trips through serialize/parse', () => {
+    const original: PaneRef[] = [
+      { kind: 'receipt', id: 'r1' },
+      { kind: 'claim', id: 'c1' },
+      { kind: 'entity', id: 'npi_1356428912' },
+    ];
+    expect(parsePanes(serializePanes(original))).toEqual(original);
+  });
+
+  it('drops unknown pane kinds silently', () => {
+    expect(parsePanes('receipt-r1,bogus-x,audit-a1')).toEqual([
+      { kind: 'receipt', id: 'r1' },
+      { kind: 'audit', id: 'a1' },
+    ]);
+  });
+
+  it('drops malformed pane ids', () => {
+    expect(parsePanes('receipt-,receipt-r1,receipt-with space')).toEqual([
+      { kind: 'receipt', id: 'r1' },
+    ]);
+  });
+
+  it('drops tokens with no kind separator', () => {
+    expect(parsePanes('receipt7a2c,audit-evt')).toEqual([
+      { kind: 'audit', id: 'evt' },
+    ]);
+  });
+
+  it('serializes a pane token canonically', () => {
+    expect(paneToken({ kind: 'receipt', id: '7a2c' })).toBe('receipt-7a2c');
+  });
+
+  it('handles empty / nullish input as empty stack', () => {
+    expect(parsePanes(null)).toEqual([]);
+    expect(parsePanes(undefined)).toEqual([]);
+    expect(parsePanes('')).toEqual([]);
+    expect(serializePanes([])).toBe('');
+  });
+});
+
+describe('pushPane · Matuschak tree-path behavior', () => {
+  const stack: PaneRef[] = [
+    { kind: 'receipt', id: 'r1' },
+    { kind: 'claim', id: 'c1' },
+    { kind: 'audit', id: 'a1' },
+  ];
+
+  it('opening a child from the rightmost pane appends', () => {
+    expect(pushPane(stack, 2, { kind: 'lineage', id: 'lk1' })).toEqual([
+      ...stack,
+      { kind: 'lineage', id: 'lk1' },
+    ]);
+  });
+
+  it('opening a child from a middle pane truncates panes to the right and appends', () => {
+    expect(pushPane(stack, 0, { kind: 'audit', id: 'a2' })).toEqual([
+      { kind: 'receipt', id: 'r1' },
+      { kind: 'audit', id: 'a2' },
+    ]);
+  });
+
+  it('re-clicking the same destination is a no-op (idempotent)', () => {
+    expect(pushPane(stack, 2, { kind: 'audit', id: 'a1' })).toEqual(stack);
+  });
+});
+
+describe('closePaneAt', () => {
+  const stack: PaneRef[] = [
+    { kind: 'receipt', id: 'r1' },
+    { kind: 'claim', id: 'c1' },
+    { kind: 'audit', id: 'a1' },
+  ];
+
+  it('removes the pane at index and every pane to its right', () => {
+    expect(closePaneAt(stack, 1)).toEqual([{ kind: 'receipt', id: 'r1' }]);
+  });
+
+  it('closing at index 0 empties the stack', () => {
+    expect(closePaneAt(stack, 0)).toEqual([]);
+  });
+
+  it('out-of-range close returns the stack unchanged', () => {
+    expect(closePaneAt(stack, 9)).toBe(stack);
+    expect(closePaneAt(stack, -1)).toBe(stack);
+  });
+});
+
+describe('visual constants', () => {
+  it('pane stack offset is the binding 40px from the design archive', () => {
+    expect(PANE_STACK_OFFSET_PX).toBe(40);
+  });
+});
+
+describe('LineageBacklinks · static render', () => {
+  it('renders an empty-state hint when no backlinks resolve', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(LineageBacklinks, { links: [] }),
+    );
+    expect(html).toContain('data-empty="true"');
+    expect(html).toContain('No artifacts bind to this pane.');
+  });
+
+  it('renders each backlink with kind chip + label + rationale', () => {
+    const links: LineageBacklinkEntry[] = [
+      {
+        ref: { kind: 'receipt', id: 'rcpt_7a2c' },
+        label: 'rcpt_7a2c',
+        rationale: 'signed this claim',
+      },
+      {
+        ref: { kind: 'entity', id: 'npi_1356428912' },
+        label: 'entity · npi_1356428912',
+      },
+    ];
+    const html = renderToStaticMarkup(
+      React.createElement(LineageBacklinks, { links }),
+    );
+    expect(html).toContain('data-target-kind="receipt"');
+    expect(html).toContain('data-target-id="rcpt_7a2c"');
+    expect(html).toContain('signed this claim');
+    expect(html).toContain('data-target-kind="entity"');
+    expect(html).toContain('npi_1356428912');
+  });
+});

--- a/apps/web/app/trust/panes/[receiptId]/PanesClient.tsx
+++ b/apps/web/app/trust/panes/[receiptId]/PanesClient.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import * as React from 'react';
+import { StackedPaneLayout } from '@/components/trust/StackedPaneLayout';
+import {
+  LineageBacklinks,
+  type LineageBacklinkEntry,
+} from '@/components/trust/LineageBacklinks';
+import type { PaneRef } from '@/lib/trust/panes';
+import type { ReplayInspection } from '@/lib/replay/getReplayInspection';
+
+/**
+ * Client wrapper for the Stacked Provenance Ledger.
+ *
+ * Defines pane renderers for `receipt`, `claim`, `audit`, `lineage`,
+ * and `entity` kinds. Each deeper pane includes `LineageBacklinks`
+ * resolved against the same `ReplayInspection` so the user sees
+ * bi-directional bindings without an additional fetch.
+ */
+export function PanesClient({ inspection }: { inspection: ReplayInspection }) {
+  const rootPane: PaneRef = { kind: 'receipt', id: paneId(inspection.receiptId) };
+
+  return (
+    <StackedPaneLayout
+      rootPane={rootPane}
+      renderRootPane={(ctx) => (
+        <ReceiptPane
+          inspection={inspection}
+          pushPane={ctx.pushPane}
+          isActive={ctx.isActive}
+        />
+      )}
+      renderPane={(ref, ctx) => {
+        switch (ref.kind) {
+          case 'receipt':
+            return (
+              <ReceiptPane
+                inspection={inspection}
+                pushPane={ctx.pushPane}
+                closeThisPane={ctx.closeThisPane}
+                isActive={ctx.isActive}
+              />
+            );
+          case 'claim':
+            return (
+              <ClaimPane
+                claimId={ref.id}
+                inspection={inspection}
+                pushPane={ctx.pushPane}
+                closeThisPane={ctx.closeThisPane}
+              />
+            );
+          case 'audit':
+            return (
+              <AuditPane
+                auditId={ref.id}
+                inspection={inspection}
+                pushPane={ctx.pushPane}
+                closeThisPane={ctx.closeThisPane}
+              />
+            );
+          case 'lineage':
+            return (
+              <LineagePane
+                lineageId={ref.id}
+                inspection={inspection}
+                pushPane={ctx.pushPane}
+                closeThisPane={ctx.closeThisPane}
+              />
+            );
+          case 'entity':
+            return (
+              <EntityPane
+                entityId={ref.id}
+                inspection={inspection}
+                pushPane={ctx.pushPane}
+                closeThisPane={ctx.closeThisPane}
+              />
+            );
+        }
+      }}
+    />
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function paneId(raw: string): string {
+  // Pane ids are constrained to [A-Za-z0-9_-]+; replace anything else.
+  return raw.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 128);
+}
+
+function PaneShell({
+  caption,
+  title,
+  onClose,
+  children,
+}: {
+  caption: string;
+  title: string;
+  onClose?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-baseline justify-between border-b border-slate-900 bg-slate-100 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-700">
+        <span>{caption}</span>
+        {onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-700 hover:text-slate-900"
+          >
+            ×
+          </button>
+        ) : null}
+      </header>
+      <div className="flex-1 overflow-y-auto bg-white">
+        <h2 className="border-b border-slate-200 px-4 py-3 font-mono text-sm text-slate-900">
+          {title}
+        </h2>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PushRow({
+  label,
+  caption,
+  onPush,
+}: {
+  label: string;
+  caption?: string;
+  onPush: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onPush}
+      className="flex w-full items-baseline justify-between gap-2 border-b border-slate-200 px-4 py-2 text-left hover:bg-slate-50"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-sm text-slate-900 break-all">{label}</div>
+        {caption ? (
+          <div className="mt-0.5 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+            {caption}
+          </div>
+        ) : null}
+      </div>
+      <span className="shrink-0 text-slate-500">→</span>
+    </button>
+  );
+}
+
+// ── Receipt pane (root) ─────────────────────────────────────────────────────
+
+function ReceiptPane({
+  inspection,
+  pushPane,
+  closeThisPane,
+  isActive,
+}: {
+  inspection: ReplayInspection;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane?: () => void;
+  isActive: boolean;
+}) {
+  return (
+    <PaneShell
+      caption={`receipt · ${isActive ? 'active' : 'in stack'}`}
+      title={inspection.receiptId}
+      onClose={closeThisPane}
+    >
+      <dl className="grid grid-cols-2 gap-3 border-b border-slate-200 px-4 py-3 font-mono text-xs">
+        <Cell label="Run id" value={inspection.runId} />
+        <Cell label="Checked at" value={inspection.checkedAt} />
+        <Cell label="Issuer DID" value={inspection.issuerDid} />
+        <Cell
+          label="Signing key"
+          value={inspection.signingKeyId?.slice(0, 24) ?? '—'}
+        />
+      </dl>
+      <section>
+        <div className="border-b border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Runs · click to push pane
+        </div>
+        {inspection.runs.map((run) => (
+          <PushRow
+            key={run.runId}
+            label={`${run.source} · ${run.checkedAt}`}
+            caption={`${run.laneId} · ${run.status} · ${run.tier}`}
+            onPush={() => pushPane({ kind: 'claim', id: paneId(run.runId) })}
+          />
+        ))}
+      </section>
+      <section>
+        <div className="border-b border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Lineage key · click to push pane
+        </div>
+        <PushRow
+          label={inspection.lineageKey}
+          caption="bi-directional binding"
+          onPush={() =>
+            pushPane({ kind: 'lineage', id: paneId(inspection.lineageKey) })
+          }
+        />
+      </section>
+      <section>
+        <div className="border-b border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Audit events · {inspection.gaps.length === 0 ? 'no gaps' : `${inspection.gaps.length} gaps`}
+        </div>
+        {inspection.gaps.length === 0 ? (
+          <PushRow
+            label="evt_no_adverse_findings"
+            caption="this is success · 0 records"
+            onPush={() =>
+              pushPane({ kind: 'audit', id: paneId(`evt_${inspection.runId}_d`) })
+            }
+          />
+        ) : (
+          inspection.gaps.map((gap, i) => (
+            <PushRow
+              key={`gap-${i}`}
+              label={gap.description}
+              caption={`${gap.gapType} · ${gap.severity}`}
+              onPush={() =>
+                pushPane({
+                  kind: 'audit',
+                  id: paneId(`evt_${inspection.runId}_${i}`),
+                })
+              }
+            />
+          ))
+        )}
+      </section>
+    </PaneShell>
+  );
+}
+
+// ── Claim pane ──────────────────────────────────────────────────────────────
+
+function ClaimPane({
+  claimId,
+  inspection,
+  pushPane,
+  closeThisPane,
+}: {
+  claimId: string;
+  inspection: ReplayInspection;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane: () => void;
+}) {
+  const run = inspection.runs.find((r) => paneId(r.runId) === claimId);
+  const backlinks = resolveClaimBacklinks(inspection, claimId);
+  return (
+    <PaneShell
+      caption="claim"
+      title={run?.source ?? `claim · ${claimId}`}
+      onClose={closeThisPane}
+    >
+      {run ? (
+        <dl className="grid grid-cols-2 gap-3 px-4 py-3 font-mono text-xs">
+          <Cell label="Lane" value={run.laneId} />
+          <Cell label="Status" value={run.status} />
+          <Cell label="Tier" value={run.tier} />
+          <Cell label="Checked at" value={run.checkedAt} />
+          {run.priorRunId ? (
+            <Cell label="Prior run" value={run.priorRunId} />
+          ) : null}
+        </dl>
+      ) : (
+        <div className="px-4 py-3 font-mono text-xs text-slate-500">
+          Claim {claimId} not found in this inspection.
+        </div>
+      )}
+      <PushRow
+        label="Open lineage key"
+        caption={inspection.lineageKey}
+        onPush={() =>
+          pushPane({ kind: 'lineage', id: paneId(inspection.lineageKey) })
+        }
+      />
+      <LineageBacklinks links={backlinks} />
+    </PaneShell>
+  );
+}
+
+function resolveClaimBacklinks(
+  inspection: ReplayInspection,
+  _claimId: string,
+): readonly LineageBacklinkEntry[] {
+  return [
+    {
+      ref: { kind: 'receipt', id: paneId(inspection.receiptId) },
+      label: inspection.receiptId,
+      rationale: 'signed this claim',
+    },
+    {
+      ref: { kind: 'lineage', id: paneId(inspection.lineageKey) },
+      label: inspection.lineageKey,
+      rationale: 'lineage key that this claim feeds',
+    },
+  ];
+}
+
+// ── Audit pane ──────────────────────────────────────────────────────────────
+
+function AuditPane({
+  auditId,
+  inspection,
+  pushPane,
+  closeThisPane,
+}: {
+  auditId: string;
+  inspection: ReplayInspection;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane: () => void;
+}) {
+  const backlinks = resolveAuditBacklinks(inspection, auditId);
+  return (
+    <PaneShell
+      caption="audit event"
+      title={auditId}
+      onClose={closeThisPane}
+    >
+      <dl className="grid grid-cols-2 gap-3 border-b border-slate-200 px-4 py-3 font-mono text-xs">
+        <Cell label="Bound receipt" value={inspection.receiptId} />
+        <Cell label="Run id" value={inspection.runId} />
+        <Cell
+          label="Degradation"
+          value={inspection.degradationOwnership}
+        />
+        <Cell
+          label="σ verdict"
+          value={
+            inspection.degradationOwnership === 'no_adverse_findings'
+              ? 'σ ok'
+              : 'σ defer'
+          }
+        />
+      </dl>
+      <p className="border-b border-slate-200 px-4 py-3 text-xs text-slate-700">
+        {inspection.degradationExplanation}
+      </p>
+      <PushRow
+        label="Open bound receipt"
+        caption={inspection.receiptId}
+        onPush={() =>
+          pushPane({ kind: 'receipt', id: paneId(inspection.receiptId) })
+        }
+      />
+      <LineageBacklinks
+        title="Bound to · cryptographic visibility"
+        links={backlinks}
+      />
+    </PaneShell>
+  );
+}
+
+function resolveAuditBacklinks(
+  inspection: ReplayInspection,
+  _auditId: string,
+): readonly LineageBacklinkEntry[] {
+  return [
+    {
+      ref: { kind: 'receipt', id: paneId(inspection.receiptId) },
+      label: inspection.receiptId,
+      rationale: 'audit row consumed this receipt',
+    },
+    {
+      ref: { kind: 'lineage', id: paneId(inspection.lineageKey) },
+      label: inspection.lineageKey,
+      rationale: 'lineage key the audit asserts against',
+    },
+    {
+      ref: {
+        kind: 'entity',
+        id: paneId(inspection.lineageKey.split(':')[1] ?? 'unknown'),
+      },
+      label: `entity · ${inspection.lineageKey.split(':')[1] ?? 'unknown'}`,
+      rationale: 'passport / NPI the audit binds to',
+    },
+  ];
+}
+
+// ── Lineage pane ────────────────────────────────────────────────────────────
+
+function LineagePane({
+  lineageId,
+  inspection,
+  pushPane,
+  closeThisPane,
+}: {
+  lineageId: string;
+  inspection: ReplayInspection;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane: () => void;
+}) {
+  return (
+    <PaneShell caption="lineage key" title={lineageId} onClose={closeThisPane}>
+      <dl className="grid grid-cols-2 gap-3 border-b border-slate-200 px-4 py-3 font-mono text-xs">
+        <Cell
+          label="Source"
+          value={inspection.sourceContinuity.displayName}
+        />
+        <Cell label="Lifecycle" value={inspection.sourceContinuity.lifecycle} />
+        <Cell
+          label="Last checked"
+          value={inspection.sourceContinuity.lastChecked ?? '—'}
+        />
+        <Cell label="Source id" value={inspection.sourceContinuity.sourceId} />
+      </dl>
+      <PushRow
+        label="Open bound receipt"
+        caption={inspection.receiptId}
+        onPush={() =>
+          pushPane({ kind: 'receipt', id: paneId(inspection.receiptId) })
+        }
+      />
+      <LineageBacklinks
+        title="Receipts that consumed this lineage"
+        links={[
+          {
+            ref: { kind: 'receipt', id: paneId(inspection.receiptId) },
+            label: inspection.receiptId,
+            rationale: 'consumed at ' + inspection.checkedAt,
+          },
+        ]}
+      />
+    </PaneShell>
+  );
+}
+
+// ── Entity pane ─────────────────────────────────────────────────────────────
+
+function EntityPane({
+  entityId,
+  inspection,
+  pushPane,
+  closeThisPane,
+}: {
+  entityId: string;
+  inspection: ReplayInspection;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane: () => void;
+}) {
+  return (
+    <PaneShell
+      caption="entity · passport"
+      title={`Entity · ${entityId}`}
+      onClose={closeThisPane}
+    >
+      <dl className="grid grid-cols-2 gap-3 border-b border-slate-200 px-4 py-3 font-mono text-xs">
+        <Cell label="Bound receipt" value={inspection.receiptId} />
+        <Cell label="Lineage key" value={inspection.lineageKey} />
+      </dl>
+      <PushRow
+        label="Open bound receipt"
+        caption={inspection.receiptId}
+        onPush={() =>
+          pushPane({ kind: 'receipt', id: paneId(inspection.receiptId) })
+        }
+      />
+      <LineageBacklinks
+        title="Artifacts bound to this entity"
+        links={[
+          {
+            ref: { kind: 'receipt', id: paneId(inspection.receiptId) },
+            label: inspection.receiptId,
+            rationale: 'signed receipt for entity',
+          },
+          {
+            ref: { kind: 'lineage', id: paneId(inspection.lineageKey) },
+            label: inspection.lineageKey,
+            rationale: 'lineage key for entity',
+          },
+        ]}
+      />
+    </PaneShell>
+  );
+}
+
+// ── Shared cell ─────────────────────────────────────────────────────────────
+
+function Cell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-0.5 font-mono text-xs text-slate-900 break-all">
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/app/trust/panes/[receiptId]/page.tsx
+++ b/apps/web/app/trust/panes/[receiptId]/page.tsx
@@ -1,0 +1,49 @@
+/**
+ * /trust/panes/[receiptId] — Stacked Provenance Ledger
+ *
+ * Server Component. Fetches a `ReplayInspection` and renders a
+ * Matuschak-style URL-driven stacked-pane interface. The root pane is
+ * the receipt; pushing pane stacks via `?panes=...` reveals audit
+ * events, claims, lineage keys, and entity bindings.
+ *
+ * Bi-directional cryptographic visibility: opening any deeper pane
+ * renders `LineageBacklinks` showing every artifact that binds TO it.
+ */
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getReplayInspection } from '@/lib/replay/getReplayInspection';
+import { PanesClient } from './PanesClient';
+
+export const metadata: Metadata = {
+  title: 'Stacked Provenance Ledger · VitalCV',
+  description:
+    'URL-driven sliding-pane interface for trust artifact exploration.',
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  params: Promise<{ receiptId: string }>;
+}
+
+export default async function StackedProvenancePage({ params }: PageProps) {
+  const { receiptId } = await params;
+
+  if (!receiptId || !/^(rcpt_|rec-)/.test(receiptId)) {
+    notFound();
+  }
+
+  const inspection = await getReplayInspection(receiptId);
+  if (!inspection) notFound();
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-900 bg-slate-950 px-5 py-3 font-mono text-xs uppercase tracking-wider text-slate-100">
+        Stacked provenance ledger · {receiptId}
+      </header>
+      <div className="h-[calc(100vh-3rem)]">
+        <PanesClient inspection={inspection} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/trust/LineageBacklinks.tsx
+++ b/apps/web/components/trust/LineageBacklinks.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { useStackedPanes } from './StackedPaneLayout';
+import type { PaneRef } from '@/lib/trust/panes';
+
+/**
+ * Lineage Backlinks — bi-directional cryptographic visibility.
+ *
+ * Inspired by the Matuschak notes pattern: whenever you open a pane,
+ * the deeper context shows every other artifact that points TO this
+ * one. Opening an audit event reveals the entity it is bound to;
+ * opening a claim reveals the receipts that signed it; opening a
+ * receipt reveals every audit row that consumed it.
+ *
+ * This is presentation-only — backlink resolution is a caller policy
+ * (the caller passes the resolved links). Keeping resolution out of
+ * the component avoids embedding fetch behavior in a primitive and
+ * lets server callers pre-resolve for offline-verifiable pages.
+ */
+
+export interface LineageBacklinkEntry {
+  /** The pane that links TO the current pane. */
+  ref: PaneRef;
+  /** Human-readable label rendered for the backlink chip. */
+  label: string;
+  /** Optional short rationale (e.g. "signed this claim", "audit row consumed"). */
+  rationale?: string;
+}
+
+export interface LineageBacklinksProps {
+  /** Title rendered above the chip rail (e.g. "Bi-directional bindings"). */
+  title?: string;
+  /** Backlinks the caller has pre-resolved for this pane. */
+  links: readonly LineageBacklinkEntry[];
+  className?: string;
+}
+
+export function LineageBacklinks({
+  title = 'Lineage backlinks · bi-directional bindings',
+  links,
+  className,
+}: LineageBacklinksProps) {
+  const { open } = useStackedPanes();
+
+  if (links.length === 0) {
+    return (
+      <section
+        data-slot="lineage-backlinks"
+        data-empty="true"
+        className={cn(
+          'border-t border-slate-900 bg-white px-4 py-3 font-mono text-[11px] text-slate-500',
+          className,
+        )}
+      >
+        <div className="uppercase tracking-wider opacity-70">{title}</div>
+        <div className="mt-2">No artifacts bind to this pane.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-slot="lineage-backlinks"
+      className={cn(
+        'border-t border-slate-900 bg-white px-4 py-3',
+        className,
+      )}
+    >
+      <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        {title}
+      </div>
+      <ul className="mt-2 space-y-1.5">
+        {links.map((entry, i) => (
+          <li key={`${entry.ref.kind}-${entry.ref.id}-${i}`}>
+            <button
+              type="button"
+              onClick={() => open(entry.ref)}
+              data-slot="lineage-backlink"
+              data-target-kind={entry.ref.kind}
+              data-target-id={entry.ref.id}
+              className={cn(
+                'flex w-full items-start gap-2 border border-slate-900 bg-white px-2 py-1.5 text-left font-mono text-xs hover:bg-slate-50',
+              )}
+            >
+              <span className="inline-flex shrink-0 items-center border border-slate-900 bg-slate-900 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-slate-50">
+                {entry.ref.kind}
+              </span>
+              <span className="flex-1 break-all text-slate-900">
+                {entry.label}
+                {entry.rationale ? (
+                  <span className="block text-[10px] text-slate-500">
+                    {entry.rationale}
+                  </span>
+                ) : null}
+              </span>
+              <span className="shrink-0 text-slate-500">→</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/trust/StackedPaneLayout.tsx
+++ b/apps/web/components/trust/StackedPaneLayout.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import {
+  PANE_STACK_OFFSET_PX,
+  PANE_WIDTH_REM,
+  closePaneAt,
+  parsePanes,
+  pushPane,
+  serializePanes,
+  type PaneRef,
+} from '@/lib/trust/panes';
+
+/**
+ * Stacked Provenance Ledger — URL-driven sliding panes.
+ *
+ * Inspired by Andy Matuschak's notes (https://notes.andymatuschak.org).
+ * The stack is canonical state in the URL: open panes are listed in
+ * `?panes=...`, the rightmost pane is the active one, panes scroll
+ * horizontally, and the left edges of overflowed panes sticky-stack so
+ * the user always sees the path they took.
+ *
+ * Visual contract (binding):
+ * - dense, quiet, institutional (no shadows, no gradients, no animation
+ *   beyond a fast linear horizontal slide)
+ * - strict --ink-900 borders (rendered as `border-slate-900`)
+ * - 40px sticky offset per stacked pane
+ * - panes are fixed-width (32rem) so the index-card metaphor holds
+ */
+export interface StackedPaneLayoutProps {
+  /**
+   * Renderer for a single pane. Called once per pane in the URL stack.
+   * The render context gives the caller the active index, the ability
+   * to push a child pane, and the ability to close panes to the right.
+   */
+  renderPane: (ref: PaneRef, ctx: PaneRenderContext) => React.ReactNode;
+  /**
+   * Optional leftmost root pane that always renders. Useful when the
+   * stack head is determined by the route (e.g. "the receipt you're
+   * inspecting") rather than the URL.
+   */
+  rootPane?: PaneRef;
+  /**
+   * Optional renderer for the root pane. Required when `rootPane` is
+   * provided.
+   */
+  renderRootPane?: (ctx: PaneRenderContext) => React.ReactNode;
+  className?: string;
+}
+
+export interface PaneRenderContext {
+  index: number;
+  isActive: boolean;
+  totalPanes: number;
+  pushPane: (next: PaneRef) => void;
+  closeThisPane: () => void;
+}
+
+/**
+ * Internal hook — synchronises the `?panes=` search param with route
+ * state. Mutations are router-pushed (not replaced) so the browser
+ * back-button walks the user's exploration path.
+ */
+function usePaneStack(): {
+  panes: readonly PaneRef[];
+  pushFrom: (fromIndex: number, ref: PaneRef) => void;
+  closeAt: (index: number) => void;
+} {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const panes = React.useMemo(
+    () => parsePanes(searchParams.get('panes')),
+    [searchParams],
+  );
+
+  const navigate = React.useCallback(
+    (next: readonly PaneRef[]) => {
+      const params = new URLSearchParams(searchParams.toString());
+      const serialized = serializePanes(next);
+      if (serialized.length > 0) {
+        params.set('panes', serialized);
+      } else {
+        params.delete('panes');
+      }
+      const query = params.toString();
+      router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
+  const pushFrom = React.useCallback(
+    (fromIndex: number, ref: PaneRef) => {
+      navigate(pushPane(panes, fromIndex, ref));
+    },
+    [navigate, panes],
+  );
+
+  const closeAt = React.useCallback(
+    (index: number) => {
+      navigate(closePaneAt(panes, index));
+    },
+    [navigate, panes],
+  );
+
+  return { panes, pushFrom, closeAt };
+}
+
+export function StackedPaneLayout({
+  renderPane,
+  rootPane,
+  renderRootPane,
+  className,
+}: StackedPaneLayoutProps) {
+  const { panes, pushFrom, closeAt } = usePaneStack();
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll the rightmost pane into view when the stack grows.
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ left: el.scrollWidth, behavior: 'smooth' });
+  }, [panes.length]);
+
+  // Including the optional root pane in offset math.
+  const rootOffset = rootPane ? 1 : 0;
+  const totalPanes = panes.length + rootOffset;
+
+  return (
+    <div
+      ref={scrollRef}
+      data-slot="stacked-pane-layout"
+      className={cn(
+        'flex h-full w-full snap-x snap-mandatory overflow-x-auto bg-slate-50',
+        // Fast linear horizontal slide — no bouncy easing, no fade.
+        'scroll-smooth',
+        className,
+      )}
+    >
+      {rootPane && renderRootPane ? (
+        <PaneSlot
+          index={0}
+          totalPanes={totalPanes}
+          stickyLeftPx={0 * PANE_STACK_OFFSET_PX}
+        >
+          {renderRootPane({
+            index: 0,
+            isActive: panes.length === 0,
+            totalPanes,
+            pushPane: (next) => pushFrom(rootOffset - 1, next),
+            closeThisPane: () => closeAt(0),
+          })}
+        </PaneSlot>
+      ) : null}
+      {panes.map((ref, i) => {
+        const absoluteIndex = i + rootOffset;
+        return (
+          <PaneSlot
+            key={`${ref.kind}-${ref.id}-${absoluteIndex}`}
+            index={absoluteIndex}
+            totalPanes={totalPanes}
+            stickyLeftPx={absoluteIndex * PANE_STACK_OFFSET_PX}
+          >
+            {renderPane(ref, {
+              index: absoluteIndex,
+              isActive: i === panes.length - 1,
+              totalPanes,
+              pushPane: (next) => pushFrom(i, next),
+              closeThisPane: () => closeAt(i),
+            })}
+          </PaneSlot>
+        );
+      })}
+    </div>
+  );
+}
+
+interface PaneSlotProps {
+  index: number;
+  totalPanes: number;
+  stickyLeftPx: number;
+  children: React.ReactNode;
+}
+
+function PaneSlot({ index, totalPanes, stickyLeftPx, children }: PaneSlotProps) {
+  // Sticky left position keeps the stacked-card metaphor: panes pile
+  // up at the left edge as the user scrolls right. No shadows by
+  // design — strict ink-900 borders only.
+  return (
+    <section
+      data-slot="stacked-pane"
+      data-pane-index={index}
+      data-pane-total={totalPanes}
+      className={cn(
+        'sticky shrink-0 snap-start border-r border-slate-900 bg-white',
+        // Each pane has a fixed width so panes feel like index cards.
+      )}
+      style={{
+        left: `${stickyLeftPx}px`,
+        width: `${PANE_WIDTH_REM}rem`,
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Convenience hook for child components living inside a pane that
+ * need to open another pane (e.g. a backlink button). Exposes the
+ * same push/close primitives as the render context, but readable
+ * from any depth.
+ */
+export function useStackedPanes() {
+  const { panes, pushFrom, closeAt } = usePaneStack();
+  return {
+    panes,
+    /** Push a new pane onto the end of the current stack. */
+    open: (ref: PaneRef) => pushFrom(panes.length - 1, ref),
+    /** Push a child of the pane at `fromIndex` (legacy callers). */
+    pushFrom,
+    closeAt,
+  };
+}

--- a/apps/web/lib/trust/panes.ts
+++ b/apps/web/lib/trust/panes.ts
@@ -1,0 +1,125 @@
+/**
+ * URL-driven pane state for the Stacked Provenance Ledger.
+ *
+ * Inspired by Andy Matuschak's working notes — every navigation step
+ * pushes a new pane to the right of the stack and the URL becomes the
+ * canonical, shareable, reload-survivable representation of the user's
+ * exploration path.
+ *
+ * URL contract:
+ *
+ *     ?panes=receipt-7a2cb8d3,audit-evt_8821,lineage-nppes_identity
+ *
+ * Each pane token is `<kind>-<id>`. Pane kinds are closed; the type
+ * system rejects unknown kinds at compile time. IDs are restricted to
+ * `[A-Za-z0-9_-]+` so the URL is never ambiguous and never needs
+ * percent-encoding.
+ */
+
+export const PANE_KINDS = [
+  'receipt',
+  'audit',
+  'claim',
+  'lineage',
+  'entity',
+] as const;
+
+export type PaneKind = (typeof PANE_KINDS)[number];
+
+export interface PaneRef {
+  readonly kind: PaneKind;
+  readonly id: string;
+}
+
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const SEPARATOR = ',';
+const KIND_SEPARATOR = '-';
+
+function isPaneKind(value: string): value is PaneKind {
+  return (PANE_KINDS as readonly string[]).includes(value);
+}
+
+function isValidId(id: string): boolean {
+  return id.length > 0 && id.length <= 128 && ID_PATTERN.test(id);
+}
+
+/**
+ * Parses the `panes` search-param value into an ordered list of
+ * `PaneRef`. Malformed tokens are silently dropped — the URL is
+ * user-editable and a bad pane should not crash the layout. Duplicates
+ * are preserved in order; deduping is a caller policy decision.
+ */
+export function parsePanes(raw: string | null | undefined): readonly PaneRef[] {
+  if (!raw) return [];
+  return raw
+    .split(SEPARATOR)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .map((token): PaneRef | null => {
+      const dashIndex = token.indexOf(KIND_SEPARATOR);
+      if (dashIndex <= 0) return null;
+      const kind = token.slice(0, dashIndex);
+      const id = token.slice(dashIndex + 1);
+      if (!isPaneKind(kind)) return null;
+      if (!isValidId(id)) return null;
+      return { kind, id };
+    })
+    .filter((ref): ref is PaneRef => ref !== null);
+}
+
+export function serializePanes(panes: readonly PaneRef[]): string {
+  return panes
+    .filter((p) => isPaneKind(p.kind) && isValidId(p.id))
+    .map((p) => `${p.kind}${KIND_SEPARATOR}${p.id}`)
+    .join(SEPARATOR);
+}
+
+/**
+ * Returns the next stack when a new pane is opened from a pane at
+ * `fromIndex`. Mirrors Matuschak's behavior: opening a child from
+ * pane N replaces panes (N+1..end) and appends the new child. This
+ * keeps the stack a single tree-path rather than a fork.
+ */
+export function pushPane(
+  current: readonly PaneRef[],
+  fromIndex: number,
+  next: PaneRef,
+): readonly PaneRef[] {
+  const cut = current.slice(0, fromIndex + 1);
+  // Avoid no-op pushes when the user re-clicks the same destination
+  const last = cut[cut.length - 1];
+  if (last && last.kind === next.kind && last.id === next.id) {
+    return cut;
+  }
+  return [...cut, next];
+}
+
+/**
+ * Removes the pane at `index` and every pane to its right.
+ */
+export function closePaneAt(
+  current: readonly PaneRef[],
+  index: number,
+): readonly PaneRef[] {
+  if (index < 0 || index >= current.length) return current;
+  return current.slice(0, index);
+}
+
+export function paneToken(ref: PaneRef): string {
+  return `${ref.kind}${KIND_SEPARATOR}${ref.id}`;
+}
+
+/**
+ * Pane stacking offset in pixels. Stacked left-edge of each pane
+ * advances by this much; the active rightmost pane scrolls into view
+ * fully. Hard-coded here so layout math is shared between
+ * StackedPaneLayout and tests.
+ */
+export const PANE_STACK_OFFSET_PX = 40;
+
+/**
+ * Default width of a single pane (rem). Pane widths are intentionally
+ * fixed so the stacked-card metaphor holds at any viewport width and
+ * panes feel like physical index cards rather than fluid grid cells.
+ */
+export const PANE_WIDTH_REM = 32;


### PR DESCRIPTION
## Mission

Build the Stacked Provenance Ledger inspired by Andy Matuschak's working notes — a URL-driven, horizontally-scrolling sliding-pane interface for trust artifact exploration. Each click pushes a new pane to the right of the stack; the URL is the canonical, shareable, reload-survivable representation of the path.

## What ships

| File | Purpose |
|---|---|
| `apps/web/lib/trust/panes.ts` | Pure URL contract — `PaneRef`, `parsePanes`, `serializePanes`, `pushPane`, `closePaneAt`, `PANE_STACK_OFFSET_PX = 40`, `PANE_WIDTH_REM = 32`. Five closed pane kinds; strict id validation rejects injection. |
| `apps/web/components/trust/StackedPaneLayout.tsx` | Sticky-positioned horizontal layout (`'use client'`). 40px sticky left offset per pane, fixed 32rem pane width, `border-slate-900` strict borders, no shadows, no gradients, fast linear horizontal slide (`scroll-smooth`). Synchronises with `?panes=...` via Next.js navigation hooks. |
| `apps/web/components/trust/LineageBacklinks.tsx` | Bi-directional cryptographic visibility primitive. Renders caller-pre-resolved backlinks ("what binds to this pane"). Clicking a backlink chip pushes the linked pane. |
| `apps/web/app/trust/panes/[receiptId]/page.tsx` | Server route — fetches `ReplayInspection`, hands to client wrapper. |
| `apps/web/app/trust/panes/[receiptId]/PanesClient.tsx` | Client wrapper — five pane renderers (`receipt` / `claim` / `audit` / `lineage` / `entity`). Every deeper pane includes `LineageBacklinks` resolved against the inspection so bi-directional bindings are visible without an additional fetch. |
| `apps/web/__tests__/stacked-provenance-panes.test.tsx` | 17 passing tests. |

## URL contract

```
/trust/panes/rcpt_7a2cb8d3?panes=audit-evt_8821,lineage-nppes_identity,entity-npi_1356428912
```

| Property | Behavior |
|---|---|
| Pane kinds (closed) | `receipt` · `audit` · `claim` · `lineage` · `entity` |
| Id grammar | `^[A-Za-z0-9_-]+$`, ≤128 chars |
| Malformed tokens | silently dropped (URL is user-editable; one bad pane must not crash the stack) |
| `pushPane(stack, fromIndex, next)` | Matuschak tree-path — opening from index N replaces panes (N+1..end) and appends `next` |
| Idempotent re-push | clicking the same destination from the rightmost pane is a no-op |
| Browser back | `router.push` (not replace) so back walks the exploration path |

## Visual contract (binding)

- 40px sticky left offset per stacked pane (physical-index-card metaphor)
- 32rem fixed pane width
- `border-slate-900` strict borders only — **no drop shadows**, no gradients
- Fast linear horizontal slide (`scroll-smooth`) — **no bouncy easing**, no fade
- Dense, quiet, institutional palette matches existing trust-canon primitives

## Bi-directional visibility

Opening any deeper pane immediately reveals what binds to it:

- **Audit pane** → bound receipt + lineage key + entity (passport/NPI it asserts against)
- **Claim pane** → receipt that signed it + lineage key it feeds
- **Lineage pane** → receipts that consumed this lineage
- **Entity pane** → all receipts + lineage keys bound to the entity

Resolution is caller policy (`LineageBacklinks` is presentational); server pages can pre-resolve for offline-verifiable rendering.

## Integration boundary

This wave **adds** a new additive route at `/trust/panes/[receiptId]` and the reusable primitives that back it. It does **not** modify:
- `apps/web/app/verify/*`
- `apps/web/app/review/*`
- `apps/web/components/review/ReviewClient.tsx` (the 2192-line decision surface)
- existing trust-canon receipt / dossier / passport routes

The primitives are immediately importable by those routes when they're ready; rewiring is a follow-up wave.

## Tests · 17 passing

| Group | Tests | What it asserts |
|---|---|---|
| URL contract | 8 | five canonical kinds; round-trip; unknown-kind drop; malformed-id drop; no kind-separator drop; canonical token; null/empty handling |
| Tree-path push | 3 | append from rightmost; truncate-and-append from middle; idempotent re-push |
| closePaneAt | 3 | remove + everything-to-right; close-at-0 empties; out-of-range no-op |
| Visual constants | 1 | `PANE_STACK_OFFSET_PX === 40` (binding archive constant) |
| LineageBacklinks render | 2 | empty-state hint; rendered chip + label + rationale |

Tests mock `next/navigation` so primitives render statically without a router context.

## Validation

```
pnpm install --frozen-lockfile  → clean
pnpm turbo run build --filter @vitalcv/trust-state  → cache hit
pnpm --filter @vitalcv/web exec tsc --noEmit
  → 2 pre-existing errors in components/clinician/intake-types.ts (unrelated)
  → 0 introduced by this wave
pnpm --filter @vitalcv/web exec vitest run stacked-provenance-panes.test.tsx
  → 1 file passed · 17/17 tests
pnpm --filter @vitalcv/web lint  → clean
```

## Test plan
- [ ] `pnpm --filter @vitalcv/web exec vitest run stacked-provenance-panes.test.tsx` passes 17 tests
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 2 pre-existing `intake-types.ts` errors
- [ ] `pnpm --filter @vitalcv/web lint` clean
- [ ] In dev: visit `/trust/panes/<a valid receipt id>` and verify clicking a run pushes a `claim-` pane to the URL; clicking the run pane's backlink opens the bound receipt pane; reloading preserves the stack
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)