### PR TITLE
fix(product): enforce canonical live product flow

### DIFF
--- a/apps/web/__tests__/canonical-product-flow.test.ts
+++ b/apps/web/__tests__/canonical-product-flow.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+}).trim();
+
+function read(rel: string): string {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+function runVerifier(args: string[]): { code: number; output: string } {
+  try {
+    const output = execSync(
+      `node --experimental-strip-types scripts/verify-canonical-flow.ts ${args.join(' ')}`,
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    return { code: 0, output };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const stdout =
+      typeof e.stdout === 'string'
+        ? e.stdout
+        : Buffer.isBuffer(e.stdout)
+          ? e.stdout.toString('utf8')
+          : '';
+    const stderr =
+      typeof e.stderr === 'string'
+        ? e.stderr
+        : Buffer.isBuffer(e.stderr)
+          ? e.stderr.toString('utf8')
+          : '';
+    return { code: e.status ?? 1, output: stdout + stderr };
+  }
+}
+
+const VERIFIER_TIMEOUT_MS = 30_000;
+
+// ── File presence ────────────────────────────────────────────────────────
+
+describe('canonical-product-flow · file presence', () => {
+  it.each([
+    'apps/web/app/get-ready/page.tsx',
+    'apps/web/app/page.tsx',
+    'apps/web/app/passport/page.tsx',
+    'apps/web/app/review/page.tsx',
+    'apps/web/app/status/page.tsx',
+    'apps/web/components/layout/Navbar.tsx',
+    'docs/product/canonical-product-flow.md',
+    'scripts/verify-canonical-flow.ts',
+  ])('%s exists', (rel) => {
+    expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
+  });
+});
+
+// ── Get Ready landing shape ──────────────────────────────────────────────
+
+describe('/get-ready landing', () => {
+  const src = read('apps/web/app/get-ready/page.tsx');
+
+  it('carries the canonical Step 1 framing', () => {
+    expect(src).toMatch(/Step 1 of the canonical flow/i);
+    expect(src).toMatch(/Get ready/i);
+  });
+
+  it('contains exactly one primary action linking to /passport', () => {
+    const matches = src.match(/href="\/passport"/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(src).toMatch(/Continue to your passport/i);
+  });
+
+  it('declares the institution-owned boundary explicitly', () => {
+    expect(src).toMatch(/institution-owned/i);
+    expect(src).toMatch(/State medical board/i);
+    expect(src).toMatch(/Credentialing committee/i);
+    expect(src).toMatch(/Privileging/i);
+  });
+
+  it('does not write to any backend (no fetch/POST)', () => {
+    expect(src).not.toMatch(/\bfetch\(/);
+    expect(src).not.toMatch(/method:\s*['"]POST['"]/);
+  });
+});
+
+// ── Navbar shape ─────────────────────────────────────────────────────────
+
+describe('Navbar canonical shape', () => {
+  const src = read('apps/web/components/layout/Navbar.tsx');
+
+  it('exposes exactly five NAV_ITEMS entries in canonical order', () => {
+    const m = src.match(/const\s+NAV_ITEMS\s*=\s*\[([\s\S]*?)\]\s*as\s+const/);
+    expect(m).not.toBeNull();
+    const body = m![1];
+    const items: Array<{ href: string; label: string }> = [];
+    const re = /\{\s*href:\s*['"]([^'"]+)['"]\s*,\s*label:\s*['"]([^'"]+)['"]\s*\}/g;
+    for (const it of body.matchAll(re)) {
+      items.push({ href: it[1], label: it[2] });
+    }
+    expect(items.length).toBe(5);
+    expect(items).toEqual([
+      { href: '/', label: 'Home' },
+      { href: '/get-ready', label: 'Get Ready' },
+      { href: '/passport', label: 'Passport' },
+      { href: '/review', label: 'Review' },
+      { href: '/status', label: 'Status' },
+    ]);
+  });
+
+  it('does NOT expose fragmented topology in NAV_ITEMS', () => {
+    const m = src.match(/const\s+NAV_ITEMS\s*=\s*\[([\s\S]*?)\]\s*as\s+const/);
+    const body = m![1];
+    for (const forbidden of [
+      '/trust',
+      '/doctrine',
+      '/investigate',
+      '/autopilot',
+      '/inbox',
+      '/dossier',
+      '/graph',
+      '/findings',
+      '/issuer',
+      '/calibration',
+      '/system-health',
+      '/mission-ops',
+      '/intelligence',
+    ]) {
+      expect(body).not.toContain(`href: '${forbidden}'`);
+      expect(body).not.toContain(`href: "${forbidden}"`);
+    }
+  });
+});
+
+// ── Audit doc shape ──────────────────────────────────────────────────────
+
+describe('canonical-product-flow audit doc', () => {
+  const md = read('docs/product/canonical-product-flow.md');
+
+  it('declares the five canonical steps', () => {
+    for (const step of ['Home', 'Get Ready', 'Passport', 'Review', 'Status']) {
+      expect(md).toContain(step);
+    }
+  });
+
+  it('declares the one-way canonical continuity progression', () => {
+    expect(md).toMatch(/\/get-ready/);
+    expect(md).toMatch(/\/passport/);
+    expect(md).toMatch(/\/review/);
+    expect(md).toMatch(/\/verify/);
+    expect(md).toMatch(/\/status/);
+    expect(md).toMatch(/progression is one-way/i);
+  });
+
+  it('declares the four continuity properties', () => {
+    expect(md).toMatch(/confirm completion/i);
+    expect(md).toMatch(/show next step/i);
+    expect(md).toMatch(/identify ownership/i);
+    expect(md).toMatch(/disclose simulation boundaries/i);
+  });
+
+  it('lists hidden/secondary route categories', () => {
+    expect(md).toMatch(/\/trust\/\*/);
+    expect(md).toMatch(/\/doctrine/);
+    expect(md).toMatch(/\/investigate\/\*/);
+    expect(md).toMatch(/\/autopilot/);
+    expect(md).toMatch(/\/inbox/);
+    expect(md).toMatch(/\/dossier\/\*/);
+    expect(md).toMatch(/operator-only/i);
+  });
+
+  it('declares the no-deletion posture', () => {
+    expect(md).toMatch(/Does NOT delete any route/i);
+    expect(md).toMatch(/remains? reachable by/i);
+  });
+});
+
+// ── Verifier behavior ────────────────────────────────────────────────────
+
+describe('verify-canonical-flow script', () => {
+  it(
+    'full mode passes on a canonical state',
+    () => {
+      const r = runVerifier(['full']);
+      expect(r.output).toContain('verify-canonical-flow');
+      expect(r.output).toMatch(/\[OK\s+\] canonical flow: no drift detected/);
+      expect(r.code).toBe(0);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'nav-shape sub-mode reports each canonical item',
+    () => {
+      const r = runVerifier(['nav-shape']);
+      for (const item of ['Home', 'Get Ready', 'Passport', 'Review', 'Status']) {
+        expect(r.output).toContain(item);
+      }
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'canonical-routes sub-mode reports each route',
+    () => {
+      const r = runVerifier(['canonical-routes']);
+      for (const rel of [
+        'apps/web/app/page.tsx',
+        'apps/web/app/get-ready/page.tsx',
+        'apps/web/app/passport/page.tsx',
+        'apps/web/app/review/page.tsx',
+        'apps/web/app/status/page.tsx',
+      ]) {
+        expect(r.output).toContain(rel);
+      }
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+});
+
+// ── Pnpm registration ────────────────────────────────────────────────────
+
+describe('package.json · canonical-flow scripts', () => {
+  const pkg = JSON.parse(read('package.json')) as { scripts: Record<string, string> };
+
+  it.each([
+    'verify:canonical-flow',
+    'verify:nav-shape',
+    'verify:canonical-routes',
+  ])('exposes pnpm %s', (key) => {
+    expect(pkg.scripts[key]).toBeDefined();
+    expect(pkg.scripts[key]).toMatch(/verify-canonical-flow/);
+  });
+});
+
+// ── Truth contract ───────────────────────────────────────────────────────
+
+describe('truth contract · canonical-flow surface', () => {
+  const TOUCHED_FILES = [
+    'apps/web/app/get-ready/page.tsx',
+    'apps/web/components/layout/Navbar.tsx',
+    'scripts/verify-canonical-flow.ts',
+  ];
+
+  const BANNED = [
+    'magical onboarding',
+    'instant verification',
+    'automatically verified',
+    'auto-approves',
+    'ai-powered',
+    'fully automated',
+    'fake-product',
+    'startup spectacle',
+    'enterprise-grade',
+  ];
+
+  it.each(TOUCHED_FILES)('%s avoids banned jargon', (rel) => {
+    const src = read(rel).toLowerCase();
+    for (const phrase of BANNED) {
+      expect(src.includes(phrase), `should not contain "${phrase}"`).toBe(false);
+    }
+  });
+
+  it('audit doc declares the no-new-features posture', () => {
+    const md = read('docs/product/canonical-product-flow.md');
+    expect(md).toMatch(/Does NOT add new features/i);
+  });
+});

--- a/apps/web/app/get-ready/page.tsx
+++ b/apps/web/app/get-ready/page.tsx
@@ -1,0 +1,110 @@
+/**
+ * /get-ready -- Canonical entry point for the institutional flow.
+ *
+ * Single calm landing surface. One primary signal, one primary
+ * action. The clinician sees this first; from here they continue
+ * to /passport. The receiving institution sees this surface when a
+ * pilot brief is being prepared.
+ *
+ * Read-only. No backend writes, no external API calls. The page
+ * exists to give the canonical nav's "Get Ready" item a resolving
+ * destination; it does NOT initiate a real exchange.
+ */
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Get ready · VitalCV',
+  description:
+    'Start your VitalCV readiness. Federal-source resolution against NPPES, OIG/LEIE, and PECOS. State medical board verification, committee review, and privileging decisions remain institution-owned.',
+};
+
+export default function GetReadyPage() {
+  return (
+    <main className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-900 bg-slate-950 px-5 py-6 text-slate-100">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+          Step 1 of the canonical flow · Get ready
+        </div>
+        <h1 className="mt-1 text-2xl font-semibold">Get ready in about two minutes.</h1>
+        <p className="mt-3 max-w-[62ch] text-sm text-slate-200">
+          Verify your NPI and we resolve federal-source lanes (NPPES,
+          OIG / LEIE, PECOS) against the public registries. State
+          medical board verification, credentialing committee review,
+          and privileging decisions remain on your receiving
+          institution&apos;s own cadence.
+        </p>
+      </header>
+
+      <div className="mx-auto max-w-2xl space-y-5 px-4 py-8 sm:px-6">
+        <section
+          data-slot="get-ready-primary-action"
+          className="overflow-hidden rounded-2xl border-2 border-slate-900 bg-slate-900 text-slate-100"
+        >
+          <Link
+            href="/passport"
+            className="flex items-center justify-between gap-4 px-5 py-5 hover:bg-slate-800"
+          >
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-wider text-slate-400">
+                Primary action
+              </div>
+              <div className="mt-1 text-lg font-semibold">Continue to your passport</div>
+              <div className="mt-1 max-w-[52ch] text-sm text-slate-300">
+                Your passport carries your federal-source resolution
+                and a portable replay envelope per lane.
+              </div>
+            </div>
+            <div aria-hidden className="font-mono text-sm text-slate-300">
+              →
+            </div>
+          </Link>
+        </section>
+
+        <section
+          data-slot="get-ready-what-happens-next"
+          className="overflow-hidden rounded-2xl border border-slate-900 bg-white"
+        >
+          <header className="border-b border-slate-900 bg-slate-50 px-4 py-2">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-slate-600">
+              What happens next
+            </div>
+          </header>
+          <ul className="list-disc space-y-1 px-8 py-3 text-sm text-slate-700">
+            <li>You verify your NPI and we resolve the federal-source lanes.</li>
+            <li>
+              Your passport shows the lane state plus an operator note
+              that travels with each lane.
+            </li>
+            <li>
+              The receiving institution reviews your passport on its
+              own credential and cadence.
+            </li>
+          </ul>
+        </section>
+
+        <section
+          data-slot="get-ready-institution-owned"
+          className="overflow-hidden rounded-2xl border border-slate-900 bg-slate-50"
+        >
+          <header className="border-b border-slate-900 bg-white px-4 py-2">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-slate-600">
+              Institution-owned · does not change with this step
+            </div>
+          </header>
+          <ul className="list-disc space-y-1 px-8 py-3 text-sm text-slate-700">
+            <li>State medical board verification (the institution&apos;s CVO channel).</li>
+            <li>Credentialing committee scheduling and review.</li>
+            <li>Privileging decisions.</li>
+            <li>Final acceptance for deployment.</li>
+          </ul>
+        </section>
+
+        <footer className="border-t border-dashed border-slate-300 pt-3 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+          Canonical flow · Get ready · Passport · Review · Verify · Status
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -16,9 +16,18 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 
-// Public-only nav items. Never add ops/internal routes here.
+// Canonical-product-flow nav items (Wave 32). The visible nav is
+// limited to the five canonical steps; every other route is either
+// secondary-grouped (under /pilot or sign-in), operator-only, or
+// noindexed. See docs/product/canonical-product-flow.md for the
+// rule and the verifier in scripts/verify-canonical-flow.ts for
+// enforcement.
 const NAV_ITEMS = [
-  { href: '/pilot',   label: 'For Employers' },
+  { href: '/',          label: 'Home' },
+  { href: '/get-ready', label: 'Get Ready' },
+  { href: '/passport',  label: 'Passport' },
+  { href: '/review',    label: 'Review' },
+  { href: '/status',    label: 'Status' },
 ] as const;
 
 export default function Navbar() {

--- a/docs/product/canonical-product-flow.md
+++ b/docs/product/canonical-product-flow.md
@@ -1,0 +1,159 @@
+# Canonical Product Flow
+
+Single binding declaration of what the live institutional product
+looks like. The visible navigation is reduced to five canonical
+steps; every other route is hidden, secondary-grouped,
+operator-only, or noindexed. The rule is enforced by
+`scripts/verify-canonical-flow.ts` and the test suite at
+`apps/web/__tests__/canonical-product-flow.test.ts`.
+
+## The five canonical steps (binding)
+
+The Navbar's `NAV_ITEMS` array in
+`apps/web/components/layout/Navbar.tsx` is the single source of
+truth for the visible top-level nav. It MUST contain exactly these
+five entries, in this order:
+
+| # | Label | Route | Role |
+|---|---|---|---|
+| 1 | Home | `/` | Marketing landing + entry |
+| 2 | Get Ready | `/get-ready` | Canonical first step; one primary action -> Passport |
+| 3 | Passport | `/passport` | Clinician's federal-source resolution |
+| 4 | Review | `/review` | Institutional review surface |
+| 5 | Status | `/status` | Operational status read |
+
+No other items may live in `NAV_ITEMS`. A wave that adds a sixth
+entry is rejected at Codex audit.
+
+## Canonical continuity progression
+
+```
+/                  (Home)
+   ↓
+/get-ready         (Get Ready)         -- this wave adds the landing
+   ↓
+/passport          (Passport)
+   ↓
+/review            (Review)
+   ↓
+/verify            (Verifier preparation, sub-step under /review)
+   ↓
+/status            (Status)
+```
+
+The progression is one-way. Every visible action on a canonical
+step MUST carry the four continuity properties:
+
+1. **confirm completion** -- the user sees that their action was recorded
+2. **show next step** -- a clear link to the next canonical step
+3. **identify ownership** -- whether the operator, the receiving
+   institution, or VitalCV owns the next action
+4. **disclose simulation boundaries** -- if the step is fixture-
+   driven or bounded, the surface says so via a
+   `BoundedSimulationDisclosure` or equivalent
+
+## Hidden / secondary routes
+
+These routes EXIST but are NOT in the visible top-level nav. They
+remain reachable by direct URL, by deep linking from a step within
+the canonical flow, or via operator-only paths. The wave does NOT
+delete implementation; it only removes nav exposure.
+
+### Hidden (no nav exposure; noindex recommended)
+
+- `/trust/*` -- trust-doctrine surfaces (consumer access via /passport detail disclosure)
+- `/doctrine` and `/trust/doctrine` -- doctrine surface (operator-only)
+- `/investigate/*` -- investigative surfaces (operator-only)
+- `/autopilot` -- autopilot surface (operator-only)
+- `/inbox` -- AI knowledge inbox (operator-only)
+- `/dossier/*` -- cryptographic proof dossier (operator-only)
+- `/graph/*` -- graph explorer (operator-only)
+- `/findings/*` -- findings explorer (operator-only)
+- `/storylines/*` -- storyline explorer (operator-only)
+- `/issuer/*` -- issuer tooling (operator-only)
+- `/verifier/*` -- legacy verifier tree (use `/verify` instead)
+- `/calibration` -- calibration console (operator-only)
+- `/system-health` -- internal system-health UI (operator-only)
+- `/network` -- network operations console (operator-only)
+- `/mission-ops` -- mission operations console (operator-only)
+- `/ops/*` -- operator console (operator-only; see Wave 23 signal hierarchy)
+- `/operator` -- operator readiness workspace (operator-only; see Wave 27)
+- `/clinician/*` -- clinician-internal surfaces (auth-gated)
+- `/admin/*` -- admin surface (auth-gated)
+- `/analytics-foundation` -- internal analytics
+- `/calibration`, `/storylines`, `/actions`, `/providers`, `/investigations` -- intelligence ops surfaces
+
+### Secondary-grouped (reachable via /pilot or /for/*)
+
+- `/pilot` -- pilot intake form
+- `/for/cvo` / `/for/payer` / `/for/staffing-exchange` -- persona landing pages
+- `/employer/*` -- employer review surface (auth-gated)
+- `/employers` -- employer marketing landing
+- `/explore` -- exploratory provider directory
+
+### Auth + onboarding
+
+- `/sign-in`, `/sign-up`, `/signup`, `/onboarding` -- authentication
+- `/account`, `/file`, `/documents` -- account-internal
+- `/apply` -- apply flow
+
+### Demo surfaces (NOT linked from canonical flow)
+
+- `/demo/*` -- demonstration routes (Cedar pilot demo, intake, waste, etc.) live on open PRs (#400, #401, #402). When those PRs merge, the demo routes remain reachable by direct URL but do NOT appear in the canonical nav.
+
+## What this wave does NOT do
+
+- Does NOT delete any route. Hidden routes remain reachable by
+  URL.
+- Does NOT add a `robots: { index: false, follow: false }` to
+  every hidden route in this PR -- that touch is large and risks
+  introducing regressions. The audit table above documents the
+  intended state; a follow-up wave can wire `noindex` per
+  directory layout.
+- Does NOT introduce a new authentication model. Auth-gated
+  routes stay as they are.
+- Does NOT add new features. `/get-ready` is a canonical entry
+  page; it carries one primary action (`Continue to your
+  passport`) and is otherwise read-only.
+
+## What this wave does
+
+- Reduces the Navbar to the five canonical items
+- Adds the missing `/get-ready` landing (previously a dangling
+  reference in `holder/page.tsx`, `PrequalificationRibbon.tsx`,
+  `ReadinessDemo.tsx`)
+- Documents the visible / hidden split here
+- Ships a verifier that confirms the Navbar exposes only the
+  five canonical items
+
+## Bounded simulations (existing surfaces)
+
+The following surfaces are bounded simulations -- they render
+fixture data, not live institutional data. They are documented in
+their own boundary docs (see Wave 22, 24, 27) and are not affected
+by this wave:
+
+- `/pilot` confirmation -- intake record + confirmation copy; no
+  CRM persistence
+- `/employer/review/[applicationId]` -- demo receipt signed
+  in-process; no live application read
+- `/verify` -- accepts a demo-token placeholder; real verification
+  requires a real signed JWT
+- `/operator` -- fixture-driven cohort; no live data wiring yet
+
+These bounded simulations remain bounded; this wave does NOT
+change their disclosure or behavior.
+
+## Governance
+
+A new visible route MUST:
+
+1. Either belong to the five canonical steps OR be added to the
+   Hidden / Secondary / Auth / Demo table in this doc.
+2. Carry the four continuity properties (confirm / next / owner /
+   disclosure) if it sits on the canonical flow.
+3. Not introduce a sixth top-level `NAV_ITEMS` entry without
+   updating this doc, the verifier, and the test suite.
+
+PRs that violate any of the three are rejected at Codex audit and
+by `scripts/verify-canonical-flow.ts`.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:backend:db": "bash scripts/backend-test-db.sh",
     "verify:production-convergence": "node --experimental-strip-types scripts/runtime/verify-production-convergence.ts",
     "verify:passport-runtime": "node --experimental-strip-types scripts/runtime/verify-passport-runtime.ts",
+    "verify:canonical-flow": "node --experimental-strip-types scripts/verify-canonical-flow.ts full",
+    "verify:nav-shape": "node --experimental-strip-types scripts/verify-canonical-flow.ts nav-shape",
+    "verify:canonical-routes": "node --experimental-strip-types scripts/verify-canonical-flow.ts canonical-routes",
     "release:readiness": "node --experimental-strip-types scripts/release/release-readiness.ts",
     "runtime:kill-shadow-runtimes": "bash scripts/runtime/kill-shadow-runtimes.sh"
   },

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,7 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';
+// Note: prior `./interoperability` re-export referenced a file that
+// was never landed. Canonical fix lives on PR #375. Removed here so
+// the local build passes; on rebase against PR #375 the change
+// collapses to a no-op.

--- a/scripts/verify-canonical-flow.ts
+++ b/scripts/verify-canonical-flow.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify-canonical-flow.ts
+ *
+ * Verifies that the five canonical nav items are present (and
+ * ONLY the five) in apps/web/components/layout/Navbar.tsx, and
+ * that each canonical route resolves to a real page on disk.
+ *
+ * Read-only. Exits non-zero on FAIL.
+ *
+ *   pnpm verify:canonical-flow    full verification
+ *   pnpm verify:nav-shape         Navbar items only
+ *   pnpm verify:canonical-routes  route existence only
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type Mode = 'full' | 'nav-shape' | 'canonical-routes';
+
+const REPO_ROOT = (() => {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+})();
+
+type Level = 'OK' | 'NOTE' | 'WARN' | 'FAIL';
+interface Entry {
+  level: Level;
+  text: string;
+}
+
+const CANONICAL_NAV: ReadonlyArray<{ href: string; label: string }> = [
+  { href: '/', label: 'Home' },
+  { href: '/get-ready', label: 'Get Ready' },
+  { href: '/passport', label: 'Passport' },
+  { href: '/review', label: 'Review' },
+  { href: '/status', label: 'Status' },
+];
+
+const CANONICAL_ROUTE_PATHS: ReadonlyArray<string> = [
+  'apps/web/app/page.tsx',
+  'apps/web/app/get-ready/page.tsx',
+  'apps/web/app/passport/page.tsx',
+  'apps/web/app/review/page.tsx',
+  'apps/web/app/status/page.tsx',
+];
+
+function readNavSource(): string {
+  const path = resolve(REPO_ROOT, 'apps/web/components/layout/Navbar.tsx');
+  if (!existsSync(path)) {
+    throw new Error(`Navbar.tsx missing at ${path}`);
+  }
+  return readFileSync(path, 'utf8');
+}
+
+interface ParsedNavItem {
+  href: string;
+  label: string;
+}
+
+function parseNavItems(src: string): ParsedNavItem[] {
+  // Match the NAV_ITEMS array block. We accept either form:
+  //   const NAV_ITEMS = [ { href: '/x', label: 'X' }, ... ] as const;
+  const m = src.match(/const\s+NAV_ITEMS\s*=\s*\[([\s\S]*?)\]\s*as\s+const/);
+  if (!m) return [];
+  const body = m[1];
+  const items: ParsedNavItem[] = [];
+  const itemRe = /\{\s*href:\s*['"]([^'"]+)['"]\s*,\s*label:\s*['"]([^'"]+)['"]\s*\}/g;
+  for (const item of body.matchAll(itemRe)) {
+    items.push({ href: item[1], label: item[2] });
+  }
+  return items;
+}
+
+function verifyNavShape(): Entry[] {
+  const entries: Entry[] = [];
+  let src: string;
+  try {
+    src = readNavSource();
+  } catch (err) {
+    return [{ level: 'FAIL', text: (err as Error).message }];
+  }
+  const parsed = parseNavItems(src);
+  if (parsed.length === 0) {
+    return [
+      {
+        level: 'FAIL',
+        text: 'Navbar.tsx: NAV_ITEMS array not found or empty',
+      },
+    ];
+  }
+  if (parsed.length !== CANONICAL_NAV.length) {
+    entries.push({
+      level: 'FAIL',
+      text: `Navbar.tsx: NAV_ITEMS length=${parsed.length}, expected=${CANONICAL_NAV.length}`,
+    });
+  }
+  for (let i = 0; i < CANONICAL_NAV.length; i += 1) {
+    const expected = CANONICAL_NAV[i]!;
+    const actual = parsed[i];
+    if (!actual) {
+      entries.push({
+        level: 'FAIL',
+        text: `Navbar.tsx: NAV_ITEMS[${i}] missing; expected { href: '${expected.href}', label: '${expected.label}' }`,
+      });
+      continue;
+    }
+    if (actual.href !== expected.href || actual.label !== expected.label) {
+      entries.push({
+        level: 'FAIL',
+        text: `Navbar.tsx: NAV_ITEMS[${i}] is { href: '${actual.href}', label: '${actual.label}' }; expected { href: '${expected.href}', label: '${expected.label}' }`,
+      });
+    } else {
+      entries.push({
+        level: 'OK',
+        text: `Navbar.tsx: NAV_ITEMS[${i}] = ${expected.label} (${expected.href})`,
+      });
+    }
+  }
+  // Reject any extra items even if length matched somehow
+  if (parsed.length > CANONICAL_NAV.length) {
+    for (let i = CANONICAL_NAV.length; i < parsed.length; i += 1) {
+      entries.push({
+        level: 'FAIL',
+        text: `Navbar.tsx: NAV_ITEMS[${i}] = ${parsed[i]!.label} (${parsed[i]!.href}) is not canonical`,
+      });
+    }
+  }
+  return entries;
+}
+
+function verifyCanonicalRoutes(): Entry[] {
+  const entries: Entry[] = [];
+  for (const rel of CANONICAL_ROUTE_PATHS) {
+    if (existsSync(resolve(REPO_ROOT, rel))) {
+      entries.push({ level: 'OK', text: `canonical route resolves: ${rel}` });
+    } else {
+      entries.push({ level: 'FAIL', text: `canonical route missing: ${rel}` });
+    }
+  }
+  return entries;
+}
+
+function verifyAuditDoc(): Entry[] {
+  const path = resolve(REPO_ROOT, 'docs/product/canonical-product-flow.md');
+  if (!existsSync(path)) {
+    return [{ level: 'FAIL', text: 'docs/product/canonical-product-flow.md missing' }];
+  }
+  return [{ level: 'OK', text: 'docs/product/canonical-product-flow.md present' }];
+}
+
+function main(): void {
+  const mode = (process.argv[2] ?? 'full') as Mode;
+  console.log(`# verify-canonical-flow (${mode}) · ${new Date().toISOString()}`);
+  console.log('#'.padEnd(72, '#'));
+
+  const entries: Entry[] = [];
+  switch (mode) {
+    case 'nav-shape':
+      entries.push(...verifyNavShape());
+      break;
+    case 'canonical-routes':
+      entries.push(...verifyCanonicalRoutes());
+      break;
+    case 'full':
+    default:
+      entries.push(...verifyAuditDoc());
+      entries.push(...verifyNavShape());
+      entries.push(...verifyCanonicalRoutes());
+      break;
+  }
+
+  for (const e of entries) console.log(`[${e.level.padEnd(4, ' ')}] ${e.text}`);
+  const failed = entries.filter((e) => e.level === 'FAIL');
+  if (failed.length > 0) {
+    console.log(
+      `\n[FAIL] canonical flow: ${failed.length} drift entr${failed.length === 1 ? 'y' : 'ies'}`,
+    );
+    process.exit(1);
+  }
+  console.log('\n[OK  ] canonical flow: no drift detected');
+}
+
+main();


### PR DESCRIPTION
## Summary

Collapses fragmented demo topology into a single coherent live institutional product flow with exactly **five visible nav items**: `Home` · `Get Ready` · `Passport` · `Review` · `Status`. Adds the previously dangling `/get-ready` landing. Ships a verifier that parses `Navbar.tsx` and rejects any non-canonical NAV_ITEMS entry.

Constrained: no new features, no deletions, no protocol expansion.

## What lands

| Artifact | File |
|---|---|
| Canonical Step 1 landing | `apps/web/app/get-ready/page.tsx` |
| Navbar (5 canonical items only) | `apps/web/components/layout/Navbar.tsx` |
| Canonical-flow doctrine | `docs/product/canonical-product-flow.md` |
| Canonical-flow verifier | `scripts/verify-canonical-flow.ts` |
| pnpm scripts | `verify:canonical-flow` · `verify:nav-shape` · `verify:canonical-routes` |
| Test suite | `apps/web/__tests__/canonical-product-flow.test.ts` (29 cases) |

## Canonical continuity progression

```
/             (Home)
   ↓
/get-ready    (Get Ready)
   ↓
/passport     (Passport)
   ↓
/review       (Review)
   ↓
/verify       (Verifier preparation, sub-step under /review)
   ↓
/status       (Status)
```

Every visible action on a canonical step MUST carry: **confirm completion** · **show next step** · **identify ownership** · **disclose simulation boundaries**.

## What is hidden from the visible nav

Routes that EXIST but no longer appear in the top-level nav:

- `/trust/*`, `/doctrine`, `/investigate/*`, `/autopilot`, `/inbox`, `/dossier/*`, `/graph/*`, `/findings/*`, `/storylines/*`, `/issuer/*`, `/verifier/*`, `/calibration`, `/system-health`, `/network`, `/mission-ops`, `/ops/*`, `/operator`, `/clinician/*`, `/admin/*`, `/analytics-foundation`, `/intelligence`, `/labs`, `/interview`
- Demo surfaces (`/demo/*`) — reachable by direct URL only; not in nav
- Secondary-grouped surfaces (`/pilot`, `/for/cvo`, `/for/payer`, `/for/staffing-exchange`, `/employer/*`, `/employers`, `/explore`)

None of these are deleted. The wave only removes nav exposure. A follow-up wave can wire systematic `noindex` per directory layout.

## /get-ready landing

Previously a dangling reference in `holder/page.tsx`, `PrequalificationRibbon.tsx`, and `ReadinessDemo.tsx`. Now ships as a calm single-page landing with one primary action (`Continue to your passport`) and explicit institution-owned boundary (state medical board / committee / privileging / final acceptance remain on the institution's cadence).

## Verifier behavior

- `pnpm verify:canonical-flow` (default) — checks audit-doc presence + NAV_ITEMS shape + canonical route resolution
- `pnpm verify:nav-shape` — parses `NAV_ITEMS` array and confirms exactly the five canonical entries in canonical order
- `pnpm verify:canonical-routes` — confirms `/`, `/get-ready`, `/passport`, `/review`, `/status` all have `page.tsx` on disk

Output on a canonical repo:

```
[OK  ] Navbar.tsx: NAV_ITEMS[0] = Home (/)
[OK  ] Navbar.tsx: NAV_ITEMS[1] = Get Ready (/get-ready)
[OK  ] Navbar.tsx: NAV_ITEMS[2] = Passport (/passport)
[OK  ] Navbar.tsx: NAV_ITEMS[3] = Review (/review)
[OK  ] Navbar.tsx: NAV_ITEMS[4] = Status (/status)
[OK  ] canonical flow: no drift detected
```

## Stacking note

Branched off `origin/main` (SHA `7f7ace10`). Carries the wallet-sdk orphan re-export fix (canonical fix on PR #375). On rebase against #375 the change collapses to a no-op.

## Validation

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `node scripts/verify-canonical-flow.ts full` — drift-free
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/canonical-product-flow.test.ts` — **29/29 passing**
- [x] `pnpm turbo run build --filter @vitalcv/web` — passes (`/get-ready` built)
- [x] `pnpm --filter @vitalcv/web exec next lint --dir app/get-ready --dir components/layout` — 0 warnings

## Test plan

- [ ] `pnpm verify:canonical-flow` locally — confirm OK (0 drift)
- [ ] Visit `/get-ready` — confirm single primary action linking to `/passport`
- [ ] Visit `/` — confirm Navbar shows exactly the five canonical items
- [ ] Codex audit · implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)