### PR TITLE
fix(web): restore truth-contract copy on onboarding + review surfaces

### DIFF
--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -102,7 +102,7 @@ export default async function OnboardingPage({
 
           <CardFooter className="border-t border-[var(--vt-border-subtle)] px-5 py-4 sm:px-6">
             <p className="text-xs leading-relaxed text-[var(--vt-text-muted)]">
-              Onboarding continues.
+              Onboarding summarizes the continuation path. It does not complete credentialing.
             </p>
           </CardFooter>
         </Card>

--- a/apps/web/app/review/[entityId]/ReviewPageClient.tsx
+++ b/apps/web/app/review/[entityId]/ReviewPageClient.tsx
@@ -147,8 +147,8 @@ export default async function ReviewPageClient({
               title="Review link unavailable"
               description={
                 isExpired
-                  ? 'This review link has expired. Ask the clinician to generate a new review link.'
-                  : 'This review link is missing, expired, or no longer maps to an active credential record.'
+                  ? 'This review link has expired. Ask the clinician to share a fresh packet.'
+                  : 'This review link is missing, expired, or no longer maps to an active packet.'
               }
               tone="warning"
               centered
@@ -168,7 +168,7 @@ export default async function ReviewPageClient({
     resolvedEntityId = tokenResult.body.entityId;
     resolvedContextId = tokenResult.body.organizationContextId ?? contextId;
     resolvedBundleId = tokenResult.body.bundleId ?? bundleId;
-    resolvedFrom = from ?? 'VitalCV review share';
+    resolvedFrom = from ?? 'VitalCV packet share';
   }
 
   const [passportResult, historyResult] = await Promise.all([


### PR DESCRIPTION
## Why

Three vitest contract suites are failing on `origin/main` HEAD (`f7b5b367a`) — verified on a clean worktree, independent of any open PR. The failures predate PR #431 (D57 visual-system port) and were left out of that wave intentionally to keep its scope tight.

The cause: three earlier copy-polish commits silently shortened load-bearing strings on the onboarding and employer-review-share surfaces, but never updated the contract tests that pin them.

| Commit | Surface | Drop |
|---|---|---|
| `7f7ace104` feat(productization): refine activation continuity | `apps/web/app/onboarding/page.tsx` CardFooter | "Onboarding summarizes the continuation path. It does not complete credentialing." → "Onboarding continues." |
| `877f455c8` refine(trust): source label completeness, review copy polish | `ReviewPageClient.tsx` `resolvedFrom` default | `'VitalCV packet share'` → `'VitalCV review share'` |
| `cb8613628` refine(confidence): institutional copy pass | `ReviewPageClient.tsx` unresolved-state descriptions | "share a fresh packet" → "generate a new review link"; "active packet" → "active credential record" |

The first drop is the most consequential — the explicit `It does not complete credentialing.` disclaimer is a CLAUDE.md truth-contract guardrail, and the foundation library still declares it at [apps/web/lib/commercial/onboardingFoundation.ts:34](apps/web/lib/commercial/onboardingFoundation.ts#L34). The page surface just stopped echoing it.

## What changed

```
apps/web/app/onboarding/page.tsx                    | 2 +-
apps/web/app/review/[entityId]/ReviewPageClient.tsx | 6 +++---
2 files changed, 4 insertions(+), 4 deletions(-)
```

Pure string-literal restoration — no logic, no imports, no exports, no config or lockfile drift.

## Failing tests this fixes

- `apps/web/__tests__/foundation-sweep-6-commercial.test.ts > onboarding route includes the required credentialing safety copy`
- `apps/web/__tests__/review-page-contract.test.tsx > resolves share tokens before hydrating the employer review surface`
- `apps/web/__tests__/wave1-external-pilot-flow.test.ts > renders a safe unresolved state for missing/expired share tokens`

## Verification

| Step | Result |
|---|---|
| `pnpm exec vitest run` on the three affected suites | **30 / 30 pass** (was 23/30) |
| `pnpm exec vitest run` on full `apps/web` | 1513 passed / 4 skipped / 2 failed |
| `pnpm turbo run typecheck --filter @vitalcv/web` | clean |
| `codex exec` x3 (implementation / diff / copy) | **SAFE / SAFE / SAFE** |

The 2 remaining vitest failures (`status-page-compliance-evidence`, `foundation-sweep-6-analytics-status`, `passport-ingest-page`) also pre-exist on pristine `origin/main` — re-confirmed by stashing this branch's edits and re-running. They are independent of the files in this change and out of scope here.

## Codex audits (transcript-visible per CLAUDE.md merge-protection hook)

```
Audit 1 (Implementation): CODEX VERDICT: SAFE — each restored string matches the test assertion;
  only string literals changed; the one banned-substring match ('complete credentialing')
  is the protected negation required by foundation-sweep-6-commercial.test.ts:169.

Audit 2 (Diff):           CODEX VERDICT: SAFE — exactly 2 modified files, 4+/4-, no config,
  no lockfile, no binary, no secrets.

Audit 3 (Copy):           CODEX VERDICT: SAFE — onboarding footer matches the foundation
  invariant at onboardingFoundation.ts:34; no new positive banned claims; 'fresh packet' /
  'active packet' / 'VitalCV packet share' preserve operator-honest framing.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)