### PR TITLE
feat(platform): versioned API contract + webhook core + typed SDK (Wave 330)

### DIFF
--- a/apps/web/__tests__/platform-contract.test.ts
+++ b/apps/web/__tests__/platform-contract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { PLATFORM_API_VERSION, PLATFORM_ENDPOINTS, isPlatformSchema, platformPath } from '../lib/platform/contract';
+
+describe('platform contract (W330-C1/C2)', () => {
+  it('pins the platform version and every endpoint is v1 + public + GET', () => {
+    expect(PLATFORM_API_VERSION).toBe('v1');
+    for (const ep of PLATFORM_ENDPOINTS) {
+      expect(ep.schema.endsWith('.v1')).toBe(true);
+      expect(ep.visibility).toBe('public');
+      expect(ep.method).toBe('GET');
+    }
+  });
+
+  it('builds encoded paths and rejects unknown endpoints', () => {
+    expect(platformPath('evidence', 'entity-1')).toBe('/api/evidence/entity-1');
+    expect(platformPath('mobility-readiness', 'a/b')).toBe('/api/mobility/a%2Fb/readiness');
+    // @ts-expect-error unknown id
+    expect(() => platformPath('nope', 'x')).toThrow();
+  });
+
+  it('validates versioned platform schemas (fail-closed on drift)', () => {
+    expect(isPlatformSchema('vitalcv.evidence-collection.v1')).toBe(true);
+    expect(isPlatformSchema('vitalcv.evidence-collection.v2')).toBe(false);
+    expect(isPlatformSchema('something.else')).toBe(false);
+    expect(isPlatformSchema(null)).toBe(false);
+  });
+});

--- a/apps/web/__tests__/platform-sdk.test.ts
+++ b/apps/web/__tests__/platform-sdk.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createVitalCVClient, PlatformContractError } from '../lib/platform/client';
+import { PLATFORM_ENDPOINTS, platformPath } from '../lib/platform/contract';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W330-C5 — External Client → SDK → API → Evidence → Trust → Timeline → Mobility.
+// A fetch that routes the SDK's requests to the REAL route handlers exercises the
+// whole platform path; also validates the C1 boundary (every endpoint returns its
+// declared schema) and the SDK's fail-closed contract checking (C4).
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+function buildPassportPayload() {
+  return {
+    entityId: 'ext-1', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: { credentials: [{ id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE', verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH', dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA', verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' }], summary: { active: 1, expired: 0, stale: 0, missing: [] } },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: { exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z', licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED', enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly', enrollmentNote: 'Current.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z', negativeFindings: [] },
+    readiness: { status: 'PARTIAL', score: 75, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 10, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: { checks: [ { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-01T00:00:00.000Z' }, { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG clear', checkedAt: '2026-03-01T00:00:00.000Z' } ] },
+    trustPosture: { band: 'L2', bandLabel: 'Moderate', score: 75, dimensions: [], freshness: { state: 'partial', label: 'Partial', items: [] }, safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [] },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+  };
+}
+
+// Map a platform URL to its real route handler.
+const ROUTES: Array<{ re: RegExp; mod: string }> = [
+  { re: /^\/api\/evidence\/[^/]+$/, mod: '../app/api/evidence/[entityId]/route' },
+  { re: /^\/api\/graph\/[^/]+\/trust$/, mod: '../app/api/graph/[entityId]/trust/route' },
+  { re: /^\/api\/timeline\/[^/]+$/, mod: '../app/api/timeline/[entityId]/route' },
+  { re: /^\/api\/mobility\/[^/]+\/readiness$/, mod: '../app/api/mobility/[entityId]/readiness/route' },
+  { re: /^\/api\/mobility\/[^/]+$/, mod: '../app/api/mobility/[entityId]/route' },
+  { re: /^\/api\/organizations\/[^/]+$/, mod: '../app/api/organizations/[entityId]/route' },
+  { re: /^\/api\/career-intelligence\/[^/]+$/, mod: '../app/api/career-intelligence/[entityId]/route' },
+];
+
+const routedFetch = (async (input: RequestInfo | URL) => {
+  const url = typeof input === 'string' ? input : input.toString();
+  const path = new URL(url).pathname;
+  const match = ROUTES.find((r) => r.re.test(path));
+  if (!match) return new Response('not found', { status: 404 });
+  const entityId = decodeURIComponent(path.split('/').filter(Boolean)[2]);
+  const { GET } = await import(match.mod);
+  return GET(new NextRequest(url), { params: Promise.resolve({ entityId }) });
+}) as unknown as typeof fetch;
+
+const client = createVitalCVClient({ baseUrl: 'https://platform.test', fetch: routedFetch });
+
+beforeEach(() => { resolveMock.mockReset(); resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload())); });
+
+describe('Platform SDK end-to-end (W330-C4/C5)', () => {
+  it('an external client retrieves typed, schema-verified projections through the pipeline', async () => {
+    const evidence = await client.getEvidence('ext-1');
+    const trust = await client.getTrust('ext-1');
+    const timeline = await client.getTimeline('ext-1');
+    const mobility = await client.getMobility('ext-1');
+    const intelligence = await client.getIntelligence('ext-1');
+
+    expect(evidence.subjectKey).toBe('ext-1');
+    expect(trust.dimensions).toHaveLength(7);
+    expect(timeline.reputation.decisionGradeEvidence).toBe(trust.overall.decisionGradeEvidence);
+    expect(mobility.licensedStates).toContain('CA');
+    expect(Array.isArray(intelligence.actions)).toBe(true);
+    expect(client.version).toBe('v1');
+  });
+
+  it('passes the state query through to per-state readiness', async () => {
+    const nv = await client.getMobilityReadiness('ext-1', 'NV');
+    expect(nv.readiness).not.toBe('ready'); // licensed CA, not NV
+  });
+
+  it('C1 boundary: every declared platform endpoint returns its declared schema', async () => {
+    for (const ep of PLATFORM_ENDPOINTS) {
+      const res = await routedFetch(`https://platform.test${platformPath(ep.id, 'ext-1')}`);
+      const body = await (res as Response).json();
+      expect(body.schema).toBe(ep.schema);
+    }
+  });
+
+  it('C4: SDK fails closed on a schema-contract mismatch', async () => {
+    const badFetch = (async () => new Response(JSON.stringify({ schema: 'vitalcv.evidence-collection.v2' }), { status: 200 })) as unknown as typeof fetch;
+    const bad = createVitalCVClient({ baseUrl: 'https://x', fetch: badFetch });
+    await expect(bad.getEvidence('ext-1')).rejects.toBeInstanceOf(PlatformContractError);
+  });
+});

--- a/apps/web/__tests__/platform-webhook.test.ts
+++ b/apps/web/__tests__/platform-webhook.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RETRY_POLICY,
+  buildWebhookEvent,
+  nextRetryDelayMs,
+  signWebhookDelivery,
+  verifyWebhookSignature,
+} from '../lib/platform/webhook';
+
+const SECRET = 'whsec_test';
+const TS = '1700000000';
+
+function delivery() {
+  const event = buildWebhookEvent({ id: 'evt_1', type: 'intelligence.notification', subjectKey: 'entity-1', occurredAt: '2026-03-01T00:00:00.000Z', data: { title: 'Trust decay' } });
+  return signWebhookDelivery(event, SECRET, TS);
+}
+
+describe('webhook signing (W330-C3)', () => {
+  it('signs deterministically and verifies a valid signature', () => {
+    const d = delivery();
+    expect(d.signature).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(d).toEqual(delivery()); // deterministic given injected timestamp
+    expect(verifyWebhookSignature({ body: d.body, timestamp: d.timestamp, signature: d.signature, secret: SECRET })).toBe(true);
+    expect(d.headers['X-VitalCV-Signature']).toBe(d.signature);
+  });
+
+  it('rejects a tampered body, wrong timestamp, or wrong secret', () => {
+    const d = delivery();
+    expect(verifyWebhookSignature({ body: d.body + ' ', timestamp: d.timestamp, signature: d.signature, secret: SECRET })).toBe(false);
+    expect(verifyWebhookSignature({ body: d.body, timestamp: '1700000001', signature: d.signature, secret: SECRET })).toBe(false);
+    expect(verifyWebhookSignature({ body: d.body, timestamp: d.timestamp, signature: d.signature, secret: 'wrong' })).toBe(false);
+  });
+});
+
+describe('webhook retry policy (W330-C3)', () => {
+  it('is deterministic exponential backoff, capped, and exhausts', () => {
+    expect(nextRetryDelayMs(1)).toBe(1_000);
+    expect(nextRetryDelayMs(2)).toBe(2_000);
+    expect(nextRetryDelayMs(3)).toBe(4_000);
+    expect(nextRetryDelayMs(4)).toBe(8_000);
+    expect(nextRetryDelayMs(DEFAULT_RETRY_POLICY.maxAttempts)).toBeNull(); // exhausted
+    expect(nextRetryDelayMs(0)).toBeNull();
+    // cap honored
+    expect(nextRetryDelayMs(2, { maxAttempts: 10, baseDelayMs: 50_000, maxDelayMs: 60_000 })).toBe(60_000);
+  });
+});

--- a/apps/web/lib/platform/client.ts
+++ b/apps/web/lib/platform/client.ts
@@ -1,0 +1,88 @@
+/**
+ * VitalCV Platform SDK (Wave 330, C4) — a typed client over the public platform
+ * contract. Strengthens SDK contracts: every method returns the typed projection,
+ * and the response is validated against the endpoint's declared schema version
+ * before it is handed back (fail-closed on contract drift).
+ *
+ * `fetch` is injectable so the SDK runs in any environment (Node, edge, browser)
+ * and is testable against the real route handlers.
+ */
+
+import type {
+  EvidenceCollection,
+  IntelligenceProjection,
+  MobilityOverview,
+  OrganizationGraph,
+  ReadinessProjection,
+  TimelineProjection,
+  TrustProjection,
+} from '@vitalcv/domain-evidence';
+import {
+  PLATFORM_API_VERSION,
+  PLATFORM_ENDPOINTS,
+  isPlatformSchema,
+  platformPath,
+  type PlatformEndpointId,
+} from './contract';
+
+export interface VitalCVClientOptions {
+  baseUrl: string;
+  /** Injected fetch; defaults to global fetch when available. */
+  fetch?: typeof fetch;
+  /** Optional bearer credential for gated deployments. */
+  apiKey?: string;
+}
+
+export class PlatformContractError extends Error {
+  constructor(message: string, readonly endpoint: PlatformEndpointId, readonly status?: number) {
+    super(message);
+    this.name = 'PlatformContractError';
+  }
+}
+
+export interface VitalCVClient {
+  readonly version: typeof PLATFORM_API_VERSION;
+  getEvidence(entityId: string): Promise<EvidenceCollection>;
+  getTrust(entityId: string): Promise<TrustProjection>;
+  getTimeline(entityId: string): Promise<TimelineProjection>;
+  getMobility(entityId: string): Promise<MobilityOverview>;
+  getMobilityReadiness(entityId: string, state?: string): Promise<ReadinessProjection>;
+  getOrganizations(entityId: string): Promise<OrganizationGraph>;
+  getIntelligence(entityId: string): Promise<IntelligenceProjection>;
+}
+
+export function createVitalCVClient(opts: VitalCVClientOptions): VitalCVClient {
+  const doFetch = opts.fetch ?? globalThis.fetch;
+  if (!doFetch) throw new Error('No fetch implementation available; pass options.fetch.');
+  const base = opts.baseUrl.replace(/\/$/, '');
+
+  async function get<T>(id: PlatformEndpointId, entityId: string, query?: string): Promise<T> {
+    const endpoint = PLATFORM_ENDPOINTS.find((e) => e.id === id)!;
+    const url = `${base}${platformPath(id, entityId)}${query ?? ''}`;
+    const res = await doFetch(url, {
+      headers: { Accept: 'application/json', ...(opts.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : {}) },
+    });
+    if (!res.ok) {
+      throw new PlatformContractError(`Platform request failed (${res.status}) for ${id}.`, id, res.status);
+    }
+    const body = (await res.json()) as { schema?: unknown };
+    if (!isPlatformSchema(body.schema)) {
+      throw new PlatformContractError(`Response for ${id} is not a versioned platform contract.`, id, res.status);
+    }
+    if (body.schema !== endpoint.schema) {
+      throw new PlatformContractError(`Schema mismatch for ${id}: expected ${endpoint.schema}, got ${String(body.schema)}.`, id, res.status);
+    }
+    return body as T;
+  }
+
+  return {
+    version: PLATFORM_API_VERSION,
+    getEvidence: (entityId) => get('evidence', entityId),
+    getTrust: (entityId) => get('trust', entityId),
+    getTimeline: (entityId) => get('timeline', entityId),
+    getMobility: (entityId) => get('mobility', entityId),
+    getMobilityReadiness: (entityId, state) => get('mobility-readiness', entityId, state ? `?state=${encodeURIComponent(state)}` : undefined),
+    getOrganizations: (entityId) => get('organizations', entityId),
+    getIntelligence: (entityId) => get('intelligence', entityId),
+  };
+}

--- a/apps/web/lib/platform/contract.ts
+++ b/apps/web/lib/platform/contract.ts
@@ -1,0 +1,73 @@
+/**
+ * VitalCV Platform API contract (Wave 330) — the stable, versioned public surface
+ * for enterprise integrations.
+ *
+ * C1 (boundaries): PLATFORM_ENDPOINTS is the explicit, read-only public surface —
+ * the source-backed projection APIs. Anything not listed here is NOT a platform
+ * contract. C2 (versioning): every endpoint declares its `schema` version; the
+ * platform version is pinned. Pure types/data — no I/O.
+ */
+
+import type {
+  EvidenceCollection,
+  IntelligenceProjection,
+  MobilityOverview,
+  OrganizationGraph,
+  ReadinessProjection,
+  TimelineProjection,
+  TrustProjection,
+} from '@vitalcv/domain-evidence';
+
+export const PLATFORM_API_VERSION = 'v1' as const;
+
+/** Every platform response is this envelope: a versioned schema + the projection. */
+export type PlatformEnvelope<T> = { schema: string } & T;
+export interface PlatformErrorEnvelope {
+  error: string;
+  error_description: string;
+}
+
+export interface PlatformEndpoint {
+  id: string;
+  /** Path template; `:entityId` is a canonicalId or 10-digit NPI. */
+  path: string;
+  method: 'GET';
+  schema: `vitalcv.${string}.v1`;
+  /** Public = part of the stable enterprise contract. */
+  visibility: 'public';
+}
+
+export const PLATFORM_ENDPOINTS = [
+  { id: 'evidence', path: '/api/evidence/:entityId', method: 'GET', schema: 'vitalcv.evidence-collection.v1', visibility: 'public' },
+  { id: 'trust', path: '/api/graph/:entityId/trust', method: 'GET', schema: 'vitalcv.evidence-graph-trust.v1', visibility: 'public' },
+  { id: 'timeline', path: '/api/timeline/:entityId', method: 'GET', schema: 'vitalcv.timeline.v1', visibility: 'public' },
+  { id: 'mobility', path: '/api/mobility/:entityId', method: 'GET', schema: 'vitalcv.mobility.v1', visibility: 'public' },
+  { id: 'mobility-readiness', path: '/api/mobility/:entityId/readiness', method: 'GET', schema: 'vitalcv.mobility-readiness.v1', visibility: 'public' },
+  { id: 'organizations', path: '/api/organizations/:entityId', method: 'GET', schema: 'vitalcv.organizations.v1', visibility: 'public' },
+  { id: 'intelligence', path: '/api/career-intelligence/:entityId', method: 'GET', schema: 'vitalcv.career-intelligence.v1', visibility: 'public' },
+] as const satisfies readonly PlatformEndpoint[];
+
+export type PlatformEndpointId = (typeof PLATFORM_ENDPOINTS)[number]['id'];
+
+/** Map an endpoint id to its concrete path for an entity. entityId is URL-encoded. */
+export function platformPath(id: PlatformEndpointId, entityId: string): string {
+  const ep = PLATFORM_ENDPOINTS.find((e) => e.id === id);
+  if (!ep) throw new Error(`Unknown platform endpoint: ${id}`);
+  return ep.path.replace(':entityId', encodeURIComponent(entityId));
+}
+
+/** True if a response schema is a recognized, current platform contract version. */
+export function isPlatformSchema(schema: unknown): schema is `vitalcv.${string}.v1` {
+  return typeof schema === 'string' && /^vitalcv\.[a-z-]+\.v1$/.test(schema);
+}
+
+/** The typed payload returned by each platform endpoint (sans envelope `schema`). */
+export interface PlatformResponseTypes {
+  evidence: EvidenceCollection;
+  trust: TrustProjection;
+  timeline: TimelineProjection;
+  mobility: MobilityOverview;
+  'mobility-readiness': ReadinessProjection;
+  organizations: OrganizationGraph;
+  intelligence: IntelligenceProjection;
+}

--- a/apps/web/lib/platform/webhook.ts
+++ b/apps/web/lib/platform/webhook.ts
@@ -1,0 +1,108 @@
+/**
+ * VitalCV Platform webhook framework — CORE (Wave 330, C3).
+ *
+ * The deterministic, testable pieces an enterprise needs to receive trustworthy
+ * events: a versioned event model, HMAC-SHA256 signed payloads (timing-safe
+ * verification), and an exponential-backoff retry policy.
+ *
+ * SCOPE: this is the framework core only. LIVE delivery (subscription store,
+ * change-detection event source, delivery worker/queue) requires the monitoring
+ * backend + infra and is intentionally NOT implemented here — these primitives are
+ * what a delivery worker would call. Pure: signing/verification/backoff are
+ * deterministic given their inputs (timestamp is injected, never read from a clock).
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export type WebhookEventType =
+  | 'evidence.updated'
+  | 'trust.changed'
+  | 'timeline.event'
+  | 'mobility.changed'
+  | 'organization.changed'
+  | 'intelligence.notification';
+
+export interface WebhookEvent<T = unknown> {
+  schema: 'vitalcv.webhook.v1';
+  id: string;
+  type: WebhookEventType;
+  subjectKey: string;
+  occurredAt: string;
+  data: T;
+}
+
+export function buildWebhookEvent<T>(input: {
+  id: string;
+  type: WebhookEventType;
+  subjectKey: string;
+  occurredAt: string;
+  data: T;
+}): WebhookEvent<T> {
+  return { schema: 'vitalcv.webhook.v1', ...input };
+}
+
+export interface SignedWebhookDelivery {
+  eventId: string;
+  /** Canonical JSON body that was signed. */
+  body: string;
+  /** Unix-seconds string included in the signature (replay protection). */
+  timestamp: string;
+  /** `sha256=<hex>` over `${timestamp}.${body}`. */
+  signature: string;
+  /** Suggested HTTP headers for the delivery. */
+  headers: Record<string, string>;
+}
+
+function computeSignature(timestamp: string, body: string, secret: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+}
+
+/** Sign an event for delivery. timestamp (unix-seconds string) is injected for determinism. */
+export function signWebhookDelivery(event: WebhookEvent, secret: string, timestamp: string): SignedWebhookDelivery {
+  const body = JSON.stringify(event);
+  const signature = computeSignature(timestamp, body, secret);
+  return {
+    eventId: event.id,
+    body,
+    timestamp,
+    signature,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-VitalCV-Event': event.type,
+      'X-VitalCV-Event-Id': event.id,
+      'X-VitalCV-Timestamp': timestamp,
+      'X-VitalCV-Signature': signature,
+    },
+  };
+}
+
+/** Verify a received webhook signature (timing-safe). */
+export function verifyWebhookSignature(input: {
+  body: string;
+  timestamp: string;
+  signature: string;
+  secret: string;
+}): boolean {
+  const expected = computeSignature(input.timestamp, input.body, input.secret);
+  const a = Buffer.from(expected);
+  const b = Buffer.from(input.signature);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export interface RetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = { maxAttempts: 5, baseDelayMs: 1_000, maxDelayMs: 60_000 };
+
+/**
+ * Deterministic exponential backoff. `attempt` is 1-based (1 = first retry).
+ * Returns the delay in ms, or null when retries are exhausted. No jitter (kept
+ * deterministic; a delivery worker may add bounded jitter at send time).
+ */
+export function nextRetryDelayMs(attempt: number, policy: RetryPolicy = DEFAULT_RETRY_POLICY): number | null {
+  if (attempt < 1 || attempt >= policy.maxAttempts) return null;
+  return Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
+}


### PR DESCRIPTION
## Platform layer (Wave 330)

Productionizes the platform layer over the existing source-backed read APIs. `domain-evidence` stays pure; platform code (contract/SDK/webhook) lives in the app where fetch/crypto belong. No new architecture.

### Built
- **C1/C2 — versioned contract** (`lib/platform/contract.ts`): the explicit public, read-only endpoint surface, each pinned to its `vitalcv.*.v1` schema; `isPlatformSchema` fails closed on version drift.
- **C3 — webhook framework CORE** (`lib/platform/webhook.ts`): event model, HMAC-SHA256 **signed + timing-safe-verified** payloads, deterministic exponential-backoff retry. *(Live delivery — subscription store, change-detection source, delivery worker — needs the monitoring backend and is intentionally not built; these are the primitives a worker calls.)*
- **C4 — typed SDK** (`lib/platform/client.ts`): `createVitalCVClient({ baseUrl, fetch })` with typed methods; **fails closed** on schema/contract mismatch.
- **C5 — integration**: an external client through the SDK to the real route handlers → the full Evidence→Trust→Timeline→Mobility pipeline.

### Success criteria — stable, documented, versioned platform
- 10 tests (contract / webhook sign+retry / SDK end-to-end + C1 boundary: every endpoint returns its declared schema)
- deterministic webhook signing/backoff · SDK fail-closed on drift
- **C6** pure/O(1) platform layer over O(n) APIs · **C7** `next build` 14/14, exit 0

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)