### PR TITLE
feat(core): implement live NPPES resolver and OpenMythos compliant endpoints (C77 + C78)

### DIFF
--- a/apps/web/__tests__/live-npi-resolver-and-openmythos-compliance.test.ts
+++ b/apps/web/__tests__/live-npi-resolver-and-openmythos-compliance.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __resetBuckets } from '@/lib/rate-limit/ipBucket';
+
+beforeEach(() => {
+  __resetBuckets();
+  vi.resetModules();
+  delete process.env.VCV_ISSUER_HOST;
+  delete process.env.VCV_ED25519_PRIVATE_JWK;
+});
+
+afterEach(() => {
+  __resetBuckets();
+  vi.restoreAllMocks();
+});
+
+// ── resolve-npi route + cache ────────────────────────────────────────────
+
+describe('resolve-npi route', () => {
+  async function callRoute(
+    npi: string,
+    headers: HeadersInit = {},
+  ): Promise<Response> {
+    const mod = await import('@/app/api/resolve-npi/route');
+    mod.__resetResolveNpiCache();
+    const req = {
+      nextUrl: new URL(`http://localhost/api/resolve-npi?npi=${npi}`),
+      headers: new Headers(headers),
+    } as unknown as import('next/server').NextRequest;
+    return mod.GET(req);
+  }
+
+  async function callRouteWithSharedCache(
+    npi: string,
+    headers: HeadersInit = {},
+  ): Promise<Response> {
+    // Re-uses the cache between calls — no reset.
+    const mod = await import('@/app/api/resolve-npi/route');
+    const req = {
+      nextUrl: new URL(`http://localhost/api/resolve-npi?npi=${npi}`),
+      headers: new Headers(headers),
+    } as unknown as import('next/server').NextRequest;
+    return mod.GET(req);
+  }
+
+  it('rejects invalid format with 400', async () => {
+    const res = await callRoute('abc');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_npi_format');
+  });
+
+  it('rejects bad Luhn with 400', async () => {
+    const res = await callRoute('1234567890');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_npi_checksum');
+  });
+
+  it('returns 404 when NPPES has no result for the NPI', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ result_count: 0, results: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch;
+    const res = await callRoute('1346053246', {
+      'x-forwarded-for': '198.51.100.10',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 + DTO on success and projects fields from NPPES', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          result_count: 1,
+          results: [
+            {
+              number: '1346053246',
+              basic: {
+                first_name: 'Mira',
+                last_name: 'Chen',
+                credential: 'MD',
+              },
+              taxonomies: [
+                {
+                  code: '207R00000X',
+                  desc: 'Internal Medicine',
+                  primary: true,
+                  state: 'CA',
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    ) as unknown as typeof fetch;
+    const res = await callRoute('1346053246', {
+      'x-forwarded-for': '198.51.100.11',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.firstName).toBe('Mira');
+    expect(body.lastName).toBe('Chen');
+    expect(body.credential).toBe('MD');
+    expect(body.primaryTaxonomy.code).toBe('207R00000X');
+    expect(body.activeState).toBe('CA');
+    expect(body.cached).toBe(false);
+    expect(res.headers.get('X-Cache')).toBe('MISS');
+  });
+
+  it('serves repeat fetches from the cache (<300ms latency contract)', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          result_count: 1,
+          results: [
+            {
+              basic: { first_name: 'A', last_name: 'B' },
+              taxonomies: [{ code: '207R00000X', primary: true }],
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    // First call - MISS
+    const first = await callRoute('1346053246', {
+      'x-forwarded-for': '198.51.100.12',
+    });
+    expect(first.headers.get('X-Cache')).toBe('MISS');
+    // Second call uses shared cache - HIT, no upstream call
+    const start = performance.now();
+    const second = await callRouteWithSharedCache('1346053246', {
+      'x-forwarded-for': '198.51.100.13',
+    });
+    const elapsed = performance.now() - start;
+    expect(second.status).toBe(200);
+    expect(second.headers.get('X-Cache')).toBe('HIT');
+    expect((await second.json()).cached).toBe(true);
+    expect(elapsed).toBeLessThan(300);
+    // Upstream fetch only invoked once across the two calls
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate-limits at 30 requests / minute per IP', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ result_count: 0, results: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch;
+    const ip = '198.51.100.99';
+    for (let i = 0; i < 30; i++) {
+      await callRouteWithSharedCache('1346053246', { 'x-forwarded-for': ip });
+    }
+    const denied = await callRouteWithSharedCache('1346053246', {
+      'x-forwarded-for': ip,
+    });
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get('Retry-After')).toBeTruthy();
+  });
+});
+
+// ── /.well-known/did.json ────────────────────────────────────────────────
+
+describe('.well-known/did.json route · W3C DID compliance', () => {
+  async function callDid(headers: HeadersInit = {}): Promise<Response> {
+    const mod = await import('@/app/.well-known/did.json/route');
+    return mod.GET(new Request('https://example.com/.well-known/did.json', {
+      headers,
+    }));
+  }
+
+  it('returns a strict W3C DID Document with did:web identity', async () => {
+    const res = await callDid({ 'x-forwarded-host': 'demo.trycloudflare.com' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toMatch(/did\+json/);
+    const body = await res.json();
+    expect(body['@context']).toContain('https://www.w3.org/ns/did/v1');
+    expect(body.id).toBe('did:web:demo.trycloudflare.com');
+    expect(body.controller).toBe('did:web:demo.trycloudflare.com');
+  });
+
+  it('exposes an Ed25519 verification method (JsonWebKey2020 with crv: Ed25519)', async () => {
+    const res = await callDid({ 'x-forwarded-host': 'demo.trycloudflare.com' });
+    const body = await res.json();
+    expect(body.verificationMethod).toHaveLength(1);
+    const vm = body.verificationMethod[0];
+    expect(vm.type).toBe('JsonWebKey2020');
+    expect(vm.publicKeyJwk.kty).toBe('OKP');
+    expect(vm.publicKeyJwk.crv).toBe('Ed25519');
+    expect(vm.publicKeyJwk.alg).toBe('EdDSA');
+    expect(vm.id).toMatch(/^did:web:demo\.trycloudflare\.com#/);
+  });
+
+  it('lists the verification method in authentication and assertionMethod', async () => {
+    const res = await callDid();
+    const body = await res.json();
+    const vmId = body.verificationMethod[0].id;
+    expect(body.authentication).toContain(vmId);
+    expect(body.assertionMethod).toContain(vmId);
+  });
+
+  it('advertises the JWKS and OID4VCI service endpoints', async () => {
+    const res = await callDid({ 'x-forwarded-host': 'demo.example.com' });
+    const body = await res.json();
+    const services = body.service as Array<{ type: string; serviceEndpoint: string }>;
+    const jwks = services.find((s) => s.type === 'KeyStore');
+    const oid4vci = services.find((s) => s.type === 'OID4VCIIssuer');
+    expect(jwks?.serviceEndpoint).toBe('https://demo.example.com/.well-known/jwks.json');
+    expect(oid4vci?.serviceEndpoint).toBe(
+      'https://demo.example.com/.well-known/openid-credential-issuer',
+    );
+  });
+
+  it('falls back to vitalcv.com when no host header is supplied', async () => {
+    const res = await callDid({});
+    const body = await res.json();
+    expect(body.id).toBe('did:web:vitalcv.com');
+  });
+});
+
+// ── /.well-known/openid-credential-issuer ───────────────────────────────
+
+describe('.well-known/openid-credential-issuer route · OID4VCI compliance', () => {
+  async function callOid4vci(headers: HeadersInit = {}): Promise<Response> {
+    const mod = await import(
+      '@/app/.well-known/openid-credential-issuer/route'
+    );
+    return mod.GET(
+      new Request('https://example.com/.well-known/openid-credential-issuer', {
+        headers,
+      }),
+    );
+  }
+
+  it('returns OID4VCI 1.0 metadata with required fields', async () => {
+    const res = await callOid4vci({ 'x-forwarded-host': 'demo.example.com' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.credential_issuer).toBe('https://demo.example.com');
+    expect(body.credential_endpoint).toBe(
+      'https://demo.example.com/api/credentials/issue',
+    );
+    expect(body.jwks_uri).toBe('https://demo.example.com/.well-known/jwks.json');
+    expect(body.authorization_servers).toEqual(['https://demo.example.com']);
+  });
+
+  it('declares VitalCVCredential in credential_configurations_supported', async () => {
+    const res = await callOid4vci();
+    const body = await res.json();
+    const cred = body.credential_configurations_supported.VitalCVCredential;
+    expect(cred).toBeTruthy();
+    expect(cred.format).toBe('jwt_vc_json');
+    expect(cred.credential_definition.type).toContain('VerifiableCredential');
+    expect(cred.credential_definition.type).toContain('VitalCVCredential');
+    expect(cred.credential_signing_alg_values_supported).toContain('EdDSA');
+    expect(cred.proof_types_supported.jwt.proof_signing_alg_values_supported)
+      .toContain('EdDSA');
+  });
+
+  it('declares subject claims (npi, taxonomyCode, activeState) on the credential', async () => {
+    const res = await callOid4vci();
+    const body = await res.json();
+    const subject =
+      body.credential_configurations_supported.VitalCVCredential
+        .credential_definition.credentialSubject;
+    expect(subject.npi).toBeTruthy();
+    expect(subject.taxonomyCode).toBeTruthy();
+    expect(subject.activeState).toBeTruthy();
+  });
+
+  it('cross-references the issuer DID', async () => {
+    const res = await callOid4vci({ 'x-forwarded-host': 'demo.example.com' });
+    const body = await res.json();
+    expect(body.issuer_did).toBe('did:web:demo.example.com');
+  });
+});

--- a/apps/web/app/.well-known/did.json/route.ts
+++ b/apps/web/app/.well-known/did.json/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /.well-known/did.json
+ *
+ * W3C DID Document for the VitalCV issuer identity (WAVE C78).
+ *
+ * Strict-compliance shape:
+ *   - `@context` includes the canonical W3C DID v1 context plus the
+ *     Ed25519VerificationKey2020 context.
+ *   - `id` and `controller` are derived per-request from the resolved
+ *     issuer host (env override > X-Forwarded-Host > Host > default).
+ *   - `verificationMethod` carries an Ed25519 entry (`JsonWebKey2020`
+ *     with `publicKeyJwk.crv = 'Ed25519'`) sourced from the runtime
+ *     keypair in `apps/web/lib/crypto/ed25519IssuerKey.ts`.
+ *   - `authentication` and `assertionMethod` both reference the
+ *     verification method id.
+ *   - `service` advertises the JWKS endpoint (which carries the
+ *     separate ES256 receipt-signing key) and the OID4VCI metadata
+ *     endpoint.
+ *
+ * Spec refs:
+ *   - https://www.w3.org/TR/did-core/
+ *   - https://w3c-ccg.github.io/did-method-web/
+ *   - https://w3c-ccg.github.io/lds-jws2020/
+ */
+
+import { NextResponse } from 'next/server';
+import { getEd25519PublicJwk } from '@/lib/crypto/ed25519IssuerKey';
+import {
+  resolveIssuerDid,
+  resolveIssuerOrigin,
+} from '@/lib/discovery/issuerHost';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const issuerDid = resolveIssuerDid(request.headers);
+  const issuerOrigin = resolveIssuerOrigin(request.headers);
+  const publicJwk = await getEd25519PublicJwk();
+  const kid =
+    typeof publicJwk.kid === 'string' ? publicJwk.kid : 'vcv-ed25519-key-1';
+  const verificationMethodId = `${issuerDid}#${kid}`;
+
+  const didDocument = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/suites/jws-2020/v1',
+    ],
+    id: issuerDid,
+    controller: issuerDid,
+    verificationMethod: [
+      {
+        id: verificationMethodId,
+        type: 'JsonWebKey2020',
+        controller: issuerDid,
+        publicKeyJwk: publicJwk,
+      },
+    ],
+    authentication: [verificationMethodId],
+    assertionMethod: [verificationMethodId],
+    service: [
+      {
+        id: `${issuerDid}#jwks`,
+        type: 'KeyStore',
+        serviceEndpoint: `${issuerOrigin}/.well-known/jwks.json`,
+      },
+      {
+        id: `${issuerDid}#openid-credential-issuer`,
+        type: 'OID4VCIIssuer',
+        serviceEndpoint: `${issuerOrigin}/.well-known/openid-credential-issuer`,
+      },
+    ],
+  };
+
+  return NextResponse.json(didDocument, {
+    headers: {
+      'Content-Type': 'application/did+json; charset=utf-8',
+      'Cache-Control':
+        'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/apps/web/app/.well-known/openid-credential-issuer/route.ts
+++ b/apps/web/app/.well-known/openid-credential-issuer/route.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /.well-known/openid-credential-issuer
+ *
+ * OpenID for Verifiable Credential Issuance (OID4VCI) issuer metadata.
+ * (WAVE C78)
+ *
+ * Strict-compliance shape per
+ * https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html:
+ *   - `credential_issuer` — resolved per-request from the issuer host
+ *   - `credential_endpoint` — POST endpoint for the credential request
+ *   - `jwks_uri` — public JWKS for receipt signature verification
+ *   - `credential_configurations_supported` — typed credentials VitalCV
+ *     issues, keyed by configuration id, each carrying `format`,
+ *     `credential_definition`, and `proof_types_supported`.
+ *
+ * `credential_configurations_supported` describes the issuer's
+ * **declared** capability — it does not assert that a particular
+ * subject possesses any of the listed credentials.
+ */
+
+import { NextResponse } from 'next/server';
+import { resolveIssuerDid, resolveIssuerOrigin } from '@/lib/discovery/issuerHost';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const issuerDid = resolveIssuerDid(request.headers);
+  const issuerOrigin = resolveIssuerOrigin(request.headers);
+
+  const metadata = {
+    credential_issuer: issuerOrigin,
+    authorization_servers: [issuerOrigin],
+    credential_endpoint: `${issuerOrigin}/api/credentials/issue`,
+    jwks_uri: `${issuerOrigin}/.well-known/jwks.json`,
+    // OID4VCI 1.0 — proof formats VitalCV will accept on credential request.
+    proof_types_supported: {
+      jwt: {
+        proof_signing_alg_values_supported: ['EdDSA', 'ES256'],
+      },
+    },
+    credential_configurations_supported: {
+      VitalCVCredential: {
+        format: 'jwt_vc_json',
+        scope: 'VitalCVCredential',
+        cryptographic_binding_methods_supported: ['did:web'],
+        credential_signing_alg_values_supported: ['EdDSA', 'ES256'],
+        credential_definition: {
+          type: ['VerifiableCredential', 'VitalCVCredential'],
+          credentialSubject: {
+            // Subject NPI is the primary identifier (NPPES-public).
+            npi: { display: [{ name: 'NPI', locale: 'en-US' }] },
+            // Source-confirmed primary taxonomy (CMS NUCC code).
+            taxonomyCode: {
+              display: [{ name: 'Primary taxonomy', locale: 'en-US' }],
+            },
+            // Active practice state (CMS NPPES location address).
+            activeState: {
+              display: [{ name: 'Active state', locale: 'en-US' }],
+            },
+          },
+        },
+        proof_types_supported: {
+          jwt: {
+            proof_signing_alg_values_supported: ['EdDSA', 'ES256'],
+          },
+        },
+        display: [
+          {
+            name: 'VitalCV Provider Credential',
+            locale: 'en-US',
+            description:
+              'Verifiable credential issued by VitalCV after source-confirmed federal-registry resolution. Re-verifiable offline against the issuer DID.',
+          },
+        ],
+      },
+    },
+    // Convenience cross-reference back to the DID identity.
+    issuer_did: issuerDid,
+    display: [
+      {
+        name: 'VitalCV',
+        locale: 'en-US',
+      },
+    ],
+  };
+
+  return NextResponse.json(metadata, {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/web/app/api/resolve-npi/route.ts
+++ b/apps/web/app/api/resolve-npi/route.ts
@@ -1,0 +1,120 @@
+/**
+ * GET /api/resolve-npi?npi=NNNNNNNNNN
+ *
+ * Live NPPES NPI resolver (WAVE C77). Consumes
+ * `@vitalcv/core` `resolveNppes(...)` and overlays:
+ *   - per-IP rate-limit (token bucket; 30/min default)
+ *   - in-memory positive-result cache (TTL 5 min) for <300ms repeat reads
+ *   - error-token discipline (machine-readable strings, not marketing copy)
+ *
+ * The route is unauthenticated. NPPES is the public, free CMS registry;
+ * the payload contains nothing beyond what is legally published there.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  isValidNpiChecksum,
+  resolveNppes,
+  type NppesProviderDto,
+} from '@vitalcv/core';
+import {
+  DEFAULT_POLICY,
+  consumeToken,
+  extractClientIp,
+} from '@/lib/rate-limit/ipBucket';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, { value: NppesProviderDto; expiresAt: number }>();
+
+export function __resetResolveNpiCache(): void {
+  cache.clear();
+}
+
+export async function GET(req: NextRequest) {
+  const ip = extractClientIp(req.headers);
+  const rl = consumeToken(ip, DEFAULT_POLICY);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: 'rate_limited', retry_after_seconds: rl.retryAfterSeconds },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rl.retryAfterSeconds),
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    );
+  }
+
+  const npi = req.nextUrl.searchParams.get('npi')?.trim() ?? '';
+  if (!/^\d{10}$/.test(npi)) {
+    return NextResponse.json(
+      { error: 'invalid_npi_format', expected: '10 digits' },
+      { status: 400 },
+    );
+  }
+  if (!isValidNpiChecksum(npi)) {
+    return NextResponse.json(
+      { error: 'invalid_npi_checksum' },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const hit = cache.get(npi);
+  if (hit && hit.expiresAt > now) {
+    return NextResponse.json(
+      { npi, ...hit.value, cached: true },
+      {
+        status: 200,
+        headers: {
+          'X-RateLimit-Remaining': String(rl.tokensRemaining),
+          'X-Cache': 'HIT',
+          'Cache-Control':
+            'public, max-age=300, stale-while-revalidate=600',
+        },
+      },
+    );
+  }
+
+  const outcome = await resolveNppes(npi);
+  if (outcome.kind === 'not_found') {
+    return NextResponse.json(
+      { error: 'npi_not_found', npi },
+      { status: 404 },
+    );
+  }
+  if (outcome.kind === 'upstream_error') {
+    return NextResponse.json(
+      { error: 'upstream_unavailable', status: outcome.status },
+      { status: 502 },
+    );
+  }
+  if (outcome.kind === 'network_error') {
+    return NextResponse.json(
+      { error: 'upstream_unreachable', detail: outcome.detail },
+      { status: 504 },
+    );
+  }
+
+  cache.set(npi, {
+    value: outcome.provider,
+    expiresAt: now + CACHE_TTL_MS,
+  });
+
+  return NextResponse.json(
+    { npi, ...outcome.provider, cached: false },
+    {
+      status: 200,
+      headers: {
+        'X-RateLimit-Remaining': String(rl.tokensRemaining),
+        'X-Cache': 'MISS',
+        'Cache-Control':
+          'public, max-age=300, stale-while-revalidate=600',
+      },
+    },
+  );
+}

--- a/apps/web/lib/crypto/ed25519IssuerKey.ts
+++ b/apps/web/lib/crypto/ed25519IssuerKey.ts
@@ -1,0 +1,92 @@
+/**
+ * Ed25519 issuer identity key for the W3C DID document.
+ *
+ * The production receipt-signing path uses ES256 (see
+ * `apps/web/lib/crypto/receiptIssuer.ts`); this module manages a
+ * separate Ed25519 keypair used solely as the DID document's
+ * verification method. A DID may legitimately publish multiple
+ * verification methods of different types — Ed25519 here, ES256 in
+ * the JWKS at `/.well-known/jwks.json`.
+ *
+ * Production: set `VCV_ED25519_PRIVATE_JWK` (JSON-encoded JWK of the
+ * private key). The matching public JWK is published in the DID doc.
+ *
+ * Dev / preview: an ephemeral keypair is generated at module load
+ * time. Not persisted; rotates on every process restart. The DID's
+ * `id` is still stable (derived from the host), so the document's
+ * shape is reproducible across restarts even if the key fingerprint
+ * changes.
+ */
+
+import { exportJWK, generateKeyPair, importJWK } from 'jose';
+
+let _keypairPromise: Promise<Ed25519Keypair> | null = null;
+
+export interface Ed25519Keypair {
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+  /** Stable key-id derived from the kid claim of the JWK. */
+  kid: string;
+}
+
+async function initKeypair(): Promise<Ed25519Keypair> {
+  const envJwkRaw = process.env.VCV_ED25519_PRIVATE_JWK;
+  if (envJwkRaw && envJwkRaw.trim().length > 0) {
+    try {
+      const privateJwk = JSON.parse(envJwkRaw) as Record<string, unknown>;
+      if (privateJwk.kty !== 'OKP' || privateJwk.crv !== 'Ed25519') {
+        throw new Error('VCV_ED25519_PRIVATE_JWK is not an Ed25519 OKP key');
+      }
+      const privateKey = (await importJWK(privateJwk, 'EdDSA')) as CryptoKey;
+      // Derive the public JWK by stripping the private 'd' component.
+      const publicJwk = { ...privateJwk };
+      delete publicJwk.d;
+      const publicKey = (await importJWK(publicJwk, 'EdDSA')) as CryptoKey;
+      const kid =
+        typeof privateJwk.kid === 'string' && privateJwk.kid.length > 0
+          ? privateJwk.kid
+          : 'vcv-ed25519-key-1';
+      return { publicKey, privateKey, kid };
+    } catch (err) {
+      throw new Error(
+        `VCV_ED25519_PRIVATE_JWK could not be parsed: ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
+  }
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', {
+    crv: 'Ed25519',
+    extractable: true,
+  });
+  return {
+    publicKey,
+    privateKey,
+    kid: 'vcv-ed25519-dev-ephemeral',
+  };
+}
+
+function getOrInitKeypair(): Promise<Ed25519Keypair> {
+  if (!_keypairPromise) {
+    _keypairPromise = initKeypair();
+  }
+  return _keypairPromise;
+}
+
+/**
+ * Returns the public Ed25519 JWK — safe to publish in the DID document.
+ * Includes `alg: 'EdDSA'`, `use: 'sig'`, and a stable `kid`.
+ */
+export async function getEd25519PublicJwk(): Promise<Record<string, unknown>> {
+  const { publicKey, kid } = await getOrInitKeypair();
+  const jwk = await exportJWK(publicKey);
+  return { ...jwk, alg: 'EdDSA', use: 'sig', kid };
+}
+
+/**
+ * For tests only — clears the cached keypair so the next call
+ * regenerates. Never call from production code paths.
+ */
+export function __resetEd25519IssuerKey(): void {
+  _keypairPromise = null;
+}

--- a/apps/web/lib/discovery/issuerHost.ts
+++ b/apps/web/lib/discovery/issuerHost.ts
@@ -1,0 +1,51 @@
+/**
+ * Resolves the issuer host for `.well-known` discovery endpoints.
+ *
+ * Resolution order (first match wins):
+ *   1. `VCV_ISSUER_HOST` env — operator override
+ *   2. `X-Forwarded-Host` first hop — proxy/tunnel injection
+ *   3. `Host` header — direct
+ *   4. `vitalcv.com` default — preserves production identity when no
+ *      headers are present (build prerender, offline tests)
+ *
+ * Strict host validation rejects path / scheme / whitespace injection
+ * so a malicious upstream proxy cannot widen the discovery doc's
+ * controller field.
+ */
+
+const DEFAULT_ISSUER_HOST = 'vitalcv.com';
+
+function isValidHost(candidate: string | null | undefined): candidate is string {
+  if (!candidate) return false;
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > 253) return false;
+  if (/\s/.test(trimmed)) return false;
+  if (trimmed.includes('/')) return false;
+  if (trimmed.includes('://')) return false;
+  return /^[A-Za-z0-9.\-:_]+$/.test(trimmed);
+}
+
+export function resolveIssuerHost(headers: Headers): string {
+  const envHost = process.env.VCV_ISSUER_HOST;
+  if (isValidHost(envHost)) return envHost.trim();
+
+  const fwdHost = headers.get('x-forwarded-host');
+  if (fwdHost) {
+    const first = fwdHost.split(',')[0]?.trim();
+    if (isValidHost(first)) return first;
+  }
+
+  const host = headers.get('host');
+  if (isValidHost(host)) return host.trim();
+
+  return DEFAULT_ISSUER_HOST;
+}
+
+export function resolveIssuerOrigin(headers: Headers): string {
+  return `https://${resolveIssuerHost(headers)}`;
+}
+
+export function resolveIssuerDid(headers: Headers): string {
+  return `did:web:${resolveIssuerHost(headers)}`;
+}

--- a/apps/web/lib/rate-limit/ipBucket.ts
+++ b/apps/web/lib/rate-limit/ipBucket.ts
@@ -1,0 +1,84 @@
+/**
+ * In-memory IP rate-limit bucket.
+ *
+ * Sliding-window token bucket keyed by IP. Lives in the route handler's
+ * Node.js process — adequate for unauthenticated demo endpoints; it is
+ * NOT a substitute for a shared store (Redis/Upstash) in a multi-process
+ * production deployment, but the demo cluster runs single-process and
+ * the threat model is "casual abuse", not "coordinated attacker".
+ *
+ * Default policy: 30 requests per IP per minute, burstable to 30.
+ */
+
+interface Bucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export interface RateLimitPolicy {
+  capacity: number;
+  refillPerSecond: number;
+}
+
+export const DEFAULT_POLICY: RateLimitPolicy = {
+  capacity: 30,
+  refillPerSecond: 0.5, // 30 tokens / 60 seconds
+};
+
+const buckets = new Map<string, Bucket>();
+
+export function extractClientIp(headers: Headers): string {
+  const fwd = headers.get('x-forwarded-for');
+  if (fwd) {
+    const first = fwd.split(',')[0]?.trim();
+    if (first && first.length > 0 && first.length < 64) return first;
+  }
+  const real = headers.get('x-real-ip');
+  if (real && real.length < 64) return real.trim();
+  return '__no_ip__';
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  tokensRemaining: number;
+  retryAfterSeconds: number;
+}
+
+export function consumeToken(
+  ip: string,
+  policy: RateLimitPolicy = DEFAULT_POLICY,
+  now: number = Date.now(),
+): RateLimitResult {
+  const existing = buckets.get(ip);
+  let bucket: Bucket;
+  if (existing) {
+    const elapsedSec = (now - existing.lastRefillMs) / 1000;
+    const refilled = Math.min(
+      policy.capacity,
+      existing.tokens + elapsedSec * policy.refillPerSecond,
+    );
+    bucket = { tokens: refilled, lastRefillMs: now };
+  } else {
+    bucket = { tokens: policy.capacity, lastRefillMs: now };
+  }
+  if (bucket.tokens >= 1) {
+    bucket.tokens -= 1;
+    buckets.set(ip, bucket);
+    return {
+      allowed: true,
+      tokensRemaining: Math.floor(bucket.tokens),
+      retryAfterSeconds: 0,
+    };
+  }
+  buckets.set(ip, bucket);
+  const deficit = 1 - bucket.tokens;
+  return {
+    allowed: false,
+    tokensRemaining: 0,
+    retryAfterSeconds: Math.ceil(deficit / policy.refillPerSecond),
+  };
+}
+
+export function __resetBuckets(): void {
+  buckets.clear();
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,7 +70,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "tippy.js": "^6.3.7",
-    "zustand": "^5.0.12"
+    "zustand": "^5.0.12",
+    "@vitalcv/core": "workspace:*"
   },
   "devDependencies": {
     "prisma": "^6.19.2",

--- a/packages/core/__tests__/nppesResolver.test.ts
+++ b/packages/core/__tests__/nppesResolver.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isValidNpiChecksum,
+  projectMinimalDto,
+  resolveNppes,
+} from '../src/services/nppesResolver';
+
+function makeResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('isValidNpiChecksum', () => {
+  it.each([
+    ['1346053246', true],
+    ['1234567893', true],
+    ['1234567890', false],
+    ['1356428912', false],
+    ['abc', false],
+    ['', false],
+    ['12345678901', false],
+  ])('Luhn(%s) = %s', (npi, expected) => {
+    expect(isValidNpiChecksum(npi)).toBe(expected);
+  });
+});
+
+describe('projectMinimalDto', () => {
+  it('extracts a clean DTO from a populated NPPES result', () => {
+    const dto = projectMinimalDto({
+      number: '1346053246',
+      basic: {
+        first_name: '  Mira ',
+        last_name: 'Chen',
+        middle_name: 'L',
+        credential: ' MD ',
+      },
+      taxonomies: [
+        { code: '207R00000X', desc: 'Internal Medicine', primary: true, state: 'CA' },
+        { code: '207RH0000X', desc: 'Hospital Medicine', primary: false, state: 'CA' },
+      ],
+      addresses: [
+        { state: 'CA', address_purpose: 'LOCATION' },
+        { state: 'NY', address_purpose: 'MAILING' },
+      ],
+    });
+    expect(dto).toEqual({
+      firstName: 'Mira',
+      lastName: 'Chen',
+      credential: 'MD',
+      primaryTaxonomy: { code: '207R00000X', desc: 'Internal Medicine' },
+      activeState: 'CA',
+    });
+  });
+
+  it('falls back to the first taxonomy when none is primary', () => {
+    const dto = projectMinimalDto({
+      taxonomies: [
+        { code: '208600000X', desc: 'Surgery' },
+        { code: '207R00000X', desc: 'Internal Medicine' },
+      ],
+    });
+    expect(dto.primaryTaxonomy.code).toBe('208600000X');
+  });
+
+  it('handles missing optional fields with null', () => {
+    const dto = projectMinimalDto({});
+    expect(dto).toEqual({
+      firstName: null,
+      lastName: null,
+      credential: null,
+      primaryTaxonomy: { code: null, desc: null },
+      activeState: null,
+    });
+  });
+
+  it('treats empty/whitespace fields as null', () => {
+    const dto = projectMinimalDto({
+      basic: { first_name: '', last_name: '   ', credential: ' ' },
+    });
+    expect(dto.firstName).toBeNull();
+    expect(dto.lastName).toBeNull();
+    expect(dto.credential).toBeNull();
+  });
+
+  it('uses LOCATION-purpose address state when no taxonomy state is set', () => {
+    const dto = projectMinimalDto({
+      addresses: [
+        { state: 'NY', address_purpose: 'MAILING' },
+        { state: 'CA', address_purpose: 'LOCATION' },
+      ],
+    });
+    expect(dto.activeState).toBe('CA');
+  });
+});
+
+describe('resolveNppes outcomes', () => {
+  it('returns "found" with a projected DTO on 200 + populated results', async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeResponse({
+        result_count: 1,
+        results: [
+          {
+            number: '1346053246',
+            basic: { first_name: 'Mira', last_name: 'Chen', credential: 'MD' },
+            taxonomies: [
+              {
+                code: '207R00000X',
+                desc: 'Internal Medicine',
+                primary: true,
+                state: 'CA',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const out = await resolveNppes('1346053246', { fetchImpl });
+    expect(out.kind).toBe('found');
+    if (out.kind !== 'found') return;
+    expect(out.provider.firstName).toBe('Mira');
+    expect(out.provider.primaryTaxonomy.code).toBe('207R00000X');
+  });
+
+  it('returns "not_found" when CMS reports result_count: 0', async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeResponse({ result_count: 0, results: [] }),
+    );
+    const out = await resolveNppes('1346053246', { fetchImpl });
+    expect(out.kind).toBe('not_found');
+  });
+
+  it('returns "upstream_error" with status on non-2xx', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response('boom', { status: 503 }),
+    );
+    const out = await resolveNppes('1346053246', { fetchImpl });
+    expect(out.kind).toBe('upstream_error');
+    if (out.kind === 'upstream_error') expect(out.status).toBe(503);
+  });
+
+  it('returns "upstream_error" 502 when CMS returns non-JSON', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response('not json', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    );
+    const out = await resolveNppes('1346053246', { fetchImpl });
+    expect(out.kind).toBe('upstream_error');
+  });
+
+  it('returns "network_error" when fetch throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNREFUSED 10.0.0.1');
+    });
+    const out = await resolveNppes('1346053246', { fetchImpl });
+    expect(out.kind).toBe('network_error');
+    if (out.kind === 'network_error') {
+      expect(out.detail).toContain('ECONNREFUSED');
+    }
+  });
+
+  it('honors apiBase override (offline mirror)', async () => {
+    let calledUrl = '';
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      calledUrl = typeof input === 'string' ? input : input.toString();
+      return makeResponse({ result_count: 0, results: [] });
+    });
+    await resolveNppes('1346053246', {
+      fetchImpl,
+      apiBase: 'https://demo-mirror.example.com/nppes/',
+    });
+    expect(calledUrl).toContain('demo-mirror.example.com');
+    expect(calledUrl).toContain('number=1346053246');
+    expect(calledUrl).toContain('version=2.1');
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitalcv/core",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @vitalcv/core — cross-app shared services.
+ */
+
+// NPPES resolver (WAVE C77)
+export {
+  NPPES_API_BASE,
+  NPPES_API_VERSION,
+  NPPES_DEFAULT_TIMEOUT_MS,
+  isValidNpiChecksum,
+  projectMinimalDto,
+  resolveNppes,
+} from './services/nppesResolver';
+export type {
+  NppesProviderDto,
+  NppesResolutionOutcome,
+  NppesResolverDeps,
+} from './services/nppesResolver';

--- a/packages/core/src/services/nppesResolver.ts
+++ b/packages/core/src/services/nppesResolver.ts
@@ -1,0 +1,193 @@
+/**
+ * Live NPPES NPI resolver — WAVE C77.
+ *
+ * Fetches the CMS public NPI registry and maps the response to a
+ * minimal DTO. Pure-functional from the caller's point of view; the
+ * fetcher is injected so tests can mock without touching the network.
+ *
+ * Source: https://npiregistry.cms.hhs.gov/api/?number={npi}&version=2.1
+ *
+ * The CMS API is public, free, no API key required. It returns HTTP
+ * 200 with `result_count: 0` for NPIs that don't exist — we surface
+ * that as a typed `NppesNotFound` outcome, never a thrown error.
+ */
+
+export const NPPES_API_BASE = 'https://npiregistry.cms.hhs.gov/api/';
+export const NPPES_API_VERSION = '2.1';
+export const NPPES_DEFAULT_TIMEOUT_MS = 4000;
+
+export interface NppesProviderDto {
+  firstName: string | null;
+  lastName: string | null;
+  credential: string | null;
+  primaryTaxonomy: {
+    code: string | null;
+    desc: string | null;
+  };
+  activeState: string | null;
+}
+
+export type NppesResolutionOutcome =
+  | { kind: 'found'; provider: NppesProviderDto }
+  | { kind: 'not_found' }
+  | { kind: 'upstream_error'; status: number }
+  | { kind: 'network_error'; detail: string };
+
+export interface NppesResolverDeps {
+  /** Override the global fetch (tests, custom proxies, mirrors). */
+  fetchImpl?: typeof fetch;
+  /** Override the API base (offline-demo mirror or staging). */
+  apiBase?: string;
+  /** Override the API version. */
+  apiVersion?: string;
+  /** Request abort timeout in ms. */
+  timeoutMs?: number;
+}
+
+// ── CMS NPPES response shapes (narrow) ────────────────────────────────────
+
+interface NppesBasic {
+  first_name?: string;
+  last_name?: string;
+  middle_name?: string;
+  credential?: string;
+  name_prefix?: string;
+  name_suffix?: string;
+  name?: string;
+}
+
+interface NppesTaxonomy {
+  code?: string;
+  desc?: string;
+  primary?: boolean;
+  state?: string;
+}
+
+interface NppesAddress {
+  state?: string;
+  address_purpose?: string;
+}
+
+interface NppesResult {
+  number?: string;
+  basic?: NppesBasic;
+  taxonomies?: NppesTaxonomy[];
+  addresses?: NppesAddress[];
+}
+
+interface NppesResponse {
+  result_count?: number;
+  results?: NppesResult[];
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Resolves an NPI against the NPPES API. Returns a typed outcome:
+ *   - `found`           — provider DTO populated from the first result
+ *   - `not_found`       — CMS returned `result_count: 0`
+ *   - `upstream_error`  — CMS returned a non-2xx status
+ *   - `network_error`   — fetch threw / timed out
+ *
+ * Never throws; callers can render every outcome deterministically.
+ */
+export async function resolveNppes(
+  npi: string,
+  deps: NppesResolverDeps = {},
+): Promise<NppesResolutionOutcome> {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  const apiBase = deps.apiBase ?? NPPES_API_BASE;
+  const apiVersion = deps.apiVersion ?? NPPES_API_VERSION;
+  const timeoutMs = deps.timeoutMs ?? NPPES_DEFAULT_TIMEOUT_MS;
+
+  const url = `${apiBase}?number=${encodeURIComponent(npi)}&version=${encodeURIComponent(apiVersion)}`;
+
+  const ac = new AbortController();
+  const timeout = setTimeout(() => ac.abort(), timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      signal: ac.signal,
+      headers: { Accept: 'application/json' },
+    });
+  } catch (err) {
+    clearTimeout(timeout);
+    const detail = err instanceof Error ? err.message.slice(0, 120) : 'unknown';
+    return { kind: 'network_error', detail };
+  }
+  clearTimeout(timeout);
+
+  if (!res.ok) {
+    // CMS treats unknown NPIs as 200 with result_count=0, so a non-2xx
+    // here is genuinely an upstream issue rather than a missing NPI.
+    return { kind: 'upstream_error', status: res.status };
+  }
+
+  let json: NppesResponse;
+  try {
+    json = (await res.json()) as NppesResponse;
+  } catch {
+    return { kind: 'upstream_error', status: 502 };
+  }
+
+  if (!json.results || json.results.length === 0 || json.result_count === 0) {
+    return { kind: 'not_found' };
+  }
+
+  return { kind: 'found', provider: projectMinimalDto(json.results[0]) };
+}
+
+/**
+ * Projects the raw NPPES result into the minimal DTO. Exported for
+ * tests; production callers should go through `resolveNppes` so the
+ * outcome envelope is consistent.
+ */
+export function projectMinimalDto(r: NppesResult): NppesProviderDto {
+  const basic = r.basic ?? {};
+  const taxonomies = r.taxonomies ?? [];
+  const primary =
+    taxonomies.find((t) => t.primary === true) ?? taxonomies[0] ?? null;
+  const locationAddr =
+    r.addresses?.find((a) => a.address_purpose === 'LOCATION' && a.state) ??
+    r.addresses?.find((a) => a.state) ??
+    null;
+  return {
+    firstName: trimToNull(basic.first_name),
+    lastName: trimToNull(basic.last_name),
+    credential: trimToNull(basic.credential),
+    primaryTaxonomy: {
+      code: trimToNull(primary?.code),
+      desc: trimToNull(primary?.desc),
+    },
+    activeState: trimToNull(primary?.state ?? locationAddr?.state),
+  };
+}
+
+function trimToNull(value: string | undefined | null): string | null {
+  if (!value) return null;
+  const t = value.trim();
+  return t.length > 0 ? t : null;
+}
+
+// ── NPI Luhn (re-exported so callers don't reimplement) ──────────────────
+
+/**
+ * Validates the 10-digit NPI Luhn checksum (ISO/IEC 7812 with "80840"
+ * prefix). Use BEFORE calling `resolveNppes` so malformed inputs never
+ * hit the upstream service.
+ */
+export function isValidNpiChecksum(npi: string): boolean {
+  if (!/^\d{10}$/.test(npi)) return false;
+  const digits = ('80840' + npi).split('').map(Number);
+  let sum = 0;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits[i];
+    if ((digits.length - 1 - i) % 2 === 1) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+  }
+  return sum % 10 === 0;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "declaration": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,12 +426,6 @@ importers:
 
   apps/api/trusted-node: {}
 
-  apps/api/zk-sample:
-    dependencies:
-      snarkjs:
-        specifier: ^0.7.5
-        version: 0.7.6
-
   apps/authz:
     dependencies:
       '@prisma/client':
@@ -755,6 +749,9 @@ importers:
       '@trustgraph/react-state':
         specifier: ^1.6.1
         version: 1.6.1(@tanstack/react-query@5.96.1(react@19.2.3))(@trustgraph/client@1.6.0)(react@19.2.3)(zustand@5.0.12(@types/react@19.2.7)(immer@10.0.2)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)))
+      '@vitalcv/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@vitalcv/crs':
         specifier: workspace:*
         version: link:../../packages/crs
@@ -913,6 +910,15 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+
+  packages/core:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@25.2.1)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.0)
 
   packages/crs:
     dependencies:
@@ -2947,12 +2953,6 @@ packages:
 
   '@ide/backoff@1.0.0':
     resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
-
-  '@iden3/bigarray@0.0.2':
-    resolution: {integrity: sha512-Xzdyxqm1bOFF6pdIsiHLLl3HkSLjbhqJHVyqaTxXt3RqXBEnmsUmEW47H7VOi/ak7TdkRpNkxjyK5Zbkm+y52g==}
-
-  '@iden3/binfileutils@0.0.12':
-    resolution: {integrity: sha512-naAmzuDufRIcoNfQ1d99d7hGHufLA3wZSibtr4dMe6ZeiOPV1KwOZWTJ1YVz4HbaWlpDuzVU72dS4ATQS4PXBQ==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -6168,10 +6168,6 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
-  bfj@7.1.0:
-    resolution: {integrity: sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==}
-    engines: {node: '>= 8.0.0'}
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -6185,9 +6181,6 @@ packages:
 
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
-
-  bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   bn.js@4.11.6:
     resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
@@ -6445,9 +6438,6 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
-  check-types@11.2.3:
-    resolution: {integrity: sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==}
-
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
@@ -6489,10 +6479,6 @@ packages:
   cipher-base@1.0.7:
     resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
     engines: {node: '>= 0.10'}
-
-  circom_runtime@0.1.28:
-    resolution: {integrity: sha512-ACagpQ7zBRLKDl5xRZ4KpmYIcZDUjOiNRuxvXLqhnnlLSVY1Dbvh73TI853nqoR0oEbihtWmMSjgc5f+pXf/jQ==}
-    hasBin: true
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -7103,11 +7089,6 @@ packages:
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
-  ejs@3.1.10:
-    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -7260,11 +7241,6 @@ packages:
     engines: {node: '>=0.12.0'}
     hasBin: true
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   eslint-config-next@15.5.9:
     resolution: {integrity: sha512-852JYI3NkFNzW8CqsMhI0K2CDRxTObdZ2jQJj5CtpEaOkYHn13107tHpNuD/h0WRpU4FAbCdUaxQsrfBtNK9Kw==}
     peerDependencies:
@@ -7360,11 +7336,6 @@ packages:
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  esprima@1.2.5:
-    resolution: {integrity: sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   esprima@2.7.3:
     resolution: {integrity: sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==}
@@ -7664,9 +7635,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastfile@0.0.20:
-    resolution: {integrity: sha512-r5ZDbgImvVWCP0lA/cGNgQcZqR+aYdFx3u+CtJqUE510pBUVGMn4ulL/iRTI4tACTYsNJ736uzFxEBXesPAktA==}
-
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -7698,21 +7666,12 @@ packages:
   fetch-retry@4.1.1:
     resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
 
-  ffjavascript@0.3.0:
-    resolution: {integrity: sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==}
-
-  ffjavascript@0.3.1:
-    resolution: {integrity: sha512-4PbK1WYodQtuF47D4pRI5KUg3Q392vuP5WjE1THSnceHdXwU3ijaoS0OqxTzLknCtz4Z2TtABzkBdBdMn3B/Aw==}
-
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  filelist@1.0.6:
-    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -8145,10 +8104,6 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
-  hoopy@0.1.4:
-    resolution: {integrity: sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==}
-    engines: {node: '>= 6.0.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -8555,11 +8510,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
@@ -8818,9 +8768,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsonpath@1.3.0:
-    resolution: {integrity: sha512-0kjkYHJBkAy50Z5QzArZ7udmvxrJzkpKYW27fiF//BrMY7TQibYLl+FYIXN2BiYmwMIVzSfD8aDRj6IzgBX2/w==}
 
   jsonschema@1.5.0:
     resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
@@ -9118,9 +9065,6 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
-
-  logplease@1.2.15:
-    resolution: {integrity: sha512-jLlHnlsPSJjpwUfcNyUxXCl33AYg2cHhIf9QhGL2T4iPT0XPB+xP1LRKFPgIg1M/sg9kAJvy94w9CzBNrfnstA==}
 
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
@@ -10272,9 +10216,6 @@ packages:
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
-  r1csfile@0.0.48:
-    resolution: {integrity: sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==}
-
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -10861,10 +10802,6 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
-  snarkjs@0.7.6:
-    resolution: {integrity: sha512-4uH1xA5JzVU5jaaWS2fXej3+RC6L5Erhr6INTJtUA27du4Elbh4VXCeeRjB4QiwL6N6y7SNKePw5prTxyEf4Zg==}
-    hasBin: true
-
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
     engines: {node: '>=10.0.0'}
@@ -10949,9 +10886,6 @@ packages:
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
-
-  static-eval@2.1.1:
-    resolution: {integrity: sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -11395,9 +11329,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  tryer@1.0.1:
-    resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
-
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -11603,9 +11534,6 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
-
-  underscore@1.13.6:
-    resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -11997,12 +11925,6 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
-  wasmbuilder@0.0.16:
-    resolution: {integrity: sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA==}
-
-  wasmcurves@0.2.2:
-    resolution: {integrity: sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==}
-
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -12019,9 +11941,6 @@ packages:
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
-
-  web-worker@1.2.0:
-    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
 
   web3-utils@1.10.4:
     resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
@@ -14633,13 +14552,6 @@ snapshots:
   '@humanwhocodes/object-schema@2.0.3': {}
 
   '@ide/backoff@1.0.0': {}
-
-  '@iden3/bigarray@0.0.2': {}
-
-  '@iden3/binfileutils@0.0.12':
-    dependencies:
-      fastfile: 0.0.20
-      ffjavascript: 0.3.1
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -18724,14 +18636,6 @@ snapshots:
     dependencies:
       open: 8.4.2
 
-  bfj@7.1.0:
-    dependencies:
-      bluebird: 3.7.2
-      check-types: 11.2.3
-      hoopy: 0.1.4
-      jsonpath: 1.3.0
-      tryer: 1.0.1
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -18741,8 +18645,6 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   blakejs@1.2.1: {}
-
-  bluebird@3.7.2: {}
 
   bn.js@4.11.6: {}
 
@@ -19074,8 +18976,6 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  check-types@11.2.3: {}
-
   cheerio-select@2.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -19148,10 +19048,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
-
-  circom_runtime@0.1.28:
-    dependencies:
-      ffjavascript: 0.3.1
 
   citty@0.1.6:
     dependencies:
@@ -19787,10 +19683,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  ejs@3.1.10:
-    dependencies:
-      jake: 10.9.4
-
   electron-to-chromium@1.5.267: {}
 
   elliptic@6.6.1:
@@ -20067,14 +19959,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.2.0
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   eslint-config-next@15.5.9(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.9
@@ -20263,8 +20147,6 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 3.4.3
-
-  esprima@1.2.5: {}
 
   esprima@2.7.3: {}
 
@@ -20766,8 +20648,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastfile@0.0.20: {}
-
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -20807,27 +20687,11 @@ snapshots:
 
   fetch-retry@4.1.1: {}
 
-  ffjavascript@0.3.0:
-    dependencies:
-      wasmbuilder: 0.0.16
-      wasmcurves: 0.2.2
-      web-worker: 1.2.0
-
-  ffjavascript@0.3.1:
-    dependencies:
-      wasmbuilder: 0.0.16
-      wasmcurves: 0.2.2
-      web-worker: 1.2.0
-
   fflate@0.4.8: {}
 
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-
-  filelist@1.0.6:
-    dependencies:
-      minimatch: 5.1.6
 
   fill-range@7.1.1:
     dependencies:
@@ -21391,8 +21255,6 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  hoopy@0.1.4: {}
-
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -21800,12 +21662,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jake@10.9.4:
-    dependencies:
-      async: 3.2.6
-      filelist: 1.0.6
-      picocolors: 1.1.1
 
   jay-peg@1.1.1:
     dependencies:
@@ -22347,12 +22203,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonpath@1.3.0:
-    dependencies:
-      esprima: 1.2.5
-      static-eval: 2.1.1
-      underscore: 1.13.6
-
   jsonschema@1.5.0: {}
 
   jsonwebtoken@9.0.3:
@@ -22607,8 +22457,6 @@ snapshots:
       is-unicode-supported: 0.1.0
 
   loglevel@1.9.2: {}
-
-  logplease@1.2.15: {}
 
   long@4.0.0: {}
 
@@ -23982,13 +23830,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
-  r1csfile@0.0.48:
-    dependencies:
-      '@iden3/bigarray': 0.0.2
-      '@iden3/binfileutils': 0.0.12
-      fastfile: 0.0.20
-      ffjavascript: 0.3.0
-
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -24795,18 +24636,6 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  snarkjs@0.7.6:
-    dependencies:
-      '@iden3/binfileutils': 0.0.12
-      '@noble/hashes': 1.8.0
-      bfj: 7.1.0
-      circom_runtime: 0.1.28
-      ejs: 3.1.10
-      fastfile: 0.0.20
-      ffjavascript: 0.3.1
-      logplease: 1.2.15
-      r1csfile: 0.0.48
-
   solc@0.8.26(debug@4.4.3):
     dependencies:
       command-exists: 1.2.9
@@ -24914,10 +24743,6 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
-
-  static-eval@2.1.1:
-    dependencies:
-      escodegen: 2.1.0
 
   statuses@1.5.0: {}
 
@@ -25396,8 +25221,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tryer@1.0.1: {}
-
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -25659,8 +25482,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  underscore@1.13.6: {}
 
   undici-types@6.19.8: {}
 
@@ -26239,12 +26060,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  wasmbuilder@0.0.16: {}
-
-  wasmcurves@0.2.2:
-    dependencies:
-      wasmbuilder: 0.0.16
-
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -26264,8 +26079,6 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.2.0: {}
-
-  web-worker@1.2.0: {}
 
   web3-utils@1.10.4:
     dependencies:


### PR DESCRIPTION
## Mission

WAVE C77 — Live NPPES NPI resolver as a typed `@vitalcv/core` service + Next.js route with in-memory cache and IP rate-limit.
WAVE C78 — Strict W3C DID Document + OID4VCI metadata at the canonical `.well-known/*` paths (direct routes, no rewrites required).

> **Stacking note:** branched off `origin/main` per spec. The `packages/core` scaffold matches PR #388/#389/#390; whichever PR lands first, the rest resolve cleanly on rebase.

## C77 · NPPES resolver

### `packages/core/src/services/nppesResolver.ts`

```ts
resolveNppes(npi: string, deps?: NppesResolverDeps): Promise<NppesResolutionOutcome>
```

Typed outcome envelope — never throws:

| Outcome | When |
|---|---|
| `{ kind: 'found', provider: NppesProviderDto }` | CMS returned a populated result |
| `{ kind: 'not_found' }` | CMS returned `result_count: 0` |
| `{ kind: 'upstream_error', status }` | CMS returned non-2xx or non-JSON |
| `{ kind: 'network_error', detail }` | fetch threw / timed out |

### Minimal DTO (mission spec)

```ts
{
  firstName: string | null;
  lastName: string | null;
  credential: string | null;
  primaryTaxonomy: { code: string | null; desc: string | null };
  activeState: string | null;
}
```

State preference: primary-taxonomy state → LOCATION-purpose address state → null.

### `apps/web/app/api/resolve-npi/route.ts`

| Property | Behavior |
|---|---|
| IP rate-limit | 30 req/min default; `Retry-After` on 429 |
| Format check | `^\d{10}$` |
| Luhn check | NPI ISO/IEC 7812 with `80840` prefix |
| Cache | In-memory Map, 5-min TTL on positive results; `X-Cache: HIT/MISS` |
| Latency | Repeat fetches verified `<300ms` by test |
| Error tokens | machine-readable strings only |

## C78 · `.well-known/did.json` (W3C DID Document)

| Field | Value |
|---|---|
| `@context` | `[ "https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1" ]` |
| `id` / `controller` | `did:web:<resolved-host>` (per-request) |
| `verificationMethod[0].type` | `JsonWebKey2020` |
| `verificationMethod[0].publicKeyJwk` | `{ kty: 'OKP', crv: 'Ed25519', alg: 'EdDSA', use: 'sig', kid, x: ... }` |
| `authentication` / `assertionMethod` | reference the verification method id |
| `service` | `KeyStore` → `/.well-known/jwks.json` ; `OID4VCIIssuer` → `/.well-known/openid-credential-issuer` |
| `Content-Type` | `application/did+json; charset=utf-8` |

### Ed25519 key surface

`apps/web/lib/crypto/ed25519IssuerKey.ts` — Ed25519 identity keypair, dev-ephemeral by default, pinned via `VCV_ED25519_PRIVATE_JWK` in production. **The DID document identity key (Ed25519) is intentionally separate from the receipt-signing key (ES256, in `receiptIssuer.ts`).** A DID may legitimately publish multiple verification methods of different types — Ed25519 in the DID doc, ES256 in the JWKS at `/.well-known/jwks.json`. Receipt verification continues against the JWKS; DID-level identity assertions use Ed25519.

### Issuer host resolution

`apps/web/lib/discovery/issuerHost.ts` — precedence: `VCV_ISSUER_HOST` env > `X-Forwarded-Host` first hop > `Host` header > `vitalcv.com` default. Strict regex validation rejects path/scheme/whitespace injection.

## C78 · `.well-known/openid-credential-issuer` (OID4VCI 1.0)

```jsonc
{
  "credential_issuer": "https://<host>",
  "authorization_servers": ["https://<host>"],
  "credential_endpoint": "https://<host>/api/credentials/issue",
  "jwks_uri": "https://<host>/.well-known/jwks.json",
  "proof_types_supported": { "jwt": { "proof_signing_alg_values_supported": ["EdDSA", "ES256"] } },
  "credential_configurations_supported": {
    "VitalCVCredential": {
      "format": "jwt_vc_json",
      "scope": "VitalCVCredential",
      "cryptographic_binding_methods_supported": ["did:web"],
      "credential_signing_alg_values_supported": ["EdDSA", "ES256"],
      "credential_definition": {
        "type": ["VerifiableCredential", "VitalCVCredential"],
        "credentialSubject": {
          "npi": { ... }, "taxonomyCode": { ... }, "activeState": { ... }
        }
      },
      "proof_types_supported": { ... },
      "display": [ ... ]
    }
  },
  "issuer_did": "did:web:<host>",
  "display": [{ "name": "VitalCV", "locale": "en-US" }]
}
```

Per-request host resolution; cross-references `issuer_did`. Direct `app/.well-known/*` routes — shadow the existing `app/api/.well-known/*` + `next.config.mjs` rewrites without requiring rewrite changes.

## Tests · 33 passing

- `packages/core/__tests__/nppesResolver.test.ts` → **18/18**
  - Luhn checksum (7 cases including the design archive's NPIs)
  - DTO projection (populated / primary fallback / nullables / whitespace / LOCATION-vs-MAILING state)
  - Outcome envelope (found / not_found / upstream_error / non-JSON / network_error / apiBase override)
- `apps/web/__tests__/live-npi-resolver-and-openmythos-compliance.test.ts` → **15/15**
  - Route input validation (4xx)
  - 404 path / 200 + DTO projection
  - Cache HIT path is `<300ms`; upstream fetch called only once
  - 429 path with `Retry-After`
  - DID doc compliance (contexts, id, controller, Ed25519 JsonWebKey2020, authentication + assertionMethod, service endpoints, host fallback)
  - OID4VCI compliance (issuer, endpoint, jwks_uri, VitalCVCredential declaration, subject claims, issuer_did cross-ref)

## Validation

```
pnpm install --no-frozen-lockfile  → clean
pnpm turbo run build --filter @vitalcv/trust-state  → cache hit
packages/core vitest run  → 18/18
packages/core tsc --noEmit  → clean
apps/web vitest run live-npi-resolver-and-openmythos-compliance  → 15/15
apps/web tsc --noEmit  → 2 pre-existing intake-types.ts errors (unrelated); 0 introduced
apps/web lint  → clean
```

## Operator instructions

```
# Live NPPES resolution:
curl 'http://localhost:3000/api/resolve-npi?npi=1346053246' | jq .

# Repeat (cache hit, <300ms):
curl -i 'http://localhost:3000/api/resolve-npi?npi=1346053246' | grep X-Cache

# Offline / synthetic mirror:
# (resolveNppes accepts a `deps.apiBase` override; route consumers can add
#  a VCV_NPPES_MIRROR_URL env wrapper as a follow-up.)

# Discovery probes (any host):
curl -i https://<tunnel>/.well-known/did.json | jq '.id, .verificationMethod[0].publicKeyJwk.crv'
#  "did:web:<tunnel>"
#  "Ed25519"

curl -i https://<tunnel>/.well-known/openid-credential-issuer | jq '.credential_issuer, .credential_configurations_supported.VitalCVCredential.format'
#  "https://<tunnel>"
#  "jwt_vc_json"
```

## Truth-contract audit

- ES256 receipt signing remains unchanged in `receiptIssuer.ts`; Ed25519 is exposed on the DID identity layer only — both are real implementations, neither is fake.
- NPPES is the public CMS registry; payload contains nothing beyond what is legally published there.
- Error tokens are machine-readable strings; no marketing copy.
- No banned phrases introduced; the rendered-route truth audit from PR #391 still passes on this branch.

## Remaining gaps

1. The legacy `apps/web/app/api/.well-known/{did.json,openid-credential-issuer}` routes still exist with hardcoded `vitalcv.com`. Next.js prefers the new direct routes for `/.well-known/*` paths, so the legacy routes are shadowed and effectively unreachable via the canonical paths. Cleanup deferred to the integration coherence wave.
2. The route's NPPES upstream URL is hardcoded; mirror override via env is a 3-line addition for a follow-up wave.
3. Production rotation of `VCV_ED25519_PRIVATE_JWK` requires an operator runbook entry — not delivered in this code wave.

## Test plan
- [ ] `packages/core` → `pnpm exec vitest run` passes 18 tests
- [ ] `apps/web` → `pnpm --filter @vitalcv/web exec vitest run live-npi-resolver-and-openmythos-compliance` passes 15 tests
- [ ] `pnpm --filter @vitalcv/web exec tsc --noEmit` reports only the 2 pre-existing `intake-types.ts` errors
- [ ] `pnpm --filter @vitalcv/web lint` clean
- [ ] Manual smoke: `curl /.well-known/did.json | jq '.verificationMethod[0].publicKeyJwk.crv'` returns `"Ed25519"`
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)