### PR TITLE
fix(p0): replace 'Readiness score generated' with 'Readiness status generated' on homepage

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -191,7 +191,7 @@ export default function HomePageClient() {
 
         {/* ── What happens after ────────────────────────────────────────── */}
         <div className="mt-6 flex flex-wrap gap-4 text-[13px] text-[var(--vt-text-muted)]">
-          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness score generated'].map((item) => (
+          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness status generated'].map((item) => (
             <span key={item} className="flex items-center gap-1.5">
               <CheckCircle2 size={13} className="text-[var(--vt-state-verified)] shrink-0" aria-hidden="true" />
               {item}


### PR DESCRIPTION
## P0 Cutover Blocker

Live verification against `https://vitalcv-web-production.up.railway.app/` returned banned phrase **`Readiness score generated`** on the homepage 'What happens after' strip. PR #417's stated change to this line did not actually land on the merged tree — `origin/wave-10a/docs-status` commit `4bb1bfae` (= live) still contains it at `apps/web/app/HomePageClient.tsx:194`.

## Change

Single-line string replacement in one file:

```diff
-          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness score generated'].map((item) => (
+          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness status generated'].map((item) => (
```

## Scope

- 1 file, 1 line, no architecture, no data deps, no routes, no copy elsewhere
- `pnpm install --frozen-lockfile` clean
- `pnpm turbo run build --filter @vitalcv/web` passes (10/10, 9 cached)
- All other routes/copy on the homepage already safe per live scan

## Verify after redeploy

```bash
BASE=https://vitalcv-web-production.up.railway.app
curl -fsS "$BASE/" | grep -i 'readiness score generated' && echo "FAIL — still banned" || echo "OK — clean"
curl -fsS "$BASE/" | grep -i 'readiness status generated' && echo "OK — safe phrase present" || echo "FAIL — safe phrase missing"
```

## Closes

P0 blocker on apex/www cutover. After merge → Railway redeploy `vitalcv-web` → re-verify → DESIGN re-QA may proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)