### PR TITLE
feat(core): enforce antigravity routing and durable cryptographic event chain (C73 + C75)

### DIFF
--- a/apps/api/backend/jest.config.js
+++ b/apps/api/backend/jest.config.js
@@ -30,6 +30,8 @@ module.exports = {
     '^@vitalcv/shared/(.*)$': '<rootDir>/../../../packages/shared/$1',
     '^@vitalcv/trust-state$': '<rootDir>/../../../packages/trust-state/index.ts',
     '^@vitalcv/trust-state/(.*)$': '<rootDir>/../../../packages/trust-state/$1',
+    '^@vitalcv/core$': '<rootDir>/../../../packages/core/src/index.ts',
+    '^@vitalcv/core/(.*)$': '<rootDir>/../../../packages/core/src/$1',
     // core/graph/* package resolution (relative depth varies by caller)
     '^(?:\\.\\./){4,8}core/graph/(.*)$': '<rootDir>/../../../core/graph/$1',
   },

--- a/apps/api/backend/package.json
+++ b/apps/api/backend/package.json
@@ -72,7 +72,8 @@
     "supercluster": "^7.1.3",
     "swagger-ui-express": "^5.0.1",
     "ts-node": "^10.9.2",
-    "web-did-resolver": "^2.0.30"
+    "web-did-resolver": "^2.0.30",
+    "@vitalcv/core": "workspace:*"
   },
   "devDependencies": {
     "@types/archiver": "^7.0.0",

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -1487,6 +1487,13 @@ model AuditEvent {
   organizationId String?
   anchored       Boolean  @default(false)
   merkleRoot     String?
+  // ── WAVE C75 · durable cryptographic event chain ──────────────────────
+  // `lineageKey` groups events into a per-subject/per-lane chain.
+  // `priorRunId` references the predecessor event's `id`; null for genesis.
+  // `hash` is repurposed by `createAuditEventWithChain` to hold the
+  // SHA-256 chain hash computed by `@vitalcv/core` HashChainService.
+  lineageKey     String?  @map("lineage_key")
+  priorRunId     String?  @map("prior_run_id") @db.Uuid
 
   @@index([type, createdAt])
   @@index([clinicianId])
@@ -1494,6 +1501,8 @@ model AuditEvent {
   @@index([organizationId])
   @@index([anchored])
   @@index([merkleRoot])
+  @@index([lineageKey])
+  @@index([priorRunId])
 }
 
 // ── Pilot Operations Events ────────────────────────────────────────────────

--- a/apps/web/__tests__/antigravity-routing.test.ts
+++ b/apps/web/__tests__/antigravity-routing.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateAntigravityRoute,
+  ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT,
+  ANTIGRAVITY_COOKIE_RECEIPT_STATUS,
+} from '@/lib/auth/antigravity';
+
+describe('antigravity · role gating', () => {
+  it('non-verifier roles always pass (antigravity is verifier-scoped)', () => {
+    for (const role of [
+      'CLINICIAN',
+      'ISSUER',
+      'ADMIN',
+      'AUTHENTICATED',
+      null,
+    ] as const) {
+      const d = evaluateAntigravityRoute({
+        role,
+        pathname: '/dashboard',
+        activeReceiptId: 'rcpt_7a2c',
+        receiptStatus: 'ACTIVE',
+      });
+      expect(d.action).toBe('pass');
+    }
+  });
+});
+
+describe('antigravity · explicit denylist', () => {
+  it('redirects verifiers off /dashboard back to active receipt', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/dashboard',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('redirect');
+    expect(d.redirectTo).toBe('/verify/receipt/rcpt_7a2c');
+    expect(d.reason).toBe('verifier_blocked_route');
+  });
+
+  it('redirects verifiers off /home', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/home',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('redirect');
+  });
+
+  it('redirects verifiers off nested /dashboard/* and /home/*', () => {
+    for (const p of ['/dashboard/clinicians', '/home/recents']) {
+      const d = evaluateAntigravityRoute({
+        role: 'VERIFIER',
+        pathname: p,
+        activeReceiptId: 'rcpt_7a2c',
+        receiptStatus: 'ACTIVE',
+      });
+      expect(d.action).toBe('redirect');
+    }
+  });
+
+  it('passes for verifier without an active receipt (no redirect target)', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/dashboard',
+      activeReceiptId: null,
+      receiptStatus: null,
+    });
+    expect(d.action).toBe('pass');
+  });
+});
+
+describe('antigravity · canonical verifier paths', () => {
+  it('passes for the active receipt URL itself', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/verify/receipt/rcpt_7a2c',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('pass');
+  });
+
+  it('passes for /verify root', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/verify',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('pass');
+  });
+
+  it('passes for /verify/guide', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/verify/guide',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('pass');
+  });
+
+  it('passes for any other /verify/receipt/<id> subpath', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/verify/receipt/another',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('pass');
+  });
+});
+
+describe('antigravity · terminal status locks to read-only receipt view', () => {
+  it.each(['ACCEPTED', 'REVOKED'] as const)(
+    '%s receipt: any non-canonical path redirects to the receipt view',
+    (status) => {
+      const d = evaluateAntigravityRoute({
+        role: 'VERIFIER',
+        pathname: '/verify',
+        activeReceiptId: 'rcpt_7a2c',
+        receiptStatus: status,
+      });
+      expect(d.action).toBe('redirect');
+      expect(d.redirectTo).toBe('/verify/receipt/rcpt_7a2c');
+      expect(d.reason).toBe('receipt_terminal_status_locked_to_read_only');
+    },
+  );
+
+  it('passes when already on the active receipt URL with ACCEPTED status', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/verify/receipt/rcpt_7a2c',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACCEPTED',
+    });
+    expect(d.action).toBe('pass');
+  });
+});
+
+describe('antigravity · cookie name surface', () => {
+  it('cookie keys are stable institutional identifiers', () => {
+    expect(ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT).toBe('vcv_active_receipt');
+    expect(ANTIGRAVITY_COOKIE_RECEIPT_STATUS).toBe(
+      'vcv_active_receipt_status',
+    );
+  });
+});
+
+describe('antigravity · off-canonical paths trigger redirect even outside denylist', () => {
+  it('verifier on /intelligence with active receipt → redirect home', () => {
+    const d = evaluateAntigravityRoute({
+      role: 'VERIFIER',
+      pathname: '/intelligence/snapshot',
+      activeReceiptId: 'rcpt_7a2c',
+      receiptStatus: 'ACTIVE',
+    });
+    expect(d.action).toBe('redirect');
+    expect(d.reason).toBe('verifier_off_canonical_path');
+  });
+});

--- a/apps/web/lib/auth/antigravity.ts
+++ b/apps/web/lib/auth/antigravity.ts
@@ -1,0 +1,152 @@
+/**
+ * Antigravity routing contract — WAVE C73.
+ *
+ * Verifiers exist to make decisions on receipts. Any navigation that
+ * pulls them off their active receipt route — onto a SaaS-style
+ * dashboard, an empty "home", or a non-canonical action subpath — is
+ * a contract violation. This module is the pure decision function for
+ * the middleware enforcement.
+ *
+ * Edge-safe: no DB, no fetch, no Clerk SDK. Reads only the request URL
+ * + cookies. Cookies are set server-side by the `/verify/receipt/<id>`
+ * page renderer when a verifier loads a receipt.
+ *
+ * Status semantics:
+ *   - `ACTIVE`   — verifier may interact (accept / revoke / etc.)
+ *   - `ACCEPTED` — read-only; no further mutating actions
+ *   - `REVOKED`  — read-only; revocation is terminal
+ */
+
+export type AntigravityRole = 'VERIFIER' | 'CLINICIAN' | 'ISSUER' | 'ADMIN' | 'AUTHENTICATED' | null;
+export type ReceiptStatus = 'ACTIVE' | 'ACCEPTED' | 'REVOKED' | null;
+
+export const ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT = 'vcv_active_receipt';
+export const ANTIGRAVITY_COOKIE_RECEIPT_STATUS = 'vcv_active_receipt_status';
+
+/**
+ * Canonical paths a VERIFIER is allowed to be on while a receipt is
+ * active. Anything outside this list redirects back to the active
+ * receipt URL.
+ *
+ * `/verify` (root) and `/verify/guide` are explicitly allowed so the
+ * verifier can return to the discovery landing without being trapped.
+ */
+const CANONICAL_VERIFIER_PATHS_EXACT = new Set<string>([
+  '/verify',
+  '/verify/',
+  '/verify/guide',
+  '/sign-in',
+  '/sign-up',
+]);
+
+const CANONICAL_VERIFIER_PATH_PREFIXES = [
+  // The active receipt-detail surface is canonical
+  '/verify/receipt/',
+] as const;
+
+/**
+ * Routes that always pull a verifier off-contract — explicit denylist
+ * for clarity in the audit log.
+ */
+const ANTIGRAVITY_BLOCKED_PATHS_EXACT = new Set<string>([
+  '/dashboard',
+  '/dashboard/',
+  '/home',
+  '/home/',
+]);
+
+const ANTIGRAVITY_BLOCKED_PATH_PREFIXES = [
+  '/dashboard/',
+  '/home/',
+] as const;
+
+export interface AntigravityInput {
+  role: AntigravityRole;
+  pathname: string;
+  activeReceiptId: string | null;
+  receiptStatus: ReceiptStatus;
+}
+
+export interface AntigravityDecision {
+  /**
+   * `pass` — allow the request through unchanged.
+   * `redirect` — issue a 307 to `redirectTo`.
+   */
+  action: 'pass' | 'redirect';
+  redirectTo?: string;
+  /** Machine-readable reason for telemetry. */
+  reason?:
+    | 'verifier_blocked_route'
+    | 'verifier_off_canonical_path'
+    | 'receipt_terminal_status_locked_to_read_only';
+}
+
+function isCanonicalVerifierPath(pathname: string): boolean {
+  if (CANONICAL_VERIFIER_PATHS_EXACT.has(pathname)) return true;
+  return CANONICAL_VERIFIER_PATH_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+function isExplicitlyBlocked(pathname: string): boolean {
+  if (ANTIGRAVITY_BLOCKED_PATHS_EXACT.has(pathname)) return true;
+  return ANTIGRAVITY_BLOCKED_PATH_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+/**
+ * Pure decision function. Given the request shape, returns whether to
+ * pass or 307-redirect, and where.
+ *
+ * Order of rules (binding):
+ *   1. Non-VERIFIER roles always pass — antigravity is verifier-scoped.
+ *   2. If the route is in the explicit denylist (`/dashboard`, `/home`,
+ *      etc.) AND the verifier has an active receipt → redirect home to
+ *      the receipt.
+ *   3. If the receipt status is terminal (ACCEPTED | REVOKED) AND the
+ *      verifier is on any path other than the canonical read-only
+ *      receipt view → redirect home to the receipt (locked-read-only).
+ *   4. If the verifier is on a non-canonical path AND has an active
+ *      receipt → redirect home.
+ *   5. Otherwise pass.
+ */
+export function evaluateAntigravityRoute(
+  input: AntigravityInput,
+): AntigravityDecision {
+  if (input.role !== 'VERIFIER') return { action: 'pass' };
+
+  const { pathname, activeReceiptId, receiptStatus } = input;
+  const homeUrl = activeReceiptId
+    ? `/verify/receipt/${encodeURIComponent(activeReceiptId)}`
+    : null;
+
+  // Rule 2 — explicit denylist
+  if (isExplicitlyBlocked(pathname) && homeUrl) {
+    return {
+      action: 'redirect',
+      redirectTo: homeUrl,
+      reason: 'verifier_blocked_route',
+    };
+  }
+
+  // Rule 3 — terminal status locks the verifier to read-only receipt
+  if (
+    homeUrl &&
+    (receiptStatus === 'ACCEPTED' || receiptStatus === 'REVOKED') &&
+    pathname !== homeUrl
+  ) {
+    return {
+      action: 'redirect',
+      redirectTo: homeUrl,
+      reason: 'receipt_terminal_status_locked_to_read_only',
+    };
+  }
+
+  // Rule 4 — non-canonical path during an active receipt session
+  if (homeUrl && !isCanonicalVerifierPath(pathname)) {
+    return {
+      action: 'redirect',
+      redirectTo: homeUrl,
+      reason: 'verifier_off_canonical_path',
+    };
+  }
+
+  return { action: 'pass' };
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -9,6 +9,13 @@ import {
   type UserRoleType,
 } from '@/lib/auth/roles';
 import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowlist';
+import {
+  ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT,
+  ANTIGRAVITY_COOKIE_RECEIPT_STATUS,
+  evaluateAntigravityRoute,
+  type AntigravityRole,
+  type ReceiptStatus,
+} from '@/lib/auth/antigravity';
 
 /**
  * Role-based middleware for VitalCV.
@@ -34,8 +41,55 @@ const isSignInPage = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
 const INTELLIGENCE_API = /^\/api\/(intelligence|investigation)(\/.*)?$/;
 const CLERK_MIDDLEWARE_ENABLED = Boolean(process.env.CLERK_SECRET_KEY);
 
+/**
+ * Antigravity routing check — WAVE C73.
+ *
+ * If the request carries an `vcv_active_receipt` cookie, the session
+ * is a verifier-with-active-receipt and any drift onto a non-canonical
+ * path (dashboards, generic landing pages, mutation surfaces while the
+ * receipt is in a terminal status) is 307-redirected back to the
+ * receipt URL. Pure decision; logic lives in `lib/auth/antigravity.ts`.
+ *
+ * Runs before public-route pass-through so verifier-blocked paths
+ * (e.g. `/dashboard`) cannot leak through even when marked public.
+ */
+function applyAntigravity(
+  req: NextRequest,
+  role: AntigravityRole,
+): NextResponse | null {
+  const activeReceiptId =
+    req.cookies.get(ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT)?.value ?? null;
+  if (!activeReceiptId) return null;
+  const status =
+    (req.cookies.get(ANTIGRAVITY_COOKIE_RECEIPT_STATUS)?.value as ReceiptStatus | undefined) ?? null;
+  const decision = evaluateAntigravityRoute({
+    role,
+    pathname: req.nextUrl.pathname,
+    activeReceiptId,
+    receiptStatus: status,
+  });
+  if (decision.action !== 'redirect' || !decision.redirectTo) return null;
+  const url = req.nextUrl.clone();
+  url.pathname = decision.redirectTo;
+  url.search = '';
+  const res = NextResponse.redirect(url, 307);
+  res.headers.set('x-antigravity-reason', decision.reason ?? 'unknown');
+  return res;
+}
+
 const clerkHandler = clerkMiddleware(async (auth, req) => {
   const { pathname } = req.nextUrl;
+
+  // 0. Antigravity check — if a verifier is off-canonical, redirect first.
+  //    Role from JWT if present; cookie presence is the active-session signal.
+  {
+    const earlySession = await auth();
+    const earlyRole = (earlySession.sessionClaims?.vitalcv?.role as
+      | UserRoleType
+      | undefined) ?? null;
+    const antigravity = applyAntigravity(req, earlyRole as AntigravityRole);
+    if (antigravity) return antigravity;
+  }
 
   // 1. Public routes pass through
   if (isPublicRoute(pathname)) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,7 +70,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "tippy.js": "^6.3.7",
-    "zustand": "^5.0.12"
+    "zustand": "^5.0.12",
+    "@vitalcv/core": "workspace:*"
   },
   "devDependencies": {
     "prisma": "^6.19.2",

--- a/packages/core/__tests__/ledger/HashChainService.test.ts
+++ b/packages/core/__tests__/ledger/HashChainService.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+
+import {
+  CHAIN_GENESIS_MARKER,
+  CHAIN_HASH_ALGORITHM,
+  calculateNextHash,
+  canonicalizePayload,
+  verifyChainSegment,
+} from '../../src/services/ledger/HashChainService';
+
+describe('canonicalizePayload · stable ordering', () => {
+  it('sorts object keys lexicographically', () => {
+    const a = { c: 1, a: 2, b: 3 };
+    const b = { b: 3, a: 2, c: 1 };
+    expect(canonicalizePayload(a)).toBe(canonicalizePayload(b));
+    expect(canonicalizePayload(a)).toBe('{"a":2,"b":3,"c":1}');
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const a = { x: { z: 1, y: 2 }, arr: [{ b: 1, a: 2 }] };
+    const b = { arr: [{ a: 2, b: 1 }], x: { y: 2, z: 1 } };
+    expect(canonicalizePayload(a)).toBe(canonicalizePayload(b));
+  });
+
+  it('preserves null + primitive values verbatim', () => {
+    expect(canonicalizePayload(null)).toBe('null');
+    expect(canonicalizePayload(0)).toBe('0');
+    expect(canonicalizePayload(false)).toBe('false');
+    expect(canonicalizePayload('abc')).toBe('"abc"');
+  });
+});
+
+describe('calculateNextHash · SHA-256 contract', () => {
+  it('exposes the algorithm identifier', () => {
+    expect(CHAIN_HASH_ALGORITHM).toBe('sha256');
+  });
+
+  it('is deterministic for the same input', () => {
+    const p = { type: 'attestation', subject: '1356428912' };
+    expect(calculateNextHash('PREV_HASH', p)).toBe(
+      calculateNextHash('PREV_HASH', p),
+    );
+  });
+
+  it('matches an externally-computed SHA-256(prev|canonical(payload))', () => {
+    const prev = 'abc123';
+    const payload = { b: 2, a: 1 };
+    const canonical = '{"a":1,"b":2}';
+    const expected = createHash('sha256')
+      .update(prev)
+      .update('|')
+      .update(canonical)
+      .digest('hex');
+    expect(calculateNextHash(prev, payload)).toBe(expected);
+  });
+
+  it('treats empty / nullish previousHash as the GENESIS marker', () => {
+    const p = { type: 'genesis_check' };
+    expect(calculateNextHash('', p)).toBe(
+      calculateNextHash(CHAIN_GENESIS_MARKER, p),
+    );
+  });
+
+  it('genesis marker is the binding literal "GENESIS_VITALCV"', () => {
+    expect(CHAIN_GENESIS_MARKER).toBe('GENESIS_VITALCV');
+  });
+
+  it('chain reacts to any payload mutation (tamper detection)', () => {
+    const h1 = calculateNextHash('PREV', { a: 1, b: 2 });
+    const h2 = calculateNextHash('PREV', { a: 1, b: 3 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('chain reacts to any previousHash mutation', () => {
+    const p = { a: 1 };
+    expect(calculateNextHash('h1', p)).not.toBe(calculateNextHash('h2', p));
+  });
+
+  it('hash boundary separator prevents payload/prevHash collision', () => {
+    // Without the '|' separator, `prev='AB', payload='C'` would hash the
+    // same as `prev='A', payload='BC'`. The separator makes that impossible.
+    const a = calculateNextHash('AB', 'C');
+    const b = calculateNextHash('A', 'BC');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('verifyChainSegment · offline replay', () => {
+  it('returns -1 when the chain reconciles end-to-end', () => {
+    const payloads = [
+      { e: 1 },
+      { e: 2 },
+      { e: 3 },
+    ];
+    let prev = CHAIN_GENESIS_MARKER;
+    const entries = payloads.map((p) => {
+      const h = calculateNextHash(prev, p);
+      prev = h;
+      return { payload: p, expectedHash: h };
+    });
+    expect(verifyChainSegment(CHAIN_GENESIS_MARKER, entries)).toBe(-1);
+  });
+
+  it('returns the index of the first divergence', () => {
+    const payloads = [{ e: 1 }, { e: 2 }, { e: 3 }];
+    let prev = CHAIN_GENESIS_MARKER;
+    const entries = payloads.map((p) => {
+      const h = calculateNextHash(prev, p);
+      prev = h;
+      return { payload: p, expectedHash: h };
+    });
+    // Tamper with entry index 1's payload
+    const tampered = entries.map((e, i) =>
+      i === 1 ? { ...e, payload: { e: 999 } } : e,
+    );
+    expect(verifyChainSegment(CHAIN_GENESIS_MARKER, tampered)).toBe(1);
+  });
+});

--- a/packages/core/__tests__/ledger/createAuditEventWithChain.test.ts
+++ b/packages/core/__tests__/ledger/createAuditEventWithChain.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAIN_GENESIS_MARKER,
+  calculateNextHash,
+} from '../../src/services/ledger/HashChainService';
+import {
+  createAuditEventWithChain,
+  type MinimalAuditPrismaClient,
+} from '../../src/services/ledger/createAuditEventWithChain';
+
+/**
+ * Builds a fake Prisma client backed by an in-memory store. Sufficient
+ * for the unit-level chain-correctness tests; integration tests against
+ * the real DB live in apps/api/backend/__tests__ already.
+ */
+function buildFakePrisma(): MinimalAuditPrismaClient {
+  interface Row {
+    id: string;
+    hash: string;
+    lineageKey: string | null;
+    priorRunId: string | null;
+    createdAt: number;
+  }
+  const rows: Row[] = [];
+  let auto = 0;
+  const tx: MinimalAuditPrismaClient = {
+    auditEvent: {
+      async findFirst({ where }) {
+        const filtered = rows
+          .filter((r) => r.lineageKey === where.lineageKey)
+          .sort((a, b) => b.createdAt - a.createdAt);
+        const first = filtered[0];
+        return first ? { id: first.id, hash: first.hash } : null;
+      },
+      async create({ data }) {
+        const id = `evt_${++auto}`;
+        const row: Row = {
+          id,
+          hash: data.hash,
+          lineageKey: data.lineageKey ?? null,
+          priorRunId: data.priorRunId ?? null,
+          createdAt: Date.now() + auto,
+        };
+        rows.push(row);
+        return { id, hash: row.hash };
+      },
+    },
+    async $transaction(fn) {
+      return fn(tx);
+    },
+  };
+  return tx;
+}
+
+describe('createAuditEventWithChain · genesis + chain', () => {
+  it('rejects empty lineageKey', async () => {
+    const prisma = buildFakePrisma();
+    await expect(() =>
+      createAuditEventWithChain(prisma, {
+        lineageKey: '',
+        data: { type: 'attestation' },
+      }),
+    ).rejects.toThrowError(/lineageKey is required/);
+  });
+
+  it('first insert in a lineage is genesis (priorRunId null, hashed against GENESIS marker)', async () => {
+    const prisma = buildFakePrisma();
+    const result = await createAuditEventWithChain(prisma, {
+      lineageKey: 'nppes_identity:1356428912',
+      data: { type: 'source_check' },
+    });
+    expect(result.isGenesis).toBe(true);
+    expect(result.priorRunId).toBeNull();
+
+    const expected = calculateNextHash(CHAIN_GENESIS_MARKER, {
+      type: 'source_check',
+      metadata: null,
+      referenceId: null,
+      clinicianId: null,
+      organizationId: null,
+      anchored: false,
+      merkleRoot: null,
+      lineageKey: 'nppes_identity:1356428912',
+    });
+    expect(result.hash).toBe(expected);
+  });
+
+  it('subsequent inserts link to the previous row', async () => {
+    const prisma = buildFakePrisma();
+    const a = await createAuditEventWithChain(prisma, {
+      lineageKey: 'oig:1356428912',
+      data: { type: 'sanction_screen' },
+    });
+    const b = await createAuditEventWithChain(prisma, {
+      lineageKey: 'oig:1356428912',
+      data: { type: 'sanction_screen', anchored: true },
+    });
+    expect(b.priorRunId).toBe(a.id);
+    expect(b.isGenesis).toBe(false);
+    // Chain reconciles offline:
+    const expectedB = calculateNextHash(a.hash, {
+      type: 'sanction_screen',
+      metadata: null,
+      referenceId: null,
+      clinicianId: null,
+      organizationId: null,
+      anchored: true,
+      merkleRoot: null,
+      lineageKey: 'oig:1356428912',
+    });
+    expect(b.hash).toBe(expectedB);
+  });
+
+  it('parallel lineages remain independent (priorRunId never crosses lineages)', async () => {
+    const prisma = buildFakePrisma();
+    await createAuditEventWithChain(prisma, {
+      lineageKey: 'lane_a',
+      data: { type: 'a1' },
+    });
+    const b1 = await createAuditEventWithChain(prisma, {
+      lineageKey: 'lane_b',
+      data: { type: 'b1' },
+    });
+    expect(b1.isGenesis).toBe(true);
+    expect(b1.priorRunId).toBeNull();
+  });
+
+  it('explicit payload override is used for the chain hash', async () => {
+    const prisma = buildFakePrisma();
+    const result = await createAuditEventWithChain(prisma, {
+      lineageKey: 'attest:1356428912',
+      data: { type: 'attestation' },
+      payload: { custom: 'receipt-body-bytes' },
+    });
+    const expected = calculateNextHash(CHAIN_GENESIS_MARKER, {
+      custom: 'receipt-body-bytes',
+    });
+    expect(result.hash).toBe(expected);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitalcv/core",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @vitalcv/core — cross-app shared services.
+ */
+
+// Ledger / hash chain (WAVE C75)
+export {
+  CHAIN_GENESIS_MARKER,
+  CHAIN_HASH_ALGORITHM,
+  calculateNextHash,
+  canonicalizePayload,
+  verifyChainSegment,
+} from './services/ledger/HashChainService';
+export type { ChainSegmentEntry } from './services/ledger/HashChainService';
+
+export { createAuditEventWithChain } from './services/ledger/createAuditEventWithChain';
+export type {
+  MinimalAuditPrismaClient,
+  AuditEventCreateData,
+  ChainedAuditEventInput,
+  ChainedAuditEventResult,
+} from './services/ledger/createAuditEventWithChain';

--- a/packages/core/src/services/ledger/HashChainService.ts
+++ b/packages/core/src/services/ledger/HashChainService.ts
@@ -1,0 +1,107 @@
+/**
+ * Durable cryptographic event chain — WAVE C75.
+ *
+ * Each AuditEvent in a lineage is bound to its predecessor by a
+ * `chainHash = SHA-256(previousHash || canonicalJSON(payload))`. The
+ * chain is hash-linked end-to-end; a single mutation anywhere in the
+ * lineage breaks every subsequent hash.
+ *
+ * Genesis: the first event in a lineage uses `GENESIS_VITALCV` as its
+ * `previousHash`. The literal is binding so verifiers can replay the
+ * chain offline without consulting VitalCV infrastructure.
+ *
+ * This module is intentionally pure — no I/O, no Prisma, no time. The
+ * persistence wrapper that calls it lives in
+ * `apps/api/backend/src/services/audit/createAuditEventWithChain.ts`.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * Binding sentinel for the first event in a new lineage. Renders as
+ * the `previousHash` argument when no predecessor exists. Encoded
+ * verbatim into the chain so an offline verifier can detect genesis
+ * deterministically.
+ */
+export const CHAIN_GENESIS_MARKER = 'GENESIS_VITALCV';
+
+/**
+ * Hash algorithm identifier surfaced alongside chain hashes so a
+ * downstream verifier knows which primitive to recompute with.
+ */
+export const CHAIN_HASH_ALGORITHM = 'sha256';
+
+/**
+ * Canonical JSON serialization for the chained payload.
+ *
+ * Object keys are sorted lexicographically and rendered without
+ * surrounding whitespace so that two semantically-equal payloads
+ * always produce the same byte string — the prerequisite for a
+ * reproducible hash chain across processes and language runtimes.
+ */
+export function canonicalizePayload(payload: unknown): string {
+  return JSON.stringify(sortKeysRecursive(payload));
+}
+
+function sortKeysRecursive(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sortKeysRecursive);
+  const entries = Object.entries(value as Record<string, unknown>);
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of entries) out[k] = sortKeysRecursive(v);
+  return out;
+}
+
+/**
+ * Compute the next chain hash.
+ *
+ *   chainHash = SHA-256( previousHash || '|' || canonicalJSON(payload) )
+ *
+ * The separator (`|`) is binding — it guarantees that no payload value
+ * can collide with the boundary between previousHash and payload.
+ */
+export function calculateNextHash(
+  previousHash: string,
+  currentEventPayload: unknown,
+): string {
+  const prev =
+    previousHash && previousHash.length > 0
+      ? previousHash
+      : CHAIN_GENESIS_MARKER;
+  const canonical = canonicalizePayload(currentEventPayload);
+  return createHash(CHAIN_HASH_ALGORITHM)
+    .update(prev)
+    .update('|')
+    .update(canonical)
+    .digest('hex');
+}
+
+/**
+ * Re-verify a hash chain segment offline.
+ *
+ * Accepts an ordered list of (payload, expectedHash) tuples plus the
+ * head hash that anchors the segment (or `CHAIN_GENESIS_MARKER` if the
+ * segment begins at genesis). Returns the index of the first divergence
+ * or `-1` if the chain reconciles end-to-end.
+ *
+ * Useful for tests, replay tooling, and the verifier-side audit
+ * inspection surface.
+ */
+export interface ChainSegmentEntry {
+  payload: unknown;
+  expectedHash: string;
+}
+
+export function verifyChainSegment(
+  anchorPreviousHash: string,
+  entries: readonly ChainSegmentEntry[],
+): number {
+  let prev = anchorPreviousHash;
+  for (let i = 0; i < entries.length; i++) {
+    const computed = calculateNextHash(prev, entries[i].payload);
+    if (computed !== entries[i].expectedHash) return i;
+    prev = computed;
+  }
+  return -1;
+}

--- a/packages/core/src/services/ledger/createAuditEventWithChain.ts
+++ b/packages/core/src/services/ledger/createAuditEventWithChain.ts
@@ -1,0 +1,143 @@
+/**
+ * createAuditEventWithChain — durable hash-chain wrapper for AuditEvent
+ * inserts (WAVE C75).
+ *
+ * For each insert into a given `lineageKey`:
+ *   1. Look up the most recent prior AuditEvent in that lineage.
+ *   2. Compute chainHash = calculateNextHash(previous.hash, payload)
+ *      via `@vitalcv/core` HashChainService (SHA-256, canonical-JSON).
+ *   3. Persist the new row with:
+ *        - hash       = chainHash         (repurposes the existing column)
+ *        - lineageKey = caller-supplied
+ *        - priorRunId = previous?.id ?? null   (null on genesis)
+ *
+ * The wrapper is intentionally tiny — it owns one Prisma read and one
+ * Prisma write inside a transaction so the chain cannot interleave
+ * across concurrent writes for the same lineage. Existing
+ * `prisma.auditEvent.create` call sites are NOT touched by this wave;
+ * adoption is per-callsite as auditors retrofit.
+ */
+
+import { calculateNextHash, CHAIN_GENESIS_MARKER } from './HashChainService';
+
+/**
+ * Narrow structural shape of the Prisma client surface we need. Keeps
+ * this module decoupled from the regenerated Prisma client types so it
+ * compiles before `prisma generate` runs in fresh environments.
+ */
+export interface MinimalAuditPrismaClient {
+  auditEvent: {
+    findFirst(args: {
+      where: { lineageKey: string };
+      orderBy: { createdAt: 'desc' };
+      select: { id: true; hash: true };
+    }): Promise<{ id: string; hash: string } | null>;
+    create(args: {
+      data: AuditEventCreateData & {
+        hash: string;
+        lineageKey: string;
+        priorRunId: string | null;
+      };
+    }): Promise<{ id: string; hash: string }>;
+  };
+  $transaction<T>(fn: (tx: MinimalAuditPrismaClient) => Promise<T>): Promise<T>;
+}
+
+/**
+ * Fields the caller supplies. `lineageKey` is required; the wrapper
+ * supplies `hash` and `priorRunId` from the chain computation.
+ */
+export interface AuditEventCreateData {
+  type: string;
+  metadata?: Record<string, unknown> | null;
+  referenceId?: string | null;
+  clinicianId?: string | null;
+  organizationId?: string | null;
+  anchored?: boolean;
+  merkleRoot?: string | null;
+}
+
+export interface ChainedAuditEventInput {
+  lineageKey: string;
+  data: AuditEventCreateData;
+  /**
+   * Payload the chain hash is computed over. Defaults to a canonical
+   * projection of `data` if not supplied. Pass an explicit payload
+   * when the chain should commit to fields outside the AuditEvent row
+   * (e.g. the receipt body, the artifact bytes).
+   */
+  payload?: unknown;
+}
+
+export interface ChainedAuditEventResult {
+  id: string;
+  hash: string;
+  priorRunId: string | null;
+  lineageKey: string;
+  isGenesis: boolean;
+}
+
+/**
+ * Insert a new AuditEvent that is hash-linked to the most recent prior
+ * event in its lineage.
+ *
+ * Concurrency: the read + write run inside a single Prisma transaction
+ * so two simultaneous inserts for the same `lineageKey` cannot produce
+ * a forked chain. The transaction isolation level is the Prisma default
+ * (Read Committed on PostgreSQL); a `SERIALIZABLE` upgrade is the next
+ * hardening step if forked-chain collisions are observed under load.
+ */
+export async function createAuditEventWithChain(
+  prisma: MinimalAuditPrismaClient,
+  input: ChainedAuditEventInput,
+): Promise<ChainedAuditEventResult> {
+  if (!input.lineageKey || input.lineageKey.length === 0) {
+    throw new Error('createAuditEventWithChain: lineageKey is required');
+  }
+  return prisma.$transaction(async (tx) => {
+    const prior = await tx.auditEvent.findFirst({
+      where: { lineageKey: input.lineageKey },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, hash: true },
+    });
+
+    const previousHash = prior?.hash ?? CHAIN_GENESIS_MARKER;
+    const payload = input.payload ?? canonicalEventPayload(input);
+    const chainHash = calculateNextHash(previousHash, payload);
+
+    const created = await tx.auditEvent.create({
+      data: {
+        ...input.data,
+        hash: chainHash,
+        lineageKey: input.lineageKey,
+        priorRunId: prior?.id ?? null,
+      },
+    });
+
+    return {
+      id: created.id,
+      hash: created.hash,
+      priorRunId: prior?.id ?? null,
+      lineageKey: input.lineageKey,
+      isGenesis: prior === null,
+    };
+  });
+}
+
+/**
+ * Default chain-payload projection. Includes the fields that are
+ * audit-relevant for tampering detection; intentionally omits volatile
+ * server-side fields (createdAt is added by the DB).
+ */
+function canonicalEventPayload(input: ChainedAuditEventInput): unknown {
+  return {
+    type: input.data.type,
+    metadata: input.data.metadata ?? null,
+    referenceId: input.data.referenceId ?? null,
+    clinicianId: input.data.clinicianId ?? null,
+    organizationId: input.data.organizationId ?? null,
+    anchored: input.data.anchored ?? false,
+    merkleRoot: input.data.merkleRoot ?? null,
+    lineageKey: input.lineageKey,
+  };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "declaration": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@vitalcv/command-registry':
         specifier: workspace:*
         version: link:../../../packages/command-registry
+      '@vitalcv/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
       '@vitalcv/crs':
         specifier: workspace:*
         version: link:../../../packages/crs
@@ -425,12 +428,6 @@ importers:
         version: 5.2.1
 
   apps/api/trusted-node: {}
-
-  apps/api/zk-sample:
-    dependencies:
-      snarkjs:
-        specifier: ^0.7.5
-        version: 0.7.6
 
   apps/authz:
     dependencies:
@@ -755,6 +752,9 @@ importers:
       '@trustgraph/react-state':
         specifier: ^1.6.1
         version: 1.6.1(@tanstack/react-query@5.96.1(react@19.2.3))(@trustgraph/client@1.6.0)(react@19.2.3)(zustand@5.0.12(@types/react@19.2.7)(immer@10.0.2)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)))
+      '@vitalcv/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@vitalcv/crs':
         specifier: workspace:*
         version: link:../../packages/crs
@@ -913,6 +913,15 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+
+  packages/core:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@25.2.1)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.0)
 
   packages/crs:
     dependencies:
@@ -2947,12 +2956,6 @@ packages:
 
   '@ide/backoff@1.0.0':
     resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
-
-  '@iden3/bigarray@0.0.2':
-    resolution: {integrity: sha512-Xzdyxqm1bOFF6pdIsiHLLl3HkSLjbhqJHVyqaTxXt3RqXBEnmsUmEW47H7VOi/ak7TdkRpNkxjyK5Zbkm+y52g==}
-
-  '@iden3/binfileutils@0.0.12':
-    resolution: {integrity: sha512-naAmzuDufRIcoNfQ1d99d7hGHufLA3wZSibtr4dMe6ZeiOPV1KwOZWTJ1YVz4HbaWlpDuzVU72dS4ATQS4PXBQ==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -6168,10 +6171,6 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
-  bfj@7.1.0:
-    resolution: {integrity: sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==}
-    engines: {node: '>= 8.0.0'}
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -6185,9 +6184,6 @@ packages:
 
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
-
-  bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   bn.js@4.11.6:
     resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
@@ -6445,9 +6441,6 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
-  check-types@11.2.3:
-    resolution: {integrity: sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==}
-
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
@@ -6489,10 +6482,6 @@ packages:
   cipher-base@1.0.7:
     resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
     engines: {node: '>= 0.10'}
-
-  circom_runtime@0.1.28:
-    resolution: {integrity: sha512-ACagpQ7zBRLKDl5xRZ4KpmYIcZDUjOiNRuxvXLqhnnlLSVY1Dbvh73TI853nqoR0oEbihtWmMSjgc5f+pXf/jQ==}
-    hasBin: true
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -7103,11 +7092,6 @@ packages:
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
-  ejs@3.1.10:
-    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -7260,11 +7244,6 @@ packages:
     engines: {node: '>=0.12.0'}
     hasBin: true
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   eslint-config-next@15.5.9:
     resolution: {integrity: sha512-852JYI3NkFNzW8CqsMhI0K2CDRxTObdZ2jQJj5CtpEaOkYHn13107tHpNuD/h0WRpU4FAbCdUaxQsrfBtNK9Kw==}
     peerDependencies:
@@ -7360,11 +7339,6 @@ packages:
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  esprima@1.2.5:
-    resolution: {integrity: sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   esprima@2.7.3:
     resolution: {integrity: sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==}
@@ -7664,9 +7638,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastfile@0.0.20:
-    resolution: {integrity: sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA==}
-
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -7698,21 +7669,12 @@ packages:
   fetch-retry@4.1.1:
     resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
 
-  ffjavascript@0.3.0:
-    resolution: {integrity: sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==}
-
-  ffjavascript@0.3.1:
-    resolution: {integrity: sha512-4PbK1WYodQtuF47D4pRI5KUg3Q392vuP5WjE1THSnceHdXwU3ijaoS0OqxTzLknCtz4Z2TtABzkBdBdMn3B/Aw==}
-
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  filelist@1.0.6:
-    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -8145,10 +8107,6 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
-  hoopy@0.1.4:
-    resolution: {integrity: sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==}
-    engines: {node: '>= 6.0.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -8555,11 +8513,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
@@ -8818,9 +8771,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsonpath@1.3.0:
-    resolution: {integrity: sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w==}
 
   jsonschema@1.5.0:
     resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
@@ -9118,9 +9068,6 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
-
-  logplease@1.2.15:
-    resolution: {integrity: sha512-jLlHnlsPSJjpwUfcNyUxXCl33AYg2cHhIf9QhGL2T4iPT0XPB+xP1LRKFPgIg1M/sg9kAJvy94w9CzBNrfnstA==}
 
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
@@ -10272,9 +10219,6 @@ packages:
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
-  r1csfile@0.0.48:
-    resolution: {integrity: sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==}
-
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -10861,10 +10805,6 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
-  snarkjs@0.7.6:
-    resolution: {integrity: sha512-4uH1xA5JzVU5jaaWS2fXej3+RC6L5Erhr6INTJtUA27du4Elbh4VXCeeRjB4QiwL6N6y7SNKePw5prTxyEf4Zg==}
-    hasBin: true
-
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
     engines: {node: '>=10.0.0'}
@@ -10949,9 +10889,6 @@ packages:
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
-  static-eval@2.1.1:
-    resolution: {integrity: sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -11395,9 +11332,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  tryer@1.0.1:
-    resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
-
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -11603,9 +11537,6 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
-
-  underscore@1.13.6:
-    resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -11997,12 +11928,6 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
-  wasmbuilder@0.0.16:
-    resolution: {integrity: sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==}
-
-  wasmcurves@0.2.2:
-    resolution: {integrity: sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==}
-
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -12019,9 +11944,6 @@ packages:
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
-
-  web-worker@1.2.0:
-    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
 
   web3-utils@1.10.4:
     resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
@@ -14633,13 +14555,6 @@ snapshots:
   '@humanwhocodes/object-schema@2.0.3': {}
 
   '@ide/backoff@1.0.0': {}
-
-  '@iden3/bigarray@0.0.2': {}
-
-  '@iden3/binfileutils@0.0.12':
-    dependencies:
-      fastfile: 0.0.20
-      ffjavascript: 0.3.1
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -18724,14 +18639,6 @@ snapshots:
     dependencies:
       open: 8.4.2
 
-  bfj@7.1.0:
-    dependencies:
-      bluebird: 3.7.2
-      check-types: 11.2.3
-      hoopy: 0.1.4
-      jsonpath: 1.3.0
-      tryer: 1.0.1
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -18741,8 +18648,6 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   blakejs@1.2.1: {}
-
-  bluebird@3.7.2: {}
 
   bn.js@4.11.6: {}
 
@@ -19074,8 +18979,6 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  check-types@11.2.3: {}
-
   cheerio-select@2.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -19148,10 +19051,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
-
-  circom_runtime@0.1.28:
-    dependencies:
-      ffjavascript: 0.3.1
 
   citty@0.1.6:
     dependencies:
@@ -19787,10 +19686,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  ejs@3.1.10:
-    dependencies:
-      jake: 10.9.4
-
   electron-to-chromium@1.5.267: {}
 
   elliptic@6.6.1:
@@ -20067,14 +19962,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.2.0
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   eslint-config-next@15.5.9(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.9
@@ -20263,8 +20150,6 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 3.4.3
-
-  esprima@1.2.5: {}
 
   esprima@2.7.3: {}
 
@@ -20766,8 +20651,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastfile@0.0.20: {}
-
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -20807,27 +20690,11 @@ snapshots:
 
   fetch-retry@4.1.1: {}
 
-  ffjavascript@0.3.0:
-    dependencies:
-      wasmbuilder: 0.0.16
-      wasmcurves: 0.2.2
-      web-worker: 1.2.0
-
-  ffjavascript@0.3.1:
-    dependencies:
-      wasmbuilder: 0.0.16
-      wasmcurves: 0.2.2
-      web-worker: 1.2.0
-
   fflate@0.4.8: {}
 
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-
-  filelist@1.0.6:
-    dependencies:
-      minimatch: 5.1.6
 
   fill-range@7.1.1:
     dependencies:
@@ -21391,8 +21258,6 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  hoopy@0.1.4: {}
-
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -21800,12 +21665,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jake@10.9.4:
-    dependencies:
-      async: 3.2.6
-      filelist: 1.0.6
-      picocolors: 1.1.1
 
   jay-peg@1.1.1:
     dependencies:
@@ -22347,12 +22206,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonpath@1.3.0:
-    dependencies:
-      esprima: 1.2.5
-      static-eval: 2.1.1
-      underscore: 1.13.6
-
   jsonschema@1.5.0: {}
 
   jsonwebtoken@9.0.3:
@@ -22607,8 +22460,6 @@ snapshots:
       is-unicode-supported: 0.1.0
 
   loglevel@1.9.2: {}
-
-  logplease@1.2.15: {}
 
   long@4.0.0: {}
 
@@ -23982,13 +23833,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
-  r1csfile@0.0.48:
-    dependencies:
-      '@iden3/bigarray': 0.0.2
-      '@iden3/binfileutils': 0.0.12
-      fastfile: 0.0.20
-      ffjavascript: 0.3.0
-
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -24795,18 +24639,6 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  snarkjs@0.7.6:
-    dependencies:
-      '@iden3/binfileutils': 0.0.12
-      '@noble/hashes': 1.8.0
-      bfj: 7.1.0
-      circom_runtime: 0.1.28
-      ejs: 3.1.10
-      fastfile: 0.0.20
-      ffjavascript: 0.3.1
-      logplease: 1.2.15
-      r1csfile: 0.0.48
-
   solc@0.8.26(debug@4.4.3):
     dependencies:
       command-exists: 1.2.9
@@ -24914,10 +24746,6 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
-
-  static-eval@2.1.1:
-    dependencies:
-      escodegen: 2.1.0
 
   statuses@1.5.0: {}
 
@@ -25396,8 +25224,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tryer@1.0.1: {}
-
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -25659,8 +25485,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  underscore@1.13.6: {}
 
   undici-types@6.19.8: {}
 
@@ -26239,12 +26063,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  wasmbuilder@0.0.16: {}
-
-  wasmcurves@0.2.2:
-    dependencies:
-      wasmbuilder: 0.0.16
-
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -26264,8 +26082,6 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.2.0: {}
-
-  web-worker@1.2.0: {}
 
   web3-utils@1.10.4:
     dependencies:


### PR DESCRIPTION
## Mission

WAVE C73 — Antigravity routing enforcement via Next.js middleware.
WAVE C75 — Durable cryptographic event chain via SHA-256 priorRunId linking on Prisma AuditEvent inserts.

> **Stacking note:** branched off `origin/main` per the wave spec. The `packages/core` scaffold matches PR #388 / #389; whichever PR lands first, the rest resolve cleanly on rebase.

## C73 · Antigravity routing

`apps/web/lib/auth/antigravity.ts` — pure decision function (edge-safe, no DB, no fetch).

| Rule | Condition | Action |
|---|---|---|
| 1 | role ≠ VERIFIER | pass |
| 2 | verifier + active-receipt cookie + path in `{ /dashboard, /home, /dashboard/*, /home/* }` | **307 redirect** to `/verify/receipt/<active>` · `verifier_blocked_route` |
| 3 | verifier + active receipt + status ∈ { ACCEPTED, REVOKED } + path ≠ receipt URL | **307 redirect** to receipt URL · `receipt_terminal_status_locked_to_read_only` |
| 4 | verifier + active receipt + path not in canonical list | **307 redirect** · `verifier_off_canonical_path` |
| 5 | otherwise | pass |

### Canonical verifier paths (allowlist)

`/verify` · `/verify/` · `/verify/guide` · `/sign-in` · `/sign-up` · `/verify/receipt/*`

### Cookies (set server-side by the `/verify/receipt/[id]` page)

- `vcv_active_receipt` — the active receipt id
- `vcv_active_receipt_status` — `ACTIVE` | `ACCEPTED` | `REVOKED`

Cookie names exported as constants (`ANTIGRAVITY_COOKIE_ACTIVE_RECEIPT`, `ANTIGRAVITY_COOKIE_RECEIPT_STATUS`) so callers cannot misspell them.

### Middleware integration

`apps/web/middleware.ts` extended with a 30-line hook **before** the public-route pass so verifier-blocked paths cannot leak through even when marked public. Response carries `x-antigravity-reason` for telemetry.

## C75 · Durable cryptographic event chain

### `packages/core/src/services/ledger/HashChainService.ts`

```ts
calculateNextHash(previousHash: string, payload: unknown): string
  // chainHash = SHA-256( previousHash || '|' || canonicalJSON(payload) )

canonicalizePayload(payload): string         // sorted-key JSON (reproducible)
verifyChainSegment(anchor, entries): number  // -1 = ok, else first-divergence index
```

| Constant | Value | Why |
|---|---|---|
| `CHAIN_GENESIS_MARKER` | `'GENESIS_VITALCV'` | binding sentinel for genesis events; verifiers can detect deterministically |
| `CHAIN_HASH_ALGORITHM` | `'sha256'` | surfaced so verifiers know which primitive to recompute |

The `'\|'` separator is binding — without it, `prev='AB'+payload='C'` would collide with `prev='A'+payload='BC'`. Test enforces this.

### `packages/core/src/services/ledger/createAuditEventWithChain.ts`

Tiny Prisma wrapper. Per insert into a `lineageKey`:

```
1. SELECT prior event WHERE lineageKey = X ORDER BY createdAt DESC LIMIT 1
2. previousHash = prior?.hash ?? GENESIS_VITALCV
3. chainHash    = calculateNextHash(previousHash, payload)
4. INSERT { ..., hash: chainHash, lineageKey, priorRunId: prior?.id ?? null }
```

Read + write run inside one `$transaction` so concurrent inserts for the same lineage cannot fork the chain. Lives in `@vitalcv/core` (not `apps/api/backend`) so unit tests run under vitest without bootstrapping the backend jest env.

### Prisma schema delta · `apps/api/backend/prisma/schema.prisma`

`AuditEvent` gains two **nullable** columns (backward-compatible):

```prisma
lineageKey  String?  @map("lineage_key")
priorRunId  String?  @map("prior_run_id") @db.Uuid
```

Plus `@@index([lineageKey])` and `@@index([priorRunId])`. Existing `prisma.auditEvent.create` call sites are **not** touched in this wave; per-callsite adoption is a follow-up.

`pnpm exec prisma generate --schema prisma/schema.prisma` succeeds with the delta. A migration file is **not** committed here per the wave constraint *"do not touch production databases"* — schema delta lives in the schema only.

### Backend jest config

`apps/api/backend/jest.config.js` gains `@vitalcv/core` in `moduleNameMapper` so future backend integration tests can import the chain primitives.

## Tests · 32 passing total

- `packages/core/__tests__/ledger/HashChainService.test.ts` → **13/13**
  - canonical-JSON sorted-key stability (recursive into objects + arrays + nulls)
  - deterministic SHA-256 over `prev || '|' || canonical(payload)`
  - empty/nullish prevHash → GENESIS marker
  - tampering detection (payload mutation + prevHash mutation)
  - separator-collision guard
  - offline replay (`verifyChainSegment` returns -1 on ok / first-divergence index on tamper)
- `packages/core/__tests__/ledger/createAuditEventWithChain.test.ts` → **5/5**
  - empty lineageKey rejected
  - first insert = genesis (priorRunId null, hashed against GENESIS_VITALCV)
  - subsequent inserts link priorRunId to the previous row's id
  - parallel lineages remain independent
  - explicit payload override is used for the chain hash
- `apps/web/__tests__/antigravity-routing.test.ts` → **14/14**
  - role gating (5 non-verifier roles all pass)
  - explicit denylist (`/dashboard`, `/home`, nested `*/`, no-active-receipt pass)
  - canonical paths (receipt URL, `/verify`, `/verify/guide`, other `/verify/receipt/*`)
  - terminal status (ACCEPTED + REVOKED) locks to read-only
  - cookie name constants
  - off-canonical paths trigger redirect even outside denylist

## Validation

```
pnpm install --no-frozen-lockfile  → clean
pnpm exec prisma generate (backend)  → succeeds with schema delta
packages/core vitest run  → 2 files passed · 18/18
apps/web vitest run antigravity-routing  → 14/14
apps/web tsc --noEmit
  → 35 pre-existing errors on origin/main (confirmed via git stash);
    my files compile clean; net change 0
apps/web lint  → clean
```

## Operator instructions (demo)

```
# Cookies set when the receipt page renders for a verifier:
#   Set-Cookie: vcv_active_receipt=rcpt_7a2c_b8d3; Path=/; SameSite=Lax
#   Set-Cookie: vcv_active_receipt_status=ACTIVE; Path=/; SameSite=Lax

# Test antigravity redirect:
curl -i -b 'vcv_active_receipt=rcpt_7a2c_b8d3' \
     -b 'vcv_active_receipt_status=ACTIVE' \
     http://localhost:3000/dashboard
# → 307 Temporary Redirect
# → Location: /verify/receipt/rcpt_7a2c_b8d3
# → x-antigravity-reason: verifier_blocked_route
```

## Truth-contract audit

- Chain hash math is real SHA-256; no fake crypto claims.
- `GENESIS_VITALCV` literal is binding and documented; verifiers can replay offline.
- Antigravity reasons are stable machine-readable tokens (`verifier_blocked_route`, `verifier_off_canonical_path`, `receipt_terminal_status_locked_to_read_only`).
- Schema additions are nullable + backward-compatible; no breaking change.

## Remaining gaps

1. Existing `prisma.auditEvent.create` call sites are unchanged. Retrofitting them to call `createAuditEventWithChain` is a follow-up wave; the wrapper is ready for adoption.
2. A migration file (`prisma/migrations/*`) is not committed — production cutover requires `prisma migrate dev` against a real DB in the appropriate environment.
3. The receipt page does not yet set the `vcv_active_receipt` and `vcv_active_receipt_status` cookies — that's a 10-line additive change to `/verify/receipt/[receiptId]` and is reserved for the integration coherence wave so the route remains untouched here.

## Test plan
- [ ] `packages/core` → `pnpm exec vitest run` passes 18 tests
- [ ] `apps/web` → `pnpm --filter @vitalcv/web exec vitest run antigravity-routing` passes 14 tests
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 35 pre-existing errors (confirmed unchanged from origin/main)
- [ ] `pnpm --filter @vitalcv/web lint` clean
- [ ] `pnpm exec prisma generate --schema apps/api/backend/prisma/schema.prisma` succeeds
- [ ] Manual smoke: set cookies, hit `/dashboard`, observe 307 with `x-antigravity-reason: verifier_blocked_route`
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)