### PR TITLE
fix(product): harden P0/P1 institutional semantics

### DIFF
--- a/apps/web/__tests__/p0-p1-institutional-hardening.test.ts
+++ b/apps/web/__tests__/p0-p1-institutional-hardening.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+}).trim();
+
+function read(rel: string): string {
+  return readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+}
+
+/**
+ * Some repaired files carry a JSDoc-block at the top that explains
+ * what was changed and includes the original banned phrases for
+ * context. Negative assertions about banned-phrase removal should
+ * strip those comments first so the explanatory text doesn't
+ * masquerade as a regression.
+ */
+function readStripped(rel: string): string {
+  const raw = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+  return raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+function runVerifier(args: string[]): { code: number; output: string } {
+  try {
+    const output = execSync(
+      `node --experimental-strip-types scripts/verify-p0-p1-institutional-hardening.ts ${args.join(' ')}`,
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    return { code: 0, output };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const stdout =
+      typeof e.stdout === 'string'
+        ? e.stdout
+        : Buffer.isBuffer(e.stdout)
+          ? e.stdout.toString('utf8')
+          : '';
+    const stderr =
+      typeof e.stderr === 'string'
+        ? e.stderr
+        : Buffer.isBuffer(e.stderr)
+          ? e.stderr.toString('utf8')
+          : '';
+    return { code: e.status ?? 1, output: stdout + stderr };
+  }
+}
+
+const VERIFIER_TIMEOUT_MS = 60_000;
+
+// ── File presence ────────────────────────────────────────────────────────
+
+describe('p0-p1-institutional-hardening · file presence', () => {
+  it.each([
+    'docs/product/p0-p1-institutional-hardening.md',
+    'scripts/verify-p0-p1-institutional-hardening.ts',
+  ])('%s exists', (rel) => {
+    expect(existsSync(resolve(REPO_ROOT, rel))).toBe(true);
+  });
+});
+
+// ── P0 repairs ───────────────────────────────────────────────────────────
+
+describe('P0 · ClearToStartBanner', () => {
+  const src = read('apps/web/components/trust-state/ClearToStartBanner.tsx');
+  const stripped = readStripped('apps/web/components/trust-state/ClearToStartBanner.tsx');
+
+  it('removes the unsafe "verified and continuously monitored" copy', () => {
+    expect(stripped).not.toMatch(/All mandatory requirements verified and continuously monitored/);
+  });
+
+  it('uses lane-evidence + institution-review framing', () => {
+    expect(src).toMatch(/Lane evidence completed/);
+    expect(src).toMatch(/Federal-source lanes were source-confirmed/);
+    expect(src).toMatch(/Institution review is still required/);
+  });
+
+  it('explicitly disavows continuous monitoring', () => {
+    expect(src).toMatch(/does not perform\s+continuous\s+monitoring/);
+  });
+
+  it('exports a data-slot for verifier integration', () => {
+    expect(src).toMatch(/data-slot="clear-to-start-banner"/);
+  });
+});
+
+describe('P0 · ConsoleWrapper proceed semantics', () => {
+  const src = read('apps/web/app/review/[entityId]/ConsoleWrapper.tsx');
+
+  it('removes "Credentials verified. Clear to proceed."', () => {
+    expect(src).not.toMatch(/Credentials verified\.\s*Clear to proceed\./);
+  });
+
+  it('every posture branch names institution review explicitly', () => {
+    const fn = src.slice(src.indexOf('function deriveNextAction'));
+    const blockedBranch = fn.match(/posture === 'blocked'[^\n]*\n[^}]+/)?.[0] ?? '';
+    const decisionGradeBranch = fn.match(/posture === 'decision_grade'[^\n]*\n[^}]+/)?.[0] ?? '';
+    expect(blockedBranch).toMatch(/Institution review required/i);
+    expect(decisionGradeBranch).toMatch(/Institution review still required/i);
+    expect(fn).toMatch(/institution review still required/i);
+  });
+
+  it('no proceed-by-default copy in the default branch', () => {
+    expect(src).not.toMatch(/You can proceed with a head start\./);
+  });
+});
+
+// ── P1 repairs ───────────────────────────────────────────────────────────
+
+describe('P1 · MonitoringStatusBadge', () => {
+  const src = read('apps/web/components/trust-state/MonitoringStatusBadge.tsx');
+  const stripped = readStripped('apps/web/components/trust-state/MonitoringStatusBadge.tsx');
+
+  it('removes "Continuously Monitored" / "Monitoring Inactive" labels', () => {
+    expect(stripped).not.toMatch(/['"]Continuously Monitored['"]/);
+    expect(stripped).not.toMatch(/['"]Monitoring Inactive['"]/);
+  });
+
+  it('uses "Re-checked on request" / "Per-request re-checks disabled"', () => {
+    expect(src).toMatch(/Re-checked on request/);
+    expect(src).toMatch(/Per-request re-checks disabled/);
+  });
+
+  it('tooltip disavows continuous monitoring', () => {
+    expect(stripped).not.toMatch(/automatically monitored/);
+    expect(src).toMatch(/No continuous monitoring is performed/);
+  });
+});
+
+describe('P1 · ApplyBundleView monitoring labels', () => {
+  const src = read('apps/web/components/apply/ApplyBundleView.tsx');
+
+  it('removes "Continuously monitored" / "Monitoring inactive"', () => {
+    expect(src).not.toMatch(/['"]Continuously monitored['"]/);
+    expect(src).not.toMatch(/['"]Monitoring inactive['"]/);
+  });
+
+  it('uses bounded labels', () => {
+    expect(src).toMatch(/['"]Re-checked on request['"]/);
+    expect(src).toMatch(/['"]Per-request re-checks disabled['"]/);
+  });
+});
+
+describe('P1 · TrustStateCard window labels', () => {
+  const src = read('apps/web/components/trust-state/TrustStateCard.tsx');
+
+  it('removes "Continuously Monitored" from WINDOW_LABEL', () => {
+    expect(src).not.toMatch(/WITHIN_WINDOW:\s*['"]Continuously Monitored['"]/);
+  });
+
+  it('uses institution-freshness-budget framing', () => {
+    expect(src).toMatch(/Within institution freshness budget/);
+    expect(src).toMatch(/Freshness budget expiring soon/);
+    expect(src).toMatch(/Stale — re-fetch required/);
+  });
+});
+
+describe('P1 · verifier-types.ts recognition + decay copy', () => {
+  const src = read('apps/web/components/employer/verifier-types.ts');
+
+  it('removes "PSV-backed recognition"', () => {
+    expect(src).not.toMatch(/PSV-backed recognition/);
+  });
+
+  it('removes "automatic decay" language', () => {
+    expect(src).not.toMatch(/triggering automatic decay/);
+    expect(src).not.toMatch(/automatically decay/);
+  });
+
+  it('uses source-confirmed lane-evidence framing', () => {
+    expect(src).toMatch(/Source-confirmed lane evidence is on record/);
+    expect(src).toMatch(/institution.+freshness budget/i);
+  });
+
+  it('replaces "safety threshold" with institution-owned review threshold', () => {
+    expect(src).not.toMatch(/safety threshold/);
+    expect(src).toMatch(/institution.+own review threshold/i);
+  });
+});
+
+describe('P1 · DisclosureScopePanel cryptographic copy', () => {
+  const src = read('apps/web/components/trust-state/DisclosureScopePanel.tsx');
+
+  it('removes "cryptographically scoped"', () => {
+    expect(src).not.toMatch(/cryptographically scoped/);
+  });
+
+  it('removes "automatically decay"', () => {
+    expect(src).not.toMatch(/automatically decay/);
+  });
+
+  it('uses signature-scoped + re-presentation framing', () => {
+    expect(src).toMatch(/signature-scoped/);
+    expect(src).toMatch(/must be re-presented/);
+  });
+});
+
+// ── Doctrine doc shape ───────────────────────────────────────────────────
+
+describe('p0-p1 hardening doctrine doc', () => {
+  const md = read('docs/product/p0-p1-institutional-hardening.md');
+
+  it('records the P0 repairs by id', () => {
+    expect(md).toMatch(/P0-1 · ClearToStartBanner/);
+    expect(md).toMatch(/P0-2 · ConsoleWrapper proceed semantics/);
+  });
+
+  it('records the P1 repairs by id', () => {
+    for (const id of [
+      'P1-1 · MonitoringStatusBadge',
+      'P1-2 · ApplyBundleView',
+      'P1-3 · TrustStateCard',
+      'P1-4 · verifier-types',
+      'P1-5 · DisclosureScopePanel',
+    ]) {
+      expect(md).toContain(id);
+    }
+  });
+
+  it('enumerates the four degraded states that must be visible', () => {
+    for (const s of ['access_required', 'source_unavailable', 'timeout', 'incomplete_evidence']) {
+      expect(md).toContain(s);
+    }
+  });
+
+  it('declares the no-new-features posture', () => {
+    expect(md).toMatch(/Does NOT add any new feature/i);
+    expect(md).toMatch(/Does NOT touch API route source code/i);
+  });
+});
+
+// ── Verifier behavior ────────────────────────────────────────────────────
+
+describe('verify-p0-p1-institutional-hardening script', () => {
+  it(
+    'enforce mode passes after the repairs (no FAIL drift)',
+    () => {
+      const r = runVerifier(['enforce']);
+      expect(r.output).toContain('verify-p0-p1-institutional-hardening');
+      expect(r.output).toMatch(/\[OK\s+\] p0-p1 institutional hardening: no FAIL drift/);
+      expect(r.code).toBe(0);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'report sub-mode never exits non-zero',
+    () => {
+      const r = runVerifier(['report']);
+      expect(r.code).toBe(0);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+
+  it(
+    'degraded-states-only emits a scan summary',
+    () => {
+      const r = runVerifier(['degraded-states-only']);
+      expect(r.code).toBe(0);
+      expect(r.output).toMatch(/degraded-states scan: \d+ verification-related file/);
+    },
+    VERIFIER_TIMEOUT_MS,
+  );
+});
+
+// ── Pnpm registration ────────────────────────────────────────────────────
+
+describe('package.json · p0-p1 scripts', () => {
+  const pkg = JSON.parse(read('package.json')) as { scripts: Record<string, string> };
+
+  it.each([
+    'verify:p0-p1-institutional-hardening',
+    'verify:p0-p1-institutional-hardening-report',
+    'verify:p0-p1-degraded-states',
+  ])('exposes pnpm %s', (key) => {
+    expect(pkg.scripts[key]).toBeDefined();
+    expect(pkg.scripts[key]).toMatch(/verify-p0-p1-institutional-hardening/);
+  });
+});

--- a/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
+++ b/apps/web/app/review/[entityId]/ConsoleWrapper.tsx
@@ -144,13 +144,21 @@ function buildBlocker(lane: LaneSnapshot): BlockerItem {
 }
 
 function deriveNextAction(posture: ReadinessPosture, blockers: BlockerItem[]): string {
-  if (posture === 'blocked') return 'Adverse finding detected. Manual review required before proceeding.';
-  if (posture === 'decision_grade') return 'Credentials verified. Clear to proceed.';
+  // Wave 37 P0/P1 hardening: every posture is evidence-bounded and
+  // ends with an explicit institution-review requirement. No
+  // proceed-by-default copy; no "clear to proceed"; no implicit
+  // green-light at access_required.
+  if (posture === 'blocked') {
+    return 'Adverse finding detected. Institution review required before any decision; do not proceed without institutional sign-off.';
+  }
+  if (posture === 'decision_grade') {
+    return 'Lane evidence completed. Institution review still required before a final decision; this surface does not grant clearance.';
+  }
   const topBlocker = blockers[0];
   if (topBlocker?.status === 'access_required') {
-    return 'Primary identity verified. Additional sources pending — proceed with head start or wait.';
+    return 'Identity lane source-confirmed. Additional sources require institutional access — institution review still required before any decision.';
   }
-  return 'Source data is being checked. You can proceed with a head start.';
+  return 'Source data is being checked. Institution review still required; this surface does not grant clearance.';
 }
 
 // ─── Component ────────────────────────────────────────────────────

--- a/apps/web/components/apply/ApplyBundleView.tsx
+++ b/apps/web/components/apply/ApplyBundleView.tsx
@@ -56,9 +56,9 @@ interface Props {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const MONITORING_META = {
-  active: { label: 'Continuously monitored', color: 'text-foreground/70', dot: 'bg-white/70' },
-  partial: { label: 'Partially monitored', color: 'text-foreground', dot: 'bg-muted5' },
-  inactive: { label: 'Monitoring inactive', color: 'text-muted-foreground/50', dot: 'bg-white/25' },
+  active: { label: 'Re-checked on request', color: 'text-foreground/70', dot: 'bg-white/70' },
+  partial: { label: 'Partial source coverage', color: 'text-foreground', dot: 'bg-muted5' },
+  inactive: { label: 'Per-request re-checks disabled', color: 'text-muted-foreground/50', dot: 'bg-white/25' },
 };
 
 const STATUS_COLORS: Record<string, string> = {

--- a/apps/web/components/employer/verifier-types.ts
+++ b/apps/web/components/employer/verifier-types.ts
@@ -84,26 +84,26 @@ export function getTrustObserverExplanation(status: TrustStateStatus | null) {
 
   if (start_ready) {
     explanation =
-      'Subject has PSV-backed recognition and employer acceptance on record. Start remains gated by explicit attestation timing.';
+      'Source-confirmed lane evidence is on record and the employer has recorded an acceptance for this scope. Institution attestation timing still gates the start.';
   } else if (!recognized) {
     explanation =
-      'Subject is not recognized by the trust network. Initial verification is required.';
+      'Subject is not on record with source-confirmed lane evidence. Source resolution is required.';
     key_blocker = 'MISSING_RECOGNITION';
   } else if (blocking_reasons?.includes('VERIFICATION_EXPIRED')) {
     explanation =
-      'Trust integrity compromised. Verification signals have aged beyond the acceptable threshold, triggering automatic decay.';
+      'Source-confirmed lane evidence has aged beyond the institution’s freshness budget. Re-fetch on the institution’s own credential to renew.';
     key_blocker = 'VERIFICATION_EXPIRED';
   } else if (blocking_reasons?.includes('ACTIVE_SANCTIONS')) {
     explanation =
-      'Critical blocker detected. Active sanctions in audit history prevent any clinical activity.';
+      'Active sanctions in source-confirmed audit history. Institution review required before any clinical activity.';
     key_blocker = 'ACTIVE_SANCTIONS';
   } else if (blocking_reasons?.includes('CRS_BELOW_THRESHOLD')) {
     explanation =
-      'Cumulative trust factors (license status, tenure, sanctions) result in a score below the safety threshold.';
+      'Cumulative review factors (license status, tenure, sanctions) sit below the institution’s own review threshold. Institution review required.';
     key_blocker = 'CRS_BELOW_THRESHOLD';
   } else if (!accepted) {
     explanation =
-      'PSV-backed recognition is present, but this employer has not recorded acceptance for this scope.';
+      'Source-confirmed lane evidence is on record, but this employer has not recorded acceptance for this scope.';
     key_blocker = 'MISSING_ACCEPTANCE';
   } else {
     explanation = 'One or more blocking criteria are unmet.';

--- a/apps/web/components/trust-state/ClearToStartBanner.tsx
+++ b/apps/web/components/trust-state/ClearToStartBanner.tsx
@@ -2,14 +2,34 @@
 
 import { CheckCircle2 } from 'lucide-react';
 
+/**
+ * Wave 37 P0 hardening: this banner formerly read
+ *   "All mandatory requirements verified and continuously monitored."
+ * which conflated substrate-side lane confirmation with continuous
+ * monitoring (no continuous monitoring is performed) and with
+ * institutional decision-grade clearance (substrate cannot grant
+ * clearance). The copy is now evidence-bounded: it names what was
+ * confirmed against the federal sources, what the receiving
+ * institution still owns, and what the surface does NOT claim.
+ */
 export function ClearToStartBanner() {
   return (
-    <div className="w-full bg-emerald-50 border-b border-emerald-200 px-4 py-3 flex items-center justify-between">
+    <div
+      data-slot="clear-to-start-banner"
+      className="w-full bg-emerald-50 border-b border-emerald-200 px-4 py-3 flex items-center justify-between"
+    >
       <div className="flex items-center gap-3">
         <CheckCircle2 className="h-5 w-5 text-emerald-600" />
         <div className="flex flex-col">
-          <span className="text-sm font-semibold text-emerald-900 tracking-tight">Clear to Start</span>
-          <span className="text-xs text-emerald-700">All mandatory requirements verified and continuously monitored.</span>
+          <span className="text-sm font-semibold text-emerald-900 tracking-tight">
+            Lane evidence completed
+          </span>
+          <span className="text-xs text-emerald-700">
+            Federal-source lanes were source-confirmed at the last
+            read. Institution review is still required before any
+            final decision; this surface does not perform continuous
+            monitoring.
+          </span>
         </div>
       </div>
     </div>

--- a/apps/web/components/trust-state/DisclosureScopePanel.tsx
+++ b/apps/web/components/trust-state/DisclosureScopePanel.tsx
@@ -20,8 +20,8 @@ export function DisclosureScopePanel({
         <div>
           <h3 className="font-semibold text-sm text-indigo-950">Minimum-Necessary Disclosure Policy</h3>
           <p className="text-xs text-indigo-800/80 mt-1 max-w-prose leading-relaxed">
-            Access to these credential facts is cryptographically scoped to the stated verification purposes. 
-            The evidence artifacts will automatically decay from the verifier's perimeter in <strong className="font-semibold text-indigo-900">{expiresInDays} days</strong>.
+            Access to these credential facts is signature-scoped to the stated review purposes.
+            The evidence artifacts expire from the verifier&apos;s perimeter in <strong className="font-semibold text-indigo-900">{expiresInDays} days</strong> and must be re-presented by the holder for any subsequent review.
           </p>
           
           <div className="mt-4">

--- a/apps/web/components/trust-state/MonitoringStatusBadge.tsx
+++ b/apps/web/components/trust-state/MonitoringStatusBadge.tsx
@@ -4,6 +4,15 @@ import { Activity, Clock } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
+/**
+ * Wave 37 P0 hardening: this badge formerly read "Continuously
+ * Monitored" and described verification as "automatically monitored
+ * for changes". VitalCV does NOT continuously monitor; lanes are
+ * resolved per-request against the published federal sources. The
+ * badge now names the per-request posture honestly: lanes are
+ * re-checked when a request is made, on the institution's freshness
+ * budget.
+ */
 export function MonitoringStatusBadge({
   active = true,
   lastMonitoredAt,
@@ -27,14 +36,16 @@ export function MonitoringStatusBadge({
             ) : (
               <Clock className="h-3 w-3 text-slate-400" />
             )}
-            {active ? 'Continuously Monitored' : 'Monitoring Inactive'}
+            {active
+              ? 'Re-checked on request'
+              : 'Per-request re-checks disabled'}
           </Badge>
         </TooltipTrigger>
         <TooltipContent side="top">
           <p>
             {active
-              ? `Verification is automatically monitored for changes.`
-              : 'Continuous monitoring is currently turned off.'}
+              ? 'Lanes are resolved per request against the published federal sources on the institution’s own freshness budget. No continuous monitoring is performed.'
+              : 'Per-request re-checks are currently turned off.'}
           </p>
           {lastMonitoredAt && (
             <p className="mt-1 text-[10px] opacity-80">

--- a/apps/web/components/trust-state/TrustStateCard.tsx
+++ b/apps/web/components/trust-state/TrustStateCard.tsx
@@ -41,10 +41,10 @@ const BAND_CONFIG: Record<
 };
 
 const WINDOW_LABEL: Record<WindowStatus, string> = {
-  WITHIN_WINDOW: 'Continuously Monitored',
-  EXPIRING_SOON: 'Monitoring Window Expiring Soon',
-  EXPIRED: 'Stale (Monitoring Expired)',
-  NOT_YET_VALID: 'Verification Not Yet Valid',
+  WITHIN_WINDOW: 'Within institution freshness budget',
+  EXPIRING_SOON: 'Freshness budget expiring soon',
+  EXPIRED: 'Stale — re-fetch required',
+  NOT_YET_VALID: 'Evidence not yet effective',
 };
 
 // ── Helpers ────────────────────────────────────────────────

--- a/docs/product/p0-p1-institutional-hardening.md
+++ b/docs/product/p0-p1-institutional-hardening.md
@@ -1,0 +1,135 @@
+# P0/P1 Institutional Hardening
+
+Binding repair record for the highest-risk institutional overclaims
+identified on origin/main. The wave targets six specific surfaces
+where positive-form certainty, fake continuous-monitoring claims,
+proceed-by-default behavior, or unsupported recognition semantics
+were rendered to operators.
+
+Cut date: 2026-05-21.
+
+## P0 (decision-grade copy that conflated substrate with institutional decision)
+
+### P0-1 · ClearToStartBanner
+
+**Before**: `All mandatory requirements verified and continuously monitored.`
+
+**After**: `Federal-source lanes were source-confirmed at the last read. Institution review is still required before any final decision; this surface does not perform continuous monitoring.`
+
+**Why**: the original copy conflated (a) substrate-side lane confirmation with (b) continuous monitoring (none is performed) and with (c) institutional decision-grade clearance (only the institution clears).
+
+### P0-2 · ConsoleWrapper proceed semantics
+
+**Before**:
+- `Credentials verified. Clear to proceed.` (decision-grade)
+- `Primary identity verified. Additional sources pending — proceed with head start or wait.` (proceed-at-access_required)
+- `Source data is being checked. You can proceed with a head start.` (proceed-by-default)
+- `Adverse finding detected. Manual review required before proceeding.` (vague review owner)
+
+**After**:
+- `Lane evidence completed. Institution review still required before a final decision; this surface does not grant clearance.`
+- `Identity lane source-confirmed. Additional sources require institutional access — institution review still required before any decision.`
+- `Source data is being checked. Institution review still required; this surface does not grant clearance.`
+- `Adverse finding detected. Institution review required before any decision; do not proceed without institutional sign-off.`
+
+**Why**: every posture now ends with an explicit institution-review requirement. No proceed-by-default copy. No implicit green-light at `access_required`. Review owner named.
+
+## P1 (monitoring overclaims, recognition / decay overclaims)
+
+### P1-1 · MonitoringStatusBadge
+
+**Before**:
+- Label: `Continuously Monitored` / `Monitoring Inactive`
+- Tooltip: `Verification is automatically monitored for changes.`
+
+**After**:
+- Label: `Re-checked on request` / `Per-request re-checks disabled`
+- Tooltip: `Lanes are resolved per request against the published federal sources on the institution's own freshness budget. No continuous monitoring is performed.`
+
+**Why**: VitalCV does NOT continuously monitor. Lanes are resolved per-request. The new copy names the per-request posture honestly.
+
+### P1-2 · ApplyBundleView monitoring labels
+
+**Before**: `Continuously monitored` / `Partially monitored` / `Monitoring inactive`
+
+**After**: `Re-checked on request` / `Partial source coverage` / `Per-request re-checks disabled`
+
+### P1-3 · TrustStateCard window labels
+
+**Before**: `Continuously Monitored` / `Monitoring Window Expiring Soon` / `Stale (Monitoring Expired)` / `Verification Not Yet Valid`
+
+**After**: `Within institution freshness budget` / `Freshness budget expiring soon` / `Stale — re-fetch required` / `Evidence not yet effective`
+
+**Why**: "Monitoring" is the wrong frame; the budget is the institution's freshness window, not a VitalCV monitoring window.
+
+### P1-4 · verifier-types.ts recognition + decay copy
+
+**Before**:
+- `Subject has PSV-backed recognition and employer acceptance on record. Start remains gated by explicit attestation timing.`
+- `Trust integrity compromised. Verification signals have aged beyond the acceptable threshold, triggering automatic decay.`
+- `PSV-backed recognition is present, but this employer has not recorded acceptance for this scope.`
+- `score below the safety threshold`
+
+**After**:
+- `Source-confirmed lane evidence is on record and the employer has recorded an acceptance for this scope. Institution attestation timing still gates the start.`
+- `Source-confirmed lane evidence has aged beyond the institution's freshness budget. Re-fetch on the institution's own credential to renew.`
+- `Source-confirmed lane evidence is on record, but this employer has not recorded acceptance for this scope.`
+- `sit below the institution's own review threshold. Institution review required.`
+
+**Why**: "PSV-backed recognition" implies VitalCV grants recognition. The substrate carries lane evidence; institutions recognize. "Automatic decay" implies a non-existent automated process; lanes go stale against an institutional freshness budget. "Safety threshold" implies a VitalCV-owned safety bar; the threshold is the institution's own.
+
+### P1-5 · DisclosureScopePanel cryptographic / decay copy
+
+**Before**: `Access to these credential facts is cryptographically scoped to the stated verification purposes. The evidence artifacts will automatically decay from the verifier's perimeter in N days.`
+
+**After**: `Access to these credential facts is signature-scoped to the stated review purposes. The evidence artifacts expire from the verifier's perimeter in N days and must be re-presented by the holder for any subsequent review.`
+
+**Why**: "cryptographically scoped" overclaims the substrate; "signature-scoped" is the accurate operational form. "Automatically decay" implies background activity; "expire and must be re-presented" is the honest operational frame.
+
+## Degraded-state visibility (binding)
+
+A verification / readiness surface MUST expose:
+
+- `access_required` (the lane requires institutional credentials)
+- `source_unavailable` (registry returned error / 5xx)
+- `timeout` (registry exceeded freshness budget)
+- `incomplete_evidence` (one or more lanes have not completed)
+
+A surface that hides any of these in a generic "pending" state is a
+regression. The doctrine forbids collapsing degraded states into a
+"good enough" aggregate.
+
+## What this wave does NOT do
+
+- Does NOT remove the `verified` TypeScript literal-type members
+  used internally (e.g. `status: 'verified' | 'degraded'` unions).
+  Those are data model values; the user-facing labels they map to
+  are normalized.
+- Does NOT touch API route source code.
+- Does NOT touch fixture string constants used for backward
+  compatibility.
+- Does NOT add any new feature or protocol surface.
+
+## Verifier behavior
+
+`scripts/verify-p0-p1-institutional-hardening.ts` scans
+`apps/web/{app,components}` for the six P0/P1 phrases this wave
+eliminated. Three sub-modes:
+
+- `enforce` (default) — exits non-zero on any FAIL
+- `report` — scan + summary; never exits non-zero
+- `degraded-states-only` — checks legitimate exposure of the four
+  degraded states (NOTE-level)
+
+Post-repair: **0 FAIL hits**.
+
+## Governance
+
+A new visible verification / monitoring / recognition surface MUST:
+
+1. Avoid every banned phrase named in this doc
+2. Use evidence-bounded language (lane state + institution review + freshness budget) for any monitoring or recognition claim
+3. Expose degraded states; never collapse them into a generic "pending"
+4. Pass `pnpm verify:p0-p1-institutional-hardening` with zero FAILs
+
+PRs that violate any of the four are rejected at Codex audit.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:backend:db": "bash scripts/backend-test-db.sh",
     "verify:production-convergence": "node --experimental-strip-types scripts/runtime/verify-production-convergence.ts",
     "verify:passport-runtime": "node --experimental-strip-types scripts/runtime/verify-passport-runtime.ts",
+    "verify:p0-p1-institutional-hardening": "node --experimental-strip-types scripts/verify-p0-p1-institutional-hardening.ts enforce",
+    "verify:p0-p1-institutional-hardening-report": "node --experimental-strip-types scripts/verify-p0-p1-institutional-hardening.ts report",
+    "verify:p0-p1-degraded-states": "node --experimental-strip-types scripts/verify-p0-p1-institutional-hardening.ts degraded-states-only",
     "release:readiness": "node --experimental-strip-types scripts/release/release-readiness.ts",
     "runtime:kill-shadow-runtimes": "bash scripts/runtime/kill-shadow-runtimes.sh"
   },

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -348,4 +348,5 @@ export default VitalCVWallet;
 // Wave 133: version + diagnostics
 export * from './version';
 export * from './diagnostics';
-export * from './interoperability';
+// Note: prior `./interoperability` re-export referenced a file that
+// was never landed. Canonical fix lives on PR #375.

--- a/scripts/verify-p0-p1-institutional-hardening.ts
+++ b/scripts/verify-p0-p1-institutional-hardening.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify-p0-p1-institutional-hardening.ts
+ *
+ * Scans apps/web/{app,components} for the specific P0/P1 phrases
+ * eliminated in Wave 37. Contract lives in
+ * docs/product/p0-p1-institutional-hardening.md.
+ *
+ * Sub-modes:
+ *   enforce               default; exit non-zero on FAIL
+ *   report                scan + summary; never exit non-zero
+ *   degraded-states-only  check exposure of access_required /
+ *                         source_unavailable / timeout /
+ *                         incomplete_evidence (NOTE-level)
+ *
+ * Excludes:
+ *   _archive/   (retired code)
+ *   node_modules/
+ *   .next/
+ *   *.test.*    (tests may reference banned phrases)
+ *   __tests__/  (test fixtures)
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+type Mode = 'enforce' | 'report' | 'degraded-states-only';
+
+const REPO_ROOT = (() => {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+})();
+
+type Level = 'OK' | 'NOTE' | 'WARN' | 'FAIL';
+interface Entry {
+  level: Level;
+  text: string;
+}
+
+interface BannedRule {
+  pattern: RegExp;
+  label: string;
+  replacement: string;
+}
+
+// P0/P1 phrases. Patterns are tight to avoid catching the
+// rejection-table strings in the doctrine doc (the doctrine lives
+// under docs/, which is excluded from the scan).
+const RULES: readonly BannedRule[] = [
+  {
+    pattern: /All mandatory requirements verified and continuously monitored/,
+    label: 'ClearToStartBanner: "All mandatory requirements verified and continuously monitored."',
+    replacement: 'Federal-source lanes were source-confirmed at the last read. Institution review still required.',
+  },
+  {
+    pattern: /Credentials verified\.\s*Clear to proceed\./,
+    label: 'ConsoleWrapper proceed-grade: "Credentials verified. Clear to proceed."',
+    replacement: 'Lane evidence completed. Institution review still required.',
+  },
+  {
+    pattern: /Continuously Monitored/,
+    label: '"Continuously Monitored" (TitleCase label)',
+    replacement: 'Re-checked on request',
+  },
+  {
+    pattern: /Continuously monitored/,
+    label: '"Continuously monitored" (sentence-case label)',
+    replacement: 'Re-checked on request',
+  },
+  {
+    pattern: /automatically monitored/,
+    label: '"automatically monitored"',
+    replacement: 'resolved per request',
+  },
+  {
+    pattern: /PSV-backed recognition/,
+    label: '"PSV-backed recognition"',
+    replacement: 'Source-confirmed lane evidence',
+  },
+  {
+    pattern: /automatically decay/,
+    label: '"automatically decay"',
+    replacement: 'expire against the institution’s freshness budget; re-presentation required',
+  },
+  {
+    pattern: /cryptographically scoped/,
+    label: '"cryptographically scoped"',
+    replacement: 'signature-scoped',
+  },
+];
+
+const DEGRADED_STATES = [
+  'access_required',
+  'source_unavailable',
+  'timeout',
+  'incomplete_evidence',
+] as const;
+
+// ── File walker ───────────────────────────────────────────────────────────
+
+function walk(root: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let stat;
+    try {
+      stat = statSync(cur);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      const entries = readdirSync(cur);
+      for (const e of entries) {
+        if (e.startsWith('.')) continue;
+        if (e === 'node_modules') continue;
+        if (e === '_archive') continue;
+        if (e === '__tests__') continue;
+        stack.push(join(cur, e));
+      }
+    } else if (stat.isFile()) {
+      if (cur.includes('.test.')) continue;
+      if (cur.endsWith('.tsx') || cur.endsWith('.ts')) {
+        out.push(cur);
+      }
+    }
+  }
+  return out;
+}
+
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+}
+
+// ── Banned scan ───────────────────────────────────────────────────────────
+
+function scanBanned(): Entry[] {
+  const entries: Entry[] = [];
+  const roots = [
+    resolve(REPO_ROOT, 'apps/web/app'),
+    resolve(REPO_ROOT, 'apps/web/components'),
+  ];
+  const files: string[] = [];
+  for (const root of roots) {
+    files.push(...walk(root));
+  }
+  if (files.length === 0) {
+    entries.push({ level: 'NOTE', text: 'no source files found under apps/web/{app,components}' });
+    return entries;
+  }
+  let scanned = 0;
+  let hits = 0;
+  for (const file of files) {
+    scanned += 1;
+    const src = stripComments(readFileSync(file, 'utf8'));
+    const rel = file.slice(REPO_ROOT.length + 1);
+    for (const rule of RULES) {
+      if (rule.pattern.test(src)) {
+        hits += 1;
+        entries.push({
+          level: 'FAIL',
+          text: `${rel}: contains "${rule.label}" — replace with: ${rule.replacement}`,
+        });
+      }
+    }
+  }
+  entries.unshift({
+    level: 'NOTE',
+    text: `p0-p1 scan: ${scanned} source files; ${hits} FAIL hit(s)`,
+  });
+  return entries;
+}
+
+function reportDegradedStates(): Entry[] {
+  const entries: Entry[] = [];
+  const roots = [
+    resolve(REPO_ROOT, 'apps/web/app'),
+    resolve(REPO_ROOT, 'apps/web/components'),
+  ];
+  const files: string[] = [];
+  for (const root of roots) {
+    files.push(...walk(root));
+  }
+  let total = 0;
+  let exposingAtLeastOne = 0;
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    // Only files that look like they render verification / readiness
+    // state are candidates; library files / API helpers are skipped.
+    if (!/verify|readiness|review|lane|posture/i.test(src)) continue;
+    total += 1;
+    const exposes = DEGRADED_STATES.some((s) => src.includes(s));
+    if (exposes) exposingAtLeastOne += 1;
+  }
+  entries.push({
+    level: 'NOTE',
+    text: `degraded-states scan: ${total} verification-related file(s); ${exposingAtLeastOne} expose at least one of [${DEGRADED_STATES.join(', ')}]`,
+  });
+  return entries;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const mode = (process.argv[2] ?? 'enforce') as Mode;
+  console.log(`# verify-p0-p1-institutional-hardening (${mode}) · ${new Date().toISOString()}`);
+  console.log('#'.padEnd(72, '#'));
+
+  let entries: Entry[];
+  switch (mode) {
+    case 'degraded-states-only':
+      entries = reportDegradedStates();
+      break;
+    case 'report':
+      entries = scanBanned();
+      break;
+    case 'enforce':
+    default:
+      entries = scanBanned();
+      break;
+  }
+
+  for (const e of entries) console.log(`[${e.level.padEnd(4, ' ')}] ${e.text}`);
+  const failed = entries.filter((e) => e.level === 'FAIL');
+  if (mode === 'enforce' && failed.length > 0) {
+    console.log(
+      `\n[FAIL] p0-p1 institutional hardening: ${failed.length} drift entr${failed.length === 1 ? 'y' : 'ies'}`,
+    );
+    process.exit(1);
+  }
+  console.log('\n[OK  ] p0-p1 institutional hardening: no FAIL drift');
+}
+
+main();


### PR DESCRIPTION
## Summary

Targeted repair of the highest-risk overclaims on origin/main. Seven specific files (ClearToStartBanner, ConsoleWrapper, MonitoringStatusBadge, ApplyBundleView, TrustStateCard, verifier-types.ts, DisclosureScopePanel) normalized to evidence-bounded language. Ships a verifier that prevents regressions.

Constrained: no new features, no protocol changes, no manifest-tier shortcut additions, no API route source changes, no fixture-string constant changes.

## P0 repairs (decision-grade copy → bounded copy)

| ID | File | Before | After |
|---|---|---|---|
| P0-1 | `trust-state/ClearToStartBanner.tsx` | `All mandatory requirements verified and continuously monitored.` | `Federal-source lanes were source-confirmed at the last read. Institution review is still required before any final decision; this surface does not perform continuous monitoring.` |
| P0-2 | `app/review/[entityId]/ConsoleWrapper.tsx` | `Credentials verified. Clear to proceed.` and three proceed-by-default sibling branches | Every posture branch ends with explicit institution-review language; no proceed-by-default; no implicit green-light at `access_required` |

## P1 repairs (monitoring / recognition / decay overclaims)

| ID | File | Before | After |
|---|---|---|---|
| P1-1 | `trust-state/MonitoringStatusBadge.tsx` | `Continuously Monitored` / tooltip `automatically monitored for changes` | `Re-checked on request` / tooltip `No continuous monitoring is performed` |
| P1-2 | `apply/ApplyBundleView.tsx` | `Continuously monitored` / `Partially monitored` / `Monitoring inactive` | `Re-checked on request` / `Partial source coverage` / `Per-request re-checks disabled` |
| P1-3 | `trust-state/TrustStateCard.tsx` | `Continuously Monitored` / `Monitoring Window Expiring Soon` / `Stale (Monitoring Expired)` | `Within institution freshness budget` / `Freshness budget expiring soon` / `Stale — re-fetch required` |
| P1-4 | `employer/verifier-types.ts` | `PSV-backed recognition` / `automatic decay` / `safety threshold` | `Source-confirmed lane evidence` / `expire against the institution's freshness budget` / `institution's own review threshold` |
| P1-5 | `trust-state/DisclosureScopePanel.tsx` | `cryptographically scoped` / `automatically decay` | `signature-scoped` / `expire ... must be re-presented by the holder` |

## Degraded-state visibility (binding)

Four degraded states MUST be exposed and never collapsed into a generic "pending":

- `access_required` (lane requires institutional credentials)
- `source_unavailable` (registry returned error / 5xx)
- `timeout` (registry exceeded freshness budget)
- `incomplete_evidence` (one or more lanes have not completed)

## Verifier behavior

`scripts/verify-p0-p1-institutional-hardening.ts` — scanner across `apps/web/{app,components}` with eight banned patterns. Excludes `_archive/`, `__tests__/`, `*.test.*`. Three sub-modes:

- `pnpm verify:p0-p1-institutional-hardening` (default `enforce`) — exits non-zero on FAIL
- `pnpm verify:p0-p1-institutional-hardening-report` — no-exit summary
- `pnpm verify:p0-p1-degraded-states` — NOTE-level scan of verification-related files for degraded-state exposure

Post-repair scan: **0 FAIL across 895 source files**.

## Stacking note

Branched off `origin/main` (SHA `7f7ace10`). Carries the wallet-sdk orphan re-export fix (canonical fix on PR #375).

## Validation

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `node scripts/verify-p0-p1-institutional-hardening.ts enforce` — drift-free (0 FAIL across 895 files)
- [x] `pnpm --filter @vitalcv/web exec vitest run __tests__/p0-p1-institutional-hardening.test.ts` — **33/33 passing**
- [x] `pnpm turbo run build --filter @vitalcv/web` — passes
- [x] `pnpm --filter @vitalcv/web exec next lint --dir components/{trust-state,employer,apply} --dir app/review` — 0 warnings

## Test plan

- [ ] `pnpm verify:p0-p1-institutional-hardening` locally — confirm 0 FAIL
- [ ] Visit `/holder/readiness` — confirm ClearToStartBanner reads "Lane evidence completed"
- [ ] Visit `/holder` — confirm MonitoringStatusBadge reads "Re-checked on request" (auth required)
- [ ] Visit `/review/<entityId>` — confirm every posture states "Institution review still required"
- [ ] Codex audit · implementation / diff / copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)