### PR TITLE
fix(api): align NPPES source_complete truth state on main

### DIFF
--- a/apps/api/backend/__tests__/ingestOrchestrator.test.ts
+++ b/apps/api/backend/__tests__/ingestOrchestrator.test.ts
@@ -345,4 +345,158 @@ describe('ingestOrchestrator', () => {
     expect(run?.id).toBe('run-1');
     expect(mockGetIngestRun).toHaveBeenCalledWith('run-1');
   });
+
+  it('promotes NPPES source_complete to SUCCESS when identity payload is intact even if pipeline reports FAILED', async () => {
+    // Reproduces the NPI 1699264564 case: NPPES identity is fully resolved
+    // by the entity resolution stage (displayName + identityStatus ACTIVE +
+    // entityId), but the downstream claim-derivation / artifact-write stage
+    // throws and the pipeline returns status: FAILED with claimsEmitted: 0.
+    // The orchestrator must emit source_complete for NPPES as SUCCESS
+    // because identity has been source-confirmed.
+    mockResolveEntityFromNpi.mockResolvedValue({
+      entity: {
+        id: 'entity-vef',
+        displayName: 'VICTORIA ELIZABETH FISCHER, MD',
+        entityType: 'PERSON',
+        npiType: 'TYPE_1',
+        metadata: {
+          status: 'ACTIVE',
+          specialty: 'Neurological Surgery',
+          credentials: 'MD',
+          enumerationDate: '2018-05-07',
+          lastUpdated: '2026-02-11',
+        },
+      },
+    });
+    mockIngestClinicianIdentity.mockResolvedValue({
+      results: [
+        {
+          npi: '1699264564',
+          source: 'NPPES_API',
+          artifactId: 'artifact-nppes-vef',
+          sourceRunId: 'source-run-nppes-vef',
+          claimIds: [],
+          credentialIds: [],
+          claimsEmitted: 0,
+          deltaEvents: [],
+          status: 'FAILED',
+          latencyMs: 15,
+        },
+        {
+          npi: '1699264564',
+          source: 'OIG_LEIE',
+          artifactId: null,
+          sourceRunId: null,
+          claimIds: [],
+          credentialIds: [],
+          claimsEmitted: 0,
+          deltaEvents: [],
+          status: 'FAILED',
+          latencyMs: 5,
+        },
+        {
+          npi: '1699264564',
+          source: 'PECOS_PUBLIC',
+          artifactId: null,
+          sourceRunId: null,
+          claimIds: [],
+          credentialIds: [],
+          claimsEmitted: 0,
+          deltaEvents: [],
+          status: 'FAILED',
+          latencyMs: 5,
+        },
+      ],
+    });
+
+    await startIngestRun('1699264564');
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    const nppesCompleteCalls = mockAppendIngestEvent.mock.calls.filter(
+      ([event]) =>
+        (event as { type: string; sourceId?: string }).type === 'source_complete'
+        && (event as { sourceId?: string }).sourceId === 'nppes',
+    );
+    expect(nppesCompleteCalls).toHaveLength(1);
+    const nppesPayload = (nppesCompleteCalls[0][0] as { payload: Record<string, unknown> }).payload;
+    expect(nppesPayload.status).toBe('SUCCESS');
+    // Truth-state alignment: status and resultStatus must agree for promoted
+    // NPPES intact-identity events. A stale `resultStatus: FAILED` leaking
+    // through the extras spread would contradict the promoted top-level status.
+    expect(nppesPayload.resultStatus).not.toBe('FAILED');
+    expect(nppesPayload.resultStatus).toBe('SUCCESS');
+    expect(nppesPayload.displayName).toBe('VICTORIA ELIZABETH FISCHER, MD');
+    expect(nppesPayload.identityStatus).toBe('ACTIVE');
+    expect(nppesPayload.entityId).toBe('entity-vef');
+
+    // OIG/PECOS must NOT be promoted — they have no identity-only success signal.
+    const oigCompleteCalls = mockAppendIngestEvent.mock.calls.filter(
+      ([event]) =>
+        (event as { type: string; sourceId?: string }).type === 'source_complete'
+        && (event as { sourceId?: string }).sourceId === 'oig',
+    );
+    const pecosCompleteCalls = mockAppendIngestEvent.mock.calls.filter(
+      ([event]) =>
+        (event as { type: string; sourceId?: string }).type === 'source_complete'
+        && (event as { sourceId?: string }).sourceId === 'pecos',
+    );
+    expect((oigCompleteCalls[0][0] as { payload: { status: string } }).payload.status).toBe('FAILED');
+    expect((pecosCompleteCalls[0][0] as { payload: { status: string } }).payload.status).toBe('FAILED');
+
+    // The persisted IngestSourceRun for NPPES must also be DONE, not ERROR.
+    const nppesUpdateCalls = mockUpdateIngestSourceRun.mock.calls.filter(
+      ([, sId]) => sId === 'nppes',
+    );
+    const lastNppesUpdate = nppesUpdateCalls[nppesUpdateCalls.length - 1];
+    expect(lastNppesUpdate[2]).toMatchObject({
+      status: 'DONE',
+      errorCode: null,
+    });
+  });
+
+  it('does not promote NPPES to SUCCESS when identity payload is empty (true upstream failure preserved)', async () => {
+    mockResolveEntityFromNpi.mockResolvedValue({
+      entity: {
+        id: '',
+        displayName: '',
+        entityType: 'PERSON',
+        npiType: 'TYPE_1',
+        metadata: { status: 'UNKNOWN' },
+      },
+    });
+    mockIngestClinicianIdentity.mockResolvedValue({
+      results: [
+        {
+          npi: '1558302470',
+          source: 'NPPES_API',
+          artifactId: null,
+          sourceRunId: null,
+          claimIds: [],
+          credentialIds: [],
+          claimsEmitted: 0,
+          deltaEvents: [],
+          status: 'FAILED',
+          latencyMs: 5,
+          error: 'NPPES API returned 502',
+        },
+      ],
+    });
+
+    await startIngestRun('1558302470');
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    const nppesCompleteCalls = mockAppendIngestEvent.mock.calls.filter(
+      ([event]) =>
+        (event as { type: string; sourceId?: string }).type === 'source_complete'
+        && (event as { sourceId?: string }).sourceId === 'nppes',
+    );
+    expect(nppesCompleteCalls).toHaveLength(1);
+    const emptyPayload = (nppesCompleteCalls[0][0] as { payload: Record<string, unknown> }).payload;
+    expect(emptyPayload.status).toBe('FAILED');
+    // No promotion occurs without intact identity payload, so resultStatus
+    // must also remain FAILED (no spurious SUCCESS leak).
+    expect(emptyPayload.resultStatus).toBe('FAILED');
+  });
 });

--- a/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
+++ b/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
@@ -153,6 +153,53 @@ async function emitSourceStart(runId: string, sourceId: IngestSourceId): Promise
   });
 }
 
+/**
+ * Truth-state guard for source_complete emission.
+ *
+ * The downstream claim-derivation / artifact-write / delta / alert stages of
+ * `ingestClinicianIdentity` can flip an overall ingest result to `FAILED`
+ * even when the source-level identity payload itself is intact (observed
+ * with NPI 1699264564: NPPES returned a full provider record but a later
+ * step threw, causing `status: 'FAILED'` to propagate while displayName,
+ * identityStatus 'ACTIVE', and entityId remained populated).
+ *
+ * For NPPES specifically, the public source_complete event must reflect
+ * whether identity was source-confirmed, not whether the downstream
+ * derivation chain succeeded. When the orchestrator already holds an
+ * authoritative NPPES identity payload (from the pre-pipeline entity
+ * resolution) and is passing it via `extras`, the emitted status for
+ * NPPES is promoted from FAILED → SUCCESS.
+ *
+ * OIG/PECOS/STATE_BOARD/FSMB/NURSYS are not promoted — those sources do
+ * not have a separate identity-only success signal, and their failure
+ * truly means the lane did not produce evidence.
+ */
+function deriveSourceCompleteStatus(
+  sourceId: IngestSourceId,
+  result: IngestionResult | null,
+  extras: Record<string, unknown> | undefined,
+): IngestionResult['status'] | undefined {
+  const rawStatus = result?.status;
+  if (sourceId !== 'nppes' || rawStatus !== 'FAILED' || !extras) {
+    return rawStatus;
+  }
+
+  const displayName = typeof extras.displayName === 'string' ? extras.displayName : '';
+  const identityStatus = typeof extras.identityStatus === 'string' ? extras.identityStatus : '';
+  const entityId = typeof extras.entityId === 'string' ? extras.entityId : '';
+
+  if (
+    displayName.length > 0
+    && identityStatus.toUpperCase() !== ''
+    && identityStatus.toUpperCase() !== 'UNKNOWN'
+    && entityId.length > 0
+  ) {
+    return 'SUCCESS';
+  }
+
+  return rawStatus;
+}
+
 async function finalizeSourceResult(
   runId: string,
   sourceId: IngestSourceId,
@@ -161,15 +208,30 @@ async function finalizeSourceResult(
 ): Promise<void> {
   const credentialIds = result?.credentialIds ?? [];
   const claimIds = result?.claimIds ?? [];
-  const status = result?.status === 'FAILED' ? 'ERROR' : 'DONE';
+  const effectiveStatus = deriveSourceCompleteStatus(sourceId, result, extras);
+  const persistStatus = effectiveStatus === 'FAILED' ? 'ERROR' : 'DONE';
+
+  // Promoted-NPPES truth-state alignment:
+  // The caller may pass `resultStatus` inside `extras` (e.g. the runPipeline
+  // NPPES call mirrors the upstream IngestionResult.status into extras for
+  // downstream consumers). When `effectiveStatus` is a promotion from FAILED
+  // -> SUCCESS for NPPES with intact identity, a stale `resultStatus: FAILED`
+  // in extras would leak into the source_complete payload via `...extras` and
+  // disagree with the emitted top-level `status`. Both fields must agree.
+  const effectiveResultStatus =
+    sourceId === 'nppes'
+      && effectiveStatus === 'SUCCESS'
+      && result?.status === 'FAILED'
+      ? effectiveStatus
+      : (result?.status ?? effectiveStatus);
 
   await updateIngestSourceRun(runId, sourceId, {
-    status,
+    status: persistStatus,
     sourceRunId: result?.sourceRunId ?? null,
     artifactId: result?.artifactId ?? null,
     claimCount: result?.claimsEmitted ?? 0,
     credentialCount: credentialIds.length,
-    errorCode: result?.status === 'FAILED' ? 'SOURCE_FAILED' : null,
+    errorCode: effectiveStatus === 'FAILED' ? 'SOURCE_FAILED' : null,
     lastError: result?.error ?? null,
     completedAt: new Date(),
   });
@@ -181,16 +243,20 @@ async function finalizeSourceResult(
     dedupeKey: dedupeKey(
       'source_complete',
       sourceId,
-      `${result?.sourceRunId ?? 'none'}:${result?.artifactId ?? 'none'}:${result?.status ?? 'missing'}`,
+      `${result?.sourceRunId ?? 'none'}:${result?.artifactId ?? 'none'}:${effectiveStatus ?? 'missing'}`,
     ),
     payload: {
       sourceId,
-      status: result?.status ?? 'FAILED',
       sourceRunId: result?.sourceRunId ?? null,
       artifactId: result?.artifactId ?? null,
       claimCount: result?.claimsEmitted ?? 0,
       credentialIds,
       ...extras,
+      // Authoritative truth-state fields written AFTER the extras spread so
+      // a stale `extras.status` or `extras.resultStatus` cannot override the
+      // promoted/derived truth-state for NPPES intact-identity cases.
+      status: effectiveStatus ?? 'FAILED',
+      resultStatus: effectiveResultStatus,
     },
   });
 

--- a/docs/ops/api-nppes-truth-state-main.md
+++ b/docs/ops/api-nppes-truth-state-main.md
@@ -1,0 +1,71 @@
+# NPPES Truth-State Backend Patch — Transplant onto `main`
+
+**Date:** 2026-05-26
+**Branch:** `fix/api-nppes-truth-state-main`
+**Base:** `origin/main`
+**Source of the patch:** the backend portion of PR #420 (`fix(api): preserve NPPES identity success when source payload is intact`), which targets `wave-10a/docs-status`.
+
+## Why this branch exists
+
+`delightful-essence` (Railway API service for `api.vitalcv.com`) watches `main`. PR #420 targets `wave-10a/docs-status`, so even after PR #420 merges to that branch, its backend SSE truth-state correction will never reach `delightful-essence` unless either:
+
+- the relevant commits also land on `main`, or
+- the operator intentionally changes the Railway watched branch.
+
+Per session policy, `wave-10a/docs-status` must not be merged into `main` wholesale. This branch is the narrow alternative — only the backend ingest-orchestrator truth-state fix is transplanted.
+
+## Relationship to PR #420
+
+This is a **subset** of PR #420, not a copy:
+
+| File | Included on `fix/api-nppes-truth-state-main` | Notes |
+|---|---|---|
+| `apps/api/backend/src/services/ingest/ingestOrchestrator.ts` | yes | Backend SSE truth-state fix + extras-spread ordering. |
+| `apps/api/backend/__tests__/ingestOrchestrator.test.ts` | yes | Regression tests for both invariants. |
+| `docs/ops/passport-railway-evidence-gate.md` | yes | Phase 1 evidence record (NPI 1699264564). |
+| `docs/ops/passport-post-deploy-design-qa.md` | yes | Design re-QA checklist. |
+| `apps/web/app/onboarding/page.tsx` | **excluded** | `main` already cleaned the prior banned phrase; current copy on `main` differs from the wave-10a baseline that PR #420 was rewriting. Skipping per "no unrelated web changes unless required for banned phrase cleanup." |
+
+## Behavior changed (same as PR #420 backend slice)
+
+`deriveSourceCompleteStatus(sourceId, result, extras)`:
+
+- Promotes `status: FAILED → SUCCESS` for `source_complete` **only** when all of:
+  - `sourceId === 'nppes'`,
+  - `extras.displayName` is a non-empty string,
+  - `extras.identityStatus` is set and not `'UNKNOWN'`,
+  - `extras.entityId` is a non-empty string.
+- Persists `IngestSourceRun.status` (`DONE` / `ERROR`) and clears `errorCode` to align with the effective status.
+- Emits `status` and `resultStatus` **after** the `...extras` spread, so a stale `extras.status` or `extras.resultStatus` can never disagree with the derived truth.
+
+## What this does NOT change
+
+- OIG / LEIE / PECOS / STATE_BOARD / FSMB / NURSYS are never promoted; their `FAILED` truly means no evidence in this run.
+- Empty / no-payload NPPES still emits `FAILED` (the promotion gate refuses).
+- No source-outage or no-payload state is rebranded as success.
+- No identity / pipeline / adapter code is touched.
+- No Prisma schema, migration, env var, Railway service config, DNS, or secret is touched.
+- No web copy changes.
+
+## Build-gap dependency
+
+`@vitalcv/api` build currently fails on `main` because helper modules referenced by `replayEngine.ts`, `employerActions.ts`, and `server.ts` were never landed on `main` (see PR #421 — `fix(api): repair Railway build module resolution`).
+
+Until PR #421 (or an equivalent build repair) lands on `main`, this branch cannot pass `pnpm turbo run build --filter @vitalcv/api`. The orchestrator change itself is syntactically valid, but the surrounding package will not compile.
+
+## Post-deploy SSE smoke (after `delightful-essence` redeploys from `main`)
+
+```bash
+BASE=https://vitalcv-web-production.up.railway.app
+RUNID=$(curl -fsS -X POST -m 20 "$BASE/api/ingest/1699264564" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["runId"])')
+
+curl -sSN -m 8 -H 'Accept: text/event-stream' \
+  "$BASE/api/ingest/stream/$RUNID" \
+  | grep -E '"status":"FAILED"|"status":"SUCCESS"' | head -5
+# Expected:
+#   NPPES source_complete  → "status":"SUCCESS"
+#   OIG / PECOS source_complete → "status":"FAILED"
+```
+
+If the SSE event payload ever shows `"status":"SUCCESS","resultStatus":"FAILED"` (or vice versa) for the same source, the extras-spread ordering has regressed and the branch must be rolled back.

--- a/docs/ops/passport-post-deploy-design-qa.md
+++ b/docs/ops/passport-post-deploy-design-qa.md
@@ -1,0 +1,139 @@
+# Passport Post-Deploy Design QA — NPI 1699264564
+
+**Date:** 2026-05-25
+**Trigger:** PR #419 (`fix(passport)`) live on `vitalcv-web` Railway deploy `1d1b8175`; backend follow-up PR (this wave) in flight against `delightful-essence`.
+
+## Base URL
+
+`https://vitalcv-web-production.up.railway.app`
+
+## Confirmed live observed states (snapshot updated 2026-05-26)
+
+PR #419 web-side defensive mapping is **confirmed live** on `vitalcv-web` Railway deploy `1d1b8175`. The `delightful-essence` API service is **NOT** running the PR #420 backend patch — Claude Browser evidence (2026-05-26) shows it is still serving an old PR #359 build from ~2 weeks ago, and newer deploy attempts fail at `@vitalcv/api` build with module-resolution errors (`runtimeTrustCohesion`, `loadDotenv`, `tenantIsolation`, `replayCorruptionContainment`, `confidenceCalibration`). That is a separate deployment-gap repair tracked outside this PR.
+
+### `/passport?npi=1699264564` — current live state (no-payload condition)
+
+Because the API service is on stale code, the SSE stream does not currently return an intact NPPES identity payload for `1699264564`. The web-side defensive mapping handles this honestly: when no identity payload arrives, NPPES does not promote to source-confirmed, and the row renders with the truthful temporarily-unavailable state.
+
+| Lane | Current live badge | Current live subtext | Doctrine compliance |
+|---|---|---|---|
+| NPPES | `Temporarily unavailable` (state: error) | `Source temporarily unavailable. Try this NPI again in a moment.` | ✅ honest no-payload state |
+| OIG / LEIE | `Not connected` (state: error) | `Federal exclusion lane is not connected in this build. Do not treat this as an exclusion clearance.` | ✅ honest |
+| CMS PECOS | `Not connected` (state: error) | `Medicare enrollment lane is not connected in this build. Institution review may require separate enrollment evidence.` | ✅ honest |
+| Configured state board lane | `Access required` (state: done by placeholder) | (no subtext) | ✅ honest |
+| Readiness card | omits the "identity source returned" contextual note (gated on `sources.nppes === 'done'`) | — | ✅ context note correctly hidden when identity not present |
+| Source operational state panel (`LaneHealthMount`) | All lanes show `Unknown / no successful read` + `Retry suggested in ~30s` (placeholder static probe seed) | (unchanged) | ⚠️ doctrine-aligned but contextually confusing — flagged P2, not addressed here |
+| Misleading copy: `Checking in the background — we'll update when it arrives.` on terminal error states | Removed entirely (PR #419) | — | ✅ |
+| Banned phrases on `/` (homepage) | 0 hits across all 11 phrases in CLAUDE.md banned list | — | ✅ |
+
+### `/passport?npi=1699264564` — post-PR #420 + API redeploy expectation
+
+Once PR #420 (this PR) is merged AND the `delightful-essence` API deployment gap is repaired AND the API service redeploys, the SSE stream for NPI 1699264564 will return the intact NPPES identity payload (displayName `VICTORIA ELIZABETH FISCHER, MD`, identityStatus `ACTIVE`, entityId, taxonomies) again. At that point the same `/passport?npi=1699264564` page is expected to render:
+
+| Lane | Expected post-deploy badge | Expected post-deploy subtext |
+|---|---|---|
+| NPPES | `Source-backed` (state: done) — Identity-confirmed card renders with name + specialty + NPI | (no subtext on done state) |
+| OIG / LEIE | `Not connected` (unchanged — no live OIG adapter in this build) | (unchanged) |
+| CMS PECOS | `Not connected` (unchanged — no live PECOS adapter in this build) | (unchanged) |
+| Configured state board lane | `Access required` (unchanged) | (no subtext) |
+| Readiness card | `PARTIAL` badge + score (20/100, L1) + contextual paragraph | `Identity source returned. Additional credential lanes require source access or are not connected in this build. Institution review is still required for any final decision.` |
+
+### Other routes (current live, 8/8 → 200)
+
+| Route | Expected | Observed |
+|---|---|---|
+| `/` | 200 HTML, no banned strings, safe equivalents present | 200, clean |
+| `/api/health` | 200 JSON `service: "web"` | 200, ok (note: `backend.status: "degraded"` field reflects the separate API deployment gap) |
+| `/trust` | 200 HTML | 200 |
+| `/trust/attribution` | 200 HTML | 200 |
+| `/.well-known/jwks.json` | 200 JSON `kid: vcv-es256-prod-1, alg: ES256, crv: P-256` | 200, matches |
+| `/status` | 200 | 200 |
+| `/contact` | 200 | 200 |
+| `/sign-in` | 200 or safe Clerk auth response | 200 |
+
+## QA checklist for Claude Design
+
+Please re-test the following on `https://vitalcv-web-production.up.railway.app` after this wave's backend patch lands and `delightful-essence` redeploys:
+
+### `/` (homepage)
+- [ ] Hero "What happens after" strip reads `Identity confirmed against NPPES | Sanctions checked via OIG | Readiness status generated` (no `score`, no `verified`)
+- [ ] No bare "Verified" badge or button
+- [ ] No "Verify a Provider" CTA
+- [ ] Footer contains `Trust`, `Attribution`, `Status`
+- [ ] Navbar contains `Check Clinician Readiness`, `Trust`
+- [ ] No "Verify once. Trust everywhere." / "Get Verified" / "already verified" / "instant credentialing" / "guaranteed verification" copy anywhere
+
+### `/passport?npi=1699264564` — current live test (pre-API-redeploy)
+
+Verify the no-payload truth-state renders honestly while the API service is on stale code:
+
+- [ ] NPPES lane shows `Temporarily unavailable` (NOT `Unavailable`, NOT `Unknown`)
+- [ ] NPPES subtext: `Source temporarily unavailable. Try this NPI again in a moment.`
+- [ ] NPPES does NOT show `Source-backed` (correct — no identity payload arrived from API)
+- [ ] OIG / LEIE row shows `Not connected` with `Federal exclusion lane is not connected in this build…` subtext
+- [ ] CMS PECOS row shows `Not connected` with `Medicare enrollment lane is not connected in this build…` subtext
+- [ ] State board lane shows `Access required`
+- [ ] No "Checking in the background" copy anywhere
+- [ ] Readiness card omits the "Identity source returned" contextual note (correct — gated on `sources.nppes === 'done'`)
+- [ ] No bare "Verified" / "Cleared" / "Approved" badges anywhere
+
+### `/passport?npi=1699264564` — post-PR #420 merge + delightful-essence redeploy
+
+Re-run only after PR #420 is merged AND the API service deployment gap (separate wave) is repaired AND `delightful-essence` redeploys a build that includes commit `09e561de` or its descendant:
+
+- [ ] NPPES lane shows `Source-backed` (or equivalent source-confirmed badge)
+- [ ] NPPES lane does NOT show `Unavailable`
+- [ ] NPPES lane does NOT show `Unknown / no successful read`
+- [ ] Identity-confirmed card renders with `VICTORIA ELIZABETH FISCHER, MD`
+- [ ] Specialty `Neurological Surgery` visible
+- [ ] OIG / LEIE row shows `Not connected` (unchanged)
+- [ ] CMS PECOS row shows `Not connected` (unchanged)
+- [ ] State board lane shows `Access required` (unchanged)
+- [ ] No "Checking in the background" copy anywhere
+- [ ] Readiness card contextual note present when NPPES done + OIG/PECOS error
+- [ ] "View full passport" button is enabled and reachable (anchor entity id is set)
+- [ ] "Re-check sources" button works (re-runs ingest)
+
+### Raw SSE smoke (post-API-redeploy)
+
+Capture the `source_complete` event for NPPES and confirm both fields agree:
+
+```bash
+BASE=https://vitalcv-web-production.up.railway.app
+RUNID=$(curl -fsS -X POST -m 20 "$BASE/api/ingest/1699264564" | python3 -c 'import sys,json;print(json.load(sys.stdin)["runId"])')
+curl -sSN -m 8 -H 'Accept: text/event-stream' "$BASE/api/ingest/stream/$RUNID" \
+  | python3 -c '
+import sys,json
+for line in sys.stdin:
+    line = line.strip()
+    if not line.startswith("data: "): continue
+    try: evt = json.loads(line[6:])
+    except: continue
+    if evt.get("type") == "source_complete" and evt.get("sourceId") == "nppes":
+        p = evt["payload"]
+        print("status:", p.get("status"), "resultStatus:", p.get("resultStatus"))
+        break
+'
+```
+
+- [ ] Expected output: `status: SUCCESS resultStatus: SUCCESS` (both fields agree — Codex's PR #420 requirement)
+- [ ] Pre-PR #420 / pre-redeploy output: `status: FAILED resultStatus: FAILED` (still acceptable — true upstream outage)
+- [ ] Forbidden output: `status: SUCCESS resultStatus: FAILED` (this is exactly what PR #420 prevents)
+
+### `/passport?npi=<other valid NPI returning identity but zero claims>`
+- [ ] After PR #420 + API redeploy: source-confirmed behavior matches 1699264564 (any provider whose NPPES record is intact but downstream claim derivation produces zero records)
+
+### `/passport?npi=<invalid or unassigned NPI>`
+- [ ] NPPES lane shows `Temporarily unavailable` OR "No profile yet" terminal card
+- [ ] Subtext: `Source temporarily unavailable. Try this NPI again in a moment.` (NOT `Checking in the background`)
+
+### Out-of-scope for this QA (separately tracked)
+
+- `LaneHealthMount` panel ("Source operational state") still shows all lanes as `Unknown / no successful read` because the placeholder probe seed has no live probe wired. This is doctrine-aligned (HONEST default) but contextually confusing alongside the live NPPES success above it. Flagged P2 for a follow-up wave that either wires a live NPPES probe or differentiates the placeholder framing (e.g., "no probe configured in this build" instead of "no successful read").
+- OIG / LEIE and CMS PECOS adapters are not wired to live data sources in this build. Doctrine-aligned and explicitly disclaimed in copy. Out of scope until those adapters land.
+- Auth/CORS guard on `/api/ingest/*` — preflighted browser requests get 403 `x-cors-blocked:1`. Doesn't affect homepage / SSR routes. File separately if Design needs to test ingest from a browser-origin tool.
+
+## Pass criteria
+
+DESIGN PASS or DESIGN PASS WITH WARNINGS (no P0) → operator may proceed with apex/www DNS cutover.
+DESIGN BLOCKED → file as P0 here; Claude Code will patch minimal surface only.

--- a/docs/ops/passport-railway-evidence-gate.md
+++ b/docs/ops/passport-railway-evidence-gate.md
@@ -1,0 +1,127 @@
+# Passport Railway Deployment Evidence Gate — NPI 1699264564
+
+**Date:** 2026-05-25
+**Author:** Claude Code Terminal
+**Trigger:** Post-merge verification of PR #419 (`fix(passport): show NPPES source-confirmed when identity payload returned`)
+
+## Summary
+
+PR #419 (defensive web-side passport truth-state fix) is merged to `wave-10a/docs-status` as commit `1d1b8175` and confirmed live on `vitalcv-web` Railway service. Live runtime evidence shows the backend ingest pipeline still emits `source_complete status: FAILED` for NPPES when the identity payload is intact but downstream claim derivation produces zero records. A backend-side guard is added in this wave to bring backend truth-state into agreement with web-side mapping.
+
+## Evidence
+
+### Railway — `vitalcv-web` (provider identity wedge — Next.js app)
+
+| Field | Value |
+|---|---|
+| Latest deployment commit SHA | `1d1b8175` |
+| Deployment ID (from operator Claude Code web verdict) | `3c3d3358-9f6e-4524-b329-7881f98aa754` |
+| Active since | `2026-05-25T03:51:51Z` |
+| Source branch | `wave-10a/docs-status` |
+| Status | Success / live |
+| Auto-deploy | ON |
+| PR #419 fix appears deployed? | **YES** — route chunk `/_next/static/chunks/app/passport/page-de565de42d82b3b2.js` (42,429 bytes) contains all four new error-copy strings: `Source temporarily unavailable`, `Federal exclusion lane is not connected`, `Medicare enrollment lane is not connected`, `Identity source returned` |
+| Open known caveats | Railway "Edited / 2 Changes" staged badge present on the `vitalcv-web` tile (operator review required before any future deploy — not touched by Claude Code) |
+
+### Live `/passport?npi=1699264564`
+
+| Surface | Web mapping output (after PR #419) | Honest truth-state |
+|---|---|---|
+| NPPES row | `Source-backed` badge, identity-confirmed card renders | Identity from NPPES is source-confirmed |
+| OIG / LEIE row | `Not connected` + "Federal exclusion lane is not connected in this build…" | OIG lane has no live evidence in this build |
+| CMS PECOS row | `Not connected` + "Medicare enrollment lane is not connected in this build…" | PECOS lane has no live evidence in this build |
+| Configured state board lane | `Access required` (unchanged) | State board has no live adapter in this build |
+| Readiness card | Contextual note: "Identity source returned. Additional credential lanes require source access or are not connected in this build. Institution review is still required for any final decision." | Truthful framing |
+| Misleading copy on terminal states (`Checking in the background — we'll update when it arrives.`) | Removed | — |
+
+### Backend SSE evidence (captured during PR #419 reproduction)
+
+Raw `source_complete` event for NPPES (NPI 1699264564) currently emitted by `apps/api/backend/src/services/ingest/ingestOrchestrator.ts::finalizeSourceResult`:
+
+```json
+{
+  "sourceId": "nppes",
+  "status": "FAILED",
+  "resultStatus": "FAILED",
+  "claimCount": 0,
+  "credentialIds": [],
+  "entityId": "d70373b4-7485-4e2c-be16-199c355bf98e",
+  "displayName": "VICTORIA ELIZABETH FISCHER, MD",
+  "identityStatus": "ACTIVE",
+  "specialty": "Neurological Surgery",
+  "taxonomies": [...],
+  "address": {...},
+  "credentials": "MD",
+  "enumerationDate": "2018-05-07",
+  "lastUpdated": "2026-02-11"
+}
+```
+
+Backend pipeline trace:
+- `resolveEntityFromNpi(1699264564)` resolves identity (displayName, status ACTIVE, entityId) BEFORE the ingest pipeline runs.
+- `ingestClinicianIdentity` calls `executeSourceIngestion` for NPPES_API. `parseSource` returns `status: 'SUCCESS'` when the NPPES adapter returns identity data (see `apps/api/backend/src/services/identity/identityIngestionPipeline.ts:1496-1521`).
+- Some later stage inside `executeSourceIngestion`'s try block throws (claim derivation / artifact write / delta detection / alert job). The catch block at line 1476 returns `status: 'FAILED', claimsEmitted: 0`. `artifactId` and `sourceRunId` are still populated because they were assigned before the throw.
+- `finalizeSourceResult` then emits `source_complete` with `status: 'FAILED'` even though the orchestrator already holds the authoritative identity payload via `extras`.
+
+## Classification
+
+**FIX LIVE BUT BACKEND STILL MISCLASSIFIES**
+
+The web-side defensive mapping shipped in PR #419 already shows NPPES as source-confirmed in the user's browser. The backend's coarse `status: FAILED` flag still leaks into the SSE event payload, which other consumers (downstream readiness aggregators, audit log readers, anyone building on the same SSE feed) would see as a failure. Bringing the backend truth-state into agreement is the next minimal step.
+
+## Recommended action
+
+Patch `apps/api/backend/src/services/ingest/ingestOrchestrator.ts::finalizeSourceResult` to derive an effective `source_complete` status for NPPES from the identity payload (`displayName + identityStatus !== UNKNOWN + entityId`). When NPPES identity is intact, emit `status: 'SUCCESS'` regardless of the upstream coarse failure flag. OIG / LEIE / PECOS / STATE_BOARD / FSMB / NURSYS are not promoted — those sources have no identity-only success signal.
+
+Add regression tests in `apps/api/backend/__tests__/ingestOrchestrator.test.ts`:
+- NPPES identity payload intact + `status: FAILED` from pipeline → emitted `status: SUCCESS`
+- NPPES empty payload + `status: FAILED` → emitted `status: FAILED` (preserved)
+- OIG / PECOS empty payload + `status: FAILED` → emitted `status: FAILED` (no promotion)
+- Persisted `IngestSourceRun.status` for promoted NPPES → `DONE`, `errorCode: null`
+
+After backend patch lands and the `delightful-essence` API service redeploys, re-capture the live SSE event for NPI 1699264564 and verify the `status: SUCCESS` outcome.
+
+## Out of scope
+
+- DNS, domain bindings, Railway env vars
+- Railway service config (the "Edited / 2 Changes" staged badge is flagged for operator review, not touched here)
+- Re-touching web-side mapping (PR #419 already correct; the defensive guard stays in place even after backend lands its agreement fix)
+- OIG / PECOS adapter wiring (those lanes remain "not connected in this build" until live integrations are added in a separate wave)
+- Auth/CORS regression on `/api/ingest/*` observed during operator probe (file separately if relevant)
+- **Backend "degraded" + "no-payload" path** — PR #420 only addresses the case where NPPES returns a valid identity payload but downstream claim derivation throws, producing `status: 'FAILED'` while the identity payload is intact. PR #420 does NOT fix the separate condition where NPPES itself fails to return any identity payload (e.g., the backend service is degraded, the NPPES API is unreachable, the NPI doesn't exist). In that case the live `/passport?npi=...` correctly shows `Temporarily unavailable` with the honest "Source temporarily unavailable. Try this NPI again in a moment." subtext, and the readiness card omits the identity-present contextual note. That is the doctrine-aligned behavior for a true upstream outage and stays unchanged here.
+- **`delightful-essence` API deployment gap** (Browser evidence, 2026-05-26): the API service is currently running an old PR #359 build from ~2 weeks ago. Newer deploy attempts fail at `@vitalcv/api` build with TypeScript module-resolution errors (`Cannot find module '../services/runtimeTrustCohesion'`, `'./config/loadDotenv'`, `'../runtimeTrustCohesion'`, `'../multi-tenant/tenantIsolation'`, `'./replayCorruptionContainment'`, `'./confidenceCalibration'`). The service watches `main`, while PR #420 is based on `wave-10a/docs-status`. This deployment gap is **NOT in PR #420's scope** — repairing the API build/deploy is a separate wave. PR #420 only fixes the source classification logic that will run once the API service is deployable again.
+
+## Non-code CI noise / unrelated checks
+
+The Web Quality CI step on PR #420 (and PR #419 before it, and every wave-10a PR for at least the last 13 hours) fails with this identical stack:
+
+```
+Error: Playwright Test did not expect test.describe() to be called here.
+ ❯ tests/trust-register.spec.ts:3:6
+ ❯ TestTypeImpl._currentSuite (.../playwright/lib/common/testType.js:75:13)
+ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @vitalcv/web@0.1.0 test: `vitest run`
+```
+
+### Root cause
+
+`apps/web/vitest.config.ts` excludes `tests/e2e/**` from the vitest run but not `tests/**`. The file `apps/web/tests/trust-register.spec.ts` is a Playwright spec (`import { test, expect } from '@playwright/test'; test.describe(...)`) that lives at `apps/web/tests/` rather than `apps/web/tests/e2e/`. Vitest's default include pattern picks up `*.spec.ts`, tries to run the Playwright spec, and throws because `test.describe` from `@playwright/test` cannot run inside a vitest worker.
+
+### Branch attribution
+
+**Pre-existing, not branch-caused.** The same failure reproduces on:
+
+- PR #418 (homepage copy fix) — closed-superseded
+- PR #419 (passport NPPES truth-state, web-side) — merged anyway as `1d1b8175` because the failure is config drift, not code
+- PR #420 (this PR) — same identical stack
+
+### Decision
+
+Documented here per Phase 1/2 of the deployment evidence wave; **not addressed in this PR** to keep scope tight. A separate, single-line follow-up wave can add `'tests/**'` (or, more targeted, `'tests/*.spec.ts'`) to the `STALE_TEST_FILES`-adjacent `exclude` array in `apps/web/vitest.config.ts`. That fix is a vitest config change with zero product impact and belongs in its own PR so the diff history stays clean.
+
+### Backend ts-jest blocker
+
+A second pre-existing infra issue: `apps/api/backend/__tests__/*` cannot run under ts-jest with a dummy `DATABASE_URL` because `ingestOrchestrator.ts:136`'s `prisma.vcvCredential.findMany().rows.map((row) => row.domain)` triggers `TS2322: Type 'unknown[]' is not assignable to type 'string[]'` when the full Prisma client typing isn't resolved at test-compile time. Reproduces on baseline `1d1b8175`. The PR #420 regression tests are correct by inspection and will execute in backend CI / when a real Prisma client + DB are present.
+
+### Vercel checks
+
+The `Vercel – vcv-web`, `Vercel – vitalcv`, and `Vercel Agent Review` checks are FAILURE / NEUTRAL because Vercel deploys are permanently blocked for this account (billing-blocked, migration to Railway is complete). These checks should be removed from required-status-checks if they aren't already. Not branch-caused, not actionable from this PR.


### PR DESCRIPTION
## Status update — ready for review

**Dependency on PR #421 resolved.** PR #421 merged to `main` as `fe9c6f9c1` on 2026-05-26 (local Claude Code audit returned SAFE; Codex was unavailable per operator decision).

This PR has been **rebased onto post-#421 main** (new head `221dba07b`) and the `@vitalcv/api` package now builds end-to-end on this branch.

## Why this branch exists

`delightful-essence` (Railway API service for `api.vitalcv.com`) watches `main`. PR #420 targets `wave-10a/docs-status`, so the backend SSE truth-state correction it ships will never reach `delightful-essence` unless either its commits also land on `main`, or the operator changes the Railway watched branch.

Per session policy, `wave-10a/docs-status` must NOT be merged into `main` wholesale. This branch is the narrow alternative — only the backend ingest-orchestrator truth-state fix is transplanted.

## Relationship to PR #420

Strict subset of PR #420:

| File | Transplanted | Notes |
|---|---|---|
| `apps/api/backend/src/services/ingest/ingestOrchestrator.ts` | ✅ | Backend SSE truth-state fix + extras-spread ordering. |
| `apps/api/backend/__tests__/ingestOrchestrator.test.ts` | ✅ | 2 new regression tests, both pass. |
| `docs/ops/passport-railway-evidence-gate.md` | ✅ | Phase 1 evidence (NPI 1699264564). |
| `docs/ops/passport-post-deploy-design-qa.md` | ✅ | Design re-QA checklist. |
| `docs/ops/api-nppes-truth-state-main.md` | ✅ (new) | Transplant runbook explaining this branch. |
| `apps/web/app/onboarding/page.tsx` | ❌ | `main` already cleaned the prior banned phrase; current copy differs from the wave-10a baseline PR #420 was rewriting. Transplanting that diff would be unrelated web drift. |

## Behavior changed

`deriveSourceCompleteStatus(sourceId, result, extras)` promotes `status: FAILED → SUCCESS` for `source_complete` only when **all** of:

- `sourceId === 'nppes'`,
- `extras.displayName` is a non-empty string,
- `extras.identityStatus` is set and not `'UNKNOWN'`,
- `extras.entityId` is a non-empty string.

`status` and `resultStatus` are written **after** the `...extras` spread, so a stale `extras.status` or `extras.resultStatus` cannot disagree with the derived truth.

## What this does NOT do

- ❌ Promote OIG / LEIE / PECOS / STATE_BOARD / FSMB / NURSYS — none of those are ever promoted; their `FAILED` truly means no evidence.
- ❌ Reclassify empty / no-payload NPPES — gate refuses promotion.
- ❌ Cover source-outage or no-payload states as success.
- ❌ Modify any identity / pipeline / adapter / route code.
- ❌ Modify Prisma schema, migrations, env, Railway, DNS, or secrets.
- ❌ Change web copy.

## Validation on rebased branch (head `221dba07b`)

```bash
pnpm install --frozen-lockfile           # lockfile unchanged
pnpm turbo run build --filter @vitalcv/api --force
                                         # Tasks: 15 successful, 15 total; 0 cached; 15.7s
pnpm --filter @vitalcv/api exec tsc -p backend/tsconfig.json --noEmit
                                         # clean

pnpm --filter @vitalcv/api test -- ingestOrchestrator
  PASS __tests__/ingestOrchestrator.test.ts
    ingestOrchestrator
      ✓ emits ordered source, claim, passport, and done events for a successful run
      ✓ reuses an open run instead of starting a second one for the same NPI
      ✓ preserves run integrity and emits an error event when the pipeline fails
      ✓ loads a persisted run by id
      ✓ promotes NPPES source_complete to SUCCESS when identity payload is intact even if pipeline reports FAILED
      ✓ does not promote NPPES to SUCCESS when identity payload is empty (true upstream failure preserved)
  Test Suites: 1 passed, 1 total
  Tests:       6 passed, 6 total

pnpm lint                                # 2/2 successful, web lint clean
```

## Deploy target

`delightful-essence` (Railway API service for `api.vitalcv.com`). After this merges to `main`, Railway should auto-redeploy. If it doesn't, operator triggers a manual redeploy.

## Post-deploy SSE smoke

```bash
BASE=https://vitalcv-web-production.up.railway.app
RUNID=$(curl -fsS -X POST -m 20 "$BASE/api/ingest/1699264564" \
  | python3 -c 'import sys,json;print(json.load(sys.stdin)["runId"])')

curl -sSN -m 8 -H 'Accept: text/event-stream' \
  "$BASE/api/ingest/stream/$RUNID" \
  | grep -E '"status":"FAILED"|"status":"SUCCESS"' | head -5
# Expected:
#   NPPES source_complete       → "status":"SUCCESS"
#   OIG / PECOS source_complete → "status":"FAILED"
```

If the SSE event payload ever shows `"status":"SUCCESS","resultStatus":"FAILED"` (or vice versa) for the same source, the extras-spread ordering has regressed and the branch must be rolled back.

## Audit gate

**No Codex used per operator instruction.** The merge gate for this PR is a local Claude Code audit against the 11-point checklist (NPPES-only promotion gate; no other source promoted; no migration / env / Railway / DNS / secret mutation; no banned phrases; build green; focused tests green). That audit follows this readiness flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)