### PR TITLE
fix(web): restore /passport completed-without-anchor copy + /status foundation-status & compliance-evidence sections

### DIFF
--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -735,8 +735,8 @@ function PassportPageContent({
             {/* Terminal completion without anchor */}
             {runCompletedWithoutAnchor && (
               <TrustStateCard
-                title="Passport is still waiting on sources."
-                description="Public NPI identity resolved, but no source-backed anchor was written."
+                title="Profile resolved, but passport continuation is still provisional."
+                description="Public NPI identity resolved, but no source-backed passport anchor was written for this run. Re-check sources before treating this as a full passport."
                 centered
               />
             )}

--- a/apps/web/app/status/page.tsx
+++ b/apps/web/app/status/page.tsx
@@ -6,16 +6,20 @@
  * chronology integrity, and links to all .well-known endpoints.
  */
 
+import * as React from 'react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { LiveTrustStatusBoard } from '@/components/ops/LiveTrustStatusBoard';
 import { SourceLaneTelemetry } from '@/components/ops/SourceLaneTelemetry';
 import { ChronologyIntegrityTelemetry } from '@/components/ops/ChronologyIntegrityTelemetry';
+import { buildAdapterMatrix } from '@/lib/authority/adapterMatrix';
+import { buildDataClassificationFoundation } from '@/lib/security/dataClassificationFoundation';
+import { buildRetentionFoundation } from '@/lib/security/retentionFoundation';
 
 export const metadata: Metadata = {
   title: 'Operational Status · VitalCV',
   description:
-    'Live operational status for VitalCV trust infrastructure. Independently verifiable.',
+    'Status surfaces are foundation previews. No uptime guarantee is implied. Live operational status for VitalCV trust infrastructure.',
 };
 
 const WELL_KNOWN_ENDPOINTS = [
@@ -82,6 +86,15 @@ const WELL_KNOWN_ENDPOINTS = [
 ];
 
 export default function StatusPage() {
+  // Compliance evidence shape — read from the foundation modules so /status
+  // and /api/compliance/evidence agree on every count + Live flag. The page
+  // renders the literal flag strings (`redactionLive: false` etc.) so the
+  // status-page-compliance-evidence regression test catches any silent
+  // regressions in the underlying foundation modules.
+  const dataClassification = buildDataClassificationFoundation();
+  const retention = buildRetentionFoundation();
+  const authority = buildAdapterMatrix();
+
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100 font-mono">
       {/* Header */}
@@ -105,6 +118,61 @@ export default function StatusPage() {
       </header>
 
       <main className="mx-auto max-w-4xl px-6 py-8 space-y-6">
+        {/* Foundation status preview — disclaimer + compliance evidence shape */}
+        <section
+          aria-labelledby="foundation-status-heading"
+          className="border border-gray-800 bg-gray-950"
+        >
+          <div className="border-b border-gray-800 px-4 py-2">
+            <h2 id="foundation-status-heading" className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+              Foundation status preview
+            </h2>
+          </div>
+          <div className="px-4 py-3 text-xs leading-relaxed text-gray-300">
+            <p>
+              <strong>{'Status surfaces are foundation previews. No uptime guarantee is implied.'}</strong>{' '}
+              Incident notices and public changelogs are planned surfaces. Neither is wired today.
+            </p>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="compliance-evidence-heading"
+          className="border border-gray-800 bg-gray-950"
+        >
+          <div className="border-b border-gray-800 px-4 py-2">
+            <h2 id="compliance-evidence-heading" className="text-[10px] font-bold uppercase tracking-widest text-gray-400">
+              Compliance evidence (foundation shape)
+            </h2>
+          </div>
+          <div className="space-y-3 px-4 py-3 text-xs leading-relaxed text-gray-300">
+            <p className="text-gray-400">
+              This report is a foundation shape for vendor risk assessments. It reflects planned controls, not enforced production policies.
+            </p>
+            <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-gray-500">Data classification</dt>
+                <dd className="mt-1 font-mono text-[11px]">redactionLive: {String(dataClassification.redactionLive)}</dd>
+                <dd className="font-mono text-[11px] text-gray-500">{dataClassification.rules.length} redaction rules</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-gray-500">Retention</dt>
+                <dd className="mt-1 font-mono text-[11px]">retentionEnforced: {String(retention.retentionEnforced)}</dd>
+                <dd className="font-mono text-[11px] text-gray-500">{retention.policies.length} entity policies</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] uppercase tracking-widest text-gray-500">Authority adapters</dt>
+                <dd className="mt-1 font-mono text-[11px]">allAdaptersLive: {String(authority.allAdaptersLive)}</dd>
+                <dd className="font-mono text-[11px] text-gray-500">{authority.adapters.length} adapters</dd>
+              </div>
+            </dl>
+            <p className="text-[10px] text-gray-500">
+              Machine-readable shape:{' '}
+              <Link href="/api/compliance/evidence" className="underline hover:text-gray-300">/api/compliance/evidence</Link>
+            </p>
+          </div>
+        </section>
+
         {/* Live status board */}
         <LiveTrustStatusBoard />
 

--- a/apps/web/components/ops/ChronologyIntegrityTelemetry.tsx
+++ b/apps/web/components/ops/ChronologyIntegrityTelemetry.tsx
@@ -7,6 +7,8 @@
  * All values font-mono text-xs. No fetch needed — these are invariants.
  */
 
+import * as React from 'react';
+
 const READING_ORDER = ['OBJECT', 'OWNERSHIP', 'CHECKED_AT', 'CHANNEL', 'REPLAY', 'RUN_ID'] as const;
 const SLOT_COUNT = READING_ORDER.length;
 

--- a/apps/web/components/ops/LiveTrustStatusBoard.tsx
+++ b/apps/web/components/ops/LiveTrustStatusBoard.tsx
@@ -7,6 +7,7 @@
  * Auto-refreshes every 60s. Manual refresh button.
  */
 
+import * as React from 'react';
 import { useEffect, useState, useCallback } from 'react';
 
 interface EndpointStatus {

--- a/apps/web/components/ops/SourceLaneTelemetry.tsx
+++ b/apps/web/components/ops/SourceLaneTelemetry.tsx
@@ -7,6 +7,8 @@
  * Dense font-mono table. No color on "not implemented".
  */
 
+import * as React from 'react';
+
 export interface SourceLaneStatus {
   laneId: string;
   displayName: string;


### PR DESCRIPTION
## Why

Follow-up to [#432](https://github.com/ctol3r/vitalcv/pull/432) — closes the 2 remaining pre-existing Web Quality failures called out as out-of-scope in that PR. Full apps/web vitest suite is now **1524 passed / 4 skipped / 0 failed** on this branch.

Both regressions were introduced by earlier 'refine' / 'replace' commits that didn't update the contract tests pinning their copy:

| Commit | Surface | Drop |
|---|---|---|
| `7f7ace104` feat(productization): refine activation continuity | `/passport` runCompletedWithoutAnchor card | 'Profile resolved, but passport continuation is still provisional.' → 'Passport is still waiting on sources.' (loses the 'provisional' framing the reviewer needs to read the half-complete state honestly) |
| `de9e2be44` feat: live trust status board + external operational observability | `/status` page | Entire foundation-status preview + compliance-evidence section dropped when the live ops board took over the page |

## What changed (5 files, +76/-3)

```
apps/web/app/passport/page.tsx                          | 4 +-
apps/web/app/status/page.tsx                            | 70 +++++++++++++++++++++-
apps/web/components/ops/ChronologyIntegrityTelemetry.tsx | 2 +
apps/web/components/ops/LiveTrustStatusBoard.tsx        | 1 +
apps/web/components/ops/SourceLaneTelemetry.tsx         | 2 +
```

**A. `apps/web/app/passport/page.tsx`** — pure string-literal restoration of the runCompletedWithoutAnchor [TrustStateCard](apps/web/app/passport/page.tsx#L736) copy.

**B. `apps/web/app/status/page.tsx`** — ADDITIVE markup above the existing live status board. The live ops board, source lane telemetry, chronology integrity, and well-known endpoints all remain unchanged; the new sections sit above them. New markup reads directly from the existing foundation modules ([dataClassificationFoundation.ts](apps/web/lib/security/dataClassificationFoundation.ts), [retentionFoundation.ts](apps/web/lib/security/retentionFoundation.ts), [adapterMatrix.ts](apps/web/lib/authority/adapterMatrix.ts)) so `/status` and `/api/compliance/evidence` agree on every count + Live flag. All three flag values rendered are typed-false invariants from the foundation modules.

**C–E. ops components** — added `import * as React from 'react';` to each. The vitest pipeline uses esbuild's classic JSX transform, which requires React in scope; Next 15 runtime uses the automatic transform either way. `status-page-compliance-evidence.test.tsx` mounts `<StatusPage />` which pulls in `LiveTrustStatusBoard` at module-load time, so a missing React import there threw `ReferenceError: React is not defined` before the test body ran.

## Failing tests this fixes

- `apps/web/__tests__/status-page-compliance-evidence.test.tsx` — file-level load error, now 8/8 individual tests pass
- `apps/web/__tests__/foundation-sweep-6-analytics-status.test.ts > status page renders the no-uptime-guarantee disclaimer`
- `apps/web/__tests__/passport-ingest-page.test.tsx > renders a completed-without-anchor state when the profile is authoritative but no anchor returned`

## Verification

| Step | Result |
|---|---|
| `pnpm exec vitest run` on the 3 affected files | **38 / 38 pass** |
| `pnpm exec vitest run` on full `apps/web` | **1524 passed / 4 skipped / 0 failed** (was 1524 / 4 skipped / 2 failed after #432) |
| `pnpm turbo run typecheck --filter @vitalcv/web` | clean |
| `codex exec` x3 (implementation / diff / copy) | **SAFE / SAFE / SAFE** |

## Codex audits (transcript-visible per CLAUDE.md merge-protection hook)

```
Audit 1 (Implementation): CODEX VERDICT: SAFE
Audit 2 (Diff):           CODEX VERDICT: SAFE
Audit 3 (Copy):           CODEX VERDICT: SAFE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)