### PR TITLE
feat(growth): professional growth — milestones, progression, gaps, mentorship model (Wave 520)

### DIFF
--- a/apps/web/__tests__/professional-growth-route.test.ts
+++ b/apps/web/__tests__/professional-growth-route.test.ts
@@ -46,9 +46,11 @@ describe('professional-growth route (W520-C6)', () => {
     // self-reported residency is reached-but-unverified (honest)
     expect(body.milestones.some((m: any) => m.type === 'training' && m.decisionGrade === false)).toBe(true);
 
-    // progression: training + licensed reached; board cert not → growth gap
-    expect(body.progression.stagesReached).toEqual(expect.arrayContaining(['training', 'licensed']));
+    // progression: decision-grade licensure reaches 'licensed'; self-reported residency does NOT advance the arc
+    expect(body.progression.stagesReached).toContain('licensed');
+    expect(body.progression.stagesReached).not.toContain('training');
     expect(body.growthGaps.some((g: any) => g.toReachStage === 'board_certified')).toBe(true);
+    expect(body.growthGaps.some((g: any) => g.toReachStage === 'training')).toBe(true); // verify your training
 
     // mentorship model present but empty (external data source)
     expect(body.mentorship).toEqual([]);

--- a/apps/web/__tests__/professional-growth-route.test.ts
+++ b/apps/web/__tests__/professional-growth-route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+// W520-C6 — Career → Education → Evidence → Trust → Organizations → Opportunities.
+// A clinician with training + licensure resolves into milestones, a career stage,
+// and growth gaps — through the real route + pipeline.
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({ resolvePassportRuntimePassport: resolveMock }));
+
+function buildPassportPayload() {
+  return {
+    entityId: 'grow-1', npi: '1234567890',
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi: '1234567890' },
+    authority: { credentials: [{ id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE', verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH', dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA', verifiedAt: '2026-03-02T00:00:00.000Z', sourceId: 'STATE_BOARD' }], summary: { active: 1, expired: 0, stale: 0, missing: [] } },
+    training: { records: [{ id: 'res-1', recordType: 'RESIDENCY', degreeOrTitle: 'IM Residency', institutionName: 'Johns Hopkins', endYear: 2018, completed: true, verificationLevel: 'SELF_REPORTED' }], hasDegree: true, degreeVerified: false, hasResidency: true, fellowshipCount: 0 },
+    standing: { exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-01T00:00:00.000Z', licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED', enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly', enrollmentNote: 'Current.', enrollmentObservedAt: '2026-03-01T00:00:00.000Z', negativeFindings: [] },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 10, nextActions: [] },
+    sources: { checked: ['NPPES_API', 'OIG_LEIE'], lastFetch: { NPPES_API: '2026-03-01T00:00:00.000Z', OIG_LEIE: '2026-03-01T00:00:00.000Z' } },
+    sourceCoverage: { checks: [ { sourceId: 'NPPES_API', state: 'checked', reason: 'identity checked', checkedAt: '2026-03-01T00:00:00.000Z' }, { sourceId: 'OIG_LEIE', state: 'checked', reason: 'OIG clear', checkedAt: '2026-03-01T00:00:00.000Z' } ] },
+    trustPosture: { band: 'L2', bandLabel: 'Moderate', score: 70, dimensions: [], freshness: { state: 'partial', label: 'Partial', items: [] }, safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [] },
+    lastCheckedAt: '2026-03-02T00:00:00.000Z',
+  };
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ entityId: id }) });
+async function call() {
+  const { GET } = await import('../app/api/professional-growth/[entityId]/route');
+  const res = await GET(new NextRequest('http://localhost/x'), ctx('grow-1'));
+  return { status: res.status, body: await res.json() };
+}
+
+beforeEach(() => { resolveMock.mockReset(); resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload())); });
+
+describe('professional-growth route (W520-C6)', () => {
+  it('derives milestones, progression, and growth gaps from the record', async () => {
+    const { status, body } = await call();
+    expect(status).toBe(200);
+    expect(body.schema).toBe('vitalcv.professional-growth.v1');
+    expect(body.subjectKey).toBe('grow-1');
+
+    // milestones from training + licensure (+ identity/exclusion)
+    expect(body.milestones.some((m: any) => m.type === 'training')).toBe(true);
+    expect(body.milestones.some((m: any) => m.type === 'licensure' && m.decisionGrade === true)).toBe(true);
+    // self-reported residency is reached-but-unverified (honest)
+    expect(body.milestones.some((m: any) => m.type === 'training' && m.decisionGrade === false)).toBe(true);
+
+    // progression: training + licensed reached; board cert not → growth gap
+    expect(body.progression.stagesReached).toEqual(expect.arrayContaining(['training', 'licensed']));
+    expect(body.growthGaps.some((g: any) => g.toReachStage === 'board_certified')).toBe(true);
+
+    // mentorship model present but empty (external data source)
+    expect(body.mentorship).toEqual([]);
+  });
+
+  it('returns a 500 envelope on runtime failure', async () => {
+    resolveMock.mockRejectedValueOnce(new Error('boom'));
+    const { status, body } = await call();
+    expect(status).toBe(500);
+    expect(body.error).toBe('professional_growth_unavailable');
+  });
+});

--- a/apps/web/app/api/professional-growth/[entityId]/route.ts
+++ b/apps/web/app/api/professional-growth/[entityId]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  projectEvidenceToGraph,
+  projectProfessionalGrowth,
+  projectTimeline,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/professional-growth/[entityId] — Professional Growth (Wave 520):
+ * milestones, career progression, growth gaps, and mentorship model, derived over
+ * the evidence/trust/timeline projections. Read-only; deterministic; mentorship
+ * data is external (empty here). No new architecture.
+ */
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = projectEvidenceToGraph(collection);
+    const trust = propagateTrust(graph);
+    const timeline = projectTimeline(collection, graph, trust);
+    const growth = projectProfessionalGrowth(collection, trust, timeline);
+    return NextResponse.json(
+      { schema: 'vitalcv.professional-growth.v1', ...growth },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Professional growth failed.';
+    return NextResponse.json(
+      { error: 'professional_growth_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/packages/domain-evidence/src/growth/growth.test.ts
+++ b/packages/domain-evidence/src/growth/growth.test.ts
@@ -36,16 +36,22 @@ describe('projectProfessionalGrowth (W520)', () => {
     expect(g.milestones.find((m) => m.evidenceId === 'training:res')?.decisionGrade).toBe(false); // self-reported, honest
   });
 
-  it('computes a career progression along the arc', () => {
+  it('reaches a stage ONLY via decision-grade evidence', () => {
     const g = growthOf([
-      makeObject('training:res', 'training', 'notDecisionGrade', 'JHU'),
-      makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD'),
+      makeObject('training:res', 'training', 'notDecisionGrade', 'JHU'), // self-reported → not a verified stage
+      makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD'),     // decision-grade licensure
     ]);
-    expect(g.progression.stagesReached).toContain('training');
+    expect(g.progression.stagesReached).not.toContain('training'); // self-reported residency does not advance the arc
     expect(g.progression.stagesReached).toContain('licensed');
-    expect(g.progression.stage).toBe('licensed'); // highest reached on the arc
+    expect(g.progression.stage).toBe('licensed');
     expect(g.progression.nextStage).toBe('practicing');
     expect(g.progression.progress).toBeGreaterThan(0);
+  });
+
+  it('does NOT mark a stage reached from gated/non-decision-grade coverage', () => {
+    const g = growthOf([makeObject('coverage:STATE_BOARD', 'licensure', 'gated', 'STATE_BOARD')]);
+    expect(g.progression.stagesReached).not.toContain('licensed'); // the exact bug: gated licensure ≠ licensed
+    expect(g.progression.stage).toBeNull();
   });
 
   it('produces growth gaps for unreached stages with rationale', () => {

--- a/packages/domain-evidence/src/growth/growth.test.ts
+++ b/packages/domain-evidence/src/growth/growth.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceCollection, isDecisionGradeStatus } from '../collection';
+import { projectEvidenceToGraph } from '../projectors/graph';
+import { propagateTrust } from '../trust/propagate';
+import { projectTimeline } from '../timeline/timeline';
+import type { EvidenceClass, EvidenceObject, EvidenceStatus } from '../types';
+import { CAREER_ARC, buildMentorship, projectProfessionalGrowth } from './growth';
+
+function makeObject(id: string, evidenceClass: EvidenceClass, status: EvidenceStatus, sourceId: string, checkedAt?: string): EvidenceObject {
+  return {
+    evidenceId: id, subjectKey: 's1', evidenceClass, label: `${evidenceClass} ${id}`, value: null, status,
+    source: { sourceId, sourceLabel: sourceId, laneType: null, governance: null },
+    trustTier: null, decisionGrade: isDecisionGradeStatus(status),
+    observedAt: null, checkedAt: checkedAt ?? '2026-03-01T00:00:00.000Z', expiresAt: null, freshnessWindowHours: null,
+    integrityHash: null, provenance: { artifactIds: [], receiptIds: [], sourceUrl: null, checksum: null, parserVersion: null },
+    lifecycle: 'active', supersedes: null, supersededBy: null,
+  };
+}
+
+function growthOf(objects: EvidenceObject[], mentorship = [] as any[]) {
+  const collection = buildEvidenceCollection({ subjectKey: 's1', generatedFor: { displayName: 'Ada', npi: '1' }, objects });
+  const graph = projectEvidenceToGraph(collection);
+  const trust = propagateTrust(graph);
+  const timeline = projectTimeline(collection, graph, trust);
+  return projectProfessionalGrowth(collection, trust, timeline, mentorship);
+}
+
+describe('projectProfessionalGrowth (W520)', () => {
+  it('derives milestones with decision-grade status, ordered by time', () => {
+    const g = growthOf([
+      makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD', '2026-02-01T00:00:00.000Z'),
+      makeObject('training:res', 'training', 'notDecisionGrade', 'JHU', '2026-01-01T00:00:00.000Z'),
+    ]);
+    expect(g.milestones.map((m) => m.evidenceId)).toEqual(['training:res', 'cred:lic']); // chronological
+    expect(g.milestones.find((m) => m.evidenceId === 'cred:lic')?.decisionGrade).toBe(true);
+    expect(g.milestones.find((m) => m.evidenceId === 'training:res')?.decisionGrade).toBe(false); // self-reported, honest
+  });
+
+  it('computes a career progression along the arc', () => {
+    const g = growthOf([
+      makeObject('training:res', 'training', 'notDecisionGrade', 'JHU'),
+      makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD'),
+    ]);
+    expect(g.progression.stagesReached).toContain('training');
+    expect(g.progression.stagesReached).toContain('licensed');
+    expect(g.progression.stage).toBe('licensed'); // highest reached on the arc
+    expect(g.progression.nextStage).toBe('practicing');
+    expect(g.progression.progress).toBeGreaterThan(0);
+  });
+
+  it('produces growth gaps for unreached stages with rationale', () => {
+    const g = growthOf([makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD')]);
+    const stages = g.growthGaps.map((x) => x.toReachStage);
+    expect(stages).toContain('board_certified');
+    expect(g.growthGaps.every((x) => x.rationale.length > 0)).toBe(true);
+    // every gap stage is a real arc stage not yet reached
+    for (const x of g.growthGaps) {
+      expect(CAREER_ARC).toContain(x.toReachStage);
+      expect(g.progression.stagesReached).not.toContain(x.toReachStage);
+    }
+  });
+
+  it('carries supplied mentorship (model only — data is external, defaults empty)', () => {
+    const empty = growthOf([makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD')]);
+    expect(empty.mentorship).toEqual([]);
+    const withMentor = growthOf([makeObject('cred:lic', 'licensure', 'checked', 'STATE_BOARD')], [buildMentorship({ from: 's1', to: 'mentor-1', role: 'mentee', context: 'residency' })]);
+    expect(withMentor.mentorship[0]).toEqual({ from: 's1', to: 'mentor-1', role: 'mentee', context: 'residency', since: null });
+  });
+
+  it('is deterministic and invents nothing for an empty record', () => {
+    const empty = growthOf([]);
+    expect(empty.progression.stage).toBeNull();
+    expect(empty.progression.stagesReached).toEqual([]);
+    expect(empty.milestones).toEqual([]);
+    expect(growthOf([])).toEqual(empty);
+  });
+});

--- a/packages/domain-evidence/src/growth/growth.ts
+++ b/packages/domain-evidence/src/growth/growth.ts
@@ -1,0 +1,165 @@
+/**
+ * Professional Growth (Wave 520).
+ *
+ * Pure, deterministic, explainable derivation of a clinician's career arc over the
+ * evidence / trust / timeline projections: professional milestones (C1), a career
+ * progression engine (C2), growth-readiness gaps (C3), and a mentorship relationship
+ * model (C4). Reuses existing projections; no rewrites.
+ *
+ * Honesty: milestones carry their decision-grade status; a stage backed only by
+ * self-reported evidence is shown as reached-but-unverified, never as decision-grade.
+ * Mentorship DATA is external (a clinician's mentors aren't in source-checked
+ * evidence) — this provides the typed model + integration point, not fabricated links.
+ */
+
+import type { EvidenceClass, EvidenceCollection } from '../types';
+import type { TrustProjection } from '../trust/propagate';
+import type { ReputationStanding, TimelineProjection } from '../timeline/timeline';
+
+// ── C1: Milestones ───────────────────────────────────────────────────────────
+
+export type MilestoneType = 'training' | 'licensure' | 'certification' | 'screening' | 'enrollment' | 'employment' | 'recognition';
+
+export interface Milestone {
+  id: string;
+  type: MilestoneType;
+  title: string;
+  occurredAt: string | null;
+  decisionGrade: boolean;
+  evidenceId: string;
+}
+
+const MILESTONE_FOR_CLASS: Partial<Record<EvidenceClass, MilestoneType>> = {
+  training: 'training',
+  licensure: 'licensure',
+  registration: 'licensure',
+  board_cert: 'certification',
+  exclusion: 'screening',
+  enrollment: 'enrollment',
+  employment: 'employment',
+  recognition: 'recognition',
+  acceptance: 'recognition',
+  start: 'employment',
+};
+
+function deriveMilestones(evidence: EvidenceCollection): Milestone[] {
+  const milestones: Milestone[] = [];
+  for (const obj of evidence.objects) {
+    const type = MILESTONE_FOR_CLASS[obj.evidenceClass];
+    if (!type) continue;
+    milestones.push({
+      id: `milestone:${obj.evidenceId}`,
+      type,
+      title: obj.label,
+      occurredAt: obj.checkedAt ?? obj.observedAt ?? null,
+      decisionGrade: obj.decisionGrade,
+      evidenceId: obj.evidenceId,
+    });
+  }
+  milestones.sort((a, b) => {
+    if (a.occurredAt === b.occurredAt) return a.id.localeCompare(b.id);
+    if (a.occurredAt === null) return 1;
+    if (b.occurredAt === null) return -1;
+    return a.occurredAt.localeCompare(b.occurredAt);
+  });
+  return milestones;
+}
+
+// ── C2: Career progression ───────────────────────────────────────────────────
+
+export type CareerStage = 'training' | 'licensed' | 'practicing' | 'board_certified' | 'established';
+export const CAREER_ARC: CareerStage[] = ['training', 'licensed', 'practicing', 'board_certified', 'established'];
+
+export interface CareerProgression {
+  stage: CareerStage | null;
+  stagesReached: CareerStage[];
+  nextStage: CareerStage | null;
+  /** 0..1 through the arc. */
+  progress: number;
+}
+
+function has(evidence: EvidenceCollection, ...classes: EvidenceClass[]): boolean {
+  return classes.some((c) => (evidence.byClass[c]?.length ?? 0) > 0);
+}
+
+function deriveProgression(evidence: EvidenceCollection, standing: ReputationStanding): CareerProgression {
+  const reached = new Set<CareerStage>();
+  if (has(evidence, 'training')) reached.add('training');
+  if (has(evidence, 'licensure', 'registration')) reached.add('licensed');
+  if (has(evidence, 'employment', 'recognition', 'acceptance', 'start')) reached.add('practicing');
+  if (has(evidence, 'board_cert')) reached.add('board_certified');
+  if (standing === 'established') reached.add('established');
+
+  const stagesReached = CAREER_ARC.filter((s) => reached.has(s));
+  const stage = stagesReached.length > 0 ? stagesReached[stagesReached.length - 1] : null;
+  const nextStage = CAREER_ARC.find((s) => !reached.has(s)) ?? null;
+  const progress = stage ? Math.round(((CAREER_ARC.indexOf(stage) + 1) / CAREER_ARC.length) * 10000) / 10000 : 0;
+  return { stage, stagesReached, nextStage, progress };
+}
+
+// ── C3: Growth-readiness gaps ────────────────────────────────────────────────
+
+export interface GrowthGap {
+  id: string;
+  title: string;
+  toReachStage: CareerStage;
+  rationale: string;
+}
+
+const STAGE_GUIDANCE: Record<CareerStage, string> = {
+  training: 'Add source-backed training/education evidence.',
+  licensed: 'Obtain and verify a state license (a launch-spine, decision-grade source).',
+  practicing: 'Record employment or a recognition event.',
+  board_certified: 'Add board certification evidence.',
+  established: 'Strengthen source-backed evidence across dimensions to reach established standing.',
+};
+
+function deriveGrowthGaps(progression: CareerProgression): GrowthGap[] {
+  return CAREER_ARC
+    .filter((s) => !progression.stagesReached.includes(s))
+    .map((s) => ({ id: `growth:${s}`, title: `Advance to ${s.replace('_', ' ')}`, toReachStage: s, rationale: STAGE_GUIDANCE[s] }));
+}
+
+// ── C4: Mentorship model (data is external) ──────────────────────────────────
+
+export type MentorshipRole = 'mentor' | 'mentee';
+
+export interface MentorshipRelationship {
+  from: string;
+  to: string;
+  role: MentorshipRole;
+  context: string;
+  since: string | null;
+}
+
+/** Build a mentorship link from declared inputs (the data source is external — e.g.
+ * a program roster or attestation — not source-checked evidence). */
+export function buildMentorship(input: { from: string; to: string; role: MentorshipRole; context: string; since?: string | null }): MentorshipRelationship {
+  return { from: input.from, to: input.to, role: input.role, context: input.context, since: input.since ?? null };
+}
+
+// ── Projection ───────────────────────────────────────────────────────────────
+
+export interface ProfessionalGrowthProjection {
+  subjectKey: string;
+  milestones: Milestone[];
+  progression: CareerProgression;
+  growthGaps: GrowthGap[];
+  mentorship: MentorshipRelationship[];
+}
+
+export function projectProfessionalGrowth(
+  evidence: EvidenceCollection,
+  _trust: TrustProjection,
+  timeline: TimelineProjection,
+  mentorship: MentorshipRelationship[] = [],
+): ProfessionalGrowthProjection {
+  const progression = deriveProgression(evidence, timeline.reputation.standing);
+  return {
+    subjectKey: evidence.subjectKey,
+    milestones: deriveMilestones(evidence),
+    progression,
+    growthGaps: deriveGrowthGaps(progression),
+    mentorship,
+  };
+}

--- a/packages/domain-evidence/src/growth/growth.ts
+++ b/packages/domain-evidence/src/growth/growth.ts
@@ -78,21 +78,26 @@ export interface CareerProgression {
   progress: number;
 }
 
-function has(evidence: EvidenceCollection, ...classes: EvidenceClass[]): boolean {
-  return classes.some((c) => (evidence.byClass[c]?.length ?? 0) > 0);
+/** A stage is reached only by DECISION-GRADE evidence — never by gated/stale/
+ * self-reported items, which can be career facts but not verified progression. */
+function hasDecisionGrade(evidence: EvidenceCollection, ...classes: EvidenceClass[]): boolean {
+  return classes.some((c) => (evidence.byClass[c] ?? []).some((o) => o.decisionGrade));
 }
 
 function deriveProgression(evidence: EvidenceCollection, standing: ReputationStanding): CareerProgression {
   const reached = new Set<CareerStage>();
-  if (has(evidence, 'training')) reached.add('training');
-  if (has(evidence, 'licensure', 'registration')) reached.add('licensed');
-  if (has(evidence, 'employment', 'recognition', 'acceptance', 'start')) reached.add('practicing');
-  if (has(evidence, 'board_cert')) reached.add('board_certified');
-  if (standing === 'established') reached.add('established');
+  if (hasDecisionGrade(evidence, 'training')) reached.add('training');
+  if (hasDecisionGrade(evidence, 'licensure', 'registration')) reached.add('licensed');
+  if (hasDecisionGrade(evidence, 'employment', 'recognition', 'acceptance', 'start')) reached.add('practicing');
+  if (hasDecisionGrade(evidence, 'board_cert')) reached.add('board_certified');
+  // 'established' is a capstone: every prior career stage verified AND established standing.
+  const careerStagesReached = (['training', 'licensed', 'practicing', 'board_certified'] as CareerStage[]).every((s) => reached.has(s));
+  if (careerStagesReached && standing === 'established') reached.add('established');
 
   const stagesReached = CAREER_ARC.filter((s) => reached.has(s));
   const stage = stagesReached.length > 0 ? stagesReached[stagesReached.length - 1] : null;
-  const nextStage = CAREER_ARC.find((s) => !reached.has(s)) ?? null;
+  const stageIdx = stage ? CAREER_ARC.indexOf(stage) : -1;
+  const nextStage = CAREER_ARC.slice(stageIdx + 1).find((s) => !reached.has(s)) ?? null;
   const progress = stage ? Math.round(((CAREER_ARC.indexOf(stage) + 1) / CAREER_ARC.length) * 10000) / 10000 : 0;
   return { stage, stagesReached, nextStage, progress };
 }

--- a/packages/domain-evidence/src/index.ts
+++ b/packages/domain-evidence/src/index.ts
@@ -99,3 +99,17 @@ export {
   type NotificationCategory,
   type PrioritizedAction,
 } from './intelligence/intelligence';
+
+export {
+  CAREER_ARC,
+  buildMentorship,
+  projectProfessionalGrowth,
+  type CareerProgression,
+  type CareerStage,
+  type GrowthGap,
+  type MentorshipRelationship,
+  type MentorshipRole,
+  type Milestone,
+  type MilestoneType,
+  type ProfessionalGrowthProjection,
+} from './growth/growth';


### PR DESCRIPTION
## Professional Growth (Wave 520)

A deterministic, explainable career-arc layer over the evidence/trust/timeline projections — no rewrites.

- **C1 Milestones** — career events from evidence, each with **honest decision-grade status** (a self-reported residency is reached-but-unverified).
- **C2 Career progression** — `training → licensed → practicing → board_certified → established`; current stage + next stage + progress.
- **C3 Growth gaps** — unreached stages with rationale.
- **C4 Mentorship model** — typed relationship + builder; **data source is external** (defaults empty, never fabricated — like the W330 webhook core).
- **C5 Timeline integration** — milestones derived from the timeline; **C6** Career→Education→Evidence→Trust chain tested.
- `GET /api/professional-growth/[entityId]`.

### Validation
package 5 + route 2 tests · `next build` 14/14, exit 0 · ESLint clean.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)