### PR TITLE
fix(trust): enforce truth-constrained operational semantics

### DIFF
--- a/apps/web/__tests__/truth-constrained-operationalization.test.ts
+++ b/apps/web/__tests__/truth-constrained-operationalization.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  OPERATIONAL_STATUSES,
+  OPERATIONAL_STATUS_DESCRIPTORS,
+  describeOperationalStatus,
+  listOperationalStatuses,
+} from '@/lib/trust/operational-status';
+import {
+  assertOperationalClaimEvidence,
+  auditEvidenceCoverage,
+  defineOperationalClaim,
+} from '@/lib/trust/assertOperationalClaimEvidence';
+
+// ── Status taxonomy ────────────────────────────────────────────────────────
+
+describe('operational-status taxonomy · closed set', () => {
+  it('exposes exactly six canonical statuses', () => {
+    expect([...OPERATIONAL_STATUSES].sort()).toEqual(
+      [
+        'implemented',
+        'institution_owned',
+        'operator_assisted',
+        'pilot_target',
+        'planned',
+        'unsupported',
+      ].sort(),
+    );
+  });
+
+  it('every status has meaning / uiSemantics / truthContractGuidance / escalation', () => {
+    for (const s of listOperationalStatuses()) {
+      const d = describeOperationalStatus(s);
+      expect(d.meaning.length).toBeGreaterThan(0);
+      expect(d.uiSemantics.length).toBeGreaterThan(0);
+      expect(d.truthContractGuidance.length).toBeGreaterThan(0);
+      expect(d.escalation.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('"implemented" requires evidence per the doctrine', () => {
+    const d = OPERATIONAL_STATUS_DESCRIPTORS.implemented;
+    expect(d.truthContractGuidance).toMatch(/banned phrases/i);
+  });
+
+  it('"unsupported" forbids implying availability under any qualifier', () => {
+    const d = OPERATIONAL_STATUS_DESCRIPTORS.unsupported;
+    expect(d.truthContractGuidance).toMatch(/never imply availability/i);
+  });
+});
+
+// ── Evidence-bound claim helper ────────────────────────────────────────────
+
+describe('assertOperationalClaimEvidence · evidence requirement', () => {
+  it('flags "implemented" claims without evidence as evidenceRequired', () => {
+    const c = assertOperationalClaimEvidence({
+      capability: 'NPI resolution',
+      status: 'implemented',
+    });
+    expect(c.evidenceRequired).toBe(true);
+    expect(c.hasEvidence).toBe(false);
+  });
+
+  it('flags "operator_assisted" claims without evidence as evidenceRequired', () => {
+    const c = assertOperationalClaimEvidence({
+      capability: 'Tunnel host pinning',
+      status: 'operator_assisted',
+    });
+    expect(c.evidenceRequired).toBe(true);
+  });
+
+  it('does not require evidence for institution_owned / pilot_target / planned / unsupported', () => {
+    for (const status of [
+      'institution_owned',
+      'pilot_target',
+      'planned',
+      'unsupported',
+    ] as const) {
+      const c = assertOperationalClaimEvidence({
+        capability: 'X',
+        status,
+      });
+      expect(c.evidenceRequired).toBe(false);
+    }
+  });
+
+  it('passes evidence through unchanged when supplied', () => {
+    const c = assertOperationalClaimEvidence({
+      capability: 'NPI resolution',
+      status: 'implemented',
+      evidence: 'apps/web/app/api/resolve-npi/route.ts',
+    });
+    expect(c.evidence).toBe('apps/web/app/api/resolve-npi/route.ts');
+    expect(c.hasEvidence).toBe(true);
+  });
+
+  it('treats empty / whitespace evidence as absent', () => {
+    const c = assertOperationalClaimEvidence({
+      capability: 'X',
+      status: 'implemented',
+      evidence: '   ',
+    });
+    expect(c.hasEvidence).toBe(false);
+  });
+});
+
+describe('auditEvidenceCoverage · CI guard', () => {
+  it('returns the empty list when every required claim has evidence', () => {
+    const claims = [
+      defineOperationalClaim({
+        capability: 'A',
+        status: 'implemented',
+        evidence: 'apps/web/x.ts',
+      }),
+      defineOperationalClaim({
+        capability: 'B',
+        status: 'pilot_target',
+      }),
+    ];
+    expect(auditEvidenceCoverage(claims)).toEqual([]);
+  });
+
+  it('returns the failing claims when evidence is missing', () => {
+    const ok = defineOperationalClaim({
+      capability: 'A',
+      status: 'implemented',
+      evidence: 'apps/web/x.ts',
+    });
+    const failing = defineOperationalClaim({
+      capability: 'B',
+      status: 'operator_assisted',
+    });
+    const audit = auditEvidenceCoverage([ok, failing]);
+    expect(audit).toHaveLength(1);
+    expect(audit[0].capability).toBe('B');
+  });
+});
+
+// ── Boundary doc presence ──────────────────────────────────────────────────
+
+describe('operational-capability-boundaries doc', () => {
+  const docPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'docs',
+    'ops',
+    'operational-capability-boundaries.md',
+  );
+
+  it('ships at docs/ops/operational-capability-boundaries.md', () => {
+    expect(fs.existsSync(docPath)).toBe(true);
+  });
+
+  it('declares all six statuses', () => {
+    const md = fs.readFileSync(docPath, 'utf8');
+    for (const s of OPERATIONAL_STATUSES) {
+      expect(md).toContain(`\`${s}\``);
+    }
+  });
+
+  it('lists banned phrases (CLAUDE.md truth contract surface)', () => {
+    const md = fs.readFileSync(docPath, 'utf8');
+    expect(md).toMatch(/HIPAA compliant/);
+    expect(md).toMatch(/SOC2 certified/);
+    expect(md).toMatch(/instant verification/);
+    expect(md).toMatch(/immutable ledger/);
+  });
+});
+
+// ── Rendered-route truth audit ─────────────────────────────────────────────
+
+describe('rendered-route truth audit · banned phrase grep', () => {
+  // Scans production code under apps/web/{app,components} for banned
+  // phrases. Strips line and block comments first so that documentation
+  // about banned phrases is not itself a violation.
+  //
+  // Test files and the _archive/ tree are exempt: tests guard against
+  // regressions, and archive code is not rendered.
+
+  const ROOTS = [
+    path.resolve(__dirname, '..', 'app'),
+    path.resolve(__dirname, '..', 'components'),
+  ];
+
+  const BANNED_RENDERED_PHRASES = [
+    'fully verified',
+    'fully automated',
+    'cryptographically guaranteed',
+    'federally integrated',
+    'immutable ledger',
+    'military-grade',
+    'enterprise-grade encryption',
+    'fully compliant',
+    'magical onboarding',
+    'magical automation',
+  ] as const;
+
+  const EXCLUDED_DIR_SUBSTR = [
+    `${path.sep}_archive${path.sep}`,
+    `${path.sep}__tests__${path.sep}`,
+    `${path.sep}node_modules${path.sep}`,
+    `${path.sep}.next${path.sep}`,
+  ];
+
+  function walk(dir: string, files: string[] = []): string[] {
+    if (!fs.existsSync(dir)) return files;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (EXCLUDED_DIR_SUBSTR.some((s) => full.includes(s))) continue;
+      if (entry.isDirectory()) {
+        walk(full, files);
+      } else if (/\.(tsx?|jsx?)$/.test(entry.name)) {
+        files.push(full);
+      }
+    }
+    return files;
+  }
+
+  function stripComments(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+  }
+
+  it('no banned phrase appears in rendered apps/web/{app,components}', () => {
+    const hits: { file: string; phrase: string; line: number }[] = [];
+    const files = ROOTS.flatMap((r) => walk(r));
+    for (const f of files) {
+      const stripped = stripComments(fs.readFileSync(f, 'utf8'));
+      const lines = stripped.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const lower = lines[i].toLowerCase();
+        for (const phrase of BANNED_RENDERED_PHRASES) {
+          if (lower.includes(phrase)) {
+            hits.push({ file: f, phrase, line: i + 1 });
+          }
+        }
+      }
+    }
+    if (hits.length > 0) {
+      const report = hits
+        .map(
+          (h) =>
+            `  ${path.relative(process.cwd(), h.file)}:${h.line}  ${h.phrase}`,
+        )
+        .join('\n');
+      throw new Error(
+        `Truth-contract violations (${hits.length}). Replace with operational-status taxonomy copy.\n${report}`,
+      );
+    }
+    expect(hits).toEqual([]);
+  });
+});

--- a/apps/web/components/developers/ConformanceReport.tsx
+++ b/apps/web/components/developers/ConformanceReport.tsx
@@ -158,7 +158,7 @@ export function ConformanceReport({ className = '' }: { className?: string }) {
                 ? <CheckCircle2 className="h-4 w-4" />
                 : <XCircle className="h-4 w-4" />
               }
-              {report.overallCompliant ? 'Fully Compliant' : 'Non-Compliant'}
+              {report.overallCompliant ? 'Conformance Suite Passed' : 'Non-Compliant'}
             </div>
           )}
         </div>

--- a/apps/web/lib/trust/assertOperationalClaimEvidence.ts
+++ b/apps/web/lib/trust/assertOperationalClaimEvidence.ts
@@ -1,0 +1,110 @@
+/**
+ * Evidence-bound operational-claim helper.
+ *
+ * Lightweight, deterministic guard for surfaces that render
+ * operational claims. The helper does NOT introduce runtime
+ * enforcement complexity — it is a tiny pure function that callers
+ * pass a claim through to surface a single object the UI can render
+ * AND a CI test can assert on.
+ *
+ * Design intent:
+ * - A claim is a (subject, capability, status) triple.
+ * - For statuses `implemented` and `operator_assisted`, the caller
+ *   MUST supply an `evidence` reference: a code path, a route, or a
+ *   well-known endpoint that exercises the capability.
+ * - For statuses `institution_owned`, `pilot_target`, `planned`, and
+ *   `unsupported`, evidence is optional but recommended.
+ * - The helper returns a typed `OperationalClaim` with a normalised
+ *   `displayStatus` label and a `hasEvidence` flag. It does not throw
+ *   in production — it tags the claim and lets the surface render.
+ *
+ * Tests can grep for `OperationalClaim` objects across the rendered
+ * UI bundle and assert that every `implemented` / `operator_assisted`
+ * claim carries an evidence reference.
+ */
+
+import {
+  OPERATIONAL_STATUS_DESCRIPTORS,
+  type OperationalStatus,
+} from './operational-status';
+
+export interface OperationalClaimInput {
+  /** What the claim is about (e.g. "DEA registration resolution"). */
+  capability: string;
+  /** Canonical operational status. */
+  status: OperationalStatus;
+  /**
+   * Implementation evidence reference. Required for
+   * `implemented` / `operator_assisted`; recommended otherwise.
+   *
+   * Examples:
+   *   "apps/web/app/api/resolve-npi/route.ts"
+   *   "GET /.well-known/did.json"
+   *   "packages/core/src/services/ledger/HashChainService.ts"
+   */
+  evidence?: string;
+  /** Optional plain-English summary rendered alongside the chip. */
+  caption?: string;
+}
+
+export interface OperationalClaim {
+  readonly capability: string;
+  readonly status: OperationalStatus;
+  readonly evidence: string | null;
+  readonly hasEvidence: boolean;
+  readonly displayStatus: string;
+  readonly caption: string | null;
+  /**
+   * True when the claim carries the required evidence per the
+   * canonical operational-status doctrine. Surfaces in this state
+   * MUST surface a "missing evidence" affordance in dev builds
+   * (handled by `auditEvidenceCoverage`).
+   */
+  readonly evidenceRequired: boolean;
+}
+
+const STATUSES_REQUIRING_EVIDENCE: ReadonlySet<OperationalStatus> = new Set([
+  'implemented',
+  'operator_assisted',
+]);
+
+export function assertOperationalClaimEvidence(
+  input: OperationalClaimInput,
+): OperationalClaim {
+  const required = STATUSES_REQUIRING_EVIDENCE.has(input.status);
+  const evidence = input.evidence?.trim() || null;
+  const displayStatus = OPERATIONAL_STATUS_DESCRIPTORS[input.status].status;
+  return {
+    capability: input.capability,
+    status: input.status,
+    evidence,
+    hasEvidence: evidence !== null,
+    displayStatus,
+    caption: input.caption ?? null,
+    evidenceRequired: required,
+  };
+}
+
+/**
+ * Audits a batch of claims and returns the ones that fail the
+ * evidence contract (status requires evidence; none was supplied).
+ *
+ * Intended for CI tests that read a fixture / registry of claims
+ * and assert that the failing-claim list is empty.
+ */
+export function auditEvidenceCoverage(
+  claims: readonly OperationalClaim[],
+): readonly OperationalClaim[] {
+  return claims.filter((c) => c.evidenceRequired && !c.hasEvidence);
+}
+
+/**
+ * Convenience builder for a typed registry of claims. Surfaces that
+ * want to enumerate their operational claims for the truth-audit can
+ * call this once per claim and ship the resulting array.
+ */
+export function defineOperationalClaim(
+  input: OperationalClaimInput,
+): OperationalClaim {
+  return assertOperationalClaimEvidence(input);
+}

--- a/apps/web/lib/trust/operational-status.ts
+++ b/apps/web/lib/trust/operational-status.ts
@@ -1,0 +1,118 @@
+/**
+ * Canonical operational-status taxonomy for VitalCV claims.
+ *
+ * Every operational capability the product surfaces to users
+ * (verification, integration, deletion, signing, audit, SLA) must be
+ * categorised under exactly one of six closed statuses. The status
+ * drives UI rendering, copy choice, and the truth-contract guardrails
+ * that prevent semantic inflation.
+ *
+ * This taxonomy is the canonical reference for governance. New
+ * statuses are not added without a corresponding doctrine update in
+ * `docs/ops/operational-capability-boundaries.md`.
+ */
+
+export const OPERATIONAL_STATUSES = [
+  'implemented',
+  'operator_assisted',
+  'institution_owned',
+  'pilot_target',
+  'planned',
+  'unsupported',
+] as const;
+
+export type OperationalStatus = (typeof OPERATIONAL_STATUSES)[number];
+
+export interface OperationalStatusDescriptor {
+  readonly status: OperationalStatus;
+  /** Operational meaning — what this status asserts to a reader. */
+  readonly meaning: string;
+  /** UI rendering rule (visual semantics). */
+  readonly uiSemantics: string;
+  /** Copy guidance — what language is and isn't acceptable. */
+  readonly truthContractGuidance: string;
+  /** Escalation rule when a surface claims this without evidence. */
+  readonly escalation: string;
+}
+
+export const OPERATIONAL_STATUS_DESCRIPTORS: Record<
+  OperationalStatus,
+  OperationalStatusDescriptor
+> = {
+  implemented: {
+    status: 'implemented',
+    meaning:
+      'Capability is wired end-to-end in shipping code. Evidence references a code path or a public endpoint that exercises the capability.',
+    uiSemantics:
+      'Solid border · canonical institutional language · no qualifier prefix.',
+    truthContractGuidance:
+      'May render in the present tense. Source citation optional but recommended. Banned phrases (CLAUDE.md) still apply.',
+    escalation:
+      'If marked implemented without an evidence reference, demote to pilot_target until a reference is supplied.',
+  },
+  operator_assisted: {
+    status: 'operator_assisted',
+    meaning:
+      'Capability requires a VitalCV operator step to complete. Not autonomous; not "automated".',
+    uiSemantics:
+      'Solid border · "operator-assisted" prefix · operator lane chrome when rendered as a workflow step.',
+    truthContractGuidance:
+      'Never describe as "automatic", "instant", or "seamless". The operator role must be named in the same sentence.',
+    escalation:
+      'If rendered as automated, replace copy with "operator-assisted" and add the operator-lane affordance.',
+  },
+  institution_owned: {
+    status: 'institution_owned',
+    meaning:
+      'Capability is owned by the customer institution (CVO, MSO, HR, legal). VitalCV does not perform the work; it integrates with or hands off to the institution.',
+    uiSemantics:
+      'Dashed border · "institution-owned" prefix · explicit hand-off affordance when rendered as a workflow step.',
+    truthContractGuidance:
+      'Never describe as VitalCV-performed. The institution role must be named explicitly. Common pattern: "institution-owned workflow".',
+    escalation:
+      'If rendered as VitalCV-performed, rewrite with explicit institution naming.',
+  },
+  pilot_target: {
+    status: 'pilot_target',
+    meaning:
+      'Capability is a target of the current pilot engagement. Not yet implemented end-to-end; planned to be exercised during the pilot window.',
+    uiSemantics:
+      'Dashed border · "pilot-target" prefix · explicit horizon language.',
+    truthContractGuidance:
+      'Never describe in the present tense as if already in place. Use future-tense or "target" language.',
+    escalation:
+      'If rendered as implemented, replace with "pilot target" copy. If the pilot has concluded successfully, propose promotion to implemented with an evidence reference.',
+  },
+  planned: {
+    status: 'planned',
+    meaning:
+      'Capability is on the documented roadmap but is not yet a pilot target and not yet implemented.',
+    uiSemantics:
+      'Dashed border · "planned" prefix · roadmap-horizon disclosure.',
+    truthContractGuidance:
+      'Never describe as available today. Always pair with a documented planning horizon (e.g. "planned Q3-2026") or omit from user-facing surfaces.',
+    escalation:
+      'If rendered as available, replace with "planned" copy or remove from user-facing surface.',
+  },
+  unsupported: {
+    status: 'unsupported',
+    meaning:
+      'Capability is explicitly NOT in scope. Listing it here documents the negative space so a reader knows what VitalCV does not do.',
+    uiSemantics:
+      'Quiet zinc-500 footnote tone · "out of scope" affordance when rendered as a workflow step.',
+    truthContractGuidance:
+      'Never imply availability under any qualifier. The status exists so surfaces can NAME the absence rather than imply presence.',
+    escalation:
+      'If rendered as available (even with a qualifier like "coming soon"), remove from user-facing copy and surface as "out of scope" in operator-facing surfaces only.',
+  },
+};
+
+export function describeOperationalStatus(
+  status: OperationalStatus,
+): OperationalStatusDescriptor {
+  return OPERATIONAL_STATUS_DESCRIPTORS[status];
+}
+
+export function listOperationalStatuses(): readonly OperationalStatus[] {
+  return OPERATIONAL_STATUSES;
+}

--- a/docs/ops/operational-capability-boundaries.md
+++ b/docs/ops/operational-capability-boundaries.md
@@ -1,0 +1,149 @@
+# VitalCV · Operational Capability Boundaries
+
+Canonical reference for what the VitalCV platform actually does, what
+it asks an operator to do, what it expects the customer institution to
+do, and what it explicitly does not do.
+
+This document is binding. All user-facing operational copy MUST map
+each claim to a row in one of the five capability tables below. New
+operational copy is rejected if it cannot be grounded in this doc.
+
+Sources:
+- `apps/web/lib/trust/operational-status.ts` — typed status taxonomy
+- `apps/web/lib/trust/assertOperationalClaimEvidence.ts` — evidence-bound claim helper
+- CLAUDE.md truth contract — project-wide banned phrases
+
+## Status taxonomy (binding)
+
+| Status | Meaning |
+|---|---|
+| `implemented` | Wired end-to-end in shipping code |
+| `operator_assisted` | Requires a VitalCV operator step; not autonomous |
+| `institution_owned` | Owned by the customer institution; VitalCV hands off |
+| `pilot_target` | Target of the current pilot engagement; not yet end-to-end |
+| `planned` | On the documented roadmap; not yet a pilot target |
+| `unsupported` | Explicitly not in scope |
+
+## 1 · Implemented capabilities (evidence-bound)
+
+| Capability | Evidence |
+|---|---|
+| Public NPI resolution against NPPES | `apps/web/app/api/resolve-npi/route.ts` (PR #388) |
+| IP rate-limit on unauthenticated routes | `apps/web/lib/rate-limit/ipBucket.ts` (PR #388) |
+| OpenEvidence ROI calculator (taxonomy → daily-bleed midpoint) | `packages/core/src/services/roiCalculator.ts` (PR #388) |
+| OpenEvidence attrition risk engine (taxonomy + rural/urban) | `packages/core/src/services/riskEngine.ts` (PR #389) |
+| Bi-directional audit lineage graph API | `apps/web/app/api/audit/[eventId]/graph/route.ts` (PR #389) |
+| SHA-256 hash chain primitives | `packages/core/src/services/ledger/HashChainService.ts` (PR #390) |
+| Antigravity verifier routing middleware | `apps/web/lib/auth/antigravity.ts` + `apps/web/middleware.ts` (PR #390) |
+| did:web discovery document | `apps/web/app/api/.well-known/did.json/route.ts` |
+| JWKS public key endpoint | `apps/web/app/api/.well-known/jwks.json/route.ts` |
+| OID4VCI issuer metadata | `apps/web/app/api/.well-known/openid-credential-issuer/route.ts` |
+| Per-request issuer host resolution (tunnel-safe) | `apps/web/lib/discovery/issuerHost.ts` (PR #384) |
+| Stacked Provenance Ledger (Matuschak panes) | `apps/web/components/trust/StackedPaneLayout.tsx` (PR #385) |
+| Canonical trust primitives (LineageHeader, ReplayTimeline, etc.) | `apps/web/components/trust/primitives/` (PR #382) |
+| Canonical operational language (status + phrase constants) | `apps/web/lib/trust/institutional-language.ts` (PR #382) |
+| Five-mode failure taxonomy + degradation states | `apps/web/lib/trust/degradation.ts` (PR #382) |
+
+## 2 · Operator-assisted capabilities
+
+| Capability | Operator role | Evidence |
+|---|---|---|
+| Audit-event chain insert | VitalCV ops triggers the wrapped insert per lineage | `packages/core/src/services/ledger/createAuditEventWithChain.ts` (PR #390) |
+| Pilot intake review | Operator manually reviews submitted NPIs before activation | Pilot Deployment Kit Section 02 (PR #387) |
+| Tunnel host pinning for demos | Operator sets `VCV_ISSUER_HOST` env on the demo cluster | `apps/web/lib/discovery/issuerHost.ts` |
+
+## 3 · Institution-owned workflows
+
+| Workflow | Institution role | Notes |
+|---|---|---|
+| State medical board PSV | Customer CVO or partner CVO | Out of pilot scope; named in Pilot Deployment Kit Section 02 |
+| Credentialing committee review | Customer credentialing committee | VitalCV emits a `committee_review` audit event only |
+| Privileging decisions | Customer facility credentialing | VitalCV makes no privileging assertion |
+| Employment eligibility (I-9, OFAC) | Customer HRIS | Out of scope |
+| Malpractice adjudication | Customer + verifier | VitalCV mints the NPDB self-query token; never the determination |
+| Re-credentialing cycles | Customer CVO | Initial verification only during pilots |
+
+## 4 · Pilot targets (Cedar Q2-2026 example)
+
+| Target | Status |
+|---|---|
+| 10 NPIs / 30 days resolution against NPPES + PECOS | pilot_target |
+| Time-to-receipt ≤ 1 h median across the cohort | pilot_target |
+| Zero substantive discrepancies vs CVO baseline | pilot_target |
+| Operator load ≤ 90 min total across 30 days | pilot_target |
+| Audit defensibility on a single-read walkthrough | pilot_target |
+
+## 5 · Planned capabilities (not yet pilot-targeted)
+
+| Capability | Horizon | Notes |
+|---|---|---|
+| DEA registration resolution (active adapter) | future pilot | Currently `pilot_target`-class in some surfaces; not implemented |
+| NPDB self-query token minting (live integration) | future pilot | Pilot Deployment Kit names this in scope; live adapter not built |
+| SAM.gov debarment screening (live integration) | future pilot | Surfaces that name SAM.gov MUST mark `pilot_target` until the adapter ships |
+| State-board PSV in-platform (under partner CVO) | post-pilot | Explicitly outside the current pilot |
+| Production Prisma `AuditEvent` chain retrofit | next coherence wave | Wrapper ready (PR #390); per-callsite adoption pending |
+
+## 6 · Explicitly unsupported
+
+The platform does NOT:
+
+- Touch patient PHI under any pilot configuration
+- Connect to customer EMR, HRIS, or scheduling systems
+- Make privileging decisions
+- Issue Final Verification without operator review
+- Provide HIPAA or SOC2 certifications (the platform is HIPAA-aware in design but does not claim certification)
+- Replace the customer's CVO; it operates side-channel
+- Provide an SLA during pilot engagements (read-only, no SLA per Pilot Deployment Kit)
+- Provide military-grade or enterprise-grade encryption claims (TLS 1.3 + EdDSA / Ed25519 are the actual primitives)
+- Guarantee cryptographic outcomes — receipts are re-verifiable against the public issuer DID, which is a different (and weaker) claim than "cryptographically guaranteed"
+
+## Wallet-SDK diagnostic
+
+`packages/wallet-sdk/` — workspace package; `main: dist/index.js` declared but `dist/` is not committed (intentional — build artifact). The only non-archive consumer in `apps/web` is `apps/web/components/developers/SdkDocs.tsx`, which references the package name in a code-example string template, not via a real `import` statement.
+
+**Findings:**
+- Not a dead package — declared workspace member with real source under `packages/wallet-sdk/src/`.
+- Not orphaned — referenced in `apps/web/package.json` as `workspace:*`.
+- No actual import-time export-resolution failure in production code on `origin/main`.
+- The wave-listed "interoperability resolution failure" appears to be a build-artifact concern: if a downstream test or build step expects `packages/wallet-sdk/dist/index.js` to exist, it must first run `pnpm --filter @vitalcv/wallet-sdk build`.
+
+**Recommendation (no fix made in this wave):** Add a turbo `dependsOn` so any task that imports `@vitalcv/wallet-sdk` runs the SDK build first. Defer until a real consumer takes a hard import dependency. Today's only consumer is a template string in `SdkDocs.tsx`, which does not require the dist artifact.
+
+## Banned phrases (CLAUDE.md project-wide truth contract)
+
+The following phrases are banned in ALL user-facing copy. Tests guard against regression. The list is mirrored in
+`apps/web/lib/trust/institutional-language.ts` (`BANNED_INSTITUTIONAL_PHRASES`):
+
+- automatically verified
+- guaranteed verification
+- complete credentialing
+- instant credentialing
+- legally accepted
+- risk transferred
+- final verification without review
+- source confirmed before response
+- certified compliant
+- HIPAA compliant
+- SOC2 certified
+- bare "Verified" as a status label
+- fully verified
+- federally integrated
+- fully automated
+- cryptographically guaranteed
+- immutable ledger
+- military-grade
+- enterprise-grade encryption
+- fully compliant
+- instant verification
+- magical / seamless / effortless / magic / seamlessly
+
+## Governance
+
+Adding a new operational claim to a user-facing surface requires:
+
+1. A row in one of tables 1–6 above
+2. For `implemented` and `operator_assisted` claims: an evidence reference (code path, route, well-known endpoint)
+3. The claim built via `defineOperationalClaim({...})` from `apps/web/lib/trust/assertOperationalClaimEvidence.ts`
+4. A test that runs `auditEvidenceCoverage([...claims])` and asserts the failing-claim list is empty
+
+PRs that introduce an unsupported claim without one of the above MUST be rejected by Codex audit.


### PR DESCRIPTION
## Mission

Truth-governance wave. Establishes the operational-status taxonomy, evidence-bound claim helper, capability-boundaries doctrine doc, and the rendered-route truth-audit test that fails CI on banned-phrase regressions. No feature expansion, no backend changes, no schema work.

## Unsupported claims removed (this wave)

| Site | Before | After | Reason |
|---|---|---|---|
| `apps/web/components/developers/ConformanceReport.tsx:161` | "Fully Compliant" badge | "Conformance Suite Passed" | The test runner reports a per-rule pass/fail set; "fully compliant" is a CLAUDE.md banned phrase |

Other production sites grepped (SAM.gov references in sandbox/marketing/cockpit components; NPDB references in trust-state/simulation/motion components) were inspected and found to already carry explicit "not integrated" guards in the same file (e.g. `LedgerTicker.tsx:9` and `TrustEngineTerminal.tsx:9`). The references are themselves the guard comments. No additional changes required there.

## Operational-status taxonomy added

`apps/web/lib/trust/operational-status.ts` — closed 6-status taxonomy:

| Status | Meaning |
|---|---|
| `implemented` | wired end-to-end; evidence reference required |
| `operator_assisted` | requires VitalCV operator step; not autonomous |
| `institution_owned` | owned by customer institution; VitalCV hands off |
| `pilot_target` | target of current pilot; not yet end-to-end |
| `planned` | on roadmap; not pilot-targeted |
| `unsupported` | explicitly out of scope |

Each status ships meaning + UI semantics + truth-contract guidance + escalation rule.

## Evidence-bound systems added

`apps/web/lib/trust/assertOperationalClaimEvidence.ts`:

```ts
defineOperationalClaim({ capability, status, evidence?, caption? })
  → OperationalClaim

auditEvidenceCoverage(claims) → failing claims
```

Statuses `implemented` and `operator_assisted` REQUIRE an evidence reference; other statuses recommend one. The audit function returns the failing-claim list so CI tests can assert it's empty.

## Routes audited

The rendered-route truth audit (`apps/web/__tests__/truth-constrained-operationalization.test.ts`) walks `apps/web/{app,components}` excluding `__tests__/`, `_archive/`, `.next/`, `node_modules/`. Strips line + block comments before scanning so documentation about banned phrases is not itself a violation. Banned-phrase set:

```
fully verified · fully automated · cryptographically guaranteed ·
federally integrated · immutable ledger · military-grade ·
enterprise-grade encryption · fully compliant ·
magical onboarding · magical automation
```

Result on `feat/truth-constrained-operationalization` (after the `ConformanceReport` fix): **zero violations**.

## Tests added · 15 passing

- Taxonomy closure (6 canonical statuses)
- Status-descriptor completeness (every status has 4 governance fields)
- Implemented + unsupported governance rules verbatim
- `evidenceRequired` gating (implemented + operator_assisted require evidence; others do not)
- Evidence pass-through; whitespace evidence treated as absent
- `auditEvidenceCoverage` empty/failing return paths
- Capability-boundaries doc presence + all six statuses named + banned-phrase list present
- Rendered-route truth audit (the CI gate itself)

## Wallet-SDK findings

Documented in `docs/ops/operational-capability-boundaries.md` §"Wallet-SDK diagnostic":

- **Not dead** · workspace package with real source under `packages/wallet-sdk/src/`
- **Not orphaned** · referenced as `workspace:*` in `apps/web/package.json`
- **No actual resolution failure** on `origin/main` · the only production consumer (`apps/web/components/developers/SdkDocs.tsx`) references the package name in a code-example template string, not a real `import` statement
- **Build artifact concern only** · if a downstream task tries to load `packages/wallet-sdk/dist/index.js`, it must first run the SDK build

**Recommendation (no fix made in this wave):** Add a turbo `dependsOn` so any task that imports `@vitalcv/wallet-sdk` runs the SDK build first. Defer until a real hard-import consumer takes a dependency.

## Operational-capability boundaries doc

`docs/ops/operational-capability-boundaries.md` — canonical reference with five tables:

1. **Implemented capabilities** — every row carries an evidence path into PRs #382-#390
2. **Operator-assisted** — names the operator role explicitly
3. **Institution-owned workflows** — names the institution role explicitly
4. **Pilot targets** — Cedar Q2-2026 example tied to the Pilot Deployment Kit
5. **Planned** — DEA / NPDB / SAM.gov live adapters; future pilot horizons
6. **Explicitly unsupported** — PHI, EMR connections, HIPAA / SOC2 certifications, military-grade encryption claims, "fully automated" / "cryptographically guaranteed" puffery

Plus the canonical banned-phrase list and governance procedure (any new claim must trace to a row in tables 1-6).

## Validation

```
pnpm install --frozen-lockfile  → clean
pnpm --filter @vitalcv/web exec vitest run truth-constrained-operationalization → 15/15
pnpm --filter @vitalcv/web exec tsc --noEmit
  → 2 pre-existing intake-types.ts errors (unrelated); 0 introduced
pnpm --filter @vitalcv/web lint  → clean
```

## Truth-contract grep

The rendered-route audit IS the truth-contract grep, codified as a CI gate. Running it now: zero violations across `apps/web/{app,components}`.

## Remaining semantic risks

1. The `_archive/` tree contains historical claims (`apps/web/app/_archive/wave119/compare/vitalcv-vs-verisys/page.tsx` uses "instant verification"). Out of scope: archive code is not rendered. The audit test explicitly excludes `_archive/`.
2. `apps/web/components/sandbox/EmployerReviewDashboard.tsx` references SAM.gov as if integrated ("SAM.gov clear. No active exclusions."). This file is in `sandbox/` — used for demo only. Recommend either marking the file `_archive/` or rewiring the demo data to render "pilot-target" badges. Deferred to keep this wave additive.
3. Documentation files (`docs/ARCHITECTURE.md`, `docs/audits/RELEASE-GATE-REPORT-*.md`) mention AES-256-GCM and "immutable ledger" — historical audit artifacts. Mutating audit records mid-wave would itself be a truth violation; left as-is.
4. The truth-audit's banned-phrase set is intentionally narrow (10 phrases). Expanding to cover the full CLAUDE.md list is a follow-up that depends on a more sophisticated word-boundary regex to avoid false positives (e.g. "HIPAA compliant" cannot be safely banned when "HIPAA-aware" is acceptable).

## Test plan
- [ ] `pnpm --filter @vitalcv/web exec vitest run truth-constrained-operationalization` passes 15 tests
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 2 pre-existing `intake-types.ts` errors
- [ ] `pnpm --filter @vitalcv/web lint` clean
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)