### PR TITLE
harden(wallet): encode credential API paths + a11y labels + tests (Wave 250)

### DIFF
--- a/apps/web/__tests__/credential-wallet.test.tsx
+++ b/apps/web/__tests__/credential-wallet.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { walletDeletePath, walletFetchPath } from '../lib/wallet/credential-wallet-paths';
+
+// W250 wallet hardening: the credential wallet had no tests on main. These cover
+// the security fix — URL-encoded identifiers in the wallet API paths, so a hostile
+// subject/credentialId can never escape its path segment. (The a11y fix — aria-label
+// on the icon-only refresh/remove buttons — is a static change validated by the
+// jsx-a11y ESLint rules enforced at build time.)
+
+describe('wallet API path builders (security)', () => {
+  it('encodes the subject in the fetch path', () => {
+    expect(walletFetchPath('http://x', '1003000126')).toBe('http://x/api/credentials/wallet/1003000126');
+  });
+
+  it('encodes the credentialId in the delete path (path-injection defense)', () => {
+    expect(walletDeletePath('http://x', 'abc-123')).toBe('http://x/api/credentials/abc-123');
+    // a hostile id can never escape the path segment
+    expect(walletDeletePath('http://x', '../../admin')).toBe('http://x/api/credentials/..%2F..%2Fadmin');
+    expect(walletDeletePath('http://x', 'a/b?c')).toBe('http://x/api/credentials/a%2Fb%3Fc');
+  });
+});

--- a/apps/web/components/wallet/CredentialWallet.tsx
+++ b/apps/web/components/wallet/CredentialWallet.tsx
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getApiBase } from '@/lib/api';
+import { walletDeletePath, walletFetchPath } from '@/lib/wallet/credential-wallet-paths';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -148,7 +149,7 @@ export function CredentialWallet({
 
   const fetchWallet = useCallback(async () => {
     try {
-      const r = await fetch(`${base}/api/credentials/wallet/${encodeURIComponent(subject)}`);
+      const r = await fetch(walletFetchPath(base, subject));
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const json = await r.json() as WalletResponse;
       setData(json);
@@ -179,7 +180,7 @@ export function CredentialWallet({
   const handleRemove = useCallback(async (credentialId: string) => {
     setRemoving((prev) => new Set(prev).add(credentialId));
     try {
-      await fetch(`${base}/api/credentials/${credentialId}`, { method: 'DELETE' });
+      await fetch(walletDeletePath(base, credentialId), { method: 'DELETE' });
       setData((prev) =>
         prev
           ? {
@@ -215,8 +216,11 @@ export function CredentialWallet({
           )}
         </div>
         <button
+          type="button"
           onClick={() => void fetchWallet()}
           disabled={loading}
+          aria-label="Refresh credential wallet"
+          aria-busy={loading}
           className="rounded p-1.5 hover:bg-secondary transition-colors disabled:opacity-40"
           title="Refresh wallet"
         >
@@ -293,8 +297,11 @@ export function CredentialWallet({
                         {credential.status}
                       </span>
                       <button
+                        type="button"
                         onClick={() => void handleRemove(credential.credentialId)}
                         disabled={isRemoving}
+                        aria-label={`Remove ${issuerLabel} credential from wallet`}
+                        aria-busy={isRemoving}
                         className="rounded p-1 hover:bg-red-50 text-muted-foreground hover:text-red-500 transition-colors disabled:opacity-40"
                         title="Remove from wallet"
                       >

--- a/apps/web/lib/wallet/credential-wallet-paths.ts
+++ b/apps/web/lib/wallet/credential-wallet-paths.ts
@@ -1,0 +1,15 @@
+/**
+ * Credential wallet API path builders (Wave 250 hardening).
+ *
+ * Centralizes + encodes the wallet API paths so user/credential identifiers can
+ * never inject into the URL path (defense-in-depth) and the paths are unit
+ * testable. Pure functions — no I/O.
+ */
+
+export function walletFetchPath(base: string, subject: string): string {
+  return `${base}/api/credentials/wallet/${encodeURIComponent(subject)}`;
+}
+
+export function walletDeletePath(base: string, credentialId: string): string {
+  return `${base}/api/credentials/${encodeURIComponent(credentialId)}`;
+}

--- a/docs/wave250/wallet-hardening-report.md
+++ b/docs/wave250/wallet-hardening-report.md
@@ -1,0 +1,44 @@
+# Wave 250 — Wallet Hardening Report
+
+**Branch:** `feat/wallet-hardening` (off `origin/main`, separate from PR #444) · **Date:** 2026-06-21
+
+Scope: the **pre-existing** Wallet surface (not authored in the Career Evidence waves). Targeted hardening only — no redesign, no new frameworks.
+
+---
+
+## What was hardened
+
+`apps/web/components/wallet/CredentialWallet.tsx` (the canonical credential wallet; live, no tests on `main`):
+
+| C | Finding | Fix |
+|---|---|---|
+| C5 Security | DELETE call interpolated `credentialId` into the URL **unencoded** (`/api/credentials/${credentialId}`) — path-injection surface | extracted `walletDeletePath`/`walletFetchPath` helpers that `encodeURIComponent` both identifiers; component now uses them |
+| C4 A11y | refresh + remove buttons were **icon-only with only `title`** (no accessible name) | added `aria-label` (+ `aria-busy`, `type="button"`) to both |
+| C2 Tests | **no wallet tests existed on `main`** | added `credential-wallet.test.tsx` — encoding/path-injection coverage for the security fix |
+
+## Audited, deliberately NOT changed
+
+| Surface | Finding | Decision |
+|---|---|---|
+| `components/wallet/WalletPassport.tsx` | buttons already have accessible names ("Retry" text; existing `aria-label`); `npi` already `encodeURIComponent`-d in fetch | no change needed |
+| `components/clinician/WalletDashboard.tsx` | **dead code — 0 importers** | flagged for removal; not deleted without owner confirmation |
+| `packages/wallet-sdk` | real SDK (OID4VP/selective disclosure); `wallet-sdk` was previously **removed from web deps** | out of scope for a UI hardening pass; no change |
+
+## Validation (C1, C5, C7)
+
+| Check | Result |
+|---|---|
+| C2 new tests | 2/2 pass (security/encoding) |
+| C1 typing | my files clean; `next build` typechecks green |
+| C6 ESLint (jsx-a11y on the new labels) | clean |
+| C5 build | `pnpm turbo run build --filter @vitalcv/web` → 13/13 tasks, exit 0 |
+
+> **Note:** running `tsc --noEmit` standalone in a fresh worktree reports ~35 implicit-`any` errors in *unrelated* files (`PassportEntityClient.tsx` etc.) — these are pre-existing on `origin/main` and surface only because the `@vitalcv/trust-state` dist isn't prebuilt in a bare worktree; the real `next build` (which prebuilds dists) is clean. Not introduced by this change.
+
+## Merge readiness (C7)
+
+This is a small, surgical, **separate** PR against `main` (not entangled with PR #444). It is build-clean, typed, and the security fix is tested. Per doctrine it still requires a **Codex SAFE verdict** before merge.
+
+## Honest scope note
+
+The Wallet is a large pre-existing surface (~2,000 LOC across 4 components + an SDK). This pass hardens the highest-value, lowest-risk issues in the live credential wallet. A fuller hardening (dead-code removal, SDK review, a jsdom test-env for interactive component coverage) would be follow-on work and is listed above as audited findings, not silently changed.


### PR DESCRIPTION
## Wallet hardening (Wave 250) — separate from PR #444

Targeted hardening of the **pre-existing** credential wallet (`components/wallet/CredentialWallet.tsx`). No redesign, no new frameworks.

### Changes
- **Security:** URL-encode `subject`/`credentialId` in the wallet API paths via new pure helpers (`lib/wallet/credential-wallet-paths.ts`) — path-injection defense. Unit-tested.
- **A11y:** `aria-label` + `aria-busy` on the icon-only refresh and remove buttons (previously `title`-only).
- **Tests:** first wallet tests on `main` (encoding/injection coverage).

### Validation
- 2/2 new tests pass · ESLint (jsx-a11y) clean · `pnpm turbo run build --filter @vitalcv/web` → 13/13 tasks, exit 0.

### Audited, not changed (see `docs/wave250/wallet-hardening-report.md`)
- `WalletPassport` already accessible/encoded — no change.
- `WalletDashboard` is dead code (0 importers) — flagged, not deleted.
- `wallet-sdk` out of scope for a UI hardening pass.

⚠️ Requires a Codex SAFE verdict before merge (doctrine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)