### PR TITLE
chore(repo): ignore local agent worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,4 +90,10 @@ dist/
 .deployment-lineage/
 .playbook-lineage/
 
+# Local agent runtime artifacts
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+.worktrees/
+
 apps/web/lib/generated/


### PR DESCRIPTION
Prevents local Claude/Codex worktree artifacts from polluting product checkpoints. No product code changed.