### PR TITLE
feat(mobility): opportunity readiness engine + /api/mobility (Wave 270)

### DIFF
--- a/apps/web/__tests__/mobility-integration.test.ts
+++ b/apps/web/__tests__/mobility-integration.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  defaultReadinessTemplate,
+  deriveMobilityOverview,
+  detectGaps,
+  projectEvidenceToGraph,
+  projectReadiness,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+function buildPassportPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'entity-1', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        { id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 72, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 10, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-01T00:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE clear', checkedAt: '2026-03-01T00:00:00.000Z' },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 72, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const ctx = (entityId: string) => ({ params: Promise.resolve({ entityId }) });
+
+beforeEach(() => {
+  resolveMock.mockReset();
+  resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload()));
+});
+
+describe('Wallet → Mobility → Opportunities integration (W270-C4)', () => {
+  it('a fully-checked clinician is READY for their licensed state, NEAR_READY for a new state', () => {
+    const collection = passportToEvidenceCollection(assertPassportData(buildPassportPayload()));
+    const trust = propagateTrust(projectEvidenceToGraph(collection));
+
+    const ca = defaultReadinessTemplate('CA');
+    expect(projectReadiness(ca, detectGaps(ca, collection, trust), trust).readiness).toBe('ready');
+
+    const nv = defaultReadinessTemplate('NV');
+    const nvReadiness = projectReadiness(nv, detectGaps(nv, collection, trust), trust);
+    expect(nvReadiness.readiness).toBe('near_ready'); // licensed CA, endorsement path to NV
+    expect(nvReadiness.fixableGaps).toContain('licensure');
+
+    const overview = deriveMobilityOverview(collection, trust);
+    expect(overview.licensedStates).toEqual(['CA']);
+  });
+});
+
+const ROUTES = [
+  { name: 'overview', path: '../app/api/mobility/[entityId]/route', schema: 'vitalcv.mobility.v1', check: (b: any) => expect(b.licensedStates).toEqual(['CA']) },
+  { name: 'readiness', path: '../app/api/mobility/[entityId]/readiness/route', schema: 'vitalcv.mobility-readiness.v1', check: (b: any) => expect(['ready', 'near_ready', 'blocked', 'unknown']).toContain(b.readiness) },
+  { name: 'gaps', path: '../app/api/mobility/[entityId]/gaps/route', schema: 'vitalcv.mobility-gaps.v1', check: (b: any) => expect(Array.isArray(b.gaps)).toBe(true) },
+];
+
+describe('mobility routes (W270)', () => {
+  for (const route of ROUTES) {
+    it(`GET ${route.name} returns 200 + ${route.schema}`, async () => {
+      const { GET } = await import(route.path);
+      const res = await GET(new NextRequest('http://localhost/api/mobility/entity-1'), ctx('entity-1'));
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Cache-Control')).toBe('no-store');
+      const body = await res.json();
+      expect(body.schema).toBe(route.schema);
+      route.check(body);
+    });
+
+    it(`GET ${route.name} returns 500 on runtime failure`, async () => {
+      resolveMock.mockRejectedValueOnce(new Error('boom'));
+      const { GET } = await import(route.path);
+      const res = await GET(new NextRequest('http://localhost/api/mobility/entity-1'), ctx('entity-1'));
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('mobility_unavailable');
+    });
+  }
+});

--- a/apps/web/app/api/mobility/[entityId]/gaps/route.ts
+++ b/apps/web/app/api/mobility/[entityId]/gaps/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  defaultReadinessTemplate,
+  detectGaps,
+  projectEvidenceToGraph,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+function safeState(value: string | null): string | undefined {
+  return value && /^[A-Za-z]{2}$/.test(value) ? value.toUpperCase() : undefined;
+}
+
+/**
+ * GET /api/mobility/[entityId]/gaps?state=XX — the GapReport against the standard
+ * readiness template (Wave 270 / W230-C3). Honest missing/insufficient/stale kinds.
+ */
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  const state = safeState(req.nextUrl.searchParams.get('state'));
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const trust = propagateTrust(projectEvidenceToGraph(collection));
+    const report = detectGaps(defaultReadinessTemplate(state), collection, trust);
+    return NextResponse.json(
+      { schema: 'vitalcv.mobility-gaps.v1', ...report },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Mobility gaps failed.';
+    return NextResponse.json(
+      { error: 'mobility_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/mobility/[entityId]/readiness/route.ts
+++ b/apps/web/app/api/mobility/[entityId]/readiness/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  defaultReadinessTemplate,
+  detectGaps,
+  projectEvidenceToGraph,
+  projectReadiness,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/** Whitelist the optional state param so it can never inject into anything downstream. */
+function safeState(value: string | null): string | undefined {
+  return value && /^[A-Za-z]{2}$/.test(value) ? value.toUpperCase() : undefined;
+}
+
+/**
+ * GET /api/mobility/[entityId]/readiness?state=XX — Ready/Near Ready/Blocked/Unknown
+ * against the STANDARD readiness template (Wave 270 / W230-C5). Not employer-opportunity
+ * matching (that is W260) — a deterministic per-entity readiness verdict.
+ */
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  const state = safeState(req.nextUrl.searchParams.get('state'));
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const trust = propagateTrust(projectEvidenceToGraph(collection));
+    const opportunity = defaultReadinessTemplate(state);
+    const readiness = projectReadiness(opportunity, detectGaps(opportunity, collection, trust), trust);
+    return NextResponse.json(
+      { schema: 'vitalcv.mobility-readiness.v1', ...readiness },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Mobility readiness failed.';
+    return NextResponse.json(
+      { error: 'mobility_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/mobility/[entityId]/route.ts
+++ b/apps/web/app/api/mobility/[entityId]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  deriveMobilityOverview,
+  projectEvidenceToGraph,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/mobility/[entityId] — per-entity mobility overview (Wave 270 / W230-C4).
+ *
+ * Leverages the evidence + trust pipeline (no new persistence, no ML, no ranking):
+ * decision-grade licensed states, mobility trust, and reusable evidence count.
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const trust = propagateTrust(projectEvidenceToGraph(collection));
+    const overview = deriveMobilityOverview(collection, trust);
+    return NextResponse.json(
+      { schema: 'vitalcv.mobility.v1', ...overview },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Mobility overview failed.';
+    return NextResponse.json(
+      { error: 'mobility_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/docs/wave270/mobility-engine-report.md
+++ b/docs/wave270/mobility-engine-report.md
@@ -1,0 +1,49 @@
+# Wave 270 — Mobility Engine (the missing layer)
+
+**Branch:** `feat/mobility-engine` (stacked on `feat/career-evidence-stack` / PR #444) · **Date:** 2026-06-23
+
+W270 asked to productionize the Opportunity Network "leveraging Mobility" — but Mobility was **design-only** (W230) and never built, making the `Wallet → Mobility → Opportunities` chain unbuildable. This PR builds the missing Mobility layer (my own W230 design) so the chain is real, not faked. The pre-existing Opportunity Network (backend TS + Python matcher + Solidity) is untouched.
+
+---
+
+## What was built
+
+Implements W230-C2/C3/C5 as a pure module + read APIs over the shipped evidence/trust pipeline.
+
+| Layer | Artifact |
+|---|---|
+| Opportunity model | `OpportunityObject` + 3 requirement kinds (`evidence`/`trust`/`experience`) — W230-C2 |
+| Gap engine | `detectGaps()` → honest `satisfied`/`missing`/`insufficient`/`stale` + remediation — W230-C3 |
+| Readiness | `projectReadiness()` → `ready`/`near_ready`/`blocked`/`unknown` precedence — W230-C5 |
+| Overview | `deriveMobilityOverview()` → licensed states + mobility trust + reusable count — W230-C4 |
+| Template | `defaultReadinessTemplate(state)` — a standard readiness template (NOT employer matching) |
+| APIs | `GET /api/mobility/:id`, `…/readiness?state=XX`, `…/gaps?state=XX` |
+
+## Success criteria
+
+| Criterion | Result |
+|---|---|
+| **typed** | `tsc`/`next build` clean (one duplicate-key bug found + fixed) |
+| **tested** | package: 38 tests (10 new mobility) · web: 7 mobility integration + route tests |
+| **secure** | `state` param whitelisted (`^[A-Za-z]{2}$`) — cannot inject; pure engine has no I/O |
+| **performant** | pure O(n) over one clinician's evidence; pipeline already measured at 25ms/5k objects (W245) |
+| **mergeable** | `pnpm turbo run build --filter @vitalcv/web` → 14/14 tasks, exit 0 |
+
+## Honesty invariants (carried from the trust layer, tested)
+
+- A mandatory requirement is satisfied **only** by decision-grade (`checked`) evidence — gated/stale never satisfies (tested).
+- `ready` is unreachable without decision-grade mandatory coverage; absent evidence is honest `unknown`, **not** `blocked`/failure (tested).
+- Deterministic; no ML, no ranking (ranking is W260, explicitly out of scope).
+- `/readiness` evaluates against a **standard readiness template**, not a specific employer opportunity — documented in the route and schema, so it is never read as a match/guarantee.
+
+## C4 — the integration that W270 wanted
+
+`Wallet → Mobility → Opportunities` is now real: a clinician's credentials (the wallet's evidence) → `EvidenceCollection` → `TrustProjection` → mobility readiness. Test proves: a CA-licensed, identity+exclusion-checked clinician is **READY** for CA and **NEAR_READY** for NV (endorsement path), with `licensedStates: ['CA']`.
+
+## What this does NOT touch
+
+The pre-existing Opportunity Network — `opportunityService.ts`, `matcha.ts`, the Python `ai-matcher-service`, `MatchingPool.sol` — is **not modified**. Wiring this readiness layer into those (e.g. `fromBackendOpportunity` to evaluate against real posted opportunities) is a documented follow-on, intentionally not done here to keep the PR scoped and avoid editing code I didn't author.
+
+## Merge
+
+Stacked on PR #444 (needs the evidence/trust pipeline). Requires a **Codex SAFE verdict** before merge, same as #444/#445.

--- a/packages/domain-evidence/src/index.ts
+++ b/packages/domain-evidence/src/index.ts
@@ -60,3 +60,23 @@ export {
   type ReputationSummary,
   type TimelineProjection,
 } from './timeline/timeline';
+
+export {
+  defaultReadinessTemplate,
+  deriveMobilityOverview,
+  detectGaps,
+  projectReadiness,
+  type EvidenceRequirement,
+  type ExperienceRequirement,
+  type Gap,
+  type GapKind,
+  type GapRemediation,
+  type GapReport,
+  type MobilityOverview,
+  type MobilityReadiness,
+  type OpportunityObject,
+  type OpportunityRequirement,
+  type ReadinessProjection,
+  type RequirementNecessity,
+  type TrustRequirement,
+} from './mobility/mobility';

--- a/packages/domain-evidence/src/mobility/mobility.test.ts
+++ b/packages/domain-evidence/src/mobility/mobility.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import { projectEvidenceToGraph } from '../projectors/graph';
+import { propagateTrust, type TrustProjection } from '../trust/propagate';
+import type { EvidenceClass, EvidenceObject, EvidenceStatus } from '../types';
+import {
+  defaultReadinessTemplate,
+  deriveMobilityOverview,
+  detectGaps,
+  projectReadiness,
+  type GapReport,
+  type OpportunityObject,
+} from './mobility';
+
+function makeObject(
+  id: string,
+  evidenceClass: EvidenceClass,
+  status: EvidenceStatus,
+  sourceId: string,
+  jurisdiction?: string,
+): EvidenceObject {
+  return {
+    evidenceId: id, subjectKey: 'subject-1', evidenceClass, label: `${evidenceClass} ${id}`,
+    value: jurisdiction ? { jurisdiction } : null, status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null, decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null, checkedAt: '2026-03-01T00:00:00.000Z', expiresAt: null, freshnessWindowHours: null,
+    integrityHash: null, provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: 'active', supersedes: null, supersededBy: null,
+  };
+}
+
+function pipeline(objects: EvidenceObject[]) {
+  const collection = buildEvidenceCollection({ subjectKey: 'subject-1', generatedFor: { displayName: 'Ada', npi: '1' }, objects });
+  const trust = propagateTrust(projectEvidenceToGraph(collection));
+  return { collection, trust };
+}
+
+const READY_OBJECTS = [
+  makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API'),
+  makeObject('coverage:OIG_LEIE', 'exclusion', 'checked', 'OIG_LEIE'),
+  makeObject('cred:lic-ca', 'licensure', 'checked', 'STATE_BOARD', 'CA'),
+];
+
+describe('detectGaps (W270/W230-C3)', () => {
+  it('marks satisfied mandatory requirements as satisfied', () => {
+    const { collection, trust } = pipeline(READY_OBJECTS);
+    const report = detectGaps(defaultReadinessTemplate('CA'), collection, trust);
+    const lic = report.gaps.find((g) => g.requirementId === 'licensure')!;
+    expect(lic.kind).toBe('satisfied');
+    expect(report.mandatoryUnmet).toBe(0);
+  });
+
+  it('marks a missing jurisdiction license as missing with an endorsement remediation', () => {
+    const { collection, trust } = pipeline(READY_OBJECTS); // licensed CA, not NV
+    const report = detectGaps(defaultReadinessTemplate('NV'), collection, trust);
+    const lic = report.gaps.find((g) => g.requirementId === 'licensure')!;
+    expect(lic.kind).toBe('missing');
+    expect(lic.remediation?.type).toBe('apply_endorsement');
+  });
+
+  it('marks gated evidence as insufficient, never satisfied', () => {
+    const { collection, trust } = pipeline([
+      makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API'),
+      makeObject('coverage:OIG_LEIE', 'exclusion', 'checked', 'OIG_LEIE'),
+      makeObject('cred:lic-ca', 'licensure', 'gated', 'STATE_BOARD', 'CA'),
+    ]);
+    const lic = detectGaps(defaultReadinessTemplate('CA'), collection, trust).gaps.find((g) => g.requirementId === 'licensure')!;
+    expect(lic.kind).toBe('insufficient'); // gated never satisfies a decision-grade requirement
+  });
+
+  it('a MANDATORY requirement is never satisfied by non-checked evidence, even if minStatus is lowered', () => {
+    const { collection, trust } = pipeline([
+      makeObject('cred:lic-ca', 'licensure', 'gated', 'STATE_BOARD', 'CA'),
+    ]);
+    // A hostile/loose opportunity tries to accept gated evidence for a mandatory lane.
+    const opp: OpportunityObject = {
+      opportunityId: 'loose', title: 'Loose', organizationKey: null, specialty: null, states: ['CA'],
+      schema: 'vitalcv.opportunity.v1',
+      requirements: [{ kind: 'evidence', requirementId: 'lic', label: 'License', necessity: 'mandatory', minStatus: 'gated', evidenceClass: 'licensure', jurisdiction: 'CA' }],
+    };
+    const gap = detectGaps(opp, collection, trust).gaps.find((g) => g.requirementId === 'lic')!;
+    expect(gap.kind).not.toBe('satisfied'); // mandatory needs decision-grade regardless of minStatus
+  });
+});
+
+describe('projectReadiness state machine (W230-C5)', () => {
+  const opp: OpportunityObject = defaultReadinessTemplate('CA');
+  const trustWith = (dg: number) => ({ overall: { score: 0.5, decisionGradeEvidence: dg, totalEvidence: dg }, dimensions: [], history: {} } as unknown as TrustProjection);
+  const report = (gaps: GapReport['gaps']): GapReport => ({ opportunityId: opp.opportunityId, subjectKey: 'subject-1', gaps, mandatoryUnmet: gaps.filter((g) => g.necessity === 'mandatory' && g.kind !== 'satisfied').length, preferredUnmet: 0 });
+
+  it('READY when all mandatory satisfied and evidence is decision-grade', () => {
+    const r = projectReadiness(opp, report([{ requirementId: 'licensure', label: 'L', necessity: 'mandatory', kind: 'satisfied', reason: '', blockingEvidenceIds: [], remediation: null }]), trustWith(3));
+    expect(r.readiness).toBe('ready');
+  });
+
+  it('NEAR_READY when mandatory gaps all have remediation', () => {
+    const r = projectReadiness(opp, report([{ requirementId: 'licensure', label: 'L', necessity: 'mandatory', kind: 'missing', reason: '', blockingEvidenceIds: [], remediation: { type: 'apply_endorsement', detail: '', estimatedDays: null } }]), trustWith(3));
+    expect(r.readiness).toBe('near_ready');
+    expect(r.fixableGaps).toContain('licensure');
+  });
+
+  it('BLOCKED when a mandatory gap is missing with no remediation', () => {
+    const r = projectReadiness(opp, report([{ requirementId: 'x', label: 'X', necessity: 'mandatory', kind: 'missing', reason: 'hard block', blockingEvidenceIds: [], remediation: null }]), trustWith(3));
+    expect(r.readiness).toBe('blocked');
+    expect(r.blockers).toContain('hard block');
+  });
+
+  it('UNKNOWN (not blocked) when there is no decision-grade evidence', () => {
+    const r = projectReadiness(opp, report([{ requirementId: 'licensure', label: 'L', necessity: 'mandatory', kind: 'insufficient', reason: '', blockingEvidenceIds: [], remediation: { type: 'await_review', detail: '', estimatedDays: null } }]), trustWith(0));
+    expect(r.readiness).toBe('unknown'); // absence of evidence is honest uncertainty, not failure
+  });
+});
+
+describe('deriveMobilityOverview (W230-C4)', () => {
+  it('reports decision-grade licensed states and reusable evidence count', () => {
+    const { collection, trust } = pipeline([
+      ...READY_OBJECTS,
+      makeObject('cred:lic-nv', 'licensure', 'checked', 'STATE_BOARD', 'NV'),
+      makeObject('cred:lic-tx', 'licensure', 'gated', 'STATE_BOARD', 'TX'), // gated → not counted
+    ]);
+    const overview = deriveMobilityOverview(collection, trust);
+    expect(overview.licensedStates).toEqual(['CA', 'NV']); // TX gated, excluded
+    expect(overview.reusableEvidenceCount).toBe(4); // 4 checked
+    expect(overview.mobilityTrust).not.toBeNull();
+  });
+});
+
+describe('end-to-end readiness', () => {
+  it('a fully-checked clinician is READY for the standard template', () => {
+    const { collection, trust } = pipeline(READY_OBJECTS);
+    const opp = defaultReadinessTemplate('CA');
+    const r = projectReadiness(opp, detectGaps(opp, collection, trust), trust);
+    expect(r.readiness).toBe('ready');
+  });
+
+  it('is deterministic', () => {
+    const { collection, trust } = pipeline(READY_OBJECTS);
+    const opp = defaultReadinessTemplate('CA');
+    expect(detectGaps(opp, collection, trust)).toEqual(detectGaps(opp, collection, trust));
+  });
+});

--- a/packages/domain-evidence/src/mobility/mobility.ts
+++ b/packages/domain-evidence/src/mobility/mobility.ts
@@ -1,0 +1,308 @@
+/**
+ * Mobility engine (Wave 270 — implements the W230 design).
+ *
+ * Pure, deterministic. Evaluates a clinician's EvidenceCollection + TrustProjection
+ * against an OpportunityObject to produce gaps and a readiness verdict. NO matching
+ * ML, NO ranking (that is W260). Honesty carries through from the trust layer:
+ * a mandatory requirement is satisfied ONLY by decision-grade ('checked') evidence;
+ * `ready` is unreachable otherwise; absent evidence is honest `unknown`, not failure.
+ *
+ * See docs/wave230/C2..C5.
+ */
+
+import type { EvidenceClass, EvidenceCollection, EvidenceObject, EvidenceStatus } from '../types';
+import { isDecisionGradeStatus } from '../collection';
+import type { TrustDimension, TrustProjection } from '../trust/propagate';
+
+// ── Opportunity model (W230-C2) ──────────────────────────────────────────────
+
+export type RequirementNecessity = 'mandatory' | 'preferred';
+
+interface RequirementBase {
+  requirementId: string;
+  label: string;
+  necessity: RequirementNecessity;
+}
+
+export interface EvidenceRequirement extends RequirementBase {
+  kind: 'evidence';
+  evidenceClass: EvidenceClass;
+  /** Minimum status that satisfies it. Defaults to decision-grade ('checked'). */
+  minStatus: EvidenceStatus;
+  /** Optional jurisdiction constraint (the mobility axis), e.g. 'CA'. */
+  jurisdiction?: string;
+}
+
+export interface TrustRequirement extends RequirementBase {
+  kind: 'trust';
+  dimension: TrustDimension;
+  minScore: number;
+}
+
+export interface ExperienceRequirement extends RequirementBase {
+  kind: 'experience';
+  dimension: TrustDimension;
+  minDecisionGradeCount: number;
+}
+
+export type OpportunityRequirement = EvidenceRequirement | TrustRequirement | ExperienceRequirement;
+
+export interface OpportunityObject {
+  opportunityId: string;
+  title: string;
+  organizationKey: string | null;
+  specialty: string | null;
+  states: string[];
+  requirements: OpportunityRequirement[];
+  schema: 'vitalcv.opportunity.v1';
+}
+
+// ── Gap model (W230-C3) ──────────────────────────────────────────────────────
+
+export type GapKind = 'satisfied' | 'missing' | 'insufficient' | 'stale';
+
+export interface GapRemediation {
+  type: 'request_refresh' | 'apply_endorsement' | 'submit_evidence' | 'await_review';
+  detail: string;
+  /** Wired from the readiness engine at the app layer; null in the pure layer. */
+  estimatedDays: number | null;
+}
+
+export interface Gap {
+  requirementId: string;
+  label: string;
+  necessity: RequirementNecessity;
+  kind: GapKind;
+  reason: string;
+  blockingEvidenceIds: string[];
+  remediation: GapRemediation | null;
+}
+
+export interface GapReport {
+  opportunityId: string;
+  subjectKey: string;
+  gaps: Gap[];
+  mandatoryUnmet: number;
+  preferredUnmet: number;
+}
+
+// ── Readiness model (W230-C5) ────────────────────────────────────────────────
+
+export type MobilityReadiness = 'ready' | 'near_ready' | 'blocked' | 'unknown';
+
+export interface ReadinessProjection {
+  subjectKey: string;
+  opportunityId: string;
+  readiness: MobilityReadiness;
+  rationale: string;
+  blockers: string[];
+  fixableGaps: string[];
+  estimatedStartDays: number | null;
+}
+
+export interface MobilityOverview {
+  subjectKey: string;
+  mobilityTrust: number | null;
+  /** Decision-grade licensure/registration jurisdictions. */
+  licensedStates: string[];
+  reusableEvidenceCount: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function jurisdictionOf(obj: EvidenceObject): string | null {
+  if (obj.value && typeof obj.value === 'object' && !Array.isArray(obj.value)) {
+    const j = (obj.value as Record<string, unknown>).jurisdiction;
+    if (typeof j === 'string' && j.trim().length > 0) return j.trim();
+  }
+  return null;
+}
+
+/** A requirement's minStatus is satisfied only by an equal-or-decision-grade status. */
+function statusSatisfies(actual: EvidenceStatus, min: EvidenceStatus): boolean {
+  if (min === 'checked') return actual === 'checked';
+  return actual === 'checked' || actual === min;
+}
+
+function dimensionOf(trust: TrustProjection, dimension: TrustDimension) {
+  return trust.dimensions.find((d) => d.dimension === dimension) ?? null;
+}
+
+// ── detectGaps (W230-C3) ─────────────────────────────────────────────────────
+
+function evaluateEvidenceRequirement(req: EvidenceRequirement, collection: EvidenceCollection): Gap {
+  const candidates = (collection.byClass[req.evidenceClass] ?? []).filter((o) =>
+    req.jurisdiction ? jurisdictionOf(o) === req.jurisdiction : true,
+  );
+
+  // A MANDATORY requirement is satisfied only by decision-grade ('checked')
+  // evidence regardless of its declared minStatus — a gated/stale mandatory lane
+  // can never make a clinician 'ready' (fail-closed readiness honesty).
+  const effectiveMinStatus: EvidenceStatus = req.necessity === 'mandatory' ? 'checked' : req.minStatus;
+  const satisfied = candidates.find((o) => statusSatisfies(o.status, effectiveMinStatus));
+  if (satisfied) {
+    return { requirementId: req.requirementId, label: req.label, necessity: req.necessity, kind: 'satisfied', reason: `${req.label} satisfied by ${satisfied.evidenceId}.`, blockingEvidenceIds: [], remediation: null };
+  }
+
+  if (candidates.length > 0) {
+    const present = candidates[0];
+    const stale = present.status === 'stale';
+    return {
+      requirementId: req.requirementId,
+      label: req.label,
+      necessity: req.necessity,
+      kind: stale ? 'stale' : 'insufficient',
+      reason: `${req.label} present but ${present.status}, not decision-grade.`,
+      blockingEvidenceIds: candidates.map((c) => c.evidenceId),
+      remediation: { type: stale ? 'request_refresh' : 'await_review', detail: `Resolve ${present.status} ${req.label}.`, estimatedDays: null },
+    };
+  }
+
+  // No evidence at all. A jurisdiction-scoped license gap has an endorsement path.
+  return {
+    requirementId: req.requirementId,
+    label: req.label,
+    necessity: req.necessity,
+    kind: 'missing',
+    reason: req.jurisdiction ? `No decision-grade ${req.label} for ${req.jurisdiction}.` : `No decision-grade ${req.label} on file.`,
+    blockingEvidenceIds: [],
+    remediation: req.jurisdiction
+      ? { type: 'apply_endorsement', detail: `Apply for ${req.jurisdiction} licensure (endorsement/compact path).`, estimatedDays: null }
+      : { type: 'submit_evidence', detail: `Submit ${req.label} for source verification.`, estimatedDays: null },
+  };
+}
+
+function evaluateTrustRequirement(req: TrustRequirement, trust: TrustProjection): Gap {
+  const dim = dimensionOf(trust, req.dimension);
+  const base = { requirementId: req.requirementId, label: req.label, necessity: req.necessity, blockingEvidenceIds: dim?.weakening ?? [] };
+  if (!dim || dim.score === null) {
+    return { ...base, kind: 'missing', reason: `No ${req.dimension} evidence to meet ${req.minScore}.`, remediation: { type: 'submit_evidence', detail: `Add source-backed ${req.dimension} evidence.`, estimatedDays: null } };
+  }
+  if (dim.score < req.minScore) {
+    return { ...base, kind: 'insufficient', reason: `${req.dimension} trust ${dim.score} < required ${req.minScore}.`, remediation: { type: 'await_review', detail: `Strengthen ${req.dimension} evidence.`, estimatedDays: null } };
+  }
+  return { ...base, kind: 'satisfied', reason: `${req.dimension} trust ${dim.score} ≥ ${req.minScore}.`, blockingEvidenceIds: [], remediation: null };
+}
+
+function evaluateExperienceRequirement(req: ExperienceRequirement, trust: TrustProjection): Gap {
+  const dim = dimensionOf(trust, req.dimension);
+  const count = dim?.decisionGradeCount ?? 0;
+  const base = { requirementId: req.requirementId, label: req.label, necessity: req.necessity, blockingEvidenceIds: [] as string[] };
+  if (count >= req.minDecisionGradeCount) {
+    return { ...base, kind: 'satisfied', reason: `${count} decision-grade ${req.dimension} items ≥ ${req.minDecisionGradeCount}.`, remediation: null };
+  }
+  return {
+    ...base,
+    kind: count === 0 ? 'missing' : 'insufficient',
+    reason: `${count} decision-grade ${req.dimension} items < required ${req.minDecisionGradeCount}.`,
+    remediation: { type: 'submit_evidence', detail: `Add ${req.minDecisionGradeCount - count} more decision-grade ${req.dimension} item(s).`, estimatedDays: null },
+  };
+}
+
+export function detectGaps(
+  opportunity: OpportunityObject,
+  collection: EvidenceCollection,
+  trust: TrustProjection,
+): GapReport {
+  const gaps = opportunity.requirements.map((req) => {
+    if (req.kind === 'evidence') return evaluateEvidenceRequirement(req, collection);
+    if (req.kind === 'trust') return evaluateTrustRequirement(req, trust);
+    return evaluateExperienceRequirement(req, trust);
+  });
+
+  // Deterministic order: mandatory first, then requirementId.
+  gaps.sort((a, b) => {
+    if (a.necessity !== b.necessity) return a.necessity === 'mandatory' ? -1 : 1;
+    return a.requirementId.localeCompare(b.requirementId);
+  });
+
+  const unmet = (g: Gap) => g.kind !== 'satisfied';
+  return {
+    opportunityId: opportunity.opportunityId,
+    subjectKey: collection.subjectKey,
+    gaps,
+    mandatoryUnmet: gaps.filter((g) => g.necessity === 'mandatory' && unmet(g)).length,
+    preferredUnmet: gaps.filter((g) => g.necessity === 'preferred' && unmet(g)).length,
+  };
+}
+
+// ── projectReadiness (W230-C5) ───────────────────────────────────────────────
+
+export function projectReadiness(
+  opportunity: OpportunityObject,
+  gaps: GapReport,
+  trust: TrustProjection,
+): ReadinessProjection {
+  const mandatory = gaps.gaps.filter((g) => g.necessity === 'mandatory');
+  const mandatoryUnmet = mandatory.filter((g) => g.kind !== 'satisfied');
+  const unremediable = mandatoryUnmet.filter((g) => g.kind === 'missing' && g.remediation === null);
+  const fixable = mandatoryUnmet.filter((g) => g.remediation !== null);
+
+  let readiness: MobilityReadiness;
+  let rationale: string;
+
+  if (unremediable.length > 0) {
+    readiness = 'blocked';
+    rationale = `Blocked: ${unremediable.length} mandatory requirement(s) missing with no remediation path.`;
+  } else if (trust.overall.decisionGradeEvidence === 0) {
+    readiness = 'unknown';
+    rationale = 'Unknown: no decision-grade evidence checked yet.';
+  } else if (mandatoryUnmet.length === 0) {
+    readiness = 'ready';
+    rationale = 'Ready: all mandatory requirements satisfied by decision-grade evidence.';
+  } else if (fixable.length === mandatoryUnmet.length) {
+    readiness = 'near_ready';
+    rationale = `Near ready: ${fixable.length} mandatory gap(s) have a remediation path.`;
+  } else {
+    readiness = 'unknown';
+    rationale = 'Unknown: coverage incomplete; manual review recommended.';
+  }
+
+  return {
+    subjectKey: gaps.subjectKey,
+    opportunityId: opportunity.opportunityId,
+    readiness,
+    rationale,
+    blockers: unremediable.map((g) => g.reason),
+    fixableGaps: fixable.map((g) => g.requirementId),
+    estimatedStartDays: null,
+  };
+}
+
+// ── Overview (W230-C4 §1) ────────────────────────────────────────────────────
+
+export function deriveMobilityOverview(collection: EvidenceCollection, trust: TrustProjection): MobilityOverview {
+  const states = new Set<string>();
+  for (const obj of collection.objects) {
+    if ((obj.evidenceClass === 'licensure' || obj.evidenceClass === 'registration') && isDecisionGradeStatus(obj.status)) {
+      const j = jurisdictionOf(obj);
+      if (j) states.add(j);
+    }
+  }
+  return {
+    subjectKey: collection.subjectKey,
+    mobilityTrust: dimensionOf(trust, 'mobility')?.score ?? null,
+    licensedStates: [...states].sort(),
+    reusableEvidenceCount: collection.objects.filter((o) => o.decisionGrade).length,
+  };
+}
+
+// ── Default readiness template (a standard template, NOT a specific employer post) ──
+
+export function defaultReadinessTemplate(state?: string, specialty?: string): OpportunityObject {
+  const stateLabel = state ? ` (${state})` : '';
+  return {
+    opportunityId: state ? `standard-readiness:${state}` : 'standard-readiness',
+    title: `Standard readiness template${stateLabel}`,
+    organizationKey: null,
+    specialty: specialty ?? null,
+    states: state ? [state] : [],
+    schema: 'vitalcv.opportunity.v1',
+    requirements: [
+      { kind: 'evidence', requirementId: 'identity', label: 'Identity verification', necessity: 'mandatory', minStatus: 'checked', evidenceClass: 'identity' },
+      { kind: 'evidence', requirementId: 'exclusion', label: 'Exclusion screening', necessity: 'mandatory', minStatus: 'checked', evidenceClass: 'exclusion' },
+      { kind: 'evidence', requirementId: 'licensure', label: 'State license', necessity: 'mandatory', minStatus: 'checked', evidenceClass: 'licensure', ...(state ? { jurisdiction: state } : {}) },
+      { kind: 'evidence', requirementId: 'enrollment', label: 'Medicare enrollment', necessity: 'preferred', minStatus: 'checked', evidenceClass: 'enrollment' },
+    ],
+  };
+}


### PR DESCRIPTION
## Mobility engine — the missing layer (Wave 270, implements W230)

W270 asked to productionize the Opportunity Network "leveraging Mobility" — but **Mobility was design-only (W230) and never built**, so the `Wallet → Mobility → Opportunities` chain was unbuildable. This builds the missing Mobility layer (my own W230 design) over the shipped evidence/trust pipeline. The pre-existing Opportunity Network (backend TS + Python matcher + Solidity) is **untouched**.

**Stacked on PR #444** (base = `feat/career-evidence-stack`) — needs the evidence/trust APIs.

### Built
- `OpportunityObject` + 3 requirement kinds, `detectGaps`, `projectReadiness` (ready/near_ready/blocked/unknown), `deriveMobilityOverview`, `defaultReadinessTemplate` — pure module.
- `GET /api/mobility/:id`, `…/readiness?state=XX`, `…/gaps?state=XX`.

### Validation
- package: 38 tests (10 new) · web: 7 mobility integration + route tests.
- `state` param whitelisted (injection-safe) · `pnpm turbo run build --filter @vitalcv/web` → 14/14 tasks, exit 0.

### Honesty (tested)
- Mandatory requirements need **decision-grade** evidence; gated/stale never satisfy.
- `ready` unreachable without decision-grade coverage; absent evidence is honest `unknown`, not `blocked`.
- No ML, no ranking (W260). `/readiness` evaluates a **standard readiness template**, not employer matching.

### C4 integration
A CA-licensed, identity+exclusion-checked clinician → **READY** for CA, **NEAR_READY** for NV (endorsement path).

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)