### PR TITLE
fix(passport): show NPPES source-confirmed when identity payload returned (NPI 1699264564 truth-state)

### DIFF
--- a/apps/web/__tests__/ingest-stream-state.test.ts
+++ b/apps/web/__tests__/ingest-stream-state.test.ts
@@ -237,4 +237,79 @@ describe('ingestStreamState', () => {
     expect(state.sources.oig).toBe('done');
     expect(state.phase).toBe('enrollment');
   });
+
+  it('treats NPPES source_complete with populated identity payload as authoritative even when backend status is FAILED', () => {
+    // Backend ingestOrchestrator currently emits source_complete with
+    // status: FAILED whenever the run produces zero normalized claim records,
+    // even when the NPPES identity payload itself (displayName, identityStatus,
+    // entityId, taxonomies) is fully intact. The UI must not show "Unavailable"
+    // for NPPES in that case — identity has been resolved.
+    let state = {
+      ...createInitialIngestStreamState(),
+      phase: 'nppes' as const,
+      sources: { nppes: 'checking' as const, oig: 'checking' as const, pecos: 'checking' as const },
+    };
+
+    state = applyIngestEvent(state, makeEvent({
+      type: 'source_complete',
+      sourceId: 'nppes',
+      payload: {
+        sourceId: 'nppes',
+        status: 'FAILED',
+        resultStatus: 'FAILED',
+        entityId: 'entity-vef',
+        displayName: 'VICTORIA ELIZABETH FISCHER, MD',
+        identityStatus: 'ACTIVE',
+        specialty: 'Neurological Surgery',
+        claimCount: 0,
+        credentialIds: [],
+      },
+    }));
+
+    expect(state.sources.nppes).toBe('done');
+    expect(state.identity.authoritative).toBe(true);
+    expect(state.identity.displayName).toBe('VICTORIA ELIZABETH FISCHER, MD');
+    expect(state.identity.entityId).toBe('entity-vef');
+  });
+
+  it('keeps NPPES as error when status FAILED and no identity payload', () => {
+    let state = {
+      ...createInitialIngestStreamState(),
+      phase: 'nppes' as const,
+      sources: { nppes: 'checking' as const, oig: 'checking' as const, pecos: 'checking' as const },
+    };
+
+    state = applyIngestEvent(state, makeEvent({
+      type: 'source_complete',
+      sourceId: 'nppes',
+      payload: {
+        sourceId: 'nppes',
+        status: 'FAILED',
+        claimCount: 0,
+        credentialIds: [],
+      },
+    }));
+
+    expect(state.sources.nppes).toBe('error');
+    expect(state.identity.authoritative).toBe(false);
+  });
+
+  it('does not promote identity to authoritative when identityStatus is UNKNOWN even with displayName', () => {
+    let state = createInitialIngestStreamState();
+
+    state = applyIngestEvent(state, makeEvent({
+      type: 'source_complete',
+      sourceId: 'nppes',
+      payload: {
+        sourceId: 'nppes',
+        status: 'FAILED',
+        entityId: 'entity-x',
+        displayName: 'SOME NAME',
+        identityStatus: 'UNKNOWN',
+      },
+    }));
+
+    expect(state.identity.authoritative).toBe(false);
+    expect(state.sources.nppes).toBe('error');
+  });
 });

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -191,7 +191,7 @@ export default function HomePageClient() {
 
         {/* ── What happens after ────────────────────────────────────────── */}
         <div className="mt-6 flex flex-wrap gap-4 text-[13px] text-[var(--vt-text-muted)]">
-          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness score generated'].map((item) => (
+          {['Identity confirmed against NPPES', 'Sanctions checked via OIG', 'Readiness status generated'].map((item) => (
             <span key={item} className="flex items-center gap-1.5">
               <CheckCircle2 size={13} className="text-[var(--vt-state-verified)] shrink-0" aria-hidden="true" />
               {item}

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -156,11 +156,23 @@ function resolveSourceBadge(state: SourceState, displayValue: string): {
   };
 }
 
-function SourceRow({ label, state, value }: { label: string; state: SourceState; value?: string }) {
+function SourceRow({
+  label,
+  state,
+  value,
+  errorLabel = 'Unavailable',
+  errorCopy,
+}: {
+  label: string;
+  state: SourceState;
+  value?: string;
+  errorLabel?: string;
+  errorCopy?: string;
+}) {
   const displayValue =
     state === 'checking' ? 'Checking…'
     : state === 'done' ? (value ?? 'Done')
-    : state === 'error' ? 'Unavailable'
+    : state === 'error' ? errorLabel
     : '—';
   const badge = resolveSourceBadge(state, displayValue);
 
@@ -180,9 +192,9 @@ function SourceRow({ label, state, value }: { label: string; state: SourceState;
         />
         <div>
           <span className="text-muted-foreground text-sm">{label}</span>
-          {state === 'error' && (
-            <p className="text-muted-foreground/40 text-xs mt-0.5">Checking in the background — we&apos;ll update when it arrives.</p>
-          )}
+          {state === 'error' && errorCopy ? (
+            <p className="text-muted-foreground/40 text-xs mt-0.5">{errorCopy}</p>
+          ) : null}
         </div>
       </div>
       <TrustStatusBadge status={badge.status} label={badge.label} size="sm" />
@@ -613,16 +625,22 @@ function PassportPageContent({
                 label="NPPES"
                 state={sources.nppes}
                 value={identityLabel}
+                errorLabel="Temporarily unavailable"
+                errorCopy="Source temporarily unavailable. Try this NPI again in a moment."
               />
               <SourceRow
                 label="OIG / LEIE"
                 state={sources.oig}
                 value={exclusionLabel}
+                errorLabel="Not connected"
+                errorCopy="Federal exclusion lane is not connected in this build. Do not treat this as an exclusion clearance."
               />
               <SourceRow
                 label="CMS PECOS"
                 state={sources.pecos}
                 value={enrollmentLabel}
+                errorLabel="Not connected"
+                errorCopy="Medicare enrollment lane is not connected in this build. Institution review may require separate enrollment evidence."
               />
               <SourceRow
                 label="Configured state board lane"
@@ -673,6 +691,14 @@ function PassportPageContent({
                     {state.readiness.status}
                   </p>
                 )}
+                {sources.nppes === 'done'
+                  && (sources.oig === 'error' || sources.pecos === 'error') ? (
+                  <p className="text-muted-foreground/60 text-xs mt-3 leading-relaxed">
+                    Identity source returned. Additional credential lanes require
+                    source access or are not connected in this build. Institution
+                    review is still required for any final decision.
+                  </p>
+                ) : null}
               </Card>
             )}
 

--- a/apps/web/hooks/ingestStreamState.ts
+++ b/apps/web/hooks/ingestStreamState.ts
@@ -167,16 +167,29 @@ function isAuthoritativeIdentity(input: {
   displayName?: string;
   identityStatus?: string;
   sourceResult?: IngestSourceResult;
+  hasEntityId?: boolean;
 }): boolean {
   if (!input.displayName) {
     return false;
+  }
+
+  if (input.identityStatus?.toUpperCase() === 'UNKNOWN') {
+    return false;
+  }
+
+  // The backend currently marks NPPES `status: FAILED` whenever the run
+  // produces zero normalized claim records, even when the identity payload
+  // itself (displayName, identityStatus, entityId, taxonomies) is intact.
+  // Trust a populated identity payload over the coarse source-level flag.
+  if (input.identityStatus?.toUpperCase() === 'ACTIVE' && input.hasEntityId) {
+    return true;
   }
 
   if (input.sourceResult && input.sourceResult !== 'SUCCESS') {
     return false;
   }
 
-  return input.identityStatus?.toUpperCase() !== 'UNKNOWN';
+  return true;
 }
 
 function mergeIdentity(
@@ -186,6 +199,7 @@ function mergeIdentity(
   const displayName = readString(payload, 'displayName') ?? prev.displayName;
   const identityStatus = readString(payload, 'identityStatus') ?? prev.status;
   const sourceResult = readSourceResult(payload) ?? prev.sourceResult;
+  const entityId = readString(payload, 'entityId') ?? prev.entityId;
 
   let taxonomies = prev.taxonomies;
   if (Array.isArray(payload.taxonomies)) {
@@ -198,7 +212,7 @@ function mergeIdentity(
   }
 
   return {
-    entityId: readString(payload, 'entityId') ?? prev.entityId,
+    entityId,
     displayName,
     specialty: readString(payload, 'specialty') ?? prev.specialty,
     credentials: readString(payload, 'credentials') ?? prev.credentials,
@@ -214,6 +228,7 @@ function mergeIdentity(
       displayName,
       identityStatus,
       sourceResult,
+      hasEntityId: Boolean(entityId),
     }),
   };
 }
@@ -427,14 +442,21 @@ export function applyIngestEvent(prev: IngestStreamState, event: IngestEvent): I
       const result = readSourceResult(event.payload);
 
       if (event.sourceId === 'nppes') {
+        const identity = mergeIdentity(prev.identity, event.payload);
+        // NPPES identity authority is the source-truth signal here. When NPPES
+        // returns a populated identity payload, treat that as a successful
+        // identity read regardless of the backend's coarse `status` flag.
+        const nppesState: 'done' | 'error' = identity.authoritative
+          ? 'done'
+          : sourceStateFromResult(result);
         return {
           ...prev,
           events,
           disconnected: false,
-          identity: mergeIdentity(prev.identity, event.payload),
+          identity,
           sources: {
             ...prev.sources,
-            nppes: sourceStateFromResult(result),
+            nppes: nppesState,
           },
         };
       }


### PR DESCRIPTION
## Root cause

Live reproduction with NPI **1699264564** (real provider Victoria Fischer, MD):

- `POST /api/ingest/1699264564` → 200, valid runId
- SSE stream returns full sequence
- `source_complete` for NPPES has **full identity payload** (displayName, identityStatus ACTIVE, entityId, taxonomies) but is flagged **`status: FAILED`** because the run produced zero normalized claim records
- OIG/LEIE, PECOS, FSMB all emit `status: FAILED` with empty payloads (no live integrations producing claims in this build)
- Frontend mapped NPPES FAILED → `'error'` → SourceRow rendered **"Unavailable"** plus the misleading subtext **"Checking in the background — we'll update when it arrives."** (the SSE stream is already closed; nothing is checked in the background)
- `identity.authoritative` was forced false, blocking the Identity-confirmed card and the passport anchor

User-visible symptom: NPPES, OIG, PECOS all showed Unavailable / Checking in the background even though NPPES had returned a valid identity record.

## Web-side fix (defensive)

Backend's source-level FAILED classification is the upstream root cause. This patch fixes the user-facing layer without requiring a backend redeploy. A separate backend wave should correct `ingestOrchestrator.ts::finalizeSourceResult` (and/or `identityIngestionPipeline.ts`) so NPPES does not emit `status: FAILED` when the identity payload is intact.

### `apps/web/hooks/ingestStreamState.ts`
- `isAuthoritativeIdentity` now accepts `displayName + identityStatus ACTIVE + entityId` as authoritative regardless of the coarse `sourceResult` flag
- The NPPES `source_complete` handler derives `sources.nppes` from `identity.authoritative` instead of the raw status flag
- True upstream errors (no identity payload) still surface as `'error'`

### `apps/web/app/passport/page.tsx`
- `SourceRow` gains per-source `errorLabel` + `errorCopy` props
- The hardcoded "Checking in the background — we'll update when it arrives." line is **removed** (it was a lie on error states)
- Honest per-lane copy on error:
  - **NPPES** → `Temporarily unavailable` + "Source temporarily unavailable. Try this NPI again in a moment."
  - **OIG / LEIE** → `Not connected` + "Federal exclusion lane is not connected in this build. Do not treat this as an exclusion clearance."
  - **CMS PECOS** → `Not connected` + "Medicare enrollment lane is not connected in this build. Institution review may require separate enrollment evidence."
  - **State board** → unchanged (already says `Access required`)
- Readiness card gets a contextual note when NPPES is connected and OIG/PECOS are not, so the `20/100 PARTIAL` doesn't read as a blanket failure when identity actually returned

### `apps/web/__tests__/ingest-stream-state.test.ts`
3 new regression tests:
1. NPPES `status: FAILED` with populated identity payload → `sources.nppes='done'`, `identity.authoritative=true`
2. NPPES `status: FAILED` with empty payload → `sources.nppes='error'`, `identity.authoritative=false` (no false promotion)
3. NPPES `status: FAILED` + `displayName` + `identityStatus: UNKNOWN` → still not authoritative

## Truth-state guarantees preserved

- No banned phrases introduced (verified / cleared / approved / accepted everywhere / etc.)
- OIG / PECOS / state board never falsely promoted to success
- Identity authoritativeness still requires `displayName + identityStatus !== UNKNOWN`
- Lanes that genuinely have no payload still render as error/Not connected
- Backend, DNS, secrets, and architecture all untouched

## Verification

```
pnpm --filter @vitalcv/web exec vitest run __tests__/ingest-stream-state.test.ts
  → Test Files 1 passed (1) — Tests 12 passed (12)
pnpm turbo run build --filter @vitalcv/web
  → Tasks 10 successful, 10 total
```

Note: `__tests__/passport-ingest-page.test.tsx` "completed-without-anchor" test fails on baseline `4bb1bfae` too — unrelated pre-existing drift against current TrustStateCard copy. Not touched.

## Live verification (after merge + Railway redeploy of vitalcv-web)

```bash
BASE=https://vitalcv-web-production.up.railway.app
# 1. Visit BASE/passport?npi=1699264564 in a browser; observe:
#    - NPPES row → "Source-backed" badge (not "Unavailable")
#    - OIG / LEIE row → "Not connected" with honest subtext
#    - CMS PECOS row → "Not connected" with honest subtext
#    - State board → "Access required"
#    - No "Checking in the background" copy anywhere
#    - Readiness card shows contextual note about identity vs other lanes
#
# 2. SSE smoke (confirms backend still emits same payload — fix is web-side):
RES=$(curl -fsS -X POST -H 'Content-Type: application/json' "$BASE/api/ingest/1699264564")
RUNID=$(echo "$RES" | python3 -c 'import sys,json;print(json.load(sys.stdin)["runId"])')
curl -sSN -m 8 -H 'Accept: text/event-stream' "$BASE/api/ingest/stream/$RUNID"
```

## Follow-up (separate wave, backend service)

Backend `apps/api/backend/src/services/ingest/ingestOrchestrator.ts::finalizeSourceResult` (and the upstream `identityIngestionPipeline.ts`) should be patched so NPPES does not emit `status: FAILED` when `entityRecord.entity.displayName + status === 'ACTIVE'` is intact. This would let any other consumer of the SSE stream see the truthful source state. That patch belongs in the API service deploy, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)