### PR TITLE
feat(intelligence): deterministic career intelligence (Wave 320)

### DIFF
--- a/apps/web/__tests__/career-intelligence-route.test.ts
+++ b/apps/web/__tests__/career-intelligence-route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W320-C4 — Evidence → Trust → Timeline → Mobility → Intelligence, through the API.
+// Proves the intelligence route composes the full pipeline into deterministic,
+// explainable insights/notifications/actions for one clinician.
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+function buildPassportPayload() {
+  return {
+    entityId: 'intel-1', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: {
+      credentials: [
+        { id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE', verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH', dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA', verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' },
+        { id: 'dea', domain: 'DEA', type: 'DEA_REGISTRATION', status: 'EXPIRED', verificationLevel: 'PRIMARY_SOURCE', stale: true, confidenceLabel: 'MEDIUM', claimConfidenceLabel: 'MEDIUM', dataFreshness: 'stale', dataFreshnessLabel: 'Stale', reviewRequired: false, expiresAt: '2026-01-01T00:00:00.000Z' },
+      ],
+      summary: { active: 1, expired: 1, stale: 1, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: { exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z', licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED', enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly', enrollmentNote: 'Current.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z', negativeFindings: [] },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 12, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: { checks: [
+      { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-01T00:00:00.000Z' },
+      { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG clear', checkedAt: '2026-03-01T00:00:00.000Z' },
+      { sourceId: 'STATE_BOARD', state: 'gated', reason: 'institutional access required', checkedAt: null },
+    ] },
+    trustPosture: { band: 'L2', bandLabel: 'Moderate', score: 70, dimensions: [], freshness: { state: 'partial', label: 'Partial', items: [] }, safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [] },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+  };
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ entityId: id }) });
+async function call() {
+  const { GET } = await import('../app/api/career-intelligence/[entityId]/route');
+  const res = await GET(new NextRequest('http://localhost/x'), ctx('intel-1'));
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => { resolveMock.mockReset(); resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload())); });
+
+describe('career-intelligence route (W320-C4)', () => {
+  it('returns 200 + schema with insights/notifications/actions', async () => {
+    const { status, body } = await call();
+    expect(status).toBe(200);
+    expect(body.schema).toBe('vitalcv.career-intelligence.v1');
+    expect(body.subjectKey).toBe('intel-1');
+    expect(Array.isArray(body.insights)).toBe(true);
+    expect(Array.isArray(body.notifications)).toBe(true);
+    expect(Array.isArray(body.actions)).toBe(true);
+  });
+
+  it('surfaces the expired DEA as a risk + high-priority action (explainable, decision-grade honest)', async () => {
+    const { body } = await call();
+    expect(body.insights.some((i: any) => i.kind === 'risk')).toBe(true);
+    expect(body.actions[0].priority).toBe('high'); // resolve decay first
+    // gated STATE_BOARD is owed, never a strength
+    expect(body.insights.some((i: any) => i.kind === 'gap')).toBe(true);
+    expect(body.insights.every((i: any) => i.basis.length > 0 || i.dimension !== null)).toBe(true); // explainable
+  });
+
+  it('is deterministic across calls', async () => {
+    const a = await call();
+    const b = await call();
+    expect(a.body).toEqual(b.body);
+  });
+
+  it('returns 500 envelope on runtime failure', async () => {
+    resolveMock.mockRejectedValueOnce(new Error('boom'));
+    const { status, body } = await call();
+    expect(status).toBe(500);
+    expect(body.error).toBe('career_intelligence_unavailable');
+  });
+});

--- a/apps/web/app/api/career-intelligence/[entityId]/route.ts
+++ b/apps/web/app/api/career-intelligence/[entityId]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  deriveMobilityOverview,
+  generateIntelligence,
+  projectEvidenceToGraph,
+  projectOrganizations,
+  projectTimeline,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/career-intelligence/[entityId] — deterministic, explainable career
+ * intelligence (Wave 320): insights, notifications, prioritized actions, derived
+ * over the evidence/trust/timeline/mobility/organization projections. No ML, no
+ * persistence. Namespaced as `career-intelligence` to stay clear of the
+ * pre-existing investigation `/api/intelligence/*` system.
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = projectEvidenceToGraph(collection);
+    const trust = propagateTrust(graph);
+    const timeline = projectTimeline(collection, graph, trust);
+    const mobility = deriveMobilityOverview(collection, trust);
+    const organizations = projectOrganizations(collection, graph);
+    const intelligence = generateIntelligence(collection, trust, timeline, mobility, organizations);
+    return NextResponse.json(
+      { schema: 'vitalcv.career-intelligence.v1', ...intelligence },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Career intelligence failed.';
+    return NextResponse.json(
+      { error: 'career_intelligence_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/career-intelligence/[entityId]/CareerIntelligenceClient.tsx
+++ b/apps/web/app/career-intelligence/[entityId]/CareerIntelligenceClient.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * Career Intelligence (Wave 320, UI) — renders the deterministic, explainable
+ * intelligence: prioritized actions, notifications, and categorized insights.
+ * Accessible: heading hierarchy, lists, severity conveyed as text (not color
+ * alone). Read-only.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Insight, IntelligenceProjection } from '@vitalcv/domain-evidence';
+
+const SEVERITY_TONE: Record<string, string> = {
+  high: 'border-rose-300 text-rose-800',
+  medium: 'border-amber-300 text-amber-800',
+  low: 'border-slate-300 text-slate-700',
+  info: 'border-emerald-300 text-emerald-800',
+};
+const KIND_LABEL: Record<Insight['kind'], string> = { strength: 'Strength', gap: 'Gap', risk: 'Risk', opportunity: 'Opportunity' };
+
+export default function CareerIntelligenceClient({ entityId }: { entityId: string }) {
+  const [data, setData] = useState<IntelligenceProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const res = await fetch(`/api/career-intelligence/${encodeURIComponent(entityId)}`, { cache: 'no-store' });
+      if (cancelled) return;
+      setData(res.ok ? ((await res.json()) as IntelligenceProjection) : null);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  if (loading) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Loading intelligence…</p></main>;
+  if (!data) return <main className="mx-auto w-full max-w-3xl px-4 py-16"><p className="text-sm text-muted-foreground">Career intelligence not available.</p></main>;
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-10">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Intelligence</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">What to do next</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {data.summary.strengths} strengths · {data.summary.gaps} gaps · {data.summary.risks} risks · {data.summary.opportunities} opportunities
+            {' · '}<Link href={`/ecosystem/${encodeURIComponent(entityId)}`} className="hover:text-foreground">← Ecosystem</Link>
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">Deterministic and explainable — every item below derives from source-backed evidence.</p>
+        </header>
+
+        {/* Prioritized actions (C3) */}
+        <section aria-labelledby="actions-h" className="rounded-2xl border border-border bg-card p-5">
+          <h2 id="actions-h" className="mb-3 text-sm font-semibold text-foreground">Prioritized actions</h2>
+          {data.actions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No outstanding actions — coverage is current.</p>
+          ) : (
+            <ol className="space-y-2">
+              {data.actions.map((a) => (
+                <li key={a.id} className="rounded-xl border border-border px-3 py-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <p className="text-sm font-medium text-foreground"><span className="text-muted-foreground">{a.rank}.</span> {a.title}</p>
+                    <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[11px] ${SEVERITY_TONE[a.priority]}`}>{a.priority} priority</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{a.rationale}</p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+
+        {/* Notifications (C2) */}
+        <section aria-labelledby="notify-h" className="rounded-2xl border border-border bg-card p-5">
+          <h2 id="notify-h" className="mb-3 text-sm font-semibold text-foreground">Notifications</h2>
+          {data.notifications.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No notifications.</p>
+          ) : (
+            <ul className="space-y-2">
+              {data.notifications.map((n) => (
+                <li key={n.id} className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
+                  <span className="text-foreground">{n.title}</span>
+                  <span className="text-xs text-muted-foreground">{n.severity} · {n.category}{n.occurredAt ? ` · ${n.occurredAt.slice(0, 10)}` : ''}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Insights (C1) */}
+        <section aria-labelledby="insights-h" className="rounded-2xl border border-border bg-card p-5">
+          <h2 id="insights-h" className="mb-3 text-sm font-semibold text-foreground">Insights</h2>
+          <ul className="space-y-2">
+            {data.insights.map((i) => (
+              <li key={i.id} className="flex flex-wrap items-baseline justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-sm text-foreground">{i.title}</p>
+                  <p className="text-xs text-muted-foreground">{i.detail}</p>
+                </div>
+                <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[11px] ${SEVERITY_TONE[i.severity]}`}>{KIND_LABEL[i.kind]}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/career-intelligence/[entityId]/page.tsx
+++ b/apps/web/app/career-intelligence/[entityId]/page.tsx
@@ -1,0 +1,13 @@
+import CareerIntelligenceClient from './CareerIntelligenceClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Career Intelligence · VitalCV',
+  description: 'Deterministic, explainable career intelligence — insights, notifications, and prioritized actions.',
+};
+
+export default async function CareerIntelligencePage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <CareerIntelligenceClient entityId={entityId} />;
+}

--- a/packages/domain-evidence/src/index.ts
+++ b/packages/domain-evidence/src/index.ts
@@ -88,3 +88,14 @@ export {
   type OrganizationKind,
   type OrganizationNode,
 } from './organizations/organizations';
+
+export {
+  generateIntelligence,
+  type Insight,
+  type InsightKind,
+  type InsightSeverity,
+  type IntelligenceProjection,
+  type Notification,
+  type NotificationCategory,
+  type PrioritizedAction,
+} from './intelligence/intelligence';

--- a/packages/domain-evidence/src/intelligence/intelligence.test.ts
+++ b/packages/domain-evidence/src/intelligence/intelligence.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import { projectEvidenceToGraph } from '../projectors/graph';
+import { propagateTrust } from '../trust/propagate';
+import { projectTimeline } from '../timeline/timeline';
+import { deriveMobilityOverview } from '../mobility/mobility';
+import { projectOrganizations } from '../organizations/organizations';
+import type { EvidenceClass, EvidenceLifecycle, EvidenceObject, EvidenceStatus } from '../types';
+import { generateIntelligence } from './intelligence';
+
+function makeObject(id: string, evidenceClass: EvidenceClass, status: EvidenceStatus, sourceId: string, opts: { jurisdiction?: string; checkedAt?: string; expiresAt?: string; lifecycle?: EvidenceLifecycle } = {}): EvidenceObject {
+  return {
+    evidenceId: id, subjectKey: 'subject-1', evidenceClass, label: `${evidenceClass} ${id}`,
+    value: opts.jurisdiction ? { jurisdiction: opts.jurisdiction } : null, status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null, decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null, checkedAt: opts.checkedAt ?? '2026-03-01T00:00:00.000Z', expiresAt: opts.expiresAt ?? null, freshnessWindowHours: null,
+    integrityHash: null, provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: opts.lifecycle ?? 'active', supersedes: null, supersededBy: null,
+  };
+}
+
+function intelOf(objects: EvidenceObject[]) {
+  const collection = buildEvidenceCollection({ subjectKey: 'subject-1', generatedFor: { displayName: 'Ada', npi: '1' }, objects });
+  const graph = projectEvidenceToGraph(collection);
+  const trust = propagateTrust(graph);
+  const timeline = projectTimeline(collection, graph, trust);
+  const mobility = deriveMobilityOverview(collection, trust);
+  const organizations = projectOrganizations(collection, graph);
+  return generateIntelligence(collection, trust, timeline, mobility, organizations);
+}
+
+const FIXTURE = [
+  makeObject('coverage:NPPES_API', 'identity', 'checked', 'NPPES_API'),
+  makeObject('cred:lic-ca', 'licensure', 'checked', 'STATE_BOARD', { jurisdiction: 'CA' }),
+  makeObject('cred:dea', 'registration', 'stale', 'DEA', { expiresAt: '2026-01-01T00:00:00.000Z', lifecycle: 'expired' }),
+  makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'GATED_BOARD'),
+];
+
+describe('generateIntelligence (W320)', () => {
+  it('generates strengths, gaps, risks, and opportunities', () => {
+    const intel = intelOf(FIXTURE);
+    expect(intel.insights.some((i) => i.kind === 'risk')).toBe(true); // expired DEA decay
+    expect(intel.insights.some((i) => i.kind === 'gap')).toBe(true); // empty dimensions + gated source
+    expect(intel.insights.some((i) => i.kind === 'opportunity')).toBe(true); // reusable + CA license
+    expect(intel.summary.risks + intel.summary.gaps + intel.summary.opportunities + intel.summary.strengths).toBe(intel.insights.length);
+  });
+
+  it('every insight is explainable (carries a basis or is dimension-tied)', () => {
+    const intel = intelOf(FIXTURE);
+    for (const i of intel.insights) {
+      expect(i.basis.length > 0 || i.dimension !== null).toBe(true);
+    }
+  });
+
+  it('notifications surface risks first (highest severity), strengths are not notifications', () => {
+    const intel = intelOf(FIXTURE);
+    expect(intel.notifications.length).toBeGreaterThan(0);
+    expect(intel.notifications[0].severity).toBe('high'); // decay risk first
+    expect(intel.notifications.every((n) => n.category !== 'review' || true)).toBe(true);
+    // no strength leaks into notifications
+    expect(intel.notifications.some((n) => n.title.startsWith('Strong'))).toBe(false);
+  });
+
+  it('actions are prioritized high→low with explainable rationale and stable ranks', () => {
+    const intel = intelOf(FIXTURE);
+    expect(intel.actions[0].priority).toBe('high'); // resolve decay first
+    expect(intel.actions[0].rank).toBe(1);
+    for (const a of intel.actions) {
+      expect(a.rationale.length).toBeGreaterThan(0);
+      expect(a.relatedInsightIds.length).toBeGreaterThan(0);
+    }
+    // ranks are 1..n contiguous
+    expect(intel.actions.map((a) => a.rank)).toEqual(intel.actions.map((_, i) => i + 1));
+  });
+
+  it('is fully deterministic', () => {
+    expect(intelOf(FIXTURE)).toEqual(intelOf(FIXTURE));
+  });
+
+  it('a clinician with no evidence yields honest gaps, no fabricated strengths', () => {
+    const intel = intelOf([makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'GATED')]);
+    expect(intel.summary.strengths).toBe(0); // nothing decision-grade → no strengths invented
+    expect(intel.summary.gaps).toBeGreaterThan(0);
+  });
+});

--- a/packages/domain-evidence/src/intelligence/intelligence.ts
+++ b/packages/domain-evidence/src/intelligence/intelligence.ts
@@ -1,0 +1,232 @@
+/**
+ * Career Intelligence (Wave 320).
+ *
+ * Pure, DETERMINISTIC, EXPLAINABLE derivation over the evidence / trust / timeline
+ * / mobility / organization projections. No ML, no opaque scoring. Every insight
+ * carries a `basis` (the evidenceIds / dimensions / sources it derives from) and
+ * every action a `rationale` — so any output can be verified by hand.
+ *
+ * Three services: insight generation (C1), a notification engine (C2), and action
+ * prioritization (C3). All are functions of the inputs only (no Date.now, no I/O).
+ */
+
+import type { EvidenceCollection } from '../types';
+import type { TrustDimension, TrustProjection } from '../trust/propagate';
+import type { TimelineProjection } from '../timeline/timeline';
+import type { MobilityOverview } from '../mobility/mobility';
+import type { OrganizationGraph } from '../organizations/organizations';
+
+// ── C1: Insights ─────────────────────────────────────────────────────────────
+
+export type InsightKind = 'strength' | 'gap' | 'risk' | 'opportunity';
+export type InsightSeverity = 'high' | 'medium' | 'low' | 'info';
+
+export interface Insight {
+  id: string;
+  kind: InsightKind;
+  title: string;
+  detail: string;
+  severity: InsightSeverity;
+  dimension: TrustDimension | null;
+  /** Explainability — the data this insight derives from. */
+  basis: string[];
+}
+
+// ── C2: Notifications ────────────────────────────────────────────────────────
+
+export type NotificationCategory = 'decay' | 'gap' | 'opportunity' | 'review';
+
+export interface Notification {
+  id: string;
+  severity: 'high' | 'medium' | 'low';
+  category: NotificationCategory;
+  title: string;
+  detail: string;
+  occurredAt: string | null;
+}
+
+// ── C3: Prioritized actions ──────────────────────────────────────────────────
+
+export interface PrioritizedAction {
+  id: string;
+  rank: number;
+  priority: 'high' | 'medium' | 'low';
+  title: string;
+  rationale: string;
+  relatedInsightIds: string[];
+}
+
+export interface IntelligenceProjection {
+  subjectKey: string;
+  insights: Insight[];
+  notifications: Notification[];
+  actions: PrioritizedAction[];
+  summary: { strengths: number; gaps: number; risks: number; opportunities: number };
+}
+
+// ── Insight generation ───────────────────────────────────────────────────────
+
+function generateInsights(
+  evidence: EvidenceCollection,
+  trust: TrustProjection,
+  timeline: TimelineProjection,
+  mobility: MobilityOverview,
+): Insight[] {
+  const insights: Insight[] = [];
+
+  // Strengths: decision-grade-strong trust dimensions.
+  for (const d of trust.dimensions) {
+    if (d.score !== null && d.score >= 0.67) {
+      insights.push({
+        id: `strength:${d.dimension}`,
+        kind: 'strength',
+        title: `Strong ${d.dimension}`,
+        detail: `${d.dimension} is source-backed (score ${d.score}) by ${d.decisionGradeCount} decision-grade item(s).`,
+        severity: 'info',
+        dimension: d.dimension,
+        basis: d.supporting,
+      });
+    }
+  }
+
+  // Gaps: dimensions with no evidence at all (honest null).
+  for (const d of trust.dimensions) {
+    if (d.score === null) {
+      insights.push({
+        id: `gap:${d.dimension}`,
+        kind: 'gap',
+        title: `No ${d.dimension} evidence`,
+        detail: `No source-backed ${d.dimension} evidence on file.`,
+        severity: 'medium',
+        dimension: d.dimension,
+        basis: [],
+      });
+    }
+  }
+
+  // Gaps: owed coverage (gated / not-decision-grade sources).
+  const owed = [...evidence.coverageSummary.gated, ...evidence.coverageSummary.accessRequired, ...evidence.coverageSummary.notDecisionGrade];
+  for (const sourceId of owed) {
+    insights.push({
+      id: `gap:source:${sourceId}`,
+      kind: 'gap',
+      title: `Evidence owed: ${sourceId}`,
+      detail: `${sourceId} is present but not decision-grade (gated / access required).`,
+      severity: 'medium',
+      dimension: null,
+      basis: [sourceId],
+    });
+  }
+
+  // Risks: decay events from the trust history.
+  for (const entry of timeline.trustHistory.entries) {
+    if (entry.type === 'decay') {
+      insights.push({
+        id: `risk:${entry.evidenceId ?? entry.dimension ?? 'decay'}`,
+        kind: 'risk',
+        title: 'Trust decay',
+        detail: entry.detail,
+        severity: 'high',
+        dimension: entry.dimension,
+        basis: entry.evidenceId ? [entry.evidenceId] : [],
+      });
+    }
+  }
+
+  // Opportunities: reusable evidence + mobility breadth.
+  if (mobility.reusableEvidenceCount > 0) {
+    insights.push({
+      id: 'opportunity:reusable',
+      kind: 'opportunity',
+      title: `${mobility.reusableEvidenceCount} reusable evidence item(s)`,
+      detail: 'Decision-grade evidence can be reused across new opportunities without re-verification.',
+      severity: 'low',
+      dimension: null,
+      basis: evidence.objects.filter((o) => o.decisionGrade).map((o) => o.evidenceId),
+    });
+  }
+  if (mobility.licensedStates.length > 0) {
+    insights.push({
+      id: 'opportunity:mobility',
+      kind: 'opportunity',
+      title: `Licensed in ${mobility.licensedStates.join(', ')}`,
+      detail: 'Source-backed licensure supports placement in these states; compact endorsement may extend reach.',
+      severity: 'low',
+      dimension: 'mobility',
+      basis: mobility.licensedStates,
+    });
+  }
+
+  // Deterministic order: by kind weight then id.
+  const kindWeight: Record<InsightKind, number> = { risk: 0, gap: 1, opportunity: 2, strength: 3 };
+  insights.sort((a, b) => (kindWeight[a.kind] - kindWeight[b.kind]) || a.id.localeCompare(b.id));
+  return insights;
+}
+
+// ── Notification engine ──────────────────────────────────────────────────────
+
+function generateNotifications(insights: Insight[], timeline: TimelineProjection): Notification[] {
+  const decayAt = new Map<string, string | null>();
+  for (const e of timeline.trustHistory.entries) {
+    if (e.type === 'decay' && e.evidenceId) decayAt.set(e.evidenceId, e.occurredAt);
+  }
+
+  const notifications: Notification[] = [];
+  for (const i of insights) {
+    if (i.kind === 'risk') {
+      notifications.push({ id: `notify:${i.id}`, severity: 'high', category: 'decay', title: i.title, detail: i.detail, occurredAt: i.basis[0] ? decayAt.get(i.basis[0]) ?? null : null });
+    } else if (i.kind === 'gap') {
+      notifications.push({ id: `notify:${i.id}`, severity: 'medium', category: 'gap', title: i.title, detail: i.detail, occurredAt: null });
+    } else if (i.kind === 'opportunity') {
+      notifications.push({ id: `notify:${i.id}`, severity: 'low', category: 'opportunity', title: i.title, detail: i.detail, occurredAt: null });
+    }
+  }
+  // strengths are informational, not notifications. Deterministic: severity then id.
+  const sevWeight = { high: 0, medium: 1, low: 2 } as const;
+  notifications.sort((a, b) => (sevWeight[a.severity] - sevWeight[b.severity]) || a.id.localeCompare(b.id));
+  return notifications;
+}
+
+// ── Action prioritization ────────────────────────────────────────────────────
+
+function prioritizeActions(insights: Insight[]): PrioritizedAction[] {
+  const actions: Omit<PrioritizedAction, 'rank'>[] = [];
+
+  for (const i of insights) {
+    if (i.kind === 'risk') {
+      actions.push({ id: `action:${i.id}`, priority: 'high', title: `Refresh: ${i.detail}`, rationale: `Resolves a trust-decay risk (${i.dimension ?? 'evidence'}).`, relatedInsightIds: [i.id] });
+    } else if (i.kind === 'gap') {
+      actions.push({ id: `action:${i.id}`, priority: 'medium', title: `Add evidence: ${i.title}`, rationale: `Closes a coverage gap in ${i.dimension ?? 'source coverage'}.`, relatedInsightIds: [i.id] });
+    } else if (i.kind === 'opportunity') {
+      actions.push({ id: `action:${i.id}`, priority: 'low', title: `Leverage: ${i.title}`, rationale: 'Reusable, source-backed evidence advances new opportunities.', relatedInsightIds: [i.id] });
+    }
+  }
+
+  const prWeight = { high: 0, medium: 1, low: 2 } as const;
+  actions.sort((a, b) => (prWeight[a.priority] - prWeight[b.priority]) || a.id.localeCompare(b.id));
+  return actions.map((a, idx) => ({ ...a, rank: idx + 1 }));
+}
+
+// ── Top-level ────────────────────────────────────────────────────────────────
+
+export function generateIntelligence(
+  evidence: EvidenceCollection,
+  trust: TrustProjection,
+  timeline: TimelineProjection,
+  mobility: MobilityOverview,
+  _organizations: OrganizationGraph,
+): IntelligenceProjection {
+  const insights = generateInsights(evidence, trust, timeline, mobility);
+  return {
+    subjectKey: evidence.subjectKey,
+    insights,
+    notifications: generateNotifications(insights, timeline),
+    actions: prioritizeActions(insights),
+    summary: {
+      strengths: insights.filter((i) => i.kind === 'strength').length,
+      gaps: insights.filter((i) => i.kind === 'gap').length,
+      risks: insights.filter((i) => i.kind === 'risk').length,
+      opportunities: insights.filter((i) => i.kind === 'opportunity').length,
+    },
+  };
+}


### PR DESCRIPTION
## Career Intelligence (Wave 320)

A deterministic, explainable intelligence layer over the merged projections (evidence/trust/timeline/mobility/organizations). **No new architecture; no ML; namespaced `career-intelligence` to avoid the pre-existing investigation `/api/intelligence/*` system.**

### Built (C1–C3)
- **Insight generation** — strength / gap / risk / opportunity, each with a `basis` (the evidenceIds/dimensions/sources it derives from).
- **Notification engine** — risks/gaps/opportunities surfaced by severity (strengths stay informational).
- **Action prioritization** — priority-ranked (high→low) actions, each with an explainable `rationale` + related insight ids.
- `GET /api/career-intelligence/[entityId]` + an accessible `/career-intelligence/[entityId]` UI.

### Success criteria
- **deterministic** — pure functions of the inputs; determinism tests · **explainable** — every insight carries a basis, every action a rationale (invariant-tested)
- **tested** — package 6 + route/integration 4 (Evidence→Trust→Timeline→Mobility→Intelligence) · **performant** — pure O(n) · **merge-ready** — `next build` 14/14, exit 0; ESLint/a11y clean

### Honesty
No fabricated strengths when nothing is decision-grade; gated/stale is a gap/risk, never a strength; decay drives the top-priority action.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)