### PR TITLE
feat(platform-cloud): Professional Trust Cloud — multi-tenant platform layer (W900)

### DIFF
--- a/apps/web/__tests__/trust-cloud.test.ts
+++ b/apps/web/__tests__/trust-cloud.test.ts
@@ -7,6 +7,8 @@
  * telemetry, and fail-closed enterprise readiness.
  */
 import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET as manifestGET } from '../app/api/platform/manifest/route';
 import { demoPlatformRegistry, resolveCloudIdentity, findTenant } from '../lib/platform-cloud/registry';
 import { demoApplicationRegistry, authorizeApplication } from '../lib/platform-cloud/applications';
 import { emitPlatformEvent, type EventSubscription } from '../lib/platform-cloud/events';
@@ -89,6 +91,29 @@ describe('Trust Cloud — telemetry (C6) & readiness (C7)', () => {
     expect(summary.total).toBe(2);
     expect(summary.byType['exchange.verified']).toBe(2);
     expect(summary.tenantCount).toBe(2);
+  });
+
+  it('rejects semantically-invalid timestamps that pass the regex shape', () => {
+    const summary = aggregateTelemetry([
+      { type: 'exchange.verified', tenantId: 'x', occurredAt: '2026-99-99T99:99:99Z' }, // impossible
+      { type: 'exchange.verified', tenantId: 'x', occurredAt: '2026-02-30T00:00:00Z' }, // overflow day
+      { type: 'exchange.verified', tenantId: 'x', occurredAt: '2026-06-20T00:00:00Z' }, // valid
+    ]);
+    expect(summary.total).toBe(1);
+  });
+
+  it('manifest is tenant-scoped — a partner app sees only its own tenants (no cross-tenant leak)', async () => {
+    // app-coastal-ats is registered for coastal-staffing only.
+    const res = await manifestGET(new NextRequest('http://localhost/api/platform/manifest?appId=app-coastal-ats'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tenants.map((t: { tenantId: string }) => t.tenantId)).toEqual(['coastal-staffing']);
+    expect(json.readiness.tenants.every((t: { tenantId: string }) => t.tenantId === 'coastal-staffing')).toBe(true);
+  });
+
+  it('manifest fails closed for an unknown app', async () => {
+    const res = await manifestGET(new NextRequest('http://localhost/api/platform/manifest?appId=app-unknown'));
+    expect(res.status).toBe(403);
   });
 
   it('fail-closed readiness: a tenant with no signing secret is not ready', () => {

--- a/apps/web/__tests__/trust-cloud.test.ts
+++ b/apps/web/__tests__/trust-cloud.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Wave 900 — Professional Trust Cloud Platform integration (C7)
+ * ──────────────────────────────────────────────────────────────────────────
+ * One cloud serving multiple products, organizations, and partner apps over the
+ * shared trust infrastructure. Validates platform federation, cross-org identity,
+ * the application registry + partner authz, signed event streaming, no-PII
+ * telemetry, and fail-closed enterprise readiness.
+ */
+import { describe, expect, it } from 'vitest';
+import { demoPlatformRegistry, resolveCloudIdentity, findTenant } from '../lib/platform-cloud/registry';
+import { demoApplicationRegistry, authorizeApplication } from '../lib/platform-cloud/applications';
+import { emitPlatformEvent, type EventSubscription } from '../lib/platform-cloud/events';
+import { aggregateTelemetry } from '../lib/platform-cloud/telemetry';
+import { platformReadiness } from '../lib/platform-cloud/readiness';
+import { computeSignature } from '../lib/platform/webhook';
+
+describe('Trust Cloud — federation & identity (C1/C2)', () => {
+  it('hosts multiple tenants (products and organizations)', () => {
+    const reg = demoPlatformRegistry();
+    expect(reg.tenants.length).toBeGreaterThanOrEqual(2);
+    expect(reg.tenants.some((t) => t.kind === 'product')).toBe(true);
+    expect(reg.tenants.some((t) => t.kind === 'organization')).toBe(true);
+  });
+
+  it('resolves one provider identity across tenants by org affiliation', () => {
+    const reg = demoPlatformRegistry();
+    const res = resolveCloudIdentity(reg, 'demo-clinician', ['org-mercy-health']);
+    expect(res.subjectKey).toBe('demo-clinician');
+    // Mercy is a member of the coastal-staffing tenant's federation.
+    expect(res.tenants.map((t) => t.tenantId)).toContain('coastal-staffing');
+    // An unaffiliated org resolves to no tenants (honest absence).
+    expect(resolveCloudIdentity(reg, 'demo-clinician', ['org-nowhere']).tenants).toHaveLength(0);
+  });
+});
+
+describe('Trust Cloud — application registry & partner authz (C3/C4)', () => {
+  it('authorizes by scope and tenant, fails closed otherwise', () => {
+    const apps = demoApplicationRegistry();
+    expect(authorizeApplication(apps, 'app-vitalcv-web', 'reasoning:read', 'vitalcv-careers').authorized).toBe(true);
+    // Partner ATS lacks reasoning:read.
+    expect(authorizeApplication(apps, 'app-coastal-ats', 'reasoning:read').authorized).toBe(false);
+    // Unknown app fails closed.
+    expect(authorizeApplication(apps, 'app-unknown', 'identity:read').authorized).toBe(false);
+    // Right scope, wrong tenant fails closed.
+    expect(authorizeApplication(apps, 'app-coastal-ats', 'trust:read', 'vitalcv-careers').authorized).toBe(false);
+  });
+});
+
+describe('Trust Cloud — event streaming (C5)', () => {
+  const subs: EventSubscription[] = [
+    { subscriptionId: 'sub-1', tenantId: 'coastal-staffing', types: ['exchange.verified'], endpoint: 'https://ats/hook', secret: 's1' },
+    { subscriptionId: 'sub-2', tenantId: 'coastal-staffing', types: ['readiness.changed'], endpoint: 'https://x/hook', secret: 's2' },
+    { subscriptionId: 'sub-3', tenantId: 'vitalcv-careers', types: ['exchange.verified'], endpoint: 'https://y/hook', secret: 's3' },
+  ];
+  const injected = { eventId: 'evt-1', timestamp: '2026-06-20T00:00:00.000Z' };
+
+  it('fans an event only to matching tenant+type subscriptions, signed with the shared HMAC', () => {
+    const deliveries = emitPlatformEvent(
+      { type: 'exchange.verified', tenantId: 'coastal-staffing', subjectKey: 'demo-clinician', payload: { ok: true } },
+      subs,
+      injected,
+    );
+    expect(deliveries.map((d) => d.subscriptionId)).toEqual(['sub-1']); // not sub-2 (type) or sub-3 (tenant)
+    // Signature matches the vetted webhook HMAC over `${timestamp}.${body}`.
+    const d = deliveries[0];
+    expect(d.signature).toBe(computeSignature(d.timestamp, d.body, 's1'));
+  });
+
+  it('drops unknown event types (fails closed, never throws)', () => {
+    const deliveries = emitPlatformEvent(
+      { type: 'not.a.real.type' as never, tenantId: 'coastal-staffing', subjectKey: 'x', payload: {} },
+      subs,
+      injected,
+    );
+    expect(deliveries).toHaveLength(0);
+  });
+});
+
+describe('Trust Cloud — telemetry (C6) & readiness (C7)', () => {
+  it('aggregates counts and rejects records carrying PII / extra keys', () => {
+    const summary = aggregateTelemetry([
+      { type: 'exchange.verified', tenantId: 'coastal-staffing', occurredAt: '2026-06-20T00:00:00.000Z' },
+      { type: 'exchange.verified', tenantId: 'vitalcv-careers', occurredAt: '2026-06-20T00:00:01.000Z' },
+      // Rejected: extra key (possible PII).
+      { type: 'evidence.updated', tenantId: 'coastal-staffing', occurredAt: '2026-06-20T00:00:02.000Z', name: 'Dr. Maya Chen' },
+      // Rejected: unknown type.
+      { type: 'bogus', tenantId: 'x', occurredAt: '2026-06-20T00:00:03.000Z' },
+    ]);
+    expect(summary.total).toBe(2);
+    expect(summary.byType['exchange.verified']).toBe(2);
+    expect(summary.tenantCount).toBe(2);
+  });
+
+  it('fail-closed readiness: a tenant with no signing secret is not ready', () => {
+    const reg = demoPlatformRegistry();
+    // No secret configured for any tenant.
+    const none = platformReadiness(reg, () => undefined, true);
+    expect(none.ready).toBe(false);
+    expect(none.tenants.every((t) => !t.ready)).toBe(true);
+
+    // All tenants configured ⇒ ready.
+    const all = platformReadiness(reg, () => 'configured-secret', true);
+    expect(all.ready).toBe(true);
+  });
+});

--- a/apps/web/app/api/platform/manifest/route.ts
+++ b/apps/web/app/api/platform/manifest/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { demoPlatformRegistry } from '@/lib/platform-cloud/registry';
-import { demoApplicationRegistry, authorizeApplication } from '@/lib/platform-cloud/applications';
+import { demoApplicationRegistry, authorizeApplication, findApplication } from '@/lib/platform-cloud/applications';
 import { platformReadiness } from '@/lib/platform-cloud/readiness';
 import { PLATFORM_EVENT_TYPES } from '@/lib/platform-cloud/events';
 
@@ -19,7 +19,8 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const appId = searchParams.get('appId')?.trim() ?? '';
 
-    const auth = authorizeApplication(demoApplicationRegistry(), appId, 'identity:read');
+    const appRegistry = demoApplicationRegistry();
+    const auth = authorizeApplication(appRegistry, appId, 'identity:read');
     if (!auth.authorized) {
       return NextResponse.json(
         { error: 'app_not_authorized', error_description: auth.reason },
@@ -27,21 +28,36 @@ export async function GET(req: NextRequest) {
       );
     }
 
+    // Tenant isolation: an app sees ONLY the tenants it is registered for, never
+    // the whole cloud. (authorizeApplication passed, so the app exists.)
+    const app = findApplication(appRegistry, appId)!;
+    const allowed = new Set(app.tenantIds);
+
     const registry = demoPlatformRegistry();
     const production = process.env.NODE_ENV === 'production';
-    const readiness = platformReadiness(
+    const fullReadiness = platformReadiness(
       registry,
       (tenantId) => process.env[`TRUST_CLOUD_SECRET_${tenantId.toUpperCase().replace(/-/g, '_')}`],
       production,
     );
 
+    const tenants = registry.tenants
+      .filter((t) => allowed.has(t.tenantId))
+      .map((t) => ({ tenantId: t.tenantId, name: t.name, kind: t.kind }));
+    const scopedReadinessTenants = fullReadiness.tenants.filter((t) => allowed.has(t.tenantId));
+
     return NextResponse.json(
       {
         schema: 'vitalcv.platform-manifest.v1',
         cloudId: registry.cloudId,
-        tenants: registry.tenants.map((t) => ({ tenantId: t.tenantId, name: t.name, kind: t.kind })),
+        tenants,
         eventTypes: PLATFORM_EVENT_TYPES,
-        readiness,
+        readiness: {
+          cloudId: fullReadiness.cloudId,
+          production,
+          tenants: scopedReadinessTenants,
+          ready: scopedReadinessTenants.every((t) => t.ready),
+        },
       },
       { status: 200, headers: { 'Cache-Control': 'no-store' } },
     );

--- a/apps/web/app/api/platform/manifest/route.ts
+++ b/apps/web/app/api/platform/manifest/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { demoPlatformRegistry } from '@/lib/platform-cloud/registry';
+import { demoApplicationRegistry, authorizeApplication } from '@/lib/platform-cloud/applications';
+import { platformReadiness } from '@/lib/platform-cloud/readiness';
+import { PLATFORM_EVENT_TYPES } from '@/lib/platform-cloud/events';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/platform/manifest — Partner API (Wave 900, C4).
+ *
+ * The scope-gated capability surface for the Professional Trust Cloud. A partner
+ * app authenticates via `?appId=` and must hold the `identity:read` scope. The
+ * manifest lists tenants, event types, and per-tenant readiness — never any
+ * provider data. Fails closed: unknown app or missing scope ⇒ 403.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const appId = searchParams.get('appId')?.trim() ?? '';
+
+    const auth = authorizeApplication(demoApplicationRegistry(), appId, 'identity:read');
+    if (!auth.authorized) {
+      return NextResponse.json(
+        { error: 'app_not_authorized', error_description: auth.reason },
+        { status: 403, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const registry = demoPlatformRegistry();
+    const production = process.env.NODE_ENV === 'production';
+    const readiness = platformReadiness(
+      registry,
+      (tenantId) => process.env[`TRUST_CLOUD_SECRET_${tenantId.toUpperCase().replace(/-/g, '_')}`],
+      production,
+    );
+
+    return NextResponse.json(
+      {
+        schema: 'vitalcv.platform-manifest.v1',
+        cloudId: registry.cloudId,
+        tenants: registry.tenants.map((t) => ({ tenantId: t.tenantId, name: t.name, kind: t.kind })),
+        eventTypes: PLATFORM_EVENT_TYPES,
+        readiness,
+      },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Manifest unavailable.';
+    return NextResponse.json(
+      { error: 'manifest_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/lib/platform-cloud/applications.ts
+++ b/apps/web/lib/platform-cloud/applications.ts
@@ -1,0 +1,91 @@
+/**
+ * Professional Trust Cloud — application registry & partner authz (Wave 900, C3/C4)
+ * ──────────────────────────────────────────────────────────────────────────
+ * The registry of partner applications permitted to call the platform, each
+ * with explicit scopes. Authorization is least-privilege and fails closed: an
+ * unknown app, or an app lacking the required scope, is refused. This is the
+ * gate in front of the Partner APIs (C4) — it governs ACCESS, never trust.
+ */
+
+/** Coarse-grained, read-oriented scopes. No scope grants write to source data. */
+export type PlatformScope =
+  | 'identity:read'
+  | 'evidence:read'
+  | 'trust:read'
+  | 'reasoning:read'
+  | 'events:subscribe';
+
+export const PLATFORM_SCOPES: readonly PlatformScope[] = [
+  'identity:read',
+  'evidence:read',
+  'trust:read',
+  'reasoning:read',
+  'events:subscribe',
+] as const;
+
+export interface Application {
+  appId: string;
+  name: string;
+  /** Granted scopes (subset of PLATFORM_SCOPES). */
+  scopes: PlatformScope[];
+  /** Tenants this app may operate within (empty ⇒ none). */
+  tenantIds: string[];
+}
+
+export interface ApplicationRegistry {
+  applications: Application[];
+}
+
+export function findApplication(registry: ApplicationRegistry, appId: string): Application | null {
+  const id = appId?.trim();
+  if (!id) return null;
+  return registry.applications.find((a) => a.appId === id) ?? null;
+}
+
+export interface AuthorizationResult {
+  authorized: boolean;
+  reason: string;
+}
+
+/**
+ * C4: authorize a partner call. Fails closed on unknown app, missing scope, or a
+ * tenant the app is not registered for. Returns a reason for honest 403 copy.
+ */
+export function authorizeApplication(
+  registry: ApplicationRegistry,
+  appId: string,
+  scope: PlatformScope,
+  tenantId?: string,
+): AuthorizationResult {
+  const app = findApplication(registry, appId);
+  if (!app) return { authorized: false, reason: `Unknown application "${appId}".` };
+  if (!app.scopes.includes(scope)) {
+    return { authorized: false, reason: `Application "${appId}" lacks the "${scope}" scope.` };
+  }
+  if (tenantId && !app.tenantIds.includes(tenantId)) {
+    return { authorized: false, reason: `Application "${appId}" is not registered for tenant "${tenantId}".` };
+  }
+  return { authorized: true, reason: 'Authorized.' };
+}
+
+/** The demo application registry: one first-party app, one partner app. */
+export function demoApplicationRegistry(): ApplicationRegistry {
+  return {
+    applications: [
+      {
+        appId: 'app-vitalcv-web',
+        name: 'VitalCV Web',
+        scopes: ['identity:read', 'evidence:read', 'trust:read', 'reasoning:read', 'events:subscribe'],
+        tenantIds: ['vitalcv-careers', 'coastal-staffing'],
+      },
+      {
+        appId: 'app-coastal-ats',
+        name: 'Coastal ATS Integration',
+        // A partner ATS may read trust/identity and subscribe to events, but not
+        // reason or read raw evidence.
+        scopes: ['identity:read', 'trust:read', 'events:subscribe'],
+        tenantIds: ['coastal-staffing'],
+      },
+    ],
+  };
+}

--- a/apps/web/lib/platform-cloud/events.ts
+++ b/apps/web/lib/platform-cloud/events.ts
@@ -1,0 +1,98 @@
+/**
+ * Professional Trust Cloud — event streaming (Wave 900, C5)
+ * ──────────────────────────────────────────────────────────────────────────
+ * A platform event stream that reuses the vetted webhook HMAC signer
+ * (`computeSignature`) — no new crypto. Subscribers register per-tenant for
+ * event types; emitting an event produces one signed delivery per matching
+ * subscription. Platform event types are distinct from the internal webhook
+ * types, so we sign our own envelope rather than coupling to WebhookEventType.
+ *
+ * Pure/deterministic: eventId + timestamp are injected (no clock), so the same
+ * inputs always produce the same signed deliveries — testable and replayable.
+ */
+import { computeSignature } from '@/lib/platform/webhook';
+
+export type PlatformEventType =
+  | 'exchange.issued'
+  | 'exchange.verified'
+  | 'readiness.changed'
+  | 'evidence.updated';
+
+export const PLATFORM_EVENT_TYPES: readonly PlatformEventType[] = [
+  'exchange.issued',
+  'exchange.verified',
+  'readiness.changed',
+  'evidence.updated',
+] as const;
+
+export const PLATFORM_EVENT_SCHEMA = 'vitalcv.platform-event.v1' as const;
+
+export interface EventSubscription {
+  subscriptionId: string;
+  tenantId: string;
+  /** Event types this subscriber wants. */
+  types: PlatformEventType[];
+  /** Delivery endpoint (opaque here). */
+  endpoint: string;
+  /** Per-subscription signing secret. */
+  secret: string;
+}
+
+export interface PlatformEvent<T = unknown> {
+  type: PlatformEventType;
+  tenantId: string;
+  /** Subject the event concerns — a stable key, never PII. */
+  subjectKey: string;
+  payload: T;
+}
+
+export interface SignedEventDelivery {
+  subscriptionId: string;
+  endpoint: string;
+  eventId: string;
+  /** Canonical JSON envelope that was signed. */
+  body: string;
+  /** Unix/ISO timestamp bound into the signature (replay context). */
+  timestamp: string;
+  /** `sha256=<hex>` over `${timestamp}.${body}`. */
+  signature: string;
+}
+
+function isValidType(t: unknown): t is PlatformEventType {
+  return typeof t === 'string' && (PLATFORM_EVENT_TYPES as readonly string[]).includes(t);
+}
+
+/**
+ * Fan an event out to matching subscriptions (tenant AND type), producing one
+ * signed delivery each. `eventId`/`timestamp` are injected for determinism.
+ * Returns [] for an unknown event type (fails closed, never throws).
+ */
+export function emitPlatformEvent(
+  event: PlatformEvent,
+  subscriptions: EventSubscription[],
+  injected: { eventId: string; timestamp: string },
+): SignedEventDelivery[] {
+  if (!isValidType(event.type)) return [];
+  return subscriptions
+    .filter((sub) => sub.tenantId === event.tenantId && sub.types.includes(event.type))
+    .map((sub) => {
+      const envelope = {
+        schema: PLATFORM_EVENT_SCHEMA,
+        id: injected.eventId,
+        type: event.type,
+        tenantId: event.tenantId,
+        subjectKey: event.subjectKey,
+        occurredAt: injected.timestamp,
+        payload: event.payload,
+      };
+      const body = JSON.stringify(envelope);
+      return {
+        subscriptionId: sub.subscriptionId,
+        endpoint: sub.endpoint,
+        eventId: injected.eventId,
+        body,
+        timestamp: injected.timestamp,
+        signature: computeSignature(injected.timestamp, body, sub.secret),
+      };
+    });
+}

--- a/apps/web/lib/platform-cloud/readiness.ts
+++ b/apps/web/lib/platform-cloud/readiness.ts
@@ -1,0 +1,55 @@
+/**
+ * Professional Trust Cloud — enterprise deployment readiness (Wave 900, C7)
+ * ──────────────────────────────────────────────────────────────────────────
+ * A fail-closed readiness check for multi-tenant deployment. It reports, per
+ * tenant, whether the configuration required to operate securely is present —
+ * without ever inventing a default secret. A tenant with no configured signing
+ * secret is reported NOT ready (it must not sign/verify with a guessable key).
+ */
+import type { PlatformRegistry } from './registry';
+
+export interface TenantReadiness {
+  tenantId: string;
+  ready: boolean;
+  /** Human-readable blockers (empty when ready). */
+  blockers: string[];
+}
+
+export interface PlatformReadiness {
+  cloudId: string;
+  ready: boolean;
+  tenants: TenantReadiness[];
+  /** True only in production posture (stricter requirements). */
+  production: boolean;
+}
+
+/**
+ * Resolve readiness. `secretFor` returns a configured signing secret for a
+ * tenant (e.g. from env), or undefined if unset — injected so this stays pure
+ * and testable. In production an unset secret is a hard blocker; outside
+ * production it is a warning-level blocker but still reported.
+ */
+export function platformReadiness(
+  registry: PlatformRegistry,
+  secretFor: (tenantId: string) => string | undefined,
+  production: boolean,
+): PlatformReadiness {
+  const tenants: TenantReadiness[] = registry.tenants.map((t) => {
+    const blockers: string[] = [];
+
+    const secret = secretFor(t.tenantId);
+    if (!secret || secret.trim().length === 0) {
+      blockers.push(`No signing secret configured for tenant "${t.tenantId}".`);
+    }
+    if (t.federation.members.length === 0) {
+      blockers.push(`Tenant "${t.tenantId}" federation has no members.`);
+    }
+
+    return { tenantId: t.tenantId, ready: blockers.length === 0, blockers };
+  });
+
+  // Fail closed: the cloud is ready only if every tenant is ready. In production
+  // this is enforced; outside production we still report it honestly.
+  const ready = tenants.every((t) => t.ready);
+  return { cloudId: registry.cloudId, ready, tenants, production };
+}

--- a/apps/web/lib/platform-cloud/registry.ts
+++ b/apps/web/lib/platform-cloud/registry.ts
@@ -1,0 +1,86 @@
+/**
+ * Professional Trust Cloud — platform federation & identity (Wave 900, C1/C2)
+ * ──────────────────────────────────────────────────────────────────────────
+ * One cloud hosting MANY federations (tenants) — products and organizations —
+ * over the shared trust infrastructure. This extends the per-federation model
+ * (lib/exchange/federation.ts) up one level into a multi-tenant registry. It
+ * holds no trust data: it answers "which tenants/orgs exist" and "which tenants
+ * reference this provider", never "how trustworthy is this provider" — trust is
+ * always re-derived from evidence by the consuming product.
+ */
+import type { FederationRegistry } from '@/lib/exchange/federation';
+import { isFederationMember } from '@/lib/exchange/federation';
+
+export interface PlatformTenant {
+  tenantId: string;
+  name: string;
+  /** The product/organization kind this tenant represents. */
+  kind: 'product' | 'organization';
+  /** This tenant's federation (members + roles). */
+  federation: FederationRegistry;
+}
+
+export interface PlatformRegistry {
+  cloudId: string;
+  tenants: PlatformTenant[];
+}
+
+export function findTenant(registry: PlatformRegistry, tenantId: string): PlatformTenant | null {
+  const id = tenantId?.trim();
+  if (!id) return null;
+  return registry.tenants.find((t) => t.tenantId === id) ?? null;
+}
+
+/**
+ * C2: cross-organization identity. A provider is identified by one stable
+ * subjectKey across the whole cloud; this resolves WHICH tenants/orgs reference
+ * that identity (by org membership), without copying any provider data between
+ * tenants. Returns an honest, evidence-free index — presence, not trust.
+ */
+export interface CloudIdentityResolution {
+  subjectKey: string;
+  /** Tenants whose federation includes the given org key(s) for this provider. */
+  tenants: { tenantId: string; name: string; kind: PlatformTenant['kind'] }[];
+}
+
+export function resolveCloudIdentity(
+  registry: PlatformRegistry,
+  subjectKey: string,
+  affiliatedOrgKeys: string[],
+): CloudIdentityResolution {
+  const orgs = new Set(affiliatedOrgKeys.map((k) => k.trim()).filter(Boolean));
+  const tenants = registry.tenants
+    .filter((t) => [...orgs].some((org) => isFederationMember(t.federation, org)))
+    .map((t) => ({ tenantId: t.tenantId, name: t.name, kind: t.kind }));
+  return { subjectKey, tenants };
+}
+
+/** The demo cloud: one product tenant + one staffing-org tenant. */
+export function demoPlatformRegistry(): PlatformRegistry {
+  return {
+    cloudId: 'vitalcv-trust-cloud',
+    tenants: [
+      {
+        tenantId: 'vitalcv-careers',
+        name: 'VitalCV Careers',
+        kind: 'product',
+        federation: {
+          federationId: 'vitalcv-careers-fed',
+          members: [{ orgKey: 'org-vitalcv-network', name: 'VitalCV Network', roles: ['issuer', 'verifier'] }],
+        },
+      },
+      {
+        tenantId: 'coastal-staffing',
+        name: 'Coastal Staffing Network',
+        kind: 'organization',
+        federation: {
+          federationId: 'coastal-fed',
+          members: [
+            { orgKey: 'org-mercy-health', name: 'Mercy Health System', roles: ['issuer'] },
+            { orgKey: 'org-coastal-staffing', name: 'Coastal Staffing Network', roles: ['verifier'] },
+          ],
+        },
+      },
+    ],
+  };
+}

--- a/apps/web/lib/platform-cloud/telemetry.ts
+++ b/apps/web/lib/platform-cloud/telemetry.ts
@@ -28,6 +28,19 @@ const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
 const ALLOWED_KEYS = new Set(['type', 'tenantId', 'occurredAt']);
 
 /**
+ * A real UTC instant — not just the right SHAPE. The regex alone accepts
+ * impossible values like `2026-99-99T99:99:99Z` or `2026-02-30T...`. We also
+ * require the string to parse AND round-trip to the same calendar Y-M-D H:M:S,
+ * which rejects out-of-range months/days/times (Date would roll them over).
+ */
+function isRealIsoInstant(value: string): boolean {
+  if (!ISO_8601.test(value)) return false;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return false;
+  return d.toISOString().slice(0, 19) === value.slice(0, 19);
+}
+
+/**
  * Strict validation — mirrors the solutions-analytics posture. A record must
  * have ONLY the three allowed keys, a known event type, a non-empty tenantId,
  * and a strict ISO-8601 timestamp. Anything else (extra keys = possible PII) is
@@ -40,7 +53,7 @@ export function isTelemetryRecord(value: unknown): value is TelemetryRecord {
   const r = value as Record<string, unknown>;
   if (!(PLATFORM_EVENT_TYPES as readonly string[]).includes(r.type as string)) return false;
   if (typeof r.tenantId !== 'string' || r.tenantId.trim().length === 0 || r.tenantId.length > 64) return false;
-  if (typeof r.occurredAt !== 'string' || !ISO_8601.test(r.occurredAt)) return false;
+  if (typeof r.occurredAt !== 'string' || !isRealIsoInstant(r.occurredAt)) return false;
   return true;
 }
 

--- a/apps/web/lib/platform-cloud/telemetry.ts
+++ b/apps/web/lib/platform-cloud/telemetry.ts
@@ -1,0 +1,61 @@
+/**
+ * Professional Trust Cloud — platform telemetry (Wave 900, C6)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Aggregate operational counters over platform events — counts only, no PII.
+ * Telemetry records carry an event type, a tenant, and a timestamp; never a
+ * subjectKey, name, or payload. Records that don't validate are dropped, so a
+ * caller cannot smuggle identifying data into the metrics.
+ */
+import { PLATFORM_EVENT_TYPES, type PlatformEventType } from './events';
+
+/** A single telemetry data point. Deliberately free of any provider identity. */
+export interface TelemetryRecord {
+  type: PlatformEventType;
+  tenantId: string;
+  /** ISO-8601 UTC, no sub-identity. */
+  occurredAt: string;
+}
+
+export interface TelemetrySummary {
+  total: number;
+  byType: Record<string, number>;
+  byTenant: Record<string, number>;
+  /** Distinct tenants seen. */
+  tenantCount: number;
+}
+
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+const ALLOWED_KEYS = new Set(['type', 'tenantId', 'occurredAt']);
+
+/**
+ * Strict validation — mirrors the solutions-analytics posture. A record must
+ * have ONLY the three allowed keys, a known event type, a non-empty tenantId,
+ * and a strict ISO-8601 timestamp. Anything else (extra keys = possible PII) is
+ * rejected.
+ */
+export function isTelemetryRecord(value: unknown): value is TelemetryRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length !== ALLOWED_KEYS.size || !keys.every((k) => ALLOWED_KEYS.has(k))) return false;
+  const r = value as Record<string, unknown>;
+  if (!(PLATFORM_EVENT_TYPES as readonly string[]).includes(r.type as string)) return false;
+  if (typeof r.tenantId !== 'string' || r.tenantId.trim().length === 0 || r.tenantId.length > 64) return false;
+  if (typeof r.occurredAt !== 'string' || !ISO_8601.test(r.occurredAt)) return false;
+  return true;
+}
+
+/** Aggregate validated records into counters. Invalid records are dropped. */
+export function aggregateTelemetry(records: unknown[]): TelemetrySummary {
+  const byType: Record<string, number> = {};
+  const byTenant: Record<string, number> = {};
+  let total = 0;
+
+  for (const rec of records) {
+    if (!isTelemetryRecord(rec)) continue;
+    total += 1;
+    byType[rec.type] = (byType[rec.type] ?? 0) + 1;
+    byTenant[rec.tenantId] = (byTenant[rec.tenantId] ?? 0) + 1;
+  }
+
+  return { total, byType, byTenant, tenantCount: Object.keys(byTenant).length };
+}


### PR DESCRIPTION
## W900 — Professional Trust Cloud Platform

One cloud serving multiple products, organizations, and partner applications over the shared trust infrastructure. **Extends** the merged exchange-federation + webhook layers; no rewrites.

### Deliverables
| | |
|---|---|
| **C1 Platform federation** | `registry.ts` — `PlatformRegistry` hosts many per-tenant federations (products + organizations) |
| **C2 Cross-org identity** | `resolveCloudIdentity()` — one stable `subjectKey` resolves which tenants reference a provider (presence, never trust; honest absence) |
| **C3 Application registry** | `applications.ts` — partner apps with explicit least-privilege scopes + allowed tenants |
| **C4 Partner APIs** | `authorizeApplication()` fails closed; `GET /api/platform/manifest` is the scope-gated capability surface (no provider data) |
| **C5 Event streaming** | `events.ts` — per-tenant/type subscriptions, signed deliveries via the vetted `computeSignature` HMAC (**no new crypto**), deterministic |
| **C6 Telemetry** | `telemetry.ts` — counts only; strict validation drops records with unknown type, bad timestamp, or extra keys (**no PII smuggling**) |
| **C7 Enterprise readiness** | `readiness.ts` — fail-closed per-tenant config check; a tenant with no signing secret is **NOT ready** (never a default key) |

### Honesty / security posture
- The cloud registry holds **no trust data** — it answers "which tenants exist / reference this provider", never "how trustworthy". Trust is always re-derived from evidence by the consuming product.
- Event signing reuses the same HMAC primitive as webhooks and the Trust Exchange.
- Telemetry is structurally PII-free (extra keys rejected).
- Readiness never invents a default secret.

### Validation
- `trust-cloud.test.ts` → 7/7 (all six layers)
- `turbo run build --filter @vitalcv/web` → compiled + lint clean; `/api/platform/manifest` registered
- No banned strings; lockfile untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)