### PR TITLE
feat(solutions): solutions platform — role-aware entry over shared infrastructure (Wave 700)

### DIFF
--- a/apps/web/__tests__/solutions.test.ts
+++ b/apps/web/__tests__/solutions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { SOLUTIONS, solutionFor, type SharedLayer } from '../lib/solutions/solutions';
+import { buildSolutionEvent, isSolutionEvent } from '../lib/solutions/analytics';
+
+const ALL_LAYERS: SharedLayer[] = ['Evidence', 'Trust', 'Timeline', 'Mobility', 'Organization', 'Career Intelligence'];
+
+// Existing surfaces (no new engine per role) — every solution must route to one of these.
+const EXISTING_SURFACE = [/^\/ecosystem\//, /^\/recruiter\/candidate\//, /^\/network\//, /^\/demo$/];
+
+describe('Solutions platform (W700-C6)', () => {
+  it('covers the four customer segments', () => {
+    expect(SOLUTIONS.map((s) => s.role).sort()).toEqual(['clinician', 'enterprise', 'organization', 'recruiter']);
+  });
+
+  it('every solution reuses ONLY the shared layers and routes to an EXISTING surface (no duplicated engine)', () => {
+    for (const s of SOLUTIONS) {
+      expect(s.reuses.length).toBeGreaterThan(0);
+      for (const layer of s.reuses) expect(ALL_LAYERS).toContain(layer);
+      const path = s.primaryPath('demo-clinician');
+      expect(EXISTING_SURFACE.some((re) => re.test(path))).toBe(true);
+    }
+  });
+
+  it('the platform spans every shared layer across its solutions', () => {
+    const union = new Set(SOLUTIONS.flatMap((s) => s.reuses));
+    for (const layer of ALL_LAYERS) expect(union.has(layer)).toBe(true);
+  });
+
+  it('solutionFor resolves and rejects unknown roles', () => {
+    expect(solutionFor('clinician').role).toBe('clinician');
+    // @ts-expect-error unknown role
+    expect(() => solutionFor('astronaut')).toThrow();
+  });
+});
+
+describe('solution analytics (W700-C5)', () => {
+  it('builds and validates the funnel events; rejects malformed', () => {
+    const e = buildSolutionEvent('role_selected', 'recruiter', '2026-06-01T00:00:00.000Z');
+    expect(e.schema).toBe('vitalcv.solution-event.v1');
+    expect(isSolutionEvent(e)).toBe(true);
+    expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'nope', role: null, occurredAt: null })).toBe(false);
+    expect(isSolutionEvent(null)).toBe(false);
+  });
+
+  it('ingestion route accepts a valid event (204) and rejects an invalid one (400)', async () => {
+    const { POST } = await import('../app/api/solution-analytics/route');
+    const ok = await POST(new NextRequest('http://localhost/api/solution-analytics', { method: 'POST', body: JSON.stringify(buildSolutionEvent('demo_requested', 'enterprise', '2026-06-01T00:00:00.000Z')) }));
+    expect(ok.status).toBe(204);
+    const bad = await POST(new NextRequest('http://localhost/api/solution-analytics', { method: 'POST', body: JSON.stringify({ foo: 'bar' }) }));
+    expect(bad.status).toBe(400);
+  });
+});

--- a/apps/web/__tests__/solutions.test.ts
+++ b/apps/web/__tests__/solutions.test.ts
@@ -44,6 +44,9 @@ describe('solution analytics (W700-C5)', () => {
     // strict / fail-closed: invalid role + ANY extra (PII) field are rejected
     expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: 'astronaut', occurredAt: null })).toBe(false);
     expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: null, occurredAt: null, email: 'a@b.com' })).toBe(false);
+    // occurredAt must be a strict ISO instant — arbitrary string PII is rejected
+    expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: null, occurredAt: 'alice@example.com' })).toBe(false);
+    expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: null, occurredAt: '2026-06-01T00:00:00.000Z' })).toBe(true);
   });
 
   it('ingestion route accepts a valid event (204) and rejects an invalid one (400)', async () => {

--- a/apps/web/__tests__/solutions.test.ts
+++ b/apps/web/__tests__/solutions.test.ts
@@ -41,6 +41,9 @@ describe('solution analytics (W700-C5)', () => {
     expect(isSolutionEvent(e)).toBe(true);
     expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'nope', role: null, occurredAt: null })).toBe(false);
     expect(isSolutionEvent(null)).toBe(false);
+    // strict / fail-closed: invalid role + ANY extra (PII) field are rejected
+    expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: 'astronaut', occurredAt: null })).toBe(false);
+    expect(isSolutionEvent({ schema: 'vitalcv.solution-event.v1', type: 'role_selected', role: null, occurredAt: null, email: 'a@b.com' })).toBe(false);
   });
 
   it('ingestion route accepts a valid event (204) and rejects an invalid one (400)', async () => {

--- a/apps/web/app/api/solution-analytics/route.ts
+++ b/apps/web/app/api/solution-analytics/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isSolutionEvent } from '@/lib/solutions/analytics';
+
+export const runtime = 'nodejs';
+
+/**
+ * POST /api/solution-analytics — solutions funnel ingestion (Wave 700, C5).
+ *
+ * Accepts a typed, validated SolutionEvent (no PII). This endpoint is the
+ * ingestion boundary; forwarding to a downstream analytics provider/warehouse is
+ * an external integration (not persisted here). Fails closed on a malformed event.
+ */
+export async function POST(req: NextRequest) {
+  const payload = await req.json().catch(() => null);
+  if (!isSolutionEvent(payload)) {
+    return NextResponse.json({ error: 'invalid_event' }, { status: 400, headers: { 'Cache-Control': 'no-store' } });
+  }
+  // Accepted. A provider integration would forward `payload` here; we keep no PII and no record.
+  return new NextResponse(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
+}

--- a/apps/web/app/solutions/page.tsx
+++ b/apps/web/app/solutions/page.tsx
@@ -1,0 +1,36 @@
+import { SOLUTIONS } from '@/lib/solutions/solutions';
+import { SolutionCard } from '@/components/solutions/SolutionCard';
+import { DEMO_ENTITY_ID } from '@/lib/demo/demo-passport';
+
+export const metadata = {
+  title: 'Solutions · VitalCV',
+  description: 'One source-backed evidence platform for clinicians, recruiters, organizations, and enterprise — choose your path.',
+};
+
+export default function SolutionsPage() {
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-5xl px-4 py-14">
+        <header className="max-w-2xl">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Solutions</p>
+          <h1 className="mt-2 text-3xl font-semibold text-foreground">One platform, every healthcare-career role</h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            Clinicians, recruiters, organizations, and enterprise teams all work from the same source-backed evidence,
+            trust, timeline, mobility, and organization layers. Pick your path — each runs the real product on a sample clinician.
+          </p>
+        </header>
+
+        <section aria-label="Solutions by role" className="mt-10 grid gap-4 sm:grid-cols-2">
+          {SOLUTIONS.map((s) => (
+            <SolutionCard key={s.role} role={s.role} title={s.title} headline={s.headline} valueProps={s.valueProps} reuses={s.reuses} href={s.primaryPath(DEMO_ENTITY_ID)} />
+          ))}
+        </section>
+
+        <p className="mt-10 text-xs text-muted-foreground">
+          Every path reuses the same shared infrastructure — no segment runs a different engine. Source coverage is reported
+          honestly (checked / gated / stale / unknown); acceptance is verifier-policy dependent.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/solutions/SolutionCard.tsx
+++ b/apps/web/components/solutions/SolutionCard.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+/**
+ * Shared solution card (Wave 700, C2) — one component for every customer segment.
+ * Tracks role selection (C5) on navigation. Accessible link card.
+ */
+
+import Link from 'next/link';
+import type { SolutionRole } from '@/lib/solutions/solutions';
+import { trackSolutionEvent } from '@/lib/solutions/analytics';
+
+// Serializable props only — a Server component can't pass the Solution's
+// primaryPath function across the boundary, so the path is resolved upstream.
+export function SolutionCard({ role, title, headline, valueProps, reuses, href }: {
+  role: SolutionRole; title: string; headline: string; valueProps: string[]; reuses: string[]; href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={() => trackSolutionEvent('role_selected', role)}
+      className="group flex h-full flex-col rounded-2xl border border-border bg-card p-6 transition-colors hover:border-foreground"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <span aria-hidden className="text-muted-foreground transition-transform group-hover:translate-x-0.5">→</span>
+      </div>
+      <p className="mt-1 text-sm text-foreground">{headline}</p>
+      <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+        {valueProps.map((p) => (
+          <li key={p} className="flex gap-2"><span aria-hidden>·</span><span>{p}</span></li>
+        ))}
+      </ul>
+      <p className="mt-4 text-[11px] uppercase tracking-wide text-muted-foreground">Reuses: {reuses.join(' · ')}</p>
+    </Link>
+  );
+}

--- a/apps/web/lib/solutions/analytics.ts
+++ b/apps/web/lib/solutions/analytics.ts
@@ -1,0 +1,57 @@
+/**
+ * Solution analytics (Wave 700, C5) — a typed event model + thin tracker for the
+ * solutions funnel: landing engagement, role selection, demo requests, pilot
+ * requests.
+ *
+ * Scope: this is the typed event contract + an ingestion endpoint. The downstream
+ * analytics PROVIDER (warehouse / product analytics) is external — `track` posts
+ * the validated event to /api/solution-analytics, which accepts it (no PII, no
+ * persistence here). Pure event construction; the emit is injectable for testing.
+ */
+
+import type { SolutionRole } from './solutions';
+
+export type SolutionEventType = 'landing_view' | 'role_selected' | 'demo_requested' | 'pilot_requested';
+
+export interface SolutionEvent {
+  schema: 'vitalcv.solution-event.v1';
+  type: SolutionEventType;
+  role: SolutionRole | null;
+  /** ISO timestamp; injected (never read from a clock here) for determinism/testability. */
+  occurredAt: string | null;
+}
+
+const EVENT_TYPES: SolutionEventType[] = ['landing_view', 'role_selected', 'demo_requested', 'pilot_requested'];
+
+export function buildSolutionEvent(type: SolutionEventType, role: SolutionRole | null = null, occurredAt: string | null = null): SolutionEvent {
+  return { schema: 'vitalcv.solution-event.v1', type, role, occurredAt };
+}
+
+/** Validate an inbound event (used by the ingestion endpoint — fail closed). */
+export function isSolutionEvent(value: unknown): value is SolutionEvent {
+  if (!value || typeof value !== 'object') return false;
+  const e = value as Record<string, unknown>;
+  return e.schema === 'vitalcv.solution-event.v1'
+    && typeof e.type === 'string'
+    && EVENT_TYPES.includes(e.type as SolutionEventType)
+    && (e.role === null || typeof e.role === 'string')
+    && (e.occurredAt === null || typeof e.occurredAt === 'string');
+}
+
+export type EventEmit = (event: SolutionEvent) => void;
+
+/** Fire-and-forget tracker. emit defaults to a beacon/fetch to the ingestion route. */
+export function trackSolutionEvent(type: SolutionEventType, role: SolutionRole | null = null, emit?: EventEmit): void {
+  const event = buildSolutionEvent(type, role, new Date().toISOString());
+  if (emit) { emit(event); return; }
+  try {
+    const body = JSON.stringify(event);
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      navigator.sendBeacon('/api/solution-analytics', body);
+    } else if (typeof fetch === 'function') {
+      void fetch('/api/solution-analytics', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, keepalive: true });
+    }
+  } catch {
+    // analytics is best-effort; never block the experience
+  }
+}

--- a/apps/web/lib/solutions/analytics.ts
+++ b/apps/web/lib/solutions/analytics.ts
@@ -22,19 +22,24 @@ export interface SolutionEvent {
 }
 
 const EVENT_TYPES: SolutionEventType[] = ['landing_view', 'role_selected', 'demo_requested', 'pilot_requested'];
+const VALID_ROLES: SolutionRole[] = ['clinician', 'recruiter', 'organization', 'enterprise'];
+const ALLOWED_KEYS = ['schema', 'type', 'role', 'occurredAt'];
 
 export function buildSolutionEvent(type: SolutionEventType, role: SolutionRole | null = null, occurredAt: string | null = null): SolutionEvent {
   return { schema: 'vitalcv.solution-event.v1', type, role, occurredAt };
 }
 
-/** Validate an inbound event (used by the ingestion endpoint — fail closed). */
+/** Validate an inbound event (ingestion boundary — STRICT / fail-closed). Rejects
+ * unknown event types, invalid roles, and ANY extra fields (so a PII-bearing body
+ * can never be accepted). */
 export function isSolutionEvent(value: unknown): value is SolutionEvent {
-  if (!value || typeof value !== 'object') return false;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const e = value as Record<string, unknown>;
+  if (Object.keys(e).some((k) => !ALLOWED_KEYS.includes(k))) return false; // no extra (PII) fields
   return e.schema === 'vitalcv.solution-event.v1'
     && typeof e.type === 'string'
     && EVENT_TYPES.includes(e.type as SolutionEventType)
-    && (e.role === null || typeof e.role === 'string')
+    && (e.role === null || (typeof e.role === 'string' && VALID_ROLES.includes(e.role as SolutionRole)))
     && (e.occurredAt === null || typeof e.occurredAt === 'string');
 }
 

--- a/apps/web/lib/solutions/analytics.ts
+++ b/apps/web/lib/solutions/analytics.ts
@@ -25,6 +25,12 @@ const EVENT_TYPES: SolutionEventType[] = ['landing_view', 'role_selected', 'demo
 const VALID_ROLES: SolutionRole[] = ['clinician', 'recruiter', 'organization', 'enterprise'];
 const ALLOWED_KEYS = ['schema', 'type', 'role', 'occurredAt'];
 
+/** Strict ISO-8601 instant (e.g. 2026-06-01T00:00:00.000Z) — so `occurredAt` can
+ * never carry arbitrary string PII. */
+function isIsoTimestamp(v: unknown): boolean {
+  return typeof v === 'string' && v.length <= 30 && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(v);
+}
+
 export function buildSolutionEvent(type: SolutionEventType, role: SolutionRole | null = null, occurredAt: string | null = null): SolutionEvent {
   return { schema: 'vitalcv.solution-event.v1', type, role, occurredAt };
 }
@@ -40,7 +46,7 @@ export function isSolutionEvent(value: unknown): value is SolutionEvent {
     && typeof e.type === 'string'
     && EVENT_TYPES.includes(e.type as SolutionEventType)
     && (e.role === null || (typeof e.role === 'string' && VALID_ROLES.includes(e.role as SolutionRole)))
-    && (e.occurredAt === null || typeof e.occurredAt === 'string');
+    && (e.occurredAt === null || isIsoTimestamp(e.occurredAt));
 }
 
 export type EventEmit = (event: SolutionEvent) => void;

--- a/apps/web/lib/solutions/solutions.ts
+++ b/apps/web/lib/solutions/solutions.ts
@@ -1,0 +1,82 @@
+/**
+ * Solutions Platform (Wave 700) — multiple customer segments from ONE platform.
+ *
+ * Each solution is an entry point for a role that routes into the EXISTING
+ * surfaces and reuses the same shared infrastructure (Evidence/Trust/Timeline/
+ * Mobility/Organization/Career Intelligence). Pure definitions — no duplicated
+ * functionality, no new subsystems. `reuses` is the explicit, testable contract
+ * that every solution sits on the shared projection layer (C6).
+ */
+
+export type SolutionRole = 'clinician' | 'recruiter' | 'organization' | 'enterprise';
+
+export type SharedLayer =
+  | 'Evidence' | 'Trust' | 'Timeline' | 'Mobility' | 'Organization' | 'Career Intelligence';
+
+export interface Solution {
+  role: SolutionRole;
+  title: string;
+  headline: string;
+  valueProps: string[];
+  /** Primary destination for an entity (the demo clinician, or a real one). */
+  primaryPath: (entityId: string) => string;
+  /** The shared layers this solution reuses (every solution must reuse ≥1). */
+  reuses: SharedLayer[];
+}
+
+export const SOLUTIONS: readonly Solution[] = [
+  {
+    role: 'clinician',
+    title: 'For Clinicians',
+    headline: 'Your career evidence, source-backed and portable.',
+    valueProps: [
+      'Carry a decision-grade readiness packet across opportunities',
+      'See what is checked, gated, or missing — honestly',
+      'Track your career arc from training onward',
+    ],
+    primaryPath: (id) => `/ecosystem/${encodeURIComponent(id)}`,
+    reuses: ['Evidence', 'Trust', 'Timeline', 'Mobility', 'Career Intelligence'],
+  },
+  {
+    role: 'recruiter',
+    title: 'For Recruiters',
+    headline: 'Decide who is ready in under a minute — source-backed.',
+    valueProps: [
+      'A placement verdict with per-state readiness',
+      'Evidence and trust at a glance',
+      'Move forward, request evidence, or pass — honestly',
+    ],
+    primaryPath: (id) => `/recruiter/candidate/${encodeURIComponent(id)}`,
+    reuses: ['Evidence', 'Trust', 'Mobility'],
+  },
+  {
+    role: 'organization',
+    title: 'For Organizations',
+    headline: 'Your provider roster, aggregated into executive metrics.',
+    valueProps: [
+      'Readiness and hiring pipeline across the roster',
+      'Decision-grade coverage and state reach',
+      'The organizations behind every provider',
+    ],
+    primaryPath: (id) => `/network/${encodeURIComponent(id)}`,
+    reuses: ['Organization', 'Trust', 'Evidence'],
+  },
+  {
+    role: 'enterprise',
+    title: 'For Enterprise',
+    headline: 'One source-backed evidence layer across your workforce.',
+    valueProps: [
+      'A versioned, documented platform API + SDK',
+      'Source honesty preserved end to end',
+      'Pilot-ready with a live demo',
+    ],
+    primaryPath: () => '/demo',
+    reuses: ['Evidence', 'Trust', 'Timeline', 'Mobility', 'Organization', 'Career Intelligence'],
+  },
+] as const;
+
+export function solutionFor(role: SolutionRole): Solution {
+  const s = SOLUTIONS.find((x) => x.role === role);
+  if (!s) throw new Error(`Unknown solution role: ${role}`);
+  return s;
+}


### PR DESCRIPTION
## Solutions Platform (Wave 700)

Multiple customer segments from ONE coherent platform — no duplicated functionality.

- **C1/C3** `/solutions` landing with four role entries (clinician / recruiter / organization / enterprise), each routing into the **existing** surfaces; per-role content.
- **C2** Shared `SolutionCard` (one component for every segment; serializable props only).
- **C4** Enterprise path → the live `/demo`.
- **C5** Typed solution-analytics funnel (landing / role_selected / demo / pilot) + a fail-closed ingestion endpoint. *(Provider/warehouse is external — endpoint keeps no PII, no persistence.)*
- **C6** Tests verify every solution **reuses only the shared layers** (Evidence/Trust/Timeline/Mobility/Organization/Career Intelligence), routes to an **existing** surface (no new engine), and the platform spans all layers.

### Validation
6 tests · `next build` 14/14, exit 0 (caught + fixed a Server→Client boundary issue) · ESLint clean.

⚠️ Requires Codex SAFE before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)