### PR TITLE
feat(reasoning): Professional Reasoning Engine — explainable semantic layer (W1200)

### DIFF
--- a/apps/web/__tests__/reasoning-engine.test.ts
+++ b/apps/web/__tests__/reasoning-engine.test.ts
@@ -104,6 +104,29 @@ describe('Reasoning Engine — scenario simulation (C5)', () => {
     );
   });
 
+  it('add_edge pulling real decision-grade evidence into scope cannot raise confidence', () => {
+    const g = graph();
+    // Shallow real reasoning where some decision-grade evidence may be out of scope.
+    const realShallow = reason(g, { maxDepth: 1 });
+
+    // Find a real decision-grade evidence entity and hypothetically wire the subject
+    // straight to it — this would expand the simulated traversal scope.
+    const dgEvidence = g.entities.find((e) => e.kind === 'evidence' && e.decisionGrade);
+    const predicate = g.edges[0]?.predicate ?? 'HAS_EVIDENCE';
+    const scenario = simulateScenario(
+      g,
+      dgEvidence ? [{ type: 'add_edge', edge: { from: g.subjectId, to: dgEvidence.id, predicate } }] : [],
+      { maxDepth: 1 },
+    );
+
+    // Even though the hypothetical edge changes the shown structure, confidence
+    // reflects the real graph and is never inflated by the hypothetical edge.
+    expect(scenario.result.explanation.confidence.decisionGradeEvidence).toBe(
+      realShallow.explanation.confidence.decisionGradeEvidence,
+    );
+    expect(scenario.result.explanation.confidence.score).toBe(realShallow.explanation.confidence.score);
+  });
+
   it('set_status on a hypothetical entity does not confer decision-grade', () => {
     const g = graph();
     const scenario = simulateScenario(g, [

--- a/apps/web/__tests__/reasoning-engine.test.ts
+++ b/apps/web/__tests__/reasoning-engine.test.ts
@@ -113,4 +113,29 @@ describe('Reasoning Engine — scenario simulation (C5)', () => {
     const h = scenario.result.explanation.evidence.find((e) => e.id === 'hypothetical:h1');
     if (h) expect(h.decisionGrade).toBe(false);
   });
+
+  it('set_status UPGRADE on a REAL non-decision-grade entity cannot raise confidence', () => {
+    const g = graph();
+    const baseline = reason(g, { maxDepth: 5 });
+
+    // A real (non-hypothetical) evidence entity that is currently NOT decision-grade
+    // (the demo has self-reported credentials/training).
+    const target = g.entities.find((e) => e.kind === 'evidence' && !e.decisionGrade && !e.id.startsWith('hypothetical:'));
+    expect(target).toBeDefined();
+
+    const scenario = simulateScenario(
+      g,
+      [{ type: 'set_status', target: target!.id, status: 'checked' }],
+      { maxDepth: 5 },
+    );
+
+    // The hypothetically-upgraded real entity must stay non-decision-grade.
+    const inSim = scenario.result.explanation.evidence.find((e) => e.id === target!.id);
+    if (inSim) expect(inSim.decisionGrade).toBe(false);
+
+    // Confidence must not be inflated above the real baseline.
+    expect(scenario.result.explanation.confidence.decisionGradeEvidence).toBeLessThanOrEqual(
+      baseline.explanation.confidence.decisionGradeEvidence,
+    );
+  });
 });

--- a/apps/web/__tests__/reasoning-engine.test.ts
+++ b/apps/web/__tests__/reasoning-engine.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Wave 1200 — Professional Reasoning Engine integration (C7)
+ * ──────────────────────────────────────────────────────────────────────────
+ * One reasoning engine over the canonical Knowledge Graph, consumed by every
+ * product (Career, Recruiter, Organization, Growth, Trust Exchange). Validates:
+ *  - every answer is explained (evidence, relationships, path, confidence) — C4
+ *  - confidence is honest: decision-grade coverage only, never inflated
+ *  - scenario simulation never mutates source data and never confers
+ *    decision-grade — a hypothetical is never real verification — C5
+ *  - traversal is bounded/cached — C6
+ */
+import { describe, expect, it } from 'vitest';
+import { buildDemoPassport } from '../lib/demo/demo-passport';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import {
+  buildKnowledgeGraph,
+  reason,
+  createReasoner,
+  simulateScenario,
+  REASONING_SCHEMA,
+} from '@vitalcv/domain-evidence';
+
+function graph() {
+  return buildKnowledgeGraph(passportToEvidenceCollection(buildDemoPassport()));
+}
+
+describe('Reasoning Engine — one semantic layer (C1/C4/C7)', () => {
+  it('every answer carries evidence, relationships, traversal path, and confidence', () => {
+    const result = reason(graph(), { maxDepth: 3 });
+    expect(result.schema).toBe(REASONING_SCHEMA);
+    expect(result.explanation).toBeDefined();
+    expect(Array.isArray(result.explanation.evidence)).toBe(true);
+    expect(Array.isArray(result.explanation.relationships)).toBe(true);
+    expect(Array.isArray(result.explanation.traversalPath)).toBe(true);
+    expect(result.explanation.traversalPath[0]).toBe(result.plan.root); // path starts at root
+    expect(result.explanation.confidence).toHaveProperty('score');
+    expect(result.explanation.confidence).toHaveProperty('basis');
+    expect(result.hypothetical).toBe(false);
+  });
+
+  it('confidence is honest — decision-grade coverage only, bounded [0,1]', () => {
+    const result = reason(graph(), { maxDepth: 4 });
+    const c = result.explanation.confidence;
+    expect(c.score).toBeGreaterThanOrEqual(0);
+    expect(c.score).toBeLessThanOrEqual(1);
+    expect(c.decisionGradeEvidence).toBeLessThanOrEqual(c.totalEvidence);
+    // The score equals the decision-grade fraction (no inflation).
+    const expected = c.totalEvidence === 0 ? 0 : Math.round((c.decisionGradeEvidence / c.totalEvidence) * 10000) / 10000;
+    expect(c.score).toBe(expected);
+  });
+
+  it('createReasoner caches the index and answers consistently (C6)', () => {
+    const g = graph();
+    const reasoner = createReasoner(g);
+    const a = reasoner.ask({ maxDepth: 2 });
+    const b = reasoner.ask({ maxDepth: 2 });
+    expect(a.answer.map((e) => e.id)).toEqual(b.answer.map((e) => e.id));
+    expect(a.explanation.confidence.score).toBe(b.explanation.confidence.score);
+  });
+});
+
+describe('Reasoning Engine — scenario simulation (C5)', () => {
+  it('never mutates the source graph', () => {
+    const g = graph();
+    const beforeEntities = g.entities.length;
+    const beforeEdges = g.edges.length;
+    const beforeHash = g.contentHash;
+
+    simulateScenario(g, [
+      { type: 'add_entity', entity: { id: 'maybe-board-cert', kind: 'evidence', label: 'Hypothetical board cert', status: 'checked' } },
+      { type: 'add_edge', edge: { from: g.subjectId, to: 'hypothetical:maybe-board-cert', predicate: g.edges[0]?.predicate ?? 'HAS_EVIDENCE' } },
+    ]);
+
+    // Source graph unchanged.
+    expect(g.entities.length).toBe(beforeEntities);
+    expect(g.edges.length).toBe(beforeEdges);
+    expect(g.contentHash).toBe(beforeHash);
+  });
+
+  it('a hypothetical checked credential is NEVER decision-grade and never inflates confidence', () => {
+    const g = graph();
+    const real = reason(g, { maxDepth: 4 });
+
+    const scenario = simulateScenario(
+      g,
+      [
+        // Add a hypothetical credential and mark it "checked" — must stay non-decision-grade.
+        { type: 'add_entity', entity: { id: 'fake-checked', kind: 'evidence', label: 'Pretend checked', status: 'checked' } },
+        { type: 'add_edge', edge: { from: g.subjectId, to: 'hypothetical:fake-checked', predicate: g.edges[0]?.predicate ?? 'HAS_EVIDENCE' } },
+      ],
+      { maxDepth: 4 },
+    );
+
+    expect(scenario.hypothetical).toBe(true);
+    expect(scenario.result.hypothetical).toBe(true);
+
+    // The hypothetical entity exists in the simulated answer but is not decision-grade.
+    const fake = scenario.result.explanation.evidence.find((e) => e.id === 'hypothetical:fake-checked');
+    if (fake) expect(fake.decisionGrade).toBe(false);
+
+    // Confidence is NOT inflated above the real decision-grade fraction.
+    expect(scenario.result.explanation.confidence.decisionGradeEvidence).toBe(
+      real.explanation.confidence.decisionGradeEvidence,
+    );
+  });
+
+  it('set_status on a hypothetical entity does not confer decision-grade', () => {
+    const g = graph();
+    const scenario = simulateScenario(g, [
+      { type: 'add_entity', entity: { id: 'h1', kind: 'evidence', label: 'Hypo', status: 'self_reported' } },
+      { type: 'set_status', target: 'hypothetical:h1', status: 'checked' },
+    ]);
+    const h = scenario.result.explanation.evidence.find((e) => e.id === 'hypothetical:h1');
+    if (h) expect(h.decisionGrade).toBe(false);
+  });
+});

--- a/apps/web/app/api/reasoning/[entityId]/route.ts
+++ b/apps/web/app/api/reasoning/[entityId]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildKnowledgeGraph, reason, type ReasoningQuery, type KnowledgeEntityKind } from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+const ENTITY_KINDS = new Set<KnowledgeEntityKind>(['subject', 'evidence', 'source', 'organization']);
+
+/**
+ * GET /api/reasoning/[entityId] — the Professional Reasoning Engine (Wave 1200,
+ * C1/C4). Reasons over the canonical Knowledge Graph and returns a fully
+ * explained answer: evidence, relationships, traversal path, and an honest
+ * confidence (decision-grade coverage only — never inflated).
+ *
+ * Query params: ?root=<id> ?kind=<kind> ?q=<label> ?decisionGrade=1 ?depth=<n>
+ */
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = buildKnowledgeGraph(collection);
+
+    const { searchParams } = new URL(req.url);
+    const kindParam = searchParams.get('kind');
+    const depthRaw = searchParams.get('depth');
+    const query: ReasoningQuery = {
+      root: searchParams.get('root') ?? undefined,
+      kind: kindParam && ENTITY_KINDS.has(kindParam as KnowledgeEntityKind) ? (kindParam as KnowledgeEntityKind) : undefined,
+      q: searchParams.get('q') ?? undefined,
+      decisionGradeOnly: searchParams.get('decisionGrade') === '1',
+      maxDepth: depthRaw !== null && Number.isFinite(Number(depthRaw)) ? Number(depthRaw) : undefined,
+    };
+
+    const result = reason(graph, query);
+    return NextResponse.json(result, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Reasoning failed.';
+    return NextResponse.json(
+      { error: 'reasoning_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/reasoning/[entityId]/simulate/route.ts
+++ b/apps/web/app/api/reasoning/[entityId]/simulate/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildKnowledgeGraph, simulateScenario, type ScenarioMutation, type ReasoningQuery } from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+
+export const runtime = 'nodejs';
+
+const MUTATION_TYPES = new Set<ScenarioMutation['type']>(['add_entity', 'add_edge', 'set_status']);
+
+/**
+ * POST /api/reasoning/[entityId]/simulate — scenario simulation (Wave 1200, C5).
+ *
+ * Body: `{ mutations: ScenarioMutation[], query?: ReasoningQuery }`.
+ *
+ * Applies hypothetical graph changes to a CLONE — source data is never mutated —
+ * and reasons over the result. The response is always `hypothetical:true`;
+ * simulated evidence is never decision-grade, so a scenario can never be
+ * presented as real verification.
+ */
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const body = (await req.json().catch(() => null)) as
+      | { mutations?: unknown; query?: ReasoningQuery }
+      | null;
+
+    const mutations = Array.isArray(body?.mutations) ? (body!.mutations as ScenarioMutation[]) : [];
+    // Validate mutation shape (only known types).
+    if (!mutations.every((m) => m && typeof m === 'object' && MUTATION_TYPES.has((m as ScenarioMutation).type))) {
+      return NextResponse.json(
+        { error: 'invalid_request', error_description: 'mutations must be an array of {type: add_entity|add_edge|set_status}.' },
+        { status: 400, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const collection = passportToEvidenceCollection(passport);
+    const graph = buildKnowledgeGraph(collection);
+
+    const scenario = simulateScenario(graph, mutations, body?.query ?? {});
+    return NextResponse.json(
+      { schema: 'vitalcv.reasoning-scenario.v1', subjectKey: graph.subjectKey, ...scenario },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Scenario simulation failed.';
+    return NextResponse.json(
+      { error: 'simulation_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/packages/domain-evidence/src/index.ts
+++ b/packages/domain-evidence/src/index.ts
@@ -145,3 +145,19 @@ export {
   type SubgraphResult,
   type KnowledgeSearchQuery,
 } from './knowledge/graph';
+
+export {
+  REASONING_SCHEMA,
+  planTraversal,
+  reason,
+  createReasoner,
+  simulateScenario,
+  type ReasoningQuery,
+  type TraversalPlan,
+  type ReasoningConfidence,
+  type ReasoningExplanation,
+  type ReasoningResult,
+  type Reasoner,
+  type ScenarioMutation,
+  type ScenarioResult,
+} from './reasoning/engine';

--- a/packages/domain-evidence/src/reasoning/engine.ts
+++ b/packages/domain-evidence/src/reasoning/engine.ts
@@ -272,10 +272,25 @@ export function simulateScenario(
   };
 
   const result = reason(draft, query, undefined, /* hypothetical */ true);
+
+  // CONFIDENCE HONESTY: a simulation must never raise confidence above reality.
+  // Hypothetical structure of ANY kind — added entities, added edges that pull
+  // real decision-grade evidence into scope, or status upgrades — must not
+  // inflate it. So the reported confidence is computed from the REAL graph for
+  // the same query; the hypothetical only changes the shown structure, never the
+  // verification standing. This closes the add_edge reachability vector.
+  const realConfidence = reason(graph, query, undefined, false).explanation.confidence;
+  result.explanation.confidence = {
+    ...realConfidence,
+    basis:
+      realConfidence.basis +
+      ' Confidence reflects the real graph; hypothetical structure cannot raise it.',
+  };
+
   return {
     hypothetical: true,
     mutations,
     result,
-    note: 'Hypothetical scenario over a cloned graph. Source data unchanged; simulated evidence is not decision-grade and is not real verification.',
+    note: 'Hypothetical scenario over a cloned graph. Source data unchanged; simulated evidence is not decision-grade, and confidence reflects the real graph — a scenario is never real verification.',
   };
 }

--- a/packages/domain-evidence/src/reasoning/engine.ts
+++ b/packages/domain-evidence/src/reasoning/engine.ts
@@ -247,9 +247,12 @@ export function simulateScenario(
       const entity = draft.entities.find((e) => e.id === m.target);
       if (entity) {
         entity.status = m.status ?? entity.status;
-        // A hypothetical status change does NOT confer decision-grade.
-        if (isHypothetical(entity)) entity.decisionGrade = false;
-        else entity.decisionGrade = entity.status === 'checked';
+        // A SIMULATED status change is hypothetical — it can never CONFER
+        // decision-grade, on a hypothetical OR a real entity. Otherwise a scenario
+        // could upgrade a real gated/self-reported credential to "checked" and
+        // inflate confidence, presenting a hypothetical as real verification.
+        // It may only REMOVE decision-grade (a hypothetical downgrade).
+        entity.decisionGrade = false;
       }
     }
   }

--- a/packages/domain-evidence/src/reasoning/engine.ts
+++ b/packages/domain-evidence/src/reasoning/engine.ts
@@ -1,0 +1,278 @@
+/**
+ * Professional Reasoning Engine (Wave 1200)
+ * ──────────────────────────────────────────────────────────────────────────
+ * The semantic layer over the canonical Knowledge Graph. It answers queries by
+ * planning and executing bounded traversals, and EVERY answer is explainable:
+ * it returns the evidence, the relationships used, the traversal path, and an
+ * honest confidence. It reuses the graph's `decisionGrade`/`trustScore` — it
+ * adds NO new trust or business logic.
+ *
+ * Two honesty rules are load-bearing:
+ *  1. Confidence is derived ONLY from decision-grade (checked) evidence. Gated,
+ *     self-reported, and hypothetical evidence never raise it.
+ *  2. Scenario simulation (C5) NEVER mutates source data and is always tagged
+ *     `hypothetical:true`. A simulated result can never be presented as real
+ *     verification — hypothetical entities are excluded from decision-grade
+ *     confidence even if a scenario marks them 'checked'.
+ */
+import {
+  indexKnowledgeGraph,
+  traverseSubgraph,
+  searchEntities,
+  type KnowledgeGraph,
+  type KnowledgeGraphIndex,
+  type KnowledgeEntity,
+  type KnowledgeEntityKind,
+  type KnowledgeEdge,
+} from '../knowledge/graph';
+import type { EvidenceStatus } from '../types';
+
+export const REASONING_SCHEMA = 'vitalcv.reasoning.v1' as const;
+
+const MAX_REASONING_DEPTH = 6;
+
+export interface ReasoningQuery {
+  /** Traversal root entity id (defaults to the subject). */
+  root?: string;
+  /** Restrict the answer to a kind. */
+  kind?: KnowledgeEntityKind;
+  /** Case-insensitive label match for the answer. */
+  q?: string;
+  /** Only decision-grade entities in the answer. */
+  decisionGradeOnly?: boolean;
+  /** Traversal depth bound (clamped to [0,6]). */
+  maxDepth?: number;
+}
+
+/** C2: the chosen traversal, with a rationale (explainability). */
+export interface TraversalPlan {
+  root: string;
+  maxDepth: number;
+  rationale: string;
+}
+
+/** Honest confidence — bounded by decision-grade coverage, never inflated. */
+export interface ReasoningConfidence {
+  /** 0..1: decisionGradeEvidence / totalEvidence in scope (0 when no evidence). */
+  score: number;
+  decisionGradeEvidence: number;
+  totalEvidence: number;
+  basis: string;
+}
+
+/** C4: every response carries a full explanation. */
+export interface ReasoningExplanation {
+  /** Evidence entities within the reasoned subgraph. */
+  evidence: KnowledgeEntity[];
+  /** Relationships traversed. */
+  relationships: KnowledgeEdge[];
+  /** Entity ids in BFS visitation order. */
+  traversalPath: string[];
+  confidence: ReasoningConfidence;
+}
+
+export interface ReasoningResult {
+  schema: typeof REASONING_SCHEMA;
+  subjectKey: string;
+  query: ReasoningQuery;
+  plan: TraversalPlan;
+  /** Entities answering the query. */
+  answer: KnowledgeEntity[];
+  explanation: ReasoningExplanation;
+  /** True only for scenario simulations. Real reasoning is always false. */
+  hypothetical: boolean;
+  /** Whether the traversal hit a bound (honest partial-answer signal). */
+  truncated: boolean;
+}
+
+/** C2: pick the root and depth for a query, with a stated rationale. */
+export function planTraversal(graph: KnowledgeGraph, query: ReasoningQuery): TraversalPlan {
+  const root = query.root && query.root.trim() ? query.root.trim() : graph.subjectId;
+  const requested = query.maxDepth ?? 2;
+  const maxDepth = Number.isFinite(requested) ? Math.min(MAX_REASONING_DEPTH, Math.max(0, Math.floor(requested))) : 2;
+  const rationale =
+    `Traverse from ${root === graph.subjectId ? 'the subject' : `"${root}"`} to depth ${maxDepth}` +
+    (query.kind ? `, answering ${query.kind} entities` : '') +
+    (query.decisionGradeOnly ? ', decision-grade only' : '') +
+    '.';
+  return { root, maxDepth, rationale };
+}
+
+function computeConfidence(evidence: KnowledgeEntity[], hypothetical: boolean): ReasoningConfidence {
+  // Hypothetical entities NEVER count toward decision-grade confidence.
+  const real = evidence.filter((e) => !isHypothetical(e));
+  const total = real.length;
+  const decisionGrade = real.filter((e) => e.decisionGrade).length;
+  const score = total === 0 ? 0 : round4(decisionGrade / total);
+  const basis =
+    total === 0
+      ? 'No real evidence in scope — confidence 0.'
+      : `${decisionGrade}/${total} in-scope evidence items are decision-grade (checked).` +
+        (hypothetical ? ' Hypothetical evidence excluded from confidence.' : '');
+  return { score, decisionGradeEvidence: decisionGrade, totalEvidence: total, basis };
+}
+
+function round4(v: number): number {
+  return Math.round(v * 10000) / 10000;
+}
+
+/**
+ * C1/C3/C4: reason over a graph. Plans a traversal (C2), projects only the
+ * needed subgraph (C3 optimizer — never the whole graph unless asked), filters
+ * the answer, and returns a full explanation (C4). `index` may be supplied to
+ * reuse a cached adjacency index across queries (C6).
+ */
+export function reason(
+  graph: KnowledgeGraph,
+  query: ReasoningQuery = {},
+  index?: KnowledgeGraphIndex,
+  hypothetical = false,
+): ReasoningResult {
+  const idx = index ?? indexKnowledgeGraph(graph);
+  const plan = planTraversal(graph, query);
+  const sub = traverseSubgraph(idx, plan.root, plan.maxDepth);
+
+  // Answer = entities in the reasoned subgraph matching the query criteria.
+  const needle = query.q?.trim().toLowerCase();
+  const answer = sub.entities
+    .filter((e) => {
+      if (query.kind && e.kind !== query.kind) return false;
+      if (query.decisionGradeOnly && !e.decisionGrade) return false;
+      if (needle && !e.label.toLowerCase().includes(needle)) return false;
+      return true;
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const evidence = sub.entities.filter((e) => e.kind === 'evidence');
+  const explanation: ReasoningExplanation = {
+    evidence,
+    relationships: sub.edges,
+    traversalPath: sub.entities.map((e) => e.id),
+    confidence: computeConfidence(evidence, hypothetical),
+  };
+
+  return {
+    schema: REASONING_SCHEMA,
+    subjectKey: graph.subjectKey,
+    query,
+    plan,
+    answer,
+    explanation,
+    hypothetical,
+    truncated: sub.truncated,
+  };
+}
+
+/** A reusable reasoner that caches the adjacency index across queries (C6). */
+export interface Reasoner {
+  graph: KnowledgeGraph;
+  ask(query?: ReasoningQuery): ReasoningResult;
+}
+
+export function createReasoner(graph: KnowledgeGraph): Reasoner {
+  const index = indexKnowledgeGraph(graph); // built once, reused (cached traversals)
+  return {
+    graph,
+    ask: (query: ReasoningQuery = {}) => reason(graph, query, index, false),
+  };
+}
+
+// ── C5: scenario simulation ──────────────────────────────────────────────────
+
+const HYPOTHETICAL_PREFIX = 'hypothetical:';
+
+function isHypothetical(entity: KnowledgeEntity): boolean {
+  return entity.id.startsWith(HYPOTHETICAL_PREFIX);
+}
+
+/** A hypothetical mutation. Source data is never touched. */
+export interface ScenarioMutation {
+  type: 'add_entity' | 'add_edge' | 'set_status';
+  /** add_entity: a new evidence entity (id auto-prefixed `hypothetical:`). */
+  entity?: { id: string; kind: KnowledgeEntityKind; label: string; status?: EvidenceStatus };
+  /** add_edge: connect two existing/added entities. */
+  edge?: { from: string; to: string; predicate: KnowledgeEdge['predicate'] };
+  /** set_status: hypothetically change an existing entity's status. */
+  target?: string;
+  status?: EvidenceStatus;
+}
+
+export interface ScenarioResult {
+  /** Always true — a simulation can never be presented as real verification. */
+  hypothetical: true;
+  mutations: ScenarioMutation[];
+  /** Reasoning over the simulated graph (its `hypothetical` is also true). */
+  result: ReasoningResult;
+  note: string;
+}
+
+/**
+ * Simulate hypothetical graph changes WITHOUT mutating the source graph. Returns
+ * a brand-new derived graph; the input is deep-cloned first. Added entities are
+ * id-prefixed `hypothetical:` and are excluded from decision-grade confidence,
+ * so a scenario can never inflate a real verification claim.
+ */
+export function simulateScenario(
+  graph: KnowledgeGraph,
+  mutations: ScenarioMutation[],
+  query: ReasoningQuery = {},
+): ScenarioResult {
+  // Deep clone — the source graph is never mutated.
+  const draft: KnowledgeGraph = structuredClone(graph);
+
+  for (const m of mutations) {
+    if (m.type === 'add_entity' && m.entity) {
+      const id = m.entity.id.startsWith(HYPOTHETICAL_PREFIX) ? m.entity.id : `${HYPOTHETICAL_PREFIX}${m.entity.id}`;
+      draft.entities.push({
+        id,
+        kind: m.entity.kind,
+        label: m.entity.label,
+        // Hypothetical evidence is NEVER decision-grade, regardless of status.
+        decisionGrade: false,
+        status: m.entity.status ?? null,
+        evidenceClass: null,
+        trustScore: null,
+        source: null,
+      });
+    } else if (m.type === 'add_edge' && m.edge) {
+      draft.edges.push({
+        id: `${HYPOTHETICAL_PREFIX}${m.edge.from}->${m.edge.to}:${m.edge.predicate}`,
+        from: m.edge.from,
+        to: m.edge.to,
+        predicate: m.edge.predicate,
+        decisionGrade: false,
+        evidenceIds: [],
+      });
+    } else if (m.type === 'set_status' && m.target) {
+      const entity = draft.entities.find((e) => e.id === m.target);
+      if (entity) {
+        entity.status = m.status ?? entity.status;
+        // A hypothetical status change does NOT confer decision-grade.
+        if (isHypothetical(entity)) entity.decisionGrade = false;
+        else entity.decisionGrade = entity.status === 'checked';
+      }
+    }
+  }
+
+  // Recompute stats over the simulated graph (kept honest for the explanation).
+  const byKind: Record<KnowledgeEntityKind, number> = { subject: 0, evidence: 0, source: 0, organization: 0 };
+  let decisionGradeEntityCount = 0;
+  for (const e of draft.entities) {
+    byKind[e.kind] += 1;
+    if (e.decisionGrade) decisionGradeEntityCount += 1;
+  }
+  draft.stats = {
+    entityCount: draft.entities.length,
+    edgeCount: draft.edges.length,
+    decisionGradeEntityCount,
+    byKind,
+  };
+
+  const result = reason(draft, query, undefined, /* hypothetical */ true);
+  return {
+    hypothetical: true,
+    mutations,
+    result,
+    note: 'Hypothetical scenario over a cloned graph. Source data unchanged; simulated evidence is not decision-grade and is not real verification.',
+  };
+}


### PR DESCRIPTION
## W1200 — Graph Reasoning Platform

The semantic layer over the canonical Knowledge Graph. Reuses the KG; **no new business logic**. Every answer is explainable.

### Deliverables
| | |
|---|---|
| **C1 Query engine** | `reason(graph, query)` — plan → bounded traversal → filtered answer |
| **C2 Traversal planner** | `planTraversal()` — root + clamped depth + stated rationale |
| **C3 Projection optimizer** | reasons over only the needed subgraph, not the whole graph |
| **C4 Explanation engine** | EVERY result returns evidence, relationships, traversal path, and an **honest confidence** (decision-grade coverage only — never inflated) |
| **C5 Scenario simulation** | `simulateScenario()` — hypothetical mutations over a **clone**; source never mutated; result always `hypothetical:true`; simulated evidence is **never decision-grade** |
| **C6 Performance** | `createReasoner()` caches the adjacency index across queries; traversal bounded |
| **C7 Integration test** | one engine across products; confidence honesty + simulation immutability asserted (6 cases) |

### The two load-bearing honesty rules
1. **Confidence is derived only from decision-grade (checked) evidence.** Gated/self-reported/hypothetical never raise it.
2. **A simulation can never be presented as real verification** — hypothetical entities are id-prefixed `hypothetical:` and excluded from decision-grade confidence even if a scenario marks them `checked`. The source graph is deep-cloned, never mutated.

### Routes
- `GET /api/reasoning/[entityId]` — explained reasoning result
- `POST /api/reasoning/[entityId]/simulate` — scenario simulation

### Validation
- `reasoning-engine.test.ts` → 6/6
- `turbo run build --filter @vitalcv/web` → compiled + lint clean; both routes registered
- No banned strings; lockfile untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)