### PR TITLE
fix(product): harden verification integrity semantics

### DIFF
--- a/apps/web/__tests__/verification-integrity-hardening.test.ts
+++ b/apps/web/__tests__/verification-integrity-hardening.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+}).trim();
+
+function read(rel: string): string {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+function runVerifier(args: string[]): { code: number; output: string } {
+  try {
+    const output = execSync(
+      `node --experimental-strip-types scripts/verify-verification-integrity.ts ${args.join(' ')}`,
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    return { code: 0, output };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const stdout =
+      typeof e.stdout === 'string'
+        ? e.stdout
+        : Buffer.isBuffer(e.stdout)
+          ? e.stdout.toString('utf8')
+          : '';
+    const stderr =
+      typeof e.stderr === 'string'
+        ? e.stderr
+        : Buffer.isBuffer(e.stderr)
+          ? e.stderr.toString('utf8')
+          : '';
+    return { code: e.status ?? 1, output: stdout + stderr };
+  }
+}
+
+const VERIFIER_TIMEOUT_MS = 60_000;
+
+// ── File presence ────────────────────────────────────────────────────────
+
+describe('verification-integrity-hardening · file presence', () => {
+  it.each([
+    'docs/product/verification-integrity-hardening.md',
+    'scripts/verify-verification-integrity.ts',
+  ])('%s exists', (rel) => {
+    expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
+  });
+});
+
+// ── Repaired files no longer carry the banned phrases ───────────────────
+
+describe('repaired files · post-normalization', () => {
+  it('review ConsoleWrapper uses lane-evidence + institution-review language', () => {
+    const src = read('apps/web/app/review/[entityId]/ConsoleWrapper.tsx');
+    expect(src).not.toMatch(/Credentials verified\.\s*Clear to proceed\./);
+    expect(src).toMatch(/Lane evidence completed\. Institution review still required/);
+    expect(src).not.toMatch(/Primary identity verified\./);
+    expect(src).toMatch(/Identity lane source-confirmed/);
+  });
+
+  it('employer dashboard uses Marked Review-Complete / Not Eligible labels', () => {
+    const src = read('apps/web/app/employer/dashboard/page.tsx');
+    expect(src).not.toMatch(/>Approved</);
+    expect(src).not.toMatch(/>Rejected</);
+    expect(src).toMatch(/Marked Review-Complete/);
+    expect(src).toMatch(/Not Eligible \(Institution-Owned\)/);
+  });
+
+  it('StartClinicianAction uses source-confirmed lane language', () => {
+    const src = read('apps/web/components/employer/StartClinicianAction.tsx');
+    expect(src).not.toMatch(/Superbrain clearance required/);
+    expect(src).toMatch(/Lane evidence required/);
+    expect(src).toMatch(/Source-confirmed/);
+    expect(src).toMatch(/institution review remains required/i);
+  });
+
+  it('VerifierCommandCenter uses "Marked review-complete" aria-label', () => {
+    const src = read('apps/web/components/employer/VerifierCommandCenter.tsx');
+    expect(src).not.toMatch(/aria-label="Approved"/);
+    expect(src).toMatch(/aria-label="Marked review-complete"/);
+  });
+
+  it('SandboxHero uses SOURCE-CONFIRMED and NO ADVERSE RECORDS', () => {
+    const src = read('apps/web/components/hero/SandboxHero.tsx');
+    expect(src).not.toMatch(/>VERIFIED</);
+    expect(src).toMatch(/SOURCE-CONFIRMED/);
+    expect(src).toMatch(/NO ADVERSE RECORDS/);
+  });
+});
+
+// ── Doctrine doc shape ───────────────────────────────────────────────────
+
+describe('verification-integrity doctrine', () => {
+  const md = read('docs/product/verification-integrity-hardening.md');
+
+  it('enumerates the six evidence-bounded states', () => {
+    for (const state of [
+      'Review completed',
+      'Review pending',
+      'Additional review required',
+      'Source unavailable',
+      'Verification incomplete',
+      'Requires institution review',
+    ]) {
+      expect(md).toContain(state);
+    }
+  });
+
+  it('enumerates the six degraded states', () => {
+    for (const state of [
+      'SOURCE_TIMEOUT',
+      'SOURCE_UNAVAILABLE',
+      'ACCESS_REQUIRED',
+      'REVIEW_PENDING',
+      'PARTIAL_COMPLETION',
+      'CONTINUITY_INTERRUPTED',
+    ]) {
+      expect(md).toContain(state);
+    }
+  });
+
+  it('declares the deterministic review posture rules', () => {
+    expect(md).toMatch(/Completed lane evidence/);
+    expect(md).toMatch(/Explicit institution review/);
+    expect(md).toMatch(/Visible bounded certainty/);
+    expect(md).toMatch(/Manifest-tier shortcuts/);
+  });
+
+  it('declares the banned-phrase rejection table', () => {
+    expect(md).toMatch(/Credentials verified\. Clear to proceed\./);
+    expect(md).toMatch(/Approved/);
+    expect(md).toMatch(/Cleared/);
+    expect(md).toMatch(/Clear to proceed/);
+  });
+
+  it('records the repaired files', () => {
+    for (const path of [
+      'apps/web/app/review/[entityId]/ConsoleWrapper.tsx',
+      'apps/web/app/employer/dashboard/page.tsx',
+      'apps/web/components/employer/StartClinicianAction.tsx',
+      'apps/web/components/employer/VerifierCommandCenter.tsx',
+      'apps/web/components/hero/SandboxHero.tsx',
+    ]) {
+      expect(md).toContain(path);
+    }
+  });
+
+  it('names the deliberately-not-modified surfaces', () => {
+    expect(md).toMatch(/_archive\/\*/);
+    expect(md).toMatch(/__tests__/);
+    expect(md).toMatch(/API route/i);
+  });
+});
+
+// ── Verifier behavior ────────────────────────────────────────────────────
+
+describe('verify-verification-integrity script', () => {
+  it(
+    'enforce mode passes after the repairs (no FAIL drift)',
+    () => {
+      const r = runVerifier(['enforce']);
+      expect(r.output).toContain('verify-verification-integrity');
+      expect(r.output).toMatch(/\[OK\s+\] verification integrity: no FAIL drift/);
+      expect(r.code).toBe(0);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'report sub-mode never exits non-zero',
+    () => {
+      const r = runVerifier(['report']);
+      expect(r.code).toBe(0);
+      expect(r.output).toContain('verify-verification-integrity (report)');
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'degraded-states-only sub-mode reports a scan summary',
+    () => {
+      const r = runVerifier(['degraded-states-only']);
+      expect(r.code).toBe(0);
+      expect(r.output).toMatch(/degraded-states scan: \d+ verification-related file/);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+});
+
+// ── Pnpm registration ────────────────────────────────────────────────────
+
+describe('package.json · verification-integrity scripts', () => {
+  const pkg = JSON.parse(read('package.json')) as { scripts: Record<string, string> };
+
+  it.each([
+    'verify:verification-integrity',
+    'verify:verification-integrity-report',
+    'verify:degraded-state-visibility',
+  ])('exposes pnpm %s', (key) => {
+    expect(pkg.scripts[key]).toBeDefined();
+    expect(pkg.scripts[key]).toMatch(/verify-verification-integrity/);
+  });
+});
+
+// ── Truth contract ───────────────────────────────────────────────────────
+
+describe('truth contract · verifier and doctrine', () => {
+  it('verifier exempts _archive/, __tests__/, and *.test.* files', () => {
+    const src = read('scripts/verify-verification-integrity.ts');
+    expect(src).toMatch(/_archive/);
+    expect(src).toMatch(/__tests__/);
+    expect(src).toMatch(/\.test\./);
+  });
+
+  it('doctrine declares the no-manifest-tier-shortcut rule', () => {
+    const md = read('docs/product/verification-integrity-hardening.md');
+    expect(md).toMatch(/Manifest-tier shortcuts/i);
+    expect(md).toMatch(/single "trust score"/i);
+  });
+});

--- a/apps/web/app/employer/dashboard/page.tsx
+++ b/apps/web/app/employer/dashboard/page.tsx
@@ -18,8 +18,8 @@ export default function EmployerDashboardPage() {
             <li className="flex justify-between"><span>New</span> <span className="font-bold">12</span></li>
             <li className="flex justify-between"><span>Under Review</span> <span className="font-bold">5</span></li>
             <li className="flex justify-between"><span>Waiting for Docs</span> <span className="font-bold">3</span></li>
-            <li className="flex justify-between"><span>Approved</span> <span className="font-bold">8</span></li>
-            <li className="flex justify-between"><span>Rejected</span> <span className="font-bold">2</span></li>
+            <li className="flex justify-between"><span>Marked Review-Complete</span> <span className="font-bold">8</span></li>
+            <li className="flex justify-between"><span>Not Eligible (Institution-Owned)</span> <span className="font-bold">2</span></li>
           </ul>
         </div>
 

--- a/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
+++ b/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
@@ -144,13 +144,13 @@ function buildBlocker(lane: LaneSnapshot): BlockerItem {
 }
 
 function deriveNextAction(posture: ReadinessPosture, blockers: BlockerItem[]): string {
-  if (posture === 'blocked') return 'Adverse finding detected. Manual review required before proceeding.';
-  if (posture === 'decision_grade') return 'Credentials verified. Clear to proceed.';
+  if (posture === 'blocked') return 'Adverse finding detected. Institution review required before proceeding.';
+  if (posture === 'decision_grade') return 'Lane evidence completed. Institution review still required before a final decision.';
   const topBlocker = blockers[0];
   if (topBlocker?.status === 'access_required') {
-    return 'Primary identity verified. Additional sources pending — proceed with head start or wait.';
+    return 'Identity lane source-confirmed. Additional sources require institutional access — proceed with head start or wait.';
   }
-  return 'Source data is being checked. You can proceed with a head start.';
+  return 'Source data is being checked. You can proceed with a head start; institution review still required.';
 }
 
 // ─── Component ────────────────────────────────────────────────────

--- a/apps/web/components/employer/StartClinicianAction.tsx
+++ b/apps/web/components/employer/StartClinicianAction.tsx
@@ -293,11 +293,11 @@ export function StartClinicianAction({
             </p>
           </div>
 
-          {/* Cleared badge */}
+          {/* Source-confirmed badge */}
           {cleared && !isLocked && (
             <span className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-[var(--trust-green)]/10 px-2.5 py-1 text-[11px] font-semibold text-[var(--trust-green)] ring-1 ring-[var(--trust-green)]/25">
               <ShieldCheck className="h-3 w-3" />
-              CLEARED
+              SOURCE-CONFIRMED
             </span>
           )}
           {isLocked && (
@@ -336,12 +336,12 @@ export function StartClinicianAction({
             >
               <Lock className="mx-auto mb-2 h-6 w-6" style={TC} />
               <p className="text-sm font-medium" style={TC}>
-                Superbrain clearance required
+                Lane evidence required
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Run the Superbrain eligibility scan. When it returns{' '}
-                <span className="font-semibold text-[var(--trust-green)]">CLEARED</span>,
-                this panel will unlock.
+                Run the source-resolution sequence. When all federal-source lanes return{' '}
+                <span className="font-semibold text-[var(--trust-green)]">Source-confirmed</span>,
+                this panel unlocks. Institution review remains required before any final decision.
               </p>
             </motion.div>
           )}

--- a/apps/web/components/employer/SuperbrainInsights.tsx
+++ b/apps/web/components/employer/SuperbrainInsights.tsx
@@ -185,11 +185,11 @@ export function SuperbrainInsights({ npi: initialNpi }: SuperbrainInsightsProps)
                     <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
                     <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400" />
                   </span>
-                  CLEARED
+                  SOURCE-CONFIRMED
                 </div>
               ) : (
                 <div className="inline-flex items-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm font-bold text-amber-400">
-                  NOT CLEARED
+                  REQUIRES INSTITUTION REVIEW
                 </div>
               )}
             </div>

--- a/apps/web/components/employer/VerifierCommandCenter.tsx
+++ b/apps/web/components/employer/VerifierCommandCenter.tsx
@@ -213,7 +213,7 @@ export function VerifierCommandCenter() {
                         <p className="text-[15px] font-semibold text-foreground truncate">
                           {candidate.name}
                           {wasApproved && (
-                            <CheckCircle2 className="ml-1.5 inline h-4 w-4 text-[var(--trust-green)]" aria-label="Approved" />
+                            <CheckCircle2 className="ml-1.5 inline h-4 w-4 text-[var(--trust-green)]" aria-label="Marked review-complete" />
                           )}
                         </p>
                         <p className="mt-0.5 text-xs text-muted-foreground">

--- a/apps/web/components/hero/SandboxHero.tsx
+++ b/apps/web/components/hero/SandboxHero.tsx
@@ -126,11 +126,11 @@ export function SandboxHero() {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 opacity-60 font-mono text-[var(--vt-text-primary)]">
           <div className="border border-[var(--vt-border)] p-3 bg-foreground/10">
             <div className="text-[8px] font-bold uppercase tracking-widest opacity-40 mb-1">Identity</div>
-            <div className="text-[10px] font-bold">VERIFIED</div>
+            <div className="text-[10px] font-bold">SOURCE-CONFIRMED</div>
           </div>
           <div className="border border-[var(--vt-border)] p-3 bg-foreground/10">
             <div className="text-[8px] font-bold uppercase tracking-widest opacity-40 mb-1">Sanctions</div>
-            <div className="text-[10px] font-bold">CLEAR</div>
+            <div className="text-[10px] font-bold">NO ADVERSE RECORDS</div>
           </div>
           <div className="border border-[var(--vt-border)] p-3 bg-foreground/10">
             <div className="text-[8px] font-bold uppercase tracking-widest opacity-40 mb-1">Licensure</div>

--- a/apps/web/components/verifier/VerifierContinuityStatusBoard.tsx
+++ b/apps/web/components/verifier/VerifierContinuityStatusBoard.tsx
@@ -91,7 +91,7 @@ function StatusDot({ status }: { status: ContinuityProbe['status'] }) {
   if (status === 'verified') {
     return (
       <span className="inline-flex items-center gap-1 text-green-600 font-mono text-[11px]">
-        <span className="text-[14px] leading-none">●</span> VERIFIED
+        <span className="text-[14px] leading-none">●</span> SOURCE-CONFIRMED
       </span>
     );
   }

--- a/docs/product/verification-integrity-hardening.md
+++ b/docs/product/verification-integrity-hardening.md
@@ -1,0 +1,143 @@
+# Verification Integrity Hardening
+
+Binding rule for what visible verification, review, and readiness
+surfaces are NOT allowed to claim. The wave normalizes six positive-
+form certainty hits found on origin/main and ships a verifier that
+blocks regressions.
+
+Cut date: 2026-05-21.
+
+## The rule
+
+A visible institutional surface (anything under `apps/web/app/**`
+and `apps/web/components/**` not under `_archive/`, `__tests__/`,
+or `*.test.*`) MUST NOT use any of the following positive-form
+claims **unless they derive deterministically from completed lane
+evidence + explicit institution review**:
+
+| Forbidden positive form | Why it is unsafe |
+|---|---|
+| `Credentials verified. Clear to proceed.` | Conflates substrate-side lane confirmation with institutional approval; the substrate cannot grant clearance |
+| `Verified` (bare JSX label) | Manifest-tier shortcut; misrepresents per-lane state |
+| `Approved` (status label) | Implies an institutional decision the surface cannot make |
+| `Cleared` / `CLEARED` (status label) | Implies a substrate-side green light; only the institution clears |
+| `Safe` / `SAFE` (status label outside merge-risk taxonomy) | Implies a guarantee no source can provide |
+| `Clear to proceed` | Decision-grade language; the substrate is not a decision-maker |
+| `Approved automatically` | Fake automation in the approval lane |
+
+## Evidence-bounded status vocabulary (binding)
+
+The visible status on any lane / review / readiness surface MUST
+draw from this six-state set:
+
+| Visible state | Meaning | Derivable from |
+|---|---|---|
+| `Review completed` | The receiving institution recorded a review outcome | Institution-owned action |
+| `Review pending` | The receiving institution has not yet reviewed | No action needed; institution-owned |
+| `Additional review required` | The substrate completed but a lane returned a stale-but-signed or access-required posture | Lane evidence + operator note |
+| `Source unavailable` | An upstream registry could not be reached within the freshness budget | Lane timeout / network failure |
+| `Verification incomplete` | One or more lanes have not completed | Lane state |
+| `Requires institution review` | The substrate has finished what it can; the next step is institutional | Lane evidence + receiving institution's ownership |
+
+Substrate-side lane states (`source_confirmed`, `evidence_pending`,
+`continuity_restored`, `continuity_interrupted`) remain as defined
+in `canonical-operational-language.md` (when merged). The
+evidence-bounded states above are derived from the substrate states
++ the institution-owned action.
+
+## Audit · what was repaired
+
+Six positive-form certainty hits were found on origin/main and
+repaired:
+
+| File | Before | After |
+|---|---|---|
+| `apps/web/app/review/[entityId]/ConsoleWrapper.tsx:148` | `Credentials verified. Clear to proceed.` | `Lane evidence completed. Institution review still required before a final decision.` |
+| `apps/web/app/review/[entityId]/ConsoleWrapper.tsx:147` | `Adverse finding detected. Manual review required before proceeding.` | `Adverse finding detected. Institution review required before proceeding.` |
+| `apps/web/app/review/[entityId]/ConsoleWrapper.tsx:151` | `Primary identity verified. Additional sources pending` | `Identity lane source-confirmed. Additional sources require institutional access` |
+| `apps/web/app/employer/dashboard/page.tsx:21-22` | `Approved` / `Rejected` (status labels) | `Marked Review-Complete` / `Not Eligible (Institution-Owned)` |
+| `apps/web/components/employer/StartClinicianAction.tsx:343` | `Superbrain ... CLEARED ... unlocks` | `Source-resolution ... Source-confirmed ... unlocks; institution review remains required` |
+| `apps/web/components/employer/VerifierCommandCenter.tsx:216` | `aria-label="Approved"` | `aria-label="Marked review-complete"` |
+| `apps/web/components/hero/SandboxHero.tsx:129` | `VERIFIED` (bare label) | `SOURCE-CONFIRMED` |
+| `apps/web/components/hero/SandboxHero.tsx:133` | `CLEAR` | `NO ADVERSE RECORDS` |
+
+## Degraded-state visibility (binding)
+
+A surface that renders any verification / review state MUST expose
+the following degraded states when they exist; it MUST NOT collapse
+them into a generic "pending" or hide them entirely:
+
+| Degraded state | When it occurs | What the surface must show |
+|---|---|---|
+| `SOURCE_TIMEOUT` | Upstream registry exceeded the freshness budget | Lane name + "Source did not respond within budget" + operator note |
+| `SOURCE_UNAVAILABLE` | Upstream registry returned an error or 5xx | Lane name + "Source unavailable" + operator note |
+| `ACCESS_REQUIRED` | The lane requires institutional credentials we don't hold | Lane name + "Requires institutional access" + which credential class |
+| `REVIEW_PENDING` | The receiving institution has the packet but has not reviewed | "Review pending with [institution]" + last-touch timestamp |
+| `PARTIAL_COMPLETION` | Some lanes completed, others did not | Per-lane breakdown; no aggregate "verified" claim |
+| `CONTINUITY_INTERRUPTED` | A lane returned stale-but-signed | "Stale-but-signed; institution dispositions on its own credential" |
+
+These six degraded states are the **complete** set the surface may
+render. Generic copy ("something went wrong", "please try again")
+is not acceptable; the operator must see which lane failed and
+what the next step is.
+
+## Deterministic review posture (binding)
+
+A surface that renders a posture (e.g. "ready to proceed",
+"requires review") MUST derive that posture from:
+
+1. **Completed lane evidence** — each lane has a recorded state
+   from the canonical Continuity axis (`source_confirmed`,
+   `evidence_pending`, etc.)
+2. **Explicit institution review** — a recorded action by the
+   receiving institution (queued / in_review / returned_to_operator /
+   institution_owned per the canonical Review-ownership axis)
+3. **Visible bounded certainty** — the surface explicitly shows
+   the operator what was checked, what was not, and what remains
+   pending
+
+It MUST NOT derive a posture from:
+
+- **Manifest-tier shortcuts** — a single "trust score" or "tier
+  badge" that aggregates multiple lanes into one number
+- **Implicit "good enough"** rules — if 3 of 4 lanes pass, do NOT
+  flip the posture to "ready" without explicit institution review
+- **Cached posture from a prior session** — every visible posture
+  must be derivable from the current substrate read
+
+## Surfaces deliberately NOT modified
+
+| Surface | Reason |
+|---|---|
+| `_archive/*` trees | Retired code |
+| `__tests__/*` | Tests may reference banned phrases for negative assertion |
+| API route source code | API surfaces serve substrate clients; substrate vocabulary is appropriate |
+| `docs/*.md` | Doctrine docs may enumerate banned phrases in rejection tables |
+| Lane status values for OIG/LEIE in fixtures (`'CLEAR'` as a positive operational finding) | The hero label "CLEAR" was normalized; data-side string "CLEAR" as a lane outcome remains in fixtures for backward compatibility, mapped to "No adverse records" on render |
+
+## Verifier behavior
+
+`scripts/verify-verification-integrity.ts` walks
+`apps/web/{app,components}` (excluding `_archive/`, `__tests__/`,
+`*.test.*`), and scans each file for the banned positive-form
+claims. Three sub-modes:
+
+- `enforce` (default) — exits non-zero on any FAIL
+- `report` — scan + summary; never exits non-zero
+- `degraded-states-only` — scans for legitimate degraded-state
+  exposure (renders NOTE entries when a verification surface does
+  not import any of the six degraded states; not a FAIL)
+
+## Governance
+
+A new visible verification / review / readiness surface MUST:
+
+1. Avoid every banned phrase in the table above
+2. Use the binding evidence-bounded vocabulary
+3. Expose degraded states (not hide them)
+4. Derive posture deterministically from lane evidence + explicit
+   institution review (no manifest-tier shortcuts)
+5. Pass `pnpm verify:verification-integrity` (default = enforce)
+   with zero FAILs
+
+PRs that violate any of the five are rejected at Codex audit.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:backend:db": "bash scripts/backend-test-db.sh",
     "verify:production-convergence": "node --experimental-strip-types scripts/runtime/verify-production-convergence.ts",
     "verify:passport-runtime": "node --experimental-strip-types scripts/runtime/verify-passport-runtime.ts",
+    "verify:verification-integrity": "node --experimental-strip-types scripts/verify-verification-integrity.ts enforce",
+    "verify:verification-integrity-report": "node --experimental-strip-types scripts/verify-verification-integrity.ts report",
+    "verify:degraded-state-visibility": "node --experimental-strip-types scripts/verify-verification-integrity.ts degraded-states-only",
     "release:readiness": "node --experimental-strip-types scripts/release/release-readiness.ts",
     "runtime:kill-shadow-runtimes": "bash scripts/runtime/kill-shadow-runtimes.sh"
   },

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,5 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';
+// Note: prior `./interoperability` re-export referenced a file that
+// was never landed. Canonical fix lives on PR #375.

--- a/scripts/verify-verification-integrity.ts
+++ b/scripts/verify-verification-integrity.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify-verification-integrity.ts
+ *
+ * Scans apps/web/{app,components} for positive-form verification
+ * certainty claims that misrepresent the operational posture.
+ * Contract lives in docs/product/verification-integrity-hardening.md.
+ *
+ * Sub-modes:
+ *   enforce              default; exit non-zero on FAIL
+ *   report               scan + summary; never exit non-zero
+ *   degraded-states-only check that verification surfaces expose
+ *                        the six degraded states (NOTE-level)
+ *
+ * Excludes:
+ *   _archive/   (retired code)
+ *   node_modules/
+ *   .next/
+ *   *.test.*    (tests may reference banned phrases)
+ *   __tests__/  (test fixtures)
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+type Mode = 'enforce' | 'report' | 'degraded-states-only';
+
+const REPO_ROOT = (() => {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+})();
+
+type Level = 'OK' | 'NOTE' | 'WARN' | 'FAIL';
+interface Entry {
+  level: Level;
+  text: string;
+}
+
+interface BannedPattern {
+  pattern: RegExp;
+  label: string;
+  replacement: string;
+}
+
+// Positive-form patterns. We match against the file content with
+// JSX-aware patterns so that bare-word JSX labels are caught
+// without flagging variable / function names like `isVerified`.
+const BANNED: readonly BannedPattern[] = [
+  {
+    pattern: /Credentials verified\.\s*Clear to proceed\./,
+    label: 'Credentials verified. Clear to proceed.',
+    replacement: 'Lane evidence completed. Institution review still required before a final decision.',
+  },
+  {
+    pattern: />\s*Verified\s*</,
+    label: '>Verified< (bare JSX label)',
+    replacement: '>Source-confirmed< or >Marked review-complete<',
+  },
+  {
+    pattern: />\s*VERIFIED\s*</,
+    label: '>VERIFIED< (bare JSX uppercase label)',
+    replacement: '>SOURCE-CONFIRMED< or >MARKED REVIEW-COMPLETE<',
+  },
+  {
+    pattern: />\s*Approved\s*</,
+    label: '>Approved< (bare JSX label)',
+    replacement: '>Marked review-complete<',
+  },
+  {
+    pattern: />\s*Cleared\s*</,
+    label: '>Cleared< (bare JSX label)',
+    replacement: '>Source-confirmed<',
+  },
+  {
+    pattern: />\s*CLEARED\s*</,
+    label: '>CLEARED< (bare JSX uppercase label)',
+    replacement: '>SOURCE-CONFIRMED<',
+  },
+  {
+    pattern: />\s*Safe\s*</,
+    label: '>Safe< (bare JSX label)',
+    replacement: '>Review completed< or domain-specific evidence-bounded label',
+  },
+  {
+    pattern: /aria-label=["']Approved["']/,
+    label: 'aria-label="Approved"',
+    replacement: 'aria-label="Marked review-complete"',
+  },
+  {
+    pattern: /aria-label=["']Verified["']/,
+    label: 'aria-label="Verified"',
+    replacement: 'aria-label="Source-confirmed"',
+  },
+  {
+    pattern: /\bclear to proceed\b/i,
+    label: '"clear to proceed" (any case)',
+    replacement: 'institution review still required',
+  },
+  {
+    pattern: /\bapproved automatically\b/i,
+    label: '"approved automatically"',
+    replacement: '(remove; no automated approval)',
+  },
+];
+
+const DEGRADED_STATES = [
+  'SOURCE_TIMEOUT',
+  'SOURCE_UNAVAILABLE',
+  'ACCESS_REQUIRED',
+  'REVIEW_PENDING',
+  'PARTIAL_COMPLETION',
+  'CONTINUITY_INTERRUPTED',
+] as const;
+
+// ── File walker ───────────────────────────────────────────────────────────
+
+function walk(root: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let stat;
+    try {
+      stat = statSync(cur);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      const entries = readdirSync(cur);
+      for (const e of entries) {
+        if (e.startsWith('.')) continue;
+        if (e === 'node_modules') continue;
+        if (e === '_archive') continue;
+        if (e === '__tests__') continue;
+        stack.push(join(cur, e));
+      }
+    } else if (stat.isFile()) {
+      if (cur.includes('.test.')) continue;
+      if (cur.endsWith('.tsx') || cur.endsWith('.ts')) {
+        out.push(cur);
+      }
+    }
+  }
+  return out;
+}
+
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+}
+
+// ── Banned-pattern scan ───────────────────────────────────────────────────
+
+function scanBanned(): Entry[] {
+  const entries: Entry[] = [];
+  const roots = [
+    resolve(REPO_ROOT, 'apps/web/app'),
+    resolve(REPO_ROOT, 'apps/web/components'),
+  ];
+  const files: string[] = [];
+  for (const root of roots) {
+    files.push(...walk(root));
+  }
+  if (files.length === 0) {
+    entries.push({ level: 'NOTE', text: 'no source files found under apps/web/{app,components}' });
+    return entries;
+  }
+  let scanned = 0;
+  let hits = 0;
+  for (const file of files) {
+    scanned += 1;
+    const src = stripComments(readFileSync(file, 'utf8'));
+    const rel = file.slice(REPO_ROOT.length + 1);
+    for (const rule of BANNED) {
+      if (rule.pattern.test(src)) {
+        hits += 1;
+        entries.push({
+          level: 'FAIL',
+          text: `${rel}: contains "${rule.label}" — replace with: ${rule.replacement}`,
+        });
+      }
+    }
+  }
+  entries.unshift({
+    level: 'NOTE',
+    text: `verification-integrity scan: ${scanned} source files; ${hits} FAIL hit(s)`,
+  });
+  return entries;
+}
+
+// ── Degraded-states sub-mode ──────────────────────────────────────────────
+
+function reportDegradedStates(): Entry[] {
+  const entries: Entry[] = [];
+  const roots = [
+    resolve(REPO_ROOT, 'apps/web/app'),
+    resolve(REPO_ROOT, 'apps/web/components'),
+  ];
+  const files: string[] = [];
+  for (const root of roots) {
+    files.push(...walk(root));
+  }
+  // Look for files that mention "verification" / "readiness" /
+  // "review" semantics and check whether any degraded state name
+  // appears in the same file. NOTE-level only; never FAIL.
+  let scanned = 0;
+  let exposing = 0;
+  let bare = 0;
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    const rel = file.slice(REPO_ROOT.length + 1);
+    const looksVerifying = /verify|review|readiness|lane/i.test(src);
+    if (!looksVerifying) continue;
+    scanned += 1;
+    const exposes = DEGRADED_STATES.some((s) => src.includes(s));
+    if (exposes) {
+      exposing += 1;
+    } else {
+      bare += 1;
+      // No FAIL — many verification surfaces legitimately don't render
+      // degraded states inline (they live elsewhere). Just NOTE.
+    }
+  }
+  entries.push({
+    level: 'NOTE',
+    text: `degraded-states scan: ${scanned} verification-related file(s); ${exposing} expose a degraded state, ${bare} do not (NOTE-level)`,
+  });
+  return entries;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const mode = (process.argv[2] ?? 'enforce') as Mode;
+  console.log(`# verify-verification-integrity (${mode}) · ${new Date().toISOString()}`);
+  console.log('#'.padEnd(72, '#'));
+
+  let entries: Entry[];
+  switch (mode) {
+    case 'degraded-states-only':
+      entries = reportDegradedStates();
+      break;
+    case 'report':
+      entries = scanBanned();
+      break;
+    case 'enforce':
+    default:
+      entries = scanBanned();
+      break;
+  }
+
+  for (const e of entries) console.log(`[${e.level.padEnd(4, ' ')}] ${e.text}`);
+  const failed = entries.filter((e) => e.level === 'FAIL');
+  if (mode === 'enforce' && failed.length > 0) {
+    console.log(
+      `\n[FAIL] verification integrity: ${failed.length} drift entr${failed.length === 1 ? 'y' : 'ies'}`,
+    );
+    process.exit(1);
+  }
+  console.log('\n[OK  ] verification integrity: no FAIL drift');
+}
+
+main();


### PR DESCRIPTION
## Summary

Eliminates positive-form verification certainty language from origin/main and replaces it with evidence-bounded states that derive deterministically from completed lane evidence + explicit institution review.

Constrained: no new features, no protocol changes, no manifest-tier shortcut additions.

## Seven files normalized

| File | Before | After |
|---|---|---|
| `review/[entityId]/ConsoleWrapper.tsx` | `Credentials verified. Clear to proceed.` | `Lane evidence completed. Institution review still required before a final decision.` |
| same | `Primary identity verified.` | `Identity lane source-confirmed.` |
| same | `Manual review required` | `Institution review required` |
| `employer/dashboard/page.tsx` | `Approved` / `Rejected` labels | `Marked Review-Complete` / `Not Eligible (Institution-Owned)` |
| `employer/StartClinicianAction.tsx` | `Superbrain clearance required ... CLEARED unlocks` | `Lane evidence required ... Source-confirmed unlocks; institution review remains required` |
| same | Badge `CLEARED` | Badge `SOURCE-CONFIRMED` |
| `employer/VerifierCommandCenter.tsx` | `aria-label="Approved"` | `aria-label="Marked review-complete"` |
| `employer/SuperbrainInsights.tsx` | `CLEARED` / `NOT CLEARED` | `SOURCE-CONFIRMED` / `REQUIRES INSTITUTION REVIEW` |
| `verifier/VerifierContinuityStatusBoard.tsx` | Status dot `VERIFIED` | `SOURCE-CONFIRMED` |
| `hero/SandboxHero.tsx` | `VERIFIED` / `CLEAR` | `SOURCE-CONFIRMED` / `NO ADVERSE RECORDS` |

## Six evidence-bounded visible states (binding)

`Review completed` · `Review pending` · `Additional review required` · `Source unavailable` · `Verification incomplete` · `Requires institution review`

Each state derives deterministically from: **completed lane evidence** + **explicit institution review** + **visible bounded certainty**. Manifest-tier shortcuts (single "trust score" aggregating multiple lanes into one number) are forbidden.

## Six degraded states (must be exposed, never hidden)

`SOURCE_TIMEOUT` · `SOURCE_UNAVAILABLE` · `ACCESS_REQUIRED` · `REVIEW_PENDING` · `PARTIAL_COMPLETION` · `CONTINUITY_INTERRUPTED`

A surface that renders verification state MUST expose these when they exist; collapsing them into a generic "pending" or hiding them is forbidden.

## Verifier behavior

`scripts/verify-verification-integrity.ts` — JSX-aware scanner across `apps/web/{app,components}`. Excludes `_archive/`, `__tests__/`, `*.test.*`. Eleven banned patterns covering:

- `>Verified<` / `>VERIFIED<` / `>Approved<` / `>Cleared<` / `>CLEARED<` / `>Safe<` JSX labels
- `aria-label="Approved"` / `aria-label="Verified"`
- `Credentials verified. Clear to proceed.` sentence
- `clear to proceed` (any case)
- `approved automatically`

Three sub-modes:

- `pnpm verify:verification-integrity` (default `enforce`) — exits non-zero on FAIL
- `pnpm verify:verification-integrity-report` — no-exit summary
- `pnpm verify:degraded-state-visibility` — NOTE-level scan of verification-related files for degraded-state exposure

Post-repair scan: **0 FAIL across 895 source files**.

## Stacking note

Branched off `origin/main` (SHA `7f7ace10`). Carries the wallet-sdk orphan re-export fix (canonical fix on PR #375).

## Validation

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `node scripts/verify-verification-integrity.ts enforce` — drift-free (0 FAIL across 895 files)
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/verification-integrity-hardening.test.ts` — **21/21 passing**
- [x] `pnpm turbo run build --filter @vitalcv/web` — passes
- [x] `pnpm --filter @vitalcv/web exec next lint --dir app/{review,employer} --dir components/{employer,hero,verifier}` — 0 warnings

## Test plan

- [ ] `pnpm verify:verification-integrity` locally — confirm 0 FAIL
- [ ] Visit `/review/<entityId>` — confirm posture copy reads "Lane evidence completed. Institution review still required"
- [ ] Visit `/employer/dashboard` — confirm `Marked Review-Complete` / `Not Eligible (Institution-Owned)`
- [ ] Open employer worklist and review surface — confirm `SOURCE-CONFIRMED` badges
- [ ] Codex audit · implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)