### PR TITLE
feat(interoperability): implement exchange rehearsal infrastructure

### DIFF
--- a/apps/web/__tests__/interoperability-rehearsal-infrastructure.test.tsx
+++ b/apps/web/__tests__/interoperability-rehearsal-infrastructure.test.tsx
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  REPLAY_ENVELOPE_ID_PREFIX,
+  summarizeReplayBundle,
+} from '@/lib/interoperability/replayBundleEnvelope';
+import {
+  describeExchangeReadiness,
+  listExchangeReadinessStates,
+  visualForExchangeReadiness,
+} from '@/lib/interoperability/exchangeReadiness';
+import {
+  getDemoExchange,
+  listDemoExchangeIds,
+} from '@/lib/interoperability/demoExchanges';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/interoperability/exchange/demo',
+  useSearchParams: () => ({ get: () => null, toString: () => '' }),
+}));
+
+import { IndependentCrossCheckPanel } from '@/components/interoperability/IndependentCrossCheckPanel';
+import { TrustExchangeTimeline } from '@/components/interoperability/TrustExchangeTimeline';
+import { EvidenceReusePanel } from '@/components/interoperability/EvidenceReusePanel';
+
+// ── Replay Bundle Envelope ────────────────────────────────────────────────
+
+describe('replay bundle envelope', () => {
+  it('declares the stable envelope id prefix', () => {
+    expect(REPLAY_ENVELOPE_ID_PREFIX).toBe('env_replay_');
+  });
+
+  it('summarizeReplayBundle counts each evidence kind correctly', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    expect(cedar).not.toBeNull();
+    if (!cedar) return;
+    const summary = summarizeReplayBundle(cedar.envelope);
+    expect(summary.evidenceCount).toBe(cedar.envelope.evidenceReferences.length);
+    expect(summary.receiptCount).toBe(1);
+    expect(summary.lineageCount).toBe(2);
+    expect(summary.auditCount).toBe(1);
+    expect(summary.claimCount).toBe(1);
+  });
+});
+
+// ── Exchange Readiness Taxonomy ────────────────────────────────────────────
+
+describe('exchange readiness taxonomy', () => {
+  it('exposes exactly the 7 canonical states', () => {
+    expect([...listExchangeReadinessStates()].sort()).toEqual(
+      [
+        'awaiting_review',
+        'continuity_gap',
+        'cross_check_available',
+        'exchange_interrupted',
+        'institution_confirmed',
+        'operator_followup_required',
+        'replay_generated',
+      ].sort(),
+    );
+  });
+
+  it('every state has a descriptor with headline + detail + degradation + owner', () => {
+    for (const state of listExchangeReadinessStates()) {
+      const d = describeExchangeReadiness(state);
+      expect(d.headline.length).toBeGreaterThan(0);
+      expect(d.detail.length).toBeGreaterThan(0);
+      expect(d.degradation).toBeTruthy();
+      expect(d.ownedBy).toMatch(
+        /^(originating_institution|receiving_institution|vitalcv|shared)$/,
+      );
+      expect(typeof d.terminal).toBe('boolean');
+    }
+  });
+
+  it('terminal states are institution_confirmed and exchange_interrupted', () => {
+    const terminals = listExchangeReadinessStates().filter(
+      (s) => describeExchangeReadiness(s).terminal,
+    );
+    expect(terminals.sort()).toEqual(
+      ['exchange_interrupted', 'institution_confirmed'].sort(),
+    );
+  });
+
+  it('reuses canonical degradation visuals (no new visual tokens)', () => {
+    const allowed = new Set([
+      'continuous',
+      'dashed',
+      'hard_interruption',
+      'manual_lane',
+      'pending_anchor',
+    ]);
+    for (const state of listExchangeReadinessStates()) {
+      expect(allowed.has(visualForExchangeReadiness(state))).toBe(true);
+    }
+  });
+
+  it('exchange_interrupted maps to hard_interruption visual', () => {
+    expect(visualForExchangeReadiness('exchange_interrupted')).toBe(
+      'hard_interruption',
+    );
+  });
+
+  it('institution_confirmed never claims VitalCV-side acceptance in detail copy', () => {
+    const d = describeExchangeReadiness('institution_confirmed');
+    expect(d.detail.toLowerCase()).toContain('institution');
+    expect(d.detail.toLowerCase()).toContain('not imply');
+  });
+});
+
+// ── Demo Exchange Fixture ──────────────────────────────────────────────────
+
+describe('demo exchange fixture', () => {
+  it('exposes the Cedar Q2-2026 cohort by default', () => {
+    expect(listDemoExchangeIds()).toContain('exch_cedar_q2_26_01');
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(getDemoExchange('does-not-exist')).toBeNull();
+  });
+
+  it('Cedar envelope is institutionally well-formed', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    expect(cedar).not.toBeNull();
+    if (!cedar) return;
+    expect(cedar.envelope.envelopeId).toMatch(/^env_replay_/);
+    expect(cedar.envelope.originatingInstitution.role).toBe('cvo');
+    expect(cedar.envelope.receivingInstitution.role).toBe('verifier');
+    expect(cedar.envelope.scope.subjectNpi).toMatch(/^\d{10}$/);
+    expect(cedar.envelope.crossCheckEligibility).toBe('eligible');
+  });
+
+  it('Cedar timeline contains continuity_interruption AND continuity_restored', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const kinds = cedar.timeline.map((e) => e.kind);
+    expect(kinds).toContain('continuity_interruption');
+    expect(kinds).toContain('continuity_restored');
+  });
+
+  it('Cedar cross-check lanes include one degraded (PECOS stale-but-signed)', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const pecos = cedar.crossCheckLanes.find((l) => l.laneId === 'pecos_enrollment');
+    expect(pecos?.continuityStatus).toBe('degraded');
+    expect(pecos?.gapNote).toBeTruthy();
+  });
+});
+
+// ── Component render isolation ────────────────────────────────────────────
+
+describe('IndependentCrossCheckPanel · render', () => {
+  it('renders one row per lane with all canonical fields', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const html = renderToStaticMarkup(
+      React.createElement(IndependentCrossCheckPanel, {
+        lanes: cedar.crossCheckLanes,
+      }),
+    );
+    expect(html).toContain('data-slot="independent-cross-check-panel"');
+    for (const lane of cedar.crossCheckLanes) {
+      expect(html).toContain(`data-lane-id="${lane.laneId}"`);
+      expect(html).toContain(`data-continuity-status="${lane.continuityStatus}"`);
+      expect(html).toContain(`data-institution-status="${lane.institutionStatus}"`);
+    }
+  });
+
+  it('degraded lanes carry the dashed left border affordance', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const html = renderToStaticMarkup(
+      React.createElement(IndependentCrossCheckPanel, {
+        lanes: cedar.crossCheckLanes.filter(
+          (l) => l.continuityStatus === 'degraded',
+        ),
+      }),
+    );
+    expect(html).toContain('border-l-amber-400');
+  });
+});
+
+describe('TrustExchangeTimeline · render', () => {
+  it('renders one row per timeline entry with the canonical kind label', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const html = renderToStaticMarkup(
+      React.createElement(TrustExchangeTimeline, { entries: cedar.timeline }),
+    );
+    expect(html).toContain('data-slot="trust-exchange-timeline"');
+    for (const entry of cedar.timeline) {
+      expect(html).toContain(`data-kind="${entry.kind}"`);
+      expect(html).toContain(entry.actor);
+    }
+  });
+
+  it('continuity_interruption entries get the dashed amber border', () => {
+    const entries = [
+      {
+        occurredAt: '2026-05-19T13:00:00Z',
+        kind: 'continuity_interruption' as const,
+        actor: 'Upstream',
+        summary: 'Stale-but-signed.',
+      },
+    ];
+    const html = renderToStaticMarkup(
+      React.createElement(TrustExchangeTimeline, { entries }),
+    );
+    expect(html).toMatch(/border-dashed/);
+    expect(html).toMatch(/amber-500/);
+  });
+});
+
+describe('EvidenceReusePanel · render', () => {
+  it('renders every reuse row with duplicate-avoided + basis + framing', () => {
+    const cedar = getDemoExchange('exch_cedar_q2_26_01');
+    if (!cedar) throw new Error('fixture missing');
+    const html = renderToStaticMarkup(
+      React.createElement(EvidenceReusePanel, { rows: cedar.evidenceReuse }),
+    );
+    expect(html).toContain('data-slot="evidence-reuse-panel"');
+    for (const row of cedar.evidenceReuse) {
+      expect(html).toContain(row.duplicateActivityAvoided);
+      expect(html).toContain(row.basisReference);
+    }
+  });
+
+  it('disclosure copy names institution ownership and rejects automation claims', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EvidenceReusePanel, { rows: [] }),
+    );
+    expect(html).toContain('not constitute automatic acceptance');
+  });
+});
+
+// ── Truth-contract grep ────────────────────────────────────────────────────
+
+describe('truth contract · interoperability surfaces', () => {
+  const TOUCHED_FILES = [
+    'apps/web/lib/interoperability/replayBundleEnvelope.ts',
+    'apps/web/lib/interoperability/exchangeReadiness.ts',
+    'apps/web/lib/interoperability/demoExchanges.ts',
+    'apps/web/components/interoperability/IndependentCrossCheckPanel.tsx',
+    'apps/web/components/interoperability/TrustExchangeTimeline.tsx',
+    'apps/web/components/interoperability/EvidenceReusePanel.tsx',
+    'apps/web/components/interoperability/ExportVerificationExchangeButton.tsx',
+    'apps/web/app/interoperability/exchange/[exchangeId]/page.tsx',
+  ];
+
+  const BANNED = [
+    'automatically verified',
+    'guaranteed acceptance',
+    'universally accepted',
+    'fully verified',
+    'instant verification',
+    'automatic trust transfer',
+    'federated by default',
+    'production-ready federation',
+    'trust transferred',
+    'credential issued via vitalcv',
+    'magical onboarding',
+  ];
+
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+  function stripComments(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+  }
+
+  it.each(TOUCHED_FILES)('%s contains no banned interoperability phrases', (rel) => {
+    const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+    const lower = stripComments(src).toLowerCase();
+    for (const banned of BANNED) {
+      expect(lower.includes(banned), `should not contain "${banned}"`).toBe(false);
+    }
+  });
+
+  it('boundaries doc declares the banned-phrase list verbatim', () => {
+    const doc = fs.readFileSync(
+      path.join(
+        repoRoot,
+        'docs/protocol/interoperability-rehearsal-boundaries.md',
+      ),
+      'utf8',
+    );
+    expect(doc).toMatch(/automatically verified/);
+    expect(doc).toMatch(/guaranteed acceptance/);
+    expect(doc).toMatch(/universally accepted/);
+  });
+});

--- a/apps/web/app/interoperability/exchange/[exchangeId]/page.tsx
+++ b/apps/web/app/interoperability/exchange/[exchangeId]/page.tsx
@@ -1,0 +1,255 @@
+/**
+ * /interoperability/exchange/[exchangeId] -- Verification Exchange
+ * Workspace (rehearsal infrastructure).
+ *
+ * Single dense institutional surface that demonstrates the SHAPE of
+ * an evidence handoff between two institutions. Reuses the canonical
+ * trust primitives (LineageHeader via ProvenanceChronology), the
+ * institutional language module, and the degradation grammar.
+ *
+ * Critical posture (binding):
+ *  - This is a REHEARSAL. Nothing on the page constitutes production
+ *    credential issuance, wallet auth, OpenID flow, or federation.
+ *  - The receiving institution OWNS the cross-check. The page shows
+ *    affordances; it does not perform trust transfers.
+ *  - Continuity states reuse the canonical DegradationState taxonomy.
+ *  - No "automatic acceptance", "instant verification", or "fully
+ *    verified" language.
+ */
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getDemoExchange } from '@/lib/interoperability/demoExchanges';
+import {
+  describeExchangeReadiness,
+  visualForExchangeReadiness,
+} from '@/lib/interoperability/exchangeReadiness';
+import { summarizeReplayBundle } from '@/lib/interoperability/replayBundleEnvelope';
+import { describeDegradation } from '@/lib/trust/degradation';
+import { ProvenanceChronology } from '@/components/trust/navigation';
+import { IndependentCrossCheckPanel } from '@/components/interoperability/IndependentCrossCheckPanel';
+import { TrustExchangeTimeline } from '@/components/interoperability/TrustExchangeTimeline';
+import { EvidenceReusePanel } from '@/components/interoperability/EvidenceReusePanel';
+import { ExportVerificationExchangeButton } from '@/components/interoperability/ExportVerificationExchangeButton';
+
+export const metadata: Metadata = {
+  title: 'Verification exchange · VitalCV interoperability rehearsal',
+  description:
+    'Rehearsal infrastructure: institutional trust-evidence handoff with replay bundle, independent cross-check lane, and operational timeline.',
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  params: Promise<{ exchangeId: string }>;
+}
+
+export default async function VerificationExchangePage({ params }: PageProps) {
+  const { exchangeId } = await params;
+  const exchange = getDemoExchange(exchangeId);
+  if (!exchange) notFound();
+
+  const readiness = describeExchangeReadiness(exchange.readiness);
+  const summary = summarizeReplayBundle(exchange.envelope);
+  const envelope = exchange.envelope;
+  const continuityCopy = describeDegradation(envelope.continuityStatus);
+  const visualToken = visualForExchangeReadiness(exchange.readiness);
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-900 bg-slate-950 px-5 py-3 font-mono text-xs uppercase tracking-wider text-slate-100">
+        Verification exchange · rehearsal · {exchange.exchangeId}
+      </header>
+
+      <div className="mx-auto max-w-[1200px] space-y-6 px-4 py-6 sm:px-6">
+        {/* Institutional masthead */}
+        <section
+          data-slot="exchange-masthead"
+          className="grid grid-cols-1 gap-4 rounded-2xl border border-slate-900 bg-white p-5 sm:grid-cols-12"
+        >
+          <div className="sm:col-span-5">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+              Originating institution
+            </div>
+            <div className="mt-1 text-base font-semibold text-slate-900">
+              {envelope.originatingInstitution.displayName}
+            </div>
+            <div className="mt-0.5 font-mono text-[11px] uppercase tracking-wider text-slate-500">
+              role · {envelope.originatingInstitution.role}
+            </div>
+            {envelope.originatingInstitution.discoveryUrl ? (
+              <div className="mt-1 font-mono text-[11px] text-slate-600 break-all">
+                {envelope.originatingInstitution.discoveryUrl}
+              </div>
+            ) : null}
+          </div>
+          <div className="hidden items-center justify-center sm:col-span-2 sm:flex">
+            <span aria-hidden="true" className="text-slate-500">
+              →
+            </span>
+          </div>
+          <div className="sm:col-span-5">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+              Receiving institution
+            </div>
+            <div className="mt-1 text-base font-semibold text-slate-900">
+              {envelope.receivingInstitution.displayName}
+            </div>
+            <div className="mt-0.5 font-mono text-[11px] uppercase tracking-wider text-slate-500">
+              role · {envelope.receivingInstitution.role}
+            </div>
+          </div>
+          <div className="border-t border-slate-200 pt-3 sm:col-span-12">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <Stat label="Envelope" value={envelope.envelopeId} />
+              <Stat label="Replay head" value={envelope.replayId} />
+              <Stat label="Evidence refs" value={String(summary.evidenceCount)} />
+              <Stat
+                label="Cross-check"
+                value={envelope.crossCheckEligibility.replace(/_/g, ' ')}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Readiness chip + actions */}
+        <section
+          data-slot="exchange-readiness"
+          data-readiness={readiness.state}
+          data-readiness-visual={visualToken}
+          className={`rounded-2xl border bg-white p-4 ${
+            visualToken === 'hard_interruption'
+              ? 'border-2 border-rose-900'
+              : visualToken === 'dashed'
+                ? 'border-dashed border-slate-700'
+                : visualToken === 'manual_lane'
+                  ? 'border-slate-900'
+                  : 'border-slate-900'
+          }`}
+        >
+          <div className="flex flex-wrap items-baseline justify-between gap-3">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Exchange readiness
+              </div>
+              <div className="mt-1 text-lg font-semibold text-slate-900">
+                {readiness.headline}
+              </div>
+              <p className="mt-1 max-w-[62ch] text-sm text-slate-700">
+                {readiness.detail}
+              </p>
+              <p className="mt-1 font-mono text-[11px] uppercase tracking-wider text-slate-500">
+                owned by · {readiness.ownedBy.replace(/_/g, ' ')}
+                {readiness.terminal ? ' · terminal' : ''}
+              </p>
+            </div>
+            <ExportVerificationExchangeButton />
+          </div>
+        </section>
+
+        {/* Canonical reading-order strip from provenance navigation */}
+        <ProvenanceChronology
+          state={envelope.continuityStatus === 'revoked' ? 'preview' : 'snapshot'}
+          chronology={{
+            object: {
+              value: `Replay bundle · ${envelope.envelopeId}`,
+              subLabel: `subject · NPI ${envelope.scope.subjectNpi}`,
+            },
+            ownership: {
+              value: 'Delegated',
+              subLabel: `originating · ${envelope.originatingInstitution.displayName}`,
+            },
+            checkedAt: {
+              value: envelope.checkedAt,
+              subLabel: 'UTC',
+            },
+            channel: {
+              value: 'interoperability · rehearsal',
+              subLabel: `lanes · ${envelope.scope.laneIds.length}`,
+            },
+            replay: {
+              value: continuityCopy.headline,
+              subLabel: continuityCopy.detail,
+            },
+            runId: {
+              value: envelope.replayId,
+              subLabel: 'verification run head',
+            },
+          }}
+        />
+
+        {/* Evidence references list */}
+        <section
+          data-slot="evidence-references"
+          className="overflow-hidden rounded-2xl border border-slate-900 bg-white"
+        >
+          <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+            <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+              Evidence references · {summary.evidenceCount} item(s)
+            </h3>
+          </header>
+          <ul className="divide-y divide-slate-200">
+            {envelope.evidenceReferences.map((ref) => (
+              <li
+                key={`${ref.kind}-${ref.id}`}
+                data-slot="evidence-reference"
+                data-kind={ref.kind}
+                className="grid grid-cols-1 gap-2 px-4 py-2 sm:grid-cols-12"
+              >
+                <div className="sm:col-span-2">
+                  <span className="inline-flex items-center border border-slate-900 bg-slate-900 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-slate-50">
+                    {ref.kind}
+                  </span>
+                </div>
+                <div className="sm:col-span-6 font-mono text-xs text-slate-900 break-all">
+                  {ref.id}
+                </div>
+                <div className="sm:col-span-4 text-xs text-slate-700">
+                  {ref.label}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Operator notes */}
+        <section
+          data-slot="operator-notes"
+          className="rounded-2xl border border-slate-900 bg-white p-4"
+        >
+          <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+            Operator notes · human-reviewed lane
+          </div>
+          <p className="mt-2 text-sm text-slate-800">{envelope.operatorNotes}</p>
+        </section>
+
+        {/* Trust exchange timeline */}
+        <TrustExchangeTimeline entries={exchange.timeline} />
+
+        {/* Independent cross-check lane */}
+        <IndependentCrossCheckPanel lanes={exchange.crossCheckLanes} />
+
+        {/* Evidence reuse panel */}
+        <EvidenceReusePanel rows={exchange.evidenceReuse} />
+
+        {/* Footer disclosure -- explicit posture (zinc-500 footnote tone) */}
+        <footer className="border-t border-dashed border-slate-400 pt-3 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Rehearsal infrastructure · institution-owned cross-check ·
+          no production credential issuance · no federation guarantee
+        </footer>
+      </div>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        {label}
+      </div>
+      <div className="mt-0.5 font-mono text-xs text-slate-900 break-all">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/interoperability/EvidenceReusePanel.tsx
+++ b/apps/web/components/interoperability/EvidenceReusePanel.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { EvidenceReuseRow } from '@/lib/interoperability/demoExchanges';
+
+/**
+ * Evidence Reuse panel.
+ *
+ * Demonstrates the operational benefit of a replay envelope: fewer
+ * duplicate primary-source queries, fewer redundant phone calls,
+ * shorter onboarding cycles. The panel NEVER claims automatic
+ * acceptance, guaranteed credential reuse, or regulatory replacement.
+ * Each row names a specific duplicate activity avoided and pairs it
+ * with an institution-owned framing line.
+ *
+ * Rendered in zinc-500 footnote tone -- this is supporting evidence,
+ * not the primary surface.
+ */
+
+export interface EvidenceReusePanelProps {
+  rows: readonly EvidenceReuseRow[];
+  className?: string;
+}
+
+export function EvidenceReusePanel({
+  rows,
+  className,
+}: EvidenceReusePanelProps) {
+  return (
+    <section
+      data-slot="evidence-reuse-panel"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-300 bg-slate-50',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-300 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Evidence reuse · what the bundle replaces
+        </h3>
+        <p className="mt-1 text-xs text-slate-600">
+          Replayable evidence reduces operational duplication. It does not
+          constitute automatic acceptance or regulatory substitution. The
+          receiving institution retains ownership of its own confirmations.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-300">
+        {rows.map((row, i) => (
+          <li
+            key={`${row.duplicateActivityAvoided}-${i}`}
+            data-slot="evidence-reuse-row"
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Duplicate activity avoided
+              </div>
+              <div className="mt-0.5 text-sm text-slate-900">
+                {row.duplicateActivityAvoided}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Basis reference
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900 break-all">
+                {row.basisReference}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Institutional framing
+              </div>
+              <div className="mt-0.5 text-xs text-slate-700">
+                {row.institutionalNote}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/interoperability/ExportVerificationExchangeButton.tsx
+++ b/apps/web/components/interoperability/ExportVerificationExchangeButton.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Institutional PDF export trigger for the verification-exchange
+ * surface. Single button, no chrome. Triggers `window.print()` --
+ * the surface is built print-ready and Letter-formatted; the operator
+ * gets an institutional summary PDF with zero additional layout.
+ *
+ * The button never advertises "share" or "send". The export is local
+ * and operator-owned.
+ */
+
+export interface ExportVerificationExchangeButtonProps {
+  /** Label rendered on the button (default: "Print exchange summary"). */
+  label?: string;
+  className?: string;
+}
+
+export function ExportVerificationExchangeButton({
+  label = 'Print exchange summary',
+  className,
+}: ExportVerificationExchangeButtonProps) {
+  return (
+    <button
+      type="button"
+      data-slot="export-verification-exchange-button"
+      onClick={() => window.print()}
+      className={cn(
+        'inline-flex items-center border border-slate-900 bg-slate-900 px-3 py-1.5 font-mono text-xs uppercase tracking-wider text-slate-50 hover:bg-slate-800',
+        className,
+      )}
+    >
+      {label} →
+    </button>
+  );
+}

--- a/apps/web/components/interoperability/IndependentCrossCheckPanel.tsx
+++ b/apps/web/components/interoperability/IndependentCrossCheckPanel.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { CrossCheckLaneRow } from '@/lib/interoperability/demoExchanges';
+
+/**
+ * Independent Cross-Check lane.
+ *
+ * Demonstrates the "trust but verify" institutional workflow: the
+ * receiving institution sees the originating institution's evidence
+ * AND a per-lane affordance to confirm the lane on its own credential.
+ *
+ * This is rehearsal infrastructure. The panel does NOT initiate
+ * cross-checks; it demonstrates the SHAPE of a cross-check workflow
+ * that a receiving institution would run on its own systems. No
+ * "instant verification" semantics, no automated trust-transfer
+ * claims. Each lane carries an institution-owned status that the
+ * receiving operator advances by hand.
+ */
+
+export interface IndependentCrossCheckPanelProps {
+  lanes: readonly CrossCheckLaneRow[];
+  className?: string;
+}
+
+const INSTITUTION_STATUS_LABEL: Record<
+  CrossCheckLaneRow['institutionStatus'],
+  string
+> = {
+  pending: 'Pending review',
+  in_review: 'Institution review in progress',
+  confirmed: 'Institution-confirmed',
+  not_eligible: 'Not eligible for cross-check',
+};
+
+const CONTINUITY_LABEL: Record<CrossCheckLaneRow['continuityStatus'], string> = {
+  fresh: 'fresh',
+  degraded: 'degraded · stale-but-signed',
+  interrupted: 'interrupted',
+};
+
+const HUMAN_REVIEW_LABEL: Record<CrossCheckLaneRow['humanReviewState'], string> = {
+  not_required: 'not required',
+  pending: 'pending operator review',
+  completed: 'completed',
+};
+
+export function IndependentCrossCheckPanel({
+  lanes,
+  className,
+}: IndependentCrossCheckPanelProps) {
+  return (
+    <section
+      data-slot="independent-cross-check-panel"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Independent cross-check lane · institution-owned confirmation
+        </h3>
+        <p className="mt-1 text-xs text-slate-600">
+          Receiving institution may confirm each lane on its own credential.
+          No lane is marked confirmed automatically; affirmative confirmation
+          is operator-owned.
+        </p>
+      </header>
+      <div className="divide-y divide-slate-200">
+        {lanes.map((lane) => (
+          <article
+            key={lane.laneId}
+            data-slot="cross-check-lane"
+            data-lane-id={lane.laneId}
+            data-institution-status={lane.institutionStatus}
+            data-continuity-status={lane.continuityStatus}
+            className={cn(
+              'grid grid-cols-1 gap-3 px-4 py-3 sm:grid-cols-12',
+              lane.continuityStatus === 'degraded' &&
+                'border-l-4 border-l-amber-400',
+              lane.continuityStatus === 'interrupted' &&
+                'border-l-4 border-l-rose-500',
+            )}
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Lane
+              </div>
+              <div className="mt-0.5 font-mono text-sm text-slate-900">
+                {lane.laneId}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-600">{lane.source}</div>
+              <div className="mt-0.5 font-mono text-[10px] text-slate-500">
+                {lane.sourceRef}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Replay ref
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900 break-all">
+                {lane.replayRef || '—'}
+              </div>
+              <div className="mt-1 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Continuity
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900">
+                {CONTINUITY_LABEL[lane.continuityStatus]}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Institution status
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900">
+                {INSTITUTION_STATUS_LABEL[lane.institutionStatus]}
+              </div>
+              <div className="mt-1 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Human review
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900">
+                {HUMAN_REVIEW_LABEL[lane.humanReviewState]}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Gap note
+              </div>
+              <div className="mt-0.5 text-xs text-slate-700">
+                {lane.gapNote ?? 'No gap recorded.'}
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/interoperability/TrustExchangeTimeline.tsx
+++ b/apps/web/components/interoperability/TrustExchangeTimeline.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { ExchangeTimelineEntry } from '@/lib/interoperability/demoExchanges';
+
+/**
+ * Trust Exchange Timeline.
+ *
+ * Vertical institutional timeline of an evidence handoff between two
+ * institutions. Dense, quiet, operational chrome -- not a consumer
+ * activity feed. Each row renders the canonical event kind, the
+ * actor, and a one-line summary. No emoji, no animations.
+ *
+ * The timeline does not editorialize. It does not say "trust
+ * transferred"; it lists the operational events that actually
+ * occurred.
+ */
+
+export interface TrustExchangeTimelineProps {
+  entries: readonly ExchangeTimelineEntry[];
+  className?: string;
+}
+
+const KIND_LABEL: Record<ExchangeTimelineEntry['kind'], string> = {
+  evidence_generated: 'Evidence generated',
+  replay_exported: 'Replay exported',
+  review_started: 'Review started',
+  cross_check_initiated: 'Cross-check initiated',
+  continuity_interruption: 'Continuity interruption',
+  continuity_restored: 'Continuity restored',
+  institution_confirmed: 'Institution-confirmed',
+  deployment_ready: 'Deployment-ready',
+  operator_note: 'Operator note',
+};
+
+const KIND_VISUAL: Record<ExchangeTimelineEntry['kind'], string> = {
+  evidence_generated: 'border-slate-900 bg-white text-slate-900',
+  replay_exported: 'border-slate-900 bg-white text-slate-900',
+  review_started: 'border-slate-700 bg-slate-50 text-slate-800',
+  cross_check_initiated: 'border-slate-700 bg-slate-50 text-slate-800',
+  continuity_interruption:
+    'border-dashed border-amber-500 bg-amber-50/50 text-slate-900',
+  continuity_restored: 'border-slate-900 bg-white text-slate-900',
+  institution_confirmed: 'border-2 border-slate-900 bg-white text-slate-900',
+  deployment_ready: 'border-2 border-slate-900 bg-white text-slate-900',
+  operator_note: 'border-slate-700 bg-slate-50 text-slate-700',
+};
+
+export function TrustExchangeTimeline({
+  entries,
+  className,
+}: TrustExchangeTimelineProps) {
+  return (
+    <section
+      data-slot="trust-exchange-timeline"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Trust exchange timeline · operational chronology
+        </h3>
+      </header>
+      <ol className="divide-y divide-slate-200">
+        {entries.map((entry, i) => (
+          <li
+            key={`${entry.occurredAt}-${i}`}
+            data-slot="trust-exchange-timeline-entry"
+            data-kind={entry.kind}
+            className={cn(
+              'grid grid-cols-1 gap-3 border-l-4 px-4 py-3 sm:grid-cols-12',
+              KIND_VISUAL[entry.kind],
+            )}
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-xs text-slate-700">
+                {entry.occurredAt}
+              </div>
+              <div className="mt-1 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                {KIND_LABEL[entry.kind]}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Actor
+              </div>
+              <div className="mt-0.5 font-mono text-xs text-slate-900">
+                {entry.actor}
+              </div>
+            </div>
+            <div className="sm:col-span-6">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Summary
+              </div>
+              <div className="mt-0.5 text-sm text-slate-900">
+                {entry.summary}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/lib/interoperability/demoExchanges.ts
+++ b/apps/web/lib/interoperability/demoExchanges.ts
@@ -1,0 +1,234 @@
+/**
+ * Demo fixtures for the interoperability rehearsal route.
+ *
+ * Lives in-process: no DB, no fetch, no env. Adding a new rehearsal
+ * cohort is a single dictionary entry. Production behavior would
+ * replace `getDemoExchange()` with a Prisma query reading from a
+ * proper `VerificationExchange` table; the response shape is stable.
+ */
+
+import type { ExchangeReadinessState } from './exchangeReadiness';
+import type { ReplayBundleEnvelope } from './replayBundleEnvelope';
+
+export interface ExchangeTimelineEntry {
+  /** ISO 8601 timestamp. */
+  occurredAt: string;
+  /** Canonical event kind. */
+  kind:
+    | 'evidence_generated'
+    | 'replay_exported'
+    | 'review_started'
+    | 'cross_check_initiated'
+    | 'continuity_interruption'
+    | 'continuity_restored'
+    | 'institution_confirmed'
+    | 'deployment_ready'
+    | 'operator_note';
+  actor: string;
+  summary: string;
+}
+
+export interface CrossCheckLaneRow {
+  laneId: string;
+  source: string;
+  sourceRef: string;
+  /** Replay receipt id the lane is anchored against. */
+  replayRef: string;
+  institutionStatus:
+    | 'pending'
+    | 'in_review'
+    | 'confirmed'
+    | 'not_eligible';
+  continuityStatus: 'fresh' | 'degraded' | 'interrupted';
+  humanReviewState: 'not_required' | 'pending' | 'completed';
+  gapNote: string | null;
+}
+
+export interface EvidenceReuseRow {
+  duplicateActivityAvoided: string;
+  basisReference: string;
+  institutionalNote: string;
+}
+
+export interface VerificationExchangeDemo {
+  exchangeId: string;
+  envelope: ReplayBundleEnvelope;
+  readiness: ExchangeReadinessState;
+  timeline: readonly ExchangeTimelineEntry[];
+  crossCheckLanes: readonly CrossCheckLaneRow[];
+  evidenceReuse: readonly EvidenceReuseRow[];
+}
+
+const CEDAR_DEMO: VerificationExchangeDemo = {
+  exchangeId: 'exch_cedar_q2_26_01',
+  envelope: {
+    envelopeId: 'env_replay_7a2cb8d3_cedar',
+    originatingInstitution: {
+      id: 'vitalcv-pilot-q2-26',
+      displayName: 'VitalCV (originating CVO)',
+      role: 'cvo',
+      discoveryUrl: 'https://vitalcv.com/.well-known/did.json',
+    },
+    receivingInstitution: {
+      id: 'cedar-health',
+      displayName: 'Cedar Health Credentialing',
+      role: 'verifier',
+    },
+    replayId: 'run_7a2cb8d3',
+    evidenceReferences: [
+      {
+        kind: 'receipt',
+        id: 'rcpt_7a2cb8d3_9d11_3e4a',
+        label: 'Credentialing bundle · 4 claims',
+      },
+      {
+        kind: 'lineage',
+        id: 'nppes_identity:1346053246',
+        label: 'NPPES identity lineage',
+      },
+      {
+        kind: 'lineage',
+        id: 'oig_exclusions:1346053246',
+        label: 'OIG/LEIE exclusion screen',
+      },
+      {
+        kind: 'audit',
+        id: 'evt_committee_review_2026_05_18',
+        label: 'Committee review event',
+        continuityStatus: 'pending_human_review',
+      },
+      {
+        kind: 'claim',
+        id: 'claim_pecos_active',
+        label: 'PECOS enrollment · active',
+        continuityStatus: 'stale',
+      },
+    ],
+    continuityStatus: 'degraded',
+    checkedAt: '2026-05-19T14:31:58Z',
+    scope: {
+      laneIds: ['nppes_identity', 'oig_exclusions', 'pecos_enrollment'],
+      subjectNpi: '1346053246',
+      window: {
+        startIso: '2026-04-19T00:00:00Z',
+        endIso: '2026-05-19T14:31:58Z',
+      },
+    },
+    operatorNotes:
+      'PECOS lane returned stale-but-signed at the freshness boundary. Source-confirmed; receiving institution should review the operator-attached note before initiating cross-check.',
+    crossCheckEligibility: 'eligible',
+  },
+  readiness: 'cross_check_available',
+  timeline: [
+    {
+      occurredAt: '2026-05-19T13:02:14Z',
+      kind: 'evidence_generated',
+      actor: 'VitalCV federal resolver',
+      summary: 'Source-confirmed federal-registry resolution completed.',
+    },
+    {
+      occurredAt: '2026-05-19T13:05:01Z',
+      kind: 'replay_exported',
+      actor: 'VitalCV ops',
+      summary:
+        'Replay bundle exported for Cedar Health review. Bundle anchored at run head 7a2c...b8d3.',
+    },
+    {
+      occurredAt: '2026-05-19T13:18:42Z',
+      kind: 'continuity_interruption',
+      actor: 'Upstream: CMS PECOS',
+      summary:
+        'PECOS lane returned with stale freshness flag. Lane recorded as σ defer; receipt continues with stale-but-signed posture.',
+    },
+    {
+      occurredAt: '2026-05-19T13:22:09Z',
+      kind: 'continuity_restored',
+      actor: 'Upstream: CMS PECOS',
+      summary:
+        'Upstream recovery anchored at next refresh window. Run replays cleanly against TSA anchor.',
+    },
+    {
+      occurredAt: '2026-05-19T14:31:58Z',
+      kind: 'operator_note',
+      actor: 'VitalCV CVO desk',
+      summary:
+        'Operator-attached note: receiving institution should review PECOS stale-but-signed posture before independent cross-check.',
+    },
+  ],
+  crossCheckLanes: [
+    {
+      laneId: 'nppes_identity',
+      source: 'CMS NPPES Registry',
+      sourceRef: 'cms.gov/nppes',
+      replayRef: 'rcpt_7a2cb8d3_nppes',
+      institutionStatus: 'pending',
+      continuityStatus: 'fresh',
+      humanReviewState: 'not_required',
+      gapNote: null,
+    },
+    {
+      laneId: 'oig_exclusions',
+      source: 'OIG LEIE',
+      sourceRef: 'oig.hhs.gov',
+      replayRef: 'rcpt_7a2cb8d3_oig',
+      institutionStatus: 'in_review',
+      continuityStatus: 'fresh',
+      humanReviewState: 'pending',
+      gapNote: null,
+    },
+    {
+      laneId: 'pecos_enrollment',
+      source: 'CMS PECOS',
+      sourceRef: 'cms.gov/pecos',
+      replayRef: 'rcpt_7a2cb8d3_pecos',
+      institutionStatus: 'in_review',
+      continuityStatus: 'degraded',
+      humanReviewState: 'pending',
+      gapNote: 'Stale-but-signed at freshness boundary; receiving institution may re-fetch on its own credential.',
+    },
+    {
+      laneId: 'state_medical_license',
+      source: 'State medical board (Cedar CVO channel)',
+      sourceRef: 'institution-owned',
+      replayRef: '',
+      institutionStatus: 'not_eligible',
+      continuityStatus: 'fresh',
+      humanReviewState: 'not_required',
+      gapNote: 'Out of pilot scope -- institution-owned PSV continues on Cedar credentials.',
+    },
+  ],
+  evidenceReuse: [
+    {
+      duplicateActivityAvoided: 'Repeat NPPES enumeration query',
+      basisReference: 'rcpt_7a2cb8d3_nppes (4 lanes anchored)',
+      institutionalNote:
+        'Source-confirmed within the freshness budget. Receiving institution may rely on this for primary identity binding pending its own confirmation step.',
+    },
+    {
+      duplicateActivityAvoided: 'Repeat OIG/LEIE sanction screen for the pilot window',
+      basisReference: 'rcpt_7a2cb8d3_oig (0 records returned)',
+      institutionalNote:
+        'Affirmative-negative recorded; not a regulatory substitute. Receiving institution retains its own cadence for re-screening.',
+    },
+    {
+      duplicateActivityAvoided: 'Operator-to-operator phone-tag for replay confirmation',
+      basisReference: 'Replay envelope env_replay_7a2cb8d3_cedar',
+      institutionalNote:
+        'Envelope replaces ad-hoc phone confirmations with a portable, replayable record. No automation claim is made.',
+    },
+  ],
+};
+
+const DEMO_EXCHANGES: Record<string, VerificationExchangeDemo> = {
+  [CEDAR_DEMO.exchangeId]: CEDAR_DEMO,
+};
+
+export function getDemoExchange(
+  exchangeId: string,
+): VerificationExchangeDemo | null {
+  return DEMO_EXCHANGES[exchangeId] ?? null;
+}
+
+export function listDemoExchangeIds(): readonly string[] {
+  return Object.keys(DEMO_EXCHANGES);
+}

--- a/apps/web/lib/interoperability/exchangeReadiness.ts
+++ b/apps/web/lib/interoperability/exchangeReadiness.ts
@@ -1,0 +1,141 @@
+/**
+ * Exchange Readiness taxonomy for institutional trust-evidence
+ * handoff. Seven closed canonical states; every state maps onto the
+ * existing degradation grammar from
+ * `apps/web/lib/trust/degradation.ts`.
+ *
+ * Semantics (binding):
+ *  - Readiness describes the institutional workflow stage of an
+ *    evidence handoff, NOT the credential's underlying truth value.
+ *  - `institution_confirmed` does NOT imply VitalCV-side acceptance;
+ *    the receiving institution owns the confirmation.
+ *  - `exchange_interrupted` is a hard-interruption state; it never
+ *    softens silently into a "continuity gap" without operator action.
+ */
+
+import {
+  type DegradationState,
+  type DegradationVisual,
+  visualForDegradation,
+} from '@/lib/trust/degradation';
+
+export type ExchangeReadinessState =
+  | 'replay_generated'
+  | 'awaiting_review'
+  | 'cross_check_available'
+  | 'continuity_gap'
+  | 'institution_confirmed'
+  | 'operator_followup_required'
+  | 'exchange_interrupted';
+
+export interface ExchangeReadinessDescriptor {
+  readonly state: ExchangeReadinessState;
+  /** Plain-English headline rendered on the readiness chip. */
+  readonly headline: string;
+  /** Operationally precise detail line; never marketing copy. */
+  readonly detail: string;
+  /**
+   * Canonical degradation state this readiness reuses. Drives the
+   * border / continuity / hard-interruption visual treatment.
+   */
+  readonly degradation: DegradationState;
+  /** Who owns the next operational step. */
+  readonly ownedBy: 'originating_institution' | 'receiving_institution' | 'vitalcv' | 'shared';
+  /** Whether this is a terminal state for the handoff. */
+  readonly terminal: boolean;
+}
+
+const DESCRIPTORS: Record<ExchangeReadinessState, ExchangeReadinessDescriptor> = {
+  replay_generated: {
+    state: 'replay_generated',
+    headline: 'Replay generated',
+    detail:
+      'Originating institution produced a replay bundle for the cohort window. Bundle is portable but not yet under review.',
+    degradation: 'fresh',
+    ownedBy: 'originating_institution',
+    terminal: false,
+  },
+  awaiting_review: {
+    state: 'awaiting_review',
+    headline: 'Awaiting institution review',
+    detail:
+      'Bundle delivered to the receiving institution. Review is institution-owned and not yet started.',
+    degradation: 'pending_human_review',
+    ownedBy: 'receiving_institution',
+    terminal: false,
+  },
+  cross_check_available: {
+    state: 'cross_check_available',
+    headline: 'Cross-check available',
+    detail:
+      'Source references are populated and replay references are anchored. Receiving institution MAY initiate an independent cross-check.',
+    degradation: 'fresh',
+    ownedBy: 'receiving_institution',
+    terminal: false,
+  },
+  continuity_gap: {
+    state: 'continuity_gap',
+    headline: 'Continuity gap',
+    detail:
+      'At least one lane in the bundle has a recorded gap. Continuity is not currently established end-to-end.',
+    degradation: 'interrupted',
+    ownedBy: 'shared',
+    terminal: false,
+  },
+  institution_confirmed: {
+    state: 'institution_confirmed',
+    headline: 'Institution-confirmed',
+    detail:
+      'Receiving institution has independently reviewed the bundle and recorded its confirmation. This does not imply VitalCV-side acceptance.',
+    degradation: 'fresh',
+    ownedBy: 'receiving_institution',
+    terminal: true,
+  },
+  operator_followup_required: {
+    state: 'operator_followup_required',
+    headline: 'Operator follow-up required',
+    detail:
+      'Bundle requires human-reviewed disposition before the exchange can advance.',
+    degradation: 'pending_human_review',
+    ownedBy: 'vitalcv',
+    terminal: false,
+  },
+  exchange_interrupted: {
+    state: 'exchange_interrupted',
+    headline: 'Exchange interrupted',
+    detail:
+      'Hard interruption -- continuity cannot be restored without a new replay bundle or an institution-owned recovery step.',
+    degradation: 'continuity_mismatch',
+    ownedBy: 'shared',
+    terminal: true,
+  },
+};
+
+export function describeExchangeReadiness(
+  state: ExchangeReadinessState,
+): ExchangeReadinessDescriptor {
+  return DESCRIPTORS[state];
+}
+
+export function listExchangeReadinessStates(): readonly ExchangeReadinessState[] {
+  return [
+    'replay_generated',
+    'awaiting_review',
+    'cross_check_available',
+    'continuity_gap',
+    'institution_confirmed',
+    'operator_followup_required',
+    'exchange_interrupted',
+  ];
+}
+
+/**
+ * Convenience: returns the visual grammar token (continuous / dashed
+ * / hard_interruption / manual_lane / pending_anchor) the UI should
+ * render for a given readiness state. Reuses canonical mapping.
+ */
+export function visualForExchangeReadiness(
+  state: ExchangeReadinessState,
+): DegradationVisual {
+  return visualForDegradation(describeExchangeReadiness(state).degradation);
+}

--- a/apps/web/lib/interoperability/replayBundleEnvelope.ts
+++ b/apps/web/lib/interoperability/replayBundleEnvelope.ts
@@ -1,0 +1,141 @@
+/**
+ * Replay Bundle Envelope -- portable operational evidence for the
+ * interoperability rehearsal infrastructure (this wave).
+ *
+ * This is NOT a credential issuance artifact. The envelope describes
+ * an evidence handoff between two institutions during a rehearsal
+ * exchange. It carries references (not signed assertions) to existing
+ * receipt / audit / claim / lineage artifacts in VitalCV's trust
+ * substrate.
+ *
+ * Semantics (binding):
+ *  - "Portable" means an institution CAN read the envelope on its own
+ *    surface; it does NOT imply the receiving institution is required
+ *    to accept the underlying evidence.
+ *  - "Continuity status" reuses the canonical DegradationState set
+ *    from `apps/web/lib/trust/degradation.ts`.
+ *  - "Cross-check eligibility" is institution-owned. The envelope
+ *    declares whether the receiving institution MAY initiate a cross-
+ *    check; it does NOT declare that the cross-check will succeed.
+ */
+
+import type { DegradationState } from '@/lib/trust/degradation';
+
+export type InstitutionRole =
+  | 'cvo'
+  | 'mso'
+  | 'employer'
+  | 'issuer'
+  | 'verifier';
+
+export interface InstitutionalParty {
+  id: string;
+  displayName: string;
+  role: InstitutionRole;
+  /** Optional URL to the party's discovery surface (did:web, etc). */
+  discoveryUrl?: string;
+}
+
+export type EvidenceReferenceKind =
+  | 'receipt'
+  | 'audit'
+  | 'claim'
+  | 'lineage';
+
+export interface EvidenceReference {
+  kind: EvidenceReferenceKind;
+  id: string;
+  label: string;
+  /**
+   * Per-reference continuity (e.g. one stale lane in an otherwise
+   * fresh bundle). Defaults to the envelope-level status when omitted.
+   */
+  continuityStatus?: DegradationState;
+}
+
+export type CrossCheckEligibility =
+  | 'eligible'
+  | 'pending_review'
+  | 'not_eligible';
+
+export interface ReplayBundleScope {
+  laneIds: readonly string[];
+  subjectNpi: string;
+  window: {
+    startIso: string;
+    endIso: string;
+  };
+}
+
+export interface ReplayBundleEnvelope {
+  envelopeId: string;
+  /** Institution that produced the bundle (e.g. originating CVO). */
+  originatingInstitution: InstitutionalParty;
+  /** Institution receiving / reviewing the bundle. */
+  receivingInstitution: InstitutionalParty;
+  /** Replay-chain head this envelope summarises. */
+  replayId: string;
+  /**
+   * Ordered references into the trust substrate. Order is meaningful
+   * for chronology rendering; readers should NOT re-sort the array.
+   */
+  evidenceReferences: readonly EvidenceReference[];
+  /** Envelope-level continuity state. */
+  continuityStatus: DegradationState;
+  /** ISO 8601 timestamp at which the envelope was produced. */
+  checkedAt: string;
+  scope: ReplayBundleScope;
+  /**
+   * Operator-authored note. Plain text; never marketing copy. Caller
+   * is responsible for honoring CLAUDE.md banned-phrase rules.
+   */
+  operatorNotes: string;
+  crossCheckEligibility: CrossCheckEligibility;
+}
+
+/**
+ * Returns a deterministic summary count for the envelope (for header
+ * chips). No semantic claims about the evidence itself.
+ */
+export interface ReplayBundleSummary {
+  evidenceCount: number;
+  receiptCount: number;
+  auditCount: number;
+  claimCount: number;
+  lineageCount: number;
+}
+
+export function summarizeReplayBundle(
+  envelope: ReplayBundleEnvelope,
+): ReplayBundleSummary {
+  const counts: ReplayBundleSummary = {
+    evidenceCount: envelope.evidenceReferences.length,
+    receiptCount: 0,
+    auditCount: 0,
+    claimCount: 0,
+    lineageCount: 0,
+  };
+  for (const ref of envelope.evidenceReferences) {
+    switch (ref.kind) {
+      case 'receipt':
+        counts.receiptCount++;
+        break;
+      case 'audit':
+        counts.auditCount++;
+        break;
+      case 'claim':
+        counts.claimCount++;
+        break;
+      case 'lineage':
+        counts.lineageCount++;
+        break;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Constant identifier prefixes for envelope ids. Encoded so the
+ * test harness can assert without redeclaring the prefix.
+ */
+export const REPLAY_ENVELOPE_ID_PREFIX = 'env_replay_';

--- a/docs/protocol/interoperability-rehearsal-boundaries.md
+++ b/docs/protocol/interoperability-rehearsal-boundaries.md
@@ -1,0 +1,102 @@
+# Interoperability Rehearsal Boundaries
+
+Authoritative reference for what the interoperability surfaces shipped
+in `feat/interoperability-rehearsal-infrastructure` claim, demonstrate,
+plan, and explicitly do not implement.
+
+This document is binding. New interoperability copy must trace to a
+row in one of the five tables below.
+
+## Rehearsal vs Production
+
+| Category | Status | What this means |
+|---|---|---|
+| **Rehearsal** | implemented | The exchange surface, replay envelope, cross-check lane, and timeline DEMONSTRATE the shape of an institutional handoff. The shape is real; the live federation that would carry it in production is NOT implemented. |
+| **Simulation** | implemented | Demo cohort data drives the surface so the workflow can be walked through without external systems. The data is fixture data; no PHI, no production records. |
+| **Supported discovery** | implemented | The receiving institution can discover the originating institution via did:web (`/.well-known/did.json`) and OID4VCI metadata. See PR #392 / #393. |
+| **Planned interoperability** | future-state | OID4VCI issuance flow, wallet handoff, federation, multi-issuer trust framework. NOT in this wave. |
+| **Unsupported federation** | not in scope | Cross-issuer trust lists, universal-resolver multi-method DID resolution, automatic acceptance, instant verification. NEVER claimed. |
+| **Unsupported production exchange** | not in scope | Real-time evidence pipeline between two production institutions; live revocation propagation; binding consent receipts. NEVER claimed. |
+
+## What the rehearsal demonstrates
+
+| Surface | Demonstrates | Does NOT claim |
+|---|---|---|
+| `/interoperability/exchange/[exchangeId]` | Two-party handoff workspace shape | Federated network |
+| Replay Bundle Envelope (`replayBundleEnvelope.ts`) | Portable evidence pointer set | Credential issuance / signed VC |
+| Independent Cross-Check Panel | Receiving institution's per-lane confirmation workflow | Automatic acceptance |
+| Trust Exchange Timeline | Operational chronology of an exchange | Real-time trust transfer |
+| Evidence Reuse Panel | Operational efficiency framing (fewer duplicate queries) | Regulatory substitution / guaranteed reuse |
+| Export Verification Exchange Button | Local PDF print of the surface | Cross-institution document sharing |
+
+## Banned language
+
+The following phrases MUST NOT appear in any rehearsal surface copy
+or component label. The truth-audit test (`apps/web/__tests__/
+interoperability-rehearsal-infrastructure.test.ts`) gates against
+regression.
+
+- "automatically verified"
+- "guaranteed acceptance"
+- "universally accepted"
+- "fully verified"
+- "instant verification"
+- "automatic trust transfer"
+- "federated by default"
+- "production-ready federation"
+- "trust transferred" (the trust is shown; transfer is institution-owned)
+- "credential issued via VitalCV" (rehearsal does not issue)
+- "magical onboarding"
+
+## Normalized language (use these)
+
+- "Rehearsal infrastructure"
+- "Institution-owned cross-check"
+- "Replay bundle"
+- "Portable operational evidence"
+- "Receiving institution"
+- "Originating institution"
+- "Source-confirmed"
+- "Continuity restored"
+- "Operator note"
+- "Independent cross-check"
+- "Replayable evidence"
+
+## Posture statements (binding)
+
+When external materials reference the interoperability rehearsal, they
+MUST use only the normalized language above. The footer line on the
+exchange page ("Rehearsal infrastructure · institution-owned cross-
+check · no production credential issuance · no federation guarantee")
+is the canonical posture; do not paraphrase it.
+
+## Codex audit checklist (rehearsal-specific)
+
+In addition to the standard checks in
+`docs/ops/codex-ready-checklist.md` (PR #394), the rehearsal wave
+adds:
+
+- [ ] Every claim in `apps/web/components/interoperability/*.tsx`
+      uses normalized language from this doc.
+- [ ] No banned phrase appears in any touched file (strict regex match
+      after comment stripping).
+- [ ] The page footer renders the canonical posture line verbatim.
+- [ ] `ExportVerificationExchangeButton` triggers `window.print()`
+      and nothing else (no `share` / `send` semantics).
+
+## Remaining interoperability gaps
+
+1. **No live receiving-institution UI.** This wave ships the SHAPE of
+   the receiving institution's view inside VitalCV's own product.
+   A real receiving-institution surface would live on the receiving
+   institution's systems.
+2. **No machine-readable envelope schema.** The
+   `ReplayBundleEnvelope` TypeScript type is the schema today;
+   serialization to a portable wire format (JSON-LD / VC 2.0
+   `evidencePackage`) is a future wave.
+3. **No revocation channel.** Revoked credentials are flagged via
+   `RevocationStateBanner` (PR #382) but the rehearsal does not
+   simulate live revocation propagation.
+4. **No discovery probe.** The rehearsal does not probe the
+   receiving institution's `.well-known/did.json` -- it assumes
+   discovery has already happened out-of-band.


### PR DESCRIPTION
## Mission

Institutional trust-exchange rehearsal atop the canonical trust primitives + provenance navigation + degradation grammar (PRs #382 / #383 / #385 / #386). **No federation, no wallet auth, no production credential issuance, no revocation infrastructure.**

> **Stacking note:** base = \`feat/canonical-provenance-navigation\` (PR #386). Rebase onto main when upstream chain merges.

## Routes added

| Route | Purpose |
|---|---|
| \`GET /interoperability/exchange/[exchangeId]\` | Verification Exchange Workspace · server component |

## Exchange primitives added

| Primitive | What it ships |
|---|---|
| \`ReplayBundleEnvelope\` (\`lib/interoperability/replayBundleEnvelope.ts\`) | Typed model · originating + receiving institution, replay_id, evidence references, continuity status (reuses canonical DegradationState), checked_at, scope, operator notes, cross-check eligibility |
| \`summarizeReplayBundle(envelope)\` | Deterministic counts (receipt / audit / claim / lineage) |
| \`ExchangeReadinessState\` (\`exchangeReadiness.ts\`) | 7 closed states reused via degradation grammar |
| \`IndependentCrossCheckPanel\` | Per-lane affordance for receiving-institution confirmation |
| \`TrustExchangeTimeline\` | 9-kind operational chronology (no emoji, no animation) |
| \`EvidenceReusePanel\` | Operational-efficiency framing (zinc-500 footnote tone) |
| \`ExportVerificationExchangeButton\` | Single \`window.print()\` action |

## Readiness states (binding)

| State | Owner | Terminal | Degradation mapping |
|---|---|---|---|
| \`replay_generated\` | originating institution | no | fresh |
| \`awaiting_review\` | receiving institution | no | pending_human_review |
| \`cross_check_available\` | receiving institution | no | fresh |
| \`continuity_gap\` | shared | no | interrupted |
| \`institution_confirmed\` | receiving institution | **yes** | fresh |
| \`operator_followup_required\` | VitalCV | no | pending_human_review |
| \`exchange_interrupted\` | shared | **yes** | continuity_mismatch |

\`institution_confirmed\` copy explicitly says: *"does not imply VitalCV-side acceptance"*.

## Provenance integrations

- Page renders \`ProvenanceChronology\` (PR #386) at the top — six-cell reading order \`object → ownership → checked_at → channel → replay → run_id\` sourced from the envelope.
- Continuity status reuses \`describeDegradation()\` and \`visualForDegradation()\` from PR #382's degradation module.
- Readiness states reuse the canonical \`DegradationState\` taxonomy — no new visual tokens introduced.
- Evidence references use the same \`receipt | audit | claim | lineage\` taxonomy as the stacked-panes URL contract (PR #385).

## Interoperability boundaries

\`docs/protocol/interoperability-rehearsal-boundaries.md\` — six-state capability table:

- **Rehearsal** (implemented) — shape only
- **Simulation** (implemented) — fixture data drives the workflow
- **Supported discovery** (implemented) — via did:web / OID4VCI from PRs #392 / #393
- **Planned interoperability** (future-state) — OID4VCI issuance flow, wallet handoff, federation
- **Unsupported federation** (not in scope) — cross-issuer trust lists, automatic acceptance
- **Unsupported production exchange** (not in scope) — real-time evidence pipeline, live revocation

Banned-phrase list (11 phrases) + normalized-language list (11 phrases) documented.

## Export surfaces

\`ExportVerificationExchangeButton\` triggers \`window.print()\`. The exchange page is built print-ready; the operator gets an institutional PDF summary with zero additional layout. No "share" or "send" semantics.

## Tests added — 28 passing

| Group | Tests |
|---|---|
| Replay bundle envelope (prefix + summary counts) | 2 |
| Exchange readiness taxonomy (closed set, descriptors, terminal, visual mapping, posture copy) | 6 |
| Demo exchange fixture (Cedar default, unknown null, envelope well-formed, timeline interruption+restored, PECOS degraded lane) | 5 |
| IndependentCrossCheckPanel render (lane rows + degraded amber border) | 2 |
| TrustExchangeTimeline render (entries + dashed amber border for continuity_interruption) | 2 |
| EvidenceReusePanel render (rows + posture copy) | 2 |
| Truth-contract per-file banned-phrase grep | 8 (one per touched file) + 1 (boundaries doc presence) |

## Validation

\`\`\`
pnpm install --frozen-lockfile  → clean
pnpm turbo run build --filter @vitalcv/trust-state  → cache hit
pnpm --filter @vitalcv/web exec vitest run interoperability-rehearsal-infrastructure
  → 28/28
pnpm --filter @vitalcv/web exec tsc --noEmit
  → 2 pre-existing intake-types.ts errors (unrelated); 0 introduced
pnpm --filter @vitalcv/web lint  → clean
\`\`\`

## Truth-contract + interoperability grep

All 8 touched code files pass the banned-phrase grep after comment stripping. Boundaries doc explicitly declares the banned list.

**Banned (none of these appear in any touched code file):**
\`automatically verified\` · \`guaranteed acceptance\` · \`universally accepted\` · \`fully verified\` · \`instant verification\` · \`automatic trust transfer\` · \`federated by default\` · \`production-ready federation\` · \`trust transferred\` · \`credential issued via vitalcv\` · \`magical onboarding\`

## Remaining interoperability gaps

1. **No live receiving-institution UI** — this wave ships the shape of the receiving institution's view inside VitalCV's own product. A real receiving-institution surface would live on the receiving institution's systems.
2. **No machine-readable envelope schema** — \`ReplayBundleEnvelope\` is the TS type today; serialization to a portable wire format (JSON-LD / VC 2.0 \`evidencePackage\`) is a future wave.
3. **No revocation channel** — \`RevocationStateBanner\` ships in PR #382 but the rehearsal does not simulate live revocation propagation.
4. **No discovery probe** — the rehearsal assumes discovery has already happened out-of-band; it does not fetch the receiving institution's \`.well-known/did.json\`.
5. **No machine cross-check workflow** — the panel demonstrates the affordance; no automation is implied (intentional).

## Test plan
- [ ] \`pnpm --filter @vitalcv/web exec vitest run interoperability-rehearsal-infrastructure\` passes 28 tests
- [ ] \`pnpm --filter @vitalcv/web exec tsc --noEmit\` reports only the 2 pre-existing \`intake-types.ts\` errors
- [ ] \`pnpm --filter @vitalcv/web lint\` clean
- [ ] Manual: visit \`/interoperability/exchange/exch_cedar_q2_26_01\` and verify originating → receiving masthead, readiness chip, provenance chronology strip, evidence refs list, operator notes, timeline (with continuity interruption + restored), cross-check lanes (PECOS degraded), evidence-reuse rows, print-summary button
- [ ] Codex SAFE verdict on (a) implementation, (b) diff, (c) commit-message copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)