### PR TITLE
feat(web): clarify auth gate with calm sign-in surfaces

### DIFF
--- a/apps/web/__tests__/auth-disclosure-card.test.tsx
+++ b/apps/web/__tests__/auth-disclosure-card.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * auth-disclosure-card.test.tsx — Wave J coverage.
+ *
+ * Asserts the calm-disclosure chrome wraps Clerk's <SignIn /> / <SignUp />
+ * primitives with the canonical operator-honest disclosure copy, the trust
+ * footer links, and nothing that implies credentialing.
+ */
+
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  AuthDisclosureCard,
+  SIGN_IN_DISCLOSURE,
+  SIGN_UP_DISCLOSURE,
+  TRUST_FOOTER_LINKS,
+} from '@/components/auth/AuthDisclosureCard';
+
+const BANNED_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bverified\b/i,
+  /\bguaranteed\s+verification\b/i,
+  /\binstant\s+credentialing\b/i,
+  /\bcomplete\s+credentialing\b/i,
+  /\bautomatically\s+verified\b/i,
+  /\bGet\s+verified\b/i,
+  /\bverify\s+your\s+email\s+to\s+get\s+verified\b/i,
+  /\bHIPAA\s+compliant\b/i,
+  /\bSOC2\s+certified\b/i,
+  /\bNCQA\s+certified\b/i,
+  /\baccepted\s+everywhere\b/i,
+  /\bcleared\b/i,
+  /\bapproved\b/i,
+];
+
+function assertNoBannedPhrases(html: string, context: string): void {
+  for (const pattern of BANNED_PATTERNS) {
+    expect(
+      pattern.test(html),
+      `Banned phrase /${pattern.source}/${pattern.flags} matched in ${context}`,
+    ).toBe(false);
+  }
+}
+
+describe('AuthDisclosureCard — sign-in mode', () => {
+  it('renders the canonical sign-in disclosure copy', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-in">
+        <div data-clerk-placeholder="" />
+      </AuthDisclosureCard>,
+    );
+    expect(html).toContain('data-auth-disclosure-card="sign-in"');
+    expect(html).toContain('data-auth-disclosure-copy="sign-in"');
+    expect(html).toContain(SIGN_IN_DISCLOSURE);
+  });
+
+  it("sign-in disclosure mentions 'live event streams' and 'operator tools'", () => {
+    expect(SIGN_IN_DISCLOSURE.toLowerCase()).toContain('live event streams');
+    expect(SIGN_IN_DISCLOSURE.toLowerCase()).toContain('operator tools');
+  });
+
+  it('sign-in disclosure confirms public passport pages remain readable without an account', () => {
+    expect(SIGN_IN_DISCLOSURE.toLowerCase()).toContain('public passport pages');
+    expect(SIGN_IN_DISCLOSURE.toLowerCase()).toContain('without an account');
+  });
+
+  it('mounts the supplied children (Clerk <SignIn /> placeholder)', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-in">
+        <div data-clerk-placeholder="signin" />
+      </AuthDisclosureCard>,
+    );
+    expect(html).toContain('data-auth-clerk-mount');
+    expect(html).toContain('data-clerk-placeholder="signin"');
+  });
+
+  it('contains no banned phrases in sign-in mode', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-in">
+        <div data-clerk-placeholder="" />
+      </AuthDisclosureCard>,
+    );
+    assertNoBannedPhrases(html, 'sign-in card');
+  });
+});
+
+describe('AuthDisclosureCard — sign-up mode', () => {
+  it('renders the canonical sign-up disclosure copy', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-up">
+        <div data-clerk-placeholder="" />
+      </AuthDisclosureCard>,
+    );
+    expect(html).toContain('data-auth-disclosure-card="sign-up"');
+    expect(html).toContain('data-auth-disclosure-copy="sign-up"');
+    expect(html).toContain(SIGN_UP_DISCLOSURE);
+  });
+
+  it('sign-up disclosure says sign-up does NOT credential a clinician', () => {
+    expect(SIGN_UP_DISCLOSURE.toLowerCase()).toContain('does not credential');
+    expect(SIGN_UP_DISCLOSURE.toLowerCase()).toContain('clinician');
+  });
+
+  it('sign-up disclosure says sign-up does NOT contact employers', () => {
+    expect(SIGN_UP_DISCLOSURE.toLowerCase()).toContain('does not contact');
+    expect(SIGN_UP_DISCLOSURE.toLowerCase()).toContain('employers');
+  });
+
+  it('contains no banned phrases in sign-up mode', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-up">
+        <div data-clerk-placeholder="" />
+      </AuthDisclosureCard>,
+    );
+    assertNoBannedPhrases(html, 'sign-up card');
+  });
+
+  it('does NOT contain "verify your email to get verified" anywhere', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-up">
+        <div data-clerk-placeholder="" />
+      </AuthDisclosureCard>,
+    );
+    expect(/verify\s+your\s+email\s+to\s+get\s+verified/i.test(html)).toBe(false);
+  });
+});
+
+describe('AuthDisclosureCard — trust footer', () => {
+  it('renders three trust footer links', () => {
+    const html = renderToStaticMarkup(
+      <AuthDisclosureCard mode="sign-in">
+        <div />
+      </AuthDisclosureCard>,
+    );
+    expect(html).toContain('data-auth-trust-footer');
+    for (const link of TRUST_FOOTER_LINKS) {
+      expect(html).toContain(`href="${link.href}"`);
+      expect(html).toContain(`>${link.label}<`);
+    }
+  });
+
+  it('exports exactly the three Status / Source attribution / Trust links', () => {
+    expect(TRUST_FOOTER_LINKS.map((l) => l.label)).toEqual([
+      'Status',
+      'Source attribution',
+      'Trust',
+    ]);
+  });
+});
+
+describe('AuthDisclosureCard — copy review constants', () => {
+  it('SIGN_IN_DISCLOSURE constant has no banned phrases', () => {
+    assertNoBannedPhrases(SIGN_IN_DISCLOSURE, 'SIGN_IN_DISCLOSURE constant');
+  });
+
+  it('SIGN_UP_DISCLOSURE constant has no banned phrases', () => {
+    assertNoBannedPhrases(SIGN_UP_DISCLOSURE, 'SIGN_UP_DISCLOSURE constant');
+  });
+});

--- a/apps/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from 'next';
 import { SignIn } from '@clerk/nextjs';
+import { AuthDisclosureCard } from '@/components/auth/AuthDisclosureCard';
 
 export const metadata: Metadata = {
   title: 'Sign In',
-  description: 'Sign in to your VitalCV account to manage credentials and readiness profiles.',
+  description:
+    'Sign in to unlock live event streams and operator tools. Public passport pages remain readable without an account.',
 };
 
 export default function SignInPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+    <AuthDisclosureCard mode="sign-in">
       <SignIn />
-    </div>
+    </AuthDisclosureCard>
   );
 }

--- a/apps/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,36 +1,25 @@
 /**
- * Sign-Up Page — Wave 136: Clerk Production Activation
+ * Sign-Up Page — Calm operator-account disclosure.
  *
- * Uses Clerk <SignUp> component. Redirect URLs are driven by
+ * Uses Clerk <SignUp> primitive. Redirect URLs are driven by
  * NEXT_PUBLIC_CLERK_SIGN_UP_URL and configured in the Clerk dashboard.
- * No hardcoded dev-instance assumptions.
+ * No hardcoded dev-instance assumptions. Clerk config NOT changed by
+ * this wave; only the visual chrome around the Clerk component.
  */
 import type { Metadata } from 'next';
 import { SignUp } from '@clerk/nextjs';
+import { AuthDisclosureCard } from '@/components/auth/AuthDisclosureCard';
 
 export const metadata: Metadata = {
   title: 'Sign Up',
-  description: 'Create your VitalCV account. Source-backed credentialing truth for clinicians and healthcare employers.',
+  description:
+    'Create an operator account. Sign-up does not credential a clinician and does not contact employers.',
 };
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-zinc-950">
-      <SignUp
-        appearance={{
-          elements: {
-            rootBox: 'rounded-2xl shadow-2xl',
-            card: 'bg-zinc-900 border border-zinc-800',
-            headerTitle: 'text-white',
-            headerSubtitle: 'text-zinc-400',
-            formButtonPrimary: 'bg-emerald-500 hover:bg-emerald-600 text-white',
-            formFieldInput:
-              'bg-zinc-800 border-zinc-700 text-foreground placeholder:text-zinc-500',
-            footerActionLink: 'text-emerald-400 hover:text-emerald-300',
-            identityPreviewEditButton: 'text-emerald-400',
-          },
-        }}
-      />
-    </div>
+    <AuthDisclosureCard mode="sign-up">
+      <SignUp />
+    </AuthDisclosureCard>
   );
 }

--- a/apps/web/components/auth/AuthDisclosureCard.tsx
+++ b/apps/web/components/auth/AuthDisclosureCard.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+/**
+ * AuthDisclosureCard — the calm chrome that wraps Clerk's <SignIn /> or
+ * <SignUp /> primitive on `/sign-in` and `/sign-up`.
+ *
+ * Layout: centered, white/warm-gray, restrained borders, one primary
+ * action (Clerk's own primary button), single disclosure paragraph that
+ * tells the operator exactly what signing in does (and what it does NOT
+ * imply about credentialing).
+ *
+ * Truth-contract guarantees (enforced by
+ * `apps/web/__tests__/auth-disclosure-card.test.tsx`):
+ *   - The sign-in disclosure explains that sign-in unlocks live event
+ *     streams + operator tools, and that public passport pages remain
+ *     readable without an account.
+ *   - The sign-up disclosure explicitly says sign-up does NOT credential
+ *     a clinician and does NOT contact employers.
+ *   - No bare "Verified", no "Get verified", no "verify your email to get
+ *     verified", no final-credentialing language.
+ *   - No HIPAA / SOC2 / NCQA certification claims.
+ *   - No marketing clutter — single card, single disclosure, three trust
+ *     links, the Clerk component itself.
+ */
+
+export const SIGN_IN_DISCLOSURE =
+  'Sign in unlocks live event streams and operator tools. Public passport pages remain readable without an account.';
+
+export const SIGN_UP_DISCLOSURE =
+  'Create an operator account. Sign-up does not credential a clinician and does not contact employers.';
+
+export const TRUST_FOOTER_LINKS: ReadonlyArray<{ label: string; href: string }> = [
+  { label: 'Status', href: '/status' },
+  { label: 'Source attribution', href: '/trust/attribution' },
+  { label: 'Trust', href: '/trust' },
+];
+
+export interface AuthDisclosureCardProps {
+  /** Which auth surface this is wrapping — drives the disclosure copy. */
+  mode: 'sign-in' | 'sign-up';
+  /** The Clerk primitive (<SignIn /> or <SignUp />). */
+  children: React.ReactNode;
+  /** Optional headline override; defaults to "Sign in" / "Create account". */
+  headline?: string;
+  /** Optional explicit disclosure copy override. Caller is responsible
+   *  for copy review. */
+  disclosure?: string;
+  className?: string;
+}
+
+/**
+ * Wraps the Clerk primitive in a calm centered card with a single
+ * disclosure paragraph and a three-link trust footer.
+ */
+export function AuthDisclosureCard({
+  mode,
+  children,
+  headline,
+  disclosure,
+  className,
+}: AuthDisclosureCardProps) {
+  const defaultHeadline = mode === 'sign-in' ? 'Sign in' : 'Create account';
+  const defaultDisclosure = mode === 'sign-in' ? SIGN_IN_DISCLOSURE : SIGN_UP_DISCLOSURE;
+  const resolvedHeadline = headline ?? defaultHeadline;
+  const resolvedDisclosure = disclosure ?? defaultDisclosure;
+
+  return (
+    <div
+      className={cn(
+        'flex min-h-screen items-center justify-center bg-[var(--vt-bg)] px-4 py-12',
+        className,
+      )}
+    >
+      <div
+        data-auth-disclosure-card={mode}
+        className="w-full max-w-md space-y-6"
+      >
+        <header className="space-y-3 text-center">
+          <h1 className="text-[clamp(1.875rem,3.5vw,2.25rem)] font-semibold tracking-[-0.02em] text-[var(--vt-text-primary)]">
+            {resolvedHeadline}
+          </h1>
+          <p
+            data-auth-disclosure-copy={mode}
+            className="mx-auto max-w-[36ch] text-[14px] leading-[1.6] text-[var(--vt-text-secondary)]"
+          >
+            {resolvedDisclosure}
+          </p>
+        </header>
+
+        <div
+          data-auth-clerk-mount=""
+          className="rounded-[1.25rem] border border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_96%,white)] p-2 shadow-[0_1px_0_rgba(255,255,255,0.6)]"
+        >
+          {children}
+        </div>
+
+        <nav
+          aria-label="Trust footer"
+          data-auth-trust-footer=""
+          className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-[12px] text-[var(--vt-text-muted)]"
+        >
+          {TRUST_FOOTER_LINKS.map((link, idx) => (
+            <React.Fragment key={link.href}>
+              {idx > 0 && (
+                <span aria-hidden="true" className="text-[var(--vt-border)]">
+                  ·
+                </span>
+              )}
+              <Link
+                href={link.href}
+                className="font-medium text-[var(--vt-text-secondary)] underline-offset-4 transition-opacity hover:underline hover:opacity-90"
+              >
+                {link.label}
+              </Link>
+            </React.Fragment>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Wave J — Sign-in / sign-up calm disclosure

Wraps Clerk's `<SignIn />` / `<SignUp />` primitives in a single shared centered-card chrome with operator-honest disclosure copy and a three-link trust footer.

## Canonical disclosures

- **Sign-in:** "Sign in unlocks live event streams and operator tools. Public passport pages remain readable without an account."
- **Sign-up:** "Create an operator account. Sign-up does not credential a clinician and does not contact employers."

## What this does NOT change

- ❌ No Clerk configuration (provider, env, redirect URLs, dashboard).
- ❌ No backend, no API, no Prisma, no Railway/DNS/env/secret.
- ❌ No auth-flow logic — Clerk primitives still drive sign-in / sign-up.
- ❌ The previous emerald/zinc Clerk-appearance overrides on `/sign-up` are dropped; we now use Clerk's default appearance + our outer chrome.

## Files

- `apps/web/components/auth/AuthDisclosureCard.tsx` (new, shared chrome)
- `apps/web/app/sign-in/[[...sign-in]]/page.tsx` (rewrite to use the card)
- `apps/web/app/sign-up/[[...sign-up]]/page.tsx` (rewrite to use the card)
- `apps/web/__tests__/auth-disclosure-card.test.tsx` (new, 14 cases)

## Validation

```bash
pnpm --filter @vitalcv/web exec vitest run auth-disclosure-card
  → Test Files: 1 passed, Tests: 14 passed.

pnpm turbo run build --filter @vitalcv/web
  → Tasks: 13 successful, 13 total.

pnpm --filter @vitalcv/web exec tsc --noEmit → clean.

pnpm lint → 2/2 successful, web lint clean.
```

## Truth-contract guarantees (enforced by 14 vitest cases)

- ❌ no bare "Verified"
- ❌ no "Get verified" / "verify your email to get verified"
- ❌ no "automatically verified" / "guaranteed verification"
- ❌ no "complete credentialing" / "instant credentialing"
- ❌ no "HIPAA compliant" / "SOC2 certified" / "NCQA certified"
- ❌ no "cleared" / "approved" / "accepted everywhere"

🤖 Generated with [Claude Code](https://claude.com/claude-code)