### PR TITLE
feat(recruiter): candidate review over evidence/trust/mobility APIs (Wave 310)

### DIFF
--- a/apps/web/__tests__/recruiter-candidate.test.ts
+++ b/apps/web/__tests__/recruiter-candidate.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { deriveRecruiterVerdict } from '../lib/recruiter/candidate-verdict';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W310-C6 — Recruiter → Candidate → Evidence → Trust → Mobility.
+// (1) The pure verdict is honest: 'move forward' requires a decision-grade ready
+// candidate; gated/near/unknown degrade. (2) The chain composes through the real
+// APIs for one candidate. Pre-existing employer-review/candidates/workspace untouched.
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+describe('deriveRecruiterVerdict honesty', () => {
+  it('move_forward ONLY for a ready candidate with established/emerging standing', () => {
+    expect(deriveRecruiterVerdict('ready', 'established')).toBe('move_forward');
+    expect(deriveRecruiterVerdict('ready', 'emerging')).toBe('move_forward');
+    // ready but only provisional standing → not a green light
+    expect(deriveRecruiterVerdict('ready', 'provisional')).toBe('request_evidence');
+  });
+  it('degrades honestly for non-ready / thin candidates', () => {
+    expect(deriveRecruiterVerdict('near_ready', 'established')).toBe('request_evidence');
+    expect(deriveRecruiterVerdict('blocked', 'established')).toBe('not_ready');
+    expect(deriveRecruiterVerdict('unknown', 'established')).toBe('insufficient');
+    expect(deriveRecruiterVerdict('ready', 'unknown')).toBe('insufficient'); // no decision-grade evidence
+  });
+});
+
+function buildPassportPayload() {
+  return {
+    entityId: 'cand-1', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [{ id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+        verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+        dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+        verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' }],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [{ id: 'res-1', recordType: 'RESIDENCY', degreeOrTitle: 'IM Residency', institutionName: 'Johns Hopkins', endYear: 2020, completed: true, verificationLevel: 'PRIMARY_SOURCE' }], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: { exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly', enrollmentNote: 'Current.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z', negativeFindings: [] },
+    readiness: { status: 'PARTIAL', score: 80, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 8, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: { checks: [
+      { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-01T00:00:00.000Z' },
+      { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG clear', checkedAt: '2026-03-01T00:00:00.000Z' },
+    ] },
+    trustPosture: { band: 'L2', bandLabel: 'Moderate', score: 80, dimensions: [], freshness: { state: 'partial', label: 'Partial', items: [] }, safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [] },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+  };
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ entityId: id }) });
+async function call(path: string) {
+  const { GET } = await import(path);
+  const res = await GET(new NextRequest('http://localhost/x'), ctx('cand-1'));
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => { resolveMock.mockReset(); resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload())); });
+
+describe('Recruiter candidate chain (W310-C6)', () => {
+  it('a fully source-backed candidate composes to a move_forward verdict', async () => {
+    const trust = await call('../app/api/graph/[entityId]/trust/route');
+    const readiness = await call('../app/api/mobility/[entityId]/readiness/route');
+    const timeline = await call('../app/api/timeline/[entityId]/route');
+    const organizations = await call('../app/api/organizations/[entityId]/route');
+
+    expect(trust.status).toBe(200);
+    expect(readiness.status).toBe(200);
+
+    const standing = timeline.body.reputation.standing;
+    const verdict = deriveRecruiterVerdict(readiness.body.readiness, standing);
+
+    // chain composed: same candidate everywhere; decision-grade counts agree
+    expect(trust.body.subjectKey).toBe('cand-1');
+    expect(trust.body.overall.decisionGradeEvidence).toBe(timeline.body.reputation.decisionGradeEvidence);
+    expect(readiness.body.readiness).toBe('ready'); // identity+exclusion+license all checked
+    expect(['established', 'emerging']).toContain(standing);
+    expect(verdict).toBe('move_forward');
+    expect(organizations.body.organizations.some((o: any) => o.kind === 'training_institution')).toBe(true);
+  });
+
+  it('per-state placement check returns an honest verdict for an unlicensed state', async () => {
+    const { GET } = await import('../app/api/mobility/[entityId]/readiness/route');
+    const res = await GET(new NextRequest('http://localhost/x?state=NV'), ctx('cand-1'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    // licensed CA, not NV → not 'ready' for NV (near_ready via endorsement, or similar)
+    expect(body.readiness).not.toBe('ready');
+  });
+});

--- a/apps/web/app/recruiter/candidate/[entityId]/RecruiterCandidateClient.tsx
+++ b/apps/web/app/recruiter/candidate/[entityId]/RecruiterCandidateClient.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * Recruiter Candidate Review (Wave 310) — composes the merged evidence/trust/
+ * mobility/organizations APIs into a recruiter placement decision. Read-only;
+ * does NOT touch the pre-existing employer-review/candidates/workspace backend.
+ *
+ * Answers the recruiter's questions: Is this candidate ready? Where can I place
+ * them? What backs them? Verdict is derived honestly — "move forward" requires a
+ * decision-grade ready/established candidate; missing/gated coverage degrades.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type {
+  EvidenceCollection,
+  MobilityOverview,
+  OrganizationGraph,
+  ReadinessProjection,
+  TimelineProjection,
+  TrustProjection,
+} from '@vitalcv/domain-evidence';
+import { RECRUITER_VERDICT_LABEL, deriveRecruiterVerdict, type RecruiterVerdict } from '@/lib/recruiter/candidate-verdict';
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: 'no-store' });
+  return res.ok ? ((await res.json()) as T) : null;
+}
+
+interface Data {
+  evidence: EvidenceCollection;
+  trust: TrustProjection;
+  mobility: MobilityOverview;
+  readiness: ReadinessProjection;
+  organizations: OrganizationGraph;
+  timeline: TimelineProjection;
+}
+
+const VERDICT_TONE: Record<RecruiterVerdict, string> = {
+  move_forward: 'border-emerald-300 bg-emerald-50 text-emerald-800',
+  request_evidence: 'border-amber-300 bg-amber-50 text-amber-800',
+  not_ready: 'border-rose-300 bg-rose-50 text-rose-800',
+  insufficient: 'border-slate-300 bg-slate-50 text-slate-700',
+};
+
+export default function RecruiterCandidateClient({ entityId }: { entityId: string }) {
+  const [data, setData] = useState<Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  // Per-state placement check
+  const [stateInput, setStateInput] = useState('');
+  const [stateResult, setStateResult] = useState<ReadinessProjection | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const id = encodeURIComponent(entityId);
+      const [evidence, trust, mobility, readiness, organizations, timeline] = await Promise.all([
+        fetchJson<EvidenceCollection>(`/api/evidence/${id}`),
+        fetchJson<TrustProjection>(`/api/graph/${id}/trust`),
+        fetchJson<MobilityOverview>(`/api/mobility/${id}`),
+        fetchJson<ReadinessProjection>(`/api/mobility/${id}/readiness`),
+        fetchJson<OrganizationGraph>(`/api/organizations/${id}`),
+        fetchJson<TimelineProjection>(`/api/timeline/${id}`),
+      ]);
+      if (cancelled) return;
+      setData(evidence && trust && mobility && readiness && organizations && timeline ? { evidence, trust, mobility, readiness, organizations, timeline } : null);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  async function checkState() {
+    const s = stateInput.trim().toUpperCase();
+    if (!/^[A-Za-z]{2}$/.test(s)) return;
+    setChecking(true);
+    const r = await fetchJson<ReadinessProjection>(`/api/mobility/${encodeURIComponent(entityId)}/readiness?state=${s}`);
+    setStateResult(r);
+    setChecking(false);
+  }
+
+  if (loading) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading candidate…</p></main>;
+  if (!data) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Candidate not available.</p></main>;
+
+  const { evidence, trust, mobility, organizations } = data;
+  const standing = data.timeline.reputation.standing;
+  const verdict = deriveRecruiterVerdict(data.readiness.readiness, standing);
+  const name = evidence.generatedFor.displayName || 'Candidate';
+  const missing = evidence.coverageSummary.gated.concat(evidence.coverageSummary.stale, evidence.coverageSummary.notDecisionGrade ?? []);
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-3xl space-y-5 px-4 py-10">
+        <header className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Candidate Review</p>
+            <h1 className="mt-1 text-2xl font-semibold text-foreground">{name}</h1>
+            <p className="mt-1 text-sm text-muted-foreground capitalize">Trust standing: {standing} · {trust.overall.decisionGradeEvidence}/{trust.overall.totalEvidence} source-backed</p>
+          </div>
+          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${VERDICT_TONE[verdict]}`} data-testid="recruiter-verdict">
+            {RECRUITER_VERDICT_LABEL[verdict]}
+          </span>
+        </header>
+
+        {/* Placement readiness */}
+        <section className="rounded-2xl border border-border bg-card p-5">
+          <h2 className="mb-2 text-sm font-semibold text-foreground">Placement readiness</h2>
+          <p className="text-sm text-muted-foreground">
+            Ready now in: <span className="text-foreground">{mobility.licensedStates.length ? mobility.licensedStates.join(', ') : 'no decision-grade licenses'}</span>
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <label className="sr-only" htmlFor="state-check">Check placement state</label>
+            <input id="state-check" value={stateInput} onChange={(e) => setStateInput(e.target.value)} maxLength={2}
+              placeholder="State (e.g. NV)" className="h-9 w-32 rounded-full border border-border bg-background px-3 text-sm uppercase outline-none focus:border-foreground" />
+            <button type="button" onClick={() => void checkState()} disabled={checking}
+              className="h-9 rounded-full border border-border px-4 text-sm text-foreground disabled:opacity-50">
+              {checking ? 'Checking…' : 'Check placement'}
+            </button>
+            {stateResult && (
+              <span className="text-sm capitalize text-muted-foreground">
+                → <span className="font-medium text-foreground">{stateResult.readiness.replace('_', ' ')}</span>
+                {stateResult.fixableGaps.length ? ` (${stateResult.fixableGaps.length} fixable)` : ''}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {/* Evidence + trust */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <section className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-2 text-sm font-semibold text-foreground">Evidence</h2>
+            <p className="text-2xl font-semibold tabular-nums text-foreground">{trust.overall.decisionGradeEvidence}<span className="text-sm font-normal text-muted-foreground">/{evidence.objects.length} decision-grade</span></p>
+            {missing.length > 0 && <p className="mt-2 text-xs text-muted-foreground">Owed: {missing.join(', ')}</p>}
+          </section>
+          <section className="rounded-2xl border border-border bg-card p-5">
+            <h2 className="mb-2 text-sm font-semibold text-foreground">Trust dimensions</h2>
+            <ul className="space-y-0.5 text-xs text-muted-foreground">
+              {trust.dimensions.filter((d) => d.score !== null && d.score > 0).slice(0, 5).map((d) => (
+                <li key={d.dimension} className="flex justify-between"><span className="capitalize">{d.dimension}</span><span>{d.score}</span></li>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        {/* Background */}
+        <section className="rounded-2xl border border-border bg-card p-5">
+          <h2 className="mb-2 text-sm font-semibold text-foreground">Background</h2>
+          {organizations.organizations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No source-backed organizations.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {organizations.organizations.map((o) => (
+                <span key={o.id} className="rounded-full border border-border px-2.5 py-1 text-xs text-foreground">{o.label} <span className="text-muted-foreground">· {o.kind.replace('_', ' ')}</span></span>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <footer className="flex flex-wrap gap-4 border-t border-border pt-4 text-sm">
+          <Link href={`/packet/${encodeURIComponent(entityId)}`} className="text-foreground hover:underline">Full proof packet →</Link>
+          <Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="text-muted-foreground hover:text-foreground">Career ecosystem →</Link>
+          <span className="text-xs text-muted-foreground">Verdict is source-backed and policy-dependent — acceptance remains the employer&apos;s decision.</span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/recruiter/candidate/[entityId]/page.tsx
+++ b/apps/web/app/recruiter/candidate/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import RecruiterCandidateClient from './RecruiterCandidateClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Candidate Review · VitalCV',
+  description: 'Recruiter candidate review — placement readiness, evidence, trust, and background, source-backed.',
+};
+
+export default async function RecruiterCandidatePage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <RecruiterCandidateClient entityId={entityId} />;
+}

--- a/apps/web/lib/recruiter/candidate-verdict.ts
+++ b/apps/web/lib/recruiter/candidate-verdict.ts
@@ -1,0 +1,29 @@
+/**
+ * Recruiter candidate verdict (Wave 310) — pure, testable.
+ *
+ * Maps the candidate's mobility readiness + trust standing to a recruiter
+ * placement decision. Honest by construction: "move forward" requires a
+ * decision-grade `ready` candidate with established/emerging standing; gated,
+ * near-ready, or unknown coverage degrades — never green-lights a thin candidate.
+ */
+
+import type { MobilityReadiness, ReputationStanding } from '@vitalcv/domain-evidence';
+
+export type RecruiterVerdict = 'move_forward' | 'request_evidence' | 'not_ready' | 'insufficient';
+
+export const RECRUITER_VERDICT_LABEL: Record<RecruiterVerdict, string> = {
+  move_forward: 'Move forward',
+  request_evidence: 'Request more evidence',
+  not_ready: 'Not ready',
+  insufficient: 'Insufficient evidence',
+};
+
+export function deriveRecruiterVerdict(
+  readiness: MobilityReadiness,
+  standing: ReputationStanding,
+): RecruiterVerdict {
+  if (readiness === 'blocked') return 'not_ready';
+  if (readiness === 'unknown' || standing === 'unknown') return 'insufficient';
+  if (readiness === 'ready' && (standing === 'established' || standing === 'emerging')) return 'move_forward';
+  return 'request_evidence';
+}


### PR DESCRIPTION
## Recruiter candidate review (Wave 310)

A recruiter placement-decision surface (`/recruiter/candidate/[entityId]`) composing the merged evidence/trust/mobility/organizations/timeline APIs. **No new architecture; the pre-existing employer-review/candidates/workspace backend is untouched.**

### Built
- Source-backed recruiter **verdict** — move forward / request evidence / not ready / insufficient — as a **pure, tested helper** (`deriveRecruiterVerdict`).
- **Per-state placement check** (interactive) via the mobility readiness API.
- Evidence (decision-grade / owed), trust dimensions, organization background; links to the proof packet + ecosystem.

### Honesty
"Move forward" requires a decision-grade **ready** candidate with established/emerging standing; gated / near-ready / unknown coverage degrades — never green-lights a thin candidate. Standing comes from the canonical timeline reputation (no re-derivation).

### Validation
- recruiter tests 4/4 (verdict honesty + the Recruiter→Candidate→Evidence→Trust→Mobility chain through the real APIs, incl. per-state check)
- `next build` 14/14, exit 0 · ESLint clean

### Honest scope (not built)
- **Discovery** (cross-clinician candidate search) and **Workspace** (multi-tenant `WorkspaceMembership`) are pre-existing backend systems — intentionally not rebuilt or faked.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)