### PR TITLE
docs(ops): define VitalCV agent operating SOP

### DIFF
--- a/docs/ops/agent-operating-sop.md
+++ b/docs/ops/agent-operating-sop.md
@@ -1,0 +1,179 @@
+# VitalCV Agent Operating SOP
+
+The canonical pattern for semi-autonomous wave-based execution across every AI tool that touches VitalCV. **All timestamps in operator reports use Pacific / San Jose time.** All percentage moves on the completion board follow the rules in §5. All safety constraints in §8 are binding.
+
+This SOP is doctrine. Tools and waves may change; the doctrine does not.
+
+## 1. VitalCV execution doctrine
+
+Tool roles, in priority order:
+
+| Tool | Role | Default state |
+|---|---|---|
+| 🤖 **Claude Code** | Primary builder + auditor. Owns: reading code, writing code, running validation, opening PRs, executing local audit gate, merging via `gh pr merge`. | **always active** |
+| 🎨 **Claude Design** | Design review + visual spec authoring + screen composition. Always included in design conversations. | **always active** |
+| 🌐 **Claude Browser** | Live verification only. Read-only against deployed services. Cannot create accounts, cannot enter credentials, cannot click mutating buttons unless explicitly authorized. Used for: `/health` polling, Railway active-deployment confirmation, post-deploy SSE smoke (within operator-signed-in browser session). | active for verification |
+| 🖥 **Claude Desktop** | Strategic planning + cross-tool orchestration. Use for: deciding next wave, reading docs across files, drafting roadmaps, picking modes. | active for planning |
+| 🟧 **OpenClaw** | Specialized tool. Only when **explicitly requested** by operator. Never default. | **disabled by default** |
+| ⏸ **Codex** | Originally the merge-gate auditor. **Currently disabled** per operator instruction (account quota / cost). Local Claude Code audit replaces the merge gate. Re-enable only on explicit operator direction. | **disabled by default** |
+
+When Codex is disabled, every PR's merge gate is **Local Claude Code audit**. The audit checklist mirrors the constraints in §8 and lives in §6 of the per-wave template (`docs/ops/wave-batch-template.md`).
+
+## 2. 20-task wave batch format
+
+A **wave batch** is a single operator-driven session that ships up to 20 discrete tasks, each scoped to one branch and one PR. Each task is one row in the batch table.
+
+```
+Wave batch N — <theme>
+ 1. <mission>           branch: <feat|docs|fix>/<slug>          mode: <money|design|backend|pilot>
+ 2. <mission>           branch: …                                mode: …
+…
+20. <mission>           branch: …                                mode: …
+```
+
+Rules:
+
+- **One mission per row.** No row can contain "and then also". If it does, split it.
+- **One branch per row.** A row may produce more than one commit on its branch but never spans multiple branches.
+- **20 max.** If the batch exceeds 20, split into N + 1.
+- **Sequenced if dependent.** When task K+1 depends on task K landing on `main`, mark task K+1 as `blocked: task K`. The wave runner does not start K+1 until K is merged.
+- **Independent rows ship in parallel.** Multiple `feat/*` branches with no shared files can be in flight simultaneously.
+
+See `docs/ops/wave-batch-template.md` for the full table template, the per-task audit checklist, and the failure-class taxonomy.
+
+## 3. Mode system
+
+A wave's **mode** determines its strategic bias and what kinds of risk it can take.
+
+| Mode | Bias | Acceptable risk | Forbidden |
+|---|---|---|---|
+| 💰 **money mode** | Revenue, pilots, conversion, sales collateral. | Marketing copy refresh; pricing surface tweaks; persona-routed landing pages; pilot-intake forms; light Slack-hook integrations. | Any product-truth-contract weakening. Any banned-phrase reintroduction. Any deployment-config change without explicit approval. |
+| 🎨 **design mode** | Visual quality, calm chrome, component library, screen composition. | New design-system components; chip family expansions; route layout refactors; copy refinements within the banned-strings contract. | Backend logic changes. Auth-flow changes. Any false source promotion. |
+| 🧱 **backend mode** | API correctness, persistence, source-adapter integrity. | Backend route handlers, services, source adapters, observability hooks. | Frontend route changes outside the API surface. Any product-copy change. |
+| 🚀 **pilot mode** | Live verification, deploy validation, real-NPI smoke, operator runbooks. | Read-only HTTP probes against deployed services; SSE stream subscription within an operator-authenticated session; Railway active-deployment inspection. | Any modification of Railway / DNS / env / secrets. Any account creation. Any credential surfacing. |
+
+A wave row's mode is declared by the operator. The agent honors the mode's forbidden list.
+
+## 4. Default strategic bias
+
+When the operator does not specify a mode, the agent picks the next-best action from this priority order:
+
+1. **Truth contract** — banned-strings + no-false-promotion is bedrock. If a task threatens it, refuse.
+2. **Deployable code** — code that ships is worth more than code that doesn't. Build, tsc, lint, tests must be green before merge.
+3. **Beautiful product** — UI that is calm, honest, and operator-grade. Design system over ad-hoc spans.
+4. **Live source validation** — SSE smoke, `/health` polling, Railway active-row verification turn "deployed" into "validated live".
+5. **Enterprise persistence / security** — TRUST-PERSIST-1 cutover (in-memory → DB writers) is the largest single board blocker. Tenant isolation, hash binding, auth scope, audit replay.
+6. **Revenue / pilots** — pilot-intake forms, persona pages, pricing surfaces, GTM funnel.
+7. **Workflow automation** — make the next session faster: SOP updates, ledger templates, scheduled workflows.
+
+If two priorities tie, pick the one with the closest "deployed → validated live" gate.
+
+## 5. Completion Board update rules
+
+Source of truth: `docs/ops/vitalcv-completion-board.md`.
+
+Hard rules:
+
+- **High-end waves left only.** A range like "8–14 waves" reports as **14**. Never report the low end.
+- **No percentage inflation for unmerged PRs.** A PR being open is not a percentage move.
+- **Raise only after one of:** ✅ committed-and-tested merged code, 🚢 deployed-to-production, 🧪 validated-live against a real client, 💰 pilot revenue or signed-pilot evidence.
+- **Allowed +1 moves** when the corresponding event lands:
+
+| Event | Allowed move |
+|---|---|
+| TruthStateChip-class foundation merged + tested | Trust/Proof +1, Frontend UX +1 |
+| Visual docs implementation-ready (merged) | Frontend UX +1, Interop +1 |
+| Passport visual upgrade merged + tested | Core Workflow +1, Frontend UX +1 |
+| Homepage role-doors merged + tested | Frontend UX +1, Demo/Sales +1 |
+| Auth disclosure merged + tested | Auth/Onboarding +1 |
+| Status/Attribution receipts merged + tested | Trust/Proof +1, Interop +1 |
+| Visual QA PASS / LIMITED PASS | Frontend UX +1 |
+| SSE smoke proves NPPES truth-state live | Product Truth Contract +2, Source Integrations / PSV +2 |
+| Pilot signed | Business / GTM +5, Demo / Sales +3 |
+| Pilot revenue collected | Business / GTM +10 |
+
+- **Held dimensions:** Source Integrations / PSV cannot rise above current baseline until SSE smoke is validated live. Business / GTM cannot rise without real pilot evidence. Auth / Onboarding cannot rise without a merged + tested auth UX wave.
+- **Emoji markers** (see §10) tag every board row's state at a glance.
+
+## 6. Next Direction Options A–E format
+
+Every wave report ends with a **Next Direction** block. Five options, every time:
+
+```
+Next Direction
+A) <specific strategic task tied to the closest-to-done bottleneck>
+B) <specific strategic task tied to the largest single board blocker>
+C) <specific strategic task in design / GTM / persistence — pick the
+    weakest non-blocked dimension>
+D) <specific strategic task in operator-side hygiene (CRON_SECRET,
+    archive sweep, dead-import cleanup, etc.)>
+E) Continue to next task / next wave batch.
+```
+
+**A, B, C, D must be concrete:** "Run the SSE smoke runbook against api.vitalcv.com for NPI 1699264564" is concrete. "Improve persistence" is not.
+
+**E is always option 5**, no exceptions. The operator picks A/B/C/D for divergence or E to keep the current wave train rolling.
+
+## 7. Tool routing matrix
+
+| Task type | Primary tool | Allowed | Forbidden |
+|---|---|---|---|
+| Read existing code | Claude Code (Read / grep) | Claude Desktop (read-only context) | Browser (cannot read repo files) |
+| Write new component / function | Claude Code (Write + Edit) | — | Browser (cannot write files) |
+| Run vitest / tsc / lint / build | Claude Code (Bash) | — | Browser (cannot execute repo commands) |
+| Open PR / merge PR | Claude Code (Bash + `gh`) | — | Browser (cannot run `gh`) |
+| Inspect Railway active deployment | Claude Browser (read-only) | Claude Code (curl `/health`) | Tool that modifies Railway settings |
+| Run authenticated SSE smoke | Claude Browser **within operator-signed-in session** | — | Any agent attempting to sign in |
+| Visual QA on rendered pages | Claude Browser | Claude Design (review screenshots) | Claude Code (cannot render visuals) |
+| Strategic planning across multiple files | Claude Desktop | Claude Code (file reading) | — |
+| Specialized one-off task | OpenClaw (only when explicitly requested) | — | OpenClaw as default |
+| Merge-gate audit | Local Claude Code audit | — | **Codex (disabled)** |
+
+The merge-protection hook (per CLAUDE.md) expects a real audit verdict in the transcript. With Codex disabled, that verdict is a **Local Claude Code audit** following the checklist in `docs/ops/wave-batch-template.md`.
+
+## 8. Safety rules (binding)
+
+Non-negotiable. Apply across every tool, every mode, every wave.
+
+| Rule | Enforcement |
+|---|---|
+| **No unsupported compliance claims** ("HIPAA compliant", "SOC2 certified", "NCQA certified", "Get verified") | Banned-strings regex test in `apps/web/__tests__/truth-state-chip.test.tsx`; banned-strings list in `CLAUDE.md`. |
+| **No bare "Verified" status label** | Type system pins state vocabularies; chip metadata asserts no `\bverified\b/i` in any visible label. |
+| **No final-credentialing claims** ("complete credentialing", "instant credentialing", "guaranteed verification", "automatically verified", "legally accepted", "risk transferred") | Same banned-strings enforcement. |
+| **No source promotion without backend evidence** | NPPES `source-backed` requires the four-field gate in `deriveSourceCompleteStatus` (PR #423). OIG/LEIE/PECOS/STATE_BOARD/FSMB/NURSYS stay `connector-not-live` until adapter wires up. |
+| **No secrets in chat or logs** | Operator never pastes cookies, JWTs, `x-clerk-user-id`, or session material into agent context. Agent never asks for them. PR descriptions never contain env values. |
+| **No accounts created by agents** | Agents never run signup flows for the operator. Operator signs in themselves; agent works within that authenticated browser session. |
+| **No Railway / DNS / env / secrets mutation** unless operator explicitly requests | Hard rule in every wave's "Hard constraints" block. |
+| **No Prisma migrations** unless approved | Same — gating phrase: "No Prisma migrations" appears in every wave spec. |
+| **No stubs that hide runtime errors** | Restored modules must be substantive; no `return undefined as any` fail-quiet patterns. |
+
+If a wave hits a constraint, the agent's response is **stop and report**. Never bypass.
+
+## 9. Output timestamp rule
+
+Every operator report includes a **Pacific / San Jose timestamp** in the form `YYYY-MM-DD HH:MM PDT` (or PST in winter). Use `date '+%Y-%m-%d %H:%M:%S %Z'` to pull from the host clock. Cross-reference with UTC when reporting GitHub event times (PR merges, deploy events) so operator can match against external logs.
+
+## 10. Emoji workflow markers
+
+For scannability across long ledgers and reports:
+
+| Emoji | Meaning |
+|---|---|
+| ✅ | done / complete |
+| 🟡 | in progress |
+| 🔴 | blocked (operator action required) |
+| 🚢 | merged to main / deployed |
+| 🧪 | validated (tests pass / live behavior confirmed) |
+| 🎨 | design / visual system work |
+| 🧱 | infrastructure / persistence / build |
+| 🔐 | auth / security |
+| 💰 | revenue / pilots / GTM |
+| 🤖 | agent / automation work |
+| 🌐 | browser / live deploy |
+| ⏸ | paused / waiting |
+
+Use sparingly — emoji should clarify, not decorate.
+
+## How this SOP gets updated
+
+When the doctrine changes (a new tool, a new mode, a new safety rule), open a `docs/agent-sop-update-NN` branch with the diff and route through the same audit gate as any other docs PR. The SOP is not above the SOP.

--- a/docs/ops/ai-tool-routing.md
+++ b/docs/ops/ai-tool-routing.md
@@ -1,0 +1,121 @@
+# AI Tool Routing Matrix
+
+The authoritative table of which AI tool handles which class of work for VitalCV. See `docs/ops/agent-operating-sop.md` for the doctrine; this file is the lookup table.
+
+## Tools at a glance
+
+| Tool | Default | Owns | Cannot |
+|---|---|---|---|
+| 🤖 **Claude Code** | active | Build, edit, audit, test, merge, ship | Render visuals; mutate Railway via UI |
+| 🎨 **Claude Design** | active | Visual review, screen composition, component spec | Run code; merge PRs |
+| 🌐 **Claude Browser** | active (read-only) | Live `/health` probes, deployed-page visual QA, Railway active-row read | Modify settings; create accounts; enter credentials |
+| 🖥 **Claude Desktop** | active (strategic) | Cross-file planning, doctrine drafts, mode selection | Execute Bash / make commits |
+| 🟧 **OpenClaw** | disabled by default | Specialized one-off tasks **only on explicit operator request** | Anything as default |
+| ⏸ **Codex** | **disabled** per operator instruction | Originally: merge-gate audit. Now replaced by Local Claude Code audit. | Re-engage without explicit operator green-light |
+
+## Per-task routing
+
+| Task class | Tool | Notes |
+|---|---|---|
+| Read repository files | 🤖 Claude Code | `Read` for known paths; `Grep` for searches |
+| Write or edit code | 🤖 Claude Code | `Write` / `Edit` tools; never paste into chat as substitute |
+| Run `pnpm install`, `pnpm turbo run build`, `vitest`, `tsc`, `lint` | 🤖 Claude Code | `Bash` tool; always validate before commit |
+| Open a PR | 🤖 Claude Code | `gh pr create` |
+| Merge a PR after local audit SAFE | 🤖 Claude Code | `gh pr merge <N> --squash --delete-branch=false` |
+| **Merge-gate audit** | 🤖 **Local Claude Code audit** | Codex is disabled; this is the replacement. Checklist lives in `docs/ops/wave-batch-template.md`. |
+| Visual QA on rendered surfaces (deployed pages) | 🌐 Claude Browser | Read-only; classify per the 5-class taxonomy in `docs/ops/authenticated-sse-smoke-runbook.md` |
+| Inspect Railway active deployment row | 🌐 Claude Browser | Read-only; never click "Apply changes" / "Deploy" / restart buttons |
+| Confirm `/health` SHA matches the latest merge | 🌐 Claude Browser **or** 🤖 Claude Code (`curl`) | Either tool; agent must use cache-busting `?cb=…` to avoid CDN staleness |
+| **Authenticated SSE smoke for NPI 1699264564** | 🌐 Claude Browser **within operator-signed-in session** | Operator does sign-in themselves; agent never enters credentials |
+| Live behavior validation (real client data) | 🌐 Claude Browser | Read-only; never mutate state |
+| Visual design review / palette / spacing / hierarchy | 🎨 Claude Design | Outputs go into `docs/design/` |
+| Component API design / screen composition recipes | 🎨 Claude Design + 🤖 Claude Code | Design specifies; Code implements |
+| Cross-file roadmap drafting | 🖥 Claude Desktop | Then handed to Claude Code for implementation |
+| Mode selection / batch theme / strategic question | 🖥 Claude Desktop or 🤖 Claude Code | Either; document the chosen mode in batch header |
+| Specialized one-off task on explicit operator request | 🟧 OpenClaw | Only when operator names the tool by name. Never default. |
+| Codex re-audit | ⏸ **Disabled** | Do not invoke. If operator wants Codex back, they say so explicitly. |
+
+## Hard prohibitions per tool
+
+### 🤖 Claude Code
+
+- ❌ Never push directly to `main`; always via PR + audit + merge.
+- ❌ Never commit secret values, `.env*` files with real values, or session tokens.
+- ❌ Never run `pnpm publish` or anything that ships to a registry.
+- ❌ Never `gh pr merge --admin` to bypass branch protection (branch protection on `main` is currently empty, but the prohibition stands).
+- ❌ Never `--no-verify`, `--no-gpg-sign`, or otherwise skip hooks.
+
+### 🎨 Claude Design
+
+- ❌ Never claim source connectivity that backend has not validated.
+- ❌ Never recommend a label that the chip vocabulary does not have a state for. Add a new state through the wave process; don't smuggle.
+
+### 🌐 Claude Browser
+
+- ❌ Never click `Deploy` / `Apply changes` / `Restart` / `Promote` / `Rollback` / `Pause` / `Resume` buttons unless explicitly authorized.
+- ❌ Never sign in. Never create an account. Never enter credentials.
+- ❌ Never paste a cookie, JWT, `x-clerk-user-id`, or any session material into a chat message.
+- ❌ Never re-auth the operator's session in a different tab/window.
+
+### 🖥 Claude Desktop
+
+- ❌ Never execute shell commands directly. If a command needs to run, hand it to Claude Code.
+- ❌ Never edit code files. Editing is Claude Code's lane.
+
+### 🟧 OpenClaw
+
+- ❌ Never used unless operator named it explicitly in the current message.
+
+### ⏸ Codex
+
+- ❌ Disabled. Do not invoke. If invoked accidentally, treat the result as informational only — the merge gate is Local Claude Code audit.
+
+## When tool routing is ambiguous
+
+Default order:
+
+1. **Claude Code** if the task involves reading or writing repo files, running validation, or shipping a PR.
+2. **Claude Browser** if the task involves a deployed-page observation.
+3. **Claude Design** if the task involves visual judgement on a screen, mockup, or component composition.
+4. **Claude Desktop** if the task is strategic planning across files / tools.
+
+If still ambiguous, the operator picks. Agents do not silently broaden their lane.
+
+## Audit gate routing (current)
+
+```
+PR opened
+   ↓
+Claude Code: run local audit checklist (docs/ops/wave-batch-template.md)
+   ↓
+Claude Code: classify SAFE / UNSAFE-<class>
+   ↓
+   ├── SAFE → Claude Code: gh pr merge <N> --squash --delete-branch=false
+   └── UNSAFE → Claude Code: stop and report; operator decides next move
+```
+
+When Codex is re-enabled (future), it slots in **between** "PR opened" and the local audit step. The local audit then becomes a redundant double-check rather than the primary gate. The merge-protection hook (per `CLAUDE.md`) currently expects a real audit verdict in the transcript; the Local Claude Code audit satisfies that requirement.
+
+## Cross-tool handoffs
+
+Common patterns:
+
+| From | To | Trigger |
+|---|---|---|
+| 🤖 Claude Code | 🌐 Claude Browser | Web-side change merged; needs visual QA on deployed surface |
+| 🌐 Claude Browser | 🤖 Claude Code | Browser surfaces a classification (AUTH BLOCKED, RUNTIME FAILURE, etc.) that needs a code fix |
+| 🎨 Claude Design | 🤖 Claude Code | New component spec → implementation wave |
+| 🤖 Claude Code | 🎨 Claude Design | Component built; design reviews rendered output |
+| 🖥 Claude Desktop | 🤖 Claude Code | Strategy chosen → execution begins |
+
+Every handoff is logged in the wave's report (`Next Direction` block or per-task report).
+
+## Re-enabling Codex (future)
+
+If the operator decides to re-enable Codex (account quota restored, cost approved):
+
+1. Operator declares re-enablement in a wave header.
+2. Subsequent PR audits route through `codex exec review --base origin/main` per the original CLAUDE.md pattern (three audits: implementation / diff / copy).
+3. Local Claude Code audit becomes the backup, not the primary gate.
+
+Until that declaration is made, **Codex remains disabled**. Every PR ships through the Local Claude Code audit.

--- a/docs/ops/wave-batch-template.md
+++ b/docs/ops/wave-batch-template.md
@@ -1,0 +1,165 @@
+# Wave Batch Template
+
+The canonical shape for one wave batch. Copy this file at the start of every batch, fill in tasks 1–N (up to 20), and append the report at the end. See `docs/ops/agent-operating-sop.md` for the doctrine that binds this template.
+
+## Batch header
+
+```
+Wave Batch <N> — <theme>
+Date: <YYYY-MM-DD HH:MM PDT (San Jose / Pacific)>
+Operator: <name>
+Mode: <money | design | backend | pilot> (default if mixed)
+`main` head at batch start: <SHA>
+```
+
+## Task table (1–20 rows max)
+
+| # | Mission | Branch | Mode | Depends on | Status |
+|--:|---|---|---|---|---|
+| 1 | <one sentence; one branch's worth of work> | `feat\|docs\|fix\|chore/<slug>` | 🎨\|🧱\|🔐\|💰\|🚀 | — or task N | 🟡 in progress / ✅ done / 🔴 blocked |
+| 2 | … | … | … | task 1 | … |
+| … | … | … | … | … | … |
+| 20 | … | … | … | … | … |
+
+Rules (from §2 of the SOP):
+
+- **20 max.** If exceeded, split into batch N + 1.
+- **One mission per row.** No "and then also". Split.
+- **One branch per row.** Multiple commits OK; multiple branches not OK.
+- **Independent rows ship in parallel.** Mark `Depends on:` only when literal dependency exists.
+
+## Per-task audit checklist
+
+Run this before merging any task's PR. Every box must be checked (or explicitly N/A with a reason).
+
+### Diff scope
+- [ ] Diff matches the mission scope (no surprise files).
+- [ ] No backend files touched in design / docs / money modes.
+- [ ] No `apps/api/backend/**` touched in design / money / pilot modes.
+- [ ] No `apps/web/middleware.ts`, no Clerk config, no auth-flow code in design / docs / money modes.
+- [ ] No `railway.toml`, `Dockerfile`, `.env*`, `pnpm-lock.yaml` (unless explicitly approved).
+- [ ] No `prisma/schema.prisma` change.
+- [ ] No new env-var or secret usage.
+
+### Truth contract
+- [ ] No bare "Verified" status label anywhere user-facing.
+- [ ] No "HIPAA compliant" / "SOC2 certified" / "NCQA certified" / "Get verified".
+- [ ] No "instant credentialing" / "complete credentialing" / "guaranteed verification" / "automatically verified" / "legally accepted" / "risk transferred" / "final verification without review".
+- [ ] No false source promotion: NPPES `source-backed` only when the four-field gate is met; OIG / LEIE / PECOS / STATE_BOARD / FSMB / NURSYS stay `connector-not-live` until their adapters land.
+- [ ] No skeleton-style loaders on terminal degraded states.
+
+### Validation
+- [ ] `pnpm install --frozen-lockfile` — lockfile unchanged.
+- [ ] `pnpm turbo run build --filter <package>` — green.
+- [ ] `pnpm --filter <package> exec tsc --noEmit` — clean (run after turbo populates dist if cross-package).
+- [ ] `pnpm lint` — green (only pre-existing warnings allowed).
+- [ ] Focused vitest run — green; any pre-existing failures explicitly classified as drift, not regression.
+
+### Banned-copy scan
+- [ ] `rg -g '*.tsx' -g '*.ts' -in "Verified|verified|cleared|approved|accepted everywhere|complete credentialing|instant credentialing|HIPAA compliant|SOC2 certified|NCQA certified|guaranteed verification|Get verified|risk transferred"` against the diff scope. Every hit is in: (a) `_archive/` (dead route — sweep later), (b) a banned-list documentation block, (c) a negative-example / "avoid" section in docs, or (d) a test assertion that the phrase is NOT present.
+
+### Merge simulation
+- [ ] `git merge --no-commit --no-ff <branch>` against `origin/main` — clean. If conflicts, return **UNSAFE** and stop.
+
+### Deploy / runtime
+- [ ] If touching API code: `delightful-essence` will auto-redeploy. Note the expected new SHA in the PR body.
+- [ ] If touching web code: `vitalcv-web` redeploy expected. Note any visible-route impact.
+- [ ] If neither: explicitly note "no deploy impact" in the PR body.
+
+## Per-task verdict
+
+Verdicts use the same five-class taxonomy as the SSE-smoke runbook:
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| **SAFE** | All checklist items pass; merge sim clean; no truth-contract or constraint violation. | Merge via `gh pr merge <N> --squash --delete-branch=false`. |
+| **UNSAFE — TRUTH-STATE** | Banned phrase, false promotion, or contradiction surfaced. | Stop. Do not merge. Author fix on the branch. |
+| **UNSAFE — SCOPE** | Diff exceeds mission scope. | Stop. Split the PR or trim the diff. |
+| **UNSAFE — VALIDATION** | Build / tsc / lint / test failure caused by this PR. | Stop. Fix and re-run. |
+| **UNSAFE — CONFLICT** | Merge sim has conflicts against `main`. | Stop. Rebase the branch; re-audit on rebased head. |
+
+The agent **never** bypasses an UNSAFE verdict. The operator may override on explicit acknowledgement of risk, but the override must be recorded in `docs/ops/merge-ledger.md` with the specific risk language used.
+
+## Per-task report shape
+
+```
+## Task <N> — <title> — <verdict>
+
+Timestamp: <YYYY-MM-DD HH:MM PDT>
+Branch: <branch>
+Head SHA: <SHA>
+PR: #<num>
+Mode: <emoji + name>
+
+Files inspected (<count>):
+- <file>: <one-line inspection note>
+
+Conflict result: <clean | conflicts list>
+Truth-contract result: <pass | concrete failure>
+Banned-copy scan: <clean | classified hits>
+Tests: <X/Y pass>
+Build: <Tasks: X successful, Y total>
+Lint: <green | warnings list>
+tsc: <clean | concrete error list>
+Merge recommendation: <Merge | Stop>
+```
+
+## Batch close
+
+At the end of a batch, append to the batch file:
+
+```
+## Batch close
+
+Timestamp: <YYYY-MM-DD HH:MM PDT>
+`main` head at batch close: <SHA>
+Tasks shipped: <list of merged PRs + SHAs>
+Tasks deferred: <list with reasons>
+Completion-board moves: <list of (dimension, before → after, reason)>
+Carry-overs to next batch: <list>
+
+### Next Direction
+A) <option A>
+B) <option B>
+C) <option C>
+D) <option D>
+E) Continue to next task / next wave batch.
+```
+
+Then update `docs/ops/wave-ledger.md` with one row per task and `docs/ops/merge-ledger.md` with one section per merged PR. Both ledgers' update conventions are documented in their own files.
+
+## Example: minimal 3-task batch
+
+```
+Wave Batch 4 — visual-system foundation
+Date: 2026-05-26 22:00 PDT
+Operator: ct
+Mode: 🎨 design
+main head at batch start: 801100c7f
+
+| # | Mission                                | Branch                           | Mode | Depends | Status |
+|--:|---|---|---|---|---|
+| 1 | TruthStateChip + Legend + tests + docs | feat/truth-state-chip            | 🎨   | —       | ✅ |
+| 2 | 6 design-system docs                   | docs/design-system-foundation    | 🎨   | task 1  | ✅ |
+| 3 | Tracking-ledger update                 | docs/wave-batch-tracking         | 🤖   | task 2  | ✅ |
+
+Batch close
+
+Timestamp: 2026-05-26 22:26 PDT
+main head at batch close: 50942ad1e
+Tasks shipped: #425 a368a1ffb, #426 a88e014e4, #424 50942ad1e
+Tasks deferred: Wave H Passport (next batch — dedicated coding turn)
+Completion-board moves:
+- Frontend UX / Role Journeys: 35% / 24 → 37% / 22 (PR #425 + #426 merged/tested)
+- Trust / Proof / Receipts: 32% / 27 → 33% / 26 (PR #425)
+- Testing / CI / Quality Gates: 31% / 26 → 32% / 25 (19 new chip regression tests)
+- Interoperability / Standards: 26% / 34 → 27% / 33 (docs implementation-ready)
+- Overall: 27% / 392 → 28% / 388
+
+Next Direction
+A) Wave H — Passport calm-degradation integration (now unblocked by #425/#426).
+B) Authenticated SSE smoke for NPI 1699264564 (operator-only; gates Product Truth Contract → "validated live").
+C) `fix/nppes-source-health-observability` — observability moat (Wave D's task 1 + task 3 bundle).
+D) Operator: configure `CRON_SECRET` repo secret to fix the failing scheduled health-probe workflows.
+E) Continue to next task / next wave batch.
+```


### PR DESCRIPTION
Docs-only SOP for semi-autonomous VitalCV wave execution, tool routing, completion-board rules, and AI-agent workflow.

Three new docs under `docs/ops/`:
- `agent-operating-sop.md` — doctrine (Claude Code primary, Claude Design always included, Browser only for live verification, Codex disabled, OpenClaw only when explicitly requested); 20-task wave batch format; mode system (money/design/backend/pilot); default strategic bias; completion-board update rules; Next Direction Options A–E; safety rules (binding); Pacific timestamp rule; emoji workflow markers.
- `wave-batch-template.md` — canonical batch shape; per-task audit checklist; 5-class verdict taxonomy; per-task report shape; worked example.
- `ai-tool-routing.md` — per-task routing matrix; hard prohibitions per tool; default order when ambiguous; cross-tool handoffs; Codex re-enable procedure.

No product code, no deployment configuration, no env/secrets/DNS/Railway/Prisma touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)