### PR TITLE
feat(product): establish pilot operator readiness (/operator)

### DIFF
--- a/apps/web/__tests__/pilot-operator-readiness.test.tsx
+++ b/apps/web/__tests__/pilot-operator-readiness.test.tsx
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  OperatorAttentionQueue,
+  ContinuityAttentionCard,
+  ReviewProgressPanel,
+  OperationalNextStepSummary,
+  InstitutionalOwnershipPanel,
+  ReadinessProgressStrip,
+} from '@/components/operator';
+import {
+  PILOT_OPERATOR_FIXTURE,
+  OPERATOR_VISIBLE_STATE_LABEL,
+  NEXT_STEP_OWNER_LABEL,
+  getOperatorFixture,
+} from '@/lib/operator/operatorFixtures';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+}
+
+// ── Fixture shape ─────────────────────────────────────────────────────────
+
+describe('operator fixture', () => {
+  it('returns the cedar fixture by default', () => {
+    expect(getOperatorFixture()).not.toBeNull();
+    expect(getOperatorFixture('cedar')).toEqual(PILOT_OPERATOR_FIXTURE);
+  });
+
+  it('returns null for unknown slugs', () => {
+    expect(getOperatorFixture('not-real')).toBeNull();
+  });
+
+  it('Cedar fixture is well-formed', () => {
+    expect(PILOT_OPERATOR_FIXTURE.attentionQueue.length).toBeGreaterThanOrEqual(1);
+    expect(PILOT_OPERATOR_FIXTURE.continuity.length).toBeGreaterThanOrEqual(3);
+    expect(PILOT_OPERATOR_FIXTURE.reviews.length).toBeGreaterThanOrEqual(2);
+    expect(PILOT_OPERATOR_FIXTURE.readiness.length).toBeGreaterThanOrEqual(1);
+    expect(PILOT_OPERATOR_FIXTURE.institutionalOwnership.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('OPERATOR_VISIBLE_STATE_LABEL has exactly six entries', () => {
+    expect(Object.keys(OPERATOR_VISIBLE_STATE_LABEL).length).toBe(6);
+    for (const label of [
+      'Ready',
+      'Pending review',
+      'Attention needed',
+      'Interrupted',
+      'Continuing',
+      'Complete',
+    ]) {
+      expect(Object.values(OPERATOR_VISIBLE_STATE_LABEL)).toContain(label);
+    }
+  });
+
+  it('NEXT_STEP_OWNER_LABEL has the expected four owners', () => {
+    expect(Object.keys(NEXT_STEP_OWNER_LABEL).length).toBe(4);
+    for (const label of ['Operator', 'Receiving institution', 'Sending institution', 'VitalCV']) {
+      expect(Object.values(NEXT_STEP_OWNER_LABEL)).toContain(label);
+    }
+  });
+});
+
+// ── Primitive render isolation ────────────────────────────────────────────
+
+describe('OperatorAttentionQueue · render', () => {
+  it('emits one row per attention item with next-step + owner', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperatorAttentionQueue, {
+        items: PILOT_OPERATOR_FIXTURE.attentionQueue,
+      }),
+    );
+    expect(html).toContain('data-slot="operator-attention-queue"');
+    expect(html).toContain(`data-item-count="${PILOT_OPERATOR_FIXTURE.attentionQueue.length}"`);
+    for (const item of PILOT_OPERATOR_FIXTURE.attentionQueue) {
+      expect(html).toContain(`data-item-id="${item.id}"`);
+      expect(html).toContain(item.what);
+      expect(html).toContain(item.nextStepLabel);
+    }
+  });
+
+  it('renders nothing when items is empty (calm == empty)', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperatorAttentionQueue, { items: [] }),
+    );
+    expect(html).toBe('');
+  });
+});
+
+describe('ContinuityAttentionCard · state mapping', () => {
+  it.each([
+    ['ready', 'Ready'],
+    ['pending_review', 'Pending review'],
+    ['attention_needed', 'Attention needed'],
+    ['interrupted', 'Interrupted'],
+    ['continuing', 'Continuing'],
+    ['complete', 'Complete'],
+  ] as const)('state %s renders user-facing label "%s"', (state, label) => {
+    const html = renderToStaticMarkup(
+      React.createElement(ContinuityAttentionCard, {
+        lane: {
+          id: 'x',
+          laneLabel: 'Test Lane',
+          state,
+          operatorNote: 'note',
+        },
+      }),
+    );
+    expect(html).toContain('data-slot="continuity-attention-card"');
+    expect(html).toContain(`data-state="${state}"`);
+    expect(html).toContain(label);
+    expect(html).toContain('Test Lane');
+  });
+});
+
+describe('ReviewProgressPanel · render', () => {
+  it('renders one row per review with stage + state + owner', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ReviewProgressPanel, {
+        reviews: PILOT_OPERATOR_FIXTURE.reviews,
+      }),
+    );
+    expect(html).toContain('data-slot="review-progress-panel"');
+    for (const review of PILOT_OPERATOR_FIXTURE.reviews) {
+      expect(html).toContain(`data-review-id="${review.id}"`);
+      expect(html).toContain(`data-stage="${review.reviewStage}"`);
+      expect(html).toContain(review.clinicianDisplayName);
+      expect(html).toContain(review.reviewStageLabel);
+    }
+  });
+
+  it('uses only the six normalized visible state labels', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ReviewProgressPanel, {
+        reviews: PILOT_OPERATOR_FIXTURE.reviews,
+      }),
+    );
+    const allowed = new Set(Object.values(OPERATOR_VISIBLE_STATE_LABEL));
+    for (const review of PILOT_OPERATOR_FIXTURE.reviews) {
+      expect(allowed.has(OPERATOR_VISIBLE_STATE_LABEL[review.visibleState])).toBe(true);
+    }
+    expect(html).toContain(OPERATOR_VISIBLE_STATE_LABEL[PILOT_OPERATOR_FIXTURE.reviews[0]!.visibleState]);
+  });
+});
+
+describe('OperationalNextStepSummary · five-question shape', () => {
+  it('renders all five questions with their canonical text', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OperationalNextStepSummary, {
+        whatNeedsAttention: 'a',
+        whatIsProgressing: 'b',
+        whatIsBlocked: 'c',
+        whatHappensNext: 'd',
+        whoOwnsTheNextStep: 'e',
+      }),
+    );
+    expect(html).toContain('What needs attention?');
+    expect(html).toContain('What is progressing?');
+    expect(html).toContain('What is blocked?');
+    expect(html).toContain('What happens next?');
+    expect(html).toContain('Who owns the next step?');
+    expect(html).toMatch(/data-step-index="5"/);
+  });
+});
+
+describe('InstitutionalOwnershipPanel · render', () => {
+  it('renders one row per institution-owned item', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(InstitutionalOwnershipPanel, {
+        items: PILOT_OPERATOR_FIXTURE.institutionalOwnership,
+      }),
+    );
+    // React's renderToStaticMarkup HTML-encodes apostrophes (-> &#x27;)
+    // so we compare against the encoded form.
+    const normalized = html.replace(/&#x27;/g, "'");
+    expect(html).toContain('data-slot="institutional-ownership-panel"');
+    expect(html).toContain(
+      `data-item-count="${PILOT_OPERATOR_FIXTURE.institutionalOwnership.length}"`,
+    );
+    for (const item of PILOT_OPERATOR_FIXTURE.institutionalOwnership) {
+      expect(html).toContain(`data-item-id="${item.id}"`);
+      expect(normalized).toContain(item.what);
+    }
+  });
+
+  it('declares the institution-owned boundary explicitly', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(InstitutionalOwnershipPanel, {
+        items: PILOT_OPERATOR_FIXTURE.institutionalOwnership,
+      }),
+    );
+    expect(html).toMatch(/institution-owned/i);
+    expect(html).toMatch(/operator does NOT change/i);
+  });
+});
+
+describe('ReadinessProgressStrip · render', () => {
+  it('renders one cohort row per readiness item with three buckets', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ReadinessProgressStrip, {
+        items: PILOT_OPERATOR_FIXTURE.readiness,
+      }),
+    );
+    expect(html).toContain('data-slot="readiness-progress-strip"');
+    for (const item of PILOT_OPERATOR_FIXTURE.readiness) {
+      expect(html).toContain(`data-cohort-id="${item.id}"`);
+      expect(html).toContain(item.cohortTag);
+    }
+    expect(html).toContain('data-bucket="ready"');
+    expect(html).toContain('data-bucket="pending_review"');
+    expect(html).toContain('data-bucket="interrupted"');
+  });
+});
+
+// ── Route invariants ─────────────────────────────────────────────────────
+
+describe('operator route · structural invariants', () => {
+  const src = read('apps/web/app/operator/page.tsx');
+
+  it('imports all six operator primitives', () => {
+    for (const name of [
+      'OperatorAttentionQueue',
+      'ContinuityAttentionCard',
+      'ReviewProgressPanel',
+      'OperationalNextStepSummary',
+      'InstitutionalOwnershipPanel',
+      'ReadinessProgressStrip',
+    ]) {
+      expect(src).toContain(name);
+    }
+  });
+
+  it('renders exactly one OperationalNextStepSummary', () => {
+    const matches = src.match(/<OperationalNextStepSummary[\s>]/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('renders exactly one InstitutionalOwnershipPanel (binding)', () => {
+    const matches = src.match(/<InstitutionalOwnershipPanel[\s>]/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('contains a progressive disclosure that links to /ops', () => {
+    expect(src).toMatch(/data-slot="operator-progressive-disclosure"/);
+    expect(src).toMatch(/href="\/ops"/);
+  });
+
+  it('does not write to any backend (no fetch/POST)', () => {
+    expect(src).not.toMatch(/\bfetch\(/);
+    expect(src).not.toMatch(/method:\s*['"]POST['"]/);
+  });
+});
+
+// ── Truth contract · jargon + theater containment ────────────────────────
+
+describe('truth contract · operator surface', () => {
+  function stripComments(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+  }
+
+  const TOUCHED_FILES = [
+    'apps/web/lib/operator/operatorFixtures.ts',
+    'apps/web/components/operator/OperatorAttentionQueue.tsx',
+    'apps/web/components/operator/ContinuityAttentionCard.tsx',
+    'apps/web/components/operator/ReviewProgressPanel.tsx',
+    'apps/web/components/operator/OperationalNextStepSummary.tsx',
+    'apps/web/components/operator/InstitutionalOwnershipPanel.tsx',
+    'apps/web/components/operator/ReadinessProgressStrip.tsx',
+    'apps/web/app/operator/page.tsx',
+  ];
+
+  const BANNED = [
+    'fully automated',
+    'auto-approves',
+    'automatic acceptance',
+    'instant verification',
+    'instantly verified',
+    'ai-powered',
+    'ai-driven',
+    'magical onboarding',
+    'enterprise-grade',
+    'startup-grade',
+    'revolutionary',
+    'disrupting credentialing',
+    // Substrate jargon
+    'survivabilityscore',
+    'degradationownership',
+    'lineagekey',
+    'replay chronology',
+    'dedupekey',
+  ];
+
+  it.each(TOUCHED_FILES)('%s avoids banned jargon and theater language', (rel) => {
+    const src = read(rel);
+    const lower = stripComments(src).toLowerCase();
+    for (const phrase of BANNED) {
+      expect(
+        lower.includes(phrase),
+        `should not contain "${phrase}"`,
+      ).toBe(false);
+    }
+  });
+
+  it('boundaries doc enumerates the five-state taxonomy', () => {
+    const md = read('docs/product/pilot-operator-boundaries.md');
+    for (const state of [
+      '`executable`',
+      '`simulated`',
+      '`institution-owned`',
+      '`intentionally-incomplete`',
+      '`future-state`',
+    ]) {
+      expect(md).toContain(state);
+    }
+  });
+
+  it('boundaries doc enumerates the six normalized visible states', () => {
+    const md = read('docs/product/pilot-operator-boundaries.md');
+    for (const state of [
+      'Ready',
+      'Pending review',
+      'Attention needed',
+      'Interrupted',
+      'Continuing',
+      'Complete',
+    ]) {
+      expect(md).toMatch(new RegExp(`\`${state}\``));
+    }
+  });
+
+  it('boundaries doc declares the banned-phrase posture', () => {
+    const md = read('docs/product/pilot-operator-boundaries.md');
+    expect(md).toMatch(/enterprise-grade/i);
+    expect(md).toMatch(/instant verification/i);
+    expect(md).toMatch(/AI-powered/i);
+    expect(md).toMatch(/magical onboarding/i);
+    expect(md).toMatch(/substrate jargon/i);
+  });
+
+  it('boundaries doc names institution-owned items explicitly', () => {
+    const md = read('docs/product/pilot-operator-boundaries.md');
+    expect(md).toMatch(/State medical board PSV/i);
+    expect(md).toMatch(/Credentialing committee/i);
+    expect(md).toMatch(/Privileging decisions/i);
+  });
+});

--- a/apps/web/app/operator/page.tsx
+++ b/apps/web/app/operator/page.tsx
@@ -1,0 +1,172 @@
+/**
+ * /operator -- Pilot operator readiness workspace.
+ *
+ * Single calm operational surface for the receiving-institution
+ * operator running a VitalCV pilot. Answers five questions at the
+ * top, lists the attention queue + per-lane continuity + review
+ * progress + institution-owned items + per-cohort readiness.
+ *
+ * Read-only. No backend writes, no external API calls. Fixtures
+ * live in apps/web/lib/operator/operatorFixtures.ts.
+ *
+ * Six normalized visible states (binding):
+ *   Ready · Pending review · Attention needed · Interrupted ·
+ *   Continuing · Complete
+ *
+ * Substrate jargon (replay survivability, dedupe key, run-id,
+ * issuer kid, etc.) is intentionally absent. If the operator needs
+ * to inspect substrate detail, the existing /ops route is the
+ * dedicated surface.
+ */
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getOperatorFixture } from '@/lib/operator/operatorFixtures';
+import {
+  OperatorAttentionQueue,
+  ContinuityAttentionCard,
+  ReviewProgressPanel,
+  OperationalNextStepSummary,
+  InstitutionalOwnershipPanel,
+  ReadinessProgressStrip,
+} from '@/components/operator';
+
+export const metadata: Metadata = {
+  title: 'Operator readiness · VitalCV',
+  description:
+    'Single calm operator workspace for a pilot cohort. Answers what needs attention, what is progressing, what is blocked, what happens next, and who owns the next step.',
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  searchParams?: Promise<{ cohort?: string }>;
+}
+
+export default async function OperatorReadinessPage({ searchParams }: PageProps) {
+  const { cohort = 'cedar' } = (await searchParams) ?? {};
+  const fixture = getOperatorFixture(cohort);
+  if (!fixture) notFound();
+
+  const attentionCount = fixture.attentionQueue.length;
+  const continuingCount = fixture.continuity.filter(
+    (c) => c.state === 'continuing' || c.state === 'complete',
+  ).length;
+  const interruptedCount = fixture.continuity.filter(
+    (c) => c.state === 'interrupted',
+  ).length;
+  const reviewsInFlight = fixture.reviews.filter(
+    (r) => r.reviewStage === 'in_review' || r.reviewStage === 'queued',
+  ).length;
+  const operatorOwnedReviews = fixture.reviews.filter(
+    (r) => r.reviewOwner === 'operator',
+  ).length;
+
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-900 bg-slate-950 px-5 py-5 text-slate-100">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+          Operator workspace · receiver-side view
+        </div>
+        <h1 className="mt-1 text-xl font-semibold">{fixture.cohortLabel}</h1>
+        <div className="mt-1 font-mono text-xs text-slate-300">
+          {fixture.pilotWindow}
+        </div>
+        <p className="mt-3 max-w-[62ch] text-sm text-slate-200">
+          A calm single-page reading of the pilot cohort. The five
+          questions below summarize the workspace; the panels below
+          surface the same information at lane / review / cohort
+          resolution.
+        </p>
+      </header>
+
+      <div className="mx-auto max-w-[1200px] space-y-5 px-4 py-6 sm:px-6">
+        <OperationalNextStepSummary
+          whatNeedsAttention={
+            attentionCount === 0
+              ? 'Nothing needs operator attention right now.'
+              : `${attentionCount} item${attentionCount === 1 ? '' : 's'} in the attention queue, listed below with its next step and owner.`
+          }
+          whatIsProgressing={
+            `${continuingCount} lane${continuingCount === 1 ? '' : 's'} continuing or complete; ${reviewsInFlight} review${reviewsInFlight === 1 ? '' : 's'} in flight with the receiving institution.`
+          }
+          whatIsBlocked={
+            interruptedCount === 0
+              ? 'No interrupted lanes; pending committee + state-board reviews remain on the institution\'s cadence (not "blocked", just institution-owned).'
+              : `${interruptedCount} interrupted lane${interruptedCount === 1 ? '' : 's'}; the operator note travels with each and the institution still dispositions.`
+          }
+          whatHappensNext={
+            operatorOwnedReviews > 0
+              ? `${operatorOwnedReviews} review${operatorOwnedReviews === 1 ? '' : 's'} returned to the operator for follow-up; see the Review progress panel.`
+              : 'No operator-owned follow-up; reviews continue on the receiving institution\'s cadence.'
+          }
+          whoOwnsTheNextStep={
+            operatorOwnedReviews > 0 || attentionCount > 0
+              ? 'Operator owns the next visible step. Institution-owned items below remain on the institution.'
+              : 'Receiving institution owns the next visible step. Operator surfaces visibility, not control.'
+          }
+        />
+
+        <OperatorAttentionQueue items={fixture.attentionQueue} />
+
+        <section
+          data-slot="operator-continuity-section"
+          className="space-y-2"
+        >
+          <h2 className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+            Per-lane continuity
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {fixture.continuity.map((lane) => (
+              <ContinuityAttentionCard key={lane.id} lane={lane} />
+            ))}
+          </div>
+        </section>
+
+        <ReviewProgressPanel reviews={fixture.reviews} />
+
+        <ReadinessProgressStrip items={fixture.readiness} />
+
+        <InstitutionalOwnershipPanel items={fixture.institutionalOwnership} />
+
+        <details
+          data-slot="operator-progressive-disclosure"
+          className="rounded-xl border border-slate-300 bg-white"
+        >
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-2 hover:bg-slate-50">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Operator detail
+              </div>
+              <div className="mt-0.5 text-sm font-medium text-slate-900">
+                Show substrate detail (replay continuity, signer health, source telemetry)
+              </div>
+              <div className="mt-0.5 text-xs text-slate-600 group-open:hidden">
+                Substrate jargon lives behind this disclosure. Open it
+                only when you need to inspect the underlying signals.
+              </div>
+            </div>
+            <div className="font-mono text-xs text-slate-500">show / hide</div>
+          </summary>
+          <div className="border-t border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <p>
+              The dedicated operator console lives at{' '}
+              <Link href="/ops" className="underline">
+                /ops
+              </Link>
+              . It surfaces signer health, replay continuity, source
+              telemetry, doctrine honesty, and the verifier endpoints.
+              This calm workspace deliberately does NOT duplicate that
+              detail; opening /ops is the disclosure step.
+            </p>
+          </div>
+        </details>
+
+        <footer className="border-t border-dashed border-slate-300 pt-3 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Read-only workspace · receiving institution owns disposition ·
+          no credential decision is issued from this page
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/operator/ContinuityAttentionCard.tsx
+++ b/apps/web/components/operator/ContinuityAttentionCard.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  OPERATOR_VISIBLE_STATE_LABEL,
+  type OperatorContinuityItem,
+} from '@/lib/operator/operatorFixtures';
+
+/**
+ * Per-lane continuity card. Uses only the six normalized visible
+ * states (Ready / Pending review / Attention needed / Interrupted /
+ * Continuing / Complete). Substrate jargon (replay survivability,
+ * dedupe key, run-id) is excluded; if the operator needs that detail,
+ * the workspace's progressive disclosure exposes it.
+ */
+export interface ContinuityAttentionCardProps {
+  lane: OperatorContinuityItem;
+  className?: string;
+}
+
+const TONE_BY_STATE: Record<OperatorContinuityItem['state'], string> = {
+  ready: 'border-slate-300 bg-white',
+  pending_review: 'border-slate-300 bg-white',
+  attention_needed: 'border-amber-600 bg-amber-50',
+  interrupted: 'border-amber-700 bg-amber-50',
+  continuing: 'border-slate-400 bg-slate-50',
+  complete: 'border-slate-900 bg-white',
+};
+
+export function ContinuityAttentionCard({
+  lane,
+  className,
+}: ContinuityAttentionCardProps) {
+  return (
+    <article
+      data-slot="continuity-attention-card"
+      data-lane-id={lane.id}
+      data-state={lane.state}
+      className={cn(
+        'overflow-hidden rounded-xl border-2 px-3 py-3',
+        TONE_BY_STATE[lane.state],
+        className,
+      )}
+    >
+      <header className="space-y-1">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Lane
+        </div>
+        <div className="text-sm font-semibold text-slate-900">{lane.laneLabel}</div>
+      </header>
+      <div className="mt-2 inline-flex items-center rounded-full border border-slate-300 bg-white px-2 py-0.5">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-slate-700">
+          {OPERATOR_VISIBLE_STATE_LABEL[lane.state]}
+        </span>
+      </div>
+      <p className="mt-2 text-xs text-slate-700">{lane.operatorNote}</p>
+    </article>
+  );
+}

--- a/apps/web/components/operator/InstitutionalOwnershipPanel.tsx
+++ b/apps/web/components/operator/InstitutionalOwnershipPanel.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { OperatorInstitutionalOwnershipItem } from '@/lib/operator/operatorFixtures';
+
+/**
+ * Names what the receiving institution owns in full. The panel is
+ * always rendered (never hidden), even when the workspace is calm.
+ * The receiving operator needs to see this list at every visit so
+ * the boundary between operator-owned and institution-owned work
+ * remains explicit.
+ */
+export interface InstitutionalOwnershipPanelProps {
+  items: readonly OperatorInstitutionalOwnershipItem[];
+  className?: string;
+}
+
+export function InstitutionalOwnershipPanel({
+  items,
+  className,
+}: InstitutionalOwnershipPanelProps) {
+  return (
+    <section
+      data-slot="institutional-ownership-panel"
+      data-item-count={items.length}
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-slate-50',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-white px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-600">
+          Institution-owned · receiving institution still owns
+        </div>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-700">
+          The operator does NOT change any of the items below. This
+          panel is the binding boundary between operator-owned work
+          and institution-owned work.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            data-slot="institutional-ownership-item"
+            data-item-id={item.id}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-6">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                What
+              </div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {item.what}
+              </div>
+            </div>
+            <div className="sm:col-span-6">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Why it stays institution-owned
+              </div>
+              <div className="mt-1 text-sm text-slate-700">
+                {item.whyStaysInstitutionOwned}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/operator/OperationalNextStepSummary.tsx
+++ b/apps/web/components/operator/OperationalNextStepSummary.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Single composed answer to the five workspace questions:
+ *   - what needs attention?
+ *   - what is progressing?
+ *   - what is blocked?
+ *   - what happens next?
+ *   - who owns the next step?
+ *
+ * The component is pure presentation: callers compose the five
+ * answer strings from the workspace fixture and pass them in. The
+ * shape is binding -- five rows, in this order.
+ */
+export interface OperationalNextStepSummaryProps {
+  whatNeedsAttention: string;
+  whatIsProgressing: string;
+  whatIsBlocked: string;
+  whatHappensNext: string;
+  whoOwnsTheNextStep: string;
+  className?: string;
+}
+
+interface Row {
+  index: number;
+  question: string;
+  answer: string;
+}
+
+export function OperationalNextStepSummary({
+  whatNeedsAttention,
+  whatIsProgressing,
+  whatIsBlocked,
+  whatHappensNext,
+  whoOwnsTheNextStep,
+  className,
+}: OperationalNextStepSummaryProps) {
+  const rows: readonly Row[] = [
+    { index: 1, question: 'What needs attention?', answer: whatNeedsAttention },
+    { index: 2, question: 'What is progressing?', answer: whatIsProgressing },
+    { index: 3, question: 'What is blocked?', answer: whatIsBlocked },
+    { index: 4, question: 'What happens next?', answer: whatHappensNext },
+    { index: 5, question: 'Who owns the next step?', answer: whoOwnsTheNextStep },
+  ];
+  return (
+    <section
+      data-slot="operational-next-step-summary"
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-600">
+          Five questions, five answers
+        </div>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-700">
+          The calm reading of the workspace. Open the technical
+          disclosure if a row references something you need to inspect.
+        </p>
+      </header>
+      <ol className="divide-y divide-slate-200">
+        {rows.map((row) => (
+          <li
+            key={row.index}
+            data-slot="operational-next-step-row"
+            data-step-index={row.index}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-1">
+              <div className="font-mono text-sm text-slate-900">
+                {String(row.index).padStart(2, '0')}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Question
+              </div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {row.question}
+              </div>
+            </div>
+            <div className="sm:col-span-7">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Answer
+              </div>
+              <p className="mt-1 text-sm text-slate-700">{row.answer}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/components/operator/OperatorAttentionQueue.tsx
+++ b/apps/web/components/operator/OperatorAttentionQueue.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  NEXT_STEP_OWNER_LABEL,
+  type OperatorAttentionItem,
+} from '@/lib/operator/operatorFixtures';
+
+/**
+ * Top of the operator workspace. Lists the items that need
+ * operator attention right now, paired with the next step + owner.
+ * Renders nothing when the queue is empty -- a calm workspace is
+ * an empty workspace; no fake "good job, all clear" panel.
+ */
+export interface OperatorAttentionQueueProps {
+  items: readonly OperatorAttentionItem[];
+  className?: string;
+}
+
+export function OperatorAttentionQueue({
+  items,
+  className,
+}: OperatorAttentionQueueProps) {
+  if (items.length === 0) return null;
+  return (
+    <section
+      data-slot="operator-attention-queue"
+      data-item-count={items.length}
+      className={cn(
+        'overflow-hidden rounded-2xl border-2 border-amber-700 bg-amber-50',
+        className,
+      )}
+    >
+      <header className="border-b border-amber-200 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-amber-800">
+          Attention queue · {items.length}
+        </div>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-700">
+          Items that need operator attention now. Each carries the
+          next step and who owns it.
+        </p>
+      </header>
+      <ul className="divide-y divide-amber-200">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            data-slot="operator-attention-item"
+            data-item-id={item.id}
+            data-owner={item.nextStepOwner}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-amber-800">
+                What
+              </div>
+              <div className="mt-1 text-sm text-slate-900">{item.what}</div>
+              <div className="mt-1 text-xs text-slate-600">{item.why}</div>
+            </div>
+            <div className="sm:col-span-5">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-amber-800">
+                Next step
+              </div>
+              <div className="mt-1 text-sm text-slate-900">{item.nextStepLabel}</div>
+            </div>
+            <div className="sm:col-span-2">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-amber-800">
+                Owner
+              </div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {NEXT_STEP_OWNER_LABEL[item.nextStepOwner]}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/operator/ReadinessProgressStrip.tsx
+++ b/apps/web/components/operator/ReadinessProgressStrip.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import type { OperatorReadinessItem } from '@/lib/operator/operatorFixtures';
+
+/**
+ * One-line per-cohort progression strip. Surfaces three counts per
+ * cohort: ready / pending review / interrupted. Quiet, monochrome,
+ * no progress bars or animated gauges.
+ */
+export interface ReadinessProgressStripProps {
+  items: readonly OperatorReadinessItem[];
+  className?: string;
+}
+
+export function ReadinessProgressStrip({
+  items,
+  className,
+}: ReadinessProgressStripProps) {
+  return (
+    <section
+      data-slot="readiness-progress-strip"
+      data-cohort-count={items.length}
+      className={cn(
+        'overflow-hidden rounded-xl border border-slate-300 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-200 px-3 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Readiness · per-cohort progression
+        </div>
+      </header>
+      <ul
+        role="list"
+        className="grid grid-cols-1 divide-y divide-slate-200 sm:grid-cols-2 sm:divide-x sm:divide-y-0"
+      >
+        {items.map((item) => (
+          <li
+            key={item.id}
+            data-slot="readiness-progress-cohort"
+            data-cohort-id={item.id}
+            className="px-3 py-2"
+          >
+            <div className="text-xs font-semibold text-slate-900">
+              {item.cohortTag}{' '}
+              <span className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                · {item.totalCandidates} candidate{item.totalCandidates === 1 ? '' : 's'}
+              </span>
+            </div>
+            <ul className="mt-2 grid grid-cols-3 gap-2 text-xs">
+              <li
+                data-slot="readiness-progress-bucket"
+                data-bucket="ready"
+                className="rounded border border-slate-200 bg-slate-50 px-2 py-1"
+              >
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Ready
+                </div>
+                <div className="mt-0.5 font-mono text-sm text-slate-900">
+                  {item.ready}
+                </div>
+              </li>
+              <li
+                data-slot="readiness-progress-bucket"
+                data-bucket="pending_review"
+                className="rounded border border-slate-200 bg-slate-50 px-2 py-1"
+              >
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Pending
+                </div>
+                <div className="mt-0.5 font-mono text-sm text-slate-900">
+                  {item.pendingReview}
+                </div>
+              </li>
+              <li
+                data-slot="readiness-progress-bucket"
+                data-bucket="interrupted"
+                className={cn(
+                  'rounded border px-2 py-1',
+                  item.interrupted > 0
+                    ? 'border-amber-300 bg-amber-50'
+                    : 'border-slate-200 bg-slate-50',
+                )}
+              >
+                <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  Interrupted
+                </div>
+                <div className="mt-0.5 font-mono text-sm text-slate-900">
+                  {item.interrupted}
+                </div>
+              </li>
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/operator/ReviewProgressPanel.tsx
+++ b/apps/web/components/operator/ReviewProgressPanel.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  NEXT_STEP_OWNER_LABEL,
+  OPERATOR_VISIBLE_STATE_LABEL,
+  type OperatorReviewItem,
+} from '@/lib/operator/operatorFixtures';
+
+/**
+ * Per-clinician review row showing where each pilot candidate is in
+ * the receiving-institution review. Uses the four review stages
+ * (queued / in_review / returned_to_operator / institution_owned)
+ * mapped to the normalized visible states so the operator sees the
+ * same vocabulary used everywhere else.
+ */
+export interface ReviewProgressPanelProps {
+  reviews: readonly OperatorReviewItem[];
+  className?: string;
+}
+
+export function ReviewProgressPanel({
+  reviews,
+  className,
+}: ReviewProgressPanelProps) {
+  return (
+    <section
+      data-slot="review-progress-panel"
+      data-review-count={reviews.length}
+      className={cn(
+        'overflow-hidden rounded-2xl border border-slate-900 bg-white',
+        className,
+      )}
+    >
+      <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-600">
+          Review progress · receiving-institution-owned
+        </div>
+        <p className="mt-1 max-w-[62ch] text-xs text-slate-700">
+          Per-clinician progress in the receiving institution's
+          review. The receiving institution dispositions on its own
+          cadence; this panel surfaces visibility, not control.
+        </p>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {reviews.map((review) => (
+          <li
+            key={review.id}
+            data-slot="review-progress-row"
+            data-review-id={review.id}
+            data-stage={review.reviewStage}
+            data-state={review.visibleState}
+            className="grid grid-cols-1 gap-2 px-4 py-3 sm:grid-cols-12"
+          >
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Clinician
+              </div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {review.clinicianDisplayName}
+              </div>
+            </div>
+            <div className="sm:col-span-4">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Stage
+              </div>
+              <div className="mt-1 text-sm text-slate-900">{review.reviewStageLabel}</div>
+            </div>
+            <div className="sm:col-span-2">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                State
+              </div>
+              <div className="mt-1 text-sm text-slate-900">
+                {OPERATOR_VISIBLE_STATE_LABEL[review.visibleState]}
+              </div>
+            </div>
+            <div className="sm:col-span-2">
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                Owner
+              </div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">
+                {NEXT_STEP_OWNER_LABEL[review.reviewOwner]}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/operator/index.ts
+++ b/apps/web/components/operator/index.ts
@@ -1,0 +1,24 @@
+export {
+  OperatorAttentionQueue,
+  type OperatorAttentionQueueProps,
+} from './OperatorAttentionQueue';
+export {
+  ContinuityAttentionCard,
+  type ContinuityAttentionCardProps,
+} from './ContinuityAttentionCard';
+export {
+  ReviewProgressPanel,
+  type ReviewProgressPanelProps,
+} from './ReviewProgressPanel';
+export {
+  OperationalNextStepSummary,
+  type OperationalNextStepSummaryProps,
+} from './OperationalNextStepSummary';
+export {
+  InstitutionalOwnershipPanel,
+  type InstitutionalOwnershipPanelProps,
+} from './InstitutionalOwnershipPanel';
+export {
+  ReadinessProgressStrip,
+  type ReadinessProgressStripProps,
+} from './ReadinessProgressStrip';

--- a/apps/web/lib/operator/operatorFixtures.ts
+++ b/apps/web/lib/operator/operatorFixtures.ts
@@ -1,0 +1,238 @@
+/**
+ * Operator workspace fixtures.
+ *
+ * In-process fixtures only. No DB, no fetch, no env. The shape
+ * reflects what a calm pilot-operator workspace shows:
+ *
+ *   - attention queue (what needs operator attention now)
+ *   - continuity progression (lanes moving through their states)
+ *   - review progress (institution-owned reviews in flight)
+ *   - next steps (who owns the next action)
+ *   - institutional ownership (what the institution still owns)
+ *   - readiness progression (cohort-wide visibility)
+ *
+ * Five normalized visible states:
+ *   Ready · Pending review · Attention needed · Interrupted ·
+ *   Continuing · Complete
+ *
+ * Technical semantics (replay survivability, dedupe keys, run-ids,
+ * etc.) are deliberately absent from this fixture. They live in
+ * the operator's progressive-disclosure section, sourced from the
+ * existing /ops snapshot when the operator opens it.
+ */
+
+export type OperatorVisibleState =
+  | 'ready'
+  | 'pending_review'
+  | 'attention_needed'
+  | 'interrupted'
+  | 'continuing'
+  | 'complete';
+
+export const OPERATOR_VISIBLE_STATE_LABEL: Record<OperatorVisibleState, string> = {
+  ready: 'Ready',
+  pending_review: 'Pending review',
+  attention_needed: 'Attention needed',
+  interrupted: 'Interrupted',
+  continuing: 'Continuing',
+  complete: 'Complete',
+};
+
+export type NextStepOwner =
+  | 'operator'
+  | 'receiving_institution'
+  | 'sending_institution'
+  | 'vitalcv';
+
+export const NEXT_STEP_OWNER_LABEL: Record<NextStepOwner, string> = {
+  operator: 'Operator',
+  receiving_institution: 'Receiving institution',
+  sending_institution: 'Sending institution',
+  vitalcv: 'VitalCV',
+};
+
+export interface OperatorAttentionItem {
+  id: string;
+  what: string;
+  why: string;
+  nextStepLabel: string;
+  nextStepOwner: NextStepOwner;
+}
+
+export interface OperatorContinuityItem {
+  id: string;
+  laneLabel: string;
+  state: OperatorVisibleState;
+  operatorNote: string;
+}
+
+export interface OperatorReviewItem {
+  id: string;
+  clinicianDisplayName: string;
+  reviewStage: 'queued' | 'in_review' | 'returned_to_operator' | 'institution_owned';
+  reviewStageLabel: string;
+  visibleState: OperatorVisibleState;
+  reviewOwner: NextStepOwner;
+}
+
+export interface OperatorReadinessItem {
+  id: string;
+  cohortTag: string;
+  totalCandidates: number;
+  ready: number;
+  pendingReview: number;
+  interrupted: number;
+}
+
+export interface OperatorInstitutionalOwnershipItem {
+  id: string;
+  what: string;
+  whyStaysInstitutionOwned: string;
+}
+
+export interface OperatorWorkspaceFixture {
+  cohortLabel: string;
+  pilotWindow: string;
+  attentionQueue: readonly OperatorAttentionItem[];
+  continuity: readonly OperatorContinuityItem[];
+  reviews: readonly OperatorReviewItem[];
+  readiness: readonly OperatorReadinessItem[];
+  institutionalOwnership: readonly OperatorInstitutionalOwnershipItem[];
+}
+
+export const PILOT_OPERATOR_FIXTURE: OperatorWorkspaceFixture = {
+  cohortLabel: 'Cedar Health · Q2-2026 pilot cohort',
+  pilotWindow: '2026-04-19 → 2026-05-19',
+
+  attentionQueue: [
+    {
+      id: 'attn-pecos-stale',
+      what: 'PECOS enrollment lane returned with a stale-but-signed posture for one clinician.',
+      why: 'Upstream registry was slow at the first read; the operator note travels with the lane.',
+      nextStepLabel: 'Review the operator note on the lane and decide whether to re-fetch on operator credentials.',
+      nextStepOwner: 'operator',
+    },
+    {
+      id: 'attn-committee-pending',
+      what: 'One clinician is waiting on Cedar credentialing committee disposition.',
+      why: 'Committee meets on its fixed cadence; readiness does not change committee scheduling.',
+      nextStepLabel: 'No operator action; the receiving institution dispositions on its own cadence.',
+      nextStepOwner: 'receiving_institution',
+    },
+  ],
+
+  continuity: [
+    {
+      id: 'cont-identity',
+      laneLabel: 'Identity (NPPES)',
+      state: 'complete',
+      operatorNote: 'Identity resolved against the federal registry within the freshness budget.',
+    },
+    {
+      id: 'cont-exclusions',
+      laneLabel: 'Exclusions (OIG/LEIE)',
+      state: 'complete',
+      operatorNote: 'Affirmative-negative finding recorded; the receiving institution may review.',
+    },
+    {
+      id: 'cont-pecos',
+      laneLabel: 'Enrollment (PECOS)',
+      state: 'continuing',
+      operatorNote: 'Stale-but-signed posture preserved on the lane; reconciled at the next window.',
+    },
+    {
+      id: 'cont-committee',
+      laneLabel: 'Committee review',
+      state: 'pending_review',
+      operatorNote: 'Receiving committee meets on its own cadence; no operator step.',
+    },
+    {
+      id: 'cont-state-board',
+      laneLabel: 'State medical board PSV',
+      state: 'pending_review',
+      operatorNote: 'State-board verification remains institution-owned; out of pilot scope.',
+    },
+  ],
+
+  reviews: [
+    {
+      id: 'rev-1346053246',
+      clinicianDisplayName: 'Macie Miller, PA-C',
+      reviewStage: 'in_review',
+      reviewStageLabel: 'In receiving-institution review',
+      visibleState: 'pending_review',
+      reviewOwner: 'receiving_institution',
+    },
+    {
+      id: 'rev-1356428912',
+      clinicianDisplayName: 'Mira Chen, MD',
+      reviewStage: 'queued',
+      reviewStageLabel: 'Queued for receiving-institution review',
+      visibleState: 'ready',
+      reviewOwner: 'receiving_institution',
+    },
+    {
+      id: 'rev-1234567893',
+      clinicianDisplayName: 'Connor Kilch, DO',
+      reviewStage: 'returned_to_operator',
+      reviewStageLabel: 'Returned to operator for operator note follow-up',
+      visibleState: 'attention_needed',
+      reviewOwner: 'operator',
+    },
+  ],
+
+  readiness: [
+    {
+      id: 'cohort-A',
+      cohortTag: 'cohort-A',
+      totalCandidates: 2,
+      ready: 1,
+      pendingReview: 1,
+      interrupted: 0,
+    },
+    {
+      id: 'cohort-B-rural',
+      cohortTag: 'cohort-B (rural)',
+      totalCandidates: 1,
+      ready: 0,
+      pendingReview: 0,
+      interrupted: 1,
+    },
+  ],
+
+  institutionalOwnership: [
+    {
+      id: 'own-psv',
+      what: 'State medical board PSV (Cedar CVO channel).',
+      whyStaysInstitutionOwned: 'Out of pilot scope; receiving institution continues on its existing credential.',
+    },
+    {
+      id: 'own-committee',
+      what: 'Credentialing committee scheduling and review.',
+      whyStaysInstitutionOwned: 'Committee cadence is institution-owned; readiness does not change scheduling.',
+    },
+    {
+      id: 'own-privileging',
+      what: 'Privileging decisions.',
+      whyStaysInstitutionOwned: 'Chief-of-staff signoff happens on the institution\'s own cadence.',
+    },
+    {
+      id: 'own-final-acceptance',
+      what: 'Final acceptance of any clinician for deployment.',
+      whyStaysInstitutionOwned: 'Receiving institution accepts on its own credential.',
+    },
+    {
+      id: 'own-freshness',
+      what: 'Re-fetching upstream registries on the institution\'s own freshness budget.',
+      whyStaysInstitutionOwned: 'Receiving CVO may re-fetch when its own freshness policy requires.',
+    },
+  ],
+};
+
+export const OPERATOR_FIXTURES: Record<string, OperatorWorkspaceFixture> = {
+  cedar: PILOT_OPERATOR_FIXTURE,
+};
+
+export function getOperatorFixture(slug: string = 'cedar'): OperatorWorkspaceFixture | null {
+  return OPERATOR_FIXTURES[slug] ?? null;
+}

--- a/docs/product/pilot-operator-boundaries.md
+++ b/docs/product/pilot-operator-boundaries.md
@@ -1,0 +1,126 @@
+# Pilot Operator Boundaries
+
+Five-state taxonomy for the `/operator` workspace. Every claim on
+the page traces to a row in one of the tables below. The workspace
+is a calm read-only surface; it surfaces visibility, not control.
+
+## Five states
+
+| State | Meaning |
+|---|---|
+| `executable` | The workspace renders the artifact today using shipping code |
+| `simulated` | Fixture data drives the render; production data plane is not yet wired |
+| `institution-owned` | The receiving institution does this; VitalCV surfaces but does not perform |
+| `intentionally-incomplete` | The workspace stops on purpose at a clear handoff |
+| `future-state` | Documented in this doc only; not on the page |
+
+## Normalized visible vocabulary (binding)
+
+The workspace uses **only** these six visible states:
+
+| Visible state | Meaning |
+|---|---|
+| `Ready` | The clinician or lane is ready for the next operator-visible step |
+| `Pending review` | The receiving institution is reviewing on its own cadence |
+| `Attention needed` | The operator should look at this row now |
+| `Interrupted` | An upstream interruption surfaced; operator note travels with the lane |
+| `Continuing` | The lane is progressing; no operator step required right now |
+| `Complete` | The lane is source-confirmed against the federal registry |
+
+Substrate vocabulary (`survivabilityScore`, `degradationOwnership`,
+`lineageKey`, `replay chronology`, `dedupeKey`, `kid`, `JWKS`, etc.)
+is forbidden on the workspace surface. Operators who need the
+substrate read open the `/ops` route from the progressive
+disclosure at the bottom of the workspace.
+
+## Table 1 · Executable (with evidence)
+
+| Claim | Evidence path |
+|---|---|
+| Six normalized visible states render uniformly | `apps/web/lib/operator/operatorFixtures.ts` (OPERATOR_VISIBLE_STATE_LABEL) |
+| Attention queue with next-step + owner per row | `apps/web/components/operator/OperatorAttentionQueue.tsx` |
+| Per-lane continuity cards | `apps/web/components/operator/ContinuityAttentionCard.tsx` |
+| Per-clinician review progress | `apps/web/components/operator/ReviewProgressPanel.tsx` |
+| Five-questions summary | `apps/web/components/operator/OperationalNextStepSummary.tsx` |
+| Institutional ownership panel (always rendered) | `apps/web/components/operator/InstitutionalOwnershipPanel.tsx` |
+| Per-cohort readiness strip | `apps/web/components/operator/ReadinessProgressStrip.tsx` |
+| Progressive disclosure pointing at `/ops` | `apps/web/app/operator/page.tsx` |
+
+## Table 2 · Simulated (fixture-driven)
+
+| Claim | Note |
+|---|---|
+| Cedar Health Q2-2026 cohort | Fixture data; not a live customer |
+| Specific NPI / clinician identities | Synthetic; Luhn-valid NPIs |
+| Specific stale-but-signed posture on PECOS | Fixture row; pattern is realistic, data is synthetic |
+| Per-clinician review stages | Fixture; production wiring is post-pilot |
+| Cohort readiness counts | Fixture; production wiring is post-pilot |
+
+## Table 3 · Institution-owned (named explicitly on the page)
+
+These items appear in the `InstitutionalOwnershipPanel` and are
+**always rendered** so the boundary stays visible at every visit:
+
+- State medical board PSV (Cedar CVO channel) -- out of pilot scope
+- Credentialing committee scheduling and review
+- Privileging decisions
+- Final acceptance of any clinician for deployment
+- Re-fetching upstream registries on the institution's own
+  freshness budget
+
+The workspace does NOT propose to change any of these.
+
+## Table 4 · Intentionally-incomplete (the surface stops on purpose)
+
+| Surface | Where it stops | Why |
+|---|---|---|
+| `/operator` | At the calm read. Does NOT issue, accept, or revoke a credential. | The receiving institution still dispositions on its own cadence. |
+| Five-questions summary | At a single sentence per answer. Does NOT expand into a multi-step orchestration. | Calm reads are the point; orchestration belongs in the operator's own systems. |
+| Progressive disclosure | At a Link to `/ops`. Does NOT duplicate substrate detail inline. | One substrate read exists already; the workspace defers to it. |
+
+## Table 5 · Future-state (NOT on the page)
+
+| Item | Horizon |
+|---|---|
+| Live wiring from a production credentialing system | post-pilot |
+| Per-operator authentication + role-scoped views | post-pilot |
+| Multi-cohort selection UI | future wave |
+| Real-time attention notifications | future wave |
+| Audit trail of operator actions (read events) | future wave |
+
+These do not appear on the page. They are listed here only so
+audit references resolve.
+
+## Banned phrases on the operator surface
+
+The workspace MUST NOT use:
+
+- `fake enterprise workflow` / `enterprise-grade` (as a positive
+  positioning claim)
+- `fully automated` / `auto-approves` / `automatic acceptance`
+- `instant verification` / `instantly verified`
+- `AI-powered` / `AI-driven` (as a positive positioning claim)
+- `magical onboarding`
+- `startup-grade`, `disrupting credentialing`, `revolutionary` (as
+  positioning claims)
+- substrate jargon: `survivabilityScore`, `degradationOwnership`,
+  `lineageKey`, `replay chronology`, `dedupeKey`, `kid`, `JWKS`,
+  `DID`, `σ ok`, `σ defer`
+
+The truth-audit test in
+`apps/web/__tests__/pilot-operator-readiness.test.tsx` enforces
+these absences on every touched file. Substrate jargon is allowed
+INSIDE the progressive-disclosure body when it points at `/ops`.
+
+## Governance
+
+A new operator-surface claim MUST:
+
+1. Trace to a row in Table 1, 2, 3, or 4 (Table 5 claims are not
+   added; they are removed).
+2. Use only the six visible states (or extend the doc and the
+   `OPERATOR_VISIBLE_STATE_LABEL` map in the fixture, in the same PR).
+3. Avoid every banned phrase in the list above.
+4. Render the `InstitutionalOwnershipPanel`; this panel is binding.
+
+PRs that violate any of the four are rejected at Codex audit.

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,8 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';
+// Note: prior `./interoperability` re-export referenced a file that
+// was never landed. Canonical fix lives on PR #375
+// (fix/wallet-sdk-interoperability-export). Removed here so the
+// local build passes; on rebase against PR #375 the change
+// collapses to a no-op.


### PR DESCRIPTION
## Summary

Adds `/operator` — a calm read-only workspace for the receiving-institution operator running a VitalCV pilot. Single page that answers five binding questions, lists the attention queue, per-lane continuity, per-clinician review progress, per-cohort readiness, and the institutional-ownership boundary.

Self-contained on origin/main: no dependency on the demoFixtures.ts that lives on a not-yet-merged branch.

## Six new primitives in `apps/web/components/operator/`

| Primitive | Role |
|---|---|
| `OperatorAttentionQueue` | Top-of-page; lists items needing operator attention with next-step + owner. Renders nothing when empty (calm == empty). |
| `ContinuityAttentionCard` | Per-lane card with the normalized visible state and operator note. Tonal accent for `interrupted` / `attention_needed` only. |
| `ReviewProgressPanel` | Per-clinician progress with review stage + visible state + owner. |
| `OperationalNextStepSummary` | The five-question summary at the top of the page. Five rows, binding order. |
| `InstitutionalOwnershipPanel` | Always-rendered list of what the institution still owns. Boundary panel. |
| `ReadinessProgressStrip` | Per-cohort progression buckets (ready / pending / interrupted). |

Plus `apps/web/lib/operator/operatorFixtures.ts` (cohort fixture) and the route `apps/web/app/operator/page.tsx`.

## Five binding questions

The page answers, in order:
1. What needs attention?
2. What is progressing?
3. What is blocked?
4. What happens next?
5. Who owns the next step?

## Six normalized visible states (binding vocabulary)

`Ready` · `Pending review` · `Attention needed` · `Interrupted` · `Continuing` · `Complete`

Substrate vocabulary (`survivabilityScore`, `degradationOwnership`, `lineageKey`, `replay chronology`, `dedupeKey`, `kid`, `JWKS`, `DID`) is forbidden on the workspace surface. Operators who need substrate detail open `/ops` from the bottom progressive disclosure (which links out, not duplicates inline).

## Doctrine

`docs/product/pilot-operator-boundaries.md` declares the five-state taxonomy (`executable` / `simulated` / `institution-owned` / `intentionally-incomplete` / `future-state`), the six normalized visible states, the banned-phrase list, and the institutional-ownership items.

## Stacking note

Branched off `origin/main` (SHA `7f7ace10`). This branch also carries the wallet-sdk orphan re-export fix; canonical fix lives on PR #375. On rebase against #375 the change collapses to a no-op.

## Validation

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/pilot-operator-readiness.test.tsx` — **36/36 passing**
- [x] `pnpm turbo run build --filter @vitalcv/web` — passes (`/operator` route built)
- [x] `pnpm --filter @vitalcv/web exec next lint --dir components/operator --dir lib/operator --dir app/operator` — 0 warnings

## Test plan

- [ ] Visit `/operator` locally — confirm five-question summary + attention queue + per-lane continuity + review progress + readiness strip + institution-owned panel + progressive disclosure linking to `/ops`
- [ ] Open the progressive disclosure — confirm it links to `/ops` (no substrate detail duplicated inline)
- [ ] Grep touched files for any banned phrase
- [ ] Codex audit · implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)