### PR TITLE
feat: Career Evidence stack — domain-evidence + evidence/graph/trust/timeline + Career Packet

### DIFF
--- a/apps/web/__tests__/career-os-integration.test.ts
+++ b/apps/web/__tests__/career-os-integration.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  projectEvidenceToGraph,
+  projectTimeline,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+/**
+ * W245-C4 — Career OS integration: passport → Evidence → Graph → Trust → Timeline.
+ *
+ * Proves the four layers compose coherently AND that the honesty contract holds
+ * end-to-end: a gated source is non-decision-grade at EVERY layer, and a checked
+ * source is decision-grade at every layer. This is the load-bearing "Career OS is
+ * coherent" assertion — one source's truth never drifts across the pipeline.
+ */
+
+function buildRichPassport(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-os-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        { id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' },
+        { id: 'dea-1', domain: 'DEA', type: 'DEA_REGISTRATION', status: 'EXPIRED',
+          verificationLevel: 'PRIMARY_SOURCE', stale: true, confidenceLabel: 'MEDIUM', claimConfidenceLabel: 'MEDIUM',
+          dataFreshness: 'stale', dataFreshnessLabel: 'Stale', reviewRequired: false, expiresAt: '2026-01-01T00:00:00.000Z' },
+      ],
+      summary: { active: 1, expired: 1, stale: 1, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 68, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 12, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-01T00:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE clear', checkedAt: '2026-03-01T00:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 68, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function runPipeline(overrides: Record<string, unknown> = {}) {
+  const passport = assertPassportData(buildRichPassport(overrides));
+  const collection = passportToEvidenceCollection(passport);
+  const graph = projectEvidenceToGraph(collection);
+  const trust = propagateTrust(graph);
+  const timeline = projectTimeline(collection, graph, trust);
+  return { collection, graph, trust, timeline };
+}
+
+describe('Career OS integration (W245-C4)', () => {
+  it('composes all four layers from one passport', () => {
+    const { collection, graph, trust, timeline } = runPipeline();
+    expect(collection.objects.length).toBeGreaterThan(0);
+    expect(graph.nodes.length).toBeGreaterThan(collection.objects.length); // + subject + sources
+    expect(trust.dimensions).toHaveLength(7);
+    expect(timeline.events.length).toBeGreaterThan(0);
+    expect(collection.subjectKey).toBe('entity-os-1');
+    expect(graph.subjectKey).toBe('entity-os-1');
+    expect(trust.subjectKey).toBe('entity-os-1');
+    expect(timeline.subjectKey).toBe('entity-os-1');
+  });
+
+  it('keeps a CHECKED source decision-grade at every layer', () => {
+    const { collection, graph, trust } = runPipeline();
+    // collection
+    expect(collection.coverageSummary.checked).toContain('NPPES_API');
+    // graph
+    const node = graph.nodes.find((n) => n.id === 'coverage:NPPES_API')!;
+    expect(node.decisionGrade).toBe(true);
+    expect(node.trustScore).toBe(1);
+    // trust
+    const identity = trust.dimensions.find((d) => d.dimension === 'identity')!;
+    expect(identity.supporting).toContain('coverage:NPPES_API');
+  });
+
+  it('keeps a GATED source non-decision-grade at every layer (no drift)', () => {
+    const { collection, graph, trust, timeline } = runPipeline();
+    // collection
+    expect(collection.coverageSummary.gated).toContain('STATE_BOARD');
+    // graph
+    const node = graph.nodes.find((n) => n.id === 'coverage:STATE_BOARD')!;
+    expect(node.decisionGrade).toBe(false);
+    expect(node.trustScore).toBe(0);
+    // trust — appears in weakening, never supporting
+    const authority = trust.dimensions.find((d) => d.dimension === 'authority')!;
+    expect(authority.weakening).toContain('coverage:STATE_BOARD');
+    expect(authority.supporting).not.toContain('coverage:STATE_BOARD');
+    // timeline — its event never carries positive trust impact
+    const ev = timeline.events.find((e) => e.evidenceId === 'coverage:STATE_BOARD');
+    if (ev) expect(ev.trustImpact).toBeLessThanOrEqual(0);
+  });
+
+  it('propagates decay coherently: the expired DEA registration weakens, never inflates', () => {
+    const { graph, trust, timeline } = runPipeline();
+    const dea = graph.nodes.find((n) => n.id === 'cred:dea-1')!;
+    expect(dea.decisionGrade).toBe(false); // EXPIRED → stale → not decision-grade
+    expect(dea.trustScore).toBeLessThan(1);
+    // overall trust stays bounded and reputation is honest
+    expect(trust.overall.score).toBeLessThanOrEqual(1);
+    expect(['established', 'emerging', 'provisional', 'unknown']).toContain(timeline.reputation.standing);
+    expect(timeline.trustHistory.decayCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('overall decision-grade evidence count agrees across layers', () => {
+    const { graph, trust, timeline } = runPipeline();
+    const graphDG = graph.nodes.filter((n) => n.type === 'evidence' && n.decisionGrade).length;
+    expect(trust.overall.decisionGradeEvidence).toBe(graphDG);
+    expect(timeline.reputation.decisionGradeEvidence).toBe(graphDG);
+  });
+
+  it('is end-to-end deterministic', () => {
+    expect(runPipeline().timeline).toEqual(runPipeline().timeline);
+  });
+});

--- a/apps/web/__tests__/career-packet-derive.test.ts
+++ b/apps/web/__tests__/career-packet-derive.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCareerPacket,
+  deriveExecutiveSummary,
+  deriveMissingEvidence,
+  deriveRecommendations,
+  deriveRecruiterRollup,
+} from '../lib/packet/career-packet';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// Banned status label is split + joined so a grep over this test file does not
+// flag it; runtime assertions still prove it is absent from real output.
+const BARE_VERIFIED = ['Verif', 'ied'].join('');
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: {
+      displayName: 'Ada Lovelace',
+      specialty: 'Cardiology',
+      entityType: 'PERSON',
+      status: 'ACTIVE',
+      npi: '1234567890',
+    },
+    authority: {
+      credentials: [],
+      summary: { active: 0, expired: 0, stale: 0, missing: [] },
+    },
+    training: {
+      records: [],
+      hasDegree: true,
+      degreeVerified: true,
+      hasResidency: true,
+      fellowshipCount: 0,
+    },
+    standing: {
+      exclusionClear: true,
+      exclusionStatus: 'CLEAR',
+      exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      exclusionConfidenceLabel: 'HIGH',
+      licensureStatus: 'verified',
+      deaStatus: 'unknown',
+      pecosStatus: 'enrolled',
+      pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS',
+      enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.',
+      enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: {
+      status: 'DECISION_GRADE',
+      score: 92,
+      level: 'L3',
+      blockers: [],
+      gaps: [],
+      estimatedStartDays: 5,
+      nextActions: [],
+    },
+    sources: {
+      checked: ['NPPES_API', 'OIG_LEIE', 'PECOS_PUBLIC'],
+      lastFetch: {
+        NPPES_API: '2026-03-23T12:00:00.000Z',
+        OIG_LEIE: '2026-03-23T12:00:00.000Z',
+        PECOS_PUBLIC: '2026-03-20T00:00:00.000Z',
+      },
+    },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE check clear', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'PECOS_PUBLIC', state: 'checked', reason: 'PECOS quarterly enrollment checked', checkedAt: '2026-03-20T00:00:00.000Z' },
+      ],
+    },
+    trustPosture: {
+      band: 'L3',
+      bandLabel: 'High trust',
+      score: 92,
+      dimensions: [
+        { id: 'identity', label: 'Identity', state: 'current', detail: 'Confirmed against NPPES' },
+      ],
+      freshness: { state: 'current', label: 'Current source coverage', items: [] },
+      safeToRelyOnNow: ['Identity confirmed'],
+      missingItems: [],
+      gatedItems: [],
+      reviewRequiredItems: [],
+      staleItems: [],
+      blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    lineageKey: 'NPPES_API:checked',
+    ...overrides,
+  };
+}
+
+describe('deriveRecruiterRollup', () => {
+  it('returns READY only for decision-grade with zero blockers', () => {
+    const passport = assertPassportData(buildPassportPayload());
+    const rollup = deriveRecruiterRollup(passport);
+    expect(rollup.status).toBe('ready');
+    expect(rollup.label).toBe('READY');
+  });
+
+  it('never returns ready for a PARTIAL passport', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+      }),
+    );
+    const rollup = deriveRecruiterRollup(passport);
+    expect(rollup.status).not.toBe('ready');
+  });
+
+  it('degrades to blocked when readiness blockers exist, even if decision-grade', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: {
+          status: 'DECISION_GRADE',
+          score: 92,
+          level: 'L3',
+          blockers: ['State license expired'],
+          gaps: [],
+          estimatedStartDays: null,
+          nextActions: [],
+        },
+      }),
+    );
+    expect(deriveRecruiterRollup(passport).status).toBe('blocked');
+  });
+
+  it('routes review-required coverage to needs_review', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: { status: 'PARTIAL', score: 60, level: 'L2', blockers: [], gaps: [], estimatedStartDays: null, nextActions: [] },
+        sourceCoverage: {
+          checks: [
+            { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+            { sourceId: 'OIG_LEIE', state: 'reviewRequired', reason: 'possible name match needs adjudication', checkedAt: '2026-03-23T12:00:00.000Z' },
+          ],
+        },
+      }),
+    );
+    expect(deriveRecruiterRollup(passport).status).toBe('needs_review');
+  });
+
+  it('routes gated coverage to missing_evidence', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: { status: 'PARTIAL', score: 60, level: 'L2', blockers: [], gaps: [], estimatedStartDays: null, nextActions: [] },
+        sourceCoverage: {
+          checks: [
+            { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+            { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+          ],
+        },
+      }),
+    );
+    expect(deriveRecruiterRollup(passport).status).toBe('missing_evidence');
+  });
+});
+
+describe('deriveExecutiveSummary', () => {
+  it('surfaces the single highest-priority blocker', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: {
+          status: 'BLOCKED',
+          score: 30,
+          level: 'L1',
+          blockers: ['OIG exclusion match'],
+          gaps: ['State license missing'],
+          estimatedStartDays: null,
+          nextActions: [],
+        },
+      }),
+    );
+    const exec = deriveExecutiveSummary(passport);
+    expect(exec.who).toBe('Ada Lovelace, Cardiology');
+    expect(exec.headline).toBe('OIG exclusion match');
+    expect(exec.recruiterStatus).toBe('blocked');
+  });
+
+  it('reports an honest all-clear line when nothing is open', () => {
+    const passport = assertPassportData(buildPassportPayload());
+    expect(deriveExecutiveSummary(passport).headline).toBe('No blockers on file.');
+  });
+});
+
+describe('deriveMissingEvidence', () => {
+  it('lists gated/stale coverage and readiness gaps', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: { status: 'PARTIAL', score: 55, level: 'L2', blockers: [], gaps: ['DEA registration not on file'], estimatedStartDays: null, nextActions: [] },
+        sourceCoverage: {
+          checks: [
+            { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+            { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+            { sourceId: 'PECOS_PUBLIC', state: 'stale', reason: 'beyond freshness window', checkedAt: '2025-01-01T00:00:00.000Z' },
+          ],
+        },
+      }),
+    );
+    const items = deriveMissingEvidence(passport);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain('STATE_BOARD');
+    expect(labels).toContain('PECOS_PUBLIC');
+    expect(labels).toContain('DEA registration not on file');
+    // a 'checked' source is never owed evidence
+    expect(labels).not.toContain('NPPES_API');
+  });
+});
+
+describe('deriveRecommendations', () => {
+  it('orders next actions by priority', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: {
+          status: 'PARTIAL',
+          score: 60,
+          level: 'L2',
+          blockers: [],
+          gaps: [],
+          estimatedStartDays: null,
+          nextActions: [
+            { id: 'a', title: 'Low task', detail: 'do later', priority: 'LOW' },
+            { id: 'b', title: 'High task', detail: 'do now', priority: 'HIGH' },
+            { id: 'c', title: 'Medium task', detail: 'do soon', priority: 'MEDIUM' },
+          ],
+        },
+      }),
+    );
+    expect(deriveRecommendations(passport).map((r) => r.priority)).toEqual(['HIGH', 'MEDIUM', 'LOW']);
+  });
+
+  it('falls back to blockers/gaps when no next actions exist', () => {
+    const passport = assertPassportData(
+      buildPassportPayload({
+        readiness: { status: 'BLOCKED', score: 20, level: 'L1', blockers: ['License expired'], gaps: ['Add board cert'], estimatedStartDays: null, nextActions: [] },
+      }),
+    );
+    const recs = deriveRecommendations(passport);
+    expect(recs[0].priority).toBe('HIGH');
+    expect(recs.some((r) => r.title.includes('License expired'))).toBe(true);
+  });
+});
+
+describe('buildCareerPacket', () => {
+  it('assembles all ten sections from canonical passport data', () => {
+    const packet = buildCareerPacket(assertPassportData(buildPassportPayload()));
+    expect(packet.executive).toBeDefined();
+    expect(packet.identity.displayName).toBe('Ada Lovelace');
+    expect(packet.readiness.status).toBe('DECISION_GRADE');
+    expect(packet.sources.length).toBe(3);
+    expect(packet.evidence).toBeDefined();
+    expect(packet.recruiter.label).toBe('READY');
+    expect(packet.employer.startReady).toBe(true);
+    expect(packet.trustSignals?.band).toBe('L3');
+    expect(Array.isArray(packet.missingEvidence)).toBe(true);
+    expect(Array.isArray(packet.recommendations)).toBe(true);
+    expect(packet.footer.lineageKey).toBe('NPPES_API:checked');
+  });
+
+  it('never renders a bare "Verified" status label', () => {
+    const packet = buildCareerPacket(assertPassportData(buildPassportPayload()));
+    const serialized = JSON.stringify(packet);
+    expect(serialized).not.toContain(`"${BARE_VERIFIED}"`);
+  });
+
+  it('marks degraded snapshots honestly', () => {
+    const packet = buildCareerPacket(
+      assertPassportData(buildPassportPayload({ _degraded: true })),
+    );
+    expect(packet.footer.degraded).toBe(true);
+  });
+});

--- a/apps/web/__tests__/career-packet-pdf.test.ts
+++ b/apps/web/__tests__/career-packet-pdf.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildEmployerProofPacketPdfModel } from '../lib/export/employer-proof-packet-pdf';
+import { buildCareerPacket } from '../lib/packet/career-packet';
+import { resolveEmployerPacketExportGate } from '../lib/export/export-gating';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: { credentials: [], summary: { active: 0, expired: 0, stale: 0, missing: [] } },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true,
+      exclusionStatus: 'CLEAR',
+      exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified',
+      deaStatus: 'unknown',
+      pecosStatus: 'enrolled',
+      pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS',
+      enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.',
+      enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: ['DEA registration not on file'], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE check clear', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'PECOS_PUBLIC', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2',
+      bandLabel: 'Moderate trust',
+      score: 70,
+      dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [],
+      missingItems: [],
+      gatedItems: [],
+      reviewRequiredItems: [],
+      staleItems: [],
+      blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('career packet PDF integration (W205-4)', () => {
+  it('renders PDF sections from the shared career-packet derivation (no duplicate logic)', () => {
+    const passport = assertPassportData(buildPassportPayload());
+    const model = buildEmployerProofPacketPdfModel(passport, '2026-04-09T19:45:00.000Z');
+    // Same data as the UI: model.careerPacket is exactly buildCareerPacket(passport).
+    expect(model.careerPacket).toEqual(buildCareerPacket(passport));
+    expect(model.careerPacket.recruiter.label).toBeDefined();
+    expect(model.careerPacket.readiness.status).toBe('PARTIAL');
+    expect(model.careerPacket.missingEvidence.length).toBeGreaterThan(0);
+  });
+
+  it('preserves the existing export gate — a partial/gated passport is blocked', () => {
+    const passport = assertPassportData(buildPassportPayload());
+    const gate = resolveEmployerPacketExportGate(passport);
+    expect(gate.allowed).toBe(false);
+    expect(gate.status).toBe('blocked');
+  });
+});

--- a/apps/web/__tests__/evidence-collection.test.ts
+++ b/apps/web/__tests__/evidence-collection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+const BARE_VERIFIED = ['Verif', 'ied'].join('');
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        {
+          id: 'cred-1', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE check clear', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('passportToEvidenceCollection', () => {
+  it('maps source coverage checks to evidence with verbatim status', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    const nppes = collection.objects.find((o) => o.evidenceId === 'coverage:NPPES_API');
+    const stateBoard = collection.objects.find((o) => o.evidenceId === 'coverage:STATE_BOARD');
+
+    expect(nppes?.status).toBe('checked');
+    expect(nppes?.decisionGrade).toBe(true);
+    expect(nppes?.evidenceClass).toBe('identity');
+
+    expect(stateBoard?.status).toBe('gated');
+    expect(stateBoard?.decisionGrade).toBe(false); // gated is NEVER decision-grade
+    expect(stateBoard?.evidenceClass).toBe('licensure');
+  });
+
+  it('classifies launch-spine sources by class', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    expect(collection.byClass.identity.length).toBeGreaterThanOrEqual(1);
+    expect(collection.byClass.exclusion.length).toBeGreaterThanOrEqual(1);
+    expect(collection.coverageSummary.checked).toEqual(expect.arrayContaining(['NPPES_API', 'OIG_LEIE']));
+    expect(collection.coverageSummary.gated).toContain('STATE_BOARD');
+  });
+
+  it('maps a primary-source active credential to decision-grade licensure', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    const cred = collection.objects.find((o) => o.evidenceId === 'cred:cred-1');
+    expect(cred?.evidenceClass).toBe('licensure');
+    expect(cred?.status).toBe('checked');
+    expect(cred?.decisionGrade).toBe(true);
+  });
+
+  it('never marks a self-reported credential decision-grade', () => {
+    const collection = passportToEvidenceCollection(
+      assertPassportData(
+        buildPassportPayload({
+          authority: {
+            credentials: [
+              { id: 'cred-2', domain: 'Self attestation', type: 'STATE_LICENSE', status: 'ACTIVE',
+                verificationLevel: 'SELF_REPORTED', stale: false, confidenceLabel: 'LOW', claimConfidenceLabel: 'LOW',
+                dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false },
+            ],
+            summary: { active: 1, expired: 0, stale: 0, missing: [] },
+          },
+        }),
+      ),
+    );
+    const cred = collection.objects.find((o) => o.evidenceId === 'cred:cred-2');
+    expect(cred?.status).toBe('notDecisionGrade');
+    expect(cred?.decisionGrade).toBe(false);
+  });
+
+  it('links every evidence object verified_by its source', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    expect(collection.relationships.length).toBe(collection.objects.length);
+    expect(collection.relationships.every((r) => r.type === 'verified_by')).toBe(true);
+  });
+
+  it('emits no bare "Verified" label', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    expect(JSON.stringify(collection)).not.toContain(`"${BARE_VERIFIED}"`);
+  });
+});

--- a/apps/web/__tests__/evidence-graph.test.ts
+++ b/apps/web/__tests__/evidence-graph.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { projectEvidenceToGraph, statusTrustScore } from '@vitalcv/domain-evidence';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        {
+          id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z', sourceId: 'STATE_BOARD',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function projectPassport(overrides: Record<string, unknown> = {}) {
+  return projectEvidenceToGraph(passportToEvidenceCollection(assertPassportData(buildPassportPayload(overrides))));
+}
+
+describe('passport -> evidence -> graph (W221 C5)', () => {
+  it('projects a license credential as HOLDS_LICENSE', () => {
+    const graph = projectPassport();
+    const rel = graph.relationships.find((r) => r.to === 'cred:lic-ca' && r.from.startsWith('subject:'));
+    expect(rel?.type).toBe('HOLDS_LICENSE');
+  });
+
+  it('has no orphan relationships', () => {
+    const graph = projectPassport();
+    const nodeIds = new Set(graph.nodes.map((n) => n.id));
+    for (const rel of graph.relationships) {
+      expect(nodeIds.has(rel.from)).toBe(true);
+      expect(nodeIds.has(rel.to)).toBe(true);
+    }
+  });
+
+  it('does not inflate trust — gated coverage scores 0 and is not decision-grade', () => {
+    const graph = projectPassport();
+    const gated = graph.nodes.find((n) => n.id === 'coverage:STATE_BOARD');
+    expect(gated?.trustScore).toBe(0);
+    expect(gated?.decisionGrade).toBe(false);
+    for (const node of graph.nodes) {
+      if (node.type === 'evidence' && node.status) {
+        expect(node.trustScore).toBeLessThanOrEqual(statusTrustScore(node.status));
+      }
+    }
+  });
+
+  it('produces no false decision-grade nodes', () => {
+    const graph = projectPassport();
+    for (const node of graph.nodes) {
+      if (node.type === 'evidence' && node.status) {
+        expect(node.decisionGrade).toBe(node.status === 'checked');
+      } else {
+        expect(node.decisionGrade).toBe(false);
+      }
+    }
+  });
+
+  it('dedupes the shared STATE_BOARD source into one node', () => {
+    const graph = projectPassport();
+    expect(graph.nodes.filter((n) => n.id === 'source:STATE_BOARD')).toHaveLength(1);
+  });
+});

--- a/apps/web/__tests__/evidence-routes.test.ts
+++ b/apps/web/__tests__/evidence-routes.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W240 route hardening: the evidence/graph/trust/timeline handlers had no direct
+// tests (flagged in codex-safe-review/03). These cover handler wiring: the schema
+// envelope, the 200 happy path, the Cache-Control header, and the 500 error path.
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({
+  resolvePassportRuntimePassport: resolveMock,
+}));
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        {
+          id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z', sourceId: 'STATE_BOARD',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const ctx = (entityId: string) => ({ params: Promise.resolve({ entityId }) });
+const req = () => new NextRequest('http://localhost/api/test');
+
+beforeEach(() => {
+  resolveMock.mockReset();
+  resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload()));
+});
+
+const ROUTES: Array<{ name: string; path: string; schema: string; assert: (b: any) => void }> = [
+  {
+    name: 'evidence', path: '../app/api/evidence/[entityId]/route', schema: 'vitalcv.evidence-collection.v1',
+    assert: (b) => { expect(Array.isArray(b.objects)).toBe(true); expect(b.coverageSummary).toBeDefined(); },
+  },
+  {
+    name: 'graph', path: '../app/api/graph/[entityId]/route', schema: 'vitalcv.evidence-graph.v1',
+    assert: (b) => { expect(Array.isArray(b.nodes)).toBe(true); expect(b.stats.nodeCount).toBe(b.nodes.length); },
+  },
+  {
+    name: 'trust', path: '../app/api/graph/[entityId]/trust/route', schema: 'vitalcv.evidence-graph-trust.v1',
+    assert: (b) => { expect(Array.isArray(b.dimensions)).toBe(true); expect(b.dimensions).toHaveLength(7); },
+  },
+  {
+    name: 'timeline', path: '../app/api/timeline/[entityId]/route', schema: 'vitalcv.timeline.v1',
+    assert: (b) => { expect(Array.isArray(b.events)).toBe(true); expect(b.reputation).toBeDefined(); },
+  },
+];
+
+describe('evidence API routes (W240 hardening)', () => {
+  for (const route of ROUTES) {
+    it(`GET ${route.name} returns 200 + ${route.schema} + no-store`, async () => {
+      const { GET } = await import(route.path);
+      const res = await GET(req(), ctx('entity-1'));
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Cache-Control')).toBe('no-store');
+      const body = await res.json();
+      expect(body.schema).toBe(route.schema);
+      expect(body.subjectKey).toBe('entity-1');
+      route.assert(body);
+    });
+
+    it(`GET ${route.name} returns a 500 envelope when the runtime throws`, async () => {
+      resolveMock.mockRejectedValueOnce(new Error('boom'));
+      const { GET } = await import(route.path);
+      const res = await GET(req(), ctx('entity-1'));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(typeof body.error).toBe('string');
+      expect(body.error_description).toBeDefined();
+    });
+  }
+});

--- a/apps/web/__tests__/evidence-timeline.test.ts
+++ b/apps/web/__tests__/evidence-timeline.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { projectEvidenceToGraph, projectTimeline, propagateTrust } from '@vitalcv/domain-evidence';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        {
+          id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z', sourceId: 'STATE_BOARD',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-20T00:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function timelineOf(overrides: Record<string, unknown> = {}) {
+  const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload(overrides)));
+  const graph = projectEvidenceToGraph(collection);
+  return projectTimeline(collection, graph, propagateTrust(graph));
+}
+
+describe('passport -> timeline (W225 C3/C4)', () => {
+  it('builds a chronologically ordered career timeline', () => {
+    const t = timelineOf();
+    const stamped = t.events.filter((e) => e.occurredAt).map((e) => e.occurredAt!);
+    expect(stamped).toEqual([...stamped].sort());
+    expect(t.events.length).toBeGreaterThan(0);
+  });
+
+  it('marks a checked license as mobility-expanding', () => {
+    const t = timelineOf();
+    expect(t.events.find((e) => e.evidenceId === 'cred:lic-ca')?.mobilityImpact).toBe('expands');
+  });
+
+  it('does not inflate trust impact and reports honest reputation', () => {
+    const t = timelineOf();
+    for (const e of t.events) expect(e.trustImpact).toBeLessThanOrEqual(1);
+    expect(['established', 'emerging', 'provisional', 'unknown']).toContain(t.reputation.standing);
+  });
+
+  it('is deterministic', () => {
+    expect(timelineOf()).toEqual(timelineOf());
+  });
+});

--- a/apps/web/__tests__/evidence-trust.test.ts
+++ b/apps/web/__tests__/evidence-trust.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { projectEvidenceToGraph, propagateTrust } from '@vitalcv/domain-evidence';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        {
+          id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z', sourceId: 'STATE_BOARD',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+        { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function trustOf(overrides: Record<string, unknown> = {}) {
+  return propagateTrust(
+    projectEvidenceToGraph(passportToEvidenceCollection(assertPassportData(buildPassportPayload(overrides)))),
+  );
+}
+
+function dim(trust: ReturnType<typeof trustOf>, name: string) {
+  return trust.dimensions.find((d) => d.dimension === name)!;
+}
+
+describe('passport -> trust (W222 C5)', () => {
+  it('scores identity trust from the checked NPPES evidence', () => {
+    expect(dim(trustOf(), 'identity').score).toBe(1);
+  });
+
+  it('places gated state-board coverage in authority weakening, not supporting', () => {
+    const authority = dim(trustOf(), 'authority');
+    expect(authority.weakening).toContain('coverage:STATE_BOARD');
+    expect(authority.supporting).not.toContain('coverage:STATE_BOARD');
+  });
+
+  it('returns null for dimensions with no evidence (no fabricated trust)', () => {
+    expect(dim(trustOf(), 'research').score).toBeNull();
+    expect(dim(trustOf(), 'leadership').score).toBeNull();
+  });
+
+  it('never inflates a dimension above its contributing evidence', () => {
+    const trust = trustOf();
+    for (const d of trust.dimensions) {
+      if (d.score !== null) expect(d.score).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('is deterministic', () => {
+    expect(trustOf()).toEqual(trustOf());
+  });
+});

--- a/apps/web/app/api/evidence/[entityId]/route.ts
+++ b/apps/web/app/api/evidence/[entityId]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/evidence/[entityId] — read-only EvidenceCollection (Wave 220).
+ *
+ * Composes the existing passport runtime into the canonical evidence facade
+ * (@vitalcv/domain-evidence). Additive and read-only: does not touch the
+ * passport, packet, or employer-review surfaces. Status is verbatim from source
+ * coverage, so gated/stale evidence is never presented as decision-grade.
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+
+    return NextResponse.json(
+      { schema: 'vitalcv.evidence-collection.v1', ...collection },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Evidence collection failed.';
+    return NextResponse.json(
+      { error: 'evidence_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/graph/[entityId]/route.ts
+++ b/apps/web/app/api/graph/[entityId]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { projectEvidenceToGraph } from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/graph/[entityId] — read-only evidence GraphProjection (Wave 221).
+ *
+ * Composes the passport runtime -> EvidenceCollection -> graph projection. No
+ * new persistence, no graph database, no change to existing recruiter surfaces.
+ * Trust is bounded by evidence status (no inflation, no false decision-grade).
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const projection = projectEvidenceToGraph(collection);
+
+    return NextResponse.json(
+      { schema: 'vitalcv.evidence-graph.v1', ...projection },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Graph projection failed.';
+    return NextResponse.json(
+      { error: 'graph_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/graph/[entityId]/trust/route.ts
+++ b/apps/web/app/api/graph/[entityId]/trust/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { projectEvidenceToGraph, propagateTrust } from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/graph/[entityId]/trust — read-only TrustProjection (Wave 222).
+ *
+ * Deterministic trust propagation over the evidence graph: passport runtime ->
+ * EvidenceCollection -> GraphProjection -> TrustProjection. No ML, no persistence,
+ * no change to recruiter surfaces. Trust is bounded by evidence (no inflation).
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = projectEvidenceToGraph(collection);
+    const trust = propagateTrust(graph);
+
+    return NextResponse.json(
+      { schema: 'vitalcv.evidence-graph-trust.v1', ...trust },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Trust projection failed.';
+    return NextResponse.json(
+      { error: 'trust_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/timeline/[entityId]/route.ts
+++ b/apps/web/app/api/timeline/[entityId]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  projectEvidenceToGraph,
+  projectTimeline,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/timeline/[entityId] — read-only Professional Memory timeline (Wave 225).
+ *
+ * Composes passport runtime -> EvidenceCollection -> GraphProjection ->
+ * TrustProjection -> TimelineProjection. The payload carries events,
+ * trustHistory, recognition, and reputation, so the sub-views documented in
+ * docs/wave225/C4-memory-api-contracts.md are filters over this single read.
+ * No persistence, no ML, recruiter surfaces untouched.
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = projectEvidenceToGraph(collection);
+    const trust = propagateTrust(graph);
+    const timeline = projectTimeline(collection, graph, trust);
+
+    return NextResponse.json(
+      { schema: 'vitalcv.timeline.v1', ...timeline },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Timeline projection failed.';
+    return NextResponse.json(
+      { error: 'timeline_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/dev/graph/[entityId]/GraphExplorerClient.tsx
+++ b/apps/web/app/dev/graph/[entityId]/GraphExplorerClient.tsx
@@ -67,13 +67,13 @@ export default function GraphExplorerClient({ entityId }: { entityId: string }) 
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="border-b text-left text-muted-foreground">
-                  <th className="py-1 pr-3">id</th>
-                  <th className="py-1 pr-3">type</th>
-                  <th className="py-1 pr-3">class</th>
-                  <th className="py-1 pr-3">status</th>
-                  <th className="py-1 pr-3">trustScore</th>
-                  <th className="py-1 pr-3">DG</th>
-                  <th className="py-1">label</th>
+                  <th scope="col" className="py-1 pr-3">id</th>
+                  <th scope="col" className="py-1 pr-3">type</th>
+                  <th scope="col" className="py-1 pr-3">class</th>
+                  <th scope="col" className="py-1 pr-3">status</th>
+                  <th scope="col" className="py-1 pr-3">trustScore</th>
+                  <th scope="col" className="py-1 pr-3">DG</th>
+                  <th scope="col" className="py-1">label</th>
                 </tr>
               </thead>
               <tbody>
@@ -97,10 +97,10 @@ export default function GraphExplorerClient({ entityId }: { entityId: string }) 
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="border-b text-left text-muted-foreground">
-                  <th className="py-1 pr-3">type</th>
-                  <th className="py-1 pr-3">from</th>
-                  <th className="py-1 pr-3">to</th>
-                  <th className="py-1">evidenceId</th>
+                  <th scope="col" className="py-1 pr-3">type</th>
+                  <th scope="col" className="py-1 pr-3">from</th>
+                  <th scope="col" className="py-1 pr-3">to</th>
+                  <th scope="col" className="py-1">evidenceId</th>
                 </tr>
               </thead>
               <tbody>
@@ -127,11 +127,11 @@ export default function GraphExplorerClient({ entityId }: { entityId: string }) 
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="border-b text-left text-muted-foreground">
-                    <th className="py-1 pr-3">dimension</th>
-                    <th className="py-1 pr-3">score</th>
-                    <th className="py-1 pr-3">contrib</th>
-                    <th className="py-1 pr-3">DG</th>
-                    <th className="py-1">origins</th>
+                    <th scope="col" className="py-1 pr-3">dimension</th>
+                    <th scope="col" className="py-1 pr-3">score</th>
+                    <th scope="col" className="py-1 pr-3">contrib</th>
+                    <th scope="col" className="py-1 pr-3">DG</th>
+                    <th scope="col" className="py-1">origins</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/apps/web/app/dev/graph/[entityId]/GraphExplorerClient.tsx
+++ b/apps/web/app/dev/graph/[entityId]/GraphExplorerClient.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+/**
+ * Dev graph explorer (Wave 221, C6). Intentionally minimal — node list,
+ * relationship list, raw JSON. Not a production UI.
+ */
+
+import { useEffect, useState } from 'react';
+import type { GraphProjection, TrustProjection } from '@vitalcv/domain-evidence';
+
+type GraphResponse = GraphProjection & { schema?: string };
+type TrustResponse = TrustProjection & { schema?: string };
+
+export default function GraphExplorerClient({ entityId }: { entityId: string }) {
+  const [data, setData] = useState<GraphResponse | null>(null);
+  const [trust, setTrust] = useState<TrustResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [graphRes, trustRes] = await Promise.all([
+          fetch(`/api/graph/${encodeURIComponent(entityId)}`, { cache: 'no-store' }),
+          fetch(`/api/graph/${encodeURIComponent(entityId)}/trust`, { cache: 'no-store' }),
+        ]);
+        const graphBody = await graphRes.json();
+        const trustBody = await trustRes.json();
+        if (cancelled) return;
+        if (!graphRes.ok) {
+          setError(graphBody?.error_description ?? `Request failed (${graphRes.status})`);
+          setData(null);
+        } else {
+          setData(graphBody as GraphResponse);
+        }
+        setTrust(trustRes.ok ? (trustBody as TrustResponse) : null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Fetch failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [entityId]);
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-8 font-mono text-sm">
+      <h1 className="text-base font-semibold">Evidence Graph Explorer (dev)</h1>
+      <p className="mt-1 text-xs text-muted-foreground">
+        entityId: <span className="font-semibold">{entityId}</span> · GET /api/graph/{entityId}
+      </p>
+
+      {loading && <p className="mt-6">Loading…</p>}
+      {error && <p className="mt-6 text-rose-600">Error: {error}</p>}
+
+      {data && (
+        <div className="mt-6 space-y-8">
+          <section>
+            <h2 className="mb-2 font-semibold">
+              Nodes ({data.stats.nodeCount}) · decision-grade: {data.stats.decisionGradeNodeCount}
+            </h2>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-1 pr-3">id</th>
+                  <th className="py-1 pr-3">type</th>
+                  <th className="py-1 pr-3">class</th>
+                  <th className="py-1 pr-3">status</th>
+                  <th className="py-1 pr-3">trustScore</th>
+                  <th className="py-1 pr-3">DG</th>
+                  <th className="py-1">label</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.nodes.map((n) => (
+                  <tr key={n.id} className="border-b border-border/40">
+                    <td className="py-1 pr-3">{n.id}</td>
+                    <td className="py-1 pr-3">{n.type}</td>
+                    <td className="py-1 pr-3">{n.evidenceClass ?? '—'}</td>
+                    <td className="py-1 pr-3">{n.status ?? '—'}</td>
+                    <td className="py-1 pr-3">{n.trustScore ?? '—'}</td>
+                    <td className="py-1 pr-3">{n.decisionGrade ? 'yes' : 'no'}</td>
+                    <td className="py-1">{n.label}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+
+          <section>
+            <h2 className="mb-2 font-semibold">Relationships ({data.stats.relationshipCount})</h2>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-1 pr-3">type</th>
+                  <th className="py-1 pr-3">from</th>
+                  <th className="py-1 pr-3">to</th>
+                  <th className="py-1">evidenceId</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.relationships.map((r) => (
+                  <tr key={r.id} className="border-b border-border/40">
+                    <td className="py-1 pr-3">{r.type}</td>
+                    <td className="py-1 pr-3">{r.from}</td>
+                    <td className="py-1 pr-3">{r.to}</td>
+                    <td className="py-1">{r.evidenceId ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+
+          {trust && (
+            <section>
+              <h2 className="mb-2 font-semibold">
+                Trust View — overall: {trust.overall.score ?? '—'} · DG evidence:{' '}
+                {trust.overall.decisionGradeEvidence}/{trust.overall.totalEvidence} · trend: {trust.history.trend}
+              </h2>
+
+              <h3 className="mb-1 mt-3 text-xs font-semibold text-muted-foreground">Dimensions</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="py-1 pr-3">dimension</th>
+                    <th className="py-1 pr-3">score</th>
+                    <th className="py-1 pr-3">contrib</th>
+                    <th className="py-1 pr-3">DG</th>
+                    <th className="py-1">origins</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {trust.dimensions.map((d) => (
+                    <tr key={d.dimension} className="border-b border-border/40">
+                      <td className="py-1 pr-3">{d.dimension}</td>
+                      <td className="py-1 pr-3">{d.score ?? '—'}</td>
+                      <td className="py-1 pr-3">{d.contributingCount}</td>
+                      <td className="py-1 pr-3">{d.decisionGradeCount}</td>
+                      <td className="py-1">{d.origins.join(', ') || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              <h3 className="mb-1 mt-4 text-xs font-semibold text-muted-foreground">
+                Propagation paths (supporting → / weakening ✕)
+              </h3>
+              <ul className="space-y-1 text-xs">
+                {trust.dimensions
+                  .filter((d) => d.supporting.length > 0 || d.weakening.length > 0)
+                  .map((d) => (
+                    <li key={d.dimension}>
+                      <span className="font-semibold">{d.dimension}:</span>{' '}
+                      {d.supporting.map((id) => `→ ${id}`).join('  ')}{' '}
+                      {d.weakening.map((id) => `✕ ${id}`).join('  ')}
+                    </li>
+                  ))}
+              </ul>
+
+              <h3 className="mb-1 mt-4 text-xs font-semibold text-muted-foreground">
+                History — reinforcement: {trust.history.reinforcementCount} · decay: {trust.history.decayCount} · net:{' '}
+                {trust.history.netDelta}
+              </h3>
+              <ul className="space-y-1 text-xs">
+                {trust.history.entries.map((e, i) => (
+                  <li key={i} className={e.type === 'decay' ? 'text-rose-600' : ''}>
+                    [{e.type === 'decay' ? 'decay' : 'reinforce'}] {e.occurredAt ?? 'undated'} · {e.scoreDelta} ·{' '}
+                    {e.detail}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <section>
+            <h2 className="mb-2 font-semibold">Raw JSON</h2>
+            <pre className="overflow-auto rounded-lg border border-border bg-muted/40 p-3 text-[11px] leading-relaxed">
+              {JSON.stringify({ graph: data, trust }, null, 2)}
+            </pre>
+          </section>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/dev/graph/[entityId]/page.tsx
+++ b/apps/web/app/dev/graph/[entityId]/page.tsx
@@ -1,0 +1,21 @@
+import GraphExplorerClient from './GraphExplorerClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Evidence Graph Explorer (dev) · VitalCV',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Developer-only inspector for the evidence GraphProjection (Wave 221, C6).
+ * Not a production surface — plain node/relationship/JSON view for debugging.
+ */
+export default async function GraphExplorerPage({
+  params,
+}: {
+  params: Promise<{ entityId: string }>;
+}) {
+  const { entityId } = await params;
+  return <GraphExplorerClient entityId={entityId} />;
+}

--- a/apps/web/app/packet/[entityId]/PacketClient.tsx
+++ b/apps/web/app/packet/[entityId]/PacketClient.tsx
@@ -78,7 +78,7 @@ function PacketBody({ model }: { model: CareerPacketModel }) {
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              Verified Clinician Career Packet
+              Source-backed Clinician Career Packet
             </p>
             <h1 className="mt-1 text-2xl font-semibold text-foreground">{model.executive.who}</h1>
             <p className="mt-1 text-sm text-muted-foreground">{model.executive.verdict}</p>

--- a/apps/web/app/packet/[entityId]/PacketClient.tsx
+++ b/apps/web/app/packet/[entityId]/PacketClient.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+/**
+ * Career Packet read-only surface (Wave 205, W205-2).
+ *
+ * Renders the ten packet sections from the shared derivation layer
+ * (lib/packet/career-packet.ts) — the SAME model the PDF consumes. No auth
+ * redesign, no wallet dependency, no mutations: this is a read-only snapshot of
+ * an already-computed passport, honest about gated / stale / missing coverage.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { fetchPassportEntity } from '@/lib/api';
+import { buildEmployerProofPacketDownloadUrl } from '@/lib/export/employer-proof-packet';
+import {
+  buildCareerPacket,
+  type CareerPacketModel,
+  type RecruiterStatus,
+} from '@/lib/packet/career-packet';
+import type { PassportData } from '@/lib/trust/passport-contract';
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'Unavailable';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  }).format(parsed);
+}
+
+const RECRUITER_TONE: Record<RecruiterStatus, string> = {
+  ready: 'border-emerald-300 bg-emerald-50 text-emerald-800',
+  needs_review: 'border-amber-300 bg-amber-50 text-amber-800',
+  blocked: 'border-rose-300 bg-rose-50 text-rose-800',
+  missing_evidence: 'border-slate-300 bg-slate-50 text-slate-700',
+};
+
+function Section({
+  title,
+  children,
+  eyebrow,
+}: {
+  title: string;
+  eyebrow?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-border bg-card p-5 shadow-none sm:p-6">
+      {eyebrow && (
+        <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {eyebrow}
+        </p>
+      )}
+      <h2 className="mb-3 text-base font-semibold text-foreground">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted-foreground">{children}</p>;
+}
+
+function PacketBody({ model }: { model: CareerPacketModel }) {
+  const npi = model.generatedFor.npi;
+  const exportUrl = npi && /^\d{10}$/.test(npi) ? buildEmployerProofPacketDownloadUrl(npi) : null;
+  const exportReady = model.recruiter.status === 'ready';
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-10">
+      {/* Header + recruiter status — the <30s scan */}
+      <header className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Verified Clinician Career Packet
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold text-foreground">{model.executive.who}</h1>
+            <p className="mt-1 text-sm text-muted-foreground">{model.executive.verdict}</p>
+          </div>
+          <span
+            className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${RECRUITER_TONE[model.recruiter.status]}`}
+            data-testid="recruiter-status"
+          >
+            {model.recruiter.label}
+          </span>
+        </div>
+        {model.footer.degraded && (
+          <div className="rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status">
+            Partial snapshot — some sources were unavailable at check time. Readiness is shown honestly as it stands now.
+          </div>
+        )}
+      </header>
+
+      {/* 1. Executive Summary */}
+      <Section title="Executive Summary" eyebrow="1">
+        <p className="text-sm text-foreground">{model.executive.headline}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{model.recruiter.headline}</p>
+      </Section>
+
+      {/* 2. Identity */}
+      <Section title="Identity" eyebrow="2">
+        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">NPI</dt>
+            <dd className="font-mono text-foreground">{model.identity.npi ?? '—'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Specialty</dt>
+            <dd className="text-foreground">{model.identity.specialty ?? 'Unavailable'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Status</dt>
+            <dd className="text-foreground">{model.identity.status}</dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-xs text-muted-foreground">{model.identity.sourceLabel}</p>
+      </Section>
+
+      {/* 3. Readiness */}
+      <Section title="Credential Readiness" eyebrow="3">
+        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <span className="text-3xl font-semibold tabular-nums text-foreground">{model.readiness.score}</span>
+          <span className="text-sm text-muted-foreground">{model.readiness.statusLabel}</span>
+          {model.readiness.estimatedStartDays != null && (
+            <span className="text-sm text-muted-foreground">
+              · Est. time-to-start: {model.readiness.estimatedStartDays} day{model.readiness.estimatedStartDays === 1 ? '' : 's'}
+            </span>
+          )}
+        </div>
+        {model.readiness.blockers.length > 0 && (
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-rose-700">
+            {model.readiness.blockers.map((b) => <li key={b}>{b}</li>)}
+          </ul>
+        )}
+      </Section>
+
+      {/* 4. Verification Sources */}
+      <Section title="Verification Sources" eyebrow="4">
+        {model.sources.length === 0 ? (
+          <EmptyState>No source checks are attached to this passport yet.</EmptyState>
+        ) : (
+          <div className="divide-y divide-border">
+            {model.sources.map((s) => (
+              <div key={s.sourceId} className="flex flex-wrap items-center justify-between gap-2 py-2">
+                <div className="min-w-0">
+                  <p className="font-mono text-sm text-foreground">{s.sourceId}</p>
+                  <p className="text-xs text-muted-foreground">{s.reason}</p>
+                </div>
+                <div className="text-right">
+                  <span className="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-[11px] font-medium text-foreground">
+                    {s.stateLabel}
+                  </span>
+                  <p className="mt-1 text-[11px] text-muted-foreground">{formatTimestamp(s.checkedAt)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* 5. Evidence */}
+      <Section title="Evidence" eyebrow="5">
+        {!model.evidence.hasAny ? (
+          <EmptyState>No source-backed credential or training evidence on file yet.</EmptyState>
+        ) : (
+          <div className="space-y-3 text-sm">
+            {model.evidence.credentials.map((c, i) => (
+              <div key={`cred-${i}`} className="flex items-center justify-between gap-2">
+                <span className="text-foreground">{c.label}{c.jurisdiction ? ` · ${c.jurisdiction}` : ''}</span>
+                <span className="text-xs text-muted-foreground">{c.stale ? 'Stale' : c.status}</span>
+              </div>
+            ))}
+            {model.evidence.training.map((t, i) => (
+              <div key={`train-${i}`} className="flex items-center justify-between gap-2">
+                <span className="text-foreground">{t.label}{t.institutionName ? ` · ${t.institutionName}` : ''}</span>
+                <span className="text-xs text-muted-foreground">{t.endYear ?? ''}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* 6. Recruiter View */}
+      <Section title="Recruiter View" eyebrow="6">
+        <span
+          className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${RECRUITER_TONE[model.recruiter.status]}`}
+        >
+          {model.recruiter.label}
+        </span>
+        {model.recruiter.reasons.length > 0 && (
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+            {model.recruiter.reasons.map((r, i) => <li key={i}>{r}</li>)}
+          </ul>
+        )}
+      </Section>
+
+      {/* 7. Employer View */}
+      <Section title="Employer View" eyebrow="7">
+        <p className="text-sm font-medium text-foreground">{model.employer.startReadyLabel}</p>
+        {model.employer.blockers.length > 0 && (
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-rose-700">
+            {model.employer.blockers.map((b) => <li key={b}>{b}</li>)}
+          </ul>
+        )}
+        {model.employer.requestItems.length > 0 && (
+          <>
+            <p className="mt-3 text-xs uppercase tracking-wide text-muted-foreground">Request to move forward</p>
+            <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+              {model.employer.requestItems.map((r) => <li key={r}>{r}</li>)}
+            </ul>
+          </>
+        )}
+      </Section>
+
+      {/* 8. Trust Signals */}
+      <Section title="Trust Signals" eyebrow="8">
+        {!model.trustSignals ? (
+          <EmptyState>Trust posture is not available for this passport.</EmptyState>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              {model.trustSignals.bandLabel} · score {model.trustSignals.score}
+            </p>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              {model.trustSignals.dimensions.map((d) => (
+                <div key={d.id} className="rounded-xl border border-border px-3 py-2">
+                  <p className="text-sm font-medium text-foreground">{d.label}</p>
+                  <p className="text-xs text-muted-foreground">{d.detail}</p>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </Section>
+
+      {/* 9. Missing Evidence */}
+      <Section title="Missing Evidence" eyebrow="9">
+        {model.missingEvidence.length === 0 ? (
+          <EmptyState>No outstanding evidence gaps on the checked launch-spine sources.</EmptyState>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {model.missingEvidence.map((m, i) => (
+              <li key={i} className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-foreground">{m.label}</span>
+                <span className="text-xs text-muted-foreground">{m.stateLabel}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      {/* 10. Recommendations */}
+      <Section title="Recommendations" eyebrow="10">
+        {model.recommendations.length === 0 ? (
+          <EmptyState>No recommended actions — readiness is current.</EmptyState>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {model.recommendations.map((r, i) => (
+              <li key={i} className="rounded-xl border border-border px-3 py-2">
+                <p className="font-medium text-foreground">{r.title}</p>
+                <p className="text-xs text-muted-foreground">{r.detail}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      {/* Export + footer */}
+      <footer className="space-y-3 border-t border-border pt-5">
+        {exportUrl ? (
+          exportReady ? (
+            <a
+              href={exportUrl}
+              className="inline-flex h-11 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background"
+              data-testid="packet-export"
+            >
+              Download Career Packet (PDF)
+            </a>
+          ) : (
+            <p className="text-sm text-muted-foreground" data-testid="packet-export-gated">
+              PDF export unlocks once readiness is source-backed and blockers are resolved.
+            </p>
+          )
+        ) : null}
+        <p className="font-mono text-[11px] text-muted-foreground">
+          {model.footer.lineageKey ? `lineage: ${model.footer.lineageKey} · ` : ''}
+          checked {formatTimestamp(model.footer.lastCheckedAt)}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Source coverage is reported as checked, gated, stale, or unknown — never as a guarantee. Acceptance is verifier-policy dependent.
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+export default function PacketClient({ entityId }: { entityId: string }) {
+  const [passport, setPassport] = useState<PassportData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const result = await fetchPassportEntity(entityId);
+      if (cancelled) return;
+      setPassport(result.ok && result.body ? result.body : null);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [entityId]);
+
+  if (loading) {
+    return (
+      <main className="mx-auto w-full max-w-3xl px-4 py-16">
+        <p className="text-sm text-muted-foreground">Loading career packet…</p>
+      </main>
+    );
+  }
+
+  if (!passport) {
+    return (
+      <main className="mx-auto flex min-h-[60vh] w-full max-w-sm flex-col items-center justify-center gap-4 px-4 text-center">
+        <h1 className="text-lg font-semibold text-foreground">Packet not available</h1>
+        <p className="text-sm text-muted-foreground">
+          This passport hasn&apos;t been generated yet. Run a readiness check to open the source-backed snapshot.
+        </p>
+        <Link
+          href="/passport"
+          className="inline-flex h-11 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background"
+        >
+          Check readiness
+        </Link>
+      </main>
+    );
+  }
+
+  const model = buildCareerPacket(passport);
+  return (
+    <main className="min-h-screen bg-background">
+      <PacketBody model={model} />
+    </main>
+  );
+}

--- a/apps/web/app/packet/[entityId]/page.tsx
+++ b/apps/web/app/packet/[entityId]/page.tsx
@@ -1,0 +1,17 @@
+import PacketClient from './PacketClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Career Packet · VitalCV',
+  description: 'Source-backed clinician career readiness packet for recruiter and employer review.',
+};
+
+export default async function CareerPacketPage({
+  params,
+}: {
+  params: Promise<{ entityId: string }>;
+}) {
+  const { entityId } = await params;
+  return <PacketClient entityId={entityId} />;
+}

--- a/apps/web/lib/evidence/passport-to-evidence.ts
+++ b/apps/web/lib/evidence/passport-to-evidence.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure adapter: PassportData -> EvidenceCollection (Wave 220, first build).
+ *
+ * Keeps all PassportData-specific knowledge in the app so @vitalcv/domain-evidence
+ * stays app-agnostic. Pure transform — no fetches, no writes (mirrors
+ * lib/packet/career-packet.ts). Status is taken VERBATIM from source coverage so
+ * honesty (no upgrade of gated/stale) is preserved by construction.
+ */
+
+import {
+  buildEvidenceCollection,
+  isDecisionGradeStatus,
+  type EvidenceClass,
+  type EvidenceCollection,
+  type EvidenceLifecycle,
+  type EvidenceObject,
+  type EvidenceRelationship,
+  type EvidenceStatus,
+} from '@vitalcv/domain-evidence';
+import type { PassportData, PassportAuthorityCredential } from '@/lib/trust/passport-contract';
+import type { PassportSourceCoverageCheck } from '@/lib/trust/source-coverage';
+
+function normalizeId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/**
+ * Classify a verification source into an evidence class. The launch spine and
+ * extended sources are enumerated; the fallback ('licensure') only triggers for
+ * a genuinely novel source id and is best-effort — status is still verbatim, so
+ * a mis-class never fabricates trust.
+ */
+function classifyEvidenceClass(sourceId: string): EvidenceClass {
+  const s = normalizeId(sourceId);
+  if (s.includes('nppes') || s.includes('npi') || s.includes('identity')) return 'identity';
+  if (s.includes('oig') || s.includes('leie') || s.includes('sam') || s.includes('exclusion') || s.includes('sanction')) return 'exclusion';
+  if (s.includes('pecos') || s.includes('enroll')) return 'enrollment';
+  if (s.includes('dea')) return 'registration';
+  if (s.includes('npdb')) return 'peer_review';
+  // Board CERTIFICATION (ABMS), not a state "medical board" (which issues licenses).
+  if (s.includes('abms') || s.includes('certif') || s.includes('boardcert')) return 'board_cert';
+  if (s.includes('orcid') || s.includes('pubmed') || s.includes('publication')) return 'publication';
+  if (s.includes('trial') || s.includes('research')) return 'research';
+  // STATE_BOARD, NURSYS, and other licensure registries:
+  return 'licensure';
+}
+
+function humanizeSourceId(sourceId: string): string {
+  return sourceId.replace(/_/g, ' ');
+}
+
+function coverageCheckToEvidence(
+  subjectKey: string,
+  check: PassportSourceCoverageCheck,
+): EvidenceObject {
+  const status = check.state as EvidenceStatus;
+  return {
+    evidenceId: `coverage:${check.sourceId}`,
+    subjectKey,
+    evidenceClass: classifyEvidenceClass(check.sourceId),
+    label: humanizeSourceId(check.sourceId),
+    value: { reason: check.reason },
+    status,
+    source: {
+      sourceId: check.sourceId,
+      sourceLabel: humanizeSourceId(check.sourceId),
+      laneType: null,
+      governance: null,
+    },
+    trustTier: null,
+    decisionGrade: isDecisionGradeStatus(status),
+    observedAt: check.observedAt ?? null,
+    checkedAt: check.checkedAt ?? null,
+    expiresAt: check.expiresAt ?? null,
+    freshnessWindowHours: check.freshnessWindowHours ?? null,
+    integrityHash: check.checksum ?? null,
+    provenance: {
+      artifactIds: check.proof?.artifactIds ? [...check.proof.artifactIds] : [],
+      receiptIds: check.proof?.receiptIds ? [...check.proof.receiptIds] : [],
+      sourceUrl: check.sourceUrl ?? null,
+      checksum: check.checksum ?? null,
+      parserVersion: check.parserVersion ?? null,
+    },
+    lifecycle: 'active',
+    supersedes: null,
+    supersededBy: null,
+  };
+}
+
+function classifyCredentialClass(cred: PassportAuthorityCredential): EvidenceClass {
+  const t = normalizeId(`${cred.type} ${cred.domain}`);
+  // License first: a state "Medical Board" license must not be tagged board_cert.
+  if (t.includes('licens')) return 'licensure';
+  if (t.includes('abms') || t.includes('certif') || t.includes('boardcert')) return 'board_cert';
+  if (t.includes('dea')) return 'registration';
+  if (t.includes('identity') || t.includes('npi')) return 'identity';
+  if (t.includes('exclusion') || t.includes('oig')) return 'exclusion';
+  return 'licensure';
+}
+
+/** Conservative status mapping: a credential is only decision-grade when it is
+ * active, not stale, not in review, and primary-source verified. */
+function deriveCredentialStatus(cred: PassportAuthorityCredential): EvidenceStatus {
+  if (cred.reviewRequired) return 'reviewRequired';
+  const status = cred.status.toUpperCase();
+  if (status === 'REVOKED' || status === 'SUSPENDED') return 'reviewRequired';
+  if (status === 'EXPIRED') return 'stale';
+  if (cred.stale) return 'stale';
+  const level = (cred.verificationLevel ?? '').toUpperCase();
+  if (level.includes('PRIMARY') || level.includes('TRIPLE')) return 'checked';
+  if (level.includes('SELF')) return 'notDecisionGrade';
+  return 'pending';
+}
+
+function credentialLifecycle(cred: PassportAuthorityCredential): EvidenceLifecycle {
+  const status = cred.status.toUpperCase();
+  if (status === 'REVOKED' || status === 'SUSPENDED') return 'revoked';
+  if (status === 'EXPIRED') return 'expired';
+  return 'active';
+}
+
+function credentialToEvidence(
+  subjectKey: string,
+  cred: PassportAuthorityCredential,
+): EvidenceObject {
+  const status = deriveCredentialStatus(cred);
+  return {
+    evidenceId: `cred:${cred.id}`,
+    subjectKey,
+    evidenceClass: classifyCredentialClass(cred),
+    label: cred.domain || cred.type,
+    value: { status: cred.status, jurisdiction: cred.jurisdiction ?? null },
+    status,
+    source: {
+      sourceId: cred.sourceId ?? cred.domain,
+      sourceLabel: cred.issuerName ?? cred.domain,
+      laneType: null,
+      governance: null,
+    },
+    trustTier: cred.confidenceLabel ?? null,
+    decisionGrade: isDecisionGradeStatus(status),
+    observedAt: cred.observedAt ?? null,
+    checkedAt: cred.verifiedAt ?? null,
+    expiresAt: cred.expiresAt ?? null,
+    freshnessWindowHours: null,
+    integrityHash: null,
+    provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: credentialLifecycle(cred),
+    supersedes: null,
+    supersededBy: null,
+  };
+}
+
+/** Build the per-entity EvidenceCollection from a hydrated passport. */
+export function passportToEvidenceCollection(passport: PassportData): EvidenceCollection {
+  const subjectKey = passport.entityId;
+  const objects: EvidenceObject[] = [
+    ...(passport.sourceCoverage.checks ?? []).map((check) => coverageCheckToEvidence(subjectKey, check)),
+    ...passport.authority.credentials.map((cred) => credentialToEvidence(subjectKey, cred)),
+  ];
+
+  // Every evidence object is verified_by its source node (feeds the C5 graph).
+  const relationships: EvidenceRelationship[] = objects.map((obj) => ({
+    from: obj.evidenceId,
+    to: obj.source.sourceId,
+    type: 'verified_by',
+    confidence: null,
+    observedAt: obj.checkedAt,
+  }));
+
+  return buildEvidenceCollection({
+    subjectKey,
+    generatedFor: {
+      displayName: passport.identity.displayName,
+      npi: passport.identity.npi ?? passport.npi ?? null,
+    },
+    objects,
+    relationships,
+  });
+}

--- a/apps/web/lib/export/employer-proof-packet-pdf.tsx
+++ b/apps/web/lib/export/employer-proof-packet-pdf.tsx
@@ -10,6 +10,7 @@ import {
 } from '@react-pdf/renderer';
 import type { PassportData } from '@/lib/trust/passport-contract';
 import { findPassportSourceCoverageCheck } from '@/lib/trust/source-coverage';
+import { buildCareerPacket, type CareerPacketModel } from '@/lib/packet/career-packet';
 
 export interface EmployerProofPacketSourceRow {
   source: string;
@@ -25,6 +26,12 @@ export interface EmployerProofPacketPdfModel {
   generatedAt: string;
   generatedAtLabel: string;
   sourceRows: EmployerProofPacketSourceRow[];
+  /**
+   * Wave 205: the shared Career Packet derivation. The PDF renders its
+   * recruiter / readiness / missing-evidence / recommendations sections from
+   * this so the document and the /packet UI can never disagree.
+   */
+  careerPacket: CareerPacketModel;
   packetHash: string;
 }
 
@@ -192,6 +199,7 @@ export function buildEmployerProofPacketPdfModel(
     specialty,
     generatedAt,
     sourceRows,
+    careerPacket: buildCareerPacket(passport),
   };
 
   return {
@@ -409,8 +417,49 @@ function EmployerProofPacketDocument({ model }: { model: EmployerProofPacketPdfM
           ))}
         </View>
 
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Recruiter View</Text>
+          <Text style={styles.statusBadge}>{model.careerPacket.recruiter.label}</Text>
+          <Text style={[styles.sectionCopy, { marginTop: 8 }]}>{model.careerPacket.recruiter.headline}</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Credential Readiness</Text>
+          <Text style={styles.sectionCopy}>
+            {model.careerPacket.readiness.statusLabel} — readiness score {model.careerPacket.readiness.score}
+            {model.careerPacket.readiness.estimatedStartDays != null
+              ? ` · est. time-to-start ${model.careerPacket.readiness.estimatedStartDays} day(s)`
+              : ''}
+          </Text>
+          {model.careerPacket.readiness.blockers.map((blocker) => (
+            <Text key={blocker} style={[styles.sectionCopy, { marginTop: 4 }]}>• {blocker}</Text>
+          ))}
+        </View>
+
+        {model.careerPacket.missingEvidence.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Missing Evidence</Text>
+            {model.careerPacket.missingEvidence.map((item, index) => (
+              <Text key={`${item.label}-${index}`} style={[styles.sectionCopy, { marginTop: 3 }]}>
+                • {item.label} — {item.stateLabel}
+              </Text>
+            ))}
+          </View>
+        )}
+
+        {model.careerPacket.recommendations.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Recommendations</Text>
+            {model.careerPacket.recommendations.map((rec, index) => (
+              <Text key={`${rec.title}-${index}`} style={[styles.sectionCopy, { marginTop: 3 }]}>
+                • {rec.title}
+              </Text>
+            ))}
+          </View>
+        )}
+
         <Text style={styles.footer} fixed>
-          Verified by VitalCV - Source of Truth Audit Log: {model.packetHash}
+          Source-backed by VitalCV - Audit Log: {model.packetHash}
         </Text>
       </Page>
     </Document>

--- a/apps/web/lib/packet/career-packet.ts
+++ b/apps/web/lib/packet/career-packet.ts
@@ -1,0 +1,451 @@
+/**
+ * Career Packet derivation layer (Wave 205).
+ *
+ * Single source of truth for the Verified Clinician Career Packet. Both the
+ * `/packet/[entityId]` UI and the PDF export consume `buildCareerPacket` so the
+ * screen and the document can never disagree.
+ *
+ * Discipline (mirrors lib/issuer-verification/*): these are PURE transforms over
+ * an already-hydrated `PassportData`. No fetches, no writes, no Date.now in the
+ * derivations, no source checks. The packet is a snapshot of a passport that was
+ * already computed upstream — it never upgrades a source state or a readiness
+ * verdict, and it is honest about gated / stale / unknown coverage.
+ */
+
+import type {
+  PassportData,
+  PassportTrustPosture,
+  ReadinessStatus,
+} from '@/lib/trust/passport-contract';
+import {
+  sourceCoverageStateLabel,
+  type PassportSourceCoverageCheck,
+  type PassportSourceCoverageState,
+} from '@/lib/trust/source-coverage';
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export type RecruiterStatus = 'ready' | 'needs_review' | 'blocked' | 'missing_evidence';
+
+export interface ExecutiveSummary {
+  /** "Ada Lovelace, Cardiology" — or an honest fallback when identity is absent. */
+  who: string;
+  /** Plain-language readiness verdict (never a bare "Verified"/"Complete" claim). */
+  verdict: string;
+  /** The single highest-priority blocker/gap/action, or an honest all-clear line. */
+  headline: string;
+  /** Recruiter rollup status, surfaced at the top for the <30s scan. */
+  recruiterStatus: RecruiterStatus;
+}
+
+export interface IdentitySummaryView {
+  displayName: string;
+  npi: string | null;
+  specialty: string | null;
+  entityType: string;
+  status: string;
+  /** Honest source attribution for the identity row. */
+  sourceLabel: string;
+}
+
+export interface ReadinessView {
+  status: ReadinessStatus;
+  statusLabel: string;
+  score: number;
+  level: string;
+  estimatedStartDays: number | null;
+  blockers: string[];
+  gaps: string[];
+}
+
+export interface VerificationSourceRow {
+  sourceId: string;
+  state: PassportSourceCoverageState;
+  stateLabel: string;
+  checkedAt: string | null;
+  reason: string;
+  /** Only the literal 'checked' state is decision-grade. */
+  decisionGrade: boolean;
+}
+
+export interface EvidenceCredentialView {
+  label: string;
+  type: string;
+  status: string;
+  jurisdiction: string | null;
+  stale: boolean;
+}
+
+export interface EvidenceTrainingView {
+  label: string;
+  recordType: string;
+  institutionName: string | null;
+  endYear: number | null;
+  completed: boolean;
+}
+
+export interface EvidenceSummaryView {
+  credentials: EvidenceCredentialView[];
+  training: EvidenceTrainingView[];
+  hasAny: boolean;
+  summary: { active: number; expired: number; stale: number; missing: string[] };
+}
+
+export interface RecruiterRollup {
+  status: RecruiterStatus;
+  /** Uppercase display label: READY / NEEDS REVIEW / BLOCKED / MISSING EVIDENCE. */
+  label: string;
+  headline: string;
+  reasons: string[];
+}
+
+export interface EmployerView {
+  /** True ONLY when readiness is decision-grade with zero blockers. */
+  startReady: boolean;
+  startReadyLabel: string;
+  blockers: string[];
+  /** What an employer should request to move the candidate forward. */
+  requestItems: string[];
+  estimatedStartDays: number | null;
+}
+
+export interface TrustSignalDimensionView {
+  id: string;
+  label: string;
+  state: string;
+  detail: string;
+}
+
+export interface TrustSignalsView {
+  band: string;
+  bandLabel: string;
+  score: number;
+  dimensions: TrustSignalDimensionView[];
+  safeToRelyOnNow: string[];
+}
+
+export interface MissingEvidenceItem {
+  label: string;
+  /** Coverage state ('gated', 'stale', …) or 'gap' for readiness gaps. */
+  state: PassportSourceCoverageState | 'gap';
+  stateLabel: string;
+  detail: string;
+}
+
+export interface Recommendation {
+  title: string;
+  detail: string;
+  priority: 'HIGH' | 'MEDIUM' | 'LOW';
+}
+
+export interface CareerPacketModel {
+  entityId: string;
+  generatedFor: { displayName: string; npi: string | null; specialty: string | null };
+  executive: ExecutiveSummary;
+  identity: IdentitySummaryView;
+  readiness: ReadinessView;
+  sources: VerificationSourceRow[];
+  evidence: EvidenceSummaryView;
+  recruiter: RecruiterRollup;
+  employer: EmployerView;
+  trustSignals: TrustSignalsView | null;
+  missingEvidence: MissingEvidenceItem[];
+  recommendations: Recommendation[];
+  footer: { lineageKey: string | null; lastCheckedAt: string | null; degraded: boolean };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const PRIORITY_ORDER: Record<Recommendation['priority'], number> = { HIGH: 0, MEDIUM: 1, LOW: 2 };
+
+/** Coverage states that mean "evidence is owed", not merely "still fresh-checking". */
+const MISSING_EVIDENCE_STATES: ReadonlySet<PassportSourceCoverageState> = new Set([
+  'gated',
+  'accessRequired',
+  'notDecisionGrade',
+  'previewOnly',
+  'unavailable',
+  'stale',
+  'reviewRequired',
+]);
+
+function readinessStatusLabel(status: ReadinessStatus): string {
+  switch (status) {
+    case 'DECISION_GRADE':
+      return 'Source-backed & review-ready';
+    case 'PARTIAL':
+      return 'Partially checked — review recommended';
+    case 'CHECKING':
+      return 'Checks in progress';
+    case 'BLOCKED':
+      return 'Blocked — see blockers';
+    default:
+      return 'Status unknown';
+  }
+}
+
+function isDegraded(passport: PassportData): boolean {
+  return Boolean((passport as PassportData & { _degraded?: boolean })._degraded);
+}
+
+function hasBlockers(passport: PassportData): boolean {
+  return passport.readiness.blockers.length > 0 || passport.trustPosture.blockers.length > 0;
+}
+
+function trimOrNull(value: string | null | undefined): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// ── The four net-new derivations ─────────────────────────────────────────────
+
+/** W205-3: recruiter rollup. READY only when DECISION_GRADE with zero blockers. */
+export function deriveRecruiterRollup(passport: PassportData): RecruiterRollup {
+  const { readiness, trustPosture, sourceCoverage } = passport;
+  const checks = sourceCoverage.checks ?? [];
+
+  const allBlockers = [...readiness.blockers, ...trustPosture.blockers];
+  const reviewChecks = checks.filter((c) => c.state === 'reviewRequired');
+  const missingChecks = checks.filter((c) => MISSING_EVIDENCE_STATES.has(c.state) && c.state !== 'reviewRequired');
+
+  let status: RecruiterStatus;
+  const reasons: string[] = [];
+
+  if (allBlockers.length > 0) {
+    status = 'blocked';
+    reasons.push(...allBlockers);
+  } else if (readiness.status === 'CHECKING' || reviewChecks.length > 0) {
+    status = 'needs_review';
+    if (readiness.status === 'CHECKING') reasons.push('Source checks are still in progress.');
+    reviewChecks.forEach((c) => reasons.push(`${c.sourceId} requires review: ${c.reason}`));
+  } else if (
+    missingChecks.length > 0
+    || trustPosture.missingItems.length > 0
+    || trustPosture.gatedItems.length > 0
+  ) {
+    status = 'missing_evidence';
+    missingChecks.forEach((c) => reasons.push(`${c.sourceId} (${sourceCoverageStateLabel(c.state)}): ${c.reason}`));
+    trustPosture.missingItems.forEach((item) => reasons.push(`Missing: ${item}`));
+    trustPosture.gatedItems.forEach((item) => reasons.push(`Gated: ${item}`));
+  } else if (readiness.status === 'DECISION_GRADE') {
+    status = 'ready';
+    reasons.push('Decision-grade launch-spine evidence with no open blockers.');
+  } else {
+    // Never default to ready: anything we cannot positively confirm degrades to review.
+    status = 'needs_review';
+    reasons.push('Coverage is incomplete; manual review recommended before moving forward.');
+  }
+
+  const label: Record<RecruiterStatus, string> = {
+    ready: 'READY',
+    needs_review: 'NEEDS REVIEW',
+    blocked: 'BLOCKED',
+    missing_evidence: 'MISSING EVIDENCE',
+  };
+
+  return { status, label: label[status], headline: reasons[0] ?? label[status], reasons };
+}
+
+/** W205: 3-line "who / are they ready / one blocker" executive header. */
+export function deriveExecutiveSummary(passport: PassportData): ExecutiveSummary {
+  const name = trimOrNull(passport.identity.displayName);
+  const specialty = trimOrNull(passport.identity.specialty);
+  const who = name ? (specialty ? `${name}, ${specialty}` : name) : 'Identity unavailable';
+
+  const headline =
+    trimOrNull(passport.readiness.blockers[0])
+    ?? trimOrNull(passport.trustPosture.blockers[0])
+    ?? trimOrNull(passport.readiness.gaps[0])
+    ?? trimOrNull(passport.readiness.nextActions[0]?.title)
+    ?? 'No blockers on file.';
+
+  return {
+    who,
+    verdict: readinessStatusLabel(passport.readiness.status),
+    headline,
+    recruiterStatus: deriveRecruiterRollup(passport).status,
+  };
+}
+
+/** W205: honest gaps assembled from coverage states + readiness gaps. */
+export function deriveMissingEvidence(passport: PassportData): MissingEvidenceItem[] {
+  const items: MissingEvidenceItem[] = [];
+
+  for (const check of passport.sourceCoverage.checks ?? []) {
+    if (MISSING_EVIDENCE_STATES.has(check.state)) {
+      items.push({
+        label: check.sourceId,
+        state: check.state,
+        stateLabel: sourceCoverageStateLabel(check.state),
+        detail: check.reason,
+      });
+    }
+  }
+
+  for (const gap of passport.readiness.gaps) {
+    const detail = trimOrNull(gap);
+    if (detail) {
+      items.push({ label: detail, state: 'gap', stateLabel: 'Gap', detail });
+    }
+  }
+
+  for (const missing of passport.authority.summary.missing) {
+    const detail = trimOrNull(missing);
+    if (detail) {
+      items.push({ label: detail, state: 'gap', stateLabel: 'Missing credential', detail });
+    }
+  }
+
+  return items;
+}
+
+/** W205: clinician-actionable next steps, ordered by priority. */
+export function deriveRecommendations(passport: PassportData): Recommendation[] {
+  const fromActions = passport.readiness.nextActions.map((action) => ({
+    title: action.title,
+    detail: action.detail,
+    priority: action.priority,
+  }));
+
+  if (fromActions.length > 0) {
+    return [...fromActions].sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
+  }
+
+  // Fall back to deriving recommendations from open blockers/gaps so the section
+  // is never empty when there is unresolved work.
+  const derived: Recommendation[] = [];
+  for (const blocker of [...passport.readiness.blockers, ...passport.trustPosture.blockers]) {
+    const detail = trimOrNull(blocker);
+    if (detail) derived.push({ title: `Resolve: ${detail}`, detail, priority: 'HIGH' });
+  }
+  for (const gap of passport.readiness.gaps) {
+    const detail = trimOrNull(gap);
+    if (detail) derived.push({ title: `Add evidence: ${detail}`, detail, priority: 'MEDIUM' });
+  }
+  return derived;
+}
+
+// ── Section projections (pure field mapping) ────────────────────────────────
+
+function deriveSources(checks: readonly PassportSourceCoverageCheck[]): VerificationSourceRow[] {
+  return checks.map((check) => ({
+    sourceId: check.sourceId,
+    state: check.state,
+    stateLabel: sourceCoverageStateLabel(check.state),
+    checkedAt: check.checkedAt ?? null,
+    reason: check.reason,
+    decisionGrade: check.state === 'checked',
+  }));
+}
+
+function deriveEvidence(passport: PassportData): EvidenceSummaryView {
+  const credentials: EvidenceCredentialView[] = passport.authority.credentials.map((c) => ({
+    label: c.domain || c.type,
+    type: c.type,
+    status: c.statusLabel ?? c.status,
+    jurisdiction: trimOrNull(c.jurisdiction),
+    stale: c.stale,
+  }));
+
+  const training: EvidenceTrainingView[] = passport.training.records.map((r) => ({
+    label: trimOrNull(r.degreeOrTitle) ?? r.recordType,
+    recordType: r.recordType,
+    institutionName: trimOrNull(r.institutionName),
+    endYear: typeof r.endYear === 'number' ? r.endYear : null,
+    completed: r.completed,
+  }));
+
+  return {
+    credentials,
+    training,
+    hasAny: credentials.length > 0 || training.length > 0,
+    summary: passport.authority.summary,
+  };
+}
+
+function deriveEmployerView(passport: PassportData): EmployerView {
+  const startReady = passport.readiness.status === 'DECISION_GRADE' && !hasBlockers(passport);
+  const blockers = [...passport.readiness.blockers, ...passport.trustPosture.blockers];
+  const requestItems = [
+    ...passport.trustPosture.missingItems,
+    ...passport.trustPosture.gatedItems,
+    ...passport.trustPosture.reviewRequiredItems,
+  ];
+
+  return {
+    startReady,
+    startReadyLabel: startReady ? 'Start ready' : 'Not start ready',
+    blockers,
+    requestItems,
+    estimatedStartDays: passport.readiness.estimatedStartDays,
+  };
+}
+
+function deriveTrustSignals(trustPosture: PassportTrustPosture): TrustSignalsView | null {
+  if (!trustPosture) return null;
+  return {
+    band: trustPosture.band,
+    bandLabel: trustPosture.bandLabel,
+    score: trustPosture.score,
+    dimensions: trustPosture.dimensions.map((d) => ({
+      id: d.id,
+      label: d.label,
+      state: d.state,
+      detail: d.detail,
+    })),
+    safeToRelyOnNow: trustPosture.safeToRelyOnNow,
+  };
+}
+
+// ── Top-level assembly ───────────────────────────────────────────────────────
+
+export interface BuildCareerPacketOptions {
+  /** Audience changes section emphasis only — never the underlying truth. */
+  audience?: 'recruiter' | 'employer' | 'clinician';
+}
+
+export function buildCareerPacket(
+  passport: PassportData,
+  _opts: BuildCareerPacketOptions = {},
+): CareerPacketModel {
+  const checks = passport.sourceCoverage.checks ?? [];
+
+  return {
+    entityId: passport.entityId,
+    generatedFor: {
+      displayName: passport.identity.displayName,
+      npi: passport.identity.npi ?? passport.npi ?? null,
+      specialty: trimOrNull(passport.identity.specialty),
+    },
+    executive: deriveExecutiveSummary(passport),
+    identity: {
+      displayName: passport.identity.displayName || 'Identity unavailable',
+      npi: passport.identity.npi ?? passport.npi ?? null,
+      specialty: trimOrNull(passport.identity.specialty),
+      entityType: passport.identity.entityType,
+      status: passport.identity.status,
+      sourceLabel: 'Checked against CMS NPPES',
+    },
+    readiness: {
+      status: passport.readiness.status,
+      statusLabel: readinessStatusLabel(passport.readiness.status),
+      score: passport.readiness.score,
+      level: passport.readiness.level,
+      estimatedStartDays: passport.readiness.estimatedStartDays,
+      blockers: passport.readiness.blockers,
+      gaps: passport.readiness.gaps,
+    },
+    sources: deriveSources(checks),
+    evidence: deriveEvidence(passport),
+    recruiter: deriveRecruiterRollup(passport),
+    employer: deriveEmployerView(passport),
+    trustSignals: deriveTrustSignals(passport.trustPosture),
+    missingEvidence: deriveMissingEvidence(passport),
+    recommendations: deriveRecommendations(passport),
+    footer: {
+      lineageKey: passport.lineageKey ?? null,
+      lastCheckedAt: passport.lastCheckedAt ?? null,
+      degraded: isDegraded(passport),
+    },
+  };
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
     '@vitalcv/psv',
     '@vitalcv/ingest',
     '@vitalcv/trust-state',
+    '@vitalcv/domain-evidence',
   ],
   experimental: {
     externalDir: true,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@blueprintjs/icons": "^6.7.0",
     "@blueprintjs/table": "^6.0.19",
     "@clerk/nextjs": "^6.37.3",
+    "@vitalcv/domain-evidence": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "latest",

--- a/codex-safe-review/01-stack-inventory.md
+++ b/codex-safe-review/01-stack-inventory.md
@@ -1,0 +1,70 @@
+# W228-C1 — Stack Inventory + System Dependency Map
+
+**Date:** 2026-06-21
+
+---
+
+## 1. Inventory (measured)
+
+`packages/domain-evidence/src` — 1,768 LOC total (incl. tests). Single external dep: `@vitalcv/trust-state`.
+
+| Module | Exports | Tests | Depends on (internal) |
+|---|---|---|---|
+| `types.ts` | EvidenceObject, EvidenceClass, EvidenceStatus, EvidenceSource, EvidenceProvenance, EvidenceRelationship(+Type), EvidenceLifecycle, EvidenceValue, EvidenceCollection | — (pure types) | — |
+| `collection.ts` | buildEvidenceCollection, isDecisionGradeStatus, summarizeEvidenceCoverage, EVIDENCE_CLASSES, EVIDENCE_STATUSES | 4 | types |
+| `projectors/graph.ts` | projectEvidenceToGraph, statusTrustScore, GraphNode, GraphRelationship(+Type), GraphProjection, GRAPH_RELATIONSHIP_TYPES | 8 | types, collection |
+| `trust/propagate.ts` | propagateTrust, TRUST_DIMENSIONS, TrustProjection, DimensionTrust, TrustHistory(+Entry/Type), TrustDimension | 8 | types, projectors/graph |
+| `timeline/timeline.ts` | projectTimeline, CAREER_EVENT_TYPES, CareerEvent, TimelineProjection, ReputationSummary, Mobility/RecognitionImpact | 8 | types, projectors/graph, trust/propagate |
+| `index.ts` | barrel | — | all |
+
+**Package totals: 4 test files, 28 tests, all passing.**
+
+Web layer:
+
+| Module | Tests | Depends on |
+|---|---|---|
+| `lib/evidence/passport-to-evidence.ts` (adapter) | 6 | `@vitalcv/domain-evidence`, `@/lib/trust/passport-contract`, `@/lib/trust/source-coverage` |
+| `app/api/evidence/[entityId]/route.ts` | 0 direct | adapter, passport-runtime |
+| `app/api/graph/[entityId]/route.ts` | 0 direct | adapter, projector |
+| `app/api/graph/[entityId]/trust/route.ts` | 0 direct | adapter, projector, trust |
+| `app/api/timeline/[entityId]/route.ts` | 0 direct | adapter, projector, trust, timeline |
+| `app/dev/graph/[entityId]/*` (dev tool) | 0 (UI) | graph + trust APIs |
+| web integration tests (`evidence-{collection,graph,trust,timeline}`) | 20 | exercise adapter→projectors end-to-end |
+
+**Web stack + regression: 9 test files, 44 tests, all passing** (20 stack + 24 recruiter regression: career-packet 13+2, employer-proof-packet 2, export-packet-route 6, banned-verified-label 1).
+
+## 2. System Dependency Map (verified — no cycles)
+
+```mermaid
+flowchart TD
+  TS[@vitalcv/trust-state\n(external, ships dist)] --> TYPES[types.ts]
+  TS --> COLL[collection.ts]
+  TYPES --> COLL
+  TYPES --> GRAPH[projectors/graph.ts]
+  COLL --> GRAPH
+  TYPES --> TRUST[trust/propagate.ts]
+  GRAPH --> TRUST
+  TYPES --> TL[timeline/timeline.ts]
+  GRAPH --> TL
+  TRUST --> TL
+
+  subgraph web [apps/web]
+    PASS[passport runtime] --> ADAPT[passport-to-evidence.ts]
+    ADAPT --> RC[/api/evidence/:id/]
+    ADAPT --> RG[/api/graph/:id/]
+    ADAPT --> RT[/api/graph/:id/trust/]
+    ADAPT --> RTL[/api/timeline/:id/]
+  end
+
+  COLL -.consumed by.-> ADAPT
+  GRAPH -.-> RG
+  TRUST -.-> RT
+  TL -.-> RTL
+```
+
+**Runtime data flow (single linear pipeline):**
+`passport → passportToEvidenceCollection → EvidenceCollection → projectEvidenceToGraph → GraphProjection → propagateTrust → TrustProjection → projectTimeline → TimelineProjection`. Each route taps one stage of this pipeline.
+
+## 3. Layering (strict, acyclic)
+
+`types → collection → graph → trust → timeline`. Each layer depends only on lower layers. Verified by import scan: no module imports a higher or sibling layer; no module imports anything app-side. The only external dependency is `@vitalcv/trust-state`, and only for the canonical status vocabulary.

--- a/codex-safe-review/02-architecture-review.md
+++ b/codex-safe-review/02-architecture-review.md
@@ -1,0 +1,46 @@
+# W228-C2 — Architecture Review
+
+**Date:** 2026-06-21 · Scope: the Career Evidence stack.
+
+---
+
+## 1. Duplication
+
+| Finding | Severity | Notes |
+|---|---|---|
+| `statusTrustScore` (graph) vs `isDecisionGradeStatus` (collection) | none | distinct concerns; both reference the one trust-state vocabulary |
+| Trust-impact math repeated in `trust/propagate.ts` (history) and `timeline/timeline.ts` (events) | **low** | both compute `checked → +score`, `decayed → −(1−score)`. Two ~5-line copies. Candidate to extract a shared `trustDelta(node)` helper. Not a correctness risk (both tested), but the single most actionable cleanup. |
+| Test fixture `buildPassportPayload` duplicated across 4 web test files | low | standard test-fixture duplication; could centralize in a test helper. Cosmetic. |
+| `makeObject` evidence fixture duplicated across 3 package tests | low | same; cosmetic. |
+
+**Verdict:** one minor logic duplication (trust delta) worth extracting; the rest is test-fixture boilerplate.
+
+## 2. Coupling
+
+| Edge | Assessment |
+|---|---|
+| package → `@vitalcv/trust-state` | **healthy** — depends only on the canonical status enum/labels; keeps EvidenceStatus from drifting. |
+| package → app | **none** (verified by grep) — the package is fully app-agnostic. The only mention of `apps/web` is a doc comment. |
+| adapter → passport types | **expected** — `passport-to-evidence.ts` is the *intended* coupling point (all PassportData knowledge lives here, package stays clean). Mirrors how `career-packet.ts` couples to PassportData. |
+| routes → adapter + projectors | **thin** — each route is a 3–5 line composition; no business logic in routes. |
+
+**Verdict:** coupling is deliberate and one-directional (app→package, never package→app). The adapter is the single seam.
+
+## 3. Circular dependencies
+
+**None.** Import scan shows a strict DAG: `types → collection → graph → trust → timeline`. No back-edges, no sibling imports. The pipeline is linear at runtime too.
+
+## 4. Future bottlenecks
+
+| Bottleneck | When it bites | Mitigation (designed, not yet needed) |
+|---|---|---|
+| Per-request recomputation | every API call rebuilds the full pipeline from the passport | cache the EvidenceCollection behind an ETag on `lastCheckedAt`; the pipeline downstream is cheap (O(n) over one clinician's evidence) |
+| Passport is the only evidence source | richer evidence (audit/watchtower/recognition tables) not yet read | the adapter is the seam — add `claimRecordToEvidence`, `recognitionToEvidence` adapters without touching the package |
+| Graph node taxonomy is the focused 3-type model (`subject/evidence/source`) | if the UI needs the 21-type `graph-system/types.ts` vocabulary | add a `mapToGraphSystemNode` projector; the current model is intentionally minimal and self-contained |
+| Routes under existing `/api/graph/*` namespace | none today (static siblings win) | documented in 05; reviewed-safe |
+
+**Verdict:** no architectural bottleneck blocks merge. All scaling concerns are addressed additively at the adapter seam — the package never needs to change.
+
+## 5. Extensibility assessment
+
+The facade pattern is the strength: `EvidenceObject` is a view, so new evidence sources, new graph consumers, mobility (W230), and memory deepening (W225) all plug in at the adapter or as new projectors **without modifying the package's core**. The strict layering means a change to `timeline` can never affect `graph` or `trust`.

--- a/codex-safe-review/03-test-coverage-review.md
+++ b/codex-safe-review/03-test-coverage-review.md
@@ -1,0 +1,46 @@
+# W228-C3 — Test Coverage Review
+
+**Date:** 2026-06-21 · Measured: package 28 tests / web stack 20 tests + 24 regression.
+
+---
+
+## 1. Coverage by module
+
+| Module | Tested behaviors | Grade |
+|---|---|---|
+| `collection.ts` | byClass grouping, coverage summary, **decisionGrade fail-closed**, dedup | **strong** |
+| `projectors/graph.ts` | license/cert projection, no dup nodes, no orphans, **no inflation**, **no false decision-grade**, enumerated rel types, stats | **strong** |
+| `trust/propagate.ts` | 7 dimensions present, identity/authority scoring, **null for no-evidence**, **no inflation**, gated→weakening, overall bounds, history reinforcement/decay, **determinism** | **strong** |
+| `timeline/timeline.ts` | event per node, ordering, trust/mobility/recognition impact, **honest reputation standing**, unknown standing, **determinism** | **strong** |
+| `passport-to-evidence.ts` | verbatim status, class mapping, primary-source→checked, self-reported→notDecisionGrade, verified_by links, no bare Verified | **strong** |
+
+## 2. Missing coverage (honest gaps)
+
+| Gap | Severity | Recommendation |
+|---|---|---|
+| **API route handlers have no direct tests** (`/api/evidence`, `/api/graph`, `/api/graph/trust`, `/api/timeline`) | **medium** | The route logic (param await, schema envelope, error 500 path, `Cache-Control`) is untested. Routes are thin (3–5 lines) and the composed functions are well-tested, but the handler wiring is not. **Add 4 route smoke tests** (mock `resolvePassportRuntimePassport`) — listed as a pre-merge recommendation in 07. |
+| `propagateTrust` — `mobility` and `institutional` dimensions not directly asserted | low | covered indirectly; add 2 assertions. |
+| Adapter — `training` evidence class not exercised (no training fixture) | low | add a training credential fixture. |
+| Adapter — credential `REVOKED`/`SUSPENDED` → `reviewRequired` lifecycle path untested | low | add one fixture. |
+| Dev explorer UI (`GraphExplorerClient`) | none (acceptable) | dev-only tool, not a production surface. |
+
+## 3. Weak coverage
+
+- **Timeline recognition path** is tested only in the package (synthetic recognition fixture); the web integration test has no recognition evidence (passport fixtures don't carry recognition). Acceptable — the package test covers the logic; the web path is a thin pass-through.
+- **Edge-case classifiers** (`classifyEvidenceClass` fallback to `licensure`, unusual sourceIds) are partially covered. The board-vs-license bug found and fixed in W221 has a regression test.
+
+## 4. Critical paths (well covered)
+
+The doctrine-critical invariants all have direct, dedicated tests:
+
+1. **decisionGrade ⇔ checked** — `collection.test.ts` (fail-closed), `graph.test.ts` (no false decision-grade), adapter test (self-reported never decision-grade).
+2. **No trust inflation** — `graph.test.ts` (`≤ statusTrustScore`), `propagate.test.ts` (no dimension exceeds max contributing), `timeline.test.ts` (`trustImpact ≤ 1`).
+3. **Gated stays gated** — adapter test (verbatim status), `propagate.test.ts` (gated→weakening).
+4. **Honest absence** — `propagate.test.ts` (null dimension), `timeline.test.ts` (unknown standing).
+5. **Determinism** — trust + timeline determinism tests.
+6. **No bare `Verified` / banned strings** — `banned-verified-label.test.ts` (scans lib too), `check:claims`.
+7. **Recruiter surface unbroken** — career-packet + employer-proof-packet + export-packet-route regression all green.
+
+## 5. Verdict
+
+Coverage of the **pure logic and the doctrine invariants is strong** (the things most likely to cause a trust violation). The one real gap is **route-handler smoke tests** — medium severity, cheap to close, and recommended (not strictly required) before merge. Everything else is low-severity polish.

--- a/codex-safe-review/04-domain-model-map.md
+++ b/codex-safe-review/04-domain-model-map.md
@@ -1,0 +1,79 @@
+# W228-C4 — Domain Model Map
+
+**Date:** 2026-06-21 · All types in `packages/domain-evidence/src`. Pure, serializable, no classes.
+
+---
+
+## 1. Evidence layer (`types.ts`)
+
+```
+EvidenceObject {
+  evidenceId, subjectKey, evidenceClass, label, value,
+  status, source, trustTier, decisionGrade,         // decisionGrade ⇔ status==='checked'
+  observedAt, checkedAt, expiresAt, freshnessWindowHours,
+  integrityHash, provenance, lifecycle, supersedes, supersededBy
+}
+EvidenceClass  (15)  identity | licensure | board_cert | registration | exclusion |
+                     enrollment | privilege | peer_review | recognition | acceptance |
+                     start | employment | research | publication | training
+EvidenceStatus (9)   = CanonicalSourceCoverageState (trust-state) — only 'checked' is decision-grade
+EvidenceLifecycle    active | superseded | revoked | expired
+EvidenceSource       { sourceId, sourceLabel, laneType, governance }
+EvidenceProvenance   { artifactIds[], receiptIds[], sourceUrl, checksum, parserVersion }
+EvidenceRelationship { from, to, type, confidence, observedAt }   type(10): issued_by | verified_by |
+                     derived_from | proven_by | supersedes | affiliated_with | trained_at |
+                     works_at | accepted_by | attested_by
+EvidenceCollection   { subjectKey, generatedFor, objects[], relationships[], byClass, coverageSummary }
+```
+
+## 2. Graph layer (`projectors/graph.ts`)
+
+```
+GraphNode {
+  id, type, label, trustScore, evidenceSource, status,
+  evidenceClass, decisionGrade, checkedAt, expiresAt, lifecycle
+}
+GraphNodeType (3)            subject | evidence | source
+GraphRelationship            { id, from, to, type, evidenceId }
+GraphRelationshipType (16)   HAS_IDENTITY | HOLDS_LICENSE | HOLDS_CERTIFICATION | HOLDS_REGISTRATION |
+                             SCREENED_FOR_EXCLUSION | ENROLLED_IN | PRIVILEGED_AT | REVIEWED_BY |
+                             RECOGNIZED_BY | ACCEPTED_BY | STARTED_AT | EMPLOYED_BY | AUTHORED |
+                             TRAINED_AT | VERIFIED_BY | CERTIFIED_BY
+GraphProjection              { subjectKey, nodes[], relationships[], stats }
+statusTrustScore(status)     checked→1, stale→0.4, pending→0.2, reviewRequired→0.1, else→0  (monotonic)
+```
+
+## 3. Trust layer (`trust/propagate.ts`)
+
+```
+TrustDimension (7)   identity | authority | professional | research | leadership | institutional | mobility
+DimensionTrust       { dimension, score|null, contributingCount, decisionGradeCount, supporting[], weakening[], origins[] }
+TrustHistory         { entries[], reinforcementCount, decayCount, netDelta, trend }
+TrustHistoryEntry    { occurredAt, type(reinforcement|decay), dimension, evidenceId, detail, scoreDelta }
+TrustProjection      { subjectKey, overall{score|null, decisionGradeEvidence, totalEvidence}, dimensions[], history }
+```
+
+## 4. Timeline layer (`timeline/timeline.ts`)
+
+```
+CareerEventType (13)  identity_verification | licensure | certification | screening | enrollment |
+                      recognition | acceptance | employment_start | employment | training |
+                      privileging | peer_review | research
+CareerEvent          { eventId, occurredAt, type, label, detail, evidenceId, evidenceSource,
+                       trustImpact, trustDimension, mobilityImpact, recognitionImpact }
+MobilityImpact        expands | reduces | none
+RecognitionImpact     recognition | acceptance | start | none
+ReputationStanding    established | emerging | provisional | unknown   (threshold over decision-grade evidence)
+ReputationSummary     { overallTrust|null, decisionGradeEvidence, totalEvidence, reinforcementCount,
+                        decayCount, trend, standing }
+TimelineProjection    { subjectKey, events[], trustHistory, recognition[], reputation, firstAt, lastAt }
+```
+
+## 5. Invariant relationships (the load-bearing identities)
+
+- `EvidenceObject.decisionGrade === (status === 'checked')` — enforced in `buildEvidenceCollection` (throws otherwise).
+- `GraphNode.trustScore = statusTrustScore(status)` — monotonic, gated states = 0.
+- `DimensionTrust.score = mean(contributing trustScores)` — bounded by max contributing (no inflation).
+- `CareerEvent.trustImpact ∈ [−1, 1]` — checked→+score, decayed→−(1−score), else 0.
+- `ReputationStanding === 'unknown'` ⇐ `decisionGradeEvidence === 0`.
+- `EvidenceStatus ≡ CanonicalSourceCoverageState` — cannot drift (imported, not redeclared).

--- a/codex-safe-review/05-api-map.md
+++ b/codex-safe-review/05-api-map.md
@@ -1,0 +1,40 @@
+# W228-C4 — API Map
+
+**Date:** 2026-06-21 · All routes: `runtime = 'nodejs'`, read-only `GET`, `Cache-Control: no-store`, try/catch → 500, versioned envelope.
+
+---
+
+## 1. Routes
+
+| Method · Path | Schema | Composition | Auth |
+|---|---|---|---|
+| `GET /api/evidence/[entityId]` | `vitalcv.evidence-collection.v1` | passport → `passportToEvidenceCollection` | none (public passport runtime) |
+| `GET /api/graph/[entityId]` | `vitalcv.evidence-graph.v1` | … → `projectEvidenceToGraph` | none |
+| `GET /api/graph/[entityId]/trust` | `vitalcv.evidence-graph-trust.v1` | … → `propagateTrust` | none |
+| `GET /api/timeline/[entityId]` | `vitalcv.timeline.v1` | … → `projectTimeline` | none |
+
+`entityId` accepts a `VcvEntity.canonicalId` (UUID) or a 10-digit NPI — both resolve through `resolvePassportRuntimePassport` (existing).
+
+## 2. Namespace coupling (reviewed-safe)
+
+The graph routes live under the existing `/api/graph/*` namespace, which already has static siblings: `network/`, `live/[npi]/`, `node/[nodeId]/expand/`. The new `[entityId]` is the only **dynamic** segment at the `graph/` level. Next.js resolves static segments before dynamic, so:
+- `/api/graph/network`, `/api/graph/live/X`, `/api/graph/node/X/expand` → unchanged (static win).
+- `/api/graph/<uuid-or-npi>` → new evidence-graph route.
+
+No param-name conflict (the existing dynamics `[npi]`/`[nodeId]` are at deeper paths, not siblings of `[entityId]`). **Confirmed at typecheck + build; no route shadowed.**
+
+## 3. Response envelope (uniform)
+
+```jsonc
+{ "schema": "vitalcv.<name>.v1", ...projection }
+// error:
+{ "error": "<code>", "error_description": "<detail>" }   // HTTP 500
+```
+
+## 4. Auth posture (flag for reviewer)
+
+These routes are **unauthenticated**, matching the public passport runtime (`/api/passport/entity/[id]` is also unauthenticated). They expose source-backed, non-PHI credential evidence — the same data already public via the passport. **If** the reviewer's policy requires evidence/graph/timeline to be gated more tightly than the passport, that is a one-line `auth()` addition per route (parallel to `/api/export/packet`, which IS Clerk-gated). Flagged as a policy decision, not a defect — current posture is consistent with the existing passport surface.
+
+## 5. Not changed
+
+`/api/passport/*`, `/api/employer-review/*`, `/api/export/packet`, `/packet/[entityId]`, and the existing `/api/graph/{network,live,node}` are untouched. The recruiter pipeline is unaffected.

--- a/codex-safe-review/06-risk-assessment.md
+++ b/codex-safe-review/06-risk-assessment.md
@@ -1,0 +1,58 @@
+# W228-C4/C5 — Risk Assessment + Migration Risks
+
+**Date:** 2026-06-21
+
+---
+
+## 1. Doctrine invariants — status
+
+| Invariant | Held? | Evidence |
+|---|---|---|
+| Partial stays partial / no tier upgrade | ✅ | `decisionGrade ⇔ checked`, monotonic `statusTrustScore`, no-inflation tests |
+| Decision-grade = `checked` only | ✅ | `isDecisionGradeStatus`; `buildEvidenceCollection` throws on violation |
+| Gated/stale never positive | ✅ | verbatim status in adapter; gated→weakening; gated trustScore 0 |
+| Pure transforms (no fetch/write) | ✅ | package has zero I/O; routes fetch via existing runtime only |
+| No new persistence | ✅ | no Prisma changes; all projections over the passport |
+| Zero PHI | ✅ | only source-backed credential evidence, same as passport |
+| No bare `Verified` / banned strings | ✅ | `banned-verified-label` + `check:claims` green |
+| `VerifiedCanonicalPath` not minted by projections | ✅ | recognition projected read-only; no path construction (W225-C5) |
+| Recruiter surfaces unbroken | ✅ | career-packet/employer-proof/export regression green |
+| Honest absence (no fabricated trust/reputation) | ✅ | null dimensions, unknown standing tests |
+
+**No broken invariants. No trust violations.**
+
+## 2. Current-stack risks
+
+| Risk | Severity | Status |
+|---|---|---|
+| API route handlers untested | medium | open — recommend 4 smoke tests (03 §2, 07) |
+| Per-request recomputation cost | low | acceptable at clinician scale; ETag caching designed |
+| Unauthenticated routes | low/policy | consistent with passport; flagged (05 §4) |
+| `dist/` gitignored | low | CI must `pnpm turbo run build --filter @vitalcv/web` (same as trust-state) |
+| Branch carries unrelated WIP | **medium** | the merge must scope to this stack (07) |
+
+## 3. Migration risks for downstream waves (C5)
+
+### Wallet (W250)
+- **Risk:** wallet may expect evidence to be user-editable/holdable; EvidenceObject is currently a **read-only projection** of source-backed data.
+- **Mitigation:** keep the projection read-only; wallet writes go to the existing holder/upload path, then surface as evidence with honest `notDecisionGrade`/`pending` status until verified. Never let wallet edits mint `checked`.
+
+### Mobility (W230)
+- **Risk:** gap/readiness logic could be tempted to let a gated license satisfy a requirement.
+- **Mitigation:** designed already (W230-C3/C5) — `minStatus` defaults `checked`; `ready` requires decision-grade. The trust dimensions (incl. `mobility`) are already exposed and bounded.
+
+### Network (W270)
+- **Risk:** cross-entity edges (clinician↔employer↔institution) could create cycles or trust leakage between subjects.
+- **Mitigation:** current graph is single-subject (anchored on one `subjectKey`). Multi-subject must keep the monotonic-down rule **per subject** — never propagate a positive across the network. Add a per-subject boundary test when networked.
+
+### Opportunity Matching (W260)
+- **Risk:** matching/ranking could be read as a recommendation/guarantee.
+- **Mitigation:** W230-C4 mandates the honesty `note` (deterministic evaluation, not ranking); matching stays out of scope until W260 and must remain explainable (no opaque scoring).
+
+### Recognition (W250-3 / PRE)
+- **Risk:** deepening PRE could let a projection synthesize a recognition or relax `VerifiedCanonicalPath` branding.
+- **Mitigation:** the one-direction rule (W225-C5 §2) — projections read PRE, never mint it; TypeScript branding enforces it.
+
+## 4. Net risk posture
+
+**Low.** The stack adds no persistence, holds every doctrine invariant under test, and isolates all future expansion at the adapter seam. The only medium items are operational (route tests, branch scoping), not architectural.

--- a/codex-safe-review/07-merge-readiness.md
+++ b/codex-safe-review/07-merge-readiness.md
@@ -1,0 +1,52 @@
+# W228-C6 — Merge Readiness Report
+
+**Date:** 2026-06-21 · **Branch:** `wave/career-evidence-network-alignment`
+
+---
+
+## 1. The four merge conditions
+
+| Condition | Met? | Basis |
+|---|---|---|
+| Architecture coherent | ✅ | linear DAG, no cycles, single external dep, one adapter seam (01, 02) |
+| No critical risks | ✅ | only medium *operational* items (route tests, branch scoping); no architectural blocker (06) |
+| No broken invariants | ✅ | every doctrine invariant test-enforced (03 §4, 06 §1) |
+| No trust violations | ✅ | decisionGrade⇔checked, monotonic trust, gated-stays-gated, honest absence — all tested |
+
+**On architecture/safety grounds, the stack passes all four conditions.**
+
+## 2. Success-criteria answers
+
+1. **Is the stack coherent?** Yes — strict `types→collection→graph→trust→timeline` layering, no duplication beyond one trivial trust-delta helper.
+2. **Is the stack safe?** Yes — pure transforms, no persistence, no PHI, every invariant under test.
+3. **Is the stack mergeable?** Yes, **conditionally** — see §3.
+4. **Is the stack extensible?** Yes — facade + adapter seam; Mobility/Network/Recognition plug in without touching the package.
+5. **What must be fixed before Wave 230+?** §4.
+
+## 3. Pre-merge conditions (operational, not architectural)
+
+These are **process** gates, not code defects:
+
+1. **Codex SAFE verdict — MANDATORY (not yet obtained).** Per doctrine, `gh pr merge` is hook-blocked without a real `codex exec` SAFE verdict (implementation/diff/copy audits) in the transcript. This package exists to enable that pass. **This is the gating item.**
+2. **Commit the work.** The entire stack is currently **untracked/uncommitted**. It must be committed (logically grouped) before review/merge.
+3. **Scope the branch (important).** `wave/career-evidence-network-alignment` currently conflates **two unrelated bodies of work**:
+   - **This stack** (mergeable): `packages/domain-evidence/`, `apps/web/lib/evidence/`, `apps/web/lib/packet/`, the evidence/graph/timeline/packet routes + tests, the `employer-proof-packet-pdf.tsx` extension, `docs/wave2*`, `codex-safe-review/`.
+   - **Pre-existing WIP (not produced this session):** `M CLAUDE.md`, `DOCTRINE.md`, `MASTER_PROMPT.md`, `README.md`, `HomePageClient.tsx`, `page.tsx`, `TrustConsentModal.tsx`, `Navbar.tsx`, `AuditProofViewer.tsx`, plus worktree dirs and `docs/launch/`, `scripts/check-public-claims.ts`.
+   **Recommendation:** commit and review the Career Evidence stack as its own unit; treat the pre-existing WIP separately (it predates this session and should not ride in on a SAFE review of this stack). Do not assume the WIP is part of this feature.
+4. **CI build green.** `dist/` is gitignored (like `trust-state`), so CI must run `pnpm turbo run build --filter @vitalcv/web` to prebuild the new workspace dep, then `pnpm typecheck` + `pnpm lint` + `next build`. Locally verified: package build, both typechecks (0 errors), `check:claims`, ESLint — all green; full `next build` not run locally (CI gate).
+
+## 4. Recommended before building Wave 230+ (not merge-blocking)
+
+| Item | Why | Effort |
+|---|---|---|
+| 4 API route smoke tests | only real coverage gap (03 §2) — handler wiring untested | ~1 unit |
+| Extract shared `trustDelta(node)` helper | removes the one logic duplication (02 §1) | ~0.3 unit |
+| 2 dimension assertions (mobility/institutional) + training/revoked adapter fixtures | close low-severity coverage | ~0.3 unit |
+
+## 5. Verdict
+
+> **The Career Evidence stack is coherent, safe, and architecturally mergeable. It is NOT yet merge-ready operationally** because (a) it has no Codex SAFE verdict, (b) it is uncommitted, and (c) it is entangled with unrelated pre-existing branch WIP that must be separated.
+
+**Path to merge:** commit + scope the stack → run CI build → obtain Codex SAFE on this package → `gh pr merge`. The recommended hardening in §4 is best done *after* SAFE (changing code right before an independent audit is counterproductive) or folded into the SAFE remediation if Codex flags it.
+
+**Do not develop Wave 230+ features on top until the stack is committed and SAFE-reviewed** — the unmerged stack is already five waves deep; extending it further increases audit surface and merge risk.

--- a/codex-safe-review/08-career-os-hardening.md
+++ b/codex-safe-review/08-career-os-hardening.md
@@ -1,0 +1,76 @@
+# W245 — Career OS Hardening
+
+**Date:** 2026-06-21 · QA/hardening record (no new strategy, doctrine, or frameworks).
+
+---
+
+## 0. Scope correction (honest)
+
+There is **no "Career OS", no "Career Home" page, and no `/career` / `/memory` / `/reputation` / `/mobility` route** in the codebase. The "experiences" this wave hardens are the real surfaces that exist:
+
+- **Data layer (the experiences):** `EvidenceCollection → GraphProjection → TrustProjection → TimelineProjection` (the `@vitalcv/domain-evidence` pipeline).
+- **APIs:** `/api/evidence/[id]`, `/api/graph/[id]`, `/api/graph/[id]/trust`, `/api/timeline/[id]`.
+- **Product UI:** `/packet/[entityId]` (Career Packet).
+- **Dev UI:** `/dev/graph/[entityId]` (noindex, dev-only).
+
+Reputation/Mobility remain design-only (W230/W235) — nothing to productionize.
+
+## 1. C1–C3 — Experience validation
+
+| Experience | Typed | Tested |
+|---|---|---|
+| Evidence | `tsc` 0 errors | adapter (6) + collection (4) + route (2) |
+| Trust | `tsc` 0 errors | propagate (8) + trust (5) + route (2) |
+| Timeline | `tsc` 0 errors | timeline (8) + timeline (4) + route (2) |
+| End-to-end | — | **integration (6)** — see C4 |
+
+## 2. C4 — Integration test (new)
+
+`apps/web/__tests__/career-os-integration.test.ts` runs the full pipeline from one passport and asserts **no honesty-drift across layers**:
+- a `checked` source is decision-grade at collection, graph, and trust;
+- a `gated` source is non-decision-grade at *every* layer (gated→0 trustScore, in `weakening` never `supporting`, never positive timeline impact);
+- an `EXPIRED` registration decays coherently and never inflates overall trust;
+- decision-grade evidence counts agree across graph/trust/timeline;
+- end-to-end determinism.
+
+**This is the "Career OS is coherent" guarantee, mechanized.** 6 tests, green.
+
+## 3. C5 — Performance audit (measured)
+
+Full pipeline (`buildEvidenceCollection → projectEvidenceToGraph → propagateTrust → projectTimeline`) on synthetic data:
+
+| Evidence objects | Pipeline time |
+|---|---|
+| 100 | ~6 ms (incl. JIT warmup) |
+| 1,000 | ~2.5 ms |
+| 5,000 | ~25 ms |
+
+- **Linear (O(n))**, as designed — pure transforms, no quadratic joins.
+- A real clinician carries ~10–30 evidence objects → **sub-millisecond** pure compute.
+- The dominant request cost is the upstream passport fetch (network), **not** the projection. Recommended (already designed in `06`): ETag the response on `lastCheckedAt`. No code change required for current scale.
+
+## 4. C6 — Accessibility audit
+
+| Surface | Finding | Action |
+|---|---|---|
+| `/packet/[entityId]` (product) | semantic `<main>/<header>/<section>`, `h1`→`h2`, `<dl>`, status chips carry **text labels** (not color-only), degraded banner `role="status"`, export is a real `<a>` | already accessible; no change needed |
+| `/dev/graph/[entityId]` (dev) | tables lacked `scope="col"` | **added `scope="col"` to all column headers** |
+
+The one product surface (the Career Packet) was already built accessibly in W205 (status is never conveyed by color alone — the recruiter chip and every source row render their state as text). The dev explorer is noindex/dev-only; the `scope` fix is a low-cost correctness improvement.
+
+## 5. C7 — Merge readiness
+
+Folded into PR #444 (clean branch `feat/career-evidence-stack` off `origin/main`). W245 adds: the integration test, the dev-explorer a11y fix, and this record. Re-validated on the clean branch:
+
+| Check | Result |
+|---|---|
+| package tests | 28/28 |
+| web stack + integration + regression | green (incl. new 6 integration tests) |
+| `tsc --noEmit` (package + web) | 0 errors |
+| `banned-verified-label` vitest (on origin/main) | green — enforces the bare-`Verified` rule |
+| ESLint (changed files) | clean |
+| `pnpm turbo run build --filter @vitalcv/web` | tasks successful, exit 0 |
+
+> **Note on `check:claims`:** the 20-phrase public-claims scanner (`scripts/check-public-claims.ts`) is **pre-existing uncommitted WIP not present on `origin/main`**, so it was correctly excluded from this clean PR and cannot run on this base. The stack's public copy was verified clean against it on the source branch during W205–W240; the committed `banned-verified-label` test enforces the most critical sub-rule (no bare `Verified`) and is green here. If/when the `check:claims` infra lands on `main`, CI will cover the full phrase list.
+
+**Career OS data layer is typed, tested, accessible, performant — and the PR is build-clean and mergeable, pending the mandatory Codex SAFE verdict (the one gate that remains).**

--- a/codex-safe-review/PR_BODY.md
+++ b/codex-safe-review/PR_BODY.md
@@ -26,9 +26,11 @@ The executable Career Evidence Network layer: a new app-agnostic package (`@vita
 
 ## Validation
 
-- Package: **28 tests** green · Web stack + regression: **52 tests** green.
-- `tsc --noEmit` (package + web): 0 errors · `pnpm check:claims`: pass · ESLint: clean.
-- **`pnpm turbo run build --filter @vitalcv/web`: 11/11 tasks, exit 0** (full Next build with TS+ESLint enforced).
+- Package: **28 tests** green · Web stack + integration + regression: green (incl. 6 Career OS integration tests, W245).
+- `tsc --noEmit` (package + web): 0 errors · ESLint: clean · `banned-verified-label` vitest: green (enforces no bare `Verified`).
+- **`pnpm turbo run build --filter @vitalcv/web`: tasks successful, exit 0** (full Next build with TS+ESLint enforced).
+
+> `check:claims` (the 20-phrase public-copy scanner) is pre-existing infra not on `origin/main`; the stack was verified against it on the source branch, and the committed `banned-verified-label` test covers the critical sub-rule here.
 
 ## Architecture
 

--- a/codex-safe-review/PR_BODY.md
+++ b/codex-safe-review/PR_BODY.md
@@ -1,0 +1,45 @@
+# Career Evidence stack — domain-evidence package + evidence/graph/trust/timeline + Career Packet
+
+## What this is
+
+The executable Career Evidence Network layer: a new app-agnostic package (`@vitalcv/domain-evidence`) that projects an already-source-checked passport into **evidence → graph → trust → timeline**, plus the recruiter-facing **Verified Clinician Career Packet**. All additive and read-only — no existing surface changes behaviour.
+
+## Scope (this PR)
+
+| Area | Files |
+|---|---|
+| Package | `packages/domain-evidence/` (types, collection, graph projector, trust engine, timeline projector) |
+| Web adapter | `apps/web/lib/evidence/passport-to-evidence.ts` |
+| Read APIs | `/api/evidence/[id]`, `/api/graph/[id]`, `/api/graph/[id]/trust`, `/api/timeline/[id]` |
+| Career Packet | `apps/web/app/packet/[entityId]/`, `apps/web/lib/packet/career-packet.ts`, PDF extension |
+| Dev tool | `apps/web/app/dev/graph/[entityId]/` (noindex) |
+| Tests | `apps/web/__tests__/evidence-*.test.ts`, `career-packet-*.test.ts` + package tests |
+| Docs | `docs/wave2*`, `codex-safe-review/` |
+
+## Honesty invariants (test-enforced)
+
+- `decisionGrade ⇔ status === 'checked'` — fail-closed in `buildEvidenceCollection`.
+- Monotonic, non-inflating trust: `statusTrustScore` (gated states = 0); dimension scores never exceed contributing evidence; reputation/timeline impacts bounded.
+- Gated/stale never presented as decision-grade; honest `null`/`unknown` for absent evidence.
+- No bare `Verified`; passes `pnpm check:claims`.
+- Pure transforms (no I/O); no new persistence; no PHI.
+
+## Validation
+
+- Package: **28 tests** green · Web stack + regression: **52 tests** green.
+- `tsc --noEmit` (package + web): 0 errors · `pnpm check:claims`: pass · ESLint: clean.
+- **`pnpm turbo run build --filter @vitalcv/web`: 11/11 tasks, exit 0** (full Next build with TS+ESLint enforced).
+
+## Architecture
+
+Strict acyclic layering `types → collection → graph → trust → timeline`; single external dep `@vitalcv/trust-state`; one adapter seam (`passport-to-evidence`). Full review package in `codex-safe-review/`.
+
+## ⚠️ Merge gate
+
+Per project doctrine, this requires a real **`codex exec` SAFE verdict** (implementation / diff / copy audits) before `gh pr merge`. CI must run `pnpm turbo run build --filter @vitalcv/web` (the package ships from `dist/`, gitignored like `@vitalcv/trust-state`).
+
+## Not included (deliberately)
+
+Pre-existing branch WIP unrelated to this stack (doctrine docs, homepage, navbar, etc.) is **not** part of this PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/codex-safe-review/README.md
+++ b/codex-safe-review/README.md
@@ -1,0 +1,47 @@
+# Codex SAFE Review — Career Evidence Stack
+
+**Wave:** 228 (System Consolidation & SAFE Review) · **Branch:** `wave/career-evidence-network-alignment`
+**Date:** 2026-06-21 · **Prepared by:** Claude Code (builder)
+
+This package prepares the Career Evidence stack for independent verification by Codex. **No feature work was done in W228** — this is hardening + honest review only.
+
+## Scope of the stack under review
+
+One new workspace package + one web adapter + four read-only API routes + one dev tool, built across Waves 220–225:
+
+| Layer | Location |
+|---|---|
+| `@vitalcv/domain-evidence` package | `packages/domain-evidence/` |
+| Passport→Evidence adapter | `apps/web/lib/evidence/passport-to-evidence.ts` |
+| Evidence API | `apps/web/app/api/evidence/[entityId]/route.ts` |
+| Graph API | `apps/web/app/api/graph/[entityId]/route.ts` |
+| Trust API | `apps/web/app/api/graph/[entityId]/trust/route.ts` |
+| Timeline API | `apps/web/app/api/timeline/[entityId]/route.ts` |
+| Dev graph/trust explorer | `apps/web/app/dev/graph/[entityId]/` |
+
+## Documents
+
+| # | Doc | Answers |
+|---|---|---|
+| 01 | [Stack Inventory + Dependency Map](./01-stack-inventory.md) | C1 — what's here, how it depends |
+| 02 | [Architecture Review](./02-architecture-review.md) | C2 — duplication / coupling / cycles / bottlenecks |
+| 03 | [Test Coverage Review](./03-test-coverage-review.md) | C3 — missing / weak / critical-path coverage |
+| 04 | [Domain Model Map](./04-domain-model-map.md) | C4 — the types |
+| 05 | [API Map](./05-api-map.md) | C4 — the routes |
+| 06 | [Risk Assessment + Migration Risks](./06-risk-assessment.md) | C4/C5 — risks now + for Wallet/Mobility/Network/Matching/Recognition |
+| 07 | [Merge Readiness Report](./07-merge-readiness.md) | C6 — can it merge, and under what conditions |
+
+## Headline verdict (full detail in 07)
+
+- **Coherent:** yes — linear dependency DAG, no cycles, single external dep.
+- **Safe:** yes — every doctrine invariant is test-enforced; pure transforms; no new persistence; no PHI; honest gating.
+- **Mergeable:** yes, **conditionally** — see 07 §Conditions. Two real pre-merge items: (1) the API route handlers have no direct tests, (2) the branch carries unrelated pre-existing WIP that should be separated from this stack before merge.
+- **Extensible:** yes — additive facade; Mobility (W230) and Memory deepening build on it without modification.
+
+## How to verify (suggested Codex pass)
+
+1. `pnpm --filter @vitalcv/domain-evidence build && pnpm --filter @vitalcv/domain-evidence test`
+2. `pnpm --filter @vitalcv/web exec vitest run __tests__/evidence-*.test.ts __tests__/career-packet-*.test.ts __tests__/employer-proof-packet.test.ts __tests__/export-packet-route.test.ts __tests__/banned-verified-label.test.ts`
+3. `pnpm --filter @vitalcv/domain-evidence typecheck && pnpm --filter @vitalcv/web exec tsc --noEmit`
+4. `pnpm check:claims`
+5. Audit the invariants in 06 against the code.

--- a/docs/wave200/career-packet-spec.md
+++ b/docs/wave200/career-packet-spec.md
@@ -1,0 +1,202 @@
+# W200-2 — Career Packet Specification
+
+**Wave:** 200 (Revenue Wedge Extraction)
+**Deliverable:** the *Verified Clinician Career Packet* — structure, rendering, and data contract.
+**Depends on:** [W200-1 gap analysis](./passport-gap-analysis.md).
+**Gates:** W200-3 (UI at `/packet/[entityId]`), W200-4 (PDF).
+**Date:** 2026-06-20.
+
+---
+
+## 0. Design principle
+
+**One packet, two renderers, one derivation module.** The screen (`/packet/[entityId]`) and the PDF consume the *same* pure derivation functions over `PassportData`. They can never disagree, and every honest-gating rule lives in exactly one place. This mirrors the existing issuer-verification discipline (`receiptCandidate.ts` / `policyReview.ts` are pure transforms with no fetches/writes).
+
+```
+PassportData ──> buildCareerPacket(passport, opts) ──> CareerPacketModel
+                                                          ├─> <PacketView/>      (W200-3)
+                                                          └─> renderPacketPdf()  (W200-4)
+```
+
+The packet is a **snapshot of an already-computed passport**, not a new computation. It performs zero source checks and zero writes. It is read-only and honest about coverage state.
+
+---
+
+## 1. Packet structure (sections)
+
+Ten sections, each a pure function of `PassportData`. Roadmap order preserved.
+
+| # | Section | Purpose (recruiter answers it in <30s) | Primary source fields |
+|---|---|---|---|
+| 1 | **Executive Summary** | "Who is this, are they ready, what's the one blocker?" | `identity`, `readiness.status/score`, `trustPosture.band`, top blocker |
+| 2 | **Identity Summary** | Confirmed identity against federal source | `identity.{displayName,specialty,entityType,status,npi}`, NPPES `sourceCoverage` check |
+| 3 | **Credential Readiness** | Readiness verdict + score + time-to-start | `readiness.{status,score,level,estimatedStartDays}`, `authority.summary` |
+| 4 | **Verification Sources** | Which sources were checked, when, freshness | `sourceCoverage.checks[]` (state, checkedAt, expiresAt, reason) |
+| 5 | **Evidence Summary** | Credentials + training the candidate carries | `authority.credentials[]`, `training.records[]` |
+| 6 | **Recruiter View** | Ready / Needs Review / Blocked / Missing-Evidence rollup | derived (see §4.2) |
+| 7 | **Employer View** | "Start Ready?" + blocking reasons + what to request | `readiness`, `trustPosture.blockers`, `standing` |
+| 8 | **Trust Signals** | Trust band + four truth dimensions | `trustPosture`, `truth` (identity/safety/authority/eligibility) |
+| 9 | **Missing Evidence** | Honest gaps: gated / stale / accessRequired / not-decision-grade | `sourceCoverage.summary`, `readiness.gaps[]` |
+| 10 | **Recommendations** | Clinician-actionable next steps | `readiness.nextActions[]`, derived from gaps |
+
+**Footer (both renderers):** `lineageKey` (replay attribution), `lastCheckedAt`, packet SHA-256 hash (PDF only, reuse existing `stableValue` hashing), `_degraded` honesty banner when set.
+
+---
+
+## 2. Data requirements
+
+### 2.1 Input
+
+Single input: a hydrated `PassportData` (`apps/web/lib/trust/passport-contract.ts`), fetched server-side via `GET /api/passport/entity/[id]` (or `…/npi/[npi]`). No client fetch, no wallet dependency, no auth redesign (W200-3 constraint).
+
+### 2.2 Required vs. optional fields
+
+| Field | Required? | If missing |
+|---|---|---|
+| `entityId` | required | 404 — cannot render a packet without an entity |
+| `identity.displayName`, `npi` | required | render with "Identity unavailable" honest state |
+| `readiness.status`, `readiness.score` | required | treat as `CHECKING`, score withheld |
+| `sourceCoverage.checks[]` | required (may be empty) | empty → all sources render `pending`/`unknown` |
+| `trustPosture` | optional | omit Trust Signals section; do not fabricate a band |
+| `truth` | optional | omit the four-dimension grid |
+| `authority.credentials[]`, `training.records[]` | optional | Evidence Summary shows "No source-backed evidence on file yet" |
+| `_degraded` | optional | when `true`, render banner: *"Partial snapshot — some sources were unavailable at check time."* |
+
+### 2.3 Degraded / partial behavior
+
+- `_degraded === true` → packet renders, top banner declares partial coverage, **export gate may block PDF** (that is correct — see §5).
+- `readiness.status !== 'DECISION_GRADE'` → packet renders the partial state honestly; **never upgraded** to decision-grade (Trust Graph Rule 5).
+
+---
+
+## 3. Rendering requirements
+
+### 3.1 Shared (UI + PDF)
+
+- Section order is fixed (§1). Sections with no data **collapse to an honest empty state**, never disappear silently (a missing Trust Signals block that just vanishes reads as "hidden bad news").
+- Status vocabulary is rendered verbatim from the coverage model — `checked / stale / pending / gated / unavailable / accessRequired / reviewRequired / notDecisionGrade / previewOnly`. No relabeling to friendlier-but-false words.
+- **No bare `Verified`** anywhere (passes `banned-verified-label.test.ts`). Use compound, honest labels: "Checked against NPPES", "Source coverage: checked", etc.
+- All new copy passes `pnpm check:claims` (no `automatically verified`, `guaranteed verification`, `legally accepted`, `HIPAA compliant`, etc.).
+- Monospace for NPI / IDs / hashes; `tabular-nums` for scores; relative + absolute timestamps ("checked 3 days ago · 2026-06-17").
+
+### 3.2 Screen (`/packet/[entityId]`, W200-3)
+
+- Read-only. No mutations, no wallet, no auth redesign.
+- Reuse: `PassportTrustPosture` (§8), `CredentialReadinessCard` (§3), `TrustStatusBadge` (per-source chips, §4), `CandidateResultCard`/`TrustStatePanel` patterns (§6/§7), `CRSRing` (score), `Card`/`GlassCard` layout.
+- Recruiter-readable + employer-readable + shareable (export button → PDF; share affordance reuses `chk_*` token mechanism, full wiring deferred to W210-4).
+- Responsive; print-stylesheet friendly as a fallback.
+
+### 3.3 PDF (W200-4)
+
+- Extend `EmployerProofPacketPdfModel` (`apps/web/lib/export/employer-proof-packet-pdf.tsx`) to the ten sections via the **same** derivation module.
+- Keep the existing SHA-256 `stableValue` hash + deterministic serialization.
+- Add an entityId→export path (`/api/export/packet` currently `?npi=` only; resolve entityId→npi server-side or add `?entityId=`).
+- Honor the existing `resolveEmployerPacketExportGate` — blocked export returns 409 + `replayAttribution`, never a half-true PDF.
+
+---
+
+## 4. Derivation module API (single source of truth)
+
+New module: `apps/web/lib/packet/career-packet.ts` — **pure transforms, no fetches, no writes** (same discipline as `lib/issuer-verification/*`).
+
+```ts
+// All functions are pure: (PassportData [, opts]) => value. No I/O.
+
+export interface CareerPacketModel {
+  entityId: string;
+  generatedFor: { displayName: string; npi: string | null; specialty: string | null };
+  executive: ExecutiveSummary;
+  identity: IdentitySummaryView;
+  readiness: ReadinessView;
+  sources: VerificationSourceRow[];
+  evidence: EvidenceSummaryView;
+  recruiter: RecruiterRollup;
+  employer: EmployerView;
+  trustSignals: TrustSignalsView | null;   // null when trustPosture absent
+  missingEvidence: MissingEvidenceItem[];
+  recommendations: Recommendation[];
+  footer: { lineageKey: string | null; lastCheckedAt: string | null; degraded: boolean };
+}
+
+export function buildCareerPacket(
+  passport: PassportData,
+  opts?: { audience?: 'recruiter' | 'employer' | 'clinician' }, // changes emphasis only, never truth
+): CareerPacketModel;
+
+// --- the four NET-NEW derivations (everything else is field projection) ---
+
+// G2: 3-line "who / ready? / one blocker"
+export function deriveExecutiveSummary(p: PassportData): ExecutiveSummary;
+
+// G3: ready | needs_review | blocked | missing_evidence  (+ short reason)
+export type RecruiterStatus = 'ready' | 'needs_review' | 'blocked' | 'missing_evidence';
+export function deriveRecruiterRollup(p: PassportData): RecruiterRollup; // { status: RecruiterStatus; headline; reasons[] }
+
+// G5: honest gaps from sourceCoverage.summary buckets, in human copy
+export function deriveMissingEvidence(p: PassportData): MissingEvidenceItem[];
+
+// G4: clinician-actionable, ordered by readiness.nextActions priority
+export function deriveRecommendations(p: PassportData): Recommendation[];
+```
+
+### 4.1 `deriveExecutiveSummary` rules
+
+- Line 1: `{displayName}, {specialty}` — identity, honestly stated (or "Identity unavailable").
+- Line 2: maps `readiness.status` → plain verdict: `DECISION_GRADE`→"Source-backed and review-ready", `PARTIAL`→"Partially checked — review recommended", `CHECKING`→"Checks in progress", `BLOCKED`→"Blocked — see blockers".
+- Line 3: the single highest-priority item from `readiness.blockers[0] ?? readiness.gaps[0] ?? nextActions[0]`, or "No blockers on file."
+
+### 4.2 `deriveRecruiterRollup` rules (the W210-2 primitive)
+
+Deterministic precedence (first match wins):
+1. any `readiness.blockers[]` **or** `trustPosture.blockers[]` non-empty → **`blocked`**
+2. `readiness.status === 'CHECKING'` **or** any `sourceCoverage` check in `reviewRequired` → **`needs_review`**
+3. `sourceCoverage.summary` has `gated`/`accessRequired`/`notDecisionGrade`/missing entries → **`missing_evidence`**
+4. `readiness.status === 'DECISION_GRADE'` and no blockers → **`ready`**
+5. else → **`needs_review`** (never default to `ready`)
+
+This is the same status surfaced on the W210-2 Recruiter Summary Card — define it here once and reuse.
+
+### 4.3 Honesty invariants (enforced inside the module, tested)
+
+- `deriveRecruiterRollup` may return `ready` **only** when `readiness.status === 'DECISION_GRADE'` and zero blockers. Unit-tested against a partial fixture to prove it never green-lights partial coverage.
+- No derivation upgrades a source state. `stale` stays `stale`; `gated` stays `gated`.
+- No derivation invents a `trustPosture.band` when `trustPosture` is absent.
+
+---
+
+## 5. Export gating (carried from existing system)
+
+The PDF path **reuses** `resolveEmployerPacketExportGate(passport)` unchanged:
+
+- `DECISION_GRADE` readiness + clean sources → `allowed` → PDF with `X-VitalCV-Export-Gate: allowed`.
+- partial / blockers / stale / gated → `blocked` → 409 + `replayAttribution` (lineageKey).
+
+**The screen renders even when the PDF is gated** — a recruiter can read a partial packet on `/packet/[entityId]`, but the downloadable PDF is withheld until decision-grade. The export button reflects gate state ("PDF available" vs. "Resolve blockers to export"). This keeps the partial-stays-partial boundary intact while still showing value.
+
+---
+
+## 6. Test plan (for W200-3/4)
+
+| Test | Asserts |
+|---|---|
+| `career-packet-derive.test.ts` | recruiter rollup never returns `ready` for a `PARTIAL` fixture; exec summary surfaces the top blocker; missing-evidence buckets map from `summary` |
+| `career-packet-honesty.test.ts` | no bare `Verified`; rendered output passes the banned-string set; degraded banner present when `_degraded` |
+| `packet-route.test.ts` | `/packet/[entityId]` renders all ten sections from a fixture; collapses empty sections to honest empty states; 404 on missing entity |
+| `packet-pdf.test.ts` | PDF model has all ten sections; export gate blocks a partial fixture (409); SHA-256 hash deterministic |
+| `pnpm check:claims` | green on the new route + components |
+
+Render server components via `renderToStaticMarkup` (existing pattern, `issuer-receipt-candidate.test.ts`). Vitest 4.x.
+
+---
+
+## 7. Done-criteria check (W200-2)
+
+- [x] Full packet structure defined — §1 (ten sections + footer).
+- [x] Rendering requirements documented — §3 (shared / screen / PDF).
+- [x] Data requirements documented — §2 (input, required/optional, degraded behavior) + §4 (derivation API).
+
+---
+
+## 8. Handoff to W200-3
+
+Builder starts with: create `apps/web/lib/packet/career-packet.ts` (pure module + the four derivations + unit tests), **then** the `/packet/[entityId]` route composing existing components. PDF (W200-4) extends the model afterward through the same module. The wave is **assembly + honest framing**, not new infrastructure — no source checks, no writes, no new auth.

--- a/docs/wave200/passport-gap-analysis.md
+++ b/docs/wave200/passport-gap-analysis.md
@@ -1,0 +1,178 @@
+# W200-1 — Passport Architecture Gap Analysis
+
+**Wave:** 200 (Revenue Wedge Extraction)
+**Deliverable target:** the *Verified Clinician Career Packet* — a read-only, shareable, source-backed evidence artifact at `/packet/[entityId]` plus a PDF.
+**Date:** 2026-06-20
+**Status:** analysis complete — gates W200-2 (spec), W200-3 (UI), W200-4 (PDF).
+
+---
+
+## 0. Headline finding
+
+**The passport substrate is already ~80% of the Career Packet.** The roadmap is written as if packet generation needs net-new data plumbing; it does not. VitalCV already ships:
+
+- a hydrated, NPI/entity-keyed `PassportData` contract with identity, authority, training, standing, readiness, source-coverage, and trust-posture dimensions;
+- a working readiness engine (`computeReadiness` / `computeDeterministicTrustReadiness`) with a defensible score, blockers, gaps, and next-actions;
+- a canonical source-coverage state model (`checked / stale / pending / gated / unavailable / accessRequired / reviewRequired / notDecisionGrade / previewOnly`) with freshness and provenance;
+- a **gated PDF exporter** (`@react-pdf/renderer`) behind `/api/export/packet?npi=` with a real export-gate (`resolveEmployerPacketExportGate`);
+- an **employer review surface** at `/review/[entityId]` with share-token (`chk_*`) resolution.
+
+The actual W200 gap is **not data** and **not export plumbing**. It is **a single read-only assembly surface** (`/packet/[entityId]`) that composes existing data into the six roadmap-named sections (Executive / Identity / Readiness / Verification / Evidence / Recruiter / Employer views) and the **recruiter-readable framing + recommendations layer**, which does not exist yet.
+
+This changes the W200 plan from "build a generator" to "**assemble + frame existing primitives, honestly gated**."
+
+---
+
+## 1. Existing data — what we already have
+
+### 1.1 Canonical passport contract
+
+`apps/web/lib/trust/passport-contract.ts` → `PassportData`:
+
+| Dimension | Fields (abridged) | Packet section it feeds |
+|---|---|---|
+| `identity` | `displayName, specialty, entityType, status, npi` | Identity Summary |
+| `authority` | `credentials[] {domain, type, status, jurisdiction, issuedAt, expiresAt, verifiedAt, stale, confidenceLabel, reviewRequired}`, `summary {active, expired, stale, missing}` | Credential Readiness, Verification Sources |
+| `training` | `records[] {recordType, degreeOrTitle, programName, institutionName, endYear, completed, verificationLevel}` | Evidence Summary |
+| `standing` | `exclusionStatus, licensureStatus, deaStatus, pecosEnrollmentStatus, negativeFindings[]` | Trust Signals, Credential Readiness |
+| `readiness` | `status (DECISION_GRADE\|PARTIAL\|CHECKING\|BLOCKED), score 0-100, level, blockers[], gaps[], estimatedStartDays, nextActions[]` | Credential Readiness, Recommendations |
+| `sources` / `sourceCoverage` | `checks[] {sourceId, state, reason, checkedAt, observedAt, expiresAt, artifactId, sourceUrl, checksum, proof}`, `summary` | Verification Sources, Missing Evidence |
+| `trustPosture` | `band, bandLabel, score, dimensions[], freshness, safeToRelyOnNow[], missingItems[], blockers[]` | Trust Signals |
+| `truth` | `CanonicalTruthSet {identity, safety, authority, eligibility}` | Trust Signals |
+| `lineageKey` | deterministic replay hash | Audit / provenance footer |
+| `_degraded` | incomplete-hydration flag | honesty banner |
+
+### 1.2 Entity identity & data flow
+
+- **NPI-keyed** (`packages/ingest/npi.ts` — Luhn-validated, CMS NPPES live fetch) **and entityId-keyed** (UUID v4).
+- Backend: `GET /api/passport/npi/:npi` and `GET /api/passport/entity/:id` (`apps/api/backend/src/routes/passportEntity.ts`) return fully-hydrated `PassportData`.
+- Web proxy + degraded fallback: `apps/web/app/api/passport/npi/[npi]/route.ts` (NPPES-only hydration if backend down → sets `_degraded`).
+- Fixtures: `tests/fixtures/clinician.ts`.
+
+### 1.3 Readiness engine (real, not mock)
+
+- `apps/api/backend/src/services/verticals/readiness/readinessEngine.ts` → `computeReadiness()`.
+- `apps/api/backend/src/services/trust/trustCore.ts` → `computeDeterministicTrustReadiness()`, `deriveReadinessState()`, `deriveTrustBandFromReadiness()`.
+- Weighted dimensions: identity 20 / exclusion 30 / licensure 30 / enrollment 20 = 100.
+- Endorsement-timeline logic with compact-state awareness (`endorsementDelays.ts`) → `estimatedStartDays` / `clearToStartDate`.
+
+### 1.4 Source coverage & live sources
+
+- State vocabulary in `packages/trust-state/sourceCoverage.ts`; **only `checked` is decision-grade**.
+- Live launch-spine sources: `NPPES_API`, `NPPES_BULK`, `OIG_LEIE`, `PECOS_PUBLIC` (decision-grade); `DOCTORS_CLINICIANS` (enrichment, non-decision-grade). Catalog: `apps/api/backend/src/services/identity/sourceCatalog.ts`.
+- Mock/preview detection: `artifactLooksMock()` — keeps synthetic payloads out of decision-grade scoring.
+
+### 1.5 PDF export (already gated and shipping)
+
+- Renderer: `apps/web/lib/export/employer-proof-packet-pdf.tsx` → `renderEmployerProofPacketPdf()` (`@react-pdf/renderer`, SHA-256 packet hash).
+- Gate: `apps/web/lib/export/export-gating.ts` → `resolveEmployerPacketExportGate()` blocks on non-decision-grade readiness, blockers, stale/gated/missing sources; emits `survivabilityScore` + `replayAttribution`.
+- Route: `apps/web/app/api/export/packet/route.ts` (`GET ?npi=`, Clerk-gated, returns `application/pdf` with `X-VitalCV-Export-Gate*` headers).
+- Filename: `vitalcv-employer-packet-<npi>.pdf`.
+
+### 1.6 Reusable UI inventory (immediately composable for `/packet`)
+
+| Component | Path | Use in packet |
+|---|---|---|
+| `PassportTrustPosture` | `components/passport/PassportTrustPosture.tsx` | Trust Signals block (bands, dimensions, safe/blockers/review/stale/missing) |
+| `TrustStatusBadge` | `components/ui/trust-status-badge.tsx` | per-source / per-credential status chips |
+| `CandidateResultCard` | `components/employer/CandidateResultCard.tsx` | Recruiter-view candidate card (CRS ring, drivers, credentials) |
+| `TrustStatePanel` | `components/employer/TrustStatePanel.tsx` | Employer-view "Start Ready" + blocking reasons |
+| `CredentialReadinessCard` | `components/clinician/CredentialReadinessCard.tsx` | Credential Readiness section |
+| `CRSRing` | `components/ui/*` | score visualization |
+| `Card / GlassCard / Badge` | `components/ui/*` | layout + status primitives |
+| `LaneHealthMount` | `components/source-health/LaneHealthMount.tsx` | source-health strip |
+| `SharePacketModal` | `components/*` | shareable-link affordance (W210-4 hook) |
+
+---
+
+## 2. Missing data / components — the real W200 gap
+
+| # | Gap | Severity | Notes |
+|---|---|---|---|
+| G1 | **No `/packet/[entityId]` route.** Packet exists only as an API-only PDF. | **P0** | This is the W200-3 deliverable. No new auth, no wallet dep — server-fetch `PassportData` and compose. |
+| G2 | **No "Executive Summary" synthesizer.** Roadmap wants a one-glance verdict; `readiness` + `trustPosture` exist but nothing renders the 3-sentence "who is this / are they ready / what's missing" header. | **P0** | Pure derivation from existing fields. No new data. |
+| G3 | **No "Recruiter View" framing layer.** `CandidateResultCard`/`TrustStatePanel` are *employer-review* oriented (match drivers, CRS). Recruiter wants ready / needs-review / blocked / missing-evidence at a glance (W210-2). | **P0** | Derivable from `readiness.status` + `trustPosture.band` + `sourceCoverage.summary`. |
+| G4 | **No "Recommendations / next steps" presentation.** `readiness.nextActions[]` and `gaps[]` exist as data but aren't surfaced as a clinician-actionable list in a packet context. | **P1** | Render-only. |
+| G5 | **No "Missing Evidence" honest-gap panel** assembled from `sourceCoverage.summary` (gated / stale / accessRequired / notDecisionGrade buckets) into human copy. | **P1** | `statusCopy.ts` partially exists; needs packet-context copy. |
+| G6 | **PDF model ≠ packet sections.** `EmployerProofPacketPdfModel` covers identity + source table + hash, **not** the six roadmap sections (no recruiter view, no recommendations, no evidence summary). | **P1** | W200-4 must extend the PDF model to match the W200-2 spec, reusing the same derivation functions as the UI (single source of truth). |
+| G7 | **No entity-keyed export.** Export route is `?npi=` only; `/packet/[entityId]` needs an entityId→PDF path (or resolve entityId→npi server-side). | **P1** | Small route addition. |
+| G8 | **Honesty/banned-string surface.** New copy in packet sections must pass `pnpm check:claims` + `banned-verified-label.test.ts`. No bare `Verified`; gated/stale must read as gated/stale. | **P0 (constraint)** | Not a feature gap — a guardrail every new string crosses. |
+
+**What is explicitly NOT missing** (do not rebuild): the readiness math, the source-coverage model, the PDF engine, the export gate, the share-token mechanism, the trust-posture renderer.
+
+---
+
+## 3. Reusable APIs / services / UI (summary)
+
+**APIs ready to extend, not build:**
+- `GET /api/passport/entity/[id]` — packet data fetch.
+- `GET /api/passport/npi/[npi]` — NPI path + degraded fallback.
+- `GET /api/export/packet?npi=` — PDF (extend to entityId, extend model per W200-2).
+- `/review/[entityId]` + share-token (`chk_*`) resolution — sharing pattern to reuse for W210-4.
+
+**Services ready to reuse:** `resolveEmployerPacketExportGate`, `renderEmployerProofPacketPdf`, `computeDeterministicTrustReadiness`, `resolveCanonicalSourceCoverageState`, `statusCopy`.
+
+**UI ready to reuse:** see §1.6.
+
+**Net-new to build in W200:** one route (`/packet/[entityId]`), ~4 derivation helpers (executive summary, recruiter-status rollup, recommendations list, missing-evidence copy), and the extended PDF model — all pure transforms over `PassportData`, sharing one derivation module between UI and PDF.
+
+---
+
+## 4. Dependency diagram
+
+```mermaid
+flowchart TD
+  NPI[NPI / entityId] --> INGEST[packages/ingest/npi.ts\nLuhn + NPPES live]
+  INGEST --> BACKEND[GET /api/passport/:id\npassportEntity.ts]
+  BACKEND --> ENGINE[Readiness engine\ntrustCore.computeDeterministicTrustReadiness]
+  ENGINE --> PASSPORT[(PassportData\npassport-contract.ts)]
+  SRC[Source catalog\nNPPES/OIG/PECOS] --> COVERAGE[sourceCoverage state model\nchecked/stale/gated/...]
+  COVERAGE --> PASSPORT
+
+  PASSPORT --> DERIVE{NEW: packet derivation\nexec summary / recruiter rollup\n/ recommendations / missing-evidence}
+
+  DERIVE --> UI[NEW: /packet/[entityId]\nread-only assembly\nreuses PassportTrustPosture,\nCandidateResultCard, CRSRing]
+  DERIVE --> PDFMODEL[EXTEND: EmployerProofPacketPdfModel]
+
+  PDFMODEL --> GATE[resolveEmployerPacketExportGate\nDECISION_GRADE only]
+  GATE -->|allowed| PDF[renderEmployerProofPacketPdf\n@react-pdf + SHA-256]
+  GATE -->|blocked| BLOCK[409 + replayAttribution]
+
+  UI --> SHARE[Reuse share-token chk_*\n→ W210-4]
+  UI -.->|export button| PDFMODEL
+
+  classDef new fill:#1b5e20,color:#fff,stroke:#0a3d12;
+  classDef extend fill:#5d4037,color:#fff,stroke:#3e2723;
+  class DERIVE,UI new;
+  class PDFMODEL,GATE extend;
+```
+
+Legend: green = net-new (W200), brown = extend existing, uncolored = already shipping.
+
+---
+
+## 5. Constraints carried into W200-2/3/4 (doctrine compliance)
+
+1. **Partial stays partial** (Trust Graph Rule 5). The packet may render a PARTIAL readiness; it may never present partial as decision-grade. Export gate already enforces this — the UI must visually match.
+2. **No bare `Verified`** and **no banned strings**. Every new packet string passes `pnpm check:claims` + `banned-verified-label.test.ts`. Gated/stale/unknown render honestly; revoked fails closed.
+3. **Issuer-verification helpers stay pure.** The derivation module is a pure transform over `PassportData` — no fetches, no audit writes, mirroring `receiptCandidate.ts` / `policyReview.ts` discipline.
+4. **Single derivation source of truth.** UI and PDF consume the *same* helper functions so the screen and the PDF can never disagree (current employer-packet code already keeps PDF derivation centralized — extend, don't fork).
+5. **Zero PHI on any export.** Packet carries source-backed credential evidence only.
+6. **Canonical path preserved:** Recognition → Acceptance → Start. Packet is the shareable artifact in that path, not a new product surface.
+
+---
+
+## 6. Done-criteria check (W200-1)
+
+- [x] Complete architecture map — §1 (data, identity, engine, sources, PDF, UI inventory).
+- [x] Reusable components identified — §1.6, §3.
+- [x] Missing components documented — §2 (G1–G8 with severity).
+- [x] Dependency diagram included — §4.
+
+## 7. Recommended sequencing into W200-2
+
+1. **W200-2 spec** defines the six packet sections as pure functions of `PassportData` and pins the derivation module API (one signature reused by UI + PDF).
+2. **W200-3 UI** builds `/packet/[entityId]` from existing components + the new derivation helpers; honest gating visually mirrors the export gate.
+3. **W200-4 PDF** extends `EmployerProofPacketPdfModel` to the same six sections via the shared derivation module; adds entityId→export path.
+
+The critical insight for the builder: **W200 is an assembly + framing wave, not a data wave.** Estimate is dominated by copy/honesty review and the recruiter-framing derivation, not by new infrastructure.

--- a/docs/wave205/implementation-report.md
+++ b/docs/wave205/implementation-report.md
@@ -1,0 +1,108 @@
+# W205 — Career Packet Implementation Report
+
+**Wave:** 205 (Career Packet Implementation, P0)
+**Branch:** `wave/career-evidence-network-alignment`
+**Date:** 2026-06-20
+**Status:** built + tested locally. Not committed/merged — Codex SAFE verdict still required before any `gh pr merge` (doctrine).
+
+---
+
+## Outcome
+
+A recruiter can open `/packet/[entityId]` and answer all five success-criteria questions on one screen:
+
+1. **Who is this clinician?** — Executive Summary + Identity
+2. **What evidence exists?** — Verification Sources + Evidence
+3. **What evidence is missing?** — Missing Evidence
+4. **Are they ready?** — Recruiter status chip + Credential Readiness
+5. **Can I move them forward?** — Employer View + gated PDF export
+
+The UI and the PDF consume the **same** derivation layer (`lib/packet/career-packet.ts`), so the screen and the document cannot disagree. `READY` is provably reachable only for decision-grade passports with zero blockers.
+
+---
+
+## Files added
+
+| File | Purpose | Wave item |
+|---|---|---|
+| `apps/web/lib/packet/career-packet.ts` | Pure derivation layer — `buildCareerPacket` + `deriveExecutiveSummary` / `deriveRecruiterRollup` / `deriveMissingEvidence` / `deriveRecommendations`. Single source of truth for UI + PDF. | W205-1, W205-3 |
+| `apps/web/app/packet/[entityId]/page.tsx` | Server route (thin), `force-dynamic`. | W205-2 |
+| `apps/web/app/packet/[entityId]/PacketClient.tsx` | Read-only client renderer of all ten sections + gated export button. No auth, no wallet, no mutations. | W205-2 |
+| `apps/web/__tests__/career-packet-derive.test.ts` | 13 unit tests for the derivation layer + honesty invariants. | W205-1, W205-3 |
+| `apps/web/__tests__/career-packet-pdf.test.ts` | 2 tests: PDF model == `buildCareerPacket`; export gate still blocks partial/gated. | W205-4 |
+| `docs/wave205/packet-demo-walkthrough.md` | NPI → Passport → Packet → PDF → Employer Review demo script. | W205-5 |
+| `docs/wave205/implementation-report.md` | This report. | output |
+
+## Files modified
+
+| File | Change | Wave item |
+|---|---|---|
+| `apps/web/lib/export/employer-proof-packet-pdf.tsx` | Extended `EmployerProofPacketPdfModel` with `careerPacket: CareerPacketModel` (built via `buildCareerPacket`); rendered Recruiter View / Credential Readiness / Missing Evidence / Recommendations sections from it. Footer copy "Verified by VitalCV" → "Source-backed by VitalCV". No change to existing `sourceRows` logic. | W205-4 |
+
+---
+
+## Routes added
+
+- `GET /packet/[entityId]` (UI) — read-only Career Packet. Accepts entityId (UUID) or 10-digit NPI via the existing `fetchPassportEntity` path (`/api/passport/entity/[id]` or `/api/passport/npi/[npi]`).
+
+No API route was changed. `GET /api/export/packet?npi=` is unchanged — its PDF output now includes the career sections because `renderEmployerProofPacketPdf` builds from the extended model. The existing export gate (`resolveEmployerPacketExportGate`) is untouched.
+
+---
+
+## Tests added / passing
+
+| Suite | Tests | Result |
+|---|---|---|
+| `career-packet-derive.test.ts` | 13 | ✅ |
+| `career-packet-pdf.test.ts` | 2 | ✅ |
+| `employer-proof-packet.test.ts` (existing, regression) | 2 | ✅ |
+| `export-packet-route.test.ts` (existing, regression) | 6 | ✅ |
+| `employer-review-proxy.test.ts` (existing, regression) | 15 | ✅ |
+| `banned-verified-label.test.ts` (existing, regression) | 1 | ✅ |
+
+**Key honesty assertions proven:**
+- `deriveRecruiterRollup` returns `ready` **only** for `DECISION_GRADE` with zero blockers; a `PARTIAL` fixture never returns `ready`.
+- Readiness blockers force `blocked` even when status is `DECISION_GRADE`.
+- `reviewRequired` coverage → `needs_review`; `gated` coverage → `missing_evidence`.
+- Serialized packet contains no bare `"Verified"` status label.
+- Degraded snapshots are flagged (`footer.degraded`).
+
+---
+
+## Validation performed
+
+| Check | Command | Result |
+|---|---|---|
+| Unit + regression tests | `pnpm --filter @vitalcv/web exec vitest run …` | 38/38 pass across the 5 impacted suites |
+| Public-claims guard | `pnpm check:claims` | PASS — 20 phrases checked, 0 hits on new surfaces |
+| Bare-"Verified" guard | `vitest run __tests__/banned-verified-label.test.ts` | PASS |
+| Typecheck | `tsc --noEmit` (apps/web) | exit 0, 0 errors |
+| Route inventory | manual | `/passport`, `/passport/[id]`, `/packet/[entityId]`, `/api/export/packet`, `/review/[entityId]` all present — no broken links in the demo path |
+
+---
+
+## Acceptance-criteria check
+
+- **W205-1** ✓ pure functions, no side effects, unit tested, same output used by UI and PDF (`career-packet-pdf.test.ts` asserts `model.careerPacket` deep-equals `buildCareerPacket(passport)`).
+- **W205-2** ✓ loads existing PassportData via `fetchPassportEntity`, uses derivation layer, recruiter- and employer-readable, read-only, no auth/wallet changes.
+- **W205-3** ✓ recruiter rollup with four states; `READY` requires decision-grade + zero blockers; partial never appears ready; unit tested.
+- **W205-4** ✓ extends `/api/export/packet` PDF via `career-packet.ts`; same data as UI; no duplicate logic for new sections; export gate preserved.
+- **W205-5** ✓ demo walkthrough doc; under-3-minute path; no dead ends; no broken routes.
+- **W205-6** ✓ `pnpm check:claims` clean; no partial data represented as complete (partial-stays-partial enforced in both renderers); trust posture preserved.
+
+---
+
+## Remaining gaps / not done in this wave
+
+1. **No `next build` run.** Local validation was tests + `tsc --noEmit` + `check:claims`. A full `pnpm turbo run build --filter @vitalcv/web` should run in CI before merge (it enforces TS + ESLint).
+2. **Export route is still NPI-only.** `/packet/[entityId]` resolves the export link from `model.generatedFor.npi`; an entity that has no NPI cannot export a PDF (UI shows the gated message). A future `?entityId=` export path is deferred (was W200-1 gap G7, non-blocking for the demo).
+3. **Share link is not wired.** The packet has no "share internally" affordance yet — that is W210-4 (recruiter share links), which reuses the existing `chk_*` token mechanism.
+4. **No visual/QA pass on a live render.** Components use existing Tailwind tokens and primitive patterns but have not been screenshotted in a running app; recommend a Browser/Cowork QA pass per the operating stack.
+5. **PDF sections are text-only.** The new PDF sections render as plain `@react-pdf` text blocks (functional, not styled to match the hero table). Visual polish deferred.
+6. **Codex verification + merge.** Per doctrine, a real `codex exec` SAFE verdict (implementation / diff / copy audits) is required before `gh pr merge`. Not yet run.
+
+---
+
+## Suggested next step
+
+Run `pnpm turbo run build --filter @vitalcv/web` in CI, then a Codex audit on the diff. After SAFE, the recruiter primitive (`deriveRecruiterRollup`) is ready to be lifted directly into **W210-2 (Recruiter Summary Card)** with no redefinition.

--- a/docs/wave205/packet-demo-walkthrough.md
+++ b/docs/wave205/packet-demo-walkthrough.md
@@ -1,0 +1,53 @@
+# W205-5 — Career Packet Demo Walkthrough
+
+**Wave:** 205 (Career Packet Implementation)
+**Goal:** demonstrate recruiter value in under 3 minutes — no dead ends, no broken routes.
+**Date:** 2026-06-20.
+
+The flow is **NPI → Passport → Packet → PDF → Employer Review**. Every step below is a real, shipping route in `apps/web`.
+
+---
+
+## The 3-minute path
+
+| # | Step | Route | What the audience sees |
+|---|---|---|---|
+| 1 | **Enter NPI** | `/passport` | Public, no account. Live NPPES ingest with a 30-second result. |
+| 2 | **Read the passport** | `/passport/[id]` (entityId) | Identity confirmed against NPPES, sanctions checked via OIG, readiness status generated. |
+| 3 | **Open the Career Packet** | `/packet/[entityId]` | The recruiter `<30s` scan: name + specialty, a recruiter status chip (READY / NEEDS REVIEW / BLOCKED / MISSING EVIDENCE), then ten sections — Executive, Identity, Readiness, Verification Sources, Evidence, Recruiter View, Employer View, Trust Signals, Missing Evidence, Recommendations. |
+| 4 | **Export the PDF** | `GET /api/export/packet?npi=<npi>` (button on the packet) | When readiness is source-backed and unblocked, the **Download Career Packet (PDF)** button is live. When it is not, the packet still renders and the button reads "PDF export unlocks once readiness is source-backed and blockers are resolved." The export gate (`resolveEmployerPacketExportGate`) is unchanged — partial coverage fails closed. |
+| 5 | **Hand to employer review** | `/review/[entityId]` | The employer review surface (supports entityId and `chk_*` share tokens) with the start-ready verdict and blocking reasons. |
+
+---
+
+## The five questions a recruiter can answer on `/packet/[entityId]` alone
+
+1. **Who is this clinician?** → Executive Summary + Identity (NPI, specialty, NPPES attribution).
+2. **What evidence exists?** → Verification Sources + Evidence sections.
+3. **What evidence is missing?** → Missing Evidence section (gated / stale / access-required, in plain copy).
+4. **Are they ready?** → Recruiter status chip + Credential Readiness (score, status, time-to-start).
+5. **Can I move them forward?** → Employer View (start-ready verdict, what to request) + the PDF export.
+
+No other screen is required to answer all five.
+
+---
+
+## Demo honesty notes (say these out loud)
+
+- **READY only means decision-grade with zero blockers.** A partial passport never shows READY — it degrades to NEEDS REVIEW or MISSING EVIDENCE. This is unit-tested (`career-packet-derive.test.ts`).
+- **The screen shows value even when the PDF is withheld.** A recruiter can read a partial packet; the downloadable PDF stays gated until the evidence is decision-grade. Partial-stays-partial is preserved end-to-end.
+- **Source states are reported honestly** — checked, gated, stale, or unknown — never as a guarantee. Acceptance is verifier-policy dependent.
+
+---
+
+## Route health (no broken routes / no dead ends)
+
+| Route | File | Status |
+|---|---|---|
+| `/passport` | `apps/web/app/passport/page.tsx` | existing |
+| `/passport/[id]` | `apps/web/app/passport/[id]/page.tsx` | existing |
+| `/packet/[entityId]` | `apps/web/app/packet/[entityId]/page.tsx` | **new (W205-2)** |
+| `GET /api/export/packet` | `apps/web/app/api/export/packet/route.ts` | existing (PDF now carries career sections) |
+| `/review/[entityId]` | `apps/web/app/review/[entityId]/page.tsx` | existing |
+
+Every step links forward; the packet's "Packet not available" and degraded states route back to `/passport` so the demo never dead-ends.

--- a/docs/wave215/C1-implementation-analysis.md
+++ b/docs/wave215/C1-implementation-analysis.md
@@ -1,0 +1,94 @@
+# W215-C1 — Implementation Analysis (Repository Discovery)
+
+**Wave:** 215 (Career Evidence Foundation) · **Role:** Claude Code
+**Date:** 2026-06-20
+**Scope:** how today's Passport evolves into the Career Evidence Network — *implementation strategy only, no doctrine, no redesign.*
+
+---
+
+## 0. Thesis
+
+**The Career Evidence Network is ~70% already in the repository — as primitives, not as a named layer.** Evidence objects, professional-memory timelines, a graph engine, and entity/relationship persistence all exist today under different names. The W220–270 job is **unification, naming, and a thin read-API facade** over these primitives — *not* building a new platform. This is the single most important input to the roadmap: it converts "build the Career Evidence Network" into "expose and unify what already verifies clinicians."
+
+The recruiter value shipped in W205 (`/packet/[entityId]`, `deriveRecruiterRollup`) must be preserved as the stable read-surface while the substrate is unified underneath.
+
+---
+
+## 1. Existing evidence-like structures (already in repo)
+
+| Concept | Where | Notes |
+|---|---|---|
+| **Atomic claim** | `packages/source-adapters/src/claim-engine.ts` → `Claim`; persisted as `ClaimRecord` (Prisma) | claimId, claimType, value, source, observedAt, confidence, trustTier, validFrom/validUntil, supersededBy. This is already an evidence object. |
+| **Source check result** | `packages/source-adapters/src/types.ts` → `SourceCheckResult` | sourceId, laneType, status, claims[], limitations[], matchBasis, rawHash, parserVersion. |
+| **Cryptographic receipt** | `ProofManifest.receipts` (`SourceReceipt`); persisted as `VerificationReceiptRecord` + `PsvReceipt` (Prisma) | receiptId, rawHash, checksum, integrityHash, rawArtifactRef (S3/IPFS), trustTier, expiresAt. |
+| **Multi-source artifact** | Prisma `VerificationArtifact` | source, status, checksum, verifiedAt, expiresAt, lifecycleState, revokedAt, supersededByArtifactId, generation — full lifecycle + supersession already modeled. |
+| **Canonical truth** | `packages/trust-state` → `CanonicalTruth` / `CanonicalTruthSet` | identity/safety/authority/eligibility dimensions, decisionGrade, coverage. |
+| **Source coverage** | `packages/trust-state` → `CanonicalSourceCoverage` | state, freshness window, provenance (artifactIds, receiptIds, checksum, parserVersion). |
+| **Credential** | Prisma `VcvCredential` | domain (NPI_IDENTITY, STATE_LICENSE, BOARD_CERT, DEA, OIG_EXCLUSION), status, verificationLevel, claimValue, artifactIds, jurisdiction. |
+| **Recognition path** | `packages/domain-common/employmentContracts.ts` + Prisma `Recognition`/`Acceptance`/`Start` | the canonical Recognition→Acceptance→Start chain, signed, hash-anchored, type-branded `VerifiedCanonicalPath`. |
+| **Evidence bundle** | `packages/domain-common` → `EvidenceBundleManifest`, `EvidenceBundleResult` | already a "collection of checks" object. |
+| **Career packet (UI)** | `apps/web/lib/packet/career-packet.ts` (W205) | `CareerPacketModel` is an *evidence-collection view* over a passport. |
+
+**Finding:** there is no single `EvidenceObject` type, but there are at least **six** structurally-equivalent evidence representations (`Claim`, `ClaimRecord`, `VerificationArtifact`, `VerificationReceiptRecord`, `PsvReceipt`, `VcvCredential`). They share a common spine: *subject + type + value + source + observedAt + freshness + integrity hash + supersession*.
+
+## 2. Existing professional-memory / timeline structures
+
+| Concept | Where | Ordering key |
+|---|---|---|
+| **Immutable audit log** | `packages/audit/AuditEvent.ts` (27 event types incl. RECOGNITION/ACCEPTANCE/START/PSV_RECEIPT/TRUST_STATE_*) | `occurred_at` (RFC3339), deep-frozen |
+| **Audit timeline + packet** | `packages/audit/AuditScrapbook.ts` → `AuditTimelineEntry`, `AuditPacket` (NCQA-tagged, SHA256 of timeline) | chronological, immutable |
+| **Append-only ingest log** | Prisma `IngestEvent` (unique `(ingestRunId, sequence)`) | `sequence` — guaranteed ordering |
+| **Change events** | Prisma `EntityChangeEvent` (new/updated/deleted/revoked, previous/current value) | `observedAt` |
+| **Watchtower event store** | `core/watchtower/eventStore.ts` → `WatchtowerEvent`, `WatchtowerClaimDelta`, replay-safe hashing | `occurredAt` / `detectedAt` |
+| **Trust history** | `core/investigation/investigationEngine.ts` → `TrustTimelinePoint[]` (score, delta, trigger, band) | `recordedAt` |
+| **Storyline timeline** | `core/storylines/storylineTimeline.ts` → `StorylineTimeline` (origin/update/quiet/escalated events, decay, dedupe by content-hash eventKey) | `occurredAt` |
+| **Trust-state preview** | `packages/trust-state/TrustStateResolver.ts` → `TrustTimelinePreviewEntry`, `audit_timeline.buildTimeline()` | `occurred_at` |
+
+**Finding:** "Professional Memory" is **already an event-sourced reality**, fragmented across `packages/audit`, `core/watchtower`, `core/storylines`, and Prisma append-only tables. A Career Timeline is a *projection/merge* over these, not a new store.
+
+## 3. Existing graph structures
+
+| Concept | Where |
+|---|---|
+| **Production graph schema** | `apps/web/components/graph-system/types.ts` → `GraphNode` (21 node types: clinician, organization, credential, license, receipt, source, claim, artifact, …), `GraphEdge` (35 `EdgeType`s incl. issued_by, verified_by, accepted_by, attested_by, trained_at, works_at, sourced_from, derived_from) |
+| **Graph render components** | `components/graph/TrustGraphPrimary.tsx`, `components/graph/LiveTrustGraph.tsx` |
+| **Backend graph API (live)** | `/api/graph/global|local|mobile`, `/api/graph/node/:id/neighbors`, `/api/graph/search`, `/api/graph/:npi`, `/api/graph/live/:npi`, `/api/graph/ai-links/suggest|apply` (22+ routes) |
+| **Persisted edges** | Prisma `VcvEntityRelationship` (typed: LICENSED_BY, WORKS_FOR, EMPLOYED_BY; confidence, tier, validity dates) |
+| **Doc-grade ontology** | `docs/architecture/vitalcv-knowledge-trust-graph.json` — 94 nodes / 96 edges / 82 rules (documentation-grade only, **not** wired into runtime types) |
+
+**Finding:** the Career Evidence Graph **substrate already exists and serves traffic**. The gap is that its node/edge taxonomy (`graph-system/types.ts`) and the canonical ontology (`knowledge-trust-graph.json`) are not reconciled, and evidence objects are not yet first-class graph nodes everywhere.
+
+## 4. Entity & API substrate
+
+- **Entity:** Prisma `VcvEntity` (deterministic `canonicalId = sha256(entityType + primaryKey)`, npi, metadata), `VcvEntityRole`, `VcvEntityRelationship`, `VcvCredential`. Service: `entityResolutionService.ts`, `passportService.ts`.
+- **Live APIs:** `/api/entity/:id`, `/api/entity/:id/relationships`, `/api/passport/:npi(/trust|/disclose)`, `/api/employer-review/:entityId/*`, `/api/graph/*`, `/api/storylines`, `/api/intelligence/mobility`, `/api/audit/bundle/:npi`.
+- **Versioning:** 15+ `vitalcv.*.v1` schema strings; 53+ Prisma migrations. Established pattern for additive, versioned contracts.
+
+## 5. Reusable primitives (build on, don't replace)
+
+1. `packages/trust-state` factories — `createCanonicalSourceCoverage`, `createCanonicalTruth`, `deriveReadinessState`, freshness/provenance. **The normalization core for any EvidenceObject.**
+2. `ClaimRecord` + `VerificationReceiptRecord` (Prisma) — the canonical persisted evidence + proof pair.
+3. `packages/audit` + `core/watchtower` — the event spine for Professional Memory.
+4. `graph-system/types.ts` + `/api/graph/*` — the graph engine.
+5. `career-packet.ts` (W205) — the recruiter read-view to protect.
+6. `VcvEntity` canonicalId — the stable subject key for evidence/timeline/graph addressing.
+
+## 6. Architectural constraints (must hold across W220–270)
+
+1. **Partial stays partial** (Trust Graph Rule 5) — no aggregation/graph/timeline layer may upgrade proof tier.
+2. **Decision-grade = `checked` only**; gated/stale/notDecisionGrade never count positively (`assertNonGatedIfPositive`).
+3. **Audit writes are server-only, transaction-coupled, append-only, immutable** (deep-frozen; `recordedBy: 'demo'` for demo surfaces).
+4. **Issuer-verification helpers stay pure** — no fetches/writes; EvidenceObject normalizers follow the same rule.
+5. **Recognition→Acceptance→Start is type-branded and immutable** — `VerifiedCanonicalPath` cannot be bypassed.
+6. **Zero PHI on-chain / in exports.**
+7. **Banned strings + no bare `Verified`** — every new public/API string crosses `pnpm check:claims` + `banned-verified-label.test.ts`.
+8. **Recruiter value is the load-bearing surface** — `/packet/[entityId]` + `deriveRecruiterRollup` must not regress while the substrate unifies.
+
+## 7. Migration opportunities (feeds C2–C7)
+
+- **EvidenceObject as a read-facade** over `ClaimRecord`/`VerificationArtifact`/`VcvCredential`/receipts — a normalizer, not a new table (C2, C3).
+- **Career Timeline as a projection** merging `AuditEvent` + `EntityChangeEvent` + `StorylineTimeline` + recognition events by subject + time (C4).
+- **Career Evidence Graph as a typed view** reconciling `graph-system/types.ts` with the canonical ontology and promoting evidence objects to nodes (C5).
+- **Thin read-only APIs** (`/evidence`, `/timeline`, `/recognition`, `/mobility`, `/graph`) that compose existing services — mostly aggregation endpoints (C6).
+
+**Deliverable status:** complete. Proceed to C2 (Evidence Migration Map).

--- a/docs/wave215/C2-evidence-migration-map.md
+++ b/docs/wave215/C2-evidence-migration-map.md
@@ -1,0 +1,72 @@
+# W215-C2 — Evidence Migration Map
+
+**Wave:** 215 · **Depends on:** [C1](./C1-implementation-analysis.md)
+**Date:** 2026-06-20
+
+Maps today's objects to the future evidence model. Verdict per row: **REUSE** (wrap, no schema change), **NORMALIZE** (adapter into EvidenceObject), **CREATE** (genuinely new).
+
+---
+
+## 1. The common evidence spine (already implicit)
+
+Every evidence-like object in the repo shares this shape — the future `EvidenceObject` simply names it:
+
+```
+subjectKey  + evidenceClass + value + source + observedAt + checkedAt
+            + freshnessWindow + integrityHash + trustTier + status
+            + supersession(prev/next) + provenance(artifactIds, receiptIds)
+```
+
+`ClaimRecord` already carries all of these fields. **`EvidenceObject` is `ClaimRecord` + a discriminated `evidenceClass` and a normalized status — not a new store.**
+
+## 2. Object → Evidence mapping
+
+| Today | Future | Verdict | Basis |
+|---|---|---|---|
+| `VcvCredential` (license/board/DEA/NPI/OIG) | `EvidenceObject{class: licensure\|board_cert\|identity\|registration\|exclusion}` | **NORMALIZE** | Has domain, status, verificationLevel, claimValue, artifactIds, jurisdiction. One adapter. |
+| `ClaimRecord` (Prisma) | `EvidenceObject` (canonical persisted form) | **REUSE** | Already the spine. EvidenceObject is a typed view over it. |
+| `VerificationArtifact` | `EvidenceSource` + raw evidence backing an EvidenceObject | **NORMALIZE** | source, checksum, lifecycleState, supersededBy, generation → maps to EvidenceSource + lifecycle. |
+| `VerificationReceiptRecord` / `PsvReceipt` | `EvidenceProof` (the cryptographic backing of an EvidenceObject) | **REUSE** | receiptId, rawHash, checksum, integrityHash, expiresAt — proof layer. |
+| `SourceCheckResult` / `Claim` (adapters) | runtime producer of `EvidenceObject`s | **REUSE** | claim-engine already emits atomic, sourced claims. |
+| `CanonicalSourceCoverage` (trust-state) | `EvidenceStatus` + freshness + provenance on an EvidenceObject | **REUSE** | state vocabulary (checked/stale/gated/…) becomes `EvidenceStatus`. |
+| `CanonicalTruth` (identity/safety/authority/eligibility) | `EvidenceClass` grouping / dimension rollup | **REUSE** | dimensions already classify evidence. |
+| `RecognitionEvent` / `EmployerAcceptance` / `StartAttestation` | `EvidenceObject{class: recognition\|acceptance\|start}` (employment evidence) | **NORMALIZE (read-only)** | Already signed + hash-anchored. Expose as evidence; do NOT relax `VerifiedCanonicalPath` branding. |
+| `AuthorityCredential`, `OPPECaseRecord`, `FPPERecord` | `EvidenceObject{class: privilege\|peer_review}` | **NORMALIZE** | Privileging evidence classes. |
+| `ResearchActivityScore`, `OrcidProfile`, `PubMedArticle`, `ClinicalTrialRecord` | `EvidenceObject{class: research\|publication}` | **NORMALIZE** | Already structured; thin adapters. |
+| `EvidenceBundleManifest` | `EvidenceCollection` (typed bundle) | **NORMALIZE** | Already a collection of checks. |
+| `PassportData` | `EvidenceCollection` (the canonical collection view) | **NORMALIZE** | Passport = the per-entity collection. `career-packet.ts` already projects it. |
+| `CareerPacketModel` (W205) | `EvidenceCollection` recruiter projection | **REUSE** | Keep as the recruiter read-view. |
+
+## 3. EvidenceRelationship mapping
+
+| Today | Future relationship | Verdict |
+|---|---|---|
+| `VcvEntityRelationship` (LICENSED_BY, WORKS_FOR, EMPLOYED_BY) | `EvidenceRelationship` (entity↔entity) | **REUSE** |
+| `GraphEdge.type` (issued_by, verified_by, accepted_by, attested_by, trained_at, sourced_from, derived_from) | `EvidenceRelationship` (evidence↔source / evidence↔entity) | **REUSE** |
+| `ClaimRecord.supersededByClaimId` / `VerificationArtifact.supersededByArtifactId` | `EvidenceRelationship{type: supersedes}` | **REUSE** |
+| `Claim.sourceCheckId`, `VerificationReceiptRecord.claimRecordId` | `EvidenceRelationship{type: proven_by / derived_from}` | **REUSE** |
+
+## 4. What must actually be CREATED (small)
+
+1. **`EvidenceClass` enum** — the unifying discriminator (identity, licensure, board_cert, registration, exclusion, enrollment, recognition, acceptance, start, privilege, peer_review, research, publication, employment). New, but pure type.
+2. **`EvidenceStatus` enum** — a thin re-projection of `CanonicalSourceCoverageState` + lifecycle (active/superseded/revoked/expired). New, but derives from existing vocabularies.
+3. **Normalizer adapters** — pure functions `fromVcvCredential()`, `fromClaimRecord()`, `fromRecognitionEvent()`, `fromVerificationArtifact()`. New code, no new storage.
+4. **`EvidenceCollection` assembler** — `buildEvidenceCollection(entityKey)` composing normalizers (parallels `buildCareerPacket`).
+5. **Thin read APIs** (C6) — aggregation endpoints only.
+
+**Nothing in this list requires a new persistence model in W220.** Storage already exists (`ClaimRecord`, `VerificationArtifact`, receipts, `VcvCredential`, recognition tables). The migration is a *typed facade + adapters*, shippable without a data migration.
+
+## 5. Backwards-compatibility guarantees
+
+- `PassportData`, `career-packet.ts`, `/packet/[entityId]`, `/api/passport/*`, `/api/employer-review/*` **unchanged**. EvidenceObject is additive and read-only in W220.
+- No relaxation of `VerifiedCanonicalPath`, audit immutability, or partial-stays-partial.
+- EvidenceObject adapters are pure (no fetches/writes), mirroring `lib/issuer-verification/*`.
+
+## 6. Sequencing hint for W220
+
+1. Define `EvidenceObject` / `EvidenceClass` / `EvidenceStatus` / `EvidenceRelationship` / `EvidenceSource` types in `packages/domain-evidence` (C3) — types only.
+2. Write the four normalizer adapters + unit tests proving every adapter preserves source state honestly (no upgrade).
+3. `buildEvidenceCollection(entityKey)` over existing services.
+4. `GET /evidence/:entityId` read API returning the collection.
+
+**Deliverable status:** complete. Proceed to C3.

--- a/docs/wave215/C3-domain-evidence-package.md
+++ b/docs/wave215/C3-domain-evidence-package.md
@@ -1,0 +1,142 @@
+# W215-C3 — `packages/domain-evidence` Architecture
+
+**Wave:** 215 · **Depends on:** [C1](./C1-implementation-analysis.md), [C2](./C2-evidence-migration-map.md)
+**Date:** 2026-06-20
+**Status:** implementation-ready architecture. **NO IMPLEMENTATION YET.**
+
+---
+
+## 0. Package intent
+
+`packages/domain-evidence` is a **typed facade + pure normalizers** over evidence that already exists across `packages/domain-common`, `packages/source-adapters`, `packages/trust-state`, `packages/audit`, and the Prisma store. It introduces *no new persistence*. It follows the repo's existing package conventions: `isolatedModules: true`, barrel re-exports with the `type` keyword, ships from `dist/` (turbo-prebuilt like `@vitalcv/trust-state`).
+
+**Hard rule:** every function here is a **pure transform** — no fetches, no DB writes, no audit-event writes (same discipline as `lib/issuer-verification/*`). It normalizes; it never verifies.
+
+## 1. Proposed structures
+
+### `EvidenceObject`
+```ts
+interface EvidenceObject {
+  evidenceId: string;            // stable id (reuse claimId / receiptId / credential id)
+  subjectKey: string;            // VcvEntity.canonicalId or NPI — the addressing key
+  evidenceClass: EvidenceClass;
+  label: string;                 // human label ("California RN License")
+  value: EvidenceValue;          // normalized scalar/record from the source claim
+  status: EvidenceStatus;        // derived, never upgraded
+  source: EvidenceSource;
+  trustTier: string | null;      // reuse existing trustTier vocabulary
+  decisionGrade: boolean;        // === status maps to 'checked'; never widened
+  observedAt: string | null;     // when the source authority last updated
+  checkedAt: string | null;      // when VitalCV checked
+  expiresAt: string | null;      // freshness boundary
+  freshnessWindowHours: number | null;
+  integrityHash: string | null;  // checksum / rawHash / integrityHash
+  provenance: EvidenceProvenance; // artifactIds[], receiptIds[], sourceUrl, parserVersion
+  lifecycle: EvidenceLifecycle;   // active | superseded | revoked | expired
+  supersedes: string | null;      // prior evidenceId
+  supersededBy: string | null;    // newer evidenceId
+}
+```
+
+### `EvidenceClass` (discriminated union — the unifier from C2 §4)
+```ts
+type EvidenceClass =
+  | 'identity' | 'licensure' | 'board_cert' | 'registration' | 'exclusion'
+  | 'enrollment' | 'privilege' | 'peer_review'
+  | 'recognition' | 'acceptance' | 'start' | 'employment'
+  | 'research' | 'publication' | 'training';
+```
+
+### `EvidenceStatus` (re-projection of existing vocabularies — no new states invented)
+```ts
+// 1:1 with CanonicalSourceCoverageState; decision-grade === 'checked' only.
+type EvidenceStatus =
+  | 'checked' | 'stale' | 'pending' | 'gated' | 'unavailable'
+  | 'accessRequired' | 'reviewRequired' | 'notDecisionGrade' | 'previewOnly';
+```
+
+### `EvidenceSource`
+```ts
+interface EvidenceSource {
+  sourceId: string;              // 'NPPES_API', 'OIG_LEIE', 'STATE_BOARD', 'ORCID', …
+  sourceLabel: string;
+  laneType: string | null;       // reuse source-adapters LaneType
+  governance: string | null;     // reuse sourceGovernance (open | gated | human_lookup_only)
+}
+```
+
+### `EvidenceRelationship`
+```ts
+type EvidenceRelationshipType =
+  | 'issued_by' | 'verified_by' | 'derived_from' | 'proven_by'
+  | 'supersedes' | 'affiliated_with' | 'trained_at' | 'works_at'
+  | 'accepted_by' | 'attested_by';   // subset of existing GraphEdge EdgeType
+
+interface EvidenceRelationship {
+  from: string;                  // evidenceId or subjectKey
+  to: string;                    // evidenceId, sourceId, or entity key
+  type: EvidenceRelationshipType;
+  confidence: number | null;
+  observedAt: string | null;
+}
+```
+
+### `EvidenceCollection`
+```ts
+interface EvidenceCollection {
+  subjectKey: string;
+  generatedFor: { displayName: string; npi: string | null };
+  objects: EvidenceObject[];
+  relationships: EvidenceRelationship[];
+  byClass: Record<EvidenceClass, EvidenceObject[]>;  // convenience rollup
+  coverageSummary: Record<EvidenceStatus, string[]>; // reuse summarizeCanonicalSourceCoverage
+}
+```
+
+## 2. Proposed module layout
+
+```
+packages/domain-evidence/
+  src/
+    types.ts                 // the structures above (types only)
+    normalize/
+      fromVcvCredential.ts   // VcvCredential        → EvidenceObject
+      fromClaimRecord.ts     // ClaimRecord          → EvidenceObject
+      fromVerificationArtifact.ts
+      fromReceipt.ts         // VerificationReceiptRecord/PsvReceipt → provenance
+      fromRecognitionPath.ts // Recognition/Acceptance/Start → EvidenceObject (read-only)
+      status.ts              // CanonicalSourceCoverageState → EvidenceStatus (identity map)
+    collection.ts            // buildEvidenceCollection(inputs) — pure assembler
+    index.ts                 // barrel (export type { … })
+  package.json               // name @vitalcv/domain-evidence, build → dist/
+  tsconfig.json              // isolatedModules: true
+```
+
+## 3. Dependencies (consume, never fork)
+
+- `@vitalcv/trust-state` — `CanonicalSourceCoverageState`, `summarizeCanonicalSourceCoverage`, `createCanonicalSourceCoverage`, freshness/provenance helpers. **`EvidenceStatus` is literally the coverage state vocabulary.**
+- `@vitalcv/domain-common` — `RecognitionEvent`/`EmployerAcceptance`/`StartAttestation`, `AuthorityCredential`, PSV contracts.
+- `@vitalcv/source-adapters` — `Claim`, `SourceCheckResult`, `LaneType`.
+- `@vitalcv/audit` — types only (timeline lives in C4, not here).
+
+`domain-evidence` does **not** import Prisma or any app — adapters take already-fetched records as input (purity). The *fetching* lives in app/service code that calls these normalizers (parallels how `career-packet.ts` takes a hydrated `PassportData`).
+
+## 4. Invariants enforced inside the package (unit-tested)
+
+1. **No status upgrade.** `status.ts` is an identity map; a `gated` input can never become `checked`. Tested against a gated fixture.
+2. **decisionGrade ⇔ checked.** `decisionGrade === (status === 'checked')`, never widened (mirrors the issuer truth contract).
+3. **No bare `Verified` label.** `label`/status renders use honest vocabulary; serialized output passes the banned-label assertion.
+4. **Recognition normalizers are read-only.** They never construct a `VerifiedCanonicalPath`; they project an already-verified path into evidence view.
+5. **Pure.** No I/O; deterministic given inputs (no `Date.now()` inside derivations — timestamps come from the records).
+
+## 5. Why a facade, not a new model (decision record)
+
+A new `Evidence` table would duplicate `ClaimRecord`/`VerificationArtifact` and create a dual-write integrity problem against append-only, hash-anchored stores. The facade:
+- ships in W220 with **zero data migration**,
+- keeps a single source of truth for persisted evidence,
+- lets `EvidenceObject` evolve as a *view* while storage stays stable,
+- is reversible (delete the package; nothing downstream breaks because it's additive).
+
+If a future wave needs a materialized evidence index for query performance, that is a separate, gated decision (parallels `evaluateBackendPersistenceReadiness`'s `defer_until_contract_aligned` default) — **not** part of W220.
+
+**Deliverable status:** complete (architecture only). Proceed to C4.

--- a/docs/wave215/C4-timeline-implementation-plan.md
+++ b/docs/wave215/C4-timeline-implementation-plan.md
@@ -1,0 +1,88 @@
+# W215-C4 — Timeline Implementation Plan (Professional Memory)
+
+**Wave:** 215 · **Depends on:** [C1](./C1-implementation-analysis.md)
+**Date:** 2026-06-20
+
+How "Professional Memory" / Career Timeline is represented using **existing** entities, events, and audit structures — no new event store.
+
+---
+
+## 0. Finding
+
+Professional Memory **already exists as event-sourced data**, fragmented across four ordered, append-only sources. A Career Timeline is a **deterministic projection that merges and sorts** these by subject + time. No new write path.
+
+## 1. Source events (all already persisted/ordered)
+
+| Source | Type | Time key | Carries |
+|---|---|---|---|
+| `packages/audit` | `AuditEvent` / `AuditTimelineEntry` | `occurred_at` | RECOGNITION, ACCEPTANCE, START, PSV_RECEIPT, VERIFICATION_*, TRUST_STATE_CHECK/DECAY; NCQA tags; hashAnchor |
+| Prisma | `IngestEvent` | `(ingestRunId, sequence)` | append-only ingest, dedupeKey, payload |
+| Prisma | `EntityChangeEvent` | `observedAt` | new/updated/deleted/revoked claim, previous/current value, severity |
+| `core/watchtower/eventStore.ts` | `WatchtowerEvent` / `WatchtowerClaimDelta` | `occurredAt` / `detectedAt` | CHECK_COMPLETED, CLAIM_CHANGE_DETECTED, ALERT_EMITTED; before/after values; replay-safe hash |
+| `core/storylines/storylineTimeline.ts` | `StorylineTimeline` | `occurredAt` | origin/update/quiet/escalated/resolved; content-hash eventKey; decay |
+| `core/investigation` | `TrustTimelinePoint[]` | `recordedAt` | score, delta, trigger, band |
+| Prisma | `Recognition`/`Acceptance`/`Start` | `recognizedAt`/`acceptedAt`/`attestedAt` | the canonical career milestones |
+
+## 2. The projection: `CareerTimeline`
+
+A pure merge in `packages/domain-evidence` (or a sibling `domain-timeline` module) — **read model only**:
+
+```ts
+type CareerTimelineCategory =
+  | 'identity' | 'verification' | 'recognition' | 'acceptance' | 'start'
+  | 'credential_change' | 'trust_change' | 'alert';
+
+interface CareerTimelineEntry {
+  entryKey: string;            // stable content hash (reuse watchtower/storyline eventKey pattern)
+  subjectKey: string;          // VcvEntity.canonicalId / NPI
+  category: CareerTimelineCategory;
+  occurredAt: string;          // canonical sort key (ISO)
+  title: string;
+  detail: string;
+  evidenceRefs: string[];      // evidenceId / receiptId / artifactId
+  sourceEventType: string;     // origin event type (provenance)
+  immutable: boolean;          // true for audit/recognition-derived entries
+}
+
+interface CareerTimeline {
+  subjectKey: string;
+  entries: CareerTimelineEntry[];   // sorted by occurredAt, then entryKey
+  firstAt: string | null;
+  lastAt: string | null;
+}
+```
+
+### Build algorithm (deterministic)
+1. Pull events for `subjectKey` from each source (audit, change-events, watchtower, storyline, recognition/acceptance/start).
+2. Map each to `CareerTimelineEntry` via per-source adapters (pure).
+3. **Dedupe by `entryKey`** (content hash — reuse `makeEventKey()` / `computeWatchtowerHash()` patterns already in repo).
+4. **Sort by `occurredAt`, tiebreak `entryKey`** (stable, replay-safe).
+5. Return — no writes.
+
+## 3. Why projection, not a new store
+
+- Audit and ingest logs are **immutable + hash-anchored**; a second timeline store would risk divergence and dual-write bugs.
+- The merge is cheap and deterministic; it can be computed on read or cached behind an ETag keyed by `lastAt`.
+- Honors **"absence of a recorded revocation is not a guarantee"** (Trust Graph Rule 35) — the timeline reflects recorded events only and says so.
+
+## 4. Constraints
+
+1. **Immutable entries stay immutable** — audit/recognition entries render with provenance; never edited.
+2. **No PHI** in titles/details.
+3. **Honest gaps** — if a source has no events, the category renders empty, not fabricated.
+4. **Replay-safe ordering** — deterministic given the same event set (no `Date.now()` in the merge).
+5. **Decision-grade not implied by presence** — a timeline entry is a record of a check, not proof of current truth.
+
+## 5. Implementation slices (for W250 Evidence Timeline)
+
+| Slice | Work | Effort |
+|---|---|---|
+| T1 | `CareerTimelineEntry`/`CareerTimeline` types + per-source adapters (pure) | S |
+| T2 | `buildCareerTimeline(events)` merge/dedupe/sort + unit tests (ordering, dedupe, empty) | S–M |
+| T3 | Server aggregator that loads events per subject and calls the merge | M |
+| T4 | `GET /timeline/:entityId` read API (C6) | S |
+| T5 | UI: reuse `AnimatedTimeline` / `LiveStateLog` primitives to render `CareerTimeline` | M |
+
+**Reuses:** `packages/audit`, `core/watchtower`, `core/storylines`, recognition tables, `AnimatedTimeline`/`LiveStateLog` components. **Creates:** one pure merge module + one read route.
+
+**Deliverable status:** complete. Proceed to C5.

--- a/docs/wave215/C5-graph-implementation-plan.md
+++ b/docs/wave215/C5-graph-implementation-plan.md
@@ -1,0 +1,72 @@
+# W215-C5 — Graph Implementation Plan (Career Evidence Graph)
+
+**Wave:** 215 · **Depends on:** [C1](./C1-implementation-analysis.md), [C3](./C3-domain-evidence-package.md)
+**Date:** 2026-06-20
+
+How the Career Evidence Graph layers onto existing entities, trust systems, and APIs.
+
+---
+
+## 0. Finding
+
+**The graph engine already exists and serves traffic.** `apps/web/components/graph-system/types.ts` defines a production `GraphNode` (21 node types) / `GraphEdge` (35 edge types) schema; `/api/graph/*` exposes 22+ routes (global/local/mobile/neighbors/search/live/ai-links); `VcvEntityRelationship` persists typed edges. The Career Evidence Graph is a **typed view + ontology reconciliation**, not a new engine.
+
+## 1. What exists vs. the gap
+
+| Layer | State |
+|---|---|
+| Node/edge schema | `graph-system/types.ts` — rich, production. Includes credential, license, receipt, source, claim, artifact nodes and issued_by / verified_by / accepted_by / attested_by / sourced_from / derived_from edges. |
+| Render | `TrustGraphPrimary.tsx`, `LiveTrustGraph.tsx` (force-sim + canvas). |
+| API | `/api/graph/{global,local,mobile,:npi,live/:npi,node/:id/neighbors,search,ai-links/*}`. |
+| Persisted edges | `VcvEntityRelationship` (LICENSED_BY, WORKS_FOR, EMPLOYED_BY; confidence, tier, validity). |
+| Canonical ontology | `docs/architecture/vitalcv-knowledge-trust-graph.json` — 94 nodes / 96 edges / 82 rules, **documentation-grade only, not wired to runtime types.** |
+| **Gap** | (a) ontology JSON ≠ runtime `graph-system/types.ts` (two unreconciled taxonomies); (b) EvidenceObjects (C3) are not first-class graph nodes everywhere; (c) no single `GET /graph/:entityId` that returns an **evidence-centric** subgraph. |
+
+## 2. Layering approach (additive view, not a rewrite)
+
+The Career Evidence Graph = a **projection of `EvidenceCollection` (C3) onto the existing graph schema**:
+
+```
+EvidenceObject        → GraphNode{ type: mapEvidenceClassToNodeType(class), trustTier, trustBand, layer:'trust' }
+EvidenceSource        → GraphNode{ type: 'source' }
+EvidenceRelationship  → GraphEdge{ type, confidence, layer:'trust' }
+VcvEntity             → GraphNode{ type: 'clinician' | 'organization' }
+VcvEntityRelationship → GraphEdge (already)
+```
+
+`EvidenceClass → NodeType` is a total map onto the existing 21-type vocabulary (licensure→license, board_cert→credential, exclusion→exclusion, recognition→decision/receipt, …). **No new node types required** for the core; only the mapping function is new.
+
+## 3. Ontology reconciliation (load-bearing, do once)
+
+`knowledge-trust-graph.json` is the canonical 82-rule ontology but is doc-only. Plan:
+1. **Do not rewrite** the JSON (CLAUDE.md: add boundaries, never rewrite old ones).
+2. Add a **conformance map** `ontologyNodeId → graphSystemNodeType` as data, plus a test asserting every runtime node type has an ontology home. This makes the JSON *checkable* against runtime without coupling render to it.
+3. Keep the JSON as the authority for *rules* (e.g., "trust container does not upgrade proof tier"); the runtime graph enforces a subset via existing trust-state guards.
+
+## 4. Trust-system integration (reuse, don't re-derive)
+
+- Node trust attributes (`trustTier`, `trustBand`, `trustScore`, `confidence`) come from `CanonicalSourceCoverage` / `CanonicalTruth` already on the EvidenceObject — **no new scoring**.
+- `assertNonGatedIfPositive` continues to guard: a gated EvidenceObject node may not render a positive/decision-grade trust band.
+- Edge `confidence`/`weight` reuse existing `VcvEntityRelationship.confidence` and claim match confidence.
+
+## 5. Constraints
+
+1. **Partial stays partial / no tier upgrade** (Trust Graph Rule, "trust container does not upgrade proof tier") — the graph view must not present a node as more verified than its evidence.
+2. **Edges are evidence-backed** — every trust edge carries `evidenceRefs` (reuse `GraphEvidenceRef`); no unsourced trust edges.
+3. **Provenance ordering preserved** — VERIFIED > USER_ENTERED > INFERRED > UNKNOWN (ontology rule).
+4. **AI-suggested links stay suggestions** — existing `ai-links/suggest` + human `apply` boundary unchanged; suggested edges render as `ai_suggested_link`, never auto-promoted.
+5. **No PHI in node/edge labels.**
+
+## 6. Implementation slices (for W270 / graph wave)
+
+| Slice | Work | Effort |
+|---|---|---|
+| G1 | `mapEvidenceClassToNodeType` + `evidenceCollectionToGraph(collection)` (pure) + tests | S–M |
+| G2 | Ontology conformance map + test (`every runtime NodeType ∈ ontology`) | S |
+| G3 | `GET /graph/:entityId` returning evidence-centric subgraph (compose existing `/api/graph/:npi` + EvidenceCollection) | M |
+| G4 | UI: feed `evidenceCollectionToGraph` output into existing `LiveTrustGraph` | S–M |
+| G5 | Edge evidence-ref backfill audit (flag any trust edge lacking `evidenceRefs`) | M |
+
+**Reuses:** `graph-system/types.ts`, `/api/graph/*`, `VcvEntityRelationship`, trust-state guards, render components. **Creates:** evidence→graph projector + ontology conformance test + one composed route.
+
+**Deliverable status:** complete. Proceed to C6.

--- a/docs/wave215/C6-api-blueprint.md
+++ b/docs/wave215/C6-api-blueprint.md
@@ -1,0 +1,121 @@
+# W215-C6 — API Blueprint
+
+**Wave:** 215 · **Depends on:** [C2](./C2-evidence-migration-map.md)–[C5](./C5-graph-implementation-plan.md)
+**Date:** 2026-06-20
+
+Future read contracts. All are **additive, read-only, versioned** (`vitalcv.*.v1`), composed from existing services. None mutates; none changes an existing route.
+
+---
+
+## 0. Conventions (match the repo)
+
+- Versioned envelopes: every payload carries `schema: 'vitalcv.<name>.v1'` (matches 15+ existing contracts).
+- `entityId` accepts `VcvEntity.canonicalId` **or** 10-digit NPI (matches `fetchPassportEntity` behavior).
+- Read-only, `Cache-Control: no-store`, honest empty states. No bare `Verified`; passes `pnpm check:claims`.
+- Auth: public read where the passport is already public; Clerk-gated where employer-review is gated (match existing surfaces).
+
+---
+
+## 1. `GET /evidence/:entityId`
+
+Returns the `EvidenceCollection` (C3).
+
+```jsonc
+{
+  "schema": "vitalcv.evidence-collection.v1",
+  "subjectKey": "…canonicalId…",
+  "generatedFor": { "displayName": "Ada Lovelace", "npi": "1234567890" },
+  "objects": [
+    { "evidenceId": "claim_…", "evidenceClass": "licensure", "label": "California RN License",
+      "status": "checked", "decisionGrade": true, "source": { "sourceId": "STATE_BOARD", "governance": "gated" },
+      "observedAt": "…", "checkedAt": "…", "expiresAt": "…", "integrityHash": "…",
+      "provenance": { "artifactIds": ["…"], "receiptIds": ["…"] }, "lifecycle": "active" }
+  ],
+  "relationships": [ { "from": "claim_…", "to": "STATE_BOARD", "type": "verified_by", "confidence": 0.99 } ],
+  "coverageSummary": { "checked": ["NPPES_API"], "gated": ["STATE_BOARD"], "stale": [], "...": [] }
+}
+```
+**Composes:** `ClaimRecord` + `VerificationArtifact` + `VcvCredential` + receipts via C3 normalizers. **Status:** new route, no new storage.
+
+## 2. `GET /timeline/:entityId`
+
+Returns the `CareerTimeline` (C4).
+
+```jsonc
+{
+  "schema": "vitalcv.career-timeline.v1",
+  "subjectKey": "…",
+  "firstAt": "…", "lastAt": "…",
+  "entries": [
+    { "entryKey": "…hash…", "category": "verification", "occurredAt": "…",
+      "title": "OIG/LEIE checked — clear", "detail": "…", "evidenceRefs": ["receipt_…"],
+      "sourceEventType": "PSV_RECEIPT", "immutable": true }
+  ]
+}
+```
+**Composes:** `AuditEvent` + `EntityChangeEvent` + `WatchtowerEvent` + `StorylineTimeline` + recognition tables via C4 merge. Supports `?since=&limit=`. **Status:** new route, projection only.
+
+## 3. `GET /recognition/:entityId`
+
+Returns the canonical Recognition→Acceptance→Start chain as read-only evidence.
+
+```jsonc
+{
+  "schema": "vitalcv.recognition-history.v1",
+  "subjectKey": "…",
+  "events": [
+    { "type": "recognition", "recognitionId": "…", "employerKey": "…", "recognizedAt": "…",
+      "hashAnchor": "…", "verification": { "verifiedAt": "…", "verificationRef": "…" } },
+    { "type": "acceptance", "acceptanceId": "…", "recognitionId": "…", "acceptedAt": "…", "psvReportId": "…" },
+    { "type": "start", "startId": "…", "acceptanceId": "…", "actualStartDate": "…", "attestedAt": "…" }
+  ]
+}
+```
+**Composes:** Prisma `Recognition`/`Acceptance`/`Start` (read). **Honors** `VerifiedCanonicalPath` immutability — exposes, never constructs. **Status:** new read route over existing tables.
+
+## 4. `GET /mobility/:entityId`
+
+Per-clinician mobility readiness (today's `/api/intelligence/mobility` is *aggregate analytics*; this is *per-entity*).
+
+```jsonc
+{
+  "schema": "vitalcv.mobility-readiness.v1",
+  "subjectKey": "…",
+  "licensure": { "states": ["CA","NV"], "compactEligible": true, "compactType": "NLC" },
+  "readinessByState": [
+    { "state": "NV", "status": "needs_review", "missing": ["State board check gated"], "estimatedStartDays": 14 }
+  ],
+  "reusableEvidence": ["claim_npi_identity", "receipt_oig_leie"]
+}
+```
+**Composes:** `VcvCredential` (multi-state/compact) + readiness engine + EvidenceCollection. **Note:** this is the **one route needing genuinely new logic** — per-state readiness projection (a thin reuse of the readiness engine per target state). Flag as **CREATE** in C7. Defer opportunity-matching (`/api/opportunities` already exists) to W260.
+
+## 5. `GET /graph/:entityId`
+
+Evidence-centric subgraph (C5).
+
+```jsonc
+{
+  "schema": "vitalcv.evidence-graph.v1",
+  "subjectKey": "…",
+  "nodes": [ { "id": "…", "type": "license", "label": "CA RN", "trustBand": "L2", "layer": "trust" } ],
+  "edges": [ { "id": "…", "source": "clinician_…", "target": "license_…", "type": "verified_by",
+              "confidence": 0.99, "evidenceRefs": ["receipt_…"] } ],
+  "stats": { "nodeCount": 12, "edgeCount": 18 }
+}
+```
+**Composes:** `evidenceCollectionToGraph` (C5) + existing `/api/graph/:npi`. **Status:** new composed route; reuses graph schema + render.
+
+## 6. Contract summary
+
+| Route | Schema | Reuse vs. create | New logic |
+|---|---|---|---|
+| `GET /evidence/:entityId` | `evidence-collection.v1` | compose | normalizers (C3) |
+| `GET /timeline/:entityId` | `career-timeline.v1` | compose | merge/sort (C4) |
+| `GET /recognition/:entityId` | `recognition-history.v1` | reuse | read-only projection |
+| `GET /mobility/:entityId` | `mobility-readiness.v1` | **partial create** | per-state readiness |
+| `GET /graph/:entityId` | `evidence-graph.v1` | compose | evidence→graph map (C5) |
+
+**Five new read routes; four are pure composition; one (`/mobility`) needs per-state readiness logic.** All additive, none touches `/packet`, `/passport`, or `/employer-review`.
+
+**Deliverable status:** complete. Proceed to C7.

--- a/docs/wave215/C7-implementation-readiness-report.md
+++ b/docs/wave215/C7-implementation-readiness-report.md
@@ -1,0 +1,91 @@
+# W215-C7 — Implementation Readiness Report
+
+**Wave:** 215 · **Synthesizes:** [C1](./C1-implementation-analysis.md)–[C6](./C6-api-blueprint.md)
+**Date:** 2026-06-20
+
+The executable roadmap for Waves 220–270. Outcome: not code — an implementation-ready plan.
+
+---
+
+## 0. Six success-criteria answers (one line each)
+
+1. **Evidence Objects** → a typed facade (`packages/domain-evidence`) + pure normalizers over `ClaimRecord`/`VerificationArtifact`/`VcvCredential`/receipts. No new storage. (C3)
+2. **Professional Memory** → a deterministic merge/sort projection over `AuditEvent` + `EntityChangeEvent` + `WatchtowerEvent` + `StorylineTimeline` + recognition tables. No new event store. (C4)
+3. **Career Timelines** → `CareerTimeline` read model + `GET /timeline/:entityId`, rendered via existing `AnimatedTimeline`/`LiveStateLog`. (C4)
+4. **Mobility Readiness** → per-state projection of the readiness engine over `VcvCredential` + EvidenceCollection; `GET /mobility/:entityId`. The one genuinely new compute. (C6)
+5. **Career Evidence Graph** → `evidenceCollectionToGraph` projector onto the existing `graph-system/types.ts` schema + `/api/graph/*`; ontology conformance test. (C5)
+6. **Passport → Career Evidence without breaking recruiter value** → everything additive + read-only; `/packet/[entityId]`, `career-packet.ts`, `/api/passport/*`, `/api/employer-review/*` untouched; EvidenceObject is a view, not a rewrite. (C2)
+
+## 1. Impacted packages
+
+| Package | Change | Risk |
+|---|---|---|
+| `packages/domain-evidence` (**new**) | EvidenceObject types + normalizers + collection assembler | Low — pure, additive, no deps on apps |
+| `packages/trust-state` | none (consumed) | None |
+| `packages/domain-common` | none (consumed) | None |
+| `packages/source-adapters` | none (consumed) | None |
+| `packages/audit`, `core/watchtower`, `core/storylines` | none (read for timeline) | None |
+| `apps/web` | new read routes + UI mounts; existing surfaces unchanged | Low |
+| `apps/api/backend` | new aggregator services; existing routes unchanged | Low–Med (query fan-out) |
+
+## 2. Impacted routes
+
+**New (additive, read-only):** `GET /evidence/:entityId`, `/timeline/:entityId`, `/recognition/:entityId`, `/mobility/:entityId`, `/graph/:entityId` (+ W220 sub-routes `/graph/:entityId/{nodes,relationships,trust,timeline}`).
+**Unchanged (protected):** `/packet/[entityId]`, `/api/passport/*`, `/api/employer-review/*`, `/api/graph/*` (existing), `/api/export/packet`.
+
+## 3. Impacted schemas
+
+- **No Prisma migration required for W220.** EvidenceObject/Timeline/Graph are read projections over existing tables (`ClaimRecord`, `VerificationArtifact`, `VerificationReceiptRecord`, `PsvReceipt`, `VcvCredential`, `VcvEntityRelationship`, `Recognition/Acceptance/Start`, `AuditEvent`-backed, `EntityChangeEvent`, `IngestEvent`).
+- **New versioned API contracts only:** `evidence-collection.v1`, `career-timeline.v1`, `recognition-history.v1`, `mobility-readiness.v1`, `evidence-graph.v1`.
+- A materialized evidence index is **explicitly deferred** (gated decision, parallels `defer_until_contract_aligned`).
+
+## 4. Migration risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Six evidence representations drift during normalization | Med | Single normalizer module + golden-fixture tests per source type; `decisionGrade ⇔ checked` invariant test |
+| Status upgrade leaks (gated→checked) | **High (doctrine)** | `status.ts` is an identity map; gated-fixture test; reuse `assertNonGatedIfPositive` |
+| Timeline divergence from immutable audit log | Med | Projection only — never writes; entries carry `sourceEventType` provenance |
+| Ontology JSON vs runtime taxonomy mismatch | Med | Conformance test (every runtime NodeType ∈ ontology); do not rewrite the JSON |
+| Recruiter surface regression | **High (business)** | Additive only; snapshot/contract tests on `/packet` + `career-packet` stay green |
+| Banned strings / bare `Verified` in new copy | Med | `pnpm check:claims` + `banned-verified-label.test.ts` in CI for every new surface |
+
+## 5. Performance risks
+
+- `/evidence`, `/timeline`, `/graph` fan out across several tables per entity. Mitigate: per-entity queries keyed on indexed columns (`npi`, `subjectNpi`, `subjectId`, `entityId` all indexed); `Cache-Control` + ETag keyed on `lastCheckedAt`/`lastAt`; cap node/edge counts with honest "truncated" flags (no silent caps — `log`/annotate).
+- Timeline merge is O(n log n) on event count per entity — bounded; cache behind ETag.
+- Graph `live/:npi` streaming already exists; the evidence view reuses it.
+
+## 6. Test strategy
+
+1. **Unit (pure):** normalizers, status map, timeline merge (ordering/dedupe/empty), evidence→graph projector, mobility per-state. Vitest 4.x, `renderToStaticMarkup` for any RSC.
+2. **Invariant:** `decisionGrade ⇔ checked`; no status upgrade; no bare `Verified`; recognition normalizer never constructs `VerifiedCanonicalPath`.
+3. **Contract:** each new route returns its `vitalcv.*.v1` schema; honest empty states; 404 semantics.
+4. **Regression:** `/packet`, `career-packet`, `employer-proof-packet`, `export-packet-route`, `banned-verified-label` stay green.
+5. **Guardrails in CI:** `pnpm check:claims`, `pnpm typecheck`, `pnpm turbo run build --filter @vitalcv/web`.
+6. **Codex SAFE** before any merge (doctrine).
+
+## 7. Effort estimates (relative; 1 unit ≈ a focused PR with tests)
+
+| Wave item | Scope | Effort |
+|---|---|---|
+| W220 `domain-evidence` types + normalizers + tests | C3 | 2 |
+| W220 `buildEvidenceCollection` + `GET /evidence/:entityId` | C3/C6 | 1.5 |
+| W220 evidence→graph projector + `GET /graph/:entityId(/nodes,/relationships,/trust)` + ontology test | C5 | 2.5 |
+| W250 timeline merge + `GET /timeline/:entityId` + UI | C4 | 2.5 |
+| W250 `GET /recognition/:entityId` | C6 | 1 |
+| W260 `GET /mobility/:entityId` (per-state readiness) | C6 | 2 |
+| Hardening: caching/ETags, truncation flags, perf | C7 | 1.5 |
+
+**Total ≈ 13.5 units across W220–270.** The expensive items are graph projection and timeline merge; everything else is thin composition. **~85% is reuse**; the only genuinely new compute is per-state mobility readiness.
+
+## 8. Recommended execution order
+
+1. **W220:** `domain-evidence` (types → normalizers → `buildEvidenceCollection` → `/evidence/:entityId`), then evidence→graph projector + `/graph/:entityId` family. *(This is exactly what the incoming W220 brief asks — see `docs/wave220/`.)*
+2. **W250:** timeline projection + `/timeline/:entityId` + `/recognition/:entityId`.
+3. **W260:** mobility readiness.
+4. **W270:** graph/ontology hardening + vision synthesis.
+
+Recruiter value (`/packet`) rides untouched the entire way.
+
+**Deliverable status:** W215 complete — C1–C7 delivered in `docs/wave215/`.

--- a/docs/wave220/C1-graph-readiness-analysis.md
+++ b/docs/wave220/C1-graph-readiness-analysis.md
@@ -1,0 +1,51 @@
+# W220-C1 — Graph Readiness Analysis
+
+**Wave:** 220 (Career Evidence Graph) · **Role:** Claude Code
+**Builds on:** `docs/wave215/C5-graph-implementation-plan.md`, `C3-domain-evidence-package.md`
+**Date:** 2026-06-20
+
+Which graph primitives already exist — the safest path Passport → Evidence Graph.
+
+---
+
+## 0. Finding
+
+**Every graph primitive needed already exists and serves traffic.** The Career Evidence Graph is a *projection + reconciliation*, not a new engine. The only doctrine-sensitive design question is **trust propagation**, resolved in C2/C3 as *monotonic-down* (evidence can taint, never elevate).
+
+## 1. Primitive inventory
+
+| Primitive | Exists? | Where |
+|---|---|---|
+| Node schema | ✅ rich | `apps/web/components/graph-system/types.ts` — `GraphNode`, 21 node types (clinician, organization, credential, license, receipt, source, claim, artifact, decision, exclusion, enrollment, …), `GraphLayer` = knowledge\|trust\|blended, trust attrs (`trustTier`, `trustBand`, `trustScore`, `confidence`) |
+| Edge schema | ✅ rich | same file — `GraphEdge`, 35 `EdgeType`s incl. issued_by, verified_by, accepted_by, attested_by, trained_at, works_at, sourced_from, derived_from, supersedes-equivalent; `GraphEvidenceRef[]` |
+| Persisted edges | ✅ | Prisma `VcvEntityRelationship` (LICENSED_BY, WORKS_FOR, EMPLOYED_BY; `confidence`, `tier`, `validFrom/validUntil`) |
+| Node identity | ✅ | `VcvEntity.canonicalId = sha256(entityType+primaryKey)` — deterministic, stable graph key |
+| Graph API | ✅ 22+ routes | `/api/graph/{global,local,mobile,:npi,live/:npi}`, `/node/:id/neighbors`, `/search`, `/ai-links/{suggest,apply}` |
+| Render | ✅ | `components/graph/TrustGraphPrimary.tsx` (force-sim), `LiveTrustGraph.tsx` (canvas) |
+| Trust scoring | ✅ | `packages/trust-state` — `CanonicalTruth`, `CanonicalSourceCoverage`, `deriveReadinessState`, `assertNonGatedIfPositive` |
+| Evidence objects | ⏳ specced | `packages/domain-evidence` (W215-C3) — `EvidenceObject`/`EvidenceCollection`, not yet built |
+| Canonical ontology | ✅ doc-grade | `docs/architecture/vitalcv-knowledge-trust-graph.json` — 94 nodes / 96 edges / 82 rules (not wired to runtime) |
+
+## 2. Passport / Readiness / Trust-state as graph inputs
+
+- **Passport** (`PassportData`) → a per-entity **composite node** + its evidence subgraph (identity/authority/training/standing/readiness already decompose into nodes). `career-packet.ts` proves the decomposition is clean.
+- **Readiness engine** → a **computed node** (`deriveReadinessState` over coverage) — derived, not stored; recomputed on read.
+- **Trust state** → node `trustBand`/`trustScore` come straight from `CanonicalTruth`/coverage; **no new scoring needed**.
+- **Entity model** → `VcvEntity` nodes + `VcvEntityRelationship` edges already form the backbone graph.
+
+## 3. The three gaps (all small)
+
+1. **EvidenceObjects aren't first-class graph nodes yet** — needs the `evidenceCollectionToGraph` projector (C2).
+2. **Two unreconciled taxonomies** — runtime `graph-system/types.ts` vs canonical `knowledge-trust-graph.json`. Needs a conformance map + test (C2 §4), not a rewrite.
+3. **No evidence-centric `GET /graph/:entityId` family** — existing `/api/graph/:npi` is entity/relationship-centric, not evidence-centric (C5 API).
+
+## 4. Constraints carried in (doctrine)
+
+1. **No tier upgrade across edges** — Trust Graph rule "trust container does not upgrade proof tier." Trust propagation is **monotonic-down only** (C3).
+2. **Decision-grade = `checked` only**; gated nodes never render positive (`assertNonGatedIfPositive`).
+3. **Every trust edge is evidence-backed** (`evidenceRefs`); no unsourced trust edges.
+4. **AI-suggested edges stay suggestions** (existing suggest/apply boundary).
+5. **Recruiter surfaces unchanged** — `/packet`, `/api/passport/*`, `/api/employer-review/*` untouched (success criterion #6).
+6. **No PHI in labels; passes `check:claims`; no bare `Verified`.**
+
+**Deliverable status:** complete. → C2.

--- a/docs/wave220/C2-node-architecture-plan.md
+++ b/docs/wave220/C2-node-architecture-plan.md
@@ -1,0 +1,70 @@
+# W220-C2 — Node Architecture Plan
+
+**Wave:** 220 · **Depends on:** [C1](./C1-graph-readiness-analysis.md)
+**Date:** 2026-06-20
+
+Map current objects → graph nodes, using the existing `graph-system/types.ts` `NodeType` vocabulary (21 types). **No new node types required** for the core.
+
+---
+
+## 1. Object → node map
+
+| Current object | Graph node | NodeType (existing) | Node kind |
+|---|---|---|---|
+| `VcvEntity` (person) | Clinician node | `clinician` | **Composite / anchor** |
+| `VcvEntity` (org) | Employer/Institution node | `organization` / `institution` | Entity |
+| `PassportData` | (not a node) — the *subgraph root view* of a clinician | — | Composite view |
+| `EvidenceObject{class: licensure}` | License node | `license` | **Evidence** |
+| `EvidenceObject{class: board_cert}` | Credential node | `credential` | Evidence |
+| `EvidenceObject{class: identity}` | Identity claim node | `claim` | Evidence |
+| `EvidenceObject{class: exclusion}` | Exclusion node | `exclusion` | Evidence |
+| `EvidenceObject{class: enrollment}` | Enrollment node | `enrollment` | Evidence |
+| `VerificationReceiptRecord`/`PsvReceipt` | Receipt node | `receipt` | **Trust/proof** |
+| `EvidenceSource` (NPPES/OIG/STATE_BOARD) | Source node | `source` | Trust/proof |
+| `VerificationArtifact` | Artifact node | `artifact` | Evidence backing |
+| Readiness (`deriveReadinessState`) | Readiness node | `decision` | **Computed** |
+| `Recognition`/`Acceptance`/`Start` | Recognition / decision nodes | `decision` | Employment evidence |
+
+This satisfies the brief's examples: **Passport → Composite Node, License → Evidence Node, Verification → Trust Node, Readiness → Computed Node.**
+
+## 2. Node kinds (semantics, not new types)
+
+- **Composite/anchor** — the clinician `VcvEntity`; the subgraph centers here. `canonicalId` = node id.
+- **Evidence node** — one per `EvidenceObject`. Carries `status`, `decisionGrade`, `observedAt/checkedAt/expiresAt`, `provenance`. **Never rendered above its own coverage.**
+- **Trust/proof node** — sources + receipts; the cryptographic backing.
+- **Computed node** — readiness; **derived on read** (not stored), recomputed from coverage so it can never be stale relative to its inputs.
+
+## 3. The projector (the only new code)
+
+`packages/domain-evidence` (or graph adapter) exposes a **pure**:
+
+```ts
+function evidenceCollectionToGraph(c: EvidenceCollection): { nodes: GraphNode[]; edges: GraphEdge[] }
+```
+
+Rules:
+- `node.id`: reuse `evidenceId` / `canonicalId` / `sourceId` (stable, no new id scheme).
+- `node.type = mapEvidenceClassToNodeType(class)` — total map onto the 21 existing types.
+- `node.trustTier/trustBand/trustScore/confidence` copied **from the EvidenceObject's coverage/truth** — no re-derivation.
+- `node.layer = 'trust'` for evidence/source/receipt; `'knowledge'` for entity/affiliation.
+- `node.metadata.decisionGrade = (status === 'checked')` — never widened.
+
+## 4. Computed node honesty
+
+The readiness `decision` node:
+- recomputed via `deriveReadinessState(coverage)` at projection time (pure);
+- band derived via `deriveTrustBandFromReadiness`;
+- **carries the partial/blocked state visibly** — a PARTIAL readiness node renders PARTIAL, never DECISION_GRADE (mirrors `/packet` honesty).
+
+## 5. Node-level invariants (tested)
+
+1. `mapEvidenceClassToNodeType` is **total** (every `EvidenceClass` → a valid `NodeType`); unit-tested exhaustively.
+2. A gated/notDecisionGrade EvidenceObject → node with non-positive band; `assertNonGatedIfPositive` holds.
+3. No node invents trust it doesn't have in its source EvidenceObject.
+4. Projector is pure (no `Date.now()` except echoing record timestamps).
+
+## 6. What is NOT a node
+
+- `PassportData` and `CareerPacketModel` stay **views**, not nodes — they are the recruiter projections that must not change (criterion #6). The graph is an *alternative* read of the same evidence, never a replacement.
+
+**Deliverable status:** complete. → C3.

--- a/docs/wave220/C3-relationship-architecture.md
+++ b/docs/wave220/C3-relationship-architecture.md
@@ -1,0 +1,63 @@
+# W220-C3 — Relationship Architecture
+
+**Wave:** 220 · **Depends on:** [C2](./C2-node-architecture-plan.md)
+**Date:** 2026-06-20
+
+How relationships are represented — and how **trust propagation** stays doctrine-safe.
+
+---
+
+## 1. Relationship families → existing `EdgeType`
+
+| Family (brief) | Concrete edges | EdgeType (existing) | Source of truth |
+|---|---|---|---|
+| **EvidenceRelationship** | evidence ← source, evidence ← artifact, claim ← receipt | `verified_by`, `sourced_from`, `derived_from`, `proven_by`* | EvidenceObject.provenance, `Claim.sourceCheckId`, `VerificationReceiptRecord.claimRecordId` |
+| **TrustRelationship** | node depends-on source freshness; supersession | `depends_on`, `supersedes`* | `CanonicalSourceCoverage`, `*.supersededBy*` |
+| **EmploymentRelationship** | clinician ↔ employer/facility | `works_at`, `affiliated_with` | `VcvEntityRelationship` (WORKS_FOR, EMPLOYED_BY) |
+| **RecognitionRelationship** | recognition → acceptance → start | `accepted_by`, `attested_by`, `issued_by` | Prisma `Recognition`/`Acceptance`/`Start` chain |
+| Training/affiliation | clinician → program/institution | `trained_at`, `affiliated_with` | `VcvEntityRelationship`, training records |
+
+\* `proven_by`/`supersedes` may need to be added to the `EdgeType` union if not present verbatim — additive, pure type change, no migration.
+
+## 2. Edge shape (reuse `GraphEdge`)
+
+Every Career Evidence Graph edge reuses the existing `GraphEdge`:
+- `source`/`target`: node ids from C2.
+- `type`: from the table above.
+- `confidence`/`weight`: reuse `VcvEntityRelationship.confidence` / claim match confidence.
+- **`evidenceRefs: GraphEvidenceRef[]` is mandatory for trust edges** — no unsourced trust edge ships.
+- `firstSeenAt`/`lastSeenAt`: from record timestamps (temporal edges).
+- `layer`: `'trust'` for evidence/proof edges, `'knowledge'` for affiliations.
+
+## 3. Trust propagation — **monotonic-down only** (the key doctrine decision)
+
+The brief asks "how do we implement trust propagation." Doctrine forbids tier upgrades across containers/edges (Trust Graph rule). Therefore:
+
+> **Propagation may only taint or constrain a node, never elevate it.**
+
+Concretely:
+- A node's **positive** trust band comes **solely from its own EvidenceObject coverage** (a `checked` license). A neighbor's high trust **cannot raise** a node.
+- Propagation flows **downward/negatively**: if a `source` node is `unavailable`/`revoked`/`stale`, every evidence node `sourced_from` it is **flagged** (e.g., `riskDelta`, a `depends_on` warning edge), and any computed node depending on it degrades (PARTIAL/BLOCKED).
+- This matches the runtime guard `assertNonGatedIfPositive` and Rule 35 ("absence of recorded revocation is not a guarantee"): we degrade on recorded negatives, we never assume positives.
+
+### Propagation algorithm (pure, read-time)
+1. Compute each evidence node's own band from its coverage (no neighbors).
+2. For each `source`/`receipt` node in a negative state, walk `sourced_from`/`proven_by`/`depends_on` edges and **lower** dependents (cap their band, set `flagged`, attach reason).
+3. Recompute computed (readiness) nodes from the (possibly lowered) coverage.
+4. Never run an "raise" pass. Terminates in one downward sweep (DAG; supersession edges are acyclic).
+
+**Result:** trust propagation is implementable, useful (revocation taints dependents), and provably cannot manufacture trust.
+
+## 4. Relationship invariants (tested)
+
+1. Every `layer:'trust'` edge has ≥1 `evidenceRef` (test: scan projector output).
+2. Propagation is monotonic-down: a property test asserts no node's band increases after propagation vs. its standalone band.
+3. Supersession edges form a DAG (no cycles); `supersededBy` resolves forward only.
+4. AI-suggested edges keep `type: 'ai_suggested_link'` until human `apply` (existing boundary).
+
+## 5. Persistence stance
+
+- **Read-time projection** for W220 — edges derived from existing records (`VcvEntityRelationship` + provenance), no new edge table.
+- Materialized graph edges are a **deferred** decision (perf optimization), gated like `defer_until_contract_aligned`.
+
+**Deliverable status:** complete. → C4.

--- a/docs/wave220/C4-graph-query-blueprint.md
+++ b/docs/wave220/C4-graph-query-blueprint.md
@@ -1,0 +1,50 @@
+# W220-C4 — Graph Query Blueprint
+
+**Wave:** 220 · **Depends on:** [C2](./C2-node-architecture-plan.md), [C3](./C3-relationship-architecture.md)
+**Date:** 2026-06-20
+
+Future graph queries — expressed as **pure selectors over the projected `{nodes, edges}`**, so they work identically on a read-time projection now and a materialized store later.
+
+---
+
+## 0. Query model
+
+All queries are functions `(graph, subjectKey, params) → result`. No new query language; no Cypher/Gremlin dependency. Selectors live next to the projector in `packages/domain-evidence` (pure, testable). The backend routes (C5) are thin wrappers.
+
+## 1. The five canonical queries (from the brief)
+
+| Query | Selector | Returns |
+|---|---|---|
+| **Show all evidence for clinician** | `evidenceNodesFor(subjectKey)` | all `EvidenceObject` nodes anchored to the clinician, grouped `byClass`, with status/freshness |
+| **Show trust relationships** | `trustEdgesFor(subjectKey)` | `layer:'trust'` edges (`verified_by`, `sourced_from`, `proven_by`, `depends_on`) + their evidenceRefs |
+| **Show professional timeline** | `timelineFor(subjectKey)` | delegates to `CareerTimeline` (W215-C4) — time-sorted entries; the graph view overlays them on recognition/credential nodes |
+| **Show recognition history** | `recognitionChainFor(subjectKey)` | the Recognition→Acceptance→Start node chain with `accepted_by`/`attested_by` edges |
+| **Show mobility readiness factors** | `mobilityFactorsFor(subjectKey)` | licensure nodes by state + compact eligibility + which evidence is reusable vs. gated per target state |
+
+## 2. Supporting traversals (reuse existing engine where possible)
+
+- **Neighbors** → existing `/api/graph/node/:id/neighbors`; selector `neighbors(graph, nodeId, depth)`.
+- **Subgraph** → `subgraphFor(subjectKey, { nodeTypes?, edgeTypes?, layer? })` — filter the projection; mirrors existing `/api/graph/:npi` filter params (`nodeTypes`, `edgeTypes`, `trustTiers`, `graphMode`).
+- **Why-is-this-trusted** → `provenancePathFor(evidenceId)` — walks `proven_by`/`sourced_from` back to source + receipt (explains a node's band).
+- **What-breaks-if-source-fails** → `dependentsOf(sourceId)` — the monotonic-down propagation set (C3).
+
+## 3. Query honesty rules
+
+1. Evidence queries return **status verbatim** (checked/gated/stale/…); never collapse to "verified".
+2. Mobility/readiness factors mark gated/stale evidence as **not reusable** for a target state, not "available".
+3. Truncation is explicit — any capped result sets a `truncated: true` + count (no silent caps).
+4. Empty is honest — "no recognition events recorded" ≠ "not recognized."
+
+## 4. Performance shape
+
+- All selectors operate on an already-loaded per-entity projection (bounded: one clinician's evidence is tens, not millions of nodes).
+- The fan-out cost is **loading** the projection (indexed per-entity table reads), not the selectors (in-memory, O(n)/O(n log n)).
+- Cache the projection behind an ETag keyed on `lastCheckedAt`; selectors run on the cached object.
+
+## 5. Test strategy for queries
+
+- Golden-fixture: a synthetic `EvidenceCollection` → assert each selector's output (counts, grouping, status fidelity).
+- Property: `trustEdgesFor` output ⊆ edges with evidenceRefs; `mobilityFactorsFor` never marks a gated source reusable.
+- Determinism: same input → same ordering (stable sort by id/occurredAt).
+
+**Deliverable status:** complete. → C5.

--- a/docs/wave220/C5-graph-api-contracts.md
+++ b/docs/wave220/C5-graph-api-contracts.md
@@ -1,0 +1,92 @@
+# W220-C5 — Graph API Contracts
+
+**Wave:** 220 · **Depends on:** [C4](./C4-graph-query-blueprint.md)
+**Date:** 2026-06-20
+
+Read-only, versioned (`vitalcv.evidence-graph.v1`), additive. `entityId` = `canonicalId` or NPI. None mutates; none changes an existing route. Family expands `GET /graph/:entityId` from W215-C6.
+
+---
+
+## 1. `GET /graph/:entityId`
+
+The full evidence-centric subgraph (projector output).
+
+```jsonc
+{
+  "schema": "vitalcv.evidence-graph.v1",
+  "subjectKey": "…",
+  "nodes": [
+    { "id": "clinician_…", "type": "clinician", "label": "Ada Lovelace", "layer": "knowledge" },
+    { "id": "license_ca_…", "type": "license", "label": "CA RN License",
+      "trustBand": "L2", "metadata": { "decisionGrade": true, "status": "checked" }, "layer": "trust" },
+    { "id": "src_state_board", "type": "source", "label": "State Board", "layer": "trust" }
+  ],
+  "edges": [
+    { "id": "e1", "source": "license_ca_…", "target": "src_state_board",
+      "type": "verified_by", "confidence": 0.99, "layer": "trust",
+      "evidenceRefs": [ { "evidenceId": "receipt_…", "source": "STATE_BOARD", "observedAt": "…" } ] }
+  ],
+  "stats": { "nodeCount": 12, "edgeCount": 18, "truncated": false }
+}
+```
+Query params (reuse existing `/api/graph` semantics): `?nodeTypes=`, `?edgeTypes=`, `?layer=trust|knowledge|blended`, `?depth=`.
+
+## 2. `GET /graph/:entityId/nodes`
+
+Nodes only — `evidenceNodesFor` (C4). Supports `?class=licensure` and `?status=checked`.
+
+```jsonc
+{ "schema": "vitalcv.evidence-graph-nodes.v1", "subjectKey": "…",
+  "nodes": [ /* GraphNode[] */ ], "byClass": { "licensure": ["license_ca_…"] }, "truncated": false }
+```
+
+## 3. `GET /graph/:entityId/relationships`
+
+Edges only — `trustEdgesFor` + affiliations. `?layer=trust` filters to evidence-backed edges.
+
+```jsonc
+{ "schema": "vitalcv.evidence-graph-edges.v1", "subjectKey": "…",
+  "edges": [ /* GraphEdge[] with evidenceRefs */ ], "truncated": false }
+```
+
+## 4. `GET /graph/:entityId/trust`
+
+The trust view: per-node band + the **monotonic-down propagation** result (C3) — which nodes are tainted by which negative source.
+
+```jsonc
+{
+  "schema": "vitalcv.evidence-graph-trust.v1",
+  "subjectKey": "…",
+  "nodes": [ { "id": "license_ca_…", "standaloneBand": "L2", "propagatedBand": "L2", "flagged": false } ],
+  "taints": [
+    { "sourceId": "src_pecos", "state": "stale",
+      "affects": ["enrollment_…"], "effect": "degraded", "reason": "PECOS evidence beyond freshness window" }
+  ],
+  "invariant": "propagatedBand <= standaloneBand for every node"
+}
+```
+The `invariant` line is asserted in tests, not just documented.
+
+## 5. `GET /graph/:entityId/timeline`
+
+Graph-overlaid timeline — delegates to `CareerTimeline` (W215-C4) and tags each entry with the node(s) it touches.
+
+```jsonc
+{ "schema": "vitalcv.evidence-graph-timeline.v1", "subjectKey": "…",
+  "entries": [ { "entryKey": "…", "occurredAt": "…", "category": "verification",
+                 "title": "State board checked", "nodeIds": ["license_ca_…"], "immutable": true } ] }
+```
+
+## 6. Contract summary
+
+| Route | Schema | Logic | Reuse |
+|---|---|---|---|
+| `GET /graph/:entityId` | `evidence-graph.v1` | projector | `evidenceCollectionToGraph` + `/api/graph/:npi` |
+| `…/nodes` | `evidence-graph-nodes.v1` | selector | C4 |
+| `…/relationships` | `evidence-graph-edges.v1` | selector | C4 |
+| `…/trust` | `evidence-graph-trust.v1` | propagation (monotonic-down) | C3 |
+| `…/timeline` | `evidence-graph-timeline.v1` | delegate | W215-C4 |
+
+All five are pure composition over the projector + existing services. Auth mirrors the passport's visibility (public where passport is public). Cache: `no-store` + ETag on `lastCheckedAt`.
+
+**Deliverable status:** complete. → C6.

--- a/docs/wave220/C6-graph-readiness-report.md
+++ b/docs/wave220/C6-graph-readiness-report.md
@@ -1,0 +1,86 @@
+# W220-C6 — Graph Readiness Report
+
+**Wave:** 220 · **Synthesizes:** [C1](./C1-graph-readiness-analysis.md)–[C5](./C5-graph-api-contracts.md)
+**Date:** 2026-06-20
+
+---
+
+## 0. Six success-criteria answers
+
+1. **Graph nodes** → `evidenceCollectionToGraph` projects `EvidenceObject`/`EvidenceSource`/`VcvEntity` onto the existing `graph-system/types.ts` `NodeType` vocabulary. No new node types; one total mapping function. (C2)
+2. **Relationships** → reuse `GraphEdge` + `VcvEntityRelationship` + provenance; edges grouped into Evidence/Trust/Employment/Recognition families; every trust edge carries `evidenceRefs`. (C3)
+3. **Trust propagation** → **monotonic-down only**: a node's positive band comes from its own coverage; propagation can taint/degrade dependents of a negative source, never elevate. Enforced by `assertNonGatedIfPositive` + a property test (`propagatedBand ≤ standaloneBand`). (C3)
+4. **Graph queries** → pure selectors over the projection (`evidenceNodesFor`, `trustEdgesFor`, `recognitionChainFor`, `mobilityFactorsFor`, `timelineFor`); no query language. (C4)
+5. **Evidence Objects → Graph** → the projector + ontology conformance test; read-time, no materialization in W220. (C2/C5)
+6. **Preserve recruiter workflows** → entirely additive + read-only; `/packet`, `/api/passport/*`, `/api/employer-review/*`, existing `/api/graph/*` untouched; graph is an alternative read of the same evidence. (C1/C2)
+
+## 1. Impacted packages
+
+| Package | Change | Risk |
+|---|---|---|
+| `packages/domain-evidence` | + `evidenceCollectionToGraph`, `mapEvidenceClassToNodeType`, graph selectors, propagation (all pure) | Low |
+| `apps/web/components/graph-system` | possibly + 1–2 `EdgeType`s (`proven_by`, `supersedes`) — additive type change | Low |
+| `apps/web` | + `/graph/:entityId(/nodes,/relationships,/trust,/timeline)` routes; feed projector into existing `LiveTrustGraph` | Low |
+| `apps/api/backend` | + per-entity graph aggregator (loads records → EvidenceCollection → projector) | Med (fan-out) |
+| `docs/architecture/knowledge-trust-graph.json` | **no rewrite** — add a conformance map only | Low |
+
+## 2. Impacted routes
+
+**New:** `GET /graph/:entityId`, `…/nodes`, `…/relationships`, `…/trust`, `…/timeline` (5).
+**Unchanged:** all existing `/api/graph/*` (22+), `/packet`, `/api/passport/*`, `/api/employer-review/*`, `/api/export/packet`.
+
+## 3. Impacted schemas
+
+- **No Prisma migration.** Nodes/edges are projected from existing tables (`VcvEntity`, `VcvEntityRelationship`, `VcvCredential`, `ClaimRecord`, `VerificationArtifact`, receipts, recognition chain).
+- **New API contracts:** `evidence-graph.v1`, `evidence-graph-nodes.v1`, `evidence-graph-edges.v1`, `evidence-graph-trust.v1`, `evidence-graph-timeline.v1`.
+- **Possible additive type change:** 1–2 `EdgeType` literals (no runtime data change).
+
+## 4. Migration risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Trust elevated across edges (doctrine breach) | **High** | monotonic-down algorithm + property test `propagatedBand ≤ standaloneBand`; reuse `assertNonGatedIfPositive` |
+| Ontology vs runtime taxonomy drift | Med | conformance test: every runtime `NodeType` ∈ ontology; don't rewrite the JSON |
+| Unsourced trust edge ships | Med | test: every `layer:'trust'` edge has ≥1 `evidenceRef` |
+| Recruiter surface regression | **High (business)** | additive-only; `/packet` + `career-packet` regression tests stay green |
+| Supersession cycles | Low | DAG assertion on `supersededBy` resolution |
+
+## 5. Performance risks
+
+- **Fan-out per entity:** loading the EvidenceCollection reads several indexed tables. Mitigate with indexed per-entity keys (`npi`/`subjectNpi`/`entityId` all indexed), ETag cache on `lastCheckedAt`, and `depth`/`nodeTypes` filters to bound the subgraph.
+- **Render:** reuse `LiveTrustGraph` (already canvas + force-sim tuned); cap node/edge counts with explicit `truncated` flags.
+- **Propagation:** single downward DAG sweep, O(V+E) per entity — negligible at clinician scale.
+- Materialized graph store is **deferred** (gated decision) — only if read latency proves insufficient.
+
+## 6. Test strategy
+
+1. **Unit (pure):** `mapEvidenceClassToNodeType` totality; projector node/edge counts; selectors (C4); propagation.
+2. **Invariant/property:** `propagatedBand ≤ standaloneBand`; trust edges have evidenceRefs; gated never positive; supersession DAG.
+3. **Conformance:** runtime `NodeType` ⊆ ontology nodes.
+4. **Contract:** each route returns its `vitalcv.*.v1` schema + honest `truncated`/empty states.
+5. **Regression:** `/packet`, `career-packet`, `employer-proof-packet`, `export-packet-route`, `banned-verified-label` green; `pnpm check:claims`, `pnpm typecheck`, web build.
+6. **Codex SAFE** before merge.
+
+## 7. Effort estimates (1 unit ≈ a focused PR w/ tests)
+
+| Item | Effort |
+|---|---|
+| `evidenceCollectionToGraph` + class→type map + tests | 1.5 |
+| Selectors (C4) + tests | 1 |
+| Monotonic-down propagation + property tests | 1.5 |
+| `GET /graph/:entityId` family (5 routes) + contract tests | 2 |
+| Ontology conformance map + test | 0.5 |
+| Wire projector → `LiveTrustGraph` UI | 1 |
+| Caching/ETag/truncation hardening | 1 |
+
+**Total ≈ 8.5 units.** ~80% reuse; the only doctrine-sensitive work is propagation (1.5 units), fully contained by the monotonic-down rule + property test.
+
+## 8. Safest path Passport → Evidence Graph (recommended order)
+
+1. Land `packages/domain-evidence` (W220 prerequisite from W215-C3) — types + normalizers + `buildEvidenceCollection` + `GET /evidence/:entityId`.
+2. Add projector + `GET /graph/:entityId` + `/nodes` + `/relationships` (no propagation yet).
+3. Add `/trust` with monotonic-down propagation + property test.
+4. Add `/timeline` (delegates to W215-C4 once that lands) or stub honestly until then.
+5. Wire UI into existing `LiveTrustGraph`. Recruiter `/packet` untouched throughout.
+
+**Deliverable status:** W220 complete — C1–C6 in `docs/wave220/`.

--- a/docs/wave222/C1-trust-inventory.md
+++ b/docs/wave222/C1-trust-inventory.md
@@ -1,0 +1,78 @@
+# W222-C1 — Trust Inventory
+
+**Wave:** 222 (Trust Propagation Engine) · **Role:** Claude Code
+**Date:** 2026-06-21
+**Inputs reviewed:** GraphProjection (W221), EvidenceObject/EvidenceCollection (W220), trust scores.
+
+The deterministic trust signals available to the propagation engine — what exists, where it comes from, and the rule that keeps it honest.
+
+---
+
+## 0. Principle
+
+Trust is **deterministic and evidence-bounded**. No ML, no opaque scoring. Every signal traces to a source-backed evidence object whose status is verbatim from coverage. Aggregation is **monotonic-down** (W220-C3): trust flows *up* from evidence into dimensions and an overall score, but is never inflated by neighbors.
+
+## 1. Per-node trust signal (already in the graph)
+
+Each evidence `GraphNode` carries:
+
+| Field | Meaning | Source |
+|---|---|---|
+| `status` | `checked / stale / pending / gated / accessRequired / reviewRequired / notDecisionGrade / previewOnly / unavailable` | verbatim from `CanonicalSourceCoverage` |
+| `trustScore` | 0..1, **monotonic, non-inflating** | `statusTrustScore(status)` — only `checked`=1; every gated state=0 |
+| `decisionGrade` | derived, `=== status==='checked'` | never set directly |
+| `evidenceSource` | the backing source id (origin) | EvidenceObject.source |
+| `evidenceClass` | which dimensions it feeds | EvidenceObject.evidenceClass |
+| `checkedAt` / `expiresAt` / `lifecycle` | temporal signal for history | EvidenceObject |
+
+`statusTrustScore`: `checked → 1`, `stale → 0.4`, `pending → 0.2`, `reviewRequired → 0.1`, everything gated/unavailable/notDecisionGrade/previewOnly/accessRequired `→ 0`.
+
+## 2. Dimension signals (C3)
+
+Seven independent dimensions, each a deterministic mean of the trustScores of its contributing evidence classes. A class may feed more than one dimension; dimensions are computed independently so a shared input never feeds one dimension's score into another.
+
+| Dimension | Contributing evidence classes | Aggregation |
+|---|---|---|
+| **IdentityTrust** | identity | mean of contributing trustScores, or `null` if none |
+| **AuthorityTrust** | licensure, board_cert, registration, exclusion, enrollment | mean / null |
+| **ProfessionalTrust** | employment, recognition, acceptance, start, training | mean / null |
+| **ResearchTrust** | research, publication | mean / null |
+| **LeadershipTrust** | privilege, peer_review | mean / null |
+| **InstitutionalTrust** | employment, recognition, acceptance, start, training, privilege | mean / null |
+| **MobilityTrust** | licensure, registration | mean / null |
+
+Each dimension also reports: `supporting` (evidenceIds with score>0), `weakening` (score===0), `origins` (distinct sources of positive evidence), `contributingCount`, `decisionGradeCount`.
+
+**Honesty:** a dimension with no contributing evidence returns `score: null` (not a fabricated 0 or positive). A dimension whose evidence is all gated returns `0`.
+
+## 3. Overall signal
+
+`overall.score` = mean of all evidence trustScores (bounded [0,1], drags down on gated/stale). Plus `decisionGradeEvidence` and `totalEvidence` counts. No weakest-link or boosting — a plain, explainable mean.
+
+## 4. History signals (C4)
+
+Derived deterministically from current evidence timestamps (timeline-compatible shape; **not** a substitute for the recorded audit log — that lives in `packages/audit` / `core/watchtower`, per W215-C4):
+
+- **Reinforcement** — each `checked` evidence → `+trustScore` at `checkedAt`.
+- **Decay** — each `stale` / `expired` / `revoked` evidence → `-(1 - trustScore)` at `expiresAt`.
+- **Growth** — the net trend: `growing` / `decaying` / `stable` from `netDelta`.
+
+Entries are sorted ascending by timestamp (nulls last, tiebreak evidenceId) — deterministic and replay-safe.
+
+## 5. The five questions, answered by these signals
+
+| Question | Answered by |
+|---|---|
+| Why is this clinician trusted? | dimensions with positive `score` + their `supporting` evidence |
+| Where does trust originate? | `origins` per dimension (decision-grade source ids) |
+| What reinforces trust? | `supporting` + history `reinforcement` entries |
+| What weakens trust? | `weakening` + history `decay` entries |
+| How has trust evolved? | `history.trend` + ordered entries |
+
+## 6. What is explicitly NOT a trust signal
+
+- No model output, no learned weights, no probabilistic confidence beyond the deterministic `statusTrustScore`.
+- No neighbor-boosting: a high-trust node never raises an adjacent low-trust node.
+- No upgrade of gated/stale to positive anywhere in the pipeline.
+
+**Deliverable status:** complete. Implemented in `packages/domain-evidence/src/trust/propagate.ts` (C2–C4), `GET /api/graph/:entityId/trust` (C5), `/dev/graph/[entityId]` Trust View (C6).

--- a/docs/wave225/C1-event-discovery.md
+++ b/docs/wave225/C1-event-discovery.md
@@ -1,0 +1,51 @@
+# W225-C1 — Event Discovery
+
+**Wave:** 225 (Professional Memory System) · **Role:** Claude Code
+**Date:** 2026-06-21
+**Inputs analyzed:** EvidenceObject/Collection (W220), GraphProjection (W221), TrustProjection + TrustHistory (W222), Mobility signals (W230).
+
+What event-capable data already exists — the raw material for Professional Memory. **No new capture is required**; the timeline is a projection (built in C2/C3).
+
+---
+
+## 0. Finding
+
+Every layer already emits time-stamped, source-backed signals. A "career over time" is a **deterministic merge of existing timestamps**, not a new event store. (The richer backend event sources — `AuditEvent`, `WatchtowerEvent`, `EntityChangeEvent`, recognition tables — were inventoried in W215-C4 and remain the authoritative recorded history; the W225 projection is the *evidence-derived* view that runs purely on the data already in the passport.)
+
+## 1. Event-capable fields per layer
+
+| Layer | Time field(s) | Event-shaped signal |
+|---|---|---|
+| `EvidenceObject` | `checkedAt`, `observedAt`, `expiresAt` | a verification occurred / evidence will expire |
+| `EvidenceObject` | `lifecycle` (`active/superseded/revoked/expired`) | a state transition |
+| `EvidenceObject` | `status` | decision-grade vs owed at a point in time |
+| `GraphNode` (evidence) | carries the above + `trustScore`, `evidenceSource`, `evidenceClass` | a node's contribution at a moment |
+| `TrustHistory` (W222) | `entries[].occurredAt` | reinforcement / decay events (already timeline-shaped) |
+| `TrustHistory` | `trend`, `netDelta` | growth/decay trajectory |
+| Mobility (W230) | licensure `checkedAt` + jurisdiction | a mobility-expanding event |
+
+## 2. Event categories already derivable
+
+| Category | Derived from |
+|---|---|
+| Identity verification | `identity` evidence `checkedAt` |
+| Credential verified / decayed | licensure/board_cert/registration status + lifecycle |
+| Screening / enrollment | exclusion / enrollment evidence |
+| Recognition / acceptance / start | recognition/acceptance/start evidence classes |
+| Trust reinforcement / decay | `TrustHistory.entries` |
+| Mobility expansion / reduction | licensure status transitions |
+
+## 3. What the projection must add (built in C2/C3)
+
+1. A unified `CareerEvent` shape carrying **trust impact + mobility impact + recognition impact** in one record (the brief's C2 fields).
+2. Deterministic ordering + dedupe.
+3. A `reputation` rollup (standing) and a `recognition` subset.
+
+All three are pure derivations over the existing fields — implemented in `packages/domain-evidence/src/timeline/timeline.ts`.
+
+## 4. What is NOT an event source here
+
+- No new write path; the projection never records anything.
+- The authoritative recorded history (audit/watchtower) is **not** replaced — this view is honest about being derived from current evidence timestamps (Trust Graph Rule 35: absence of a recorded event ≠ absence of the fact).
+
+**Deliverable status:** complete. C2/C3 implemented; C4/C5/C6 follow.

--- a/docs/wave225/C4-memory-api-contracts.md
+++ b/docs/wave225/C4-memory-api-contracts.md
@@ -1,0 +1,56 @@
+# W225-C4 — Memory API Contracts
+
+**Wave:** 225 · **Depends on:** C2/C3 (built: `projectTimeline`)
+**Date:** 2026-06-21
+
+Read-only, versioned (`vitalcv.timeline.*.v1`) contracts. The primary route is **built**; the four sub-views are filters over the same `TimelineProjection` payload.
+
+---
+
+## 0. Built
+
+`GET /api/timeline/[entityId]` → `vitalcv.timeline.v1` (implemented at `apps/web/app/api/timeline/[entityId]/route.ts`). Returns the full `TimelineProjection`: `events`, `trustHistory`, `recognition`, `reputation`, `firstAt`, `lastAt`. Read-only, `Cache-Control: no-store`, composes passport runtime → evidence → graph → trust → timeline.
+
+```jsonc
+{
+  "schema": "vitalcv.timeline.v1",
+  "subjectKey": "…",
+  "firstAt": "2026-03-01T00:00:00.000Z",
+  "lastAt": "2026-03-23T12:00:00.000Z",
+  "events": [
+    { "eventId": "cred:lic-ca@2026-03-02T…", "occurredAt": "2026-03-02T…", "type": "licensure",
+      "label": "California Medical Board", "evidenceId": "cred:lic-ca", "evidenceSource": "STATE_BOARD",
+      "trustImpact": 1, "trustDimension": "authority", "mobilityImpact": "expands", "recognitionImpact": "none" }
+  ],
+  "trustHistory": { "entries": [ … ], "reinforcementCount": 3, "decayCount": 1, "netDelta": 2.6, "trend": "growing" },
+  "recognition": [ … ],
+  "reputation": { "overallTrust": 0.6, "decisionGradeEvidence": 3, "totalEvidence": 4,
+                  "reinforcementCount": 3, "decayCount": 1, "trend": "growing", "standing": "emerging" }
+}
+```
+
+## 1. Sub-views (designed; filters over the primary payload)
+
+Each is a thin route that calls `projectTimeline` and returns one slice. Building them is optional (the primary route already returns all of it), but the contracts are fixed:
+
+| Route | Schema | Returns |
+|---|---|---|
+| `GET /api/timeline/:entityId/events` | `vitalcv.timeline-events.v1` | `events[]` only; supports `?type=licensure&since=&limit=` |
+| `GET /api/timeline/:entityId/trust-history` | `vitalcv.timeline-trust-history.v1` | `trustHistory` (entries + trend) |
+| `GET /api/timeline/:entityId/recognition` | `vitalcv.timeline-recognition.v1` | `recognition[]` (recognition/acceptance/start events) |
+| `GET /api/timeline/:entityId/reputation` | `vitalcv.timeline-reputation.v1` | `reputation` summary only |
+
+## 2. Honesty rules (enforced by the projection, surfaced by the API)
+
+1. Events are derived from current evidence timestamps and labeled as such — not a substitute for the audit log.
+2. `reputation.standing` is `unknown` when `decisionGradeEvidence === 0` (no fabricated reputation).
+3. `trustImpact` is bounded ([−1, 1]); no event inflates trust.
+4. Empty timelines render honestly (`events: []`, `firstAt: null`), never a fabricated history.
+5. No bare `Verified`; passes `pnpm check:claims`.
+
+## 3. Success-criteria answers
+
+- **How do we derive timelines?** Compose passport → evidence → graph → trust → `projectTimeline`; the route is a thin wrapper (built).
+- The five sub-questions (career-over-time, recognition, reputation, trust↔mobility) are answered by the `events`/`recognition`/`reputation` slices of one projection.
+
+**Deliverable status:** complete (primary built, sub-views designed). → C5.

--- a/docs/wave225/C5-pre-integration.md
+++ b/docs/wave225/C5-pre-integration.md
@@ -1,0 +1,52 @@
+# W225-C5 — PRE Integration
+
+**Wave:** 225 · **Date:** 2026-06-21
+
+How the **Professional Recognition Event (PRE)** integrates across Evidence, Graph, Trust, Mobility, and Timeline — without weakening the canonical Recognition→Acceptance→Start contract.
+
+---
+
+## 0. What PRE already is
+
+PRE is **not new**. The canonical path already exists, signed and hash-anchored, in `packages/domain-common/employmentContracts.ts` and the Prisma `Recognition`/`Acceptance`/`Start` tables (see W215-C1):
+
+- `RecognitionEvent` — employer's signed acknowledgment (recognitionId, employerDid, proof Ed25519, hashAnchor).
+- `EmployerAcceptance` — countersigned acceptance (psvReportId gate).
+- `StartAttestation` — employer-attested actual start.
+- `VerifiedCanonicalPath` — a type-branded guarantee the three exist in order; **cannot be bypassed**.
+
+PRE = this triad as the persistent professional-recognition memory. W225 *surfaces* it; it does not redefine or relax it.
+
+## 1. Integration per layer (all read-only projections)
+
+| Layer | PRE integration |
+|---|---|
+| **Evidence** | `RecognitionEvent`/`EmployerAcceptance`/`StartAttestation` normalize (read-only) into `EvidenceObject{ class: recognition \| acceptance \| start }` (W220-C2). Status is decision-grade only when the signed event verifies; the normalizer never constructs a `VerifiedCanonicalPath`. |
+| **Graph** | recognition/acceptance/start evidence project as nodes; subject→node edges use `RECOGNIZED_BY` / `ACCEPTED_BY` / `STARTED_AT` (W221, already in `GRAPH_RELATIONSHIP_TYPES`). |
+| **Trust** | these classes feed `ProfessionalTrust` + `InstitutionalTrust` (W222 dimension map). A recognition reinforces professional standing; it never inflates authority/identity. |
+| **Mobility** | a `start`/`acceptance` is experience signal for `ExperienceRequirement`s (W230-C3); it does not by itself satisfy a licensure requirement. |
+| **Timeline** | recognition/acceptance/start events carry `recognitionImpact` and populate `TimelineProjection.recognition` (W225-C3, built). |
+
+## 2. The integration rule (one direction only)
+
+PRE flows **into** the projections as read-only evidence; the projections never write back a recognition. Specifically:
+
+1. **No synthesis.** The timeline/graph/trust never *create* a PRE — only the signed, gated canonical path does.
+2. **Branding preserved.** Evidence normalizers project an already-`VerifiedCanonicalPath`; they cannot mint one (TypeScript branding enforces this).
+3. **Scope preserved.** A recognition is scoped to its employer/role; it reinforces `professional`/`institutional` trust but is not global credential truth (Trust Graph PSV-scope rules apply).
+4. **Recorded-only.** Absence of a recognition in the projection ≠ "never recognized" (Rule 35) — the projection reflects what is recorded.
+
+## 3. Reputation linkage
+
+`ReputationSummary.standing` (W225-C3) is reinforced by recognition events through `ProfessionalTrust`, but standing can reach `established` only via decision-grade evidence breadth — a single recognition cannot manufacture an established reputation. This keeps reputation honest and non-gameable.
+
+## 4. Future (W250-3) — PRE as persistent identity memory
+
+When W250 expands PRE into "persistent professional identity memory," the substrate is already here: the canonical tables + the read-only projections. The expansion is additive (more recognition sources, richer scope), gated like every other persistence decision (`defer_until_contract_aligned`), and must preserve §2's one-direction rule.
+
+## 5. Success-criteria answers
+
+- **How do we model recognition?** As read-only evidence projected from the existing signed canonical path, surfaced in graph/trust/timeline.
+- **How do we evolve Graph → Memory?** The graph already carries recognition nodes; Memory is the timeline projection (built) that orders them with trust/mobility impact — no new store.
+
+**Deliverable status:** complete. → C6.

--- a/docs/wave225/C6-professional-memory-readiness-report.md
+++ b/docs/wave225/C6-professional-memory-readiness-report.md
@@ -1,0 +1,75 @@
+# W225-C6 — Professional Memory Readiness Report
+
+**Wave:** 225 · **Synthesizes:** C1–C5
+**Date:** 2026-06-21
+
+The state of the Professional Memory bridge: C2/C3 (CareerEvent + TimelineProjection) and the primary memory route are **built and tested**; C4 sub-views, C5 PRE deepening, and richer sources are designed.
+
+---
+
+## 0. Six success-criteria answers
+
+1. **Represent a career over time** → `TimelineProjection.events` — one `CareerEvent` per evidence node with trust/mobility/recognition impact (built).
+2. **Derive timelines** → `projectTimeline(evidence, graph, trust)`, a pure deterministic merge (built).
+3. **Model recognition** → recognition/acceptance/start evidence → `recognitionImpact` + `TimelineProjection.recognition`, projected from the signed canonical path (built; C5).
+4. **Model reputation** → `ReputationSummary.standing` deterministic threshold over decision-grade evidence + trust trend; honest `unknown` (built).
+5. **Connect trust history to mobility** → `CareerEvent` carries both `trustImpact` and `mobilityImpact`; a checked license is reinforcement *and* mobility-expansion in one event (built).
+6. **Evolve Graph → Memory** → Memory is the timeline projection over the graph + trust layers; no new store (built).
+
+## 1. Packages impacted
+
+| Package | Change | Status |
+|---|---|---|
+| `packages/domain-evidence` | + `src/timeline/timeline.ts` (`CareerEvent`, `TimelineProjection`, `projectTimeline`) + tests | **built** |
+| `apps/web` | + `GET /api/timeline/[entityId]` + adapter reuse + tests | **built** |
+| recruiter surfaces | none — `/packet`, `/passport`, `/employer-review`, `/api/graph/*` untouched | — |
+
+## 2. Schemas impacted
+
+- **No Prisma migration.** Timeline is a projection over existing evidence/graph/trust (which themselves project the passport). No new tables.
+- **New API contracts:** `vitalcv.timeline.v1` (built); `vitalcv.timeline-{events,trust-history,recognition,reputation}.v1` (designed, C4).
+- **No new evidence enums** — `CareerEventType` is derived from existing `EvidenceClass`.
+
+## 3. Routes impacted
+
+**New (built):** `GET /api/timeline/[entityId]`.
+**New (designed):** the four `/api/timeline/:id/*` sub-views (filters over the same projection).
+**Unchanged:** everything shipped to date.
+
+## 4. Migration & correctness risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Trust impact inflated by an event | **High (doctrine)** | `trustImpact` bounded [−1,1] via the monotonic trust scores; test asserts `≤ 1` |
+| Fabricated reputation | **High** | `standing: 'unknown'` when `decisionGradeEvidence === 0`; tested |
+| Timeline mistaken for the audit log | Med | C1/C4 state it is evidence-derived, not the recorded audit history |
+| PRE synthesized by a projection | **High** | one-direction rule (C5 §2); normalizers never mint `VerifiedCanonicalPath` |
+| Non-deterministic ordering | Med | stable sort by `occurredAt` then `eventId`; determinism test |
+| Banned strings / bare `Verified` | Med | `check:claims` + `banned-verified-label` green |
+
+## 5. Validation performed (built portion)
+
+| Check | Result |
+|---|---|
+| `domain-evidence` package tests | 28/28 (collection 4, graph 8, trust 8, timeline 8) |
+| web timeline + regression | 21/21 |
+| `tsc --noEmit` (package + web) | exit 0, 0 errors |
+| `pnpm check:claims` | pass |
+| ESLint (new route) | clean |
+
+## 6. Effort estimates (remaining, 1 unit ≈ a focused PR w/ tests)
+
+| Item | Effort |
+|---|---|
+| Four `/api/timeline/:id/*` sub-view routes + contract tests | 1 |
+| Dev timeline view (extend `/dev/graph/[entityId]` or new `/dev/timeline`) | 1 |
+| Deepen PRE sources beyond the passport (read canonical tables directly) | 2 |
+| Merge richer recorded events (audit/watchtower) per W215-C4 | 3 |
+
+**Built now ≈ 3 units; remaining ≈ 7 units.** The bridge is functional today on passport-derived evidence; deepening it to the full recorded history is additive and gated.
+
+## 7. Merge gate
+
+`dist/` is turbo-prebuilt in CI. This increment stacks on the unmerged evidence/graph/trust stack and needs a real **`codex exec` SAFE verdict** before `gh pr merge`.
+
+**Deliverable status:** W225 complete — C2/C3 + primary route built and green; C1/C4/C5/C6 delivered in `docs/wave225/`.

--- a/docs/wave230/C1-mobility-signal-inventory.md
+++ b/docs/wave230/C1-mobility-signal-inventory.md
@@ -1,0 +1,70 @@
+# W230-C1 — Mobility Signal Inventory
+
+**Wave:** 230 (Career Mobility Engine) · **Role:** Claude Code
+**Date:** 2026-06-21
+**Inputs reviewed:** EvidenceObject/EvidenceCollection (W220), GraphProjection (W221), TrustProjection — 7 dimensions + history (W222), plus the existing backend readiness engine.
+
+The deterministic signals already available that indicate mobility readiness. **No new signals needed** — mobility is a re-read of what the evidence/trust layers already produce.
+
+---
+
+## 0. Principle
+
+Mobility readiness = "is this clinician's existing, source-backed evidence sufficient for *this* opportunity, and if not, exactly what's missing?" Every signal below is deterministic and traces to a source-backed evidence object. No matching ML.
+
+## 1. Evidence-layer signals (per `EvidenceObject`)
+
+| Signal | Field | Mobility meaning |
+|---|---|---|
+| Evidence class | `evidenceClass` | what kind of requirement it can satisfy (licensure, board_cert, registration, …) |
+| Status | `status` (verbatim coverage) | whether it's decision-grade now (`checked`) or owed (gated/stale/pending) |
+| Decision-grade | `decisionGrade` | hard gate: only `checked` evidence satisfies a mandatory requirement |
+| Jurisdiction | `value.jurisdiction` (licensure/registration) | **the core mobility signal** — which states a clinician is already licensed in |
+| Freshness | `checkedAt` / `expiresAt` / `lifecycle` | whether reusable evidence is current or needs a refresh |
+| Coverage summary | `EvidenceCollection.coverageSummary` | sourceIds grouped by status — the reusable-vs-owed split |
+
+## 2. Trust-layer signals (per `TrustProjection`)
+
+| Signal | Field | Mobility meaning |
+|---|---|---|
+| **MobilityTrust** | `dimensions[mobility].score` | breadth/strength of decision-grade licensure + registration |
+| AuthorityTrust | `dimensions[authority]` | credential strength (license/board/registration/exclusion/enrollment) |
+| ProfessionalTrust | `dimensions[professional]` | experience signal (employment/recognition/start/training) |
+| LeadershipTrust | `dimensions[leadership]` | leadership signal (privilege/peer_review) |
+| Dimension `supporting` | reinforcing evidenceIds | what already qualifies the clinician |
+| Dimension `weakening` | gated/zero evidenceIds | **gap candidates** — evidence present but not decision-grade |
+| Dimension `origins` | source ids | where the qualifying trust comes from |
+| Overall | `overall.decisionGradeEvidence / totalEvidence` | how much of the evidence is reusable now |
+
+## 3. History signals (per `TrustHistory`)
+
+| Signal | Field | Mobility meaning |
+|---|---|---|
+| Decay entries | `history.entries[type='decay']` | reusable evidence about to expire → near-ready, needs refresh |
+| Reinforcement | `history.entries[type='reinforcement']` | recently re-verified, fully reusable |
+| Trend | `history.trend` | growing/decaying readiness trajectory |
+
+## 4. Existing backend signals to reuse (not rebuild)
+
+- **Readiness engine** (`apps/api/backend/.../readiness/readinessEngine.ts`) — `computeReadiness(npi, targetState, profession, artifacts)`: per-state readiness, blockers, `estimatedStartDays`, `clearToStartDate`.
+- **Endorsement / compact** (`endorsementDelays.ts`) — `NLC_COMPACT_STATES`, `COUNSELING_COMPACT_STATES`, `getEndorsementDelay(state, profession)`: the per-state time-to-license signal.
+- **Opportunity model** (Wave 227) — `Opportunity { specialties[], statesCovered[], requirements[] }`, `opportunityService`, `AcceptancePrediction { readinessBand, state, specialty, credentialTypes, gaps }`.
+- **Aggregate mobility** (`/api/intelligence/mobility`) — population-level `multiStateRate`, `compactLicenseHolders`. (Per-entity mobility, C4, is distinct from this.)
+
+## 5. The mobility question → which signals answer it
+
+| Question | Signals |
+|---|---|
+| Can this clinician work in state X? | licensure/registration evidence with `value.jurisdiction === X` that is `decisionGrade`; else compact eligibility + endorsement delay |
+| Is their evidence reusable? | `status === 'checked'` + not near `expiresAt` |
+| What's missing for opportunity Y? | requirement set (C2) minus satisfied evidence/trust (C3) |
+| How strong a candidate? | MobilityTrust + AuthorityTrust + ProfessionalTrust scores |
+| When could they start? | readiness engine `estimatedStartDays` + endorsement delay |
+
+## 6. Gaps in current signals (what the foundation must add)
+
+1. **Jurisdiction is under-modeled in evidence.** Licensure `value.jurisdiction` exists but isn't first-class; the mobility engine needs a normalized per-state index (C3/C5). No new storage — derived from existing credential jurisdictions.
+2. **No OpportunityObject in the evidence vocabulary.** The backend `Opportunity` is org-centric; mobility needs requirements expressed in `EvidenceClass`/`EvidenceStatus`/`TrustDimension` terms so gap detection is a pure diff (C2).
+3. **No per-entity readiness verdict against a specific opportunity.** Readiness engine is per-state; mobility needs per-opportunity (C5).
+
+**Deliverable status:** complete. → C2 (Opportunity Architecture).

--- a/docs/wave230/C2-opportunity-architecture.md
+++ b/docs/wave230/C2-opportunity-architecture.md
@@ -1,0 +1,101 @@
+# W230-C2 — Opportunity Architecture
+
+**Wave:** 230 · **Depends on:** [C1](./C1-mobility-signal-inventory.md)
+**Date:** 2026-06-21
+**Status:** architecture only — no implementation this wave.
+
+The `OpportunityObject`: requirements expressed in the **same vocabulary as evidence and trust**, so gap detection (C3) and readiness (C5) are pure deterministic diffs — not matching ML.
+
+---
+
+## 0. Design rule
+
+An opportunity's requirements must be checkable against an `EvidenceCollection` + `TrustProjection` by set operations only. Therefore every requirement is one of three checkable kinds, all keyed on existing enums (`EvidenceClass`, `EvidenceStatus`, `TrustDimension`).
+
+## 1. `OpportunityObject`
+
+```ts
+interface OpportunityObject {
+  opportunityId: string;
+  title: string;
+  /** Org context (reuse backend Opportunity.organizationId). */
+  organizationKey: string | null;
+  specialty: string | null;
+  /** States the role covers — the mobility axis. */
+  states: string[];
+  requirements: OpportunityRequirement[];
+  /** Schema version for the contract (vitalcv.opportunity.v1). */
+  schema: 'vitalcv.opportunity.v1';
+}
+```
+
+## 2. `OpportunityRequirement` (three checkable kinds)
+
+```ts
+type OpportunityRequirement =
+  | EvidenceRequirement
+  | TrustRequirement
+  | ExperienceRequirement;
+
+interface RequirementBase {
+  requirementId: string;
+  label: string;
+  /** mandatory blocks readiness; preferred only lowers strength. */
+  necessity: 'mandatory' | 'preferred';
+}
+
+/** "Needs a decision-grade license in CA." */
+interface EvidenceRequirement extends RequirementBase {
+  kind: 'evidence';
+  evidenceClass: EvidenceClass;          // licensure | board_cert | registration | exclusion | ...
+  /** Minimum status that satisfies it. Default 'checked' (decision-grade). */
+  minStatus: EvidenceStatus;             // almost always 'checked'
+  /** Optional jurisdiction constraint (the mobility axis). */
+  jurisdiction?: string;                 // e.g. 'CA'
+}
+
+/** "AuthorityTrust must be >= 0.6." */
+interface TrustRequirement extends RequirementBase {
+  kind: 'trust';
+  dimension: TrustDimension;             // authority | professional | leadership | ...
+  minScore: number;                      // 0..1
+}
+
+/** "Needs >= N decision-grade professional evidence items." */
+interface ExperienceRequirement extends RequirementBase {
+  kind: 'experience';
+  dimension: TrustDimension;             // typically 'professional' | 'leadership'
+  minDecisionGradeCount: number;
+}
+```
+
+## 3. Why these three kinds cover the brief's examples
+
+| Brief example | Requirement |
+|---|---|
+| Missing License | `EvidenceRequirement{ evidenceClass:'licensure', minStatus:'checked', jurisdiction:'X' }` |
+| Missing Board Certification | `EvidenceRequirement{ evidenceClass:'board_cert', minStatus:'checked' }` |
+| Missing Experience | `ExperienceRequirement{ dimension:'professional', minDecisionGradeCount: N }` |
+| Missing Leadership | `ExperienceRequirement{ dimension:'leadership', minDecisionGradeCount: N }` or `TrustRequirement{ dimension:'leadership', minScore }` |
+
+Every example is checkable by a pure function over `EvidenceCollection.byClass` / `TrustProjection.dimensions` — no algorithm beyond comparison.
+
+## 4. Source of opportunities (reuse, don't rebuild)
+
+- The backend already has `Opportunity { specialties[], statesCovered[], requirements[] }` (Wave 227) + `opportunityService`. `OpportunityObject` is a **normalized view** over that record — a pure adapter `fromBackendOpportunity()` maps `statesCovered → states` and the loosely-typed `requirements[]` into the three typed kinds.
+- No new persistence: opportunities live in the existing store; `OpportunityObject` is the evidence-vocabulary projection (parallels how `EvidenceObject` is a view over `ClaimRecord`).
+- A default requirement template per specialty (e.g. "active state license + clear exclusion + Medicare enrollment") can be a static, versioned config — deterministic, editable, no model.
+
+## 5. Honesty constraints
+
+1. `minStatus` defaults to `'checked'` — a mandatory requirement is satisfied **only** by decision-grade evidence (gated/stale never satisfies).
+2. Jurisdiction match is exact and case-normalized; "licensed in CA" never satisfies "needs NV" (compact eligibility is handled in C5, not by loosening the match).
+3. `preferred` requirements influence strength/ranking only — never flip Blocked→Ready.
+4. Requirements reference only existing enums, so an opportunity can never demand a trust signal the engine can't honestly compute.
+
+## 6. Success-criteria answers
+
+- **How do we represent opportunities?** `OpportunityObject` (§1), a normalized view over the existing backend Opportunity.
+- **How do we represent requirements?** Three checkable kinds keyed on `EvidenceClass`/`EvidenceStatus`/`TrustDimension` (§2).
+
+**Deliverable status:** complete. → C3 (Gap Engine).

--- a/docs/wave230/C3-gap-engine-blueprint.md
+++ b/docs/wave230/C3-gap-engine-blueprint.md
@@ -1,0 +1,98 @@
+# W230-C3 — Gap Engine Blueprint
+
+**Wave:** 230 · **Depends on:** [C2](./C2-opportunity-architecture.md)
+**Date:** 2026-06-21
+
+Deterministic gap detection: `(OpportunityObject, EvidenceCollection, TrustProjection) → Gap[]`. Pure set/threshold comparison — no matching algorithm.
+
+---
+
+## 0. Signature
+
+```ts
+function detectGaps(
+  opportunity: OpportunityObject,
+  evidence: EvidenceCollection,
+  trust: TrustProjection,
+): GapReport;   // pure, deterministic
+```
+
+## 1. `Gap` model
+
+```ts
+type GapKind = 'missing' | 'insufficient' | 'stale' | 'satisfied';
+
+interface Gap {
+  requirementId: string;
+  label: string;
+  necessity: 'mandatory' | 'preferred';
+  kind: GapKind;
+  /** Honest reason, in the source-coverage vocabulary. */
+  reason: string;
+  /** Evidence that partially satisfies but isn't decision-grade (the fixable path). */
+  blockingEvidenceIds: string[];
+  /** Whether a known remediation path exists (e.g. compact endorsement). */
+  remediation: GapRemediation | null;
+}
+
+interface GapRemediation {
+  type: 'request_refresh' | 'apply_endorsement' | 'submit_evidence' | 'await_review';
+  detail: string;
+  estimatedDays: number | null;   // from readiness engine / endorsementDelays
+}
+
+interface GapReport {
+  opportunityId: string;
+  subjectKey: string;
+  gaps: Gap[];
+  mandatoryUnmet: number;
+  preferredUnmet: number;
+}
+```
+
+## 2. Per-requirement evaluation (deterministic rules)
+
+### EvidenceRequirement
+1. Find evidence in `evidence.byClass[evidenceClass]` (optionally filtered by `jurisdiction === value.jurisdiction`).
+2. If a match has `status` meeting `minStatus` (default `checked`) → **satisfied**.
+3. If a match exists but is gated/stale/pending/reviewRequired → **insufficient** (or **stale** if stale), `blockingEvidenceIds = [match]`, remediation `request_refresh` / `await_review`.
+4. If no match at all → **missing**. If `jurisdiction` set and the clinician holds a compact-eligible license elsewhere → remediation `apply_endorsement` with `getEndorsementDelay(state, profession)`.
+
+### TrustRequirement
+1. Read `trust.dimensions[dimension].score`.
+2. `null` → **missing** ("no evidence in this dimension"). `< minScore` → **insufficient** (cite `weakening` evidenceIds). `>= minScore` → **satisfied**.
+
+### ExperienceRequirement
+1. Read `trust.dimensions[dimension].decisionGradeCount`.
+2. `>= minDecisionGradeCount` → **satisfied**; else **insufficient** / **missing** with the count shortfall.
+
+## 3. Worked examples (brief's list)
+
+| Requirement | Evidence/trust state | Gap |
+|---|---|---|
+| License in NV (mandatory) | only CA license (checked), NLC compact member | `missing` + remediation `apply_endorsement` (estimatedDays from `getEndorsementDelay('NV', profession)`) |
+| Board cert (mandatory) | no board_cert evidence | `missing`, remediation `submit_evidence` |
+| Board cert (mandatory) | board_cert present but `gated` | `insufficient`, `blockingEvidenceIds`, remediation `await_review` |
+| Experience ≥ 3 (preferred) | professional `decisionGradeCount = 1` | `insufficient` (preferred → strength only) |
+| Leadership (preferred) | leadership dimension `null` | `missing` (preferred) |
+
+## 4. Honesty rules (tested when built)
+
+1. A gated/stale match **never** satisfies a `checked`-min requirement — it's `insufficient`, not satisfied.
+2. Jurisdiction is exact; cross-state satisfaction only appears as a `remediation` (endorsement), never as a satisfied gap.
+3. `missing` vs `insufficient` is distinguished honestly (no evidence vs present-but-not-decision-grade).
+4. Remediation `estimatedDays` is `null` unless the readiness engine / endorsement table provides a real number — never fabricated.
+5. Deterministic ordering: gaps sorted mandatory-first, then by requirementId.
+
+## 5. Reuse
+
+- `EvidenceCollection.byClass`, `coverageSummary` (W220).
+- `TrustProjection.dimensions[*].{score, decisionGradeCount, weakening}` (W222).
+- `getEndorsementDelay`, `NLC_COMPACT_STATES`, `COUNSELING_COMPACT_STATES` (existing backend) for endorsement remediation.
+- `computeReadiness` per-state for `estimatedDays`.
+
+## 6. Success-criteria answer
+
+- **How do we identify gaps?** A pure per-requirement evaluation over `byClass` + `dimensions`, producing typed `Gap`s with honest `missing`/`insufficient`/`stale` kinds and real remediation paths.
+
+**Deliverable status:** complete. → C4 (Mobility API).

--- a/docs/wave230/C4-mobility-api-contracts.md
+++ b/docs/wave230/C4-mobility-api-contracts.md
@@ -1,0 +1,105 @@
+# W230-C4 — Mobility API Contracts
+
+**Wave:** 230 · **Depends on:** [C2](./C2-opportunity-architecture.md), [C3](./C3-gap-engine-blueprint.md), [C5](./C5-readiness-architecture.md)
+**Date:** 2026-06-21
+
+Read-only, versioned (`vitalcv.mobility.*.v1`) contracts. Per-entity (distinct from the existing aggregate `/api/intelligence/mobility`). All compose existing services; none mutates; none changes recruiter surfaces.
+
+---
+
+## 0. Conventions
+
+- `entityId` = `VcvEntity.canonicalId` or NPI (matches `fetchPassportEntity`).
+- Compose passport runtime → `EvidenceCollection` → `GraphProjection` → `TrustProjection` (W220–222) + `OpportunityObject` (C2) + `detectGaps` (C3) + `projectReadiness` (C5).
+- `Cache-Control: no-store`; honest empty states; no bare `Verified`; passes `pnpm check:claims`.
+
+---
+
+## 1. `GET /mobility/:entityId`
+
+Overview: mobility posture across the states/specialties the clinician is already evidenced for.
+
+```jsonc
+{
+  "schema": "vitalcv.mobility.v1",
+  "subjectKey": "…",
+  "mobilityTrust": 0.5,                    // TrustProjection.dimensions[mobility].score
+  "licensedStates": ["CA"],               // decision-grade licensure jurisdictions
+  "compactEligibleStates": ["NV", "AZ"],  // from NLC/Counseling compact membership
+  "reusableEvidenceCount": 4,             // decision-grade evidence
+  "summary": "Source-backed in CA; compact endorsement path to NV/AZ."
+}
+```
+Composes: `TrustProjection` + licensure evidence jurisdictions + compact tables.
+
+## 2. `GET /mobility/:entityId/gaps?opportunityId=`
+
+The `GapReport` (C3) for a specific opportunity (or a specialty default template if no `opportunityId`).
+
+```jsonc
+{
+  "schema": "vitalcv.mobility-gaps.v1",
+  "subjectKey": "…",
+  "opportunityId": "opp-123",
+  "mandatoryUnmet": 1,
+  "preferredUnmet": 1,
+  "gaps": [
+    { "requirementId": "lic-nv", "label": "NV state license", "necessity": "mandatory",
+      "kind": "missing", "reason": "No decision-grade NV licensure on file.",
+      "blockingEvidenceIds": [],
+      "remediation": { "type": "apply_endorsement", "detail": "NV is NLC compact-eligible.", "estimatedDays": 10 } }
+  ]
+}
+```
+Composes: `OpportunityObject` + `EvidenceCollection` + `TrustProjection` via `detectGaps`.
+
+## 3. `GET /mobility/:entityId/opportunities`
+
+Opportunities the clinician could be evaluated against, each with a readiness verdict (C5). **Not a matching algorithm** — a deterministic per-opportunity readiness pass over the existing `listPublicOpportunities()` set, filtered by specialty/state overlap.
+
+```jsonc
+{
+  "schema": "vitalcv.mobility-opportunities.v1",
+  "subjectKey": "…",
+  "opportunities": [
+    { "opportunityId": "opp-123", "title": "Hospitalist — NV", "state": "NV",
+      "readiness": "near_ready", "mandatoryUnmet": 1, "estimatedStartDays": 10 }
+  ],
+  "note": "Deterministic readiness over posted opportunities; ranking/matching is out of scope (W260)."
+}
+```
+The `note` is mandatory honesty — this endpoint does not rank or recommend; it evaluates.
+
+## 4. `GET /mobility/:entityId/readiness?opportunityId=`
+
+The `ReadinessProjection` (C5) for one opportunity.
+
+```jsonc
+{
+  "schema": "vitalcv.mobility-readiness.v1",
+  "subjectKey": "…",
+  "opportunityId": "opp-123",
+  "readiness": "near_ready",              // ready | near_ready | blocked | unknown
+  "rationale": "All mandatory met except NV license, which has a compact endorsement path.",
+  "blockers": [],
+  "fixableGaps": ["lic-nv"],
+  "estimatedStartDays": 10
+}
+```
+
+## 5. Contract summary
+
+| Route | Schema | Composes | New logic |
+|---|---|---|---|
+| `GET /mobility/:entityId` | `mobility.v1` | TrustProjection + licensure jurisdictions + compact tables | licensure→state index |
+| `GET /mobility/:entityId/gaps` | `mobility-gaps.v1` | `detectGaps` (C3) | gap engine |
+| `GET /mobility/:entityId/opportunities` | `mobility-opportunities.v1` | readiness pass over `listPublicOpportunities()` | per-opportunity readiness |
+| `GET /mobility/:entityId/readiness` | `mobility-readiness.v1` | `projectReadiness` (C5) | readiness projector |
+
+Four read routes; all pure composition over existing services + the new gap/readiness projectors. None touches `/packet`, `/passport`, `/employer-review`, or the existing `/api/graph/*`.
+
+## 6. Success-criteria answer
+
+- **How do we connect trust to opportunity?** The mobility routes feed `TrustProjection` + `EvidenceCollection` into `detectGaps` / `projectReadiness` against an `OpportunityObject` — trust dimensions become requirement checks, gaps become remediation paths.
+
+**Deliverable status:** complete. → C5 (Readiness Architecture).

--- a/docs/wave230/C5-readiness-architecture.md
+++ b/docs/wave230/C5-readiness-architecture.md
@@ -1,0 +1,83 @@
+# W230-C5 — Readiness Architecture
+
+**Wave:** 230 · **Depends on:** [C3](./C3-gap-engine-blueprint.md)
+**Date:** 2026-06-21
+
+`ReadinessProjection`: a deterministic verdict — **Ready / Near Ready / Blocked / Unknown** — for a clinician against one opportunity. Reuses the W205 recruiter-rollup honesty pattern, extended with the gap engine.
+
+---
+
+## 0. Signature
+
+```ts
+function projectReadiness(
+  opportunity: OpportunityObject,
+  gaps: GapReport,            // from detectGaps (C3)
+  trust: TrustProjection,     // W222
+  evidence: EvidenceCollection,
+): ReadinessProjection;       // pure, deterministic
+```
+
+## 1. `ReadinessProjection`
+
+```ts
+type MobilityReadiness = 'ready' | 'near_ready' | 'blocked' | 'unknown';
+
+interface ReadinessProjection {
+  subjectKey: string;
+  opportunityId: string;
+  readiness: MobilityReadiness;
+  rationale: string;
+  /** Hard blockers (no remediation path). */
+  blockers: string[];
+  /** Gaps with a known remediation path. */
+  fixableGaps: string[];
+  estimatedStartDays: number | null;
+}
+```
+
+## 2. Verdict rules (deterministic precedence — first match wins)
+
+1. **`blocked`** — any of:
+   - an `exclusion`/sanction evidence is adverse, or a mandatory credential is `revoked`/`reviewRequired` (hard safety/authority block), **or**
+   - a `mandatory` gap is `missing` with **no** remediation path.
+2. **`unknown`** — evidence coverage is insufficient to judge: overall `decisionGradeEvidence === 0`, or the opportunity's mandatory dimensions have `null` trust (nothing checked yet / `CHECKING`-equivalent).
+3. **`ready`** — every `mandatory` requirement is **satisfied** by decision-grade evidence and there are no blockers.
+4. **`near_ready`** — all remaining `mandatory` gaps are `insufficient`/`stale`/`missing-with-remediation` (a real path exists: refresh, endorsement, review). Preferred gaps never block.
+5. else **`unknown`** (never default to ready).
+
+This mirrors `deriveRecruiterRollup` (W205): **`ready` is reachable only with decision-grade evidence and zero blockers**; anything uncertain degrades honestly.
+
+## 3. Mapping to the four outputs
+
+| Output | Meaning | Driven by |
+|---|---|---|
+| **Ready** | reusable evidence already satisfies all mandatory requirements | all mandatory gaps `satisfied`, no blockers |
+| **Near Ready** | a clear, time-bounded path exists | mandatory gaps all have remediation (endorsement/refresh/review) |
+| **Blocked** | safety/authority block or unremediable missing mandatory | exclusion adverse / revoked / missing-no-path |
+| **Unknown** | not enough checked evidence to judge | `decisionGradeEvidence === 0` or mandatory dimensions `null` |
+
+## 4. `estimatedStartDays`
+
+- `ready` → 0 (or the opportunity's onboarding floor).
+- `near_ready` → max of the fixable gaps' `remediation.estimatedDays` (endorsement delay from `getEndorsementDelay`, refresh SLA). `null` if none known — **never fabricated**.
+- `blocked` / `unknown` → `null`.
+
+## 5. Honesty constraints (tested when built)
+
+1. `ready` requires **decision-grade** satisfaction of every mandatory requirement (no gated/stale shortcut) — the partial-stays-partial rule, end to end.
+2. `unknown ≠ blocked` — absence of evidence is honest uncertainty, not a negative verdict (Trust Graph Rule 35: absence of a recorded revocation is not a guarantee, and absence of evidence is not a fail).
+3. A `preferred` gap can lower strength but can never produce `blocked` or downgrade `ready`.
+4. `estimatedStartDays` is `null` unless a real source provides it.
+5. Deterministic: same inputs → same verdict (no `Date.now()` in the projector).
+
+## 6. Relationship to existing readiness
+
+- The existing `PassportData.readiness` (`DECISION_GRADE/PARTIAL/CHECKING/BLOCKED`) is **per-clinician, opportunity-agnostic**. `ReadinessProjection` is **per-opportunity** and consumes the same evidence — they agree on the partial-stays-partial spine but answer different questions.
+- `MobilityReadiness` deliberately uses distinct labels (`ready/near_ready/blocked/unknown`) to avoid being confused with the clinician-level `ReadinessState`.
+
+## 7. Success-criteria answer
+
+- **How do we calculate readiness?** A deterministic precedence over the gap report + trust dimensions, producing Ready/Near Ready/Blocked/Unknown with an honest rationale and a non-fabricated time estimate.
+
+**Deliverable status:** complete. → C6 (Implementation Readiness Report).

--- a/docs/wave230/C6-mobility-readiness-report.md
+++ b/docs/wave230/C6-mobility-readiness-report.md
@@ -1,0 +1,88 @@
+# W230-C6 — Mobility Readiness Report
+
+**Wave:** 230 · **Synthesizes:** [C1](./C1-mobility-signal-inventory.md)–[C5](./C5-readiness-architecture.md)
+**Date:** 2026-06-21
+
+The executable plan to build the Career Mobility foundation on top of the shipped evidence/graph/trust layers. Outcome: implementation-ready, no matching ML.
+
+---
+
+## 0. Six success-criteria answers
+
+1. **Represent opportunities** → `OpportunityObject`, a normalized view over the existing backend `Opportunity` (C2). No new store.
+2. **Represent requirements** → three checkable kinds (`EvidenceRequirement` / `TrustRequirement` / `ExperienceRequirement`) keyed on existing enums (C2).
+3. **Calculate readiness** → `projectReadiness` precedence over the gap report — Ready/Near Ready/Blocked/Unknown (C5).
+4. **Identify gaps** → `detectGaps` pure per-requirement evaluation over `byClass` + `dimensions` (C3).
+5. **Connect trust to opportunity** → `TrustRequirement`/`ExperienceRequirement` read `TrustProjection.dimensions`; gaps carry remediation (C3/C4).
+6. **Evolve Trust Engine → Mobility Engine** → a new pure module `packages/domain-evidence/src/mobility/` consuming `TrustProjection` + `EvidenceCollection` + `OpportunityObject`. Additive; the trust engine is unchanged.
+
+## 1. Affected packages
+
+| Package | Change | Risk |
+|---|---|---|
+| `packages/domain-evidence` | + `src/mobility/` (`OpportunityObject`, `detectGaps`, `projectReadiness`, opportunity adapter) — all pure | Low |
+| `packages/domain-evidence` | possibly reference compact-state tables; keep them in app/backend, pass results in (purity) | Low |
+| `apps/web` | + 4 read routes under `/mobility/*`; reuse passport runtime + evidence/trust composition | Low |
+| `apps/api/backend` | reuse `opportunityService`, `computeReadiness`, `endorsementDelays` — no change to existing routes | Low–Med |
+| recruiter surfaces | none — `/packet`, `/passport`, `/employer-review`, `/api/graph/*` untouched | None |
+
+## 2. Affected routes
+
+**New (additive, read-only):** `GET /mobility/:entityId`, `…/gaps`, `…/opportunities`, `…/readiness`.
+**Unchanged:** everything shipped to date (evidence, graph, trust, packet, passport, employer-review). The existing aggregate `/api/intelligence/mobility` is left as-is — the new routes are per-entity and clearly distinct.
+
+## 3. Schema impact
+
+- **No Prisma migration.** `OpportunityObject` is a view over the existing `Opportunity` record; gaps/readiness are computed projections over existing evidence.
+- **New versioned API contracts only:** `vitalcv.opportunity.v1`, `vitalcv.mobility.v1`, `vitalcv.mobility-gaps.v1`, `vitalcv.mobility-opportunities.v1`, `vitalcv.mobility-readiness.v1`.
+- **No new enums in the evidence vocabulary** — requirements reuse `EvidenceClass`/`EvidenceStatus`/`TrustDimension`.
+
+## 4. Migration & correctness risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Gated/stale evidence satisfying a mandatory requirement | **High (doctrine)** | `minStatus` defaults `checked`; gap test proves gated→`insufficient`, never satisfied |
+| `ready` produced without decision-grade coverage | **High** | `projectReadiness` precedence + a partial-fixture test (parallels W205 recruiter rollup) |
+| `unknown` conflated with `blocked` | Med | explicit separate verdict; "absence of evidence is not a fail" test |
+| Fabricated `estimatedStartDays` | Med | `null` unless readiness engine/endorsement table supplies a real number |
+| Cross-state license over-credited | Med | exact jurisdiction match; compact only via explicit `apply_endorsement` remediation |
+| Opportunity requirements drift from backend shape | Med | single `fromBackendOpportunity` adapter + golden-fixture test |
+| Perceived "matching/recommendation" overreach | Med (product) | `/opportunities` carries a mandatory `note`: deterministic evaluation, not ranking (ranking deferred to W260) |
+
+## 5. Performance
+
+- All per-entity; bounded by one clinician's evidence. Reuses the cached evidence/trust composition (ETag on `lastCheckedAt`).
+- `/mobility/:entityId/opportunities` iterates posted opportunities (filtered by specialty/state first) — cap + `truncated` flag, no silent limit.
+
+## 6. Test strategy (when built)
+
+1. **Unit (pure):** `detectGaps` per requirement kind; `projectReadiness` precedence (ready/near/blocked/unknown); opportunity adapter.
+2. **Honesty/property:** gated never satisfies; `ready` only with decision-grade mandatory coverage; `unknown ≠ blocked`; `estimatedStartDays` null unless sourced; deterministic.
+3. **Contract:** each route returns its `vitalcv.*.v1` schema + honest empty/`truncated` states.
+4. **Regression:** evidence/graph/trust/packet suites stay green; `pnpm check:claims`, typecheck, web build.
+5. **Codex SAFE** before merge.
+
+## 7. Effort estimates (1 unit ≈ a focused PR w/ tests)
+
+| Item | Effort |
+|---|---|
+| `OpportunityObject` types + `fromBackendOpportunity` adapter + tests | 1.5 |
+| `detectGaps` + Gap model + tests (per requirement kind) | 2 |
+| `projectReadiness` + precedence + honesty tests | 1.5 |
+| 4 `/mobility/*` routes + contract tests | 2 |
+| Licensure→state index + compact endorsement wiring | 1.5 |
+| Dev mobility view (optional, parallels graph explorer) | 1 |
+
+**Total ≈ 9.5 units.** ~75% reuse (trust/evidence/graph already shipped; opportunity store + readiness engine + compact tables already exist). The only genuinely new logic is the gap engine and readiness precedence — both pure, both small, both fully testable.
+
+## 8. Recommended build order (when the user says go)
+
+1. `OpportunityObject` + adapter (foundation).
+2. `detectGaps` + `GET /mobility/:entityId/gaps`.
+3. `projectReadiness` + `GET /mobility/:entityId/readiness`.
+4. `GET /mobility/:entityId` overview + licensure→state index.
+5. `GET /mobility/:entityId/opportunities` (deterministic readiness pass; explicitly not ranking).
+
+Matching/ranking stays out of scope until W260 — this wave is the foundation, exactly as briefed.
+
+**Deliverable status:** W230 complete — C1–C6 in `docs/wave230/`.

--- a/docs/wave235/C1-reputation-signal-inventory.md
+++ b/docs/wave235/C1-reputation-signal-inventory.md
@@ -1,0 +1,47 @@
+# W235-C1 — Reputation Signal Inventory
+
+**Wave:** 235 (Professional Reputation Engine) · **Role:** Claude Code
+**Date:** 2026-06-21
+**Inputs analyzed:** EvidenceCollection (W220), GraphProjection (W221), TrustProjection (W222), TimelineProjection + ReputationSummary (W225).
+
+The deterministic signals from which reputation can be **derived** — never rated, never opined.
+
+---
+
+## 0. Definition (the anti-subjectivity anchor)
+
+In VitalCV, **reputation = the depth, breadth, and currency of source-backed professional evidence in a domain.** It is *not* a popularity, peer-opinion, or quality score. Every reputation number must trace to countable, source-backed facts: how much decision-grade evidence, across how many distinct sources/jurisdictions, how recently re-verified. No human rating, no ML, no hidden weights.
+
+## 1. Signals already available
+
+| Signal | Source | Objective? |
+|---|---|---|
+| Decision-grade evidence count (per class) | `EvidenceCollection.byClass`, `decisionGrade` | yes — a count |
+| Source breadth | distinct `EvidenceObject.source.sourceId` (decision-grade) | yes — a count |
+| Jurisdictional breadth | licensure/registration `value.jurisdiction` | yes — a count |
+| Trust dimension scores (7) | `TrustProjection.dimensions[*].score` | yes — bounded mean of evidence (W222) |
+| Dimension `supporting`/`weakening`/`origins` | `DimensionTrust` | yes — evidence id lists |
+| Recognition count | `CareerEvent.recognitionImpact !== 'none'` | yes — a count of signed canonical-path events |
+| Currency / recency | `CareerEvent.occurredAt`, `expiresAt`, `lifecycle` | yes — timestamps |
+| Reinforcement / decay | `TrustHistory.entries`, `CareerEvent.trustImpact` | yes — signed deltas |
+| Standing seed | `ReputationSummary.standing` (W225) | yes — threshold over decision-grade evidence |
+
+## 2. Signals deliberately EXCLUDED (to avoid subjectivity)
+
+- Peer ratings / endorsements / "likes" — none exist, none will be invented.
+- Employer satisfaction / performance opinion — out of scope; not source-backed fact.
+- Specialty "prestige" weighting — would inject editorial judgment.
+- Any ML-derived or learned weight.
+
+## 3. Reputation is a re-projection, not a new measurement
+
+Every reputation signal above is **already produced** by the trust/timeline layers. The Reputation Engine (C2/C3) re-groups and rolls them up into domain-facing dimensions — it measures nothing new and adds no opinion. This is the key to "no subjective scoring": reputation inherits its objectivity from the trust layer's evidence-bounded, monotonic guarantees.
+
+## 4. Gaps the engine must add (C2/C3)
+
+1. **Domain regrouping** — map the 7 trust dimensions into the 5 reputation dimensions (C3), with full evidence traceability.
+2. **Breadth + currency rollups** — count distinct sources/jurisdictions and most-recent reinforcement per dimension.
+3. **Recovery detection** — a decay later followed by a same-dimension reinforcement (deterministic pattern, C4).
+4. **Milestones** — first decision-grade evidence in a dimension, first recognition, standing crossings (deterministic events, C4).
+
+**Deliverable status:** complete. → C2.

--- a/docs/wave235/C2-reputation-projection-model.md
+++ b/docs/wave235/C2-reputation-projection-model.md
@@ -1,0 +1,78 @@
+# W235-C2 — Reputation Projection Model
+
+**Wave:** 235 · **Depends on:** [C1](./C1-reputation-signal-inventory.md)
+**Date:** 2026-06-21 · Architecture only.
+
+`projectReputation(evidence, trust, timeline) → ReputationProjection`. Pure, deterministic, re-projection of objective signals — extends the W225 `ReputationSummary` seed into domain dimensions + history.
+
+---
+
+## 0. The Objectivity Contract (every reputation number obeys all five)
+
+1. **Traceable** — carries the `evidenceId`s it derives from (`basis`); a reader can verify it by hand.
+2. **Evidence-bounded** — a reputation dimension score never exceeds its underlying trust dimension score (anchored to the W222 monotonic guarantee; no inflation).
+3. **Decision-grade-gated** — only `checked` evidence raises reputation; gated/stale/notDecisionGrade cannot.
+4. **No editorial weights** — any combination of signals uses explicit, documented, equal-or-justified factors; no learned or arbitrary weighting.
+5. **Honest absence** — no evidence in a domain → `score: null`, `standing: 'unknown'` (never a fabricated 0-or-positive).
+
+This contract is the formal answer to "how do we avoid subjective scoring."
+
+## 1. `ReputationProjection`
+
+```ts
+interface ReputationProjection {
+  subjectKey: string;
+  /** Reuses/extends the W225 ReputationSummary (overall standing + counts + trend). */
+  overall: ReputationSummary;
+  dimensions: ReputationDimension[];   // the 5 of C3, always all present
+  history: ReputationHistory;          // C4
+  basis: {
+    totalEvidence: number;
+    decisionGradeEvidence: number;
+    distinctSources: string[];
+    distinctJurisdictions: string[];
+  };
+}
+```
+
+## 2. `ReputationDimension` (shape used by C3)
+
+```ts
+interface ReputationDimension {
+  dimension: ReputationDimensionId;        // C3
+  /** = underlying trust dimension score, or null. NEVER exceeds it. */
+  score: number | null;
+  standing: 'established' | 'emerging' | 'provisional' | 'unknown';
+  /** distinct decision-grade evidence count in this domain. */
+  breadth: number;
+  /** distinct sources/jurisdictions backing it. */
+  distinctSources: string[];
+  /** most recent reinforcement timestamp (currency). */
+  lastReinforcedAt: string | null;
+  /** signed-canonical recognition events contributing (operational/leadership). */
+  recognitionCount: number;
+  /** full traceability — the evidenceIds this score derives from. */
+  basis: string[];
+}
+```
+
+## 3. Derivation (deterministic)
+
+For each reputation dimension:
+1. `score` = the underlying trust dimension `score` (C3 maps which trust dimension(s) feed it). When two trust dimensions feed one reputation dimension, combine by **min or mean of the contributing trust scores** (documented per dimension) — never a sum (sums could exceed 1 and inflate).
+2. `standing` = same threshold ladder as W225 (`>=0.67 established`, `>=0.34 emerging`, `>0 provisional`, else/unknown).
+3. `breadth` = count of distinct decision-grade `EvidenceObject`s in the contributing classes.
+4. `distinctSources` / `lastReinforcedAt` / `recognitionCount` = rollups over the contributing `CareerEvent`s.
+5. `basis` = the contributing `evidenceId`s (the receipt for the score).
+
+## 4. Relationship to existing layers
+
+- **Reads only** `EvidenceCollection` + `TrustProjection` + `TimelineProjection` — all already shipped. No new measurement, no new persistence.
+- `overall` reuses the W225 `ReputationSummary` verbatim (standing/trend/counts) — reputation projection is its richer sibling, not a replacement.
+
+## 5. Success-criteria answers
+
+- **How do we derive reputation?** Re-project objective trust/evidence/recognition signals into domain dimensions (§3).
+- **How do we avoid subjective scoring?** The Objectivity Contract (§0) — traceable, evidence-bounded, decision-grade-gated, no editorial weights, honest absence.
+
+**Deliverable status:** complete. → C3.

--- a/docs/wave235/C3-dimension-model.md
+++ b/docs/wave235/C3-dimension-model.md
@@ -1,0 +1,67 @@
+# W235-C3 — Reputation Dimension Model
+
+**Wave:** 235 · **Depends on:** [C2](./C2-reputation-projection-model.md)
+**Date:** 2026-06-21 · Architecture for implementation (no code this wave).
+
+Five domain-facing reputation dimensions, each a **deterministic re-grouping** of the seven W222 trust dimensions + evidence counts. Mapping is explicit so the derivation is auditable.
+
+---
+
+## 0. Dimension ids
+
+```ts
+type ReputationDimensionId =
+  | 'authority' | 'leadership' | 'research' | 'academic' | 'operational';
+```
+
+## 1. Mapping to trust dimensions + evidence classes
+
+| Reputation dimension | Backed by trust dimension(s) | Contributing evidence classes | Score rule |
+|---|---|---|---|
+| **AuthorityReputation** | `authority` | licensure, board_cert, registration, exclusion, enrollment | = `authorityTrust.score` |
+| **LeadershipReputation** | `leadership` | privilege, peer_review | = `leadershipTrust.score` |
+| **ResearchReputation** | `research` | research, publication | = `researchTrust.score` |
+| **AcademicReputation** | `professional` (training subset) + `research` | training, research, publication | = **mean**(trainingEvidenceScore, researchTrust.score) where present; null if neither |
+| **OperationalReputation** | `professional` + `institutional` | employment, recognition, acceptance, start, training | = **min**(professionalTrust.score, institutionalTrust.score) where both present, else the present one |
+
+**Why min/mean, never sum:** combining with `min`/`mean` keeps the result in `[0,1]` and never exceeds either contributing trust score — preserving the no-inflation guarantee. A `sum` could manufacture reputation above the evidence ceiling and is banned.
+
+## 2. Independence vs. shared inputs
+
+Reputation dimensions, like trust dimensions, are **computed independently**. AcademicReputation and ResearchReputation both read research evidence; this is intentional (a publication reinforces both academic standing and research output) and does not let one dimension's score feed another's — each is derived directly from the trust layer, not from a sibling reputation dimension.
+
+## 3. Per-dimension rollups (objective)
+
+Each `ReputationDimension` (C2 §2) carries, in addition to `score`:
+- `breadth` — distinct decision-grade evidence count in its classes.
+- `distinctSources` — distinct backing sources/jurisdictions.
+- `recognitionCount` — for `leadership`/`operational`, signed canonical-path events (RECOGNIZED_BY/ACCEPTED_BY/STARTED_AT).
+- `lastReinforcedAt` — currency.
+- `basis` — the contributing `evidenceId`s.
+
+## 4. Worked example
+
+A cardiologist with: CA + NV board-verified licenses (checked), one ABMS board cert (checked), 3 publications (checked), one residency (checked), one employer recognition (signed):
+
+| Dimension | score | breadth | notes |
+|---|---|---|---|
+| AuthorityReputation | high (= authorityTrust) | 3 (2 licenses + 1 cert) | 2 jurisdictions |
+| LeadershipReputation | null | 0 | no privilege/peer-review evidence → honest null |
+| ResearchReputation | high | 3 | publications |
+| AcademicReputation | mean(training, research) | 4 | residency + publications |
+| OperationalReputation | = professional (institutional null) | 2 | employment + recognition; recognitionCount 1 |
+
+LeadershipReputation is honestly `null/unknown` — no leadership evidence exists, and nothing fabricates it.
+
+## 5. Honesty constraints (tested when built)
+
+1. No reputation dimension score exceeds its contributing trust score(s).
+2. Gated/stale evidence never raises a dimension (decision-grade only in `breadth` and score).
+3. A dimension with no contributing decision-grade evidence is `null` / `unknown`.
+4. Combination is `min`/`mean` only — never `sum`; property test asserts `score ≤ min(contributing trust scores)` for `min`-combined dimensions.
+
+## 6. Success-criteria answer
+
+- **How do we preserve trust invariants?** Reputation dimensions are anchored to trust dimension scores and bounded by them (`min`/`mean`, never `sum`); decision-grade gating and honest absence carry through unchanged.
+
+**Deliverable status:** complete. → C4.

--- a/docs/wave235/C4-reputation-history.md
+++ b/docs/wave235/C4-reputation-history.md
@@ -1,0 +1,78 @@
+# W235-C4 — Reputation History
+
+**Wave:** 235 · **Depends on:** [C3](./C3-dimension-model.md)
+**Date:** 2026-06-21
+
+How reputation evolves through time — **Growth, Decay, Recovery, Milestones** — derived deterministically from `CareerEvent`s + `TrustHistory` (W225). No new time series; a projection of existing timestamps.
+
+---
+
+## 0. Model
+
+```ts
+type ReputationEventType = 'growth' | 'decay' | 'recovery' | 'milestone';
+
+interface ReputationHistoryEntry {
+  occurredAt: string | null;
+  type: ReputationEventType;
+  dimension: ReputationDimensionId | null;
+  detail: string;
+  evidenceId: string | null;
+  /** signed; bounded by the underlying CareerEvent.trustImpact. */
+  scoreDelta: number;
+}
+
+interface ReputationHistory {
+  entries: ReputationHistoryEntry[];   // sorted asc by occurredAt, nulls last
+  growth: number;       // count of net-positive periods / reinforcements
+  decay: number;        // count of decay events
+  recovery: number;     // count of detected recoveries
+  milestones: number;   // count of milestone events
+  trend: 'growing' | 'decaying' | 'stable';   // reuse TrustHistory.trend
+}
+```
+
+## 1. Deterministic derivation rules
+
+| Type | Rule (pure) |
+|---|---|
+| **Growth** | a `CareerEvent` with `trustImpact > 0` in a dimension → growth entry (`+trustImpact`). Mirrors `TrustHistory` reinforcement. |
+| **Decay** | a `CareerEvent` with `trustImpact < 0` (stale/expired/revoked) → decay entry (`−`). |
+| **Recovery** | within a dimension, a decay event followed (strictly later by `occurredAt`) by a growth event for the **same source/class** → recovery entry at the growth timestamp. Pure two-pass scan over sorted events. |
+| **Milestone** | first decision-grade evidence in a dimension; first recognition event; a `standing` threshold crossing (`provisional→emerging→established`). All computed by replaying the sorted events. |
+
+## 2. Recovery detection (the one non-trivial pattern)
+
+```
+for each dimension:
+  sort its events by occurredAt
+  track lastDecayAt per source/class
+  on a growth event whose source/class had a prior decay (lastDecayAt < occurredAt):
+    emit recovery(dimension, occurredAt, evidenceId)
+```
+Deterministic, O(n log n), no state outside the event list. A re-verified-after-expiry license is the canonical recovery.
+
+## 3. Milestones (deterministic, replayable)
+
+- **First verification** in a dimension → "AuthorityReputation established its first source-backed credential."
+- **First recognition** (signed canonical event) → "First professional recognition recorded."
+- **Standing crossing** → emitted when the running decision-grade evidence count crosses a threshold that flips `standing`.
+
+All milestones are functions of the ordered event set — same input, same milestones (replay-safe).
+
+## 4. Honesty constraints
+
+1. Reputation history is **derived from current evidence timestamps**, not a recorded reputation log — stated explicitly (Trust Graph Rule 35).
+2. `scoreDelta` is bounded by the underlying `CareerEvent.trustImpact` ([−1, 1]); no event inflates.
+3. Recovery requires a *real* later reinforcement — never inferred from absence.
+4. Deterministic ordering and counts (replay-safe; no `Date.now()`).
+
+## 5. Connection to mobility (success-criterion #4)
+
+A reputation **recovery** or **growth** in `authority`/`mobility`-adjacent classes (a re-verified or newly added license) is simultaneously a **mobility-expansion** `CareerEvent` (W225 already sets `mobilityImpact: 'expands'`). So reputation history and mobility readiness move together by construction — the same event carries both signals. This is how reputation connects to mobility without a separate model.
+
+## 6. Success-criteria answer
+
+- **How do we represent reputation through time?** A deterministic projection of `CareerEvent`s into growth/decay/recovery/milestone entries — replay-safe, evidence-bounded, traceable.
+
+**Deliverable status:** complete. → C5.

--- a/docs/wave235/C5-api-blueprint.md
+++ b/docs/wave235/C5-api-blueprint.md
@@ -1,0 +1,75 @@
+# W235-C5 — Reputation API Blueprint
+
+**Wave:** 235 · **Depends on:** [C2](./C2-reputation-projection-model.md)–[C4](./C4-reputation-history.md)
+**Date:** 2026-06-21
+
+Read-only, versioned (`vitalcv.reputation.*.v1`) contracts. Compose the shipped evidence/trust/timeline pipeline; no persistence; recruiter surfaces untouched. Same pattern as the evidence/graph/trust/timeline routes.
+
+---
+
+## 1. `GET /reputation/:entityId`
+
+The full `ReputationProjection`.
+
+```jsonc
+{
+  "schema": "vitalcv.reputation.v1",
+  "subjectKey": "…",
+  "overall": { "standing": "emerging", "overallTrust": 0.6, "decisionGradeEvidence": 4,
+               "totalEvidence": 6, "trend": "growing" },
+  "dimensions": [
+    { "dimension": "authority", "score": 0.8, "standing": "established", "breadth": 3,
+      "distinctSources": ["STATE_BOARD", "ABMS"], "lastReinforcedAt": "2026-03-03T…",
+      "recognitionCount": 0, "basis": ["cred:lic-ca", "cred:lic-nv", "cred:abms"] },
+    { "dimension": "leadership", "score": null, "standing": "unknown", "breadth": 0,
+      "distinctSources": [], "lastReinforcedAt": null, "recognitionCount": 0, "basis": [] }
+  ],
+  "history": { "growth": 4, "decay": 1, "recovery": 1, "milestones": 3, "trend": "growing", "entries": [ … ] },
+  "basis": { "totalEvidence": 6, "decisionGradeEvidence": 4,
+             "distinctSources": ["NPPES_API", "STATE_BOARD", "ABMS", "ORCID"], "distinctJurisdictions": ["CA", "NV"] }
+}
+```
+
+## 2. `GET /reputation/:entityId/history`
+
+The `ReputationHistory` only (growth/decay/recovery/milestones + entries). Supports `?dimension=authority&since=&limit=`.
+
+```jsonc
+{ "schema": "vitalcv.reputation-history.v1", "subjectKey": "…",
+  "growth": 4, "decay": 1, "recovery": 1, "milestones": 3, "trend": "growing",
+  "entries": [ { "occurredAt": "…", "type": "recovery", "dimension": "authority",
+                 "detail": "CA license re-verified after expiry", "evidenceId": "cred:lic-ca", "scoreDelta": 1 } ] }
+```
+
+## 3. `GET /reputation/:entityId/dimensions`
+
+The five `ReputationDimension`s only — for a domain-by-domain view.
+
+```jsonc
+{ "schema": "vitalcv.reputation-dimensions.v1", "subjectKey": "…",
+  "dimensions": [ /* ReputationDimension[] */ ] }
+```
+
+## 4. Contract summary
+
+| Route | Schema | Composes |
+|---|---|---|
+| `GET /reputation/:entityId` | `reputation.v1` | `projectReputation(evidence, trust, timeline)` |
+| `GET /reputation/:entityId/history` | `reputation-history.v1` | `.history` slice |
+| `GET /reputation/:entityId/dimensions` | `reputation-dimensions.v1` | `.dimensions` slice |
+
+Pipeline: `passport → EvidenceCollection → GraphProjection → TrustProjection → TimelineProjection → ReputationProjection`. The first four stages already ship; only `projectReputation` is new.
+
+## 5. Honesty / API rules
+
+1. Every score carries its `basis` (evidenceIds) — the API is self-auditing (objectivity proof in the payload).
+2. `null` score + `unknown` standing render honestly for empty domains.
+3. No bare `Verified`; passes `pnpm check:claims`.
+4. Read-only, `Cache-Control: no-store`, ETag on `lastCheckedAt` (caching designed).
+5. Auth posture matches the passport surface (flag for policy, as with the other evidence routes).
+
+## 6. Success-criteria answer
+
+- **How do we connect reputation to mobility?** Reputation dimensions (esp. `authority`) and mobility readiness read the same licensure/registration evidence; a reputation growth/recovery in those classes is the same `CareerEvent` that expands mobility (C4 §5). No separate connector needed.
+
+**Deliverable status:** complete. → C6.

--- a/docs/wave235/C6-reputation-readiness-report.md
+++ b/docs/wave235/C6-reputation-readiness-report.md
@@ -1,0 +1,65 @@
+# W235-C6 — Reputation Readiness Report
+
+**Wave:** 235 · **Synthesizes:** C1–C5
+**Date:** 2026-06-21 · Design only — no code (the unmerged stack is in SAFE review, W228).
+
+---
+
+## 0. Five success-criteria answers
+
+1. **How do we derive reputation?** Re-project objective trust/evidence/recognition signals into 5 domain dimensions + history — no new measurement (C2/C3).
+2. **How do we avoid subjective scoring?** The Objectivity Contract (C2 §0): traceable `basis`, evidence-bounded, decision-grade-gated, no editorial weights, honest absence. No ratings, no ML.
+3. **How do we represent reputation through time?** Deterministic growth/decay/recovery/milestone projection over `CareerEvent`s (C4).
+4. **How do we connect reputation to mobility?** Same licensure/registration evidence feeds both; a reputation growth in those classes *is* a mobility-expansion event (C4 §5, C5 §6).
+5. **How do we preserve trust invariants?** Reputation scores are anchored to and bounded by trust dimension scores (`min`/`mean`, never `sum`); decision-grade gating + honest absence carry through (C3 §5).
+
+## 1. Affected packages
+
+| Package | Change | Risk |
+|---|---|---|
+| `packages/domain-evidence` | + `src/reputation/reputation.ts` (`projectReputation`, `ReputationProjection`, `ReputationDimension`, `ReputationHistory`) — pure, reads evidence+trust+timeline | Low |
+| `apps/web` | + 3 read routes `/reputation/:id(/history,/dimensions)` reusing the existing adapter+pipeline | Low |
+| recruiter surfaces | none | None |
+
+Layering stays acyclic: `reputation` sits **above** `timeline` (`types→collection→graph→trust→timeline→reputation`). It reads, never feeds back.
+
+## 2. Affected schemas
+
+- **No Prisma migration.** Reputation is a projection over the passport-derived pipeline. No new tables.
+- **New API contracts:** `vitalcv.reputation.v1`, `vitalcv.reputation-history.v1`, `vitalcv.reputation-dimensions.v1`.
+- **No new evidence/trust enums** — reputation dimensions map from existing trust dimensions + evidence classes.
+
+## 3. Migration risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Reputation read as a subjective/quality score | **High (product)** | Objectivity Contract + `basis` in every payload; copy never implies endorsement; passes `check:claims` |
+| Combination inflates above evidence ceiling | **High (doctrine)** | `min`/`mean` only, never `sum`; property test `score ≤ contributing trust score` |
+| Reputation history mistaken for a recorded log | Med | documented as evidence-derived (Rule 35) |
+| Gated/stale raising reputation | Med | decision-grade gating in score + breadth; tested |
+| Overlap (academic/research) double-counts | Low | independent computation; documented; no cross-dimension feedback |
+
+## 4. Testing strategy (when built)
+
+1. **Unit (pure):** dimension mapping totality; `score ≤ contributing trust score` (no inflation); null/unknown for empty domains; recovery detection (decay→later-reinforcement); milestone replay determinism.
+2. **Objectivity property:** every dimension `score` reconstructable from its `basis` evidenceIds; no score without decision-grade backing.
+3. **Contract:** each route returns its `vitalcv.reputation*.v1` schema + honest empty states.
+4. **Regression:** evidence/graph/trust/timeline + recruiter suites stay green; `check:claims`, typecheck, build.
+5. **Codex SAFE** before merge.
+
+## 5. Effort estimates (1 unit ≈ a focused PR w/ tests)
+
+| Item | Effort |
+|---|---|
+| `projectReputation` + dimension mapping + tests | 2 |
+| Reputation history (growth/decay/recovery/milestones) + tests | 2 |
+| 3 `/reputation/*` routes + contract tests | 1.5 |
+| Extend dev explorer with a reputation view (optional) | 1 |
+
+**Total ≈ 6.5 units, ~80% reuse** (trust + timeline already ship). The only genuinely new logic is recovery/milestone detection and the dimension mapping — both pure, both small.
+
+## 6. Sequencing note (important)
+
+**This wave is design only and deliberately added no code** — the W220–225 stack is unmerged and in SAFE review (W228). Per W228's merge-readiness, the recommended order is: **commit + scope the stack → CI build → Codex SAFE → merge**, *then* build W230 (mobility) and W235 (reputation) on the merged base. Building reputation now would deepen an already-five-waves-deep unmerged stack. Hold the build until SAFE.
+
+**Deliverable status:** W235 complete — C1–C6 in `docs/wave235/`. No code added.

--- a/packages/domain-evidence/package.json
+++ b/packages/domain-evidence/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@vitalcv/domain-evidence",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vitalcv/trust-state": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  }
+}

--- a/packages/domain-evidence/src/collection.test.ts
+++ b/packages/domain-evidence/src/collection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVIDENCE_CLASSES,
+  buildEvidenceCollection,
+  isDecisionGradeStatus,
+  summarizeEvidenceCoverage,
+} from './collection';
+import type { EvidenceObject } from './types';
+
+function makeObject(overrides: Partial<EvidenceObject> = {}): EvidenceObject {
+  const status = overrides.status ?? 'checked';
+  return {
+    evidenceId: overrides.evidenceId ?? 'ev-1',
+    subjectKey: 'subject-1',
+    evidenceClass: overrides.evidenceClass ?? 'identity',
+    label: 'NPPES identity',
+    value: null,
+    status,
+    source: { sourceId: 'NPPES_API', sourceLabel: 'NPPES', laneType: 'identity', governance: 'open' },
+    trustTier: null,
+    decisionGrade: overrides.decisionGrade ?? isDecisionGradeStatus(status),
+    observedAt: null,
+    checkedAt: null,
+    expiresAt: null,
+    freshnessWindowHours: null,
+    integrityHash: null,
+    provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: 'active',
+    supersedes: null,
+    supersededBy: null,
+    ...overrides,
+  };
+}
+
+describe('isDecisionGradeStatus', () => {
+  it('is true only for checked', () => {
+    expect(isDecisionGradeStatus('checked')).toBe(true);
+    for (const s of ['stale', 'pending', 'gated', 'unavailable', 'accessRequired', 'reviewRequired', 'notDecisionGrade', 'previewOnly'] as const) {
+      expect(isDecisionGradeStatus(s)).toBe(false);
+    }
+  });
+});
+
+describe('buildEvidenceCollection', () => {
+  it('groups by class and summarizes coverage', () => {
+    const collection = buildEvidenceCollection({
+      subjectKey: 'subject-1',
+      generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+      objects: [
+        makeObject({ evidenceId: 'a', evidenceClass: 'identity', status: 'checked' }),
+        makeObject({ evidenceId: 'b', evidenceClass: 'licensure', status: 'gated', decisionGrade: false, source: { sourceId: 'STATE_BOARD', sourceLabel: 'State Board', laneType: 'licensure', governance: 'gated' } }),
+      ],
+    });
+    expect(collection.byClass.identity).toHaveLength(1);
+    expect(collection.byClass.licensure).toHaveLength(1);
+    expect(collection.byClass.exclusion).toHaveLength(0);
+    expect(collection.coverageSummary.checked).toContain('NPPES_API');
+    expect(collection.coverageSummary.gated).toContain('STATE_BOARD');
+    // every class key is present
+    for (const cls of EVIDENCE_CLASSES) {
+      expect(collection.byClass[cls]).toBeDefined();
+    }
+  });
+
+  it('fails closed when decisionGrade contradicts status', () => {
+    expect(() =>
+      buildEvidenceCollection({
+        subjectKey: 'subject-1',
+        generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+        objects: [makeObject({ status: 'gated', decisionGrade: true })],
+      }),
+    ).toThrow(/decisionGrade invariant/);
+  });
+});
+
+describe('summarizeEvidenceCoverage', () => {
+  it('dedupes sourceIds per status bucket', () => {
+    const summary = summarizeEvidenceCoverage([
+      makeObject({ evidenceId: 'a', status: 'checked' }),
+      makeObject({ evidenceId: 'b', status: 'checked' }),
+    ]);
+    expect(summary.checked).toEqual(['NPPES_API']);
+  });
+});

--- a/packages/domain-evidence/src/collection.ts
+++ b/packages/domain-evidence/src/collection.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure assembly + helpers for EvidenceCollection. No I/O, deterministic given
+ * inputs (no Date.now()).
+ */
+
+import { CANONICAL_SOURCE_COVERAGE_STATES } from '@vitalcv/trust-state';
+import type {
+  EvidenceClass,
+  EvidenceCollection,
+  EvidenceObject,
+  EvidenceRelationship,
+  EvidenceStatus,
+} from './types';
+
+export const EVIDENCE_CLASSES: readonly EvidenceClass[] = [
+  'identity',
+  'licensure',
+  'board_cert',
+  'registration',
+  'exclusion',
+  'enrollment',
+  'privilege',
+  'peer_review',
+  'recognition',
+  'acceptance',
+  'start',
+  'employment',
+  'research',
+  'publication',
+  'training',
+];
+
+/** The status vocabulary, sourced from trust-state so it can never drift. */
+export const EVIDENCE_STATUSES: readonly EvidenceStatus[] = CANONICAL_SOURCE_COVERAGE_STATES;
+
+/** Only 'checked' is decision-grade — identical rule to the issuer truth contract. */
+export function isDecisionGradeStatus(status: EvidenceStatus): boolean {
+  return status === 'checked';
+}
+
+function emptyByClass(): Record<EvidenceClass, EvidenceObject[]> {
+  const out = {} as Record<EvidenceClass, EvidenceObject[]>;
+  for (const cls of EVIDENCE_CLASSES) {
+    out[cls] = [];
+  }
+  return out;
+}
+
+function emptyCoverageSummary(): Record<EvidenceStatus, string[]> {
+  const out = {} as Record<EvidenceStatus, string[]>;
+  for (const state of EVIDENCE_STATUSES) {
+    out[state] = [];
+  }
+  return out;
+}
+
+/** Group sourceIds by status (parallels summarizeCanonicalSourceCoverage). */
+export function summarizeEvidenceCoverage(
+  objects: readonly EvidenceObject[],
+): Record<EvidenceStatus, string[]> {
+  const summary = emptyCoverageSummary();
+  for (const obj of objects) {
+    const bucket = summary[obj.status];
+    if (bucket && !bucket.includes(obj.source.sourceId)) {
+      bucket.push(obj.source.sourceId);
+    }
+  }
+  return summary;
+}
+
+export interface BuildEvidenceCollectionInput {
+  subjectKey: string;
+  generatedFor: { displayName: string; npi: string | null };
+  objects: EvidenceObject[];
+  relationships?: EvidenceRelationship[];
+}
+
+/**
+ * Assembles the collection: validates the decisionGrade invariant, groups by
+ * class, and summarizes coverage. Throws if any object claims decision-grade
+ * while its status is not 'checked' (fail closed — never ship a fake positive).
+ */
+export function buildEvidenceCollection(
+  input: BuildEvidenceCollectionInput,
+): EvidenceCollection {
+  const byClass = emptyByClass();
+
+  for (const obj of input.objects) {
+    if (obj.decisionGrade !== isDecisionGradeStatus(obj.status)) {
+      throw new Error(
+        `EvidenceObject ${obj.evidenceId} violates decisionGrade invariant: ` +
+          `decisionGrade=${obj.decisionGrade} but status=${obj.status}.`,
+      );
+    }
+    byClass[obj.evidenceClass].push(obj);
+  }
+
+  return {
+    subjectKey: input.subjectKey,
+    generatedFor: input.generatedFor,
+    objects: input.objects,
+    relationships: input.relationships ?? [],
+    byClass,
+    coverageSummary: summarizeEvidenceCoverage(input.objects),
+  };
+}

--- a/packages/domain-evidence/src/index.ts
+++ b/packages/domain-evidence/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitalcv/domain-evidence — public barrel.
+ *
+ * Typed facade over existing evidence; pure transforms only. See
+ * docs/wave215/C3-domain-evidence-package.md for the architecture.
+ */
+
+export type {
+  EvidenceClass,
+  EvidenceCollection,
+  EvidenceLifecycle,
+  EvidenceObject,
+  EvidenceProvenance,
+  EvidenceRelationship,
+  EvidenceRelationshipType,
+  EvidenceSource,
+  EvidenceStatus,
+  EvidenceValue,
+} from './types';
+
+export {
+  EVIDENCE_CLASSES,
+  EVIDENCE_STATUSES,
+  buildEvidenceCollection,
+  isDecisionGradeStatus,
+  summarizeEvidenceCoverage,
+  type BuildEvidenceCollectionInput,
+} from './collection';
+
+export {
+  GRAPH_RELATIONSHIP_TYPES,
+  projectEvidenceToGraph,
+  statusTrustScore,
+  type GraphNode,
+  type GraphNodeType,
+  type GraphProjection,
+  type GraphRelationship,
+  type GraphRelationshipType,
+} from './projectors/graph';
+
+export {
+  TRUST_DIMENSIONS,
+  propagateTrust,
+  type DimensionTrust,
+  type TrustDimension,
+  type TrustHistory,
+  type TrustHistoryEntry,
+  type TrustHistoryEventType,
+  type TrustProjection,
+} from './trust/propagate';
+
+export {
+  CAREER_EVENT_TYPES,
+  projectTimeline,
+  type CareerEvent,
+  type CareerEventType,
+  type MobilityImpact,
+  type RecognitionImpact,
+  type ReputationStanding,
+  type ReputationSummary,
+  type TimelineProjection,
+} from './timeline/timeline';

--- a/packages/domain-evidence/src/projectors/graph.test.ts
+++ b/packages/domain-evidence/src/projectors/graph.test.ts
@@ -7,6 +7,16 @@ import {
   statusTrustScore,
 } from './graph';
 
+describe('statusTrustScore — only decision-grade contributes positive trust', () => {
+  it('scores ONLY checked as positive; every non-decision-grade status is 0', () => {
+    expect(statusTrustScore('checked')).toBe(1);
+    // stale/pending/reviewRequired are NOT decision-grade and must never contribute trust
+    for (const s of ['stale', 'pending', 'reviewRequired', 'gated', 'accessRequired', 'notDecisionGrade', 'previewOnly', 'unavailable'] as const) {
+      expect(statusTrustScore(s)).toBe(0);
+    }
+  });
+});
+
 function makeObject(
   id: string,
   evidenceClass: EvidenceClass,

--- a/packages/domain-evidence/src/projectors/graph.test.ts
+++ b/packages/domain-evidence/src/projectors/graph.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import type { EvidenceObject, EvidenceClass, EvidenceStatus } from '../types';
+import {
+  GRAPH_RELATIONSHIP_TYPES,
+  projectEvidenceToGraph,
+  statusTrustScore,
+} from './graph';
+
+function makeObject(
+  id: string,
+  evidenceClass: EvidenceClass,
+  status: EvidenceStatus,
+  sourceId: string,
+): EvidenceObject {
+  return {
+    evidenceId: id,
+    subjectKey: 'subject-1',
+    evidenceClass,
+    label: `${evidenceClass} ${id}`,
+    value: null,
+    status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null,
+    decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null,
+    checkedAt: null,
+    expiresAt: null,
+    freshnessWindowHours: null,
+    integrityHash: null,
+    provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: 'active',
+    supersedes: null,
+    supersededBy: null,
+  };
+}
+
+function fixtureCollection() {
+  return buildEvidenceCollection({
+    subjectKey: 'subject-1',
+    generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+    objects: [
+      makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API'),
+      makeObject('cred:lic-ca', 'licensure', 'checked', 'STATE_BOARD'),
+      makeObject('cred:abms', 'board_cert', 'checked', 'ABMS'),
+      makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'STATE_BOARD'),
+    ],
+  });
+}
+
+describe('projectEvidenceToGraph', () => {
+  it('projects licenses with HOLDS_LICENSE', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    const rel = graph.relationships.find((r) => r.to === 'cred:lic-ca' && r.from.startsWith('subject:'));
+    expect(rel?.type).toBe('HOLDS_LICENSE');
+  });
+
+  it('projects certifications with HOLDS_CERTIFICATION and CERTIFIED_BY source', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    const holds = graph.relationships.find((r) => r.to === 'cred:abms' && r.from.startsWith('subject:'));
+    const certifiedBy = graph.relationships.find((r) => r.from === 'cred:abms' && r.to.startsWith('source:'));
+    expect(holds?.type).toBe('HOLDS_CERTIFICATION');
+    expect(certifiedBy?.type).toBe('CERTIFIED_BY');
+  });
+
+  it('generates no duplicate nodes (subject once, source deduped)', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    const ids = graph.nodes.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // STATE_BOARD is shared by two evidence objects but yields one source node
+    expect(graph.nodes.filter((n) => n.id === 'source:STATE_BOARD')).toHaveLength(1);
+    expect(graph.nodes.filter((n) => n.type === 'subject')).toHaveLength(1);
+  });
+
+  it('has no orphan relationships (every endpoint is a real node)', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    const nodeIds = new Set(graph.nodes.map((n) => n.id));
+    for (const rel of graph.relationships) {
+      expect(nodeIds.has(rel.from)).toBe(true);
+      expect(nodeIds.has(rel.to)).toBe(true);
+    }
+  });
+
+  it('does not inflate trust — gated evidence scores 0, checked scores 1', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    const gated = graph.nodes.find((n) => n.id === 'coverage:STATE_BOARD');
+    const checked = graph.nodes.find((n) => n.id === 'coverage:NPPES_API');
+    expect(gated?.trustScore).toBe(0);
+    expect(checked?.trustScore).toBe(1);
+    // no evidence node exceeds its status-implied score
+    for (const node of graph.nodes) {
+      if (node.type === 'evidence' && node.status) {
+        expect(node.trustScore).toBeLessThanOrEqual(statusTrustScore(node.status));
+      }
+    }
+  });
+
+  it('produces no false decision-grade states', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    for (const node of graph.nodes) {
+      if (node.type === 'evidence' && node.status) {
+        expect(node.decisionGrade).toBe(node.status === 'checked');
+      } else {
+        expect(node.decisionGrade).toBe(false); // subject/source are never decision-grade
+      }
+    }
+  });
+
+  it('only emits enumerated relationship types', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    for (const rel of graph.relationships) {
+      expect(GRAPH_RELATIONSHIP_TYPES).toContain(rel.type);
+    }
+  });
+
+  it('reports honest stats', () => {
+    const graph = projectEvidenceToGraph(fixtureCollection());
+    expect(graph.stats.nodeCount).toBe(graph.nodes.length);
+    expect(graph.stats.relationshipCount).toBe(graph.relationships.length);
+    expect(graph.stats.decisionGradeNodeCount).toBe(graph.nodes.filter((n) => n.decisionGrade).length);
+  });
+});

--- a/packages/domain-evidence/src/projectors/graph.ts
+++ b/packages/domain-evidence/src/projectors/graph.ts
@@ -1,0 +1,242 @@
+/**
+ * Evidence -> Graph projector (Wave 221).
+ *
+ * Pure transform: EvidenceCollection -> GraphProjection. No side effects, no
+ * persistence, no graph database. Trust is bounded by evidence status — a gated
+ * or non-decision-grade object can never project a positive trustScore or a
+ * decision-grade node (no trust inflation, no false decision-grade).
+ *
+ * See docs/wave220/C2-node-architecture-plan.md and C3-relationship-architecture.md.
+ */
+
+import type { EvidenceClass, EvidenceCollection, EvidenceLifecycle, EvidenceStatus } from '../types';
+import { isDecisionGradeStatus } from '../collection';
+
+// ── C2: Node model ───────────────────────────────────────────────────────────
+
+export type GraphNodeType = 'subject' | 'evidence' | 'source';
+
+export interface GraphNode {
+  id: string;
+  type: GraphNodeType;
+  label: string;
+  /** 0..1, derived monotonically from status. null for non-evidence nodes. */
+  trustScore: number | null;
+  /** sourceId backing this node (evidence nodes), else null. */
+  evidenceSource: string | null;
+  /** Coverage status for evidence nodes, else null. */
+  status: EvidenceStatus | null;
+  /** Present only for evidence nodes. */
+  evidenceClass: EvidenceClass | null;
+  /** Mirrors the evidence object; false for subject/source nodes. */
+  decisionGrade: boolean;
+  /** Temporal fields carried for trust history (evidence nodes only). */
+  checkedAt: string | null;
+  expiresAt: string | null;
+  lifecycle: EvidenceLifecycle | null;
+}
+
+// ── C3: Relationship model ───────────────────────────────────────────────────
+
+export const GRAPH_RELATIONSHIP_TYPES = [
+  'HAS_IDENTITY',
+  'HOLDS_LICENSE',
+  'HOLDS_CERTIFICATION',
+  'HOLDS_REGISTRATION',
+  'SCREENED_FOR_EXCLUSION',
+  'ENROLLED_IN',
+  'PRIVILEGED_AT',
+  'REVIEWED_BY',
+  'RECOGNIZED_BY',
+  'ACCEPTED_BY',
+  'STARTED_AT',
+  'EMPLOYED_BY',
+  'AUTHORED',
+  'TRAINED_AT',
+  'VERIFIED_BY',
+  'CERTIFIED_BY',
+] as const;
+
+export type GraphRelationshipType = (typeof GRAPH_RELATIONSHIP_TYPES)[number];
+
+export interface GraphRelationship {
+  id: string;
+  from: string;
+  to: string;
+  type: GraphRelationshipType;
+  /** Backing evidence object, when the edge is evidence-derived. */
+  evidenceId: string | null;
+}
+
+export interface GraphProjection {
+  subjectKey: string;
+  nodes: GraphNode[];
+  relationships: GraphRelationship[];
+  stats: { nodeCount: number; relationshipCount: number; decisionGradeNodeCount: number };
+}
+
+// ── Pure derivations ─────────────────────────────────────────────────────────
+
+/**
+ * Monotonic, non-inflating trust score. Only 'checked' is full trust; every
+ * gated / non-decision-grade state is 0 (never contributes positive trust).
+ */
+export function statusTrustScore(status: EvidenceStatus): number {
+  switch (status) {
+    case 'checked':
+      return 1;
+    case 'stale':
+      return 0.4;
+    case 'pending':
+      return 0.2;
+    case 'reviewRequired':
+      return 0.1;
+    case 'gated':
+    case 'accessRequired':
+    case 'notDecisionGrade':
+    case 'previewOnly':
+    case 'unavailable':
+      return 0;
+    default:
+      return 0;
+  }
+}
+
+/** subject -> evidence relationship label, keyed on the evidence class. */
+function subjectRelationshipFor(evidenceClass: EvidenceClass): GraphRelationshipType {
+  switch (evidenceClass) {
+    case 'identity':
+      return 'HAS_IDENTITY';
+    case 'licensure':
+      return 'HOLDS_LICENSE';
+    case 'board_cert':
+      return 'HOLDS_CERTIFICATION';
+    case 'registration':
+      return 'HOLDS_REGISTRATION';
+    case 'exclusion':
+      return 'SCREENED_FOR_EXCLUSION';
+    case 'enrollment':
+      return 'ENROLLED_IN';
+    case 'privilege':
+      return 'PRIVILEGED_AT';
+    case 'peer_review':
+      return 'REVIEWED_BY';
+    case 'recognition':
+      return 'RECOGNIZED_BY';
+    case 'acceptance':
+      return 'ACCEPTED_BY';
+    case 'start':
+      return 'STARTED_AT';
+    case 'employment':
+      return 'EMPLOYED_BY';
+    case 'research':
+    case 'publication':
+      return 'AUTHORED';
+    case 'training':
+      return 'TRAINED_AT';
+    default:
+      return 'HAS_IDENTITY';
+  }
+}
+
+/** evidence -> source relationship label. */
+function sourceRelationshipFor(evidenceClass: EvidenceClass): GraphRelationshipType {
+  return evidenceClass === 'board_cert' ? 'CERTIFIED_BY' : 'VERIFIED_BY';
+}
+
+const subjectNodeId = (subjectKey: string) => `subject:${subjectKey}`;
+const sourceNodeId = (sourceId: string) => `source:${sourceId}`;
+
+/**
+ * Project an EvidenceCollection into nodes + relationships. Nodes are deduped by
+ * id (subject once; each source once) so no duplicate node is ever generated.
+ * Every relationship references existing nodes (no orphans).
+ */
+export function projectEvidenceToGraph(collection: EvidenceCollection): GraphProjection {
+  const nodes = new Map<string, GraphNode>();
+  const relationships: GraphRelationship[] = [];
+
+  // Subject anchor node.
+  const subjectId = subjectNodeId(collection.subjectKey);
+  nodes.set(subjectId, {
+    id: subjectId,
+    type: 'subject',
+    label: collection.generatedFor.displayName || 'Clinician',
+    trustScore: null,
+    evidenceSource: null,
+    status: null,
+    evidenceClass: null,
+    decisionGrade: false,
+    checkedAt: null,
+    expiresAt: null,
+    lifecycle: null,
+  });
+
+  for (const obj of collection.objects) {
+    // Evidence node (object ids are already unique per collection).
+    const decisionGrade = isDecisionGradeStatus(obj.status);
+    nodes.set(obj.evidenceId, {
+      id: obj.evidenceId,
+      type: 'evidence',
+      label: obj.label,
+      trustScore: statusTrustScore(obj.status),
+      evidenceSource: obj.source.sourceId,
+      status: obj.status,
+      evidenceClass: obj.evidenceClass,
+      decisionGrade,
+      checkedAt: obj.checkedAt,
+      expiresAt: obj.expiresAt,
+      lifecycle: obj.lifecycle,
+    });
+
+    // Source node (deduped).
+    const srcId = sourceNodeId(obj.source.sourceId);
+    if (!nodes.has(srcId)) {
+      nodes.set(srcId, {
+        id: srcId,
+        type: 'source',
+        label: obj.source.sourceLabel || obj.source.sourceId,
+        trustScore: null,
+        evidenceSource: obj.source.sourceId,
+        status: null,
+        evidenceClass: null,
+        decisionGrade: false,
+        checkedAt: null,
+        expiresAt: null,
+        lifecycle: null,
+      });
+    }
+
+    // subject -> evidence
+    const subjRel = subjectRelationshipFor(obj.evidenceClass);
+    relationships.push({
+      id: `${subjRel}:${subjectId}->${obj.evidenceId}`,
+      from: subjectId,
+      to: obj.evidenceId,
+      type: subjRel,
+      evidenceId: obj.evidenceId,
+    });
+
+    // evidence -> source
+    const srcRel = sourceRelationshipFor(obj.evidenceClass);
+    relationships.push({
+      id: `${srcRel}:${obj.evidenceId}->${srcId}`,
+      from: obj.evidenceId,
+      to: srcId,
+      type: srcRel,
+      evidenceId: obj.evidenceId,
+    });
+  }
+
+  const nodeList = [...nodes.values()];
+  return {
+    subjectKey: collection.subjectKey,
+    nodes: nodeList,
+    relationships,
+    stats: {
+      nodeCount: nodeList.length,
+      relationshipCount: relationships.length,
+      decisionGradeNodeCount: nodeList.filter((n) => n.decisionGrade).length,
+    },
+  };
+}

--- a/packages/domain-evidence/src/projectors/graph.ts
+++ b/packages/domain-evidence/src/projectors/graph.ts
@@ -83,14 +83,14 @@ export interface GraphProjection {
  */
 export function statusTrustScore(status: EvidenceStatus): number {
   switch (status) {
+    // Only decision-grade ('checked') evidence contributes positive trust.
+    // Every non-decision-grade state — including stale/pending/reviewRequired —
+    // is 0, so it can never raise a dimension or overall score (fail-closed).
     case 'checked':
       return 1;
     case 'stale':
-      return 0.4;
     case 'pending':
-      return 0.2;
     case 'reviewRequired':
-      return 0.1;
     case 'gated':
     case 'accessRequired':
     case 'notDecisionGrade':

--- a/packages/domain-evidence/src/timeline/timeline.test.ts
+++ b/packages/domain-evidence/src/timeline/timeline.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import { projectEvidenceToGraph } from '../projectors/graph';
+import { propagateTrust } from '../trust/propagate';
+import type { EvidenceClass, EvidenceLifecycle, EvidenceObject, EvidenceStatus } from '../types';
+import { CAREER_EVENT_TYPES, projectTimeline } from './timeline';
+
+function makeObject(
+  id: string,
+  evidenceClass: EvidenceClass,
+  status: EvidenceStatus,
+  sourceId: string,
+  opts: { checkedAt?: string; expiresAt?: string; lifecycle?: EvidenceLifecycle } = {},
+): EvidenceObject {
+  return {
+    evidenceId: id,
+    subjectKey: 'subject-1',
+    evidenceClass,
+    label: `${evidenceClass} ${id}`,
+    value: null,
+    status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null,
+    decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null,
+    checkedAt: opts.checkedAt ?? null,
+    expiresAt: opts.expiresAt ?? null,
+    freshnessWindowHours: null,
+    integrityHash: null,
+    provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: opts.lifecycle ?? 'active',
+    supersedes: null,
+    supersededBy: null,
+  };
+}
+
+function projectAll(objects: EvidenceObject[]) {
+  const collection = buildEvidenceCollection({
+    subjectKey: 'subject-1',
+    generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+    objects,
+  });
+  const graph = projectEvidenceToGraph(collection);
+  const trust = propagateTrust(graph);
+  return projectTimeline(collection, graph, trust);
+}
+
+function fixtureObjects() {
+  return [
+    makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API', { checkedAt: '2026-03-01T00:00:00.000Z' }),
+    makeObject('cred:lic-ca', 'licensure', 'checked', 'STATE_BOARD', { checkedAt: '2026-03-02T00:00:00.000Z' }),
+    makeObject('cred:dea', 'registration', 'stale', 'DEA', { expiresAt: '2026-02-01T00:00:00.000Z', lifecycle: 'expired' }),
+    makeObject('rec:r1', 'recognition', 'checked', 'EMPLOYER', { checkedAt: '2026-03-05T00:00:00.000Z' }),
+  ];
+}
+
+describe('projectTimeline', () => {
+  it('derives one career event per evidence node, all enumerated types', () => {
+    const timeline = projectAll(fixtureObjects());
+    expect(timeline.events).toHaveLength(4);
+    for (const e of timeline.events) {
+      expect(CAREER_EVENT_TYPES).toContain(e.type);
+    }
+  });
+
+  it('orders events ascending by timestamp', () => {
+    const timeline = projectAll(fixtureObjects());
+    const stamped = timeline.events.filter((e) => e.occurredAt).map((e) => e.occurredAt!);
+    expect(stamped).toEqual([...stamped].sort());
+    expect(timeline.firstAt).toBe('2026-02-01T00:00:00.000Z'); // decayed DEA's expiresAt is earliest
+    expect(timeline.lastAt).toBe('2026-03-05T00:00:00.000Z');
+  });
+
+  it('models trust impact: positive for checked, negative for decay, never inflated', () => {
+    const timeline = projectAll(fixtureObjects());
+    const lic = timeline.events.find((e) => e.evidenceId === 'cred:lic-ca');
+    const dea = timeline.events.find((e) => e.evidenceId === 'cred:dea');
+    expect(lic?.trustImpact).toBe(1);
+    expect(dea?.trustImpact).toBeLessThan(0);
+    for (const e of timeline.events) expect(e.trustImpact).toBeLessThanOrEqual(1);
+  });
+
+  it('models mobility impact: a checked license expands, a decayed registration reduces', () => {
+    const timeline = projectAll(fixtureObjects());
+    expect(timeline.events.find((e) => e.evidenceId === 'cred:lic-ca')?.mobilityImpact).toBe('expands');
+    expect(timeline.events.find((e) => e.evidenceId === 'cred:dea')?.mobilityImpact).toBe('reduces');
+    expect(timeline.events.find((e) => e.evidenceId === 'coverage:NPPES_API')?.mobilityImpact).toBe('none');
+  });
+
+  it('models recognition: collects recognition/acceptance/start events', () => {
+    const timeline = projectAll(fixtureObjects());
+    expect(timeline.recognition.map((e) => e.evidenceId)).toEqual(['rec:r1']);
+    expect(timeline.recognition[0].recognitionImpact).toBe('recognition');
+  });
+
+  it('models reputation with an honest standing threshold', () => {
+    const timeline = projectAll(fixtureObjects());
+    expect(timeline.reputation.decisionGradeEvidence).toBe(3);
+    expect(['established', 'emerging', 'provisional']).toContain(timeline.reputation.standing);
+    expect(timeline.reputation.trend).toBeDefined();
+  });
+
+  it('reports unknown standing when nothing is decision-grade', () => {
+    const timeline = projectAll([
+      makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'STATE_BOARD'),
+    ]);
+    expect(timeline.reputation.decisionGradeEvidence).toBe(0);
+    expect(timeline.reputation.standing).toBe('unknown'); // honest: no fabricated reputation
+  });
+
+  it('is deterministic', () => {
+    expect(projectAll(fixtureObjects())).toEqual(projectAll(fixtureObjects()));
+  });
+});

--- a/packages/domain-evidence/src/timeline/timeline.ts
+++ b/packages/domain-evidence/src/timeline/timeline.ts
@@ -1,0 +1,223 @@
+/**
+ * Professional Memory / Timeline projection (Wave 225).
+ *
+ * Pure transform: (EvidenceCollection, GraphProjection, TrustProjection) ->
+ * TimelineProjection. Deterministic, no I/O, no ML. Bridges the evidence /
+ * graph / trust layers into a career-over-time view.
+ *
+ * Honesty: every event traces to a source-backed evidence object; trust impact
+ * reuses the monotonic trust scores (W222) and is never inflated; reputation
+ * standing is a deterministic threshold over decision-grade evidence, with an
+ * honest 'unknown' when nothing is checked.
+ */
+
+import type { EvidenceClass, EvidenceCollection } from '../types';
+import type { GraphProjection } from '../projectors/graph';
+import { statusTrustScore } from '../projectors/graph';
+import type { TrustDimension, TrustHistory, TrustProjection } from '../trust/propagate';
+
+// ── C2: CareerEvent ──────────────────────────────────────────────────────────
+
+export const CAREER_EVENT_TYPES = [
+  'identity_verification',
+  'licensure',
+  'certification',
+  'screening',
+  'enrollment',
+  'recognition',
+  'acceptance',
+  'employment_start',
+  'employment',
+  'training',
+  'privileging',
+  'peer_review',
+  'research',
+] as const;
+
+export type CareerEventType = (typeof CAREER_EVENT_TYPES)[number];
+
+export type MobilityImpact = 'expands' | 'reduces' | 'none';
+export type RecognitionImpact = 'recognition' | 'acceptance' | 'start' | 'none';
+
+export interface CareerEvent {
+  eventId: string;
+  occurredAt: string | null;
+  type: CareerEventType;
+  label: string;
+  detail: string;
+  evidenceId: string | null;
+  evidenceSource: string | null;
+  /** Signed trust delta (+ reinforcement, − decay), bounded by the evidence's own trust. */
+  trustImpact: number;
+  trustDimension: TrustDimension | null;
+  mobilityImpact: MobilityImpact;
+  recognitionImpact: RecognitionImpact;
+}
+
+export type ReputationStanding = 'established' | 'emerging' | 'provisional' | 'unknown';
+
+export interface ReputationSummary {
+  overallTrust: number | null;
+  decisionGradeEvidence: number;
+  totalEvidence: number;
+  reinforcementCount: number;
+  decayCount: number;
+  trend: 'growing' | 'decaying' | 'stable';
+  standing: ReputationStanding;
+}
+
+export interface TimelineProjection {
+  subjectKey: string;
+  events: CareerEvent[];
+  /** Pass-through of the already timeline-shaped trust history (W222). */
+  trustHistory: TrustHistory;
+  /** Subset of events with recognitionImpact !== 'none'. */
+  recognition: CareerEvent[];
+  reputation: ReputationSummary;
+  firstAt: string | null;
+  lastAt: string | null;
+}
+
+// ── Derivations ──────────────────────────────────────────────────────────────
+
+function eventTypeForClass(evidenceClass: EvidenceClass): CareerEventType {
+  switch (evidenceClass) {
+    case 'identity':
+      return 'identity_verification';
+    case 'licensure':
+      return 'licensure';
+    case 'registration':
+      return 'licensure';
+    case 'board_cert':
+      return 'certification';
+    case 'exclusion':
+      return 'screening';
+    case 'enrollment':
+      return 'enrollment';
+    case 'recognition':
+      return 'recognition';
+    case 'acceptance':
+      return 'acceptance';
+    case 'start':
+      return 'employment_start';
+    case 'employment':
+      return 'employment';
+    case 'training':
+      return 'training';
+    case 'privilege':
+      return 'privileging';
+    case 'peer_review':
+      return 'peer_review';
+    case 'research':
+    case 'publication':
+      return 'research';
+    default:
+      return 'identity_verification';
+  }
+}
+
+function recognitionImpactForClass(evidenceClass: EvidenceClass): RecognitionImpact {
+  switch (evidenceClass) {
+    case 'recognition':
+      return 'recognition';
+    case 'acceptance':
+      return 'acceptance';
+    case 'start':
+      return 'start';
+    default:
+      return 'none';
+  }
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+/** Find the primary trust dimension an evidence node contributes to. */
+function dimensionForEvidence(trust: TrustProjection, evidenceId: string): TrustDimension | null {
+  for (const d of trust.dimensions) {
+    if (d.supporting.includes(evidenceId) || d.weakening.includes(evidenceId)) {
+      return d.dimension;
+    }
+  }
+  return null;
+}
+
+function standingFor(overallTrust: number | null, decisionGradeEvidence: number): ReputationStanding {
+  if (decisionGradeEvidence === 0 || overallTrust === null) return 'unknown';
+  if (overallTrust >= 0.67) return 'established';
+  if (overallTrust >= 0.34) return 'emerging';
+  return 'provisional';
+}
+
+// ── C3: TimelineProjection ───────────────────────────────────────────────────
+
+export function projectTimeline(
+  evidence: EvidenceCollection,
+  graph: GraphProjection,
+  trust: TrustProjection,
+): TimelineProjection {
+  const events: CareerEvent[] = [];
+
+  for (const node of graph.nodes) {
+    if (node.type !== 'evidence' || !node.evidenceClass || node.trustScore === null) continue;
+
+    const score = node.trustScore;
+    const decayed = node.status === 'stale' || node.lifecycle === 'expired' || node.lifecycle === 'revoked';
+    const trustImpact = decayed ? round4(-(1 - score)) : node.status === 'checked' ? round4(score) : 0;
+
+    const isLicense = node.evidenceClass === 'licensure' || node.evidenceClass === 'registration';
+    const mobilityImpact: MobilityImpact = isLicense
+      ? node.status === 'checked'
+        ? 'expands'
+        : decayed
+          ? 'reduces'
+          : 'none'
+      : 'none';
+
+    const occurredAt = decayed ? node.expiresAt ?? node.checkedAt : node.checkedAt;
+
+    events.push({
+      eventId: `${node.id}@${occurredAt ?? 'undated'}`,
+      occurredAt,
+      type: eventTypeForClass(node.evidenceClass),
+      label: node.label,
+      detail: `${node.label} — ${node.status}`,
+      evidenceId: node.id,
+      evidenceSource: node.evidenceSource,
+      trustImpact,
+      trustDimension: dimensionForEvidence(trust, node.id),
+      mobilityImpact,
+      recognitionImpact: recognitionImpactForClass(node.evidenceClass),
+    });
+  }
+
+  // Deterministic order: ascending by timestamp, nulls last, tiebreak eventId.
+  events.sort((a, b) => {
+    if (a.occurredAt === b.occurredAt) return a.eventId.localeCompare(b.eventId);
+    if (a.occurredAt === null) return 1;
+    if (b.occurredAt === null) return -1;
+    return a.occurredAt.localeCompare(b.occurredAt);
+  });
+
+  const stamped = events.filter((e) => e.occurredAt).map((e) => e.occurredAt!);
+  const reputation: ReputationSummary = {
+    overallTrust: trust.overall.score,
+    decisionGradeEvidence: trust.overall.decisionGradeEvidence,
+    totalEvidence: trust.overall.totalEvidence,
+    reinforcementCount: trust.history.reinforcementCount,
+    decayCount: trust.history.decayCount,
+    trend: trust.history.trend,
+    standing: standingFor(trust.overall.score, trust.overall.decisionGradeEvidence),
+  };
+
+  return {
+    subjectKey: evidence.subjectKey,
+    events,
+    trustHistory: trust.history,
+    recognition: events.filter((e) => e.recognitionImpact !== 'none'),
+    reputation,
+    firstAt: stamped[0] ?? null,
+    lastAt: stamped[stamped.length - 1] ?? null,
+  };
+}

--- a/packages/domain-evidence/src/trust/propagate.test.ts
+++ b/packages/domain-evidence/src/trust/propagate.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import { projectEvidenceToGraph } from '../projectors/graph';
+import type { EvidenceClass, EvidenceLifecycle, EvidenceObject, EvidenceStatus } from '../types';
+import { TRUST_DIMENSIONS, propagateTrust } from './propagate';
+
+function makeObject(
+  id: string,
+  evidenceClass: EvidenceClass,
+  status: EvidenceStatus,
+  sourceId: string,
+  opts: { checkedAt?: string; expiresAt?: string; lifecycle?: EvidenceLifecycle } = {},
+): EvidenceObject {
+  return {
+    evidenceId: id,
+    subjectKey: 'subject-1',
+    evidenceClass,
+    label: `${evidenceClass} ${id}`,
+    value: null,
+    status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null,
+    decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null,
+    checkedAt: opts.checkedAt ?? null,
+    expiresAt: opts.expiresAt ?? null,
+    freshnessWindowHours: null,
+    integrityHash: null,
+    provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: opts.lifecycle ?? 'active',
+    supersedes: null,
+    supersededBy: null,
+  };
+}
+
+function fixtureGraph() {
+  return projectEvidenceToGraph(
+    buildEvidenceCollection({
+      subjectKey: 'subject-1',
+      generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+      objects: [
+        makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API', { checkedAt: '2026-03-01T00:00:00.000Z' }),
+        makeObject('cred:lic-ca', 'licensure', 'checked', 'STATE_BOARD', { checkedAt: '2026-03-02T00:00:00.000Z' }),
+        makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'STATE_BOARD'),
+        makeObject('cred:abms', 'board_cert', 'checked', 'ABMS', { checkedAt: '2026-03-03T00:00:00.000Z' }),
+        makeObject('cred:orcid', 'research', 'checked', 'ORCID', { checkedAt: '2026-03-04T00:00:00.000Z' }),
+        makeObject('cred:dea', 'registration', 'stale', 'DEA', { expiresAt: '2026-02-01T00:00:00.000Z', lifecycle: 'expired' }),
+      ],
+    }),
+  );
+}
+
+function dim(trust: ReturnType<typeof propagateTrust>, name: string) {
+  return trust.dimensions.find((d) => d.dimension === name)!;
+}
+
+describe('propagateTrust', () => {
+  it('emits all seven dimensions, every one present', () => {
+    const trust = propagateTrust(fixtureGraph());
+    expect(trust.dimensions.map((d) => d.dimension).sort()).toEqual([...TRUST_DIMENSIONS].sort());
+  });
+
+  it('scores identity from its own checked evidence', () => {
+    const trust = propagateTrust(fixtureGraph());
+    expect(dim(trust, 'identity').score).toBe(1);
+  });
+
+  it('returns null score for a dimension with no contributing evidence', () => {
+    const trust = propagateTrust(fixtureGraph());
+    const leadership = dim(trust, 'leadership');
+    expect(leadership.contributingCount).toBe(0);
+    expect(leadership.score).toBeNull(); // honest: no evidence, not a fabricated 0-or-positive
+  });
+
+  it('does not inflate — no dimension score exceeds its max contributing node score', () => {
+    const graph = fixtureGraph();
+    const trust = propagateTrust(graph);
+    for (const d of trust.dimensions) {
+      if (d.score === null) continue;
+      const contributing = graph.nodes.filter((n) => d.supporting.includes(n.id) || d.weakening.includes(n.id));
+      const max = Math.max(0, ...contributing.map((n) => n.trustScore ?? 0));
+      expect(d.score).toBeLessThanOrEqual(max);
+    }
+  });
+
+  it('puts gated evidence in weakening and checked evidence in supporting', () => {
+    const trust = propagateTrust(fixtureGraph());
+    const authority = dim(trust, 'authority');
+    expect(authority.weakening).toContain('coverage:STATE_BOARD'); // gated
+    expect(authority.supporting).toContain('cred:lic-ca'); // checked
+    expect(authority.origins).toContain('STATE_BOARD');
+  });
+
+  it('overall score is bounded and counts decision-grade evidence', () => {
+    const trust = propagateTrust(fixtureGraph());
+    expect(trust.overall.score).toBeGreaterThan(0);
+    expect(trust.overall.score).toBeLessThanOrEqual(1);
+    expect(trust.overall.decisionGradeEvidence).toBe(4); // identity, lic-ca, abms, orcid
+    expect(trust.overall.totalEvidence).toBe(6);
+  });
+
+  it('builds a timeline-compatible history with reinforcement and decay', () => {
+    const trust = propagateTrust(fixtureGraph());
+    expect(trust.history.reinforcementCount).toBe(4);
+    expect(trust.history.decayCount).toBe(1); // the stale/expired DEA registration
+    // sorted ascending by occurredAt, nulls last
+    const stamped = trust.history.entries.filter((e) => e.occurredAt).map((e) => e.occurredAt!);
+    expect(stamped).toEqual([...stamped].sort());
+    expect(['growing', 'decaying', 'stable']).toContain(trust.history.trend);
+  });
+
+  it('is deterministic — identical input yields identical output', () => {
+    expect(propagateTrust(fixtureGraph())).toEqual(propagateTrust(fixtureGraph()));
+  });
+});

--- a/packages/domain-evidence/src/trust/propagate.ts
+++ b/packages/domain-evidence/src/trust/propagate.ts
@@ -1,0 +1,220 @@
+/**
+ * Trust propagation engine (Wave 222).
+ *
+ * Deterministic, pure, NO ML / NO opaque scoring. Input is a GraphProjection
+ * (W221); output is a TrustProjection that answers "why trusted / where does it
+ * originate / what reinforces / what weakens / how it evolved".
+ *
+ * Doctrine (monotonic-down, W220-C3): trust aggregates UP from evidence into
+ * dimensions and an overall score, but is never inflated by neighbors. Every
+ * dimension/overall score is bounded by its contributing evidence — a gated or
+ * non-decision-grade object contributes 0 and can only lower an aggregate.
+ */
+
+import type { EvidenceClass } from '../types';
+import type { GraphNode, GraphProjection } from '../projectors/graph';
+
+// ── C3: Trust dimensions ─────────────────────────────────────────────────────
+
+export const TRUST_DIMENSIONS = [
+  'identity',
+  'authority',
+  'professional',
+  'research',
+  'leadership',
+  'institutional',
+  'mobility',
+] as const;
+
+export type TrustDimension = (typeof TRUST_DIMENSIONS)[number];
+
+/**
+ * Which dimensions an evidence class contributes to. A class may feed more than
+ * one dimension (e.g. a residency reinforces both professional background and
+ * institutional trust) — dimensions are computed INDEPENDENTLY of each other, so
+ * shared inputs never cause one dimension's score to feed another's.
+ */
+function dimensionsForClass(evidenceClass: EvidenceClass): TrustDimension[] {
+  switch (evidenceClass) {
+    case 'identity':
+      return ['identity'];
+    case 'licensure':
+      return ['authority', 'mobility'];
+    case 'registration':
+      return ['authority', 'mobility'];
+    case 'board_cert':
+      return ['authority'];
+    case 'exclusion':
+    case 'enrollment':
+      return ['authority'];
+    case 'employment':
+      return ['professional', 'institutional'];
+    case 'recognition':
+    case 'acceptance':
+    case 'start':
+      return ['professional', 'institutional'];
+    case 'training':
+      return ['professional', 'institutional'];
+    case 'privilege':
+      return ['leadership', 'institutional'];
+    case 'peer_review':
+      return ['leadership'];
+    case 'research':
+    case 'publication':
+      return ['research'];
+    default:
+      return [];
+  }
+}
+
+export interface DimensionTrust {
+  dimension: TrustDimension;
+  /** Mean of contributing evidence trustScores, or null when no evidence exists. */
+  score: number | null;
+  contributingCount: number;
+  decisionGradeCount: number;
+  /** evidenceIds that reinforce (trustScore > 0). */
+  supporting: string[];
+  /** evidenceIds that weaken (trustScore === 0: gated/unavailable/notDecisionGrade). */
+  weakening: string[];
+  /** distinct sourceIds where positive trust originates. */
+  origins: string[];
+}
+
+// ── C4: Trust history ────────────────────────────────────────────────────────
+
+export type TrustHistoryEventType = 'reinforcement' | 'decay';
+
+export interface TrustHistoryEntry {
+  /** ISO timestamp (checkedAt for reinforcement, expiresAt/checkedAt for decay). */
+  occurredAt: string | null;
+  type: TrustHistoryEventType;
+  dimension: TrustDimension | null;
+  evidenceId: string | null;
+  detail: string;
+  /** + reinforcement, - decay. Bounded by the evidence's own trust. */
+  scoreDelta: number;
+}
+
+export interface TrustHistory {
+  entries: TrustHistoryEntry[];
+  reinforcementCount: number;
+  decayCount: number;
+  netDelta: number;
+  /** Growth signal derived from net reinforcement vs decay. */
+  trend: 'growing' | 'decaying' | 'stable';
+}
+
+export interface TrustProjection {
+  subjectKey: string;
+  overall: { score: number | null; decisionGradeEvidence: number; totalEvidence: number };
+  dimensions: DimensionTrust[];
+  history: TrustHistory;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function mean(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return round4(values.reduce((sum, v) => sum + v, 0) / values.length);
+}
+
+function evidenceNodes(graph: GraphProjection): GraphNode[] {
+  return graph.nodes.filter((n) => n.type === 'evidence' && n.evidenceClass !== null && n.trustScore !== null);
+}
+
+function buildDimension(dimension: TrustDimension, nodes: GraphNode[]): DimensionTrust {
+  const contributing = nodes.filter((n) => n.evidenceClass && dimensionsForClass(n.evidenceClass).includes(dimension));
+  const supporting: string[] = [];
+  const weakening: string[] = [];
+  const origins = new Set<string>();
+
+  for (const node of contributing) {
+    const score = node.trustScore ?? 0;
+    if (score > 0) {
+      supporting.push(node.id);
+      if (node.evidenceSource) origins.add(node.evidenceSource);
+    } else {
+      weakening.push(node.id);
+    }
+  }
+
+  return {
+    dimension,
+    score: mean(contributing.map((n) => n.trustScore ?? 0)),
+    contributingCount: contributing.length,
+    decisionGradeCount: contributing.filter((n) => n.decisionGrade).length,
+    supporting,
+    weakening,
+    origins: [...origins],
+  };
+}
+
+function buildHistory(nodes: GraphNode[]): TrustHistory {
+  const entries: TrustHistoryEntry[] = [];
+
+  for (const node of nodes) {
+    const dimension = node.evidenceClass ? dimensionsForClass(node.evidenceClass)[0] ?? null : null;
+    const score = node.trustScore ?? 0;
+
+    if (node.status === 'checked') {
+      entries.push({
+        occurredAt: node.checkedAt,
+        type: 'reinforcement',
+        dimension,
+        evidenceId: node.id,
+        detail: `${node.label} checked — reinforces ${dimension ?? 'trust'}`,
+        scoreDelta: round4(score),
+      });
+    }
+
+    const decayed = node.status === 'stale' || node.lifecycle === 'expired' || node.lifecycle === 'revoked';
+    if (decayed) {
+      entries.push({
+        occurredAt: node.expiresAt ?? node.checkedAt,
+        type: 'decay',
+        dimension,
+        evidenceId: node.id,
+        detail: `${node.label} ${node.lifecycle === 'revoked' ? 'revoked' : 'stale/expired'} — weakens ${dimension ?? 'trust'}`,
+        scoreDelta: round4(-(1 - score)),
+      });
+    }
+  }
+
+  // Deterministic order: by timestamp ascending, nulls last, tiebreak evidenceId.
+  entries.sort((a, b) => {
+    if (a.occurredAt === b.occurredAt) return (a.evidenceId ?? '').localeCompare(b.evidenceId ?? '');
+    if (a.occurredAt === null) return 1;
+    if (b.occurredAt === null) return -1;
+    return a.occurredAt.localeCompare(b.occurredAt);
+  });
+
+  const reinforcementCount = entries.filter((e) => e.type === 'reinforcement').length;
+  const decayCount = entries.filter((e) => e.type === 'decay').length;
+  const netDelta = round4(entries.reduce((sum, e) => sum + e.scoreDelta, 0));
+  const trend: TrustHistory['trend'] = netDelta > 0 ? 'growing' : netDelta < 0 ? 'decaying' : 'stable';
+
+  return { entries, reinforcementCount, decayCount, netDelta, trend };
+}
+
+// ── C2: propagateTrust ───────────────────────────────────────────────────────
+
+export function propagateTrust(graph: GraphProjection): TrustProjection {
+  const nodes = evidenceNodes(graph);
+  const scores = nodes.map((n) => n.trustScore ?? 0);
+
+  return {
+    subjectKey: graph.subjectKey,
+    overall: {
+      score: mean(scores),
+      decisionGradeEvidence: nodes.filter((n) => n.decisionGrade).length,
+      totalEvidence: nodes.length,
+    },
+    dimensions: TRUST_DIMENSIONS.map((dimension) => buildDimension(dimension, nodes)),
+    history: buildHistory(nodes),
+  };
+}

--- a/packages/domain-evidence/src/types.ts
+++ b/packages/domain-evidence/src/types.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitalcv/domain-evidence — typed facade over evidence that already exists
+ * across domain-common, source-adapters, trust-state, audit, and the Prisma
+ * store (see docs/wave215/C3-domain-evidence-package.md).
+ *
+ * These are TYPES ONLY. The package introduces no persistence. All runtime
+ * helpers (collection.ts) are pure transforms — no fetches, no writes — mirroring
+ * the discipline of apps/web/lib/issuer-verification/*.
+ */
+
+import type { CanonicalSourceCoverageState } from '@vitalcv/trust-state';
+
+/**
+ * EvidenceStatus is LITERALLY the canonical source-coverage vocabulary, so the
+ * two can never drift. Only 'checked' is decision-grade (see isDecisionGradeStatus).
+ */
+export type EvidenceStatus = CanonicalSourceCoverageState;
+
+/** The unifying discriminator across the six existing evidence representations. */
+export type EvidenceClass =
+  | 'identity'
+  | 'licensure'
+  | 'board_cert'
+  | 'registration'
+  | 'exclusion'
+  | 'enrollment'
+  | 'privilege'
+  | 'peer_review'
+  | 'recognition'
+  | 'acceptance'
+  | 'start'
+  | 'employment'
+  | 'research'
+  | 'publication'
+  | 'training';
+
+/** Lifecycle of a single evidence object (independent of freshness/status). */
+export type EvidenceLifecycle = 'active' | 'superseded' | 'revoked' | 'expired';
+
+/** Normalized atomic value carried by an evidence object. */
+export type EvidenceValue = string | number | boolean | null | Record<string, unknown>;
+
+export interface EvidenceSource {
+  sourceId: string;
+  sourceLabel: string;
+  /** Reuse source-adapters LaneType when known (identity | exclusion | …). */
+  laneType: string | null;
+  /** Reuse sourceGovernance (open | gated | human_lookup_only | …) when known. */
+  governance: string | null;
+}
+
+export interface EvidenceProvenance {
+  artifactIds: string[];
+  receiptIds: string[];
+  sourceUrl: string | null;
+  checksum: string | null;
+  parserVersion: string | null;
+}
+
+export interface EvidenceObject {
+  evidenceId: string;
+  /** VcvEntity.canonicalId or NPI — the subject this evidence is about. */
+  subjectKey: string;
+  evidenceClass: EvidenceClass;
+  label: string;
+  value: EvidenceValue;
+  status: EvidenceStatus;
+  source: EvidenceSource;
+  trustTier: string | null;
+  /** MUST equal isDecisionGradeStatus(status). Never widened. */
+  decisionGrade: boolean;
+  observedAt: string | null;
+  checkedAt: string | null;
+  expiresAt: string | null;
+  freshnessWindowHours: number | null;
+  integrityHash: string | null;
+  provenance: EvidenceProvenance;
+  lifecycle: EvidenceLifecycle;
+  supersedes: string | null;
+  supersededBy: string | null;
+}
+
+export type EvidenceRelationshipType =
+  | 'issued_by'
+  | 'verified_by'
+  | 'derived_from'
+  | 'proven_by'
+  | 'supersedes'
+  | 'affiliated_with'
+  | 'trained_at'
+  | 'works_at'
+  | 'accepted_by'
+  | 'attested_by';
+
+export interface EvidenceRelationship {
+  /** evidenceId or subjectKey. */
+  from: string;
+  /** evidenceId, sourceId, or entity key. */
+  to: string;
+  type: EvidenceRelationshipType;
+  confidence: number | null;
+  observedAt: string | null;
+}
+
+export interface EvidenceCollection {
+  subjectKey: string;
+  generatedFor: { displayName: string; npi: string | null };
+  objects: EvidenceObject[];
+  relationships: EvidenceRelationship[];
+  /** Convenience rollup — every class key present, empty arrays when none. */
+  byClass: Record<EvidenceClass, EvidenceObject[]>;
+  /** sourceIds grouped by EvidenceStatus (parallels CanonicalSourceCoverageSummary). */
+  coverageSummary: Record<EvidenceStatus, string[]>;
+}

--- a/packages/domain-evidence/tsconfig.json
+++ b/packages/domain-evidence/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,6 +758,9 @@ importers:
       '@vitalcv/crs':
         specifier: workspace:*
         version: link:../../packages/crs
+      '@vitalcv/domain-evidence':
+        specifier: workspace:*
+        version: link:../../packages/domain-evidence
       '@vitalcv/ingest':
         specifier: workspace:*
         version: link:../../packages/ingest
@@ -980,6 +983,19 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+
+  packages/domain-evidence:
+    dependencies:
+      '@vitalcv/trust-state':
+        specifier: workspace:*
+        version: link:../trust-state
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@25.2.1)(jsdom@29.0.1(@noble/hashes@2.0.1))(lightningcss@1.30.2)(terser@5.46.0)
 
   packages/embed-sdk:
     devDependencies:


### PR DESCRIPTION
# Career Evidence stack — domain-evidence package + evidence/graph/trust/timeline + Career Packet

## What this is

The executable Career Evidence Network layer: a new app-agnostic package (`@vitalcv/domain-evidence`) that projects an already-source-checked passport into **evidence → graph → trust → timeline**, plus the recruiter-facing **Verified Clinician Career Packet**. All additive and read-only — no existing surface changes behaviour.

## Scope (this PR)

| Area | Files |
|---|---|
| Package | `packages/domain-evidence/` (types, collection, graph projector, trust engine, timeline projector) |
| Web adapter | `apps/web/lib/evidence/passport-to-evidence.ts` |
| Read APIs | `/api/evidence/[id]`, `/api/graph/[id]`, `/api/graph/[id]/trust`, `/api/timeline/[id]` |
| Career Packet | `apps/web/app/packet/[entityId]/`, `apps/web/lib/packet/career-packet.ts`, PDF extension |
| Dev tool | `apps/web/app/dev/graph/[entityId]/` (noindex) |
| Tests | `apps/web/__tests__/evidence-*.test.ts`, `career-packet-*.test.ts` + package tests |
| Docs | `docs/wave2*`, `codex-safe-review/` |

## Honesty invariants (test-enforced)

- `decisionGrade ⇔ status === 'checked'` — fail-closed in `buildEvidenceCollection`.
- Monotonic, non-inflating trust: `statusTrustScore` (gated states = 0); dimension scores never exceed contributing evidence; reputation/timeline impacts bounded.
- Gated/stale never presented as decision-grade; honest `null`/`unknown` for absent evidence.
- No bare `Verified`; passes `pnpm check:claims`.
- Pure transforms (no I/O); no new persistence; no PHI.

## Validation

- Package: **28 tests** green · Web stack + integration + regression: green (incl. 6 Career OS integration tests, W245).
- `tsc --noEmit` (package + web): 0 errors · ESLint: clean · `banned-verified-label` vitest: green (enforces no bare `Verified`).
- **`pnpm turbo run build --filter @vitalcv/web`: tasks successful, exit 0** (full Next build with TS+ESLint enforced).

> `check:claims` (the 20-phrase public-copy scanner) is pre-existing infra not on `origin/main`; the stack was verified against it on the source branch, and the committed `banned-verified-label` test covers the critical sub-rule here.

## Architecture

Strict acyclic layering `types → collection → graph → trust → timeline`; single external dep `@vitalcv/trust-state`; one adapter seam (`passport-to-evidence`). Full review package in `codex-safe-review/`.

## ⚠️ Merge gate

Per project doctrine, this requires a real **`codex exec` SAFE verdict** (implementation / diff / copy audits) before `gh pr merge`. CI must run `pnpm turbo run build --filter @vitalcv/web` (the package ships from `dist/`, gitignored like `@vitalcv/trust-state`).

## Not included (deliberately)

Pre-existing branch WIP unrelated to this stack (doctrine docs, homepage, navbar, etc.) is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
