### PR TITLE
feat(web): TruthStateChip + TruthStateLegend visual foundation (Wave G)

### DIFF
--- a/apps/web/__tests__/truth-state-chip.test.tsx
+++ b/apps/web/__tests__/truth-state-chip.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * truth-state-chip.test.tsx — Wave G coverage.
+ *
+ * Asserts:
+ *   - every TruthStateKind renders without throwing,
+ *   - every visible label is operator-honest (no bare "Verified", no
+ *     banned phrases from CLAUDE.md),
+ *   - aria-label exists and is descriptive,
+ *   - source label is folded into aria-label only (never visible chrome),
+ *   - the 5-row Passport legend renders all 5 default rows,
+ *   - the 8-row "all" legend renders all 8 default rows,
+ *   - legend rows expose a chip + a meaning string for each state.
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  TruthStateChip,
+  TRUTH_STATE_META,
+  TRUTH_STATE_ORDER,
+  type TruthStateKind,
+} from '@/design-system/components/TruthStateChip';
+import {
+  TruthStateLegend,
+  PASSPORT_LEGEND_ROWS,
+  FULL_LEGEND_ROWS,
+} from '@/design-system/components/TruthStateLegend';
+
+/**
+ * The banned-strings list mirrors CLAUDE.md. Any visible UI string
+ * matching one of these patterns (case-insensitive) is a regression.
+ * The bare word "verified" is matched by word boundary so it does NOT
+ * collide with substrings like "verifier" or "verification".
+ */
+const BANNED_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bverified\b/i,
+  /\bguaranteed\s+verification\b/i,
+  /\binstant\s+credentialing\b/i,
+  /\bcomplete\s+credentialing\b/i,
+  /\bautomatically\s+verified\b/i,
+  /\blegally\s+accepted\b/i,
+  /\brisk\s+transferred\b/i,
+  /\bsource\s+confirmed\s+before\s+response\b/i,
+  /\bcertified\s+compliant\b/i,
+  /\bHIPAA\s+compliant\b/i,
+  /\bSOC2\s+certified\b/i,
+  /\bNCQA\s+certified\b/i,
+];
+
+function assertNotBanned(text: string, context: string): void {
+  for (const pattern of BANNED_PATTERNS) {
+    expect(
+      pattern.test(text),
+      `Banned phrase /${pattern.source}/${pattern.flags} matched in ${context}: ${text}`,
+    ).toBe(false);
+  }
+}
+
+describe('TruthStateChip — vocabulary', () => {
+  it('renders every truth state without throwing', () => {
+    for (const state of TRUTH_STATE_ORDER) {
+      const html = renderToStaticMarkup(<TruthStateChip state={state} />);
+      expect(html).toContain('data-truth-state="' + state + '"');
+      expect(html).toContain(TRUTH_STATE_META[state].label);
+    }
+  });
+
+  it('every visible label passes the banned-strings check', () => {
+    for (const state of TRUTH_STATE_ORDER) {
+      const meta = TRUTH_STATE_META[state];
+      assertNotBanned(meta.label, `TRUTH_STATE_META[${state}].label`);
+      assertNotBanned(meta.description, `TRUTH_STATE_META[${state}].description`);
+    }
+  });
+
+  it('every aria-label is descriptive and non-empty', () => {
+    for (const state of TRUTH_STATE_ORDER) {
+      const meta = TRUTH_STATE_META[state];
+      expect(meta.ariaPrefix.length).toBeGreaterThan(5);
+      expect(meta.ariaPrefix.toLowerCase()).toContain('truth state');
+    }
+  });
+
+  it('folds the source label into aria-label, never into visible chrome', () => {
+    const html = renderToStaticMarkup(
+      <TruthStateChip state="source-backed" sourceLabel="NPPES" />,
+    );
+    expect(html).toContain('aria-label="Truth state: source-backed for NPPES"');
+    // The source label must NOT leak into the visible chip body.
+    // The visible body is wrapped in a <span> sibling of the <svg> icon.
+    expect(html).not.toMatch(/<span[^>]*>[^<]*NPPES[^<]*<\/span>/);
+  });
+
+  it('emits a hidden <time> element when timestamp is provided', () => {
+    const iso = '2026-05-27T03:18:00Z';
+    const html = renderToStaticMarkup(
+      <TruthStateChip state="snapshot-only" timestamp={iso} />,
+    );
+    // renderToStaticMarkup preserves the JSX camelCase attribute name.
+    expect(html).toContain(`<time dateTime="${iso}"`);
+    expect(html).toContain('sr-only');
+  });
+
+  it('does not include the bare word "Verified" anywhere in the metadata', () => {
+    const blob = JSON.stringify(
+      Object.values(TRUTH_STATE_META).map((m) => ({
+        label: m.label,
+        description: m.description,
+        ariaPrefix: m.ariaPrefix,
+      })),
+    );
+    expect(/\bverified\b/i.test(blob)).toBe(false);
+  });
+
+  it('source-backed uses the neutral (restrained) variant — never warning or accent', () => {
+    expect(TRUTH_STATE_META['source-backed'].variant).toBe('neutral');
+  });
+
+  it('access-required uses the warning variant — caller action expected', () => {
+    expect(TRUTH_STATE_META['access-required'].variant).toBe('warning');
+  });
+
+  it('connector-not-live uses the outline variant — restrained, not alarming', () => {
+    expect(TRUTH_STATE_META['connector-not-live'].variant).toBe('outline');
+  });
+
+  it('temporarily-unavailable uses the muted variant — system condition, not finding', () => {
+    expect(TRUTH_STATE_META['temporarily-unavailable'].variant).toBe('muted');
+  });
+
+  it('TRUTH_STATE_ORDER enumerates exactly the eight truth states (no duplicates, no extras)', () => {
+    const expected: ReadonlySet<TruthStateKind> = new Set<TruthStateKind>([
+      'source-backed',
+      'snapshot-only',
+      'institution-review-required',
+      'access-required',
+      'auth-required',
+      'temporarily-unavailable',
+      'connector-not-live',
+      'demo-only',
+    ]);
+    expect(new Set(TRUTH_STATE_ORDER)).toEqual(expected);
+    expect(TRUTH_STATE_ORDER).toHaveLength(8);
+  });
+});
+
+describe('TruthStateLegend — Passport 5-row default', () => {
+  it('PASSPORT_LEGEND_ROWS has exactly 5 entries', () => {
+    expect(PASSPORT_LEGEND_ROWS).toHaveLength(5);
+  });
+
+  it('default render produces all 5 rows', () => {
+    const html = renderToStaticMarkup(<TruthStateLegend />);
+    for (const row of PASSPORT_LEGEND_ROWS) {
+      expect(html).toContain('data-truth-state="' + row.state + '"');
+    }
+  });
+
+  it('each row passes the banned-strings check', () => {
+    for (const row of PASSPORT_LEGEND_ROWS) {
+      const meaning = row.meaning ?? TRUTH_STATE_META[row.state].description;
+      assertNotBanned(meaning, `PASSPORT_LEGEND_ROWS[${row.state}] meaning`);
+    }
+  });
+
+  it('renders with optional heading', () => {
+    const html = renderToStaticMarkup(
+      <TruthStateLegend heading="What these tags mean" />,
+    );
+    expect(html).toContain('What these tags mean');
+  });
+});
+
+describe('TruthStateLegend — full 8-row', () => {
+  it('FULL_LEGEND_ROWS has exactly 8 entries', () => {
+    expect(FULL_LEGEND_ROWS).toHaveLength(8);
+  });
+
+  it('rows="all" renders all 8 states', () => {
+    const html = renderToStaticMarkup(<TruthStateLegend rows="all" />);
+    for (const state of TRUTH_STATE_ORDER) {
+      expect(html).toContain('data-truth-state="' + state + '"');
+    }
+  });
+
+  it('custom row array overrides default and respects supplied order', () => {
+    const html = renderToStaticMarkup(
+      <TruthStateLegend
+        rows={[
+          { state: 'auth-required', meaning: 'Sign in to see live source events.' },
+          { state: 'demo-only', meaning: 'This view is synthetic; not a real source confirmation.' },
+        ]}
+      />,
+    );
+    // Both supplied rows should appear; default rows must NOT bleed through.
+    expect(html).toContain('data-truth-state="auth-required"');
+    expect(html).toContain('data-truth-state="demo-only"');
+    expect(html).not.toContain('data-truth-state="source-backed"');
+  });
+
+  it('rejects banned phrases even when caller supplies custom meaning', () => {
+    // This is a sanity check on the call-site contract; the legend itself
+    // does not enforce, but the default rows do.
+    for (const row of FULL_LEGEND_ROWS) {
+      const meaning = TRUTH_STATE_META[row.state].description;
+      assertNotBanned(meaning, `FULL_LEGEND_ROWS[${row.state}].meaning`);
+    }
+  });
+});

--- a/apps/web/design-system/components/TruthStateChip.tsx
+++ b/apps/web/design-system/components/TruthStateChip.tsx
@@ -1,0 +1,254 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import {
+  AlertTriangle,
+  Camera,
+  Database,
+  EyeOff,
+  Inbox,
+  Lock,
+  PauseCircle,
+  ScanLine,
+  type LucideIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * TruthStateChip — the canonical, product-vocabulary chip for "what is the
+ * system reporting about this fact right now".
+ *
+ * Distinct from:
+ *   - LaneStateBadge: the operations vocabulary for credential-readiness
+ *     lanes (checked / pending / access / blocked / contradicted / unknown).
+ *   - TrustTierBadge: the trust-tier axis (T1–T4) for the underlying source.
+ *   - VerificationBadge / DecisionBadge / ExclusionBadge: domain-specific
+ *     decision artefacts.
+ *
+ * TruthStateChip answers a single question: how should a viewer interpret
+ * the *current* visible state of a source row, a passport field, or a
+ * connector matrix entry? Every label is operator-honest and avoids the
+ * banned vocabulary from CLAUDE.md (no bare "Verified", no
+ * "guaranteed verification", no "instant credentialing", no claim of
+ * final credentialing).
+ */
+
+/**
+ * The eight operator-honest truth states. Identifiers are kebab-cased so
+ * they can be passed verbatim from server props without transformation.
+ */
+export type TruthStateKind =
+  | 'source-backed'
+  | 'temporarily-unavailable'
+  | 'connector-not-live'
+  | 'access-required'
+  | 'institution-review-required'
+  | 'snapshot-only'
+  | 'demo-only'
+  | 'auth-required';
+
+/**
+ * Visual variant taxonomy — mirrors the existing Badge variants in this
+ * design system so the chip slots into the same theme tokens.
+ *   - neutral  : factual, restrained (source-backed, snapshot-only)
+ *   - muted    : system condition, not a finding (temporarily-unavailable)
+ *   - outline  : connector not live / awaiting review / demo / auth
+ *   - warning  : caller action required (access-required)
+ */
+export type TruthStateVariant = 'neutral' | 'muted' | 'outline' | 'warning';
+
+interface TruthStateMeta {
+  /** Visible chip label. NEVER the bare word "Verified". */
+  label: string;
+  /** Sentence used in the legend; describes what the state means in plain
+   *  operator language. */
+  description: string;
+  /** Visual treatment per Wave G spec. */
+  variant: TruthStateVariant;
+  Icon: LucideIcon;
+  /**
+   * The aria-label prefix used by assistive tech. Combined with the source
+   * label (if any) into "Truth state: source-backed for NPPES". Always
+   * uses the kebab-case key so the same prefix reads cleanly with or
+   * without a source.
+   */
+  ariaPrefix: string;
+}
+
+export const TRUTH_STATE_META: Record<TruthStateKind, TruthStateMeta> = {
+  'source-backed': {
+    label: 'Source-backed',
+    description: 'A primary source returned a usable payload for this field. Not a final credentialing decision.',
+    variant: 'neutral',
+    Icon: Database,
+    ariaPrefix: 'Truth state: source-backed',
+  },
+  'temporarily-unavailable': {
+    label: 'Temporarily unavailable',
+    description: 'The source did not return a payload on this attempt. System condition, not a finding about the clinician.',
+    variant: 'muted',
+    Icon: PauseCircle,
+    ariaPrefix: 'Truth state: temporarily unavailable',
+  },
+  'connector-not-live': {
+    label: 'Connector not live',
+    description: 'This connector is intentionally not running in the current build. Do not interpret as an exclusion clearance.',
+    variant: 'outline',
+    Icon: EyeOff,
+    ariaPrefix: 'Truth state: connector not live',
+  },
+  'access-required': {
+    label: 'Access required',
+    description: 'Authorization is needed before this lane can be read. Caller action expected.',
+    variant: 'warning',
+    Icon: Lock,
+    ariaPrefix: 'Truth state: access required',
+  },
+  'institution-review-required': {
+    label: 'Institution review',
+    description: 'This view is a reviewer-ready head start, not a final credentialing decision.',
+    variant: 'outline',
+    Icon: Inbox,
+    ariaPrefix: 'Truth state: institution review required',
+  },
+  'snapshot-only': {
+    label: 'Snapshot only',
+    description: 'Point-in-time read; current state may have changed since the snapshot.',
+    variant: 'neutral',
+    Icon: Camera,
+    ariaPrefix: 'Truth state: snapshot only',
+  },
+  'demo-only': {
+    label: 'Demo only',
+    description: 'Synthetic data for demonstration. Not a real source confirmation.',
+    variant: 'outline',
+    Icon: ScanLine,
+    ariaPrefix: 'Truth state: demo only',
+  },
+  'auth-required': {
+    label: 'Sign in to view',
+    description: 'Operator sign-in unlocks the live read. Public passport pages remain readable without an account.',
+    variant: 'outline',
+    Icon: AlertTriangle,
+    ariaPrefix: 'Truth state: sign-in required',
+  },
+};
+
+const chipVariants = cva(
+  [
+    'inline-flex items-center gap-1.5',
+    'rounded-[var(--vt-radius-pill)] border',
+    'px-[var(--vt-space-12)] py-[var(--vt-space-4)]',
+    'text-[length:var(--vt-type-caption-size)] leading-[var(--vt-line-tight)]',
+    'font-[var(--vt-font-weight-semibold)] uppercase tracking-[0.12em]',
+    'transition-[background-color,border-color,color] duration-[var(--vt-motion-fast)] ease-[var(--vt-ease-standard)]',
+    'whitespace-nowrap',
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        neutral:
+          'border-[var(--vt-border)] bg-[var(--vt-surface-subtle)] text-[var(--vt-text-secondary)]',
+        muted:
+          'border-[var(--vt-border-subtle,var(--vt-border))] bg-transparent text-[var(--vt-text-tertiary,var(--vt-text-secondary))] opacity-90',
+        outline:
+          'border-[var(--vt-border)] bg-transparent text-[var(--vt-text-secondary)]',
+        warning:
+          'border-transparent bg-[var(--vt-severity-medium)]/15 text-[var(--vt-severity-medium)]',
+      },
+      size: {
+        sm: 'gap-1 px-[var(--vt-space-8)] py-[var(--vt-space-2)] text-[10px] tracking-[0.16em]',
+        md: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'neutral',
+      size: 'md',
+    },
+  },
+);
+
+export interface TruthStateChipProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'aria-label'>,
+    VariantProps<typeof chipVariants> {
+  /** The truth state to display. */
+  state: TruthStateKind;
+  /**
+   * Optional source identifier appended to the aria-label for context
+   * (e.g. "NPPES"). Never shown visually inside the chip itself.
+   */
+  sourceLabel?: string;
+  /**
+   * Optional ISO timestamp. If provided, rendered after the chip text
+   * inside a `<time>` element for screen readers. Visually, the chip
+   * stays concise; timestamps are surfaced by the *row*, not the chip.
+   * Provided here so call sites that want a fully-self-describing chip
+   * (e.g. tooltips) can opt in.
+   */
+  timestamp?: string;
+  /** Override the default visual variant. Use sparingly. */
+  variant?: TruthStateVariant;
+  /** Override the default size. Defaults to `md`. */
+  size?: 'sm' | 'md';
+  /** Optional override for the visible label. Caller is responsible for
+   *  copy review (banned-strings list). */
+  label?: string;
+}
+
+/**
+ * Render the canonical chip for a given truth state.
+ *
+ * Visual treatment is determined by `TRUTH_STATE_META[state].variant`
+ * unless the caller overrides via the `variant` prop.
+ */
+export function TruthStateChip({
+  state,
+  sourceLabel,
+  timestamp,
+  variant,
+  size,
+  label,
+  className,
+  ...rest
+}: TruthStateChipProps) {
+  const meta = TRUTH_STATE_META[state];
+  const visibleLabel = label ?? meta.label;
+  const ariaLabel = sourceLabel
+    ? `${meta.ariaPrefix} for ${sourceLabel}`
+    : meta.ariaPrefix;
+
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      data-truth-state={state}
+      className={cn(
+        chipVariants({ variant: variant ?? meta.variant, size }),
+        className,
+      )}
+      {...rest}
+    >
+      <meta.Icon aria-hidden="true" className="h-3 w-3" />
+      <span>{visibleLabel}</span>
+      {timestamp && (
+        <time dateTime={timestamp} className="sr-only">
+          {timestamp}
+        </time>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The eight states in operator-friendly default order. Useful for
+ * legend rendering and story/test enumeration.
+ */
+export const TRUTH_STATE_ORDER: ReadonlyArray<TruthStateKind> = Object.freeze([
+  'source-backed',
+  'snapshot-only',
+  'institution-review-required',
+  'access-required',
+  'auth-required',
+  'temporarily-unavailable',
+  'connector-not-live',
+  'demo-only',
+] as const);

--- a/apps/web/design-system/components/TruthStateLegend.tsx
+++ b/apps/web/design-system/components/TruthStateLegend.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import {
+  TruthStateChip,
+  TRUTH_STATE_META,
+  TRUTH_STATE_ORDER,
+  type TruthStateKind,
+} from './TruthStateChip';
+
+/**
+ * TruthStateLegend — the canonical key for the truth-state chip vocabulary.
+ *
+ * Two shapes:
+ *   - the full 8-row legend (every chip variant), useful on `/status` or
+ *     `/trust/attribution` where viewers see the entire vocabulary at once.
+ *   - the 5-row Passport legend (`PASSPORT_LEGEND_ROWS` below), which is
+ *     the trimmed vocabulary surfaced on the public Passport view.
+ *
+ * Default is the 5-row Passport legend because that is the most common
+ * call site. Pass `rows="all"` for the full 8.
+ */
+
+/** A single legend row — a chip + the operator-friendly meaning string. */
+export interface TruthStateLegendRow {
+  /** The truth state to render for this row. */
+  state: TruthStateKind;
+  /**
+   * Override the default `TRUTH_STATE_META[state].description`. Caller
+   * is responsible for copy review (banned-strings list).
+   */
+  meaning?: string;
+  /**
+   * Optional one-line example, surfaced under the meaning text. Useful for
+   * showing the operator how a given state appears in practice.
+   */
+  example?: string;
+}
+
+/**
+ * The 5-row Passport legend, in the order the Passport surface shows them.
+ *
+ *   1. known                 → source-backed
+ *   2. source-backed where   → snapshot-only        (system holds a
+ *      available                                       point-in-time read)
+ *   3. unavailable / gated   → temporarily-unavailable
+ *   4. awaiting institution  → institution-review-required
+ *      review
+ *   5. next step             → access-required        (when caller-action
+ *                                                       is the next step)
+ *
+ * Wave H may swap row 5 to `auth-required` when the call site renders the
+ * unauthenticated public Passport (where sign-in is the next step). The
+ * default here matches the *authenticated* Passport surface — most rows.
+ */
+export const PASSPORT_LEGEND_ROWS: ReadonlyArray<TruthStateLegendRow> =
+  Object.freeze([
+    { state: 'source-backed' },
+    { state: 'snapshot-only' },
+    { state: 'temporarily-unavailable' },
+    { state: 'institution-review-required' },
+    { state: 'access-required' },
+  ] as const);
+
+/**
+ * The full 8-row legend, in `TRUTH_STATE_ORDER` (the operator-friendly
+ * default order).
+ */
+export const FULL_LEGEND_ROWS: ReadonlyArray<TruthStateLegendRow> = Object.freeze(
+  TRUTH_STATE_ORDER.map((state) => ({ state })),
+);
+
+export interface TruthStateLegendProps {
+  /**
+   * Rows to render. Pass `'passport'` for the 5-row Passport legend
+   * (default), `'all'` for the full 8-row legend, or an explicit array
+   * for a custom legend (e.g. on `/status` you might want only the four
+   * states that apply to connector rows).
+   */
+  rows?: 'passport' | 'all' | ReadonlyArray<TruthStateLegendRow>;
+  /** Stacked (default) for prose-heavy surfaces or compact for chrome. */
+  layout?: 'stack' | 'compact';
+  /** Optional heading shown above the legend. Omitted by default. */
+  heading?: string;
+  className?: string;
+}
+
+function resolveRows(
+  rows: TruthStateLegendProps['rows'],
+): ReadonlyArray<TruthStateLegendRow> {
+  if (rows === 'all') return FULL_LEGEND_ROWS;
+  if (rows === undefined || rows === 'passport') return PASSPORT_LEGEND_ROWS;
+  return rows;
+}
+
+/**
+ * Render the canonical truth-state legend.
+ */
+export function TruthStateLegend({
+  rows,
+  layout = 'stack',
+  heading,
+  className,
+}: TruthStateLegendProps) {
+  const resolved = resolveRows(rows);
+
+  return (
+    <section
+      aria-label={heading ?? 'Truth state legend'}
+      className={cn(
+        layout === 'stack'
+          ? 'flex flex-col gap-3'
+          : 'flex flex-wrap items-start gap-x-6 gap-y-3',
+        className,
+      )}
+    >
+      {heading && (
+        <h2 className="text-[length:var(--vt-type-caption-size)] font-[var(--vt-font-weight-semibold)] uppercase tracking-[0.16em] text-[var(--vt-text-secondary)]">
+          {heading}
+        </h2>
+      )}
+      <ul
+        role="list"
+        className={cn(
+          layout === 'stack'
+            ? 'flex flex-col gap-3'
+            : 'flex flex-wrap items-start gap-x-6 gap-y-3',
+        )}
+      >
+        {resolved.map((row) => {
+          const meta = TRUTH_STATE_META[row.state];
+          return (
+            <li
+              key={row.state}
+              className={cn(
+                'flex',
+                layout === 'stack' ? 'items-start gap-3' : 'items-center gap-2',
+              )}
+            >
+              <TruthStateChip state={row.state} size="sm" />
+              <div className="text-[length:var(--vt-type-body-size,14px)] text-[var(--vt-text-secondary)]">
+                <span className="block">{row.meaning ?? meta.description}</span>
+                {row.example && (
+                  <span className="mt-1 block text-[length:var(--vt-type-caption-size,12px)] text-[var(--vt-text-tertiary,var(--vt-text-secondary))] opacity-80">
+                    {row.example}
+                  </span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/design-system/components/index.ts
+++ b/apps/web/design-system/components/index.ts
@@ -29,3 +29,5 @@ export * from './Table';
 export * from './Tabs';
 export * from './Timeline';
 export * from './Toast';
+export * from './TruthStateChip';
+export * from './TruthStateLegend';

--- a/apps/web/design-system/docs/truth-state-chip.md
+++ b/apps/web/design-system/docs/truth-state-chip.md
@@ -1,0 +1,149 @@
+# TruthStateChip — usage guide
+
+The canonical chip for "what is the system reporting about this truth claim right now."
+
+## When to reach for it
+
+- A row in the Passport surface that displays per-source state (NPPES, OIG/LEIE, PECOS, state board).
+- The Connector Matrix on `/status` (which connectors are live, which are not).
+- The per-field register on `/trust/attribution`.
+- Any operator-facing surface where you want a one-glance honest summary of what the system observed — without making promises about credentialing decisions.
+
+## When NOT to use it
+
+- For credential-tier indicators (T1–T4): use `TrustTierBadge`.
+- For audit replay integrity signals: use `ReplayIntegrityBadge`.
+- For OIG exclusion outcomes that need a decision artifact: use `ExclusionBadge`.
+- For severity/risk scores: use `SeverityBadge` / `RiskScoreBadge`.
+
+`TruthStateChip` is **system-state** chrome, not a decision artifact.
+
+## The eight states
+
+| State | Visible label | When to use |
+|---|---|---|
+| `source-backed` | "Source-backed" | A primary source returned a usable payload. The field is backed by that source — never claim it's "verified" in the credentialing sense. |
+| `snapshot-only` | "Snapshot only" | The system holds a point-in-time read; current state may have changed since. |
+| `temporarily-unavailable` | "Temporarily unavailable" | The source did not return a payload on this attempt. **System condition**, not a finding about the clinician. |
+| `connector-not-live` | "Connector not live" | This connector is intentionally not running in the current build. Do **not** interpret as an exclusion clearance. |
+| `access-required` | "Access required" | Authorization is needed before this lane can be read. Caller action expected. |
+| `auth-required` | "Sign in to view" | Operator sign-in unlocks the live read. Public passport pages remain readable without an account. |
+| `institution-review-required` | "Institution review" | This view is a reviewer-ready head start, not a final credentialing decision. |
+| `demo-only` | "Demo only" | Synthetic data for demonstration. Not a real source confirmation. |
+
+Every label was reviewed against the banned-strings list in `CLAUDE.md`:
+
+- No bare "Verified".
+- No "automatically verified", "guaranteed verification", "instant credentialing", "complete credentialing", "legally accepted", "risk transferred", "HIPAA compliant", "SOC2 certified", "NCQA certified".
+
+The tests in `apps/web/__tests__/truth-state-chip.test.tsx` enforce this — adding a new state or editing an existing label without updating the test will fail CI.
+
+## Visual treatments
+
+The variant is determined by the state, not by the caller, so the same state always reads the same across surfaces:
+
+| State | Variant | Visual intent |
+|---|---|---|
+| `source-backed` | `neutral` | Factual, restrained. Never alarming, never celebratory. |
+| `snapshot-only` | `neutral` | Same as source-backed; the modifier ("snapshot") lives in the label. |
+| `temporarily-unavailable` | `muted` | Lower contrast — signals "the system is in a transient condition", not a credential finding. |
+| `connector-not-live` | `outline` | Outline gray. Quiet acknowledgement that this lane is intentionally not connected. |
+| `institution-review-required` | `outline` | Quiet action outline; the next move is a human review, not a system claim. |
+| `access-required` | `warning` | Restrained amber. Caller action expected; the chip is the only chip we let raise pulse. |
+| `auth-required` | `outline` | Outline gray — the caller needs to sign in; we don't pretend that's an alarm. |
+| `demo-only` | `outline` | Outline gray — visibly different from production states. |
+
+If you ever feel tempted to override `variant`, ask whether the situation is genuinely a different *truth state* (in which case introduce a new state with its own canonical visual) rather than reskinning an existing one.
+
+## Basic usage
+
+```tsx
+import { TruthStateChip } from '@/design-system/components';
+
+<TruthStateChip state="source-backed" />
+<TruthStateChip state="temporarily-unavailable" />
+<TruthStateChip state="connector-not-live" />
+```
+
+## With a source label (aria-only)
+
+```tsx
+<TruthStateChip state="source-backed" sourceLabel="NPPES" />
+```
+
+This renders the same visible chip but the `aria-label` becomes:
+
+```
+Truth state: source-backed for NPPES
+```
+
+The source label never leaks into the chip's visible body; it's only there for assistive tech and for hover tooltips composed by the consumer.
+
+## With a timestamp
+
+```tsx
+<TruthStateChip state="snapshot-only" timestamp="2026-05-27T03:18:00Z" />
+```
+
+A hidden `<time>` element is emitted alongside the chip's visible label so screen readers can announce "Truth state: snapshot only, 2026-05-27 03:18 UTC". The visible chip stays terse — surface timestamps in the *row*, not in the chip.
+
+## Compact size
+
+```tsx
+<TruthStateChip state="source-backed" size="sm" />
+```
+
+Use `size="sm"` inside compact tables or legends where the default `md` chip would crowd. The default size is `md`.
+
+## Custom label override
+
+```tsx
+<TruthStateChip state="access-required" label="Sign in required" />
+```
+
+If your surface demands a different label *for this one render*, pass `label`. You are responsible for copy review — the test suite cannot catch a banned-string violation passed at runtime.
+
+## Use with the legend
+
+```tsx
+import { TruthStateLegend } from '@/design-system/components';
+
+// Default: 5-row Passport legend
+<TruthStateLegend />
+
+// Or with optional heading
+<TruthStateLegend heading="What these tags mean" />
+
+// Full 8-row legend (use on /status, /trust/attribution)
+<TruthStateLegend rows="all" />
+
+// Custom subset, e.g. for an employer review surface
+<TruthStateLegend
+  rows={[
+    { state: 'source-backed' },
+    { state: 'institution-review-required', meaning: 'Reviewer-ready head start; institution makes the final call.' },
+  ]}
+/>
+```
+
+The default 5-row Passport legend matches Wave H's specified Passport vocabulary:
+
+1. **known** → `source-backed`
+2. **source-backed where available** → `snapshot-only`
+3. **unavailable / gated** → `temporarily-unavailable`
+4. **awaiting institution review** → `institution-review-required`
+5. **next step** → `access-required`
+
+## Migration notes
+
+If you currently render an ad-hoc `<span>Unavailable</span>` on a source row, swap it for `<TruthStateChip state="temporarily-unavailable" />`. If you currently render bare `>Verified<` (banned!), swap it for `<TruthStateChip state="source-backed" />` and update any tooltip / accessibility text to drop the "Verified" word.
+
+`LaneStateBadge` continues to live in the design system for the ops-lane vocabulary (checked / pending / access / blocked / contradicted / unknown / info). The two systems are complementary, not redundant — `TruthStateChip` is *what the public sees*; `LaneStateBadge` is *what ops sees*.
+
+## Where this is enforced
+
+- Component: `apps/web/design-system/components/TruthStateChip.tsx`.
+- Legend: `apps/web/design-system/components/TruthStateLegend.tsx`.
+- Public re-export: `apps/web/design-system/components/index.ts`.
+- Tests: `apps/web/__tests__/truth-state-chip.test.tsx`.
+- Banned-string list (mirrored): `CLAUDE.md` "Banned strings" section.


### PR DESCRIPTION
## Why

Wave G of the visual-system upgrade. Adds the canonical truth-state chip family that downstream waves (H Passport / I Homepage / J Auth / K Status+Trust Attribution) will import.

The existing app has ~30 badge/chip-shaped components scattered across two parallel design systems (\`apps/web/design-system/components/\` and \`apps/web/components/ui/\`) — see \`docs/design/current-ui-inventory.md\` for the full audit. Wave G centralizes the **system-state vocabulary** (\"what the system observed about this fact right now\") into one component so every surface reads the same.

## What this is NOT

- Not a credential-tier indicator (T1–T4) — that stays in \`TrustTierBadge\`.
- Not an adverse-finding indicator (OIG/sanctions) — those stay in \`ExclusionBadge\` / \`SanctionRiskBadge\`. **TruthStateChip reports system state, never findings about the clinician.**
- Not a route mutation. Zero routes touched. The chip is wired but not yet imported by any surface.

## The 8 truth states

| State | Label | Variant |
|---|---|---|
| \`source-backed\` | Source-backed | neutral (factual, never celebratory) |
| \`snapshot-only\` | Snapshot only | neutral |
| \`institution-review-required\` | Institution review | outline (quiet action) |
| \`access-required\` | Access required | warning (restrained amber) |
| \`auth-required\` | Sign in to view | outline |
| \`temporarily-unavailable\` | Temporarily unavailable | muted (system condition, not finding) |
| \`connector-not-live\` | Connector not live | outline |
| \`demo-only\` | Demo only | outline |

Variant assignment is fixed per state (not caller-driven) so the same state reads the same across surfaces.

## Files (5, +770 / −0)

| File | Purpose |
|---|---|
| \`apps/web/design-system/components/TruthStateChip.tsx\` | Component + 8-state vocabulary + canonical metadata |
| \`apps/web/design-system/components/TruthStateLegend.tsx\` | 5-row Passport default legend + 8-row full legend + custom-rows |
| \`apps/web/design-system/components/index.ts\` | Re-exports |
| \`apps/web/design-system/docs/truth-state-chip.md\` | Usage guide: when to use, when not to use, every state, every prop, migration notes |
| \`apps/web/__tests__/truth-state-chip.test.tsx\` | 19 vitest cases |

## Validation

\`\`\`bash
pnpm --filter @vitalcv/web exec vitest run truth-state-chip
  → Test Files: 1 passed, Tests: 19 passed

pnpm --filter @vitalcv/web exec tsc --noEmit
  → clean

pnpm turbo run build --filter @vitalcv/web
  → Tasks: 13 successful, 13 total

pnpm lint
  → Tasks: 2 successful, 2 total — web lint clean
\`\`\`

## Truth-contract guarantees (enforced by test)

- **No bare \"Verified\"** — \`source-backed\` label is \`\"Source-backed\"\`. Internal type identifier never leaks to UI.
- **No banned phrases** — every visible label and meaning text is regex-checked against the CLAUDE.md banned-strings list (\`/\\bverified\\b/i\`, \`/guaranteed verification/i\`, \`/instant credentialing/i\`, \`/complete credentialing/i\`, \`/HIPAA compliant/i\`, \`/SOC2 certified/i\`, \`/NCQA certified/i\`, etc.).
- **No false source promotion** — \`source-backed\` is the *only* positive state, and it explicitly does not claim credentialing.
- **No final-credentialing language** anywhere.
- Source label folds into \`aria-label\` only, never visible chip body.

## What this does NOT do

- ❌ Modify any product route, page, or component outside design-system.
- ❌ Touch backend, auth, Clerk, Prisma, env, Railway, DNS, or secrets.
- ❌ Add Tailwind config (the app uses CSS-variable tokens; this matches).
- ❌ Retire any existing badge component. Long-tail consolidation is a separate sweep.

## Audit gate

Per session policy: **local Claude Code audit replaces Codex** while Codex remains operator-discretion. This PR is ready for that audit; the validation block above is the evidence it should pass on.

## Next route integration waves (separate PRs)

- **Wave H** — Passport degraded-state surface adopts the chip + 5-row legend; replaces ad-hoc \`<span>Unavailable</span>\` rows; removes skeleton feel in terminal degraded state.
- **Wave I** — Homepage NPI-first hero + 4 role doors + proof strip + footer trust row.
- **Wave J** — Sign-in / sign-up disclosure card; uses \`auth-required\` chip context.
- **Wave K** — \`/status\` Connector Matrix + \`/trust/attribution\` register; uses the full 8-row legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)