### PR TITLE
feat(demo): implement operational waste visibility (/demo/waste)

### DIFF
--- a/apps/web/__tests__/operational-waste-visibility.test.tsx
+++ b/apps/web/__tests__/operational-waste-visibility.test.tsx
@@ -1,0 +1,379 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { CEDAR_PILOT_DEMO } from '@/lib/demo/demoFixtures';
+import { WasteEntryHeader } from '@/components/waste/WasteEntryHeader';
+import { DuplicateOutreachNarrative } from '@/components/waste/DuplicateOutreachNarrative';
+import { ContinuityInterruptionNarrative } from '@/components/waste/ContinuityInterruptionNarrative';
+import { EvidenceFragmentationNarrative } from '@/components/waste/EvidenceFragmentationNarrative';
+import { OperationalDeadTimeNarrative } from '@/components/waste/OperationalDeadTimeNarrative';
+import { ManualReviewLoopNarrative } from '@/components/waste/ManualReviewLoopNarrative';
+import { DeploymentDelayNarrative } from '@/components/waste/DeploymentDelayNarrative';
+import { OperationalContinuityComparison } from '@/components/waste/OperationalContinuityComparison';
+import { InstitutionalFrictionTimeline } from '@/components/waste/InstitutionalFrictionTimeline';
+import { WasteVisibilitySummary } from '@/components/waste/WasteVisibilitySummary';
+
+// ── Primitive render isolation ────────────────────────────────────────────
+
+describe('WasteEntryHeader · render', () => {
+  it('emits cohort + window + visibility framing', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WasteEntryHeader, {
+        cohortLabel: 'Cedar · Q2-26',
+        pilotWindow: '2026-04-19 → 2026-05-19',
+      }),
+    );
+    expect(html).toContain('data-slot="waste-entry-header"');
+    expect(html).toContain('Cedar · Q2-26');
+    expect(html).toContain('2026-04-19');
+    expect(html).toMatch(/visibility, not elimination/i);
+  });
+
+  it('never claims savings or ROI in the header copy', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WasteEntryHeader, {
+        cohortLabel: 'Cedar',
+        pilotWindow: '2026-04-19 → 2026-05-19',
+      }),
+    ).toLowerCase();
+    expect(html).not.toContain('save millions');
+    expect(html).not.toContain('guaranteed savings');
+    expect(html).not.toContain('fake roi');
+  });
+});
+
+describe('DuplicateOutreachNarrative · render', () => {
+  it('renders one row per cross-check lane', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DuplicateOutreachNarrative, {
+        lanes: CEDAR_PILOT_DEMO.crossCheckLanes,
+      }),
+    );
+    expect(html).toContain('data-slot="duplicate-outreach-narrative"');
+    for (const lane of CEDAR_PILOT_DEMO.crossCheckLanes) {
+      expect(html).toContain(`data-lane-id="${lane.laneId}"`);
+      expect(html).toContain(lane.source);
+    }
+    expect(html).toMatch(/Sending operator/i);
+  });
+
+  it('frames duplication as visible, not eliminated', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DuplicateOutreachNarrative, {
+        lanes: CEDAR_PILOT_DEMO.crossCheckLanes,
+      }),
+    );
+    expect(html).toMatch(/Visibility, not elimination/i);
+    expect(html).toMatch(/still reviews/i);
+  });
+});
+
+describe('ContinuityInterruptionNarrative · render', () => {
+  it('renders one row per interruption with cause + institution-owned step', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ContinuityInterruptionNarrative, {
+        interruptions: CEDAR_PILOT_DEMO.interruptions,
+      }),
+    );
+    expect(html).toContain('data-slot="continuity-interruption-narrative"');
+    for (const i of CEDAR_PILOT_DEMO.interruptions) {
+      expect(html).toContain(i.cause);
+      expect(html).toContain(i.institutionOwnedStep);
+    }
+  });
+
+  it('describes recovery as institution-owned', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ContinuityInterruptionNarrative, {
+        interruptions: CEDAR_PILOT_DEMO.interruptions,
+      }),
+    );
+    expect(html).toMatch(/Institution-owned recovery step/i);
+    expect(html).toMatch(/operator-led/i);
+  });
+});
+
+describe('EvidenceFragmentationNarrative · render', () => {
+  it('renders one row per evidence lane with status mapping', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EvidenceFragmentationNarrative, {
+        evidenceLanes: CEDAR_PILOT_DEMO.evidenceContinuity,
+      }),
+    );
+    expect(html).toContain('data-slot="evidence-fragmentation-narrative"');
+    for (const lane of CEDAR_PILOT_DEMO.evidenceContinuity) {
+      expect(html).toContain(`data-lane-id="${lane.laneId}"`);
+      expect(html).toContain(`data-status="${lane.status}"`);
+      expect(html).toContain(lane.source);
+    }
+    // Status labels
+    expect(html).toContain('Source-confirmed');
+  });
+
+  it('names institution records as staying institution-owned', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(EvidenceFragmentationNarrative, {
+        evidenceLanes: CEDAR_PILOT_DEMO.evidenceContinuity,
+      }),
+    );
+    expect(html).toMatch(/institution records stay institution-owned/i);
+  });
+});
+
+describe('OperationalDeadTimeNarrative · render', () => {
+  it('renders the five dead-time categories', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperationalDeadTimeNarrative, {}),
+    );
+    expect(html).toContain('data-slot="operational-dead-time-narrative"');
+    expect(html).toContain('Federal-source resolution wait');
+    expect(html).toContain('Phone-tag confirmation');
+    expect(html).toContain('Re-query after registry lag');
+    expect(html).toContain('Committee-window dead time');
+    expect(html).toContain('Privileging-decision dead time');
+  });
+
+  it('does not claim committee or privileging accelerates', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperationalDeadTimeNarrative, {}),
+    );
+    expect(html).toMatch(/Committee cadence is institution-owned/i);
+    expect(html).toMatch(/Privileging is institution-owned/i);
+  });
+});
+
+describe('ManualReviewLoopNarrative · render', () => {
+  it('renders the five manual review loops', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ManualReviewLoopNarrative, {}),
+    );
+    expect(html).toContain('data-slot="manual-review-loop-narrative"');
+    expect(html).toContain('Re-reading the same NPPES record');
+    expect(html).toContain('Re-summarising the same operator note');
+    expect(html).toContain('Re-checking exclusion-list status');
+    expect(html).toContain('Reconciling source timestamps by hand');
+    expect(html).toContain('Tracking down the original requester');
+  });
+
+  it('separates re-reading from deliberate judgement', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ManualReviewLoopNarrative, {}),
+    );
+    expect(html).toMatch(/Some review is judgement/i);
+    expect(html).toMatch(/Some review is re-reading the packet/i);
+    expect(html).toMatch(/deliberate institutional judgement/i);
+  });
+});
+
+describe('DeploymentDelayNarrative · render', () => {
+  it('renders the three delay axes and the metric rows', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DeploymentDelayNarrative, {
+        rows: CEDAR_PILOT_DEMO.deploymentReadiness,
+      }),
+    );
+    expect(html).toContain('data-slot="deployment-delay-narrative"');
+    expect(html).toContain('Federal-source resolution axis');
+    expect(html).toContain('Committee-review axis');
+    expect(html).toContain('Privileging-decision axis');
+    for (const row of CEDAR_PILOT_DEMO.deploymentReadiness) {
+      expect(html).toContain(row.metric);
+    }
+  });
+
+  it('names federal-source as the only compressing axis', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DeploymentDelayNarrative, {
+        rows: CEDAR_PILOT_DEMO.deploymentReadiness,
+      }),
+    );
+    expect(html).toMatch(/Only one compresses/i);
+    expect(html).toMatch(/Committee cadence is institution-owned/i);
+    expect(html).toMatch(/Privileging is institution-owned/i);
+  });
+
+  it('flags after column as a pilot target, not measured', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DeploymentDelayNarrative, {
+        rows: CEDAR_PILOT_DEMO.deploymentReadiness,
+      }),
+    );
+    expect(html).toMatch(/Pilot target/i);
+    expect(html).toMatch(/not a measured cohort result/i);
+  });
+});
+
+describe('OperationalContinuityComparison · render', () => {
+  it('renders eight steps with today vs pilot framing', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperationalContinuityComparison, {}),
+    );
+    expect(html).toContain('data-slot="operational-continuity-comparison"');
+    for (let i = 1; i <= 8; i += 1) {
+      expect(html).toContain(`data-step-index="${i}"`);
+    }
+  });
+
+  it('marks the four institution-owned steps explicitly', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperationalContinuityComparison, {}),
+    );
+    const ownedMatches = html.match(/data-institution-owned="true"/g) ?? [];
+    expect(ownedMatches.length).toBe(4);
+    expect(html).toContain('State medical board PSV');
+    expect(html).toContain('Credentialing committee review');
+    expect(html).toContain('Privileging decision');
+    expect(html).toContain('Final acceptance');
+  });
+});
+
+describe('InstitutionalFrictionTimeline · render', () => {
+  it('renders six checkpoints T-0 through T-5', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(InstitutionalFrictionTimeline, {}),
+    );
+    expect(html).toContain('data-slot="institutional-friction-timeline"');
+    for (const marker of ['T-0', 'T-1', 'T-2', 'T-3', 'T-4', 'T-5']) {
+      expect(html).toContain(`data-marker="${marker}"`);
+    }
+    expect(html).toContain('Candidate identified');
+    expect(html).toContain('Federal-source resolution');
+    expect(html).toContain('State medical board PSV');
+    expect(html).toContain('Committee scheduling');
+    expect(html).toContain('Committee disposition');
+    expect(html).toContain('Privileging + deployment');
+  });
+
+  it('names committee + privileging as institution-owned', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(InstitutionalFrictionTimeline, {}),
+    );
+    expect(html).toMatch(/Committee cadence is institution-owned/i);
+    expect(html).toMatch(/Privileging and deployment cadence are institution-owned/i);
+  });
+});
+
+describe('WasteVisibilitySummary · render', () => {
+  it('renders six narrative summary rows', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WasteVisibilitySummary, {}),
+    );
+    expect(html).toContain('data-slot="waste-visibility-summary"');
+    for (const id of ['01', '02', '03', '04', '05', '06']) {
+      expect(html).toContain(`data-narrative-id="${id}"`);
+    }
+  });
+
+  it('enumerates the institution-owned-in-full list', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WasteVisibilitySummary, {}),
+    );
+    expect(html).toContain('State medical board PSV');
+    expect(html).toContain('Credentialing committee review');
+    expect(html).toContain('Privileging decisions');
+    expect(html).toContain('Final acceptance');
+    expect(html).toMatch(/freshness/i);
+    expect(html).toMatch(/stale-but-signed/i);
+  });
+
+  it('declares "no ROI or savings claim" in the footer', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(WasteVisibilitySummary, {}),
+    );
+    expect(html).toMatch(/no ROI or savings claim/i);
+    expect(html).toMatch(/Visibility, not elimination/i);
+  });
+});
+
+// ── Truth contract · banned-jargon leakage ────────────────────────────────
+
+describe('truth contract · waste surface', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+  function stripDeclarativeMatter(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+  }
+
+  const TOUCHED_FILES = [
+    'apps/web/components/waste/WasteEntryHeader.tsx',
+    'apps/web/components/waste/DuplicateOutreachNarrative.tsx',
+    'apps/web/components/waste/ContinuityInterruptionNarrative.tsx',
+    'apps/web/components/waste/EvidenceFragmentationNarrative.tsx',
+    'apps/web/components/waste/OperationalDeadTimeNarrative.tsx',
+    'apps/web/components/waste/ManualReviewLoopNarrative.tsx',
+    'apps/web/components/waste/DeploymentDelayNarrative.tsx',
+    'apps/web/components/waste/OperationalContinuityComparison.tsx',
+    'apps/web/components/waste/InstitutionalFrictionTimeline.tsx',
+    'apps/web/components/waste/WasteVisibilitySummary.tsx',
+    'apps/web/app/demo/waste/page.tsx',
+  ];
+
+  const BANNED = [
+    'save millions',
+    'instant onboarding',
+    'instant verification',
+    'fake roi',
+    'ai-powered',
+    'guaranteed savings',
+    'protocol theater',
+    'automatic acceptance',
+    'automatically verified',
+    'magical onboarding',
+    'cryptographically guaranteed',
+  ];
+
+  it.each(TOUCHED_FILES)(
+    '%s avoids banned waste-surface jargon',
+    (rel) => {
+      const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+      const lower = stripDeclarativeMatter(src).toLowerCase();
+      for (const phrase of BANNED) {
+        expect(
+          lower.includes(phrase),
+          `should not contain "${phrase}"`,
+        ).toBe(false);
+      }
+    },
+  );
+
+  it('boundaries doc declares the banned-phrase posture', () => {
+    const md = fs.readFileSync(
+      path.join(repoRoot, 'docs/demo/operational-waste-boundaries.md'),
+      'utf8',
+    );
+    expect(md).toMatch(/save millions/i);
+    expect(md).toMatch(/instant onboarding/i);
+    expect(md).toMatch(/fake roi/i);
+    expect(md).toMatch(/AI-powered/i);
+    expect(md).toMatch(/protocol theater/i);
+    expect(md).toMatch(/guaranteed savings/i);
+  });
+
+  it('boundaries doc enumerates the five taxonomy states', () => {
+    const md = fs.readFileSync(
+      path.join(repoRoot, 'docs/demo/operational-waste-boundaries.md'),
+      'utf8',
+    );
+    expect(md).toMatch(/`demonstrated`/i);
+    expect(md).toMatch(/`observed`/i);
+    expect(md).toMatch(/`simulated`/i);
+    expect(md).toMatch(/`unsupported`/i);
+    expect(md).toMatch(/`institution-owned`/i);
+  });
+
+  it('boundaries doc names institution-owned items explicitly', () => {
+    const md = fs.readFileSync(
+      path.join(repoRoot, 'docs/demo/operational-waste-boundaries.md'),
+      'utf8',
+    );
+    expect(md).toMatch(/State medical board PSV/i);
+    expect(md).toMatch(/Credentialing committee review/i);
+    expect(md).toMatch(/Privileging decisions/i);
+    expect(md).toMatch(/stale-but-signed lanes/i);
+  });
+});

--- a/apps/web/app/demo/waste/page.tsx
+++ b/apps/web/app/demo/waste/page.tsx
@@ -1,0 +1,97 @@
+/**
+ * /demo/waste -- Operational waste visibility route.
+ *
+ * Single read-only surface that names where credentialing operations
+ * leak today (duplicate outreach, continuity interruption, evidence
+ * fragmentation, dead time, manual review loops, deployment delay)
+ * and pairs each leak with the institution-owned step that does NOT
+ * move. The page demonstrates visibility, not elimination. It does
+ * not claim savings, ROI, regulatory substitution, or "AI-powered"
+ * anything.
+ *
+ * Reuses the Cedar Q2-2026 demo fixture from PR #400; no duplicate
+ * fixture system.
+ *
+ * Sequence:
+ *   1. WasteEntryHeader                  -- framing, "visibility not elimination"
+ *   2. DuplicateOutreachNarrative        -- narrative 01
+ *   3. ContinuityInterruptionNarrative   -- narrative 02
+ *   4. EvidenceFragmentationNarrative    -- narrative 03
+ *   5. OperationalDeadTimeNarrative      -- narrative 04
+ *   6. ManualReviewLoopNarrative         -- narrative 05
+ *   7. DeploymentDelayNarrative          -- narrative 06
+ *   8. OperationalContinuityComparison   -- today vs pilot, 8 steps
+ *   9. InstitutionalFrictionTimeline     -- T-0 through T-5 chronology
+ *  10. WasteVisibilitySummary            -- six narratives folded together
+ */
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getDemoFixture } from '@/lib/demo/demoFixtures';
+import { WasteEntryHeader } from '@/components/waste/WasteEntryHeader';
+import { DuplicateOutreachNarrative } from '@/components/waste/DuplicateOutreachNarrative';
+import { ContinuityInterruptionNarrative } from '@/components/waste/ContinuityInterruptionNarrative';
+import { EvidenceFragmentationNarrative } from '@/components/waste/EvidenceFragmentationNarrative';
+import { OperationalDeadTimeNarrative } from '@/components/waste/OperationalDeadTimeNarrative';
+import { ManualReviewLoopNarrative } from '@/components/waste/ManualReviewLoopNarrative';
+import { DeploymentDelayNarrative } from '@/components/waste/DeploymentDelayNarrative';
+import { OperationalContinuityComparison } from '@/components/waste/OperationalContinuityComparison';
+import { InstitutionalFrictionTimeline } from '@/components/waste/InstitutionalFrictionTimeline';
+import { WasteVisibilitySummary } from '@/components/waste/WasteVisibilitySummary';
+
+export const metadata: Metadata = {
+  title: 'Operational waste visibility · VitalCV',
+  description:
+    'Receiver-side observation of where credentialing operations leak today. Six narratives, eight-step continuity comparison, six-checkpoint chronology, summary panel. The page demonstrates visibility, not elimination.',
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  searchParams?: Promise<{ cohort?: string }>;
+}
+
+export default async function OperationalWasteVisibilityPage({
+  searchParams,
+}: PageProps) {
+  const { cohort = 'cedar' } = (await searchParams) ?? {};
+  const fixture = getDemoFixture(cohort);
+  if (!fixture) notFound();
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <WasteEntryHeader
+        cohortLabel={fixture.cohortLabel}
+        pilotWindow={fixture.pilotWindow}
+      />
+
+      <div className="mx-auto max-w-[1200px] space-y-6 px-4 py-6 sm:px-6">
+        <DuplicateOutreachNarrative lanes={fixture.crossCheckLanes} />
+
+        <ContinuityInterruptionNarrative
+          interruptions={fixture.interruptions}
+        />
+
+        <EvidenceFragmentationNarrative
+          evidenceLanes={fixture.evidenceContinuity}
+        />
+
+        <OperationalDeadTimeNarrative />
+
+        <ManualReviewLoopNarrative />
+
+        <DeploymentDelayNarrative rows={fixture.deploymentReadiness} />
+
+        <OperationalContinuityComparison />
+
+        <InstitutionalFrictionTimeline />
+
+        <WasteVisibilitySummary />
+
+        <footer className="border-t border-dashed border-slate-400 pt-3 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Read-only observation · no credential decision occurs on this page ·
+          visibility, not elimination
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/waste/ContinuityInterruptionNarrative.tsx
+++ b/apps/web/components/waste/ContinuityInterruptionNarrative.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { InterruptionExample } from '@/lib/demo/demoFixtures';
+
+/**
+ * Narrative 2 · Continuity interruption as waste.
+ *
+ * Today, when an upstream registry is slow or returns a stale answer,
+ * the receiving operator either re-queries (duplicate work) or paginates
+ * back through phone calls (lost time). The narrative names the
+ * interruption and the operator-owned recovery step. It does NOT
+ * claim continuity is "magical" or "instant"; the institution still
+ * dispositions the stale-but-signed posture on its own credential.
+ */
+export interface ContinuityInterruptionNarrativeProps {
+  interruptions: readonly InterruptionExample[];
+  className?: string;
+}
+
+export function ContinuityInterruptionNarrative({
+  interruptions,
+  className,
+}: ContinuityInterruptionNarrativeProps) {
+  return (
+    <section
+      data-slot="continuity-interruption-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 02 · continuity interruption
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          Upstream registries blip. Today, that becomes a phone tree.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          When PECOS lags, the conventional response is a phone call and
+          a re-query. The receiving operator carries the loss as dead
+          time. With a replay envelope, the operator note travels with
+          the lane; the receiving institution dispositions the
+          stale-but-signed posture on its own credential.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {interruptions.map((interruption) => (
+          <li
+            key={interruption.laneId}
+            data-slot="continuity-interruption-row"
+            data-lane-id={interruption.laneId}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Lane
+              </div>
+              <div className="mt-1 font-mono text-xs text-slate-900">
+                {interruption.laneId}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Where continuity broke
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {interruption.cause}
+              </div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Institution-owned recovery step
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {interruption.institutionOwnedStep}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <footer className="border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        Interruption is visible · resolution remains operator-led
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/waste/DeploymentDelayNarrative.tsx
+++ b/apps/web/components/waste/DeploymentDelayNarrative.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { DeploymentReadinessExample } from '@/lib/demo/demoFixtures';
+
+/**
+ * Narrative 6 · Deployment delay as waste.
+ *
+ * The deployment date is the date the clinician sees patients. Today
+ * deployment delay shows up across federal-source wait, committee
+ * cadence, and privileging cadence. The narrative names each axis
+ * with its before/after framing taken from the deployment-readiness
+ * fixture. The page does NOT claim the committee/privileging axes
+ * compress; only the federal-source axis is named as compressing.
+ */
+export interface DeploymentDelayNarrativeProps {
+  rows: readonly DeploymentReadinessExample[];
+  className?: string;
+}
+
+interface DelayAxis {
+  axis: string;
+  whatDelays: string;
+  whatStays: string;
+}
+
+const DELAY_AXES: readonly DelayAxis[] = [
+  {
+    axis: 'Federal-source resolution axis',
+    whatDelays:
+      'Receiving CVO waits for NPPES, OIG/LEIE, and PECOS to come back through normal channels. This is the only axis the page claims compresses.',
+    whatStays:
+      'Receiving CVO still confirms each lane on its own credential.',
+  },
+  {
+    axis: 'Committee-review axis',
+    whatDelays:
+      'The credentialing committee meets on a fixed schedule. Clinician readiness does not change committee scheduling.',
+    whatStays:
+      'Committee cadence is institution-owned; the page does not claim acceleration here.',
+  },
+  {
+    axis: 'Privileging-decision axis',
+    whatDelays:
+      'Privileging signoff happens on the institution\'s own cadence.',
+    whatStays:
+      'Privileging is institution-owned; the page does not claim acceleration here.',
+  },
+];
+
+export function DeploymentDelayNarrative({
+  rows,
+  className,
+}: DeploymentDelayNarrativeProps) {
+  return (
+    <section
+      data-slot="deployment-delay-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 06 · deployment delay
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          Deployment is held up by three axes. Only one compresses.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          Federal-source resolution, committee review, and privileging
+          all contribute to the gap between hire and first patient. The
+          page is honest about which axis compresses (federal-source)
+          and which axes stay on the institution's existing cadence.
+        </p>
+      </header>
+
+      <section
+        data-slot="deployment-delay-axes"
+        className="border-b border-slate-200 px-4 py-3"
+      >
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Where deployment delay accumulates
+        </div>
+        <ul className="mt-2 divide-y divide-slate-200">
+          {DELAY_AXES.map((axis) => (
+            <li
+              key={axis.axis}
+              data-slot="deployment-delay-axis"
+              className="grid grid-cols-1 gap-2 py-2 sm:grid-cols-12"
+            >
+              <div className="sm:col-span-4">
+                <div className="text-xs font-semibold text-slate-900">
+                  {axis.axis}
+                </div>
+              </div>
+              <div className="sm:col-span-4">
+                <div className="text-xs text-slate-700">{axis.whatDelays}</div>
+              </div>
+              <div className="sm:col-span-4">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Institution-owned
+                </div>
+                <div className="mt-1 text-xs text-slate-700">{axis.whatStays}</div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section data-slot="deployment-delay-metrics" className="px-4 py-3">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Federal-source axis · before / after (pilot target framing)
+        </div>
+        <ul className="mt-2 divide-y divide-slate-200">
+          {rows.map((row) => (
+            <li
+              key={row.metric}
+              data-slot="deployment-delay-metric-row"
+              className="grid grid-cols-1 gap-2 py-2 sm:grid-cols-12"
+            >
+              <div className="sm:col-span-4">
+                <div className="text-xs font-semibold text-slate-900">
+                  {row.metric}
+                </div>
+              </div>
+              <div className="sm:col-span-3">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Before
+                </div>
+                <div className="mt-1 text-xs text-slate-700">{row.before}</div>
+              </div>
+              <div className="sm:col-span-3">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  After (pilot target)
+                </div>
+                <div className="mt-1 text-xs text-slate-700">{row.after}</div>
+              </div>
+              <div className="sm:col-span-2">
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Framing
+                </div>
+                <div className="mt-1 text-xs text-slate-700">
+                  {row.institutionalFraming}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer className="border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        Pilot target · not a measured cohort result · committee + privileging stay institution-owned
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/waste/DuplicateOutreachNarrative.tsx
+++ b/apps/web/components/waste/DuplicateOutreachNarrative.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { CrossCheckExample } from '@/lib/demo/demoFixtures';
+
+/**
+ * Narrative 1 · Duplicate outreach as waste.
+ *
+ * The same primary source (NPPES, OIG/LEIE, PECOS) is queried by the
+ * sending operator, by the receiving CVO, and sometimes by the
+ * receiving committee. The narrative names the duplication, names
+ * the lanes where the duplication shows up, and names what does
+ * NOT change (institution-owned review).
+ */
+export interface DuplicateOutreachNarrativeProps {
+  lanes: readonly CrossCheckExample[];
+  className?: string;
+}
+
+export function DuplicateOutreachNarrative({
+  lanes,
+  className,
+}: DuplicateOutreachNarrativeProps) {
+  return (
+    <section
+      data-slot="duplicate-outreach-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 01 · duplicate outreach
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          The same primary source gets queried three times.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          Sending operator queries NPPES. Receiving CVO queries NPPES
+          again. Receiving committee sometimes queries NPPES a third
+          time. The query is the same; the work is duplicated. VitalCV
+          replaces the duplicate query with a portable replay envelope
+          while the receiving institution retains its own review.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {lanes.map((lane) => (
+          <li
+            key={lane.laneId}
+            data-slot="duplicate-outreach-row"
+            data-lane-id={lane.laneId}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Source
+              </div>
+              <div className="mt-1 font-mono text-xs text-slate-900">
+                {lane.source}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Where the duplicate query happens
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                Sending operator → receiving CVO → sometimes committee
+              </div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What the institution still owns
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{lane.note}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <footer className="border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        Visibility, not elimination · receiving institution still reviews each lane
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/waste/EvidenceFragmentationNarrative.tsx
+++ b/apps/web/components/waste/EvidenceFragmentationNarrative.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { EvidenceContinuityExample } from '@/lib/demo/demoFixtures';
+
+/**
+ * Narrative 3 · Evidence fragmentation as waste.
+ *
+ * Today, evidence about a single clinician scatters: NPPES lives in
+ * one system, state board screenshots live in a folder, OIG/LEIE
+ * confirmations live in email, committee minutes live in the
+ * institution's records system. The narrative names each fragment,
+ * names where the fragment lives today, and names what the replay
+ * envelope reorganizes (NOT replaces).
+ */
+export interface EvidenceFragmentationNarrativeProps {
+  evidenceLanes: readonly EvidenceContinuityExample[];
+  className?: string;
+}
+
+const STATUS_LABEL: Record<EvidenceContinuityExample['status'], string> = {
+  source_confirmed: 'Source-confirmed',
+  evidence_pending: 'Evidence pending',
+  continuity_restored: 'Continuity restored',
+  continuity_interrupted: 'Continuity interrupted',
+};
+
+export function EvidenceFragmentationNarrative({
+  evidenceLanes,
+  className,
+}: EvidenceFragmentationNarrativeProps) {
+  return (
+    <section
+      data-slot="evidence-fragmentation-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 03 · evidence fragmentation
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          One clinician, six places. The receiving operator chases each.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          NPPES lives in one system. OIG/LEIE confirmations live in
+          email. PECOS lookups live in a printout. State board
+          screenshots live in a folder. Committee minutes live in the
+          institution's records system. A replay envelope reorganizes
+          the federal-source fragments into one portable artifact; the
+          institution's own records, notes, and committee minutes stay
+          where they are.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {evidenceLanes.map((lane) => (
+          <li
+            key={lane.laneId}
+            data-slot="evidence-fragmentation-row"
+            data-lane-id={lane.laneId}
+            data-status={lane.status}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Fragment
+              </div>
+              <div className="mt-1 font-mono text-xs text-slate-900">
+                {lane.source}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Status
+              </div>
+              <div className="mt-1 font-mono text-xs text-slate-900">
+                {STATUS_LABEL[lane.status]}
+              </div>
+            </div>
+            <div className="sm:col-span-6">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Operator note
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {lane.operatorNote}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <footer className="border-t border-slate-200 bg-slate-50 px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        Federal-source fragments only · institution records stay institution-owned
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/waste/InstitutionalFrictionTimeline.tsx
+++ b/apps/web/components/waste/InstitutionalFrictionTimeline.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * A read-only chronology of where institutional friction shows up
+ * across a typical credentialing cycle. The timeline names six
+ * checkpoints from "candidate identified" through "deployment", and
+ * for each names (a) what slows down today and (b) what remains on
+ * the institution's existing cadence. The component is presentational
+ * and stateless.
+ */
+export interface InstitutionalFrictionTimelineProps {
+  className?: string;
+}
+
+interface TimelineCheckpoint {
+  marker: string;
+  label: string;
+  friction: string;
+  institutionOwned: string;
+}
+
+const CHECKPOINTS: readonly TimelineCheckpoint[] = [
+  {
+    marker: 'T-0',
+    label: 'Candidate identified',
+    friction:
+      'Receiving institution opens a file; sending operator collects the federal-source artifacts the receiving CVO will ask for.',
+    institutionOwned:
+      'Receiving institution defines its own intake checklist.',
+  },
+  {
+    marker: 'T-1',
+    label: 'Federal-source resolution',
+    friction:
+      'Receiving CVO queries NPPES, OIG/LEIE, PECOS. Sending operator already queried them. The receive-side query is duplicative.',
+    institutionOwned:
+      'Receiving CVO still owns the read on its own credential, even when a replay envelope carries the lane.',
+  },
+  {
+    marker: 'T-2',
+    label: 'State medical board PSV',
+    friction:
+      'Receiving CVO PSVs the state board; this is the receiving institution\'s job and continues to be.',
+    institutionOwned:
+      'State medical board PSV remains institution-owned in full.',
+  },
+  {
+    marker: 'T-3',
+    label: 'Committee scheduling',
+    friction:
+      'Committee meets on its fixed cadence. Clinician readiness does not move the meeting.',
+    institutionOwned:
+      'Committee cadence is institution-owned; the page does not claim acceleration here.',
+  },
+  {
+    marker: 'T-4',
+    label: 'Committee disposition',
+    friction:
+      'Committee reads the packet; sometimes pauses on stale-but-signed lanes; sometimes asks the operator to re-confirm.',
+    institutionOwned:
+      'Committee judgement remains institution-owned. The page surfaces the operator note in place to avoid re-summarization, but does not propose to remove the judgement.',
+  },
+  {
+    marker: 'T-5',
+    label: 'Privileging + deployment',
+    friction:
+      'Privileging signoff awaits chief-of-staff schedule; deployment happens after privileging clears.',
+    institutionOwned:
+      'Privileging and deployment cadence are institution-owned in full.',
+  },
+];
+
+export function InstitutionalFrictionTimeline({
+  className,
+}: InstitutionalFrictionTimelineProps) {
+  return (
+    <section
+      data-slot="institutional-friction-timeline"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Friction timeline · six checkpoints
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          A receiver-side chronology of where credentialing slows down,
+          checkpoint by checkpoint. Five of six checkpoints carry
+          institution-owned work that does not move; the page names
+          each one explicitly so no acceleration claim drifts.
+        </p>
+      </header>
+      <ol className="divide-y divide-slate-200">
+        {CHECKPOINTS.map((cp) => (
+          <li
+            key={cp.marker}
+            data-slot="institutional-friction-checkpoint"
+            data-marker={cp.marker}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-2">
+              <div className="font-mono text-sm text-slate-900">{cp.marker}</div>
+              <div className="mt-1 text-xs font-semibold text-slate-700">
+                {cp.label}
+              </div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Where friction shows up
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{cp.friction}</div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Institution-owned
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {cp.institutionOwned}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/components/waste/ManualReviewLoopNarrative.tsx
+++ b/apps/web/components/waste/ManualReviewLoopNarrative.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Narrative 5 · Manual review loops as waste.
+ *
+ * The receiving operator opens a packet, scans it, makes a note,
+ * closes it, then comes back the next day and reads the same packet
+ * again because nothing carried forward. The narrative names these
+ * loops and names what the institution keeps doing (real review,
+ * deliberate decisions). It does NOT claim to remove review; it
+ * names the parts that are redundant scanning vs. the parts that
+ * are deliberate judgement.
+ */
+export interface ManualReviewLoopNarrativeProps {
+  className?: string;
+}
+
+interface ReviewLoopRow {
+  loopName: string;
+  whatRepeats: string;
+  whatVitalCvCarries: string;
+  whatStays: string;
+}
+
+const REVIEW_LOOP_ROWS: readonly ReviewLoopRow[] = [
+  {
+    loopName: 'Re-reading the same NPPES record',
+    whatRepeats:
+      'Sending operator reads NPPES. Receiving CVO reads NPPES the next day. Committee reviewer reads NPPES the week after.',
+    whatVitalCvCarries:
+      'The NPPES lane state, source reference, and observed-at timestamp travel with the replay envelope.',
+    whatStays:
+      'Each institution still reviews the lane on its own credential and dispositions on its own cadence.',
+  },
+  {
+    loopName: 'Re-summarising the same operator note',
+    whatRepeats:
+      'Sending operator wrote a note about the PECOS stale-flag. Receiving operator re-summarises it for the committee. Committee re-summarises it for the chief of staff.',
+    whatVitalCvCarries:
+      'The operator note remains attached to the lane; subsequent reviewers read the note in place.',
+    whatStays:
+      'Each reviewer still decides whether the note is sufficient on their own credential.',
+  },
+  {
+    loopName: 'Re-checking exclusion-list status',
+    whatRepeats:
+      'OIG/LEIE was checked at intake. Then checked again before deployment. Then sometimes a third time for the privileging packet.',
+    whatVitalCvCarries:
+      'The most recent exclusion-list check is in the lane with an explicit observed-at timestamp.',
+    whatStays:
+      'Each institution\'s freshness policy still determines whether to re-fetch on their own credential.',
+  },
+  {
+    loopName: 'Reconciling source timestamps by hand',
+    whatRepeats:
+      'Operator opens three printouts and writes down the timestamps to compare them.',
+    whatVitalCvCarries:
+      'Timestamps and source references are rendered uniformly on the lane.',
+    whatStays:
+      'Reviewer still decides whether the timestamps satisfy the institution\'s freshness budget.',
+  },
+  {
+    loopName: 'Tracking down the original requester',
+    whatRepeats:
+      'Receiving CVO sometimes has to phone the sending operator to ask "who actually ran this query?"',
+    whatVitalCvCarries:
+      'The operator identifier is recorded on the lane along with the run context.',
+    whatStays:
+      'Receiving CVO still owns the decision of whether to trust the upstream operator\'s read.',
+  },
+];
+
+export function ManualReviewLoopNarrative({
+  className,
+}: ManualReviewLoopNarrativeProps) {
+  return (
+    <section
+      data-slot="manual-review-loop-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 05 · manual review loops
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          Some review is judgement. Some review is re-reading the packet.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          The page does not propose removing review. It separates the
+          parts that are redundant scanning (the same NPPES record read
+          three times) from the parts that are deliberate institutional
+          judgement (committee disposition, privileging). VitalCV carries
+          the lane forward; the institution keeps the judgement.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {REVIEW_LOOP_ROWS.map((row) => (
+          <li
+            key={row.loopName}
+            data-slot="manual-review-loop-row"
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Loop
+              </div>
+              <div className="mt-1 text-xs font-semibold text-slate-900">
+                {row.loopName}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What repeats today
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.whatRepeats}</div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What the envelope carries
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {row.whatVitalCvCarries}
+              </div>
+            </div>
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What stays with the institution
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.whatStays}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/waste/OperationalContinuityComparison.tsx
+++ b/apps/web/components/waste/OperationalContinuityComparison.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Side-by-side comparison of the conventional credentialing flow vs
+ * the pilot's federal-source resolution flow. The component is
+ * intentionally narrow: it names eight steps that occur today and
+ * pairs each with the corresponding pilot state. The pilot column
+ * does NOT claim the institution-owned steps move; it shows them
+ * sitting in the same column position so the reader sees they are
+ * preserved.
+ */
+export interface OperationalContinuityComparisonProps {
+  className?: string;
+}
+
+interface ComparisonRow {
+  step: string;
+  today: string;
+  pilot: string;
+  institutionOwned: boolean;
+}
+
+const COMPARISON_ROWS: readonly ComparisonRow[] = [
+  {
+    step: 'NPPES identity check',
+    today: 'Sending operator + receiving CVO both query NPPES independently.',
+    pilot: 'NPPES lane carried on a replay envelope; receiving CVO confirms on its own credential.',
+    institutionOwned: false,
+  },
+  {
+    step: 'OIG / LEIE exclusion screen',
+    today: 'Sending operator + receiving CVO each query OIG/LEIE; some institutions repeat for privileging.',
+    pilot: 'OIG/LEIE lane carried with affirmative-negative finding; receiving CVO confirms on its own credential.',
+    institutionOwned: false,
+  },
+  {
+    step: 'PECOS enrollment check',
+    today: 'Sending operator queries PECOS; receiving CVO re-queries; if PECOS lags, phone-tag begins.',
+    pilot: 'PECOS lane carried with operator note; stale-but-signed posture explicit; receiving CVO dispositions on its own credential.',
+    institutionOwned: false,
+  },
+  {
+    step: 'State medical board PSV',
+    today: 'Receiving CVO PSVs state medical board on the institution\'s own credential.',
+    pilot: 'State medical board PSV remains institution-owned. The pilot does not change this step.',
+    institutionOwned: true,
+  },
+  {
+    step: 'Credentialing committee review',
+    today: 'Committee meets on a fixed cadence; clinician readiness does not change scheduling.',
+    pilot: 'Committee review remains institution-owned. The pilot does not change this step.',
+    institutionOwned: true,
+  },
+  {
+    step: 'Privileging decision',
+    today: 'Chief of staff signs off privileging on the institution\'s own cadence.',
+    pilot: 'Privileging remains institution-owned. The pilot does not change this step.',
+    institutionOwned: true,
+  },
+  {
+    step: 'Operator-to-operator phone confirmation',
+    today: 'Sending and receiving operators exchange voicemails to confirm primary-source reads.',
+    pilot: 'Operator note travels with each lane; voicemails are no longer the substrate of confirmation.',
+    institutionOwned: false,
+  },
+  {
+    step: 'Final acceptance of clinician for deployment',
+    today: 'Receiving institution accepts the clinician for deployment on its own credential.',
+    pilot: 'Final acceptance remains institution-owned. The pilot does not change this step.',
+    institutionOwned: true,
+  },
+];
+
+export function OperationalContinuityComparison({
+  className,
+}: OperationalContinuityComparisonProps) {
+  return (
+    <section
+      data-slot="operational-continuity-comparison"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Continuity comparison · today vs pilot
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          Eight steps. The federal-source steps move onto a replay
+          envelope. The institution-owned steps (state board PSV,
+          committee, privileging, final acceptance) sit in the same
+          column position they always have.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {COMPARISON_ROWS.map((row, idx) => (
+          <li
+            key={row.step}
+            data-slot="operational-continuity-row"
+            data-step-index={idx + 1}
+            data-institution-owned={row.institutionOwned ? 'true' : 'false'}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Step {String(idx + 1).padStart(2, '0')}
+              </div>
+              <div className="mt-1 text-xs font-semibold text-slate-900">
+                {row.step}
+              </div>
+              {row.institutionOwned ? (
+                <div className="mt-1 inline-flex rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-slate-700">
+                  institution-owned
+                </div>
+              ) : null}
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Today
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.today}</div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Pilot
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.pilot}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/waste/OperationalDeadTimeNarrative.tsx
+++ b/apps/web/components/waste/OperationalDeadTimeNarrative.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Narrative 4 · Operational dead time as waste.
+ *
+ * The clinician is hired, signed, oriented, and ready to see patients,
+ * but the credentialing committee is still scheduled four weeks out.
+ * That gap is dead time. The narrative names the categories of dead
+ * time, names what the institution still owns (committee cadence,
+ * privileging decisions), and avoids any claim that committee
+ * scheduling itself shortens.
+ */
+export interface OperationalDeadTimeNarrativeProps {
+  className?: string;
+}
+
+interface DeadTimeRow {
+  category: string;
+  whatHappens: string;
+  whatStays: string;
+}
+
+const DEAD_TIME_ROWS: readonly DeadTimeRow[] = [
+  {
+    category: 'Federal-source resolution wait',
+    whatHappens:
+      'Receiving CVO waits days for NPPES, OIG/LEIE, PECOS confirmations to come back through their normal channels.',
+    whatStays:
+      'Receiving CVO continues to confirm against its own credential on intake day.',
+  },
+  {
+    category: 'Phone-tag confirmation',
+    whatHappens:
+      'Sending operator and receiving operator exchange voicemails confirming the same primary source.',
+    whatStays:
+      'Operators continue to talk for everything outside federal-source lanes (committee context, references, history).',
+  },
+  {
+    category: 'Re-query after registry lag',
+    whatHappens:
+      'When PECOS lags, the receiving operator re-queries themselves to satisfy their own freshness budget.',
+    whatStays:
+      'Receiving operator may still re-fetch on their own credentials when their freshness policy requires it.',
+  },
+  {
+    category: 'Committee-window dead time',
+    whatHappens:
+      'Clinician is otherwise ready; the next credentialing committee is two-to-four weeks out.',
+    whatStays:
+      'Committee cadence is institution-owned; this page does not claim committee scheduling accelerates.',
+  },
+  {
+    category: 'Privileging-decision dead time',
+    whatHappens:
+      'Privileging decisions await chief-of-staff sign-off on the institution\'s schedule.',
+    whatStays:
+      'Privileging is institution-owned; nothing on this page changes that.',
+  },
+];
+
+export function OperationalDeadTimeNarrative({
+  className,
+}: OperationalDeadTimeNarrativeProps) {
+  return (
+    <section
+      data-slot="operational-dead-time-narrative"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Narrative 04 · operational dead time
+        </div>
+        <h3 className="mt-1 text-sm font-semibold text-slate-900">
+          Dead time has a category. Most categories are still institution-owned.
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          Five places dead time shows up. Only one (federal-source
+          resolution wait) compresses. Four remain on the institution's
+          own cadence and the page does not claim otherwise.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {DEAD_TIME_ROWS.map((row) => (
+          <li
+            key={row.category}
+            data-slot="operational-dead-time-row"
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Category
+              </div>
+              <div className="mt-1 text-xs font-semibold text-slate-900">
+                {row.category}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What happens today
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.whatHappens}</div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What stays institution-owned
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.whatStays}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/waste/WasteEntryHeader.tsx
+++ b/apps/web/components/waste/WasteEntryHeader.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Top header for the /demo/waste route. Reads as institutional
+ * observation, not as marketing copy. The page demonstrates where
+ * credentialing waste shows up; the header frames the demonstration
+ * as a receiver-side audit, not as a vendor pitch.
+ */
+export interface WasteEntryHeaderProps {
+  cohortLabel: string;
+  pilotWindow: string;
+  className?: string;
+}
+
+export function WasteEntryHeader({
+  cohortLabel,
+  pilotWindow,
+  className,
+}: WasteEntryHeaderProps) {
+  return (
+    <header
+      data-slot="waste-entry-header"
+      className={cn(
+        'border-b border-slate-900 bg-slate-950 px-5 py-5 text-slate-100',
+        className,
+      )}
+    >
+      <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+        Operational waste · receiver-side observation
+      </div>
+      <h1 className="mt-1 text-xl font-semibold">
+        Where credentialing operations leak time, evidence, and review.
+      </h1>
+      <p className="mt-3 max-w-[62ch] text-sm text-slate-200">
+        This page names six places credentialing operations leak today.
+        Each section pairs the leak with the institution-owned step that
+        still has to happen. The page does not claim savings, ROI, or
+        regulatory substitution. It demonstrates visibility, not
+        elimination.
+      </p>
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+          <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+            Cohort observed
+          </div>
+          <div className="mt-1 text-sm font-semibold">{cohortLabel}</div>
+        </div>
+        <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+          <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+            Observation window
+          </div>
+          <div className="mt-1 font-mono text-sm">{pilotWindow}</div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/waste/WasteVisibilitySummary.tsx
+++ b/apps/web/components/waste/WasteVisibilitySummary.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Final summary panel for the /demo/waste route. Pulls the six
+ * narratives together with a single-sentence framing per narrative
+ * and a single-line "what stays institution-owned" line. The panel
+ * deliberately avoids any quantitative ROI claim; the only numeric
+ * claims (time-to-resolution, operator minutes) are the pilot
+ * targets already documented in the deployment readiness fixture.
+ */
+export interface WasteVisibilitySummaryProps {
+  className?: string;
+}
+
+interface SummaryRow {
+  narrative: string;
+  oneSentence: string;
+  institutionOwned: string;
+}
+
+const SUMMARY_ROWS: readonly SummaryRow[] = [
+  {
+    narrative: '01 · duplicate outreach',
+    oneSentence:
+      'The same federal source gets queried multiple times; the replay envelope carries the lane forward.',
+    institutionOwned:
+      'Receiving institution still reviews each lane on its own credential.',
+  },
+  {
+    narrative: '02 · continuity interruption',
+    oneSentence:
+      'Upstream registry blips today become phone-tag; the operator note travels with the lane instead.',
+    institutionOwned:
+      'Receiving institution dispositions stale-but-signed lanes on its own credential.',
+  },
+  {
+    narrative: '03 · evidence fragmentation',
+    oneSentence:
+      'Federal-source fragments live in different systems; the envelope reorganizes only the federal-source ones.',
+    institutionOwned:
+      'Institution records, committee minutes, and notes stay institution-owned.',
+  },
+  {
+    narrative: '04 · operational dead time',
+    oneSentence:
+      'Five categories of dead time exist; only federal-source resolution wait compresses.',
+    institutionOwned:
+      'Committee, privileging, and re-fetch cadences remain institution-owned.',
+  },
+  {
+    narrative: '05 · manual review loops',
+    oneSentence:
+      'Some review is re-reading the packet; the envelope carries the lane so subsequent reviewers read it in place.',
+    institutionOwned:
+      'Committee judgement and privileging decisions remain institution-owned.',
+  },
+  {
+    narrative: '06 · deployment delay',
+    oneSentence:
+      'Three axes hold deployment up; only the federal-source axis compresses.',
+    institutionOwned:
+      'Committee and privileging cadence remain institution-owned.',
+  },
+];
+
+const STAYS_INSTITUTION_OWNED: readonly string[] = [
+  'State medical board PSV (Cedar CVO channel)',
+  'Credentialing committee review',
+  'Privileging decisions',
+  'Final acceptance of any clinician for deployment',
+  'Re-fetching upstream registries on the institution\'s own credential and freshness budget',
+  'Disposition of stale-but-signed lanes',
+];
+
+export function WasteVisibilitySummary({
+  className,
+}: WasteVisibilitySummaryProps) {
+  return (
+    <section
+      data-slot="waste-visibility-summary"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          Waste visibility · summary
+        </h3>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-600">
+          A single page reading of where credentialing operations leak
+          today, paired with the institution-owned step that does not
+          move. The page does not claim savings or quantitative ROI;
+          it demonstrates visibility, not elimination.
+        </p>
+      </header>
+
+      <ul className="divide-y divide-slate-200">
+        {SUMMARY_ROWS.map((row) => (
+          <li
+            key={row.narrative}
+            data-slot="waste-visibility-summary-row"
+            data-narrative-id={row.narrative.split(' ')[0]}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-3">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Narrative
+              </div>
+              <div className="mt-1 font-mono text-xs text-slate-900">
+                {row.narrative}
+              </div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What the page demonstrates
+              </div>
+              <div className="mt-1 text-xs text-slate-700">{row.oneSentence}</div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What stays institution-owned
+              </div>
+              <div className="mt-1 text-xs text-slate-700">
+                {row.institutionOwned}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <section
+        data-slot="waste-visibility-summary-institution-owned"
+        className="border-t border-slate-200 bg-slate-50 px-4 py-3"
+      >
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Institution-owned in full · the page names these explicitly
+        </div>
+        <ul className="mt-2 list-disc pl-5 text-xs text-slate-700">
+          {STAYS_INSTITUTION_OWNED.map((item) => (
+            <li
+              key={item}
+              data-slot="waste-visibility-summary-institution-owned-item"
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer className="border-t border-slate-200 bg-white px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+        Visibility, not elimination · no ROI or savings claim on this page
+      </footer>
+    </section>
+  );
+}

--- a/docs/demo/operational-waste-boundaries.md
+++ b/docs/demo/operational-waste-boundaries.md
@@ -1,0 +1,131 @@
+# Operational Waste Visibility Boundaries
+
+Five-state taxonomy for the `/demo/waste` route. Every claim on the
+page traces to a row in one of the tables below. The page is a
+receiver-side observation of where credentialing operations leak
+today. It demonstrates visibility, not elimination, and it does not
+claim savings or ROI.
+
+Audiences: institutional reader (CVO / MSO / hospital operations) +
+operator running the demonstration + Codex audits cross-checking
+copy against the underlying infrastructure.
+
+## Five states
+
+| State | Meaning |
+|---|---|
+| `demonstrated` | The route renders the artifact today using shipping code |
+| `observed` | Drawn from credentialing operations in the field; pattern is real, the cohort here is fixture-driven |
+| `simulated` | Fixture data drives the render; production data plane is not yet wired |
+| `unsupported` | Explicitly not in scope; not on the page |
+| `institution-owned` | The institution does this; VitalCV surfaces but does not perform |
+
+## Table 1 · Demonstrated (with evidence)
+
+| Claim | Evidence path |
+|---|---|
+| Six waste narratives (duplicate outreach / continuity interruption / evidence fragmentation / dead time / manual review loops / deployment delay) | `apps/web/components/waste/` (this PR) |
+| Continuity comparison today vs pilot (8 steps) | `apps/web/components/waste/OperationalContinuityComparison.tsx` (this PR) |
+| Friction chronology (T-0 through T-5, six checkpoints) | `apps/web/components/waste/InstitutionalFrictionTimeline.tsx` (this PR) |
+| Waste visibility summary (six narratives folded together) | `apps/web/components/waste/WasteVisibilitySummary.tsx` (this PR) |
+| Federal-source resolution as the only acceleration axis named | `packages/core/src/services/nppesResolver.ts` (#388/#392) |
+| Replay envelope as portable evidence pointer | `apps/web/lib/interoperability/replayBundleEnvelope.ts` (#395) |
+| Per-lane operator note carried through the envelope | `apps/web/lib/interoperability/demoExchanges.ts` (#395) |
+| Per-lane continuity status (source-confirmed / evidence-pending / continuity-restored / continuity-interrupted) | `apps/web/lib/trust/degradation.ts` (#382) |
+
+## Table 2 · Observed (pattern in the field, fixture-driven cohort)
+
+| Claim | Note |
+|---|---|
+| Sending operator + receiving CVO duplicate NPPES queries | Pattern is widespread across credentialing operations |
+| PECOS registry lag triggering phone-tag confirmation | Pattern is widespread; the Cedar cohort uses a fixture row for the demonstration |
+| Receiving CVO re-reads the same lane the next day | Pattern is widespread; manual review loops happen across institutions |
+| Committee + privileging cadence holding deployment | Pattern is widespread; the page names these as institution-owned, not as accelerated |
+| Receiving operator phoning the sending operator to confirm "who ran this query" | Pattern is widespread; the envelope records the operator identifier in place |
+
+## Table 3 · Simulated (fixture-driven)
+
+| Claim | Note |
+|---|---|
+| Cedar Health pilot cohort | Fixture data in `lib/demo/demoFixtures.ts`; not a live customer |
+| Specific NPI / clinician identities | Fixture (NPIs are Luhn-valid; clinicians are synthetic) |
+| Specific stale-but-signed posture on PECOS at the Cedar window | Fixture row; pattern is realistic but the data is synthetic |
+| "Under 1 hour" federal-source resolution target | Pilot target per the deployment kit (#387); not a measured cohort result |
+| "Under 90 minutes total" operator load target | Pilot target; not a measured cohort result |
+
+## Table 4 · Unsupported (explicitly NOT claimed)
+
+The route does NOT claim:
+
+- savings, ROI, "save millions", "guaranteed savings"
+- "instant" anything (instant onboarding, instant verification)
+- "automatic" anything (automatic acceptance, automatically verified)
+- "AI-powered" anything
+- elimination of human review
+- regulatory substitution (the institution retains its own cadence)
+- federation between issuers
+- HIPAA or SOC2 certification (the platform is HIPAA-aware in design but does not claim certification)
+- "protocol theater" or "fake ROI"
+- production credential issuance (the observation is read-only)
+- elimination of committee or privileging cadence
+- universal interoperability
+
+These are banned in copy and gated by the truth-audit test in
+`apps/web/__tests__/operational-waste-visibility.test.tsx`.
+
+## Table 5 · Institution-owned (named explicitly on the page)
+
+The route names what the institution owns in full and does NOT
+propose to change:
+
+- State medical board PSV (Cedar CVO channel) -- out of pilot scope
+- Credentialing committee review
+- Privileging decisions
+- Final acceptance of any clinician for deployment
+- Re-fetching upstream registries on the institution's own credential
+- Disposition of stale-but-signed lanes
+- Receiving CVO's own freshness policy and review cadence
+
+The summary panel (`WasteVisibilitySummary`) is the single place this
+list is enumerated; it must NEVER drift to make any of these items
+sound accelerated.
+
+## Compressed terminology (binding)
+
+The page uses only these labels for the underlying states. Other
+labels (`σ ok`, `σ defer`, `replay-anchored`, `continuous`, etc.) are
+infrastructure jargon and MUST NOT leak into the demonstration
+surface.
+
+| User-facing label | Underlying state |
+|---|---|
+| Source-confirmed | `source_confirmed` (continuity) |
+| Evidence pending | `evidence_pending` (continuity) |
+| Continuity restored | `continuity_restored` (continuity) |
+| Continuity interrupted | `continuity_interrupted` (continuity) |
+| Pending review | `pending_review` (cross-check) |
+| In review | `in_review` (cross-check) |
+| Institution-confirmed | `institution_confirmed` (cross-check) |
+| Not eligible (institution-owned) | `not_eligible` (cross-check) |
+| Stale-but-signed | operator-visible posture preserved on the lane |
+
+## Visibility framing (binding)
+
+The page is structured around six binding statements:
+
+1. **The duplicate query is duplicate work.** The replay envelope carries the lane; the receiving institution still owns the read.
+2. **The interruption is operator-visible.** Operator note travels with the lane; the receiving institution still owns the disposition.
+3. **Federal-source fragments only.** The envelope reorganizes federal-source artifacts. Institution records stay where they are.
+4. **Dead time has categories.** Only the federal-source resolution category compresses. Committee and privileging cadence remain institution-owned.
+5. **Review has two parts.** Re-reading the packet (redundant scanning) is what the envelope reduces. Committee judgement remains institution-owned.
+6. **Three axes, one compression.** Only the federal-source axis compresses. Committee + privileging axes stay on the institution's existing cadence.
+
+Adding a new claim to the `/demo/waste` page requires:
+
+1. A row in Table 1, 2, 3, or 5 above (Table 4 claims are not added; they are removed)
+2. For Table 1 (demonstrated) claims: an evidence path into a shipping PR
+3. The compressed-terminology table extended if a new user-facing label is required
+4. The truth-audit test extended to catch any new banned phrase
+
+PRs that introduce an unsupported claim without one of the above
+MUST be rejected at Codex audit.

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,7 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';
+// Note: the prior `./interoperability` re-export referenced a file
+// that was never landed (see PR #398). Removed here to unblock the
+// build for this branch; the canonical fix lives on
+// fix/ci-unlock-and-stack-convergence.


### PR DESCRIPTION
## Summary

Introduces `/demo/waste`, a receiver-side observation of where credentialing operations leak today. Six narrative primitives, an 8-step today-vs-pilot continuity comparison, a 6-checkpoint friction chronology (T-0 through T-5), and a single summary panel that folds the six narratives together with the institution-owned-in-full list.

The page is structured around six binding statements:
1. The duplicate query is duplicate work; the receiving institution still owns the read.
2. The interruption is operator-visible; the receiving institution still owns disposition.
3. Federal-source fragments only; institution records stay where they are.
4. Dead time has categories — only the federal-source resolution category compresses.
5. Review has two parts — re-reading the packet vs. deliberate institutional judgement. The envelope reduces re-reading; judgement remains institution-owned.
6. Three axes hold deployment up; only the federal-source axis compresses.

## What is shipped

| Surface | File |
|---|---|
| Route | `apps/web/app/demo/waste/page.tsx` |
| Header | `apps/web/components/waste/WasteEntryHeader.tsx` |
| Narrative 01 · duplicate outreach | `apps/web/components/waste/DuplicateOutreachNarrative.tsx` |
| Narrative 02 · continuity interruption | `apps/web/components/waste/ContinuityInterruptionNarrative.tsx` |
| Narrative 03 · evidence fragmentation | `apps/web/components/waste/EvidenceFragmentationNarrative.tsx` |
| Narrative 04 · operational dead time | `apps/web/components/waste/OperationalDeadTimeNarrative.tsx` |
| Narrative 05 · manual review loops | `apps/web/components/waste/ManualReviewLoopNarrative.tsx` |
| Narrative 06 · deployment delay | `apps/web/components/waste/DeploymentDelayNarrative.tsx` |
| 8-step today vs pilot | `apps/web/components/waste/OperationalContinuityComparison.tsx` |
| 6-checkpoint chronology | `apps/web/components/waste/InstitutionalFrictionTimeline.tsx` |
| Summary panel | `apps/web/components/waste/WasteVisibilitySummary.tsx` |
| Boundaries doc | `docs/demo/operational-waste-boundaries.md` |
| Test suite | `apps/web/__tests__/operational-waste-visibility.test.tsx` |

## Truth contract

- 5-state taxonomy: `demonstrated` / `observed` / `simulated` / `unsupported` / `institution-owned`
- Banned phrases (gated by the truth-audit test on every touched file): `save millions`, `instant onboarding`, `instant verification`, `fake roi`, `ai-powered`, `guaranteed savings`, `protocol theater`, `automatic acceptance`, `automatically verified`, `magical onboarding`, `cryptographically guaranteed`
- The summary panel declares `no ROI or savings claim on this page` in its footer
- Institution-owned items (state board PSV, committee review, privileging, final acceptance, re-fetching on own freshness budget, stale-but-signed disposition) are enumerated in one place to prevent drift

## Stacking note

Branched off `feat/institutional-intake-momentum` (#401, SHA `83651912`). Reuses the Cedar Q2-2026 demo fixture from PR #400; no duplicate fixture system.

This branch also carries the wallet-sdk orphan re-export fix (`packages/wallet-sdk/src/index.ts:351`). The canonical fix lives on `fix/ci-unlock-and-stack-convergence` (PR #398). The change is included here so the local build passes; on rebase against #398 it collapses to a no-op.

## Validation

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/operational-waste-visibility.test.tsx` — **36/36 passing**
- [x] `pnpm turbo run build --filter @vitalcv/web` — passes, `/demo/waste` route built
- [x] `pnpm --filter @vitalcv/web exec tsc --noEmit` — passes
- [x] `pnpm --filter @vitalcv/web exec next lint --dir components/waste --dir app/demo/waste` — 0 warnings

## Test plan

- [ ] Visit `/demo/waste` locally — confirm six narratives + comparison + timeline + summary render
- [ ] Inspect `data-slot` attributes on each section
- [ ] Verify the footer reads `Read-only observation · no credential decision occurs on this page · visibility, not elimination`
- [ ] Grep touched files for any banned phrase that escaped the test suite
- [ ] Codex audit · implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)