### PR TITLE
feat(web): make homepage NPI-first with role doors

### DIFF
--- a/apps/web/__tests__/home-npi-role-doors.test.tsx
+++ b/apps/web/__tests__/home-npi-role-doors.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * home-npi-role-doors.test.tsx — Wave I coverage.
+ *
+ * Asserts the homepage renders:
+ *   - the canonical NPI-first headline + subhead,
+ *   - "Look up an NPI" as the primary CTA label,
+ *   - a "Sign in" secondary link,
+ *   - four role doors (Verifier / Clinician / Employer / Issuer)
+ *     each with the documented action label,
+ *   - a three-column proof strip (Source / State / Review boundary),
+ *   - a trust footer row (Status / Source attribution / Trust),
+ *   - zero banned phrases anywhere on the rendered surface.
+ *
+ * The component is a client component that depends on `next/navigation`
+ * and `@clerk/nextjs`. We render the inner content by reaching into the
+ * exported component via a server-side static render — Clerk providers
+ * are not exercised in vitest, so SignedIn returns null, which matches
+ * the unauthenticated public surface.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+// Stub next/navigation — server-side render does not need real router.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => undefined, replace: () => undefined }),
+}));
+
+// Stub @clerk/nextjs — SignedIn returns null when no provider in scope.
+vi.mock('@clerk/nextjs', () => ({
+  SignedIn: ({ children }: { children: React.ReactNode }) => null,
+}));
+
+import HomePageClient from '@/app/HomePageClient';
+
+const BANNED_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bverified\b/i,
+  /\bguaranteed\s+verification\b/i,
+  /\binstant\s+credentialing\b/i,
+  /\bcomplete\s+credentialing\b/i,
+  /\bautomatically\s+verified\b/i,
+  /\blegally\s+accepted\b/i,
+  /\brisk\s+transferred\b/i,
+  /\bcertified\s+compliant\b/i,
+  /\bHIPAA\s+compliant\b/i,
+  /\bSOC2\s+certified\b/i,
+  /\bNCQA\s+certified\b/i,
+  /\bGet\s+verified\b/i,
+  /\baccepted\s+everywhere\b/i,
+];
+
+function assertNoBannedPhrases(html: string): void {
+  for (const pattern of BANNED_PATTERNS) {
+    expect(
+      pattern.test(html),
+      `Banned phrase /${pattern.source}/${pattern.flags} matched`,
+    ).toBe(false);
+  }
+}
+
+describe('HomePageClient — NPI-first hero', () => {
+  it('renders the canonical hero headline and subhead', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('Look up an NPI.');
+    expect(html).toContain('data-home-hero-subhead');
+    expect(html).toContain(
+      'See what is source-backed, what is gated, and what still needs institution review.',
+    );
+  });
+
+  it('renders "Look up an NPI" as the primary CTA label', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-primary-cta');
+    expect(html).toMatch(/Look up an NPI[^<]*<svg/);
+  });
+
+  it('renders a "Sign in" secondary link', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-secondary-cta');
+    expect(html).toContain('href="/sign-in"');
+    expect(html).toContain('>Sign in<');
+  });
+});
+
+describe('HomePageClient — role doors', () => {
+  it('renders four role doors', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-role-doors');
+    expect(html).toContain('data-home-role-door="verifier"');
+    expect(html).toContain('data-home-role-door="clinician"');
+    expect(html).toContain('data-home-role-door="employer"');
+    expect(html).toContain('data-home-role-door="issuer"');
+  });
+
+  it('each role door advertises its canonical action label', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('Look up an NPI'); // verifier (also matches the primary CTA above the doors)
+    expect(html).toContain('Claim my NPI record'); // clinician
+    expect(html).toContain('Review a passport'); // employer
+    expect(html).toContain('Connect a source'); // issuer
+  });
+});
+
+describe('HomePageClient — proof strip', () => {
+  it('renders the three proof-strip columns', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-proof-strip');
+    expect(html).toContain('data-home-proof-col="source"');
+    expect(html).toContain('data-home-proof-col="state"');
+    expect(html).toContain('data-home-proof-col="review-boundary"');
+  });
+
+  it('proof-strip copy names source / state / review boundary in operator-honest language', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('Every field names the primary source');
+    // "Source-backed" appears in the state column as part of operator-honest copy.
+    expect(html).toMatch(/Source-backed,\s+gated,\s+or\s+temporarily\s+unavailable/);
+    expect(html).toContain(
+      'Institution review remains the final step.',
+    );
+  });
+});
+
+describe('HomePageClient — trust footer row', () => {
+  it('renders the footer trust row with three links', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-trust-footer');
+    expect(html).toContain('href="/status"');
+    expect(html).toContain('href="/trust/attribution"');
+    expect(html).toContain('href="/trust"');
+  });
+});
+
+describe('HomePageClient — banned-phrase scan', () => {
+  it('contains no banned phrases anywhere in the rendered HTML', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    assertNoBannedPhrases(html);
+  });
+
+  it('does NOT contain "Get verified" (per Wave I hard constraint)', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(/\bGet\s+verified\b/i.test(html)).toBe(false);
+  });
+
+  it('does NOT contain "accepted everywhere" (per Wave I hard constraint)', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(/\baccepted\s+everywhere\b/i.test(html)).toBe(false);
+  });
+});

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -17,15 +17,67 @@ function formatNpi(value: string): string {
   return `${digits.slice(0, 3)} ${digits.slice(3, 6)} ${digits.slice(6)}`;
 }
 
-const PREVIEW_STEPS = [
+/**
+ * Role doors — four entry points keyed off operator role.
+ *
+ * Each door is a calm card with a single action. Doors share a flat
+ * visual treatment (no gradients, no hover lift, no shadow-stack drama)
+ * so the NPI lookup above remains the unambiguous primary action.
+ */
+const ROLE_DOORS = [
   {
-    title: 'Recognized',
-    body: 'One NPI opens a source-backed snapshot.',
+    role: 'Verifier',
+    action: 'Look up an NPI',
+    href: '/',
+    blurb: 'See what is source-backed about a clinician.',
   },
   {
-    title: 'Moving forward',
-    body: 'Onboarding continues the path.',
+    role: 'Clinician',
+    action: 'Claim my NPI record',
+    href: '/onboarding',
+    blurb: 'Open the snapshot tied to your NPI.',
   },
+  {
+    role: 'Employer',
+    action: 'Review a passport',
+    href: '/employers',
+    blurb: 'Reviewer-ready head start, not a final credentialing decision.',
+  },
+  {
+    role: 'Issuer',
+    action: 'Connect a source',
+    href: '/issuer',
+    blurb: 'Add a primary-source lane to the trust register.',
+  },
+] as const;
+
+/**
+ * Proof strip — three terse columns that name what every Passport row
+ * carries. Avoids dashboard chrome; reads like a document caption.
+ */
+const PROOF_STRIP = [
+  {
+    label: 'Source',
+    text: 'Every field names the primary source we read.',
+  },
+  {
+    label: 'State',
+    text: 'Source-backed, gated, or temporarily unavailable.',
+  },
+  {
+    label: 'Review boundary',
+    text: 'Institution review remains the final step.',
+  },
+] as const;
+
+/**
+ * Footer trust row — small links the operator can use to inspect the
+ * truth contract directly. Local; no marketing chrome.
+ */
+const TRUST_FOOTER_LINKS = [
+  { label: 'Status', href: '/status' },
+  { label: 'Source attribution', href: '/trust/attribution' },
+  { label: 'Trust', href: '/trust' },
 ] as const;
 
 export default function HomePageClient() {
@@ -77,119 +129,194 @@ export default function HomePageClient() {
         </SignedIn>
       )}
 
-      <main className="relative mx-auto flex min-h-screen w-full max-w-5xl items-center px-6 py-16 sm:py-20">
-        <div className="w-full max-w-3xl">
-          <div className="space-y-6">
-            <h1 className="max-w-2xl text-[clamp(3rem,7.5vw,5rem)] leading-[0.92] font-semibold tracking-[-0.06em] text-[var(--vt-text-primary)]">
-              Enter your NPI.
-              <br />
-              See what is ready.
-            </h1>
+      <main className="relative mx-auto flex min-h-screen w-full max-w-5xl items-start px-6 py-16 sm:py-20">
+        <div className="w-full">
 
-            <p className="max-w-xl text-[18px] leading-[1.65] text-[var(--vt-text-secondary)]">
-              VitalCV turns one NPI into a source-backed snapshot that recognizes you and points forward.
-            </p>
-          </div>
-
-          <Card className="mt-10 max-w-2xl border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_96%,white)] shadow-[0_1px_0_rgba(255,255,255,0.72),0_18px_48px_rgba(15,23,42,0.05)]">
-            <CardContent className="space-y-5 px-5 py-5 sm:px-6 sm:py-6">
-              <form
-                className="space-y-2"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  handleSubmit();
-                }}
+          {/* Hero — NPI-first lookup with trust-bounded headline */}
+          <section aria-label="NPI lookup" data-home-hero="" className="max-w-3xl">
+            <div className="space-y-5">
+              <h1 className="text-[clamp(2.5rem,6vw,4rem)] leading-[0.96] font-semibold tracking-[-0.04em] text-[var(--vt-text-primary)]">
+                Look up an NPI.
+              </h1>
+              <p
+                data-home-hero-subhead=""
+                className="max-w-2xl text-[18px] leading-[1.6] text-[var(--vt-text-secondary)]"
               >
-                <label
-                  htmlFor="npi"
-                  className="text-[11px] font-medium uppercase tracking-[0.2em] text-[var(--vt-text-muted)]"
-                >
-                  NPI
-                </label>
+                See what is source-backed, what is gated, and what still needs institution review.
+              </p>
+            </div>
 
-                <div
-                  className={cn(
-                    'flex flex-col overflow-hidden rounded-[1.5rem] border bg-[var(--vt-bg)] transition-colors sm:flex-row',
-                    focused
-                      ? 'border-[var(--vt-text-primary)] ring-2 ring-[var(--vt-focus-ring)]/15'
-                      : 'border-[var(--vt-border)]',
-                  )}
+            <Card className="mt-8 max-w-2xl border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_96%,white)] shadow-[0_1px_0_rgba(255,255,255,0.72),0_18px_48px_rgba(15,23,42,0.05)]">
+              <CardContent className="space-y-5 px-5 py-5 sm:px-6 sm:py-6">
+                <form
+                  className="space-y-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    handleSubmit();
+                  }}
                 >
-                  <div className="flex items-center gap-3 px-4 pt-4 text-[var(--vt-text-muted)] sm:pt-0">
-                    <Fingerprint size={18} aria-hidden="true" />
-                  </div>
-                  <Input
-                    id="npi"
-                    type="text"
-                    inputMode="numeric"
-                    autoComplete="off"
-                    placeholder="Enter 10-digit NPI"
-                    value={formatNpi(raw)}
-                    onChange={(event) => {
-                      setRaw(event.target.value);
-                      setError(null);
-                    }}
-                    onFocus={() => setFocused(true)}
-                    onBlur={() => setFocused(false)}
-                    aria-invalid={Boolean(error)}
-                    aria-describedby={error ? 'home-npi-error' : undefined}
-                    className="h-14 flex-1 border-0 bg-transparent px-4 text-[18px] font-medium tracking-[0.14em] text-[var(--vt-text-primary)] shadow-none placeholder:text-[var(--vt-text-muted)]/40 focus-visible:ring-0"
-                  />
-                  <button
-                    type="submit"
-                    disabled={!isFull}
+                  <label
+                    htmlFor="npi"
+                    className="text-[11px] font-medium uppercase tracking-[0.2em] text-[var(--vt-text-muted)]"
+                  >
+                    NPI
+                  </label>
+
+                  <div
                     className={cn(
-                      'inline-flex h-14 items-center justify-center gap-2 border-t border-[var(--vt-border)] px-5 text-[13px] font-semibold transition-colors sm:border-l sm:border-t-0 sm:px-6',
-                      isFull
-                        ? 'bg-[var(--vt-text-primary)] text-[var(--vt-bg)] hover:bg-[color-mix(in_oklab,var(--vt-text-primary)_90%,black)]'
-                        : 'cursor-not-allowed bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
+                      'flex flex-col overflow-hidden rounded-[1.5rem] border bg-[var(--vt-bg)] transition-colors sm:flex-row',
+                      focused
+                        ? 'border-[var(--vt-text-primary)] ring-2 ring-[var(--vt-focus-ring)]/15'
+                        : 'border-[var(--vt-border)]',
                     )}
                   >
-                    Open passport
-                    <ArrowRight size={16} aria-hidden="true" />
-                  </button>
+                    <div className="flex items-center gap-3 px-4 pt-4 text-[var(--vt-text-muted)] sm:pt-0">
+                      <Fingerprint size={18} aria-hidden="true" />
+                    </div>
+                    <Input
+                      id="npi"
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="off"
+                      placeholder="Enter 10-digit NPI"
+                      value={formatNpi(raw)}
+                      onChange={(event) => {
+                        setRaw(event.target.value);
+                        setError(null);
+                      }}
+                      onFocus={() => setFocused(true)}
+                      onBlur={() => setFocused(false)}
+                      aria-invalid={Boolean(error)}
+                      aria-describedby={error ? 'home-npi-error' : undefined}
+                      className="h-14 flex-1 border-0 bg-transparent px-4 text-[18px] font-medium tracking-[0.14em] text-[var(--vt-text-primary)] shadow-none placeholder:text-[var(--vt-text-muted)]/40 focus-visible:ring-0"
+                    />
+                    <button
+                      type="submit"
+                      data-home-primary-cta=""
+                      disabled={!isFull}
+                      className={cn(
+                        'inline-flex h-14 items-center justify-center gap-2 border-t border-[var(--vt-border)] px-5 text-[13px] font-semibold transition-colors sm:border-l sm:border-t-0 sm:px-6',
+                        isFull
+                          ? 'bg-[var(--vt-text-primary)] text-[var(--vt-bg)] hover:bg-[color-mix(in_oklab,var(--vt-text-primary)_90%,black)]'
+                          : 'cursor-not-allowed bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
+                      )}
+                    >
+                      Look up an NPI
+                      <ArrowRight size={16} aria-hidden="true" />
+                    </button>
+                  </div>
+                </form>
+
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--vt-text-secondary)]">
+                  <span
+                    className={error ? 'text-[var(--vt-state-blocked)]' : undefined}
+                    role={error ? 'alert' : undefined}
+                    id={error ? 'home-npi-error' : undefined}
+                  >
+                    {error ?? (isFull ? 'Press Enter to continue' : `${digits.length}/10 digits`)}
+                  </span>
+                  <span className="text-[var(--vt-border)]" aria-hidden="true">
+                    ·
+                  </span>
+                  <span>No account required</span>
+                  <span className="text-[var(--vt-border)]" aria-hidden="true">
+                    ·
+                  </span>
+                  <Link
+                    href="/sign-in"
+                    data-home-secondary-cta=""
+                    className="font-medium text-[var(--vt-text-secondary)] underline underline-offset-4 transition-opacity hover:opacity-80"
+                  >
+                    Sign in
+                  </Link>
                 </div>
-              </form>
+              </CardContent>
+            </Card>
+          </section>
 
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--vt-text-secondary)]">
-                <span
-                  className={error ? 'text-[var(--vt-state-blocked)]' : undefined}
-                  role={error ? 'alert' : undefined}
-                  id={error ? 'home-npi-error' : undefined}
+          {/* Role doors — four calm entry points */}
+          <section
+            aria-label="Role-specific entry points"
+            data-home-role-doors=""
+            className="mt-14"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              By role
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {ROLE_DOORS.map((door) => (
+                <Link
+                  key={door.role}
+                  href={door.href}
+                  data-home-role-door={door.role.toLowerCase()}
+                  className="group flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.6)] transition-colors hover:border-[var(--vt-text-primary)]"
                 >
-                  {error ?? (isFull ? 'Press Enter to continue' : `${digits.length}/10 digits`)}
-                </span>
-                <span className="text-[var(--vt-border)]" aria-hidden="true">
-                  ·
-                </span>
-                <span>No account required</span>
-                <span className="text-[var(--vt-border)]" aria-hidden="true">
-                  ·
-                </span>
-                <span>Source-backed</span>
-              </div>
-            </CardContent>
-          </Card>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
+                    {door.role}
+                  </p>
+                  <p className="text-sm font-semibold leading-snug text-[var(--vt-text-primary)]">
+                    {door.action}
+                  </p>
+                  <p className="text-[12px] leading-relaxed text-[var(--vt-text-secondary)]">
+                    {door.blurb}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </section>
 
-          <div className="mt-6 grid gap-3 sm:grid-cols-3">
-            {PREVIEW_STEPS.map((step) => (
-              <div
-                key={step.title}
-                className="rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_92%,white)] px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.6)]"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
-                  {step.title}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[var(--vt-text-secondary)]">
-                  {step.body}
-                </p>
-              </div>
+          {/* Proof strip — what every passport row carries */}
+          <section
+            aria-label="What every passport row carries"
+            data-home-proof-strip=""
+            className="mt-14"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              Every row carries
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              {PROOF_STRIP.map((col) => (
+                <div
+                  key={col.label}
+                  data-home-proof-col={col.label.toLowerCase().replace(/\s+/g, '-')}
+                  className="rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
+                    {col.label}
+                  </p>
+                  <p className="mt-2 text-[13px] leading-relaxed text-[var(--vt-text-secondary)]">
+                    {col.text}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Trust footer row — calm pointer links, no marketing chrome */}
+          <nav
+            aria-label="Trust footer"
+            data-home-trust-footer=""
+            className="mt-14 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-[var(--vt-border-subtle)] pt-6 text-[12px] text-[var(--vt-text-muted)]"
+          >
+            <span className="text-[11px] font-semibold uppercase tracking-[0.18em]">
+              Trust
+            </span>
+            {TRUST_FOOTER_LINKS.map((link, idx) => (
+              <React.Fragment key={link.href}>
+                {idx > 0 && (
+                  <span aria-hidden="true" className="text-[var(--vt-border)]">
+                    ·
+                  </span>
+                )}
+                <Link
+                  href={link.href}
+                  className="font-medium text-[var(--vt-text-secondary)] underline-offset-4 transition-opacity hover:underline hover:opacity-90"
+                >
+                  {link.label}
+                </Link>
+              </React.Fragment>
             ))}
-          </div>
-
-          <p className="mt-5 max-w-2xl text-sm leading-relaxed text-[var(--vt-text-muted)]">
-            The first result is a passport snapshot. Onboarding continues the path.
-          </p>
+          </nav>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Wave I — Homepage NPI-first + role doors

Updates homepage hierarchy around NPI lookup, role-specific entry points, and a proof-strip + trust footer. Preserves truth-contract language throughout. No backend, auth, or deployment changes.

## Highlights

- **Hero headline:** "Look up an NPI." + subhead "See what is source-backed, what is gated, and what still needs institution review."
- **Primary CTA** (inside the NPI input): "Look up an NPI" (was "Open passport").
- **Secondary CTA:** "Sign in" link below the NPI input.
- **Role doors** — 4-tile grid: Verifier (Look up an NPI), Clinician (Claim my NPI record), Employer (Review a passport), Issuer (Connect a source).
- **Proof strip** — 3 columns: Source / State / Review boundary, each with operator-honest one-line copy.
- **Trust footer row** — small links: Status · Source attribution · Trust.

## Visual

Calm, white/warm-gray. Flat role-door cards (no hover lift, no shadow stack). One primary action above the fold. Existing radial-gradient backdrop preserved.

## Truth-contract guarantees (enforced by 11 vitest cases)

- ❌ no bare "Verified"
- ❌ no "Get verified"
- ❌ no "accepted everywhere"
- ❌ no "complete credentialing" / "instant credentialing" / "automatically verified" / "guaranteed verification"
- ❌ no "HIPAA compliant" / "SOC2 certified" / "NCQA certified"
- ❌ no fake source connectivity ("Connect a source" routes to /issuer where adapter wiring is real work)

## Files

- `apps/web/app/HomePageClient.tsx` (edit)
- `apps/web/__tests__/home-npi-role-doors.test.tsx` (new, 11 cases)

## Validation

```bash
pnpm --filter @vitalcv/web exec vitest run home-npi-role-doors
  → Test Files: 1 passed, Tests: 11 passed.

pnpm turbo run build --filter @vitalcv/web
  → Tasks: 13 successful, 13 total.

pnpm --filter @vitalcv/web exec tsc --noEmit → clean.

pnpm lint → 2/2 successful, web lint clean.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)