### PR TITLE
feat(ecosystem): Provider Career Ecosystem surfaces (Wave 300)

### DIFF
--- a/apps/web/__tests__/ecosystem-integration.test.ts
+++ b/apps/web/__tests__/ecosystem-integration.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W300-C6 — Ecosystem integration: one clinician resolves coherently across ALL
+// six APIs the ecosystem UI composes (evidence → trust → timeline → mobility →
+// organizations). Proves the layers agree (same subject, consistent decision-grade
+// counts) — the data backbone behind the Ecosystem Home / Map / Feed / Network.
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+function buildPassportPayload() {
+  return {
+    entityId: 'entity-eco', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        { id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: {
+      records: [{ id: 'res-1', recordType: 'RESIDENCY', degreeOrTitle: 'IM Residency', specialty: 'Internal Medicine', programName: 'IM', institutionName: 'Johns Hopkins', endYear: 2020, completed: true, verificationLevel: 'PRIMARY_SOURCE' }],
+      hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0,
+    },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z', negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 72, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 10, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-01T00:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG LEIE clear', checkedAt: '2026-03-01T00:00:00.000Z' },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 72, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+  };
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ entityId: id }) });
+const req = () => new NextRequest('http://localhost/api/test');
+async function call(path: string) {
+  const { GET } = await import(path);
+  const res = await GET(req(), ctx('entity-eco'));
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => {
+  resolveMock.mockReset();
+  resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload()));
+});
+
+describe('Ecosystem integration across all six APIs (W300-C6)', () => {
+  it('resolves a coherent ecosystem for one clinician', async () => {
+    const evidence = await call('../app/api/evidence/[entityId]/route');
+    const trust = await call('../app/api/graph/[entityId]/trust/route');
+    const timeline = await call('../app/api/timeline/[entityId]/route');
+    const mobility = await call('../app/api/mobility/[entityId]/route');
+    const readiness = await call('../app/api/mobility/[entityId]/readiness/route');
+    const organizations = await call('../app/api/organizations/[entityId]/route');
+
+    for (const r of [evidence, trust, timeline, mobility, readiness, organizations]) {
+      expect(r.status).toBe(200);
+    }
+
+    // Same subject across every layer
+    expect(evidence.body.subjectKey).toBe('entity-eco');
+    expect(trust.body.subjectKey).toBe('entity-eco');
+    expect(timeline.body.subjectKey).toBe('entity-eco');
+    expect(mobility.body.subjectKey).toBe('entity-eco');
+    expect(organizations.body.subjectKey).toBe('entity-eco');
+
+    // Decision-grade evidence count AGREES across trust and timeline (the layers compose honestly)
+    expect(trust.body.overall.decisionGradeEvidence).toBe(timeline.body.reputation.decisionGradeEvidence);
+
+    // The training institution surfaces as an organization (the network)
+    expect(organizations.body.organizations.some((o: any) => o.kind === 'training_institution')).toBe(true);
+
+    // Mobility reflects the CA license; readiness is a valid honest verdict
+    expect(mobility.body.licensedStates).toContain('CA');
+    expect(['ready', 'near_ready', 'blocked', 'unknown']).toContain(readiness.body.readiness);
+
+    // Ecosystem Home's "career health" standing is honest (decision-grade evidence exists)
+    expect(['established', 'emerging', 'provisional']).toContain(timeline.body.reputation.standing);
+  });
+});

--- a/apps/web/app/activity/[entityId]/ActivityClient.tsx
+++ b/apps/web/app/activity/[entityId]/ActivityClient.tsx
@@ -28,7 +28,7 @@ function badge(e: CareerEvent): string {
   if (e.trustImpact < 0) return 'decay';
   if (e.mobilityImpact === 'expands') return 'mobility unlock';
   if (e.recognitionImpact !== 'none') return e.recognitionImpact;
-  if (e.trustImpact > 0) return 'verified';
+  if (e.trustImpact > 0) return 'source-backed';
   return e.type.replace(/_/g, ' ');
 }
 

--- a/apps/web/app/activity/[entityId]/ActivityClient.tsx
+++ b/apps/web/app/activity/[entityId]/ActivityClient.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * Ecosystem Feed (Wave 300, D3) — the clinician career activity feed, projected
+ * from the timeline layer: evidence verified, trust reinforcement/decay, mobility
+ * changes, recognition. Derived from recorded evidence timestamps (not a substitute
+ * for the audit log); honest about what is recorded.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { CareerEvent, TimelineProjection } from '@vitalcv/domain-evidence';
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Undated';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function tone(e: CareerEvent): string {
+  if (e.trustImpact < 0) return 'text-rose-700';
+  if (e.mobilityImpact === 'expands') return 'text-emerald-700';
+  if (e.recognitionImpact !== 'none') return 'text-sky-700';
+  return 'text-foreground';
+}
+
+function badge(e: CareerEvent): string {
+  if (e.trustImpact < 0) return 'decay';
+  if (e.mobilityImpact === 'expands') return 'mobility unlock';
+  if (e.recognitionImpact !== 'none') return e.recognitionImpact;
+  if (e.trustImpact > 0) return 'verified';
+  return e.type.replace(/_/g, ' ');
+}
+
+export default function ActivityClient({ entityId }: { entityId: string }) {
+  const [timeline, setTimeline] = useState<TimelineProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const res = await fetch(`/api/timeline/${encodeURIComponent(entityId)}`, { cache: 'no-store' });
+      if (cancelled) return;
+      setTimeline(res.ok ? ((await res.json()) as TimelineProjection) : null);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  if (loading) return <main className="mx-auto w-full max-w-2xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading activity…</p></main>;
+  if (!timeline) return <main className="mx-auto w-full max-w-2xl px-4 py-16"><p className="text-sm text-muted-foreground">Activity not available.</p></main>;
+
+  const events = [...timeline.events].reverse();
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-2xl space-y-6 px-4 py-10">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Activity</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">Career Feed</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {timeline.trustHistory.reinforcementCount} reinforcement{timeline.trustHistory.reinforcementCount === 1 ? '' : 's'} · {timeline.trustHistory.decayCount} decay · trend {timeline.trustHistory.trend}
+            {' · '}<Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="hover:text-foreground">← Ecosystem</Link>
+          </p>
+        </header>
+
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No recorded activity yet.</p>
+        ) : (
+          <ol className="relative space-y-4 border-l border-border pl-5">
+            {events.map((e) => (
+              <li key={e.eventId} className="relative">
+                <span className="absolute -left-[23px] top-1.5 h-2 w-2 rounded-full border border-border bg-card" />
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className={`text-sm font-medium ${tone(e)}`}>{e.label}</p>
+                  <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{badge(e)}</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {e.evidenceSource ?? '—'} · {formatDate(e.occurredAt)}
+                  {e.trustDimension ? ` · ${e.trustDimension}` : ''}
+                </p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/activity/[entityId]/page.tsx
+++ b/apps/web/app/activity/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import ActivityClient from './ActivityClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Activity · VitalCV',
+  description: 'The clinician career feed — evidence verified, trust milestones, recognition, and mobility changes.',
+};
+
+export default async function ActivityPage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <ActivityClient entityId={entityId} />;
+}

--- a/apps/web/app/activity/[entityId]/page.tsx
+++ b/apps/web/app/activity/[entityId]/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic';
 
 export const metadata = {
   title: 'Activity · VitalCV',
-  description: 'The clinician career feed — evidence verified, trust milestones, recognition, and mobility changes.',
+  description: 'The clinician career feed — evidence checks, trust milestones, recognition, and mobility changes.',
 };
 
 export default async function ActivityPage({ params }: { params: Promise<{ entityId: string }> }) {

--- a/apps/web/app/career-map/[entityId]/CareerMapClient.tsx
+++ b/apps/web/app/career-map/[entityId]/CareerMapClient.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * Career Map (Wave 300, D2) — a navigable map of the clinician's career graph:
+ * Clinician ↔ Evidence ↔ Source/Organization, with trust. Interactive: select an
+ * evidence class to focus its evidence and the sources/relationships behind it.
+ * Read-only; status and trust are verbatim from the graph/trust layers.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import type { GraphProjection, TrustProjection } from '@vitalcv/domain-evidence';
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: 'no-store' });
+  return res.ok ? ((await res.json()) as T) : null;
+}
+
+export default function CareerMapClient({ entityId }: { entityId: string }) {
+  const [graph, setGraph] = useState<GraphProjection | null>(null);
+  const [trust, setTrust] = useState<TrustProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [focusClass, setFocusClass] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const id = encodeURIComponent(entityId);
+      const [g, t] = await Promise.all([
+        fetchJson<GraphProjection>(`/api/graph/${id}`),
+        fetchJson<TrustProjection>(`/api/graph/${id}/trust`),
+      ]);
+      if (cancelled) return;
+      setGraph(g); setTrust(t); setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  const evidenceNodes = useMemo(() => (graph?.nodes ?? []).filter((n) => n.type === 'evidence'), [graph]);
+  const sourceNodes = useMemo(() => (graph?.nodes ?? []).filter((n) => n.type === 'source'), [graph]);
+  const classes = useMemo(() => [...new Set(evidenceNodes.map((n) => n.evidenceClass).filter(Boolean))] as string[], [evidenceNodes]);
+
+  if (loading) return <main className="mx-auto w-full max-w-4xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading career map…</p></main>;
+  if (!graph) return <main className="mx-auto w-full max-w-4xl px-4 py-16"><p className="text-sm text-muted-foreground">Career map not available.</p></main>;
+
+  const subject = graph.nodes.find((n) => n.type === 'subject');
+  const shown = focusClass ? evidenceNodes.filter((n) => n.evidenceClass === focusClass) : evidenceNodes;
+  const shownEvidenceIds = new Set(shown.map((n) => n.id));
+  const relevantSources = sourceNodes.filter((s) =>
+    graph.relationships.some((r) => shownEvidenceIds.has(r.from) && r.to === s.id),
+  );
+  const sourceFor = (evId: string) => graph.relationships.find((r) => r.from === evId && r.to.startsWith('source:'))?.to ?? null;
+  const labelOf = (nodeId: string) => graph.nodes.find((n) => n.id === nodeId)?.label ?? nodeId;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-10">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Map</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">{subject?.label ?? 'Clinician'}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {graph.stats.nodeCount} nodes · {graph.stats.relationshipCount} connections · {graph.stats.decisionGradeNodeCount} decision-grade
+            {' · '}<Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="hover:text-foreground">← Ecosystem</Link>
+          </p>
+        </header>
+
+        {/* Class filter */}
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={() => setFocusClass(null)}
+            className={`rounded-full border px-3 py-1 text-xs ${focusClass === null ? 'border-foreground bg-foreground text-background' : 'border-border text-muted-foreground'}`}>
+            All evidence
+          </button>
+          {classes.map((c) => (
+            <button key={c} type="button" onClick={() => setFocusClass(c)}
+              className={`rounded-full border px-3 py-1 text-xs capitalize ${focusClass === c ? 'border-foreground bg-foreground text-background' : 'border-border text-muted-foreground'}`}>
+              {c.replace(/_/g, ' ')}
+            </button>
+          ))}
+        </div>
+
+        {/* Map: three columns — clinician | evidence | sources */}
+        <div className="grid gap-4 md:grid-cols-[1fr_1.4fr_1fr]">
+          <section className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Clinician</h2>
+            <p className="text-sm font-medium text-foreground">{subject?.label ?? 'Clinician'}</p>
+            {trust && (
+              <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                {trust.dimensions.filter((d) => d.score !== null && d.score > 0).map((d) => (
+                  <li key={d.dimension} className="flex justify-between"><span className="capitalize">{d.dimension}</span><span>{d.score}</span></li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Evidence ({shown.length})</h2>
+            <ul className="space-y-2">
+              {shown.map((n) => (
+                <li key={n.id} className="rounded-xl border border-border px-3 py-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm text-foreground">{n.label}</span>
+                    <span className="text-[11px] text-muted-foreground">{n.status ?? '—'}</span>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">
+                    <span className="capitalize">{n.evidenceClass?.replace(/_/g, ' ')}</span>
+                    {sourceFor(n.id) ? ` → ${labelOf(sourceFor(n.id)!)}` : ''}
+                    {n.decisionGrade ? ' · decision-grade' : ''}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sources & Orgs ({relevantSources.length})</h2>
+            <ul className="space-y-1.5">
+              {relevantSources.map((s) => (
+                <li key={s.id} className="rounded-lg border border-border px-2.5 py-1.5 text-xs text-foreground">{s.label}</li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/career-map/[entityId]/page.tsx
+++ b/apps/web/app/career-map/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import CareerMapClient from './CareerMapClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Career Map · VitalCV',
+  description: 'A navigable map of a clinician’s career — evidence, sources, organizations, and trust, connected.',
+};
+
+export default async function CareerMapPage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <CareerMapClient entityId={entityId} />;
+}

--- a/apps/web/app/ecosystem/[entityId]/EcosystemHomeClient.tsx
+++ b/apps/web/app/ecosystem/[entityId]/EcosystemHomeClient.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+/**
+ * Ecosystem Home (Wave 300, D1) — the operating system for a healthcare career.
+ *
+ * Composes the merged data layers (evidence / trust / mobility / organizations /
+ * timeline) into a single 60-second view that answers: What do I have? Where am I?
+ * What's next? Who is connected to me? Read-only; honest about decision-grade vs
+ * gated/stale (status comes verbatim from the trust layer).
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type {
+  EvidenceCollection,
+  MobilityOverview,
+  OrganizationGraph,
+  ReadinessProjection,
+  TimelineProjection,
+  TrustProjection,
+} from '@vitalcv/domain-evidence';
+
+interface EcosystemData {
+  evidence: EvidenceCollection;
+  trust: TrustProjection;
+  timeline: TimelineProjection;
+  mobility: MobilityOverview;
+  readiness: ReadinessProjection;
+  organizations: OrganizationGraph;
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) return null;
+  return (await res.json()) as T;
+}
+
+const READINESS_TONE: Record<string, string> = {
+  ready: 'text-emerald-700',
+  near_ready: 'text-amber-700',
+  blocked: 'text-rose-700',
+  unknown: 'text-muted-foreground',
+};
+
+const STANDING_TONE: Record<string, string> = {
+  established: 'text-emerald-700',
+  emerging: 'text-sky-700',
+  provisional: 'text-amber-700',
+  unknown: 'text-muted-foreground',
+};
+
+function Card({ title, eyebrow, children, href }: { title: string; eyebrow?: string; href?: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-border bg-card p-5">
+      <div className="mb-2 flex items-baseline justify-between">
+        <div>
+          {eyebrow && <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{eyebrow}</p>}
+          <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        </div>
+        {href && <Link href={href} className="text-xs text-muted-foreground hover:text-foreground">View →</Link>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function EcosystemHomeClient({ entityId }: { entityId: string }) {
+  const [data, setData] = useState<EcosystemData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const id = encodeURIComponent(entityId);
+      const [evidence, trust, timeline, mobility, readiness, organizations] = await Promise.all([
+        fetchJson<EvidenceCollection>(`/api/evidence/${id}`),
+        fetchJson<TrustProjection>(`/api/graph/${id}/trust`),
+        fetchJson<TimelineProjection>(`/api/timeline/${id}`),
+        fetchJson<MobilityOverview>(`/api/mobility/${id}`),
+        fetchJson<ReadinessProjection>(`/api/mobility/${id}/readiness`),
+        fetchJson<OrganizationGraph>(`/api/organizations/${id}`),
+      ]);
+      if (cancelled) return;
+      if (evidence && trust && timeline && mobility && readiness && organizations) {
+        setData({ evidence, trust, timeline, mobility, readiness, organizations });
+      } else {
+        setData(null);
+      }
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  if (loading) {
+    return <main className="mx-auto w-full max-w-4xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading career ecosystem…</p></main>;
+  }
+  if (!data) {
+    return (
+      <main className="mx-auto flex min-h-[60vh] w-full max-w-sm flex-col items-center justify-center gap-4 px-4 text-center">
+        <h1 className="text-lg font-semibold text-foreground">Ecosystem not available</h1>
+        <p className="text-sm text-muted-foreground">Run a readiness check to generate this clinician&apos;s source-backed career snapshot.</p>
+        <Link href="/passport" className="inline-flex h-11 items-center justify-center rounded-full bg-foreground px-5 text-sm font-medium text-background">Check readiness</Link>
+      </main>
+    );
+  }
+
+  const { evidence, trust, timeline, mobility, readiness, organizations } = data;
+  const name = evidence.generatedFor.displayName || 'Clinician';
+  const rep = timeline.reputation;
+  const decisionGradeDimensions = trust.dimensions.filter((d) => d.score !== null && d.score > 0);
+  const recentEvents = [...timeline.events].reverse().slice(0, 5);
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-10">
+        {/* Header — Career Health (answers "where am I?") */}
+        <header className="rounded-2xl border border-border bg-card p-6">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Ecosystem</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">{name}</h1>
+          <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+            <span>
+              Career health:{' '}
+              <span className={`font-semibold capitalize ${STANDING_TONE[rep.standing] ?? ''}`}>{rep.standing}</span>
+              {rep.overallTrust !== null && <span className="text-muted-foreground"> · trust {rep.overallTrust}</span>}
+            </span>
+            <span className="text-muted-foreground">Trend: {rep.trend}</span>
+            <span className="text-muted-foreground">{rep.decisionGradeEvidence}/{rep.totalEvidence} evidence source-backed</span>
+          </div>
+        </header>
+
+        {/* Status row — Evidence / Trust / Mobility */}
+        <div className="grid gap-4 sm:grid-cols-3">
+          {/* What do I have? */}
+          <Card title="Evidence" eyebrow="What do I have?">
+            <p className="text-2xl font-semibold tabular-nums text-foreground">{evidence.objects.length}</p>
+            <p className="text-xs text-muted-foreground">{rep.decisionGradeEvidence} decision-grade</p>
+            <ul className="mt-2 space-y-0.5 text-xs text-muted-foreground">
+              {Object.entries(evidence.byClass).filter(([, v]) => v.length > 0).slice(0, 4).map(([cls, v]) => (
+                <li key={cls} className="flex justify-between"><span className="capitalize">{cls.replace('_', ' ')}</span><span>{v.length}</span></li>
+              ))}
+            </ul>
+          </Card>
+
+          {/* Where am I? (trust) */}
+          <Card title="Trust" eyebrow="Where am I?">
+            <p className={`text-2xl font-semibold capitalize ${STANDING_TONE[rep.standing] ?? ''}`}>{rep.standing}</p>
+            <p className="text-xs text-muted-foreground">{decisionGradeDimensions.length} active dimensions</p>
+            <ul className="mt-2 space-y-0.5 text-xs text-muted-foreground">
+              {decisionGradeDimensions.slice(0, 4).map((d) => (
+                <li key={d.dimension} className="flex justify-between"><span className="capitalize">{d.dimension}</span><span>{d.score}</span></li>
+              ))}
+            </ul>
+          </Card>
+
+          {/* What's next? (mobility) */}
+          <Card title="Mobility" eyebrow="What's next?">
+            <p className={`text-2xl font-semibold capitalize ${READINESS_TONE[readiness.readiness] ?? ''}`}>{readiness.readiness.replace('_', ' ')}</p>
+            <p className="text-xs text-muted-foreground">{mobility.licensedStates.length ? `Licensed: ${mobility.licensedStates.join(', ')}` : 'No decision-grade licenses'}</p>
+            <p className="mt-2 text-xs text-muted-foreground">{readiness.rationale}</p>
+          </Card>
+        </div>
+
+        {/* Organizations — Who is connected to me? */}
+        <Card title="Organizations" eyebrow="Who is connected to me?" href={`/network/${encodeURIComponent(entityId)}`}>
+          {organizations.organizations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No source-backed organizations yet.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {organizations.organizations.slice(0, 8).map((o) => (
+                <span key={o.id} className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-xs">
+                  <span className="text-foreground">{o.label}</span>
+                  <span className="text-muted-foreground">· {o.kind.replace('_', ' ')}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        {/* Recent Activity */}
+        <Card title="Recent Activity" href={`/activity/${encodeURIComponent(entityId)}`}>
+          {recentEvents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No recorded activity yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {recentEvents.map((e) => (
+                <li key={e.eventId} className="flex items-center justify-between gap-3 text-sm">
+                  <span className="text-foreground">{e.label}</span>
+                  <span className="text-xs text-muted-foreground">{e.type.replace(/_/g, ' ')} · {formatDate(e.occurredAt)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <p className="text-xs text-muted-foreground">
+          Source coverage is reported honestly as checked, gated, stale, or unknown — never as a guarantee. Decision-grade reflects current source-backed verification only.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/ecosystem/[entityId]/page.tsx
+++ b/apps/web/app/ecosystem/[entityId]/page.tsx
@@ -1,0 +1,17 @@
+import EcosystemHomeClient from './EcosystemHomeClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Career Ecosystem · VitalCV',
+  description: 'The operating system for a healthcare career — evidence, trust, mobility, organizations, and activity in one view.',
+};
+
+export default async function EcosystemHomePage({
+  params,
+}: {
+  params: Promise<{ entityId: string }>;
+}) {
+  const { entityId } = await params;
+  return <EcosystemHomeClient entityId={entityId} />;
+}

--- a/apps/web/app/network/[entityId]/NetworkClient.tsx
+++ b/apps/web/app/network/[entityId]/NetworkClient.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+/**
+ * My Network (Wave 300, D4) — the organizations connected to a clinician,
+ * projected from source-backed evidence (training institutions, credential
+ * issuers, licensing boards, verification authorities, employers). Read-only;
+ * an org's trust contribution is bounded (gated org contributes 0).
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { OrganizationGraph, OrganizationKind } from '@vitalcv/domain-evidence';
+
+const KIND_LABELS: Record<OrganizationKind, string> = {
+  employer: 'Employers',
+  training_institution: 'Training Programs',
+  credential_issuer: 'Credential Issuers',
+  licensing_board: 'Licensing Boards',
+  verification_authority: 'Verification Authorities',
+  other: 'Other',
+};
+
+const KIND_ORDER: OrganizationKind[] = ['employer', 'training_institution', 'credential_issuer', 'licensing_board', 'verification_authority', 'other'];
+
+export default function NetworkClient({ entityId }: { entityId: string }) {
+  const [graph, setGraph] = useState<OrganizationGraph | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const res = await fetch(`/api/organizations/${encodeURIComponent(entityId)}`, { cache: 'no-store' });
+      if (cancelled) return;
+      setGraph(res.ok ? ((await res.json()) as OrganizationGraph) : null);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  if (loading) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading network…</p></main>;
+  if (!graph) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Network not available.</p></main>;
+
+  const relFor = (orgId: string) => graph.relationships.find((r) => r.to === orgId)?.type ?? '';
+  const grouped = KIND_ORDER.map((kind) => ({ kind, orgs: graph.organizations.filter((o) => o.kind === kind) })).filter((g) => g.orgs.length > 0);
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-10">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">My Network</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">Career Relationships</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {graph.stats.organizationCount} organization{graph.stats.organizationCount === 1 ? '' : 's'} · {graph.stats.decisionGradeOrganizations} with decision-grade evidence
+            {' · '}<Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="hover:text-foreground">← Ecosystem</Link>
+          </p>
+        </header>
+
+        {grouped.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No source-backed organizations yet.</p>
+        ) : grouped.map(({ kind, orgs }) => (
+          <section key={kind} className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-3 text-sm font-semibold text-foreground">{KIND_LABELS[kind]}</h2>
+            <ul className="divide-y divide-border">
+              {orgs.map((o) => (
+                <li key={o.id} className="flex flex-wrap items-center justify-between gap-2 py-2">
+                  <div className="min-w-0">
+                    <p className="text-sm text-foreground">{o.label}</p>
+                    <p className="text-xs text-muted-foreground">{relFor(o.id).replace(/_/g, ' ').toLowerCase()} · {o.evidenceCount} evidence item{o.evidenceCount === 1 ? '' : 's'}</p>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {o.decisionGradeCount > 0 ? `${o.decisionGradeCount} decision-grade` : 'not decision-grade'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/network/[entityId]/page.tsx
+++ b/apps/web/app/network/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import NetworkClient from './NetworkClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'My Network · VitalCV',
+  description: 'The organizations connected to a clinician — training institutions, credential issuers, licensing boards, and verification authorities.',
+};
+
+export default async function NetworkPage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <NetworkClient entityId={entityId} />;
+}

--- a/apps/web/app/search/[entityId]/SearchClient.tsx
+++ b/apps/web/app/search/[entityId]/SearchClient.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * Unified Search (Wave 300, D5) — searches across a clinician's OWN career
+ * ecosystem: evidence, organizations, and career events. Honest scope: this is
+ * within-ecosystem search; cross-clinician "people" search requires a backend
+ * search index and is intentionally out of scope here (not faked).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import type { EvidenceCollection, OrganizationGraph, TimelineProjection } from '@vitalcv/domain-evidence';
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: 'no-store' });
+  return res.ok ? ((await res.json()) as T) : null;
+}
+
+interface Hit { kind: 'Evidence' | 'Organization' | 'Career Event'; label: string; detail: string }
+
+export default function SearchClient({ entityId }: { entityId: string }) {
+  const [evidence, setEvidence] = useState<EvidenceCollection | null>(null);
+  const [orgs, setOrgs] = useState<OrganizationGraph | null>(null);
+  const [timeline, setTimeline] = useState<TimelineProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const id = encodeURIComponent(entityId);
+      const [e, o, t] = await Promise.all([
+        fetchJson<EvidenceCollection>(`/api/evidence/${id}`),
+        fetchJson<OrganizationGraph>(`/api/organizations/${id}`),
+        fetchJson<TimelineProjection>(`/api/timeline/${id}`),
+      ]);
+      if (cancelled) return;
+      setEvidence(e); setOrgs(o); setTimeline(t); setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  const corpus: Hit[] = useMemo(() => {
+    const hits: Hit[] = [];
+    for (const obj of evidence?.objects ?? []) hits.push({ kind: 'Evidence', label: obj.label, detail: `${obj.evidenceClass.replace(/_/g, ' ')} · ${obj.status}` });
+    for (const o of orgs?.organizations ?? []) hits.push({ kind: 'Organization', label: o.label, detail: o.kind.replace(/_/g, ' ') });
+    for (const ev of timeline?.events ?? []) hits.push({ kind: 'Career Event', label: ev.label, detail: `${ev.type.replace(/_/g, ' ')} · ${ev.occurredAt ?? 'undated'}` });
+    return hits;
+  }, [evidence, orgs, timeline]);
+
+  const q = query.trim().toLowerCase();
+  const results = q ? corpus.filter((h) => h.label.toLowerCase().includes(q) || h.detail.toLowerCase().includes(q)) : corpus;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-2xl space-y-5 px-4 py-10">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Search</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">Career Ecosystem Search</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Across evidence, organizations, and career events.{' '}
+            <Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="hover:text-foreground">← Ecosystem</Link>
+          </p>
+        </header>
+
+        <label className="block">
+          <span className="sr-only">Search the career ecosystem</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search evidence, organizations, events…"
+            className="h-11 w-full rounded-full border border-border bg-card px-4 text-sm text-foreground outline-none focus:border-foreground"
+            aria-label="Search the career ecosystem"
+          />
+        </label>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading ecosystem…</p>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">{results.length} result{results.length === 1 ? '' : 's'}{q ? ` for “${query}”` : ''}</p>
+            <ul className="divide-y divide-border">
+              {results.map((h, i) => (
+                <li key={i} className="flex items-center justify-between gap-3 py-2.5">
+                  <div className="min-w-0">
+                    <p className="text-sm text-foreground">{h.label}</p>
+                    <p className="text-xs text-muted-foreground">{h.detail}</p>
+                  </div>
+                  <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">{h.kind}</span>
+                </li>
+              ))}
+            </ul>
+            {results.length === 0 && <p className="text-sm text-muted-foreground">No matches in this clinician&apos;s ecosystem.</p>}
+            <p className="pt-2 text-xs text-muted-foreground">
+              Scope: this clinician&apos;s own source-backed ecosystem. Cross-clinician and opportunity search require a backend search index (not enabled here).
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/search/[entityId]/page.tsx
+++ b/apps/web/app/search/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import SearchClient from './SearchClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Search · VitalCV',
+  description: 'Unified search across a clinician’s career ecosystem — evidence, organizations, and career events.',
+};
+
+export default async function SearchPage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <SearchClient entityId={entityId} />;
+}


### PR DESCRIPTION
## Provider Career Ecosystem — first ecosystem experience (Wave 300)

Five read-only surfaces composing the merged data layers (evidence/trust/timeline/mobility/organizations). **No new architecture, and the marketing homepage at `/` is untouched** — the ecosystem home lives at `/ecosystem/[entityId]` (entity-keyed, like `/packet`).

| Surface | Route |
|---|---|
| Ecosystem Home (D1) | `/ecosystem/[entityId]` — career health, evidence/trust/mobility status, orgs, recent activity |
| Career Map (D2) | `/career-map/[entityId]` — navigable clinician↔evidence↔source↔trust map, filterable |
| Activity Feed (D3) | `/activity/[entityId]` — verified / decay / mobility-unlock / recognition events |
| My Network (D4) | `/network/[entityId]` — organizations grouped by kind |
| Unified Search (D5) | `/search/[entityId]` — within-ecosystem search across evidence/orgs/events |

### Success criteria
- **typed** — `next build` clean · **deployable** — turbo build 14/14, exit 0
- **tested** — C6 integration test: all six APIs compose coherently for one clinician (consistent subject + decision-grade counts)
- **accessible** — semantic headings, labeled controls/search input; build's jsx-a11y + CI axe gate
- **performant** — surfaces fetch the APIs in parallel; pure O(n) pipeline underneath

### Honest scope notes
- `/` (marketing homepage) preserved; ecosystem home is entity-keyed.
- Unified search is within a clinician's own ecosystem; cross-clinician/opportunity search needs a backend index — intentionally not faked.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)