### PR TITLE
refactor(consolidation): one shared workspace nav + portfolio grouping (Wave 600)

### DIFF
--- a/apps/web/__tests__/workspace-nav.test.ts
+++ b/apps/web/__tests__/workspace-nav.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { WORKSPACE_SURFACES, workspaceNavLinks } from '../lib/workspace/nav';
+
+// W600-C6 — the ONE canonical navigation: grouped portfolio + normalized terminology,
+// shared by every surface so VitalCV reads as one product.
+
+describe('workspaceNavLinks (W600)', () => {
+  it('groups surfaces into the product portfolio in order', () => {
+    const groups = workspaceNavLinks('entity-1').map((g) => g.group);
+    expect(groups).toEqual(['Career', 'Trust', 'Growth', 'Organizations', 'Platform']);
+  });
+
+  it('builds entity-encoded hrefs for every surface (single source of truth)', () => {
+    const links = workspaceNavLinks('a/b').flatMap((g) => g.links);
+    expect(links).toHaveLength(WORKSPACE_SURFACES.length);
+    expect(links.find((l) => l.id === 'ecosystem')?.href).toBe('/ecosystem/a%2Fb');
+    expect(links.find((l) => l.id === 'professional-growth')?.href).toBe('/professional-growth/a%2Fb');
+    expect(links.find((l) => l.id === 'network')?.href).toBe('/network/a%2Fb');
+  });
+
+  it('uses the normalized "Professional …" terminology (C4)', () => {
+    const labels = workspaceNavLinks('e').flatMap((g) => g.links).map((l) => l.label);
+    expect(labels).toContain('Professional Evidence');
+    expect(labels).toContain('Professional Trust');
+    expect(labels).toContain('Professional Growth');
+    expect(labels).toContain('Professional Timeline');
+  });
+
+  it('is deterministic', () => {
+    expect(workspaceNavLinks('x')).toEqual(workspaceNavLinks('x'));
+  });
+});

--- a/apps/web/app/activity/[entityId]/ActivityClient.tsx
+++ b/apps/web/app/activity/[entityId]/ActivityClient.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { CareerEvent, TimelineProjection } from '@vitalcv/domain-evidence';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 function formatDate(value: string | null): string {
   if (!value) return 'Undated';
@@ -55,6 +56,7 @@ export default function ActivityClient({ entityId }: { entityId: string }) {
 
   return (
     <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="activity" />
       <div className="mx-auto w-full max-w-2xl space-y-6 px-4 py-10">
         <header>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Activity</p>

--- a/apps/web/app/career-intelligence/[entityId]/CareerIntelligenceClient.tsx
+++ b/apps/web/app/career-intelligence/[entityId]/CareerIntelligenceClient.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { Insight, IntelligenceProjection } from '@vitalcv/domain-evidence';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 const SEVERITY_TONE: Record<string, string> = {
   high: 'border-rose-300 text-rose-800',
@@ -40,6 +41,7 @@ export default function CareerIntelligenceClient({ entityId }: { entityId: strin
 
   return (
     <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="career-intelligence" />
       <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-10">
         <header>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Intelligence</p>

--- a/apps/web/app/career-map/[entityId]/CareerMapClient.tsx
+++ b/apps/web/app/career-map/[entityId]/CareerMapClient.tsx
@@ -10,11 +10,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import type { GraphProjection, TrustProjection } from '@vitalcv/domain-evidence';
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  const res = await fetch(url, { cache: 'no-store' });
-  return res.ok ? ((await res.json()) as T) : null;
-}
+import { fetchJson } from '@/lib/workspace/fetch-json';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 export default function CareerMapClient({ entityId }: { entityId: string }) {
   const [graph, setGraph] = useState<GraphProjection | null>(null);
@@ -55,6 +52,7 @@ export default function CareerMapClient({ entityId }: { entityId: string }) {
 
   return (
     <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="career-map" />
       <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-10">
         <header>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Map</p>

--- a/apps/web/app/ecosystem/[entityId]/EcosystemHomeClient.tsx
+++ b/apps/web/app/ecosystem/[entityId]/EcosystemHomeClient.tsx
@@ -19,6 +19,8 @@ import type {
   TimelineProjection,
   TrustProjection,
 } from '@vitalcv/domain-evidence';
+import { fetchJson } from '@/lib/workspace/fetch-json';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 interface EcosystemData {
   evidence: EvidenceCollection;
@@ -27,12 +29,6 @@ interface EcosystemData {
   mobility: MobilityOverview;
   readiness: ReadinessProjection;
   organizations: OrganizationGraph;
-}
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  const res = await fetch(url, { cache: 'no-store' });
-  if (!res.ok) return null;
-  return (await res.json()) as T;
 }
 
 const READINESS_TONE: Record<string, string> = {
@@ -112,7 +108,8 @@ export default function EcosystemHomeClient({ entityId }: { entityId: string }) 
 
   return (
     <main className="min-h-screen bg-background">
-      <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-10">
+      <WorkspaceNav entityId={entityId} active="ecosystem" />
+      <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-6">
         {/* Header — Career Health (answers "where am I?") */}
         <header className="rounded-2xl border border-border bg-card p-6">
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Career Ecosystem</p>

--- a/apps/web/app/network/[entityId]/NetworkClient.tsx
+++ b/apps/web/app/network/[entityId]/NetworkClient.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { OrganizationGraph, OrganizationKind } from '@vitalcv/domain-evidence';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 const KIND_LABELS: Record<OrganizationKind, string> = {
   employer: 'Employers',
@@ -46,6 +47,7 @@ export default function NetworkClient({ entityId }: { entityId: string }) {
 
   return (
     <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="network" />
       <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-10">
         <header>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">My Network</p>

--- a/apps/web/app/professional-growth/[entityId]/ProfessionalGrowthClient.tsx
+++ b/apps/web/app/professional-growth/[entityId]/ProfessionalGrowthClient.tsx
@@ -45,7 +45,7 @@ export default function ProfessionalGrowthClient({ entityId }: { entityId: strin
                 Stage: <span className="font-medium capitalize">{data.progression.stage?.replace('_', ' ') ?? 'not yet established'}</span>
                 {data.progression.nextStage && <span className="text-muted-foreground"> · next: {data.progression.nextStage.replace('_', ' ')}</span>}
               </p>
-              <p className="mt-1 text-xs text-muted-foreground">Verified stages: {data.progression.stagesReached.join(', ') || 'none'}</p>
+              <p className="mt-1 text-xs text-muted-foreground">Source-backed stages: {data.progression.stagesReached.join(', ') || 'none'}</p>
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">

--- a/apps/web/app/professional-growth/[entityId]/ProfessionalGrowthClient.tsx
+++ b/apps/web/app/professional-growth/[entityId]/ProfessionalGrowthClient.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+/**
+ * Professional Growth surface (Wave 600) — a thin, accessible view over the growth
+ * API (milestones / progression / gaps). Carries the shared WorkspaceNav.
+ */
+
+import { useEffect, useState } from 'react';
+import type { ProfessionalGrowthProjection } from '@vitalcv/domain-evidence';
+import { fetchJson } from '@/lib/workspace/fetch-json';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
+
+export default function ProfessionalGrowthClient({ entityId }: { entityId: string }) {
+  const [data, setData] = useState<ProfessionalGrowthProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const d = await fetchJson<ProfessionalGrowthProjection>(`/api/professional-growth/${encodeURIComponent(entityId)}`);
+      if (!cancelled) { setData(d); setLoading(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [entityId]);
+
+  return (
+    <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="professional-growth" />
+      <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-8">
+        <header>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Professional Growth</p>
+          <h1 className="mt-1 text-2xl font-semibold text-foreground">Career arc</h1>
+        </header>
+
+        {loading ? (
+          <p role="status" aria-live="polite" className="text-sm text-muted-foreground">Loading growth…</p>
+        ) : !data ? (
+          <p className="text-sm text-muted-foreground">Growth not available.</p>
+        ) : (
+          <>
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <h2 className="mb-2 text-sm font-semibold text-foreground">Progression</h2>
+              <p className="text-sm text-foreground">
+                Stage: <span className="font-medium capitalize">{data.progression.stage?.replace('_', ' ') ?? 'not yet established'}</span>
+                {data.progression.nextStage && <span className="text-muted-foreground"> · next: {data.progression.nextStage.replace('_', ' ')}</span>}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">Verified stages: {data.progression.stagesReached.join(', ') || 'none'}</p>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <h2 className="mb-2 text-sm font-semibold text-foreground">Milestones</h2>
+              {data.milestones.length === 0 ? <p className="text-sm text-muted-foreground">No milestones yet.</p> : (
+                <ul className="space-y-1.5 text-sm">
+                  {data.milestones.map((m) => (
+                    <li key={m.id} className="flex items-center justify-between gap-2">
+                      <span className="text-foreground">{m.title}</span>
+                      <span className="text-xs text-muted-foreground">{m.type} · {m.decisionGrade ? 'source-backed' : 'self-reported'}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <h2 className="mb-2 text-sm font-semibold text-foreground">Growth opportunities</h2>
+              <ul className="space-y-1.5 text-sm">
+                {data.growthGaps.map((g) => (
+                  <li key={g.id}><span className="text-foreground">{g.title}</span> <span className="text-xs text-muted-foreground">— {g.rationale}</span></li>
+                ))}
+              </ul>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/professional-growth/[entityId]/page.tsx
+++ b/apps/web/app/professional-growth/[entityId]/page.tsx
@@ -1,0 +1,14 @@
+import ProfessionalGrowthClient from './ProfessionalGrowthClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Professional Growth · VitalCV',
+  description: 'A clinician’s career arc — milestones, progression, and growth-readiness gaps.',
+  robots: { index: false, follow: false },
+};
+
+export default async function ProfessionalGrowthPage({ params }: { params: Promise<{ entityId: string }> }) {
+  const { entityId } = await params;
+  return <ProfessionalGrowthClient entityId={entityId} />;
+}

--- a/apps/web/app/search/[entityId]/SearchClient.tsx
+++ b/apps/web/app/search/[entityId]/SearchClient.tsx
@@ -10,11 +10,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import type { EvidenceCollection, OrganizationGraph, TimelineProjection } from '@vitalcv/domain-evidence';
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  const res = await fetch(url, { cache: 'no-store' });
-  return res.ok ? ((await res.json()) as T) : null;
-}
+import { fetchJson } from '@/lib/workspace/fetch-json';
+import { WorkspaceNav } from '@/components/workspace/WorkspaceNav';
 
 interface Hit { kind: 'Evidence' | 'Organization' | 'Career Event'; label: string; detail: string }
 
@@ -54,6 +51,7 @@ export default function SearchClient({ entityId }: { entityId: string }) {
 
   return (
     <main className="min-h-screen bg-background">
+      <WorkspaceNav entityId={entityId} active="search" />
       <div className="mx-auto w-full max-w-2xl space-y-5 px-4 py-10">
         <header>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Search</p>

--- a/apps/web/components/workspace/WorkspaceNav.tsx
+++ b/apps/web/components/workspace/WorkspaceNav.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * WorkspaceNav (Wave 600, C1/C5) — the shared, grouped navigation rendered at the
+ * top of every clinician workspace surface, so VitalCV reads as one product.
+ * Accessible: a labelled <nav> with the active surface marked aria-current.
+ */
+
+import Link from 'next/link';
+import { workspaceNavLinks } from '@/lib/workspace/nav';
+
+export function WorkspaceNav({ entityId, active }: { entityId: string; active?: string }) {
+  const groups = workspaceNavLinks(entityId);
+  return (
+    <nav aria-label="Workspace" className="mx-auto w-full max-w-5xl px-4 pt-4">
+      <ul className="flex flex-wrap items-center gap-x-1 gap-y-1 text-xs">
+        {groups.flatMap((g) =>
+          g.links.map((l) => (
+            <li key={l.id}>
+              <Link
+                href={l.href}
+                aria-current={active === l.id ? 'page' : undefined}
+                className={`rounded-full border px-3 py-1 transition-colors ${
+                  active === l.id ? 'border-foreground bg-foreground text-background' : 'border-border text-muted-foreground hover:border-foreground hover:text-foreground'
+                }`}
+              >
+                {l.label}
+              </Link>
+            </li>
+          )),
+        )}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/lib/workspace/fetch-json.ts
+++ b/apps/web/lib/workspace/fetch-json.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared workspace fetch helper (Wave 600, C3) — one definition, replacing the
+ * copy-pasted `fetchJson` in each surface client. Returns null on a non-OK
+ * response so callers gate rendering consistently.
+ */
+export async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { cache: 'no-store' });
+  return res.ok ? ((await res.json()) as T) : null;
+}

--- a/apps/web/lib/workspace/nav.ts
+++ b/apps/web/lib/workspace/nav.ts
@@ -1,0 +1,51 @@
+/**
+ * Workspace navigation (Wave 600, C1/C2/C4) — the ONE canonical, grouped map of
+ * the clinician workspace surfaces, so every surface shares the same navigation
+ * and VitalCV reads as a single product. Pure (entityId → links); no I/O.
+ *
+ * Groups mirror the product portfolio (C2): Career · Trust · Growth · Organizations
+ * · Platform. Labels use the normalized terminology (C4): Professional Identity /
+ * Trust / Evidence / Growth / Mobility.
+ */
+
+export type WorkspaceGroup = 'Career' | 'Trust' | 'Growth' | 'Organizations' | 'Platform';
+
+export interface WorkspaceLink {
+  label: string;
+  href: string;
+  /** The surface's id, for active-state detection. */
+  id: string;
+}
+
+export interface WorkspaceNavGroup {
+  group: WorkspaceGroup;
+  links: WorkspaceLink[];
+}
+
+interface SurfaceDef {
+  id: string;
+  label: string;
+  group: WorkspaceGroup;
+  path: (id: string) => string;
+}
+
+/** Single source of truth for the workspace surfaces (de-duplicated concept, C3). */
+export const WORKSPACE_SURFACES: readonly SurfaceDef[] = [
+  { id: 'ecosystem', label: 'Career Ecosystem', group: 'Career', path: (id) => `/ecosystem/${id}` },
+  { id: 'activity', label: 'Professional Timeline', group: 'Career', path: (id) => `/activity/${id}` },
+  { id: 'career-map', label: 'Professional Evidence', group: 'Trust', path: (id) => `/career-map/${id}` },
+  { id: 'career-intelligence', label: 'Professional Trust', group: 'Trust', path: (id) => `/career-intelligence/${id}` },
+  { id: 'professional-growth', label: 'Professional Growth', group: 'Growth', path: (id) => `/professional-growth/${id}` },
+  { id: 'network', label: 'Organizations', group: 'Organizations', path: (id) => `/network/${id}` },
+  { id: 'search', label: 'Search', group: 'Platform', path: (id) => `/search/${id}` },
+] as const;
+
+const GROUP_ORDER: WorkspaceGroup[] = ['Career', 'Trust', 'Growth', 'Organizations', 'Platform'];
+
+export function workspaceNavLinks(entityId: string): WorkspaceNavGroup[] {
+  const id = encodeURIComponent(entityId);
+  return GROUP_ORDER.map((group) => ({
+    group,
+    links: WORKSPACE_SURFACES.filter((s) => s.group === group).map((s) => ({ id: s.id, label: s.label, href: s.path(id) })),
+  })).filter((g) => g.links.length > 0);
+}


### PR DESCRIPTION
## Platform consolidation (Wave 600) — one product

Makes the surfaces read as ONE product. No new subsystems; URLs unchanged.

- **C1/C2/C4** Canonical grouped nav (`lib/workspace/nav.ts`): Career · Trust · Growth · Organizations · Platform, with normalized 'Professional …' terminology — a single source of truth.
- **C1/C5** Shared `WorkspaceNav` rendered across all 7 clinician surfaces (accessible `<nav>` with `aria-current`).
- **C3** De-duplicated `fetchJson` (one shared helper replacing per-file copies).
- New thin `/professional-growth/[entityId]` page so the Growth group has a destination (noindex, reuses the growth API).

### Validation (C6/C7)
- nav logic 4/4 (grouping order, encoded hrefs, terminology, deterministic).
- `next build` 14/14, exit 0 · ESLint clean.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)