### PR TITLE
fix(test): exclude Playwright specs from Vitest web quality run

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['./test/setup.ts'],
-    exclude: [...configDefaults.exclude, 'tests/e2e/**', ...STALE_TEST_FILES],
+    exclude: [...configDefaults.exclude, 'tests/**', ...STALE_TEST_FILES],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Why

Web Quality CI was failing because Vitest discovered a Playwright spec.

`apps/web/tests/trust-register.spec.ts` uses `@playwright/test` and calls `test.describe()`. `apps/web/vitest.config.ts` only excluded `tests/e2e/**`, so the file at `tests/trust-register.spec.ts` (one level up) was collected by Vitest, which then threw:

```
Playwright Test did not expect test.describe() to be called here.
```

This is pre-existing drift — unrelated to recent product work, but it has been gating the Web Quality pipeline.

## Convention being restored

- `apps/web/__tests__/*` — Vitest unit / server-component tests.
- `apps/web/tests/*` — Playwright specs (existing `tests/e2e/*.spec.ts` + the misfiled-but-still-Playwright `tests/trust-register.spec.ts`).

Broadening the Vitest exclude from `tests/e2e/**` to `tests/**` re-asserts that convention.

## Change

```diff
- exclude: [...configDefaults.exclude, 'tests/e2e/**', ...STALE_TEST_FILES],
+ exclude: [...configDefaults.exclude, 'tests/**', ...STALE_TEST_FILES],
```

One line. Pure CI configuration.

## Before / after Vitest discovery

| File | Before | After |
|---|---|---|
| `apps/web/tests/e2e/*.spec.ts` | excluded | excluded |
| `apps/web/tests/trust-register.spec.ts` | **discovered → Playwright error** | excluded |
| `apps/web/__tests__/**/*.test.{ts,tsx}` | discovered | discovered |
| `STALE_TEST_FILES` (9 files under `__tests__/`) | excluded | excluded |

## Validation on this branch (off `origin/main`)

```bash
pnpm --filter @vitalcv/web exec vitest run
# trust-register.spec.ts no longer collected.
# "Playwright Test did not expect test.describe()" is gone.
# 23 pre-existing __tests__/ failures remain — unrelated drift, out of scope.

pnpm --filter @vitalcv/web exec tsc --noEmit
# clean (after turbo prebuild populated @vitalcv/trust-state dist/)

pnpm turbo run build --filter @vitalcv/web
# Tasks: 13 successful, 13 total
```

## What this does NOT do

- Does not change any product code, copy, route, or backend.
- Does not change Prisma schema or migrations.
- Does not touch Railway, DNS, env vars, or secrets.
- Does not fix the 23 unrelated `__tests__/` failures — those are pre-existing drift requiring separate waves.
- Does not modify PR #420 or PR #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)