### PR TITLE
feat(workspace-config): Configurable Platform — declarative tenant config over shared services (W1300)

### DIFF
--- a/apps/web/__tests__/workspace-config.test.ts
+++ b/apps/web/__tests__/workspace-config.test.ts
@@ -83,38 +83,51 @@ describe('Configurable Platform (C1/C6)', () => {
     expect(validateWorkspaceConfig(degenerate).valid).toBe(false);
   });
 
-  it('route authorizes the caller: an app may only assume a granted role', async () => {
-    const cfg = demoWorkspaceConfig();
-    // Partner ATS is granted recruiter only.
-    expect(isRoleGranted(cfg, 'app-coastal-ats', 'recruiter')).toBe(true);
-    expect(isRoleGranted(cfg, 'app-coastal-ats', 'clinician')).toBe(false);
-    expect(isRoleGranted(cfg, '', 'clinician')).toBe(false);
+  it('route authenticates the caller before authorizing — a claimed appId is not enough', async () => {
+    // Configure per-app keys (server-side secrets).
+    process.env.WORKSPACE_APP_KEY_APP_COASTAL_ATS = 'coastal-secret';
+    process.env.WORKSPACE_APP_KEY_APP_VITALCV_WEB = 'web-secret';
 
-    // Route: ATS requesting the broad clinician role is refused.
-    const denied = await workspaceGET(
-      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=clinician&appId=app-coastal-ats'),
-      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
-    );
+    const call = (qs: string, headers?: Record<string, string>) =>
+      workspaceGET(
+        new NextRequest(`http://localhost/api/workspace-config/demo-clinician?${qs}`, { headers }),
+        { params: Promise.resolve({ entityId: 'demo-clinician' }) },
+      );
+
+    // THE BYPASS CODEX FOUND: claiming a granted appId WITHOUT its key must fail
+    // closed (401) — you cannot just assert appId=app-vitalcv-web.
+    const spoof = await call('role=clinician&appId=app-vitalcv-web');
+    expect(spoof.status).toBe(401);
+    expect((await spoof.json()).error).toBe('app_not_authenticated');
+
+    // Wrong key → 401.
+    const wrongKey = await call('role=clinician&appId=app-vitalcv-web&appKey=not-the-key');
+    expect(wrongKey.status).toBe(401);
+
+    // No appId at all → 401.
+    expect((await call('role=clinician')).status).toBe(401);
+
+    // Authenticated app, but role NOT granted → 403 (authn passes, authz fails).
+    const denied = await call('role=clinician&appId=app-coastal-ats', { 'x-app-key': 'coastal-secret' });
     expect(denied.status).toBe(403);
     expect((await denied.json()).error).toBe('role_not_granted');
 
-    // Route: no appId at all is refused (no anonymous broadest-role access).
-    const anon = await workspaceGET(
-      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=clinician'),
-      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
-    );
-    expect(anon.status).toBe(403);
-
-    // Route: ATS in its granted recruiter role is allowed.
-    const ok = await workspaceGET(
-      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=recruiter&appId=app-coastal-ats'),
-      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
-    );
+    // Authenticated + granted role → 200, still correctly section-scoped.
+    const ok = await call('role=recruiter&appId=app-coastal-ats', { 'x-app-key': 'coastal-secret' });
     expect(ok.status).toBe(200);
     const json = await ok.json();
     expect(json.role.roleId).toBe('recruiter');
-    // The recruiter projection cannot see raw evidence.
     expect(json.projection.hiddenSections).toContain('evidence');
+
+    delete process.env.WORKSPACE_APP_KEY_APP_COASTAL_ATS;
+    delete process.env.WORKSPACE_APP_KEY_APP_VITALCV_WEB;
+  });
+
+  it('role grant check is fail-closed at the unit level too', () => {
+    const cfg = demoWorkspaceConfig();
+    expect(isRoleGranted(cfg, 'app-coastal-ats', 'recruiter')).toBe(true);
+    expect(isRoleGranted(cfg, 'app-coastal-ats', 'clinician')).toBe(false);
+    expect(isRoleGranted(cfg, '', 'clinician')).toBe(false);
   });
 
   it('workflow steps are gated by REAL decision-grade facts, not configuration', () => {

--- a/apps/web/__tests__/workspace-config.test.ts
+++ b/apps/web/__tests__/workspace-config.test.ts
@@ -7,10 +7,12 @@
  * gates, and routes — it NEVER alters, fabricates, or elevates trust facts.
  */
 import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET as workspaceGET } from '../app/api/workspace-config/[entityId]/route';
 import { buildDemoPassport } from '../lib/demo/demo-passport';
 import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
 import { composeCareerModel } from '@vitalcv/domain-evidence';
-import { demoWorkspaceConfig, validateWorkspaceConfig, findRole } from '../lib/workspace-config/config';
+import { demoWorkspaceConfig, validateWorkspaceConfig, findRole, isRoleGranted } from '../lib/workspace-config/config';
 import { projectForRole, CAREER_SECTIONS } from '../lib/workspace-config/roles';
 import { evaluateWorkflow } from '../lib/workspace-config/workflows';
 import { evaluateAutomations } from '../lib/workspace-config/automation';
@@ -63,6 +65,56 @@ describe('Configurable Platform (C1/C6)', () => {
       // Visible sections are always a subset of the canonical sections.
       expect(proj.visibleSections.every((s) => (CAREER_SECTIONS as readonly string[]).includes(s))).toBe(true);
     }
+  });
+
+  it('rejects an empty/degenerate workflow gate — config cannot force completion', () => {
+    const m = model();
+    const bad = demoWorkspaceConfig();
+    bad.workflows[0].steps[0].gate = {}; // empty gate
+    expect(validateWorkspaceConfig(bad).valid).toBe(false);
+
+    // And defensively: an empty gate never satisfies (step is not 'complete').
+    const evaln = evaluateWorkflow(bad.workflows[0], m);
+    expect(evaln.steps[0].state).not.toBe('complete');
+
+    // A degenerate "needs 0" gate is also non-factual.
+    const degenerate = demoWorkspaceConfig();
+    degenerate.workflows[0].steps[0].gate = { minDecisionGradeEvidence: 0 };
+    expect(validateWorkspaceConfig(degenerate).valid).toBe(false);
+  });
+
+  it('route authorizes the caller: an app may only assume a granted role', async () => {
+    const cfg = demoWorkspaceConfig();
+    // Partner ATS is granted recruiter only.
+    expect(isRoleGranted(cfg, 'app-coastal-ats', 'recruiter')).toBe(true);
+    expect(isRoleGranted(cfg, 'app-coastal-ats', 'clinician')).toBe(false);
+    expect(isRoleGranted(cfg, '', 'clinician')).toBe(false);
+
+    // Route: ATS requesting the broad clinician role is refused.
+    const denied = await workspaceGET(
+      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=clinician&appId=app-coastal-ats'),
+      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
+    );
+    expect(denied.status).toBe(403);
+    expect((await denied.json()).error).toBe('role_not_granted');
+
+    // Route: no appId at all is refused (no anonymous broadest-role access).
+    const anon = await workspaceGET(
+      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=clinician'),
+      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
+    );
+    expect(anon.status).toBe(403);
+
+    // Route: ATS in its granted recruiter role is allowed.
+    const ok = await workspaceGET(
+      new NextRequest('http://localhost/api/workspace-config/demo-clinician?role=recruiter&appId=app-coastal-ats'),
+      { params: Promise.resolve({ entityId: 'demo-clinician' }) },
+    );
+    expect(ok.status).toBe(200);
+    const json = await ok.json();
+    expect(json.role.roleId).toBe('recruiter');
+    // The recruiter projection cannot see raw evidence.
+    expect(json.projection.hiddenSections).toContain('evidence');
   });
 
   it('workflow steps are gated by REAL decision-grade facts, not configuration', () => {

--- a/apps/web/__tests__/workspace-config.test.ts
+++ b/apps/web/__tests__/workspace-config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Wave 1300 — Configurable Platform integration (C6)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Chain: Workspace → Roles → Workflow → Evidence → Trust → Career →
+ * Organization → Automation, all driven by declarative configuration over the
+ * shared platform services. Asserts the load-bearing rule: configuration scopes,
+ * gates, and routes — it NEVER alters, fabricates, or elevates trust facts.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildDemoPassport } from '../lib/demo/demo-passport';
+import { passportToEvidenceCollection } from '../lib/evidence/passport-to-evidence';
+import { composeCareerModel } from '@vitalcv/domain-evidence';
+import { demoWorkspaceConfig, validateWorkspaceConfig, findRole } from '../lib/workspace-config/config';
+import { projectForRole, CAREER_SECTIONS } from '../lib/workspace-config/roles';
+import { evaluateWorkflow } from '../lib/workspace-config/workflows';
+import { evaluateAutomations } from '../lib/workspace-config/automation';
+import { projectDashboard } from '../lib/workspace-config/dashboard';
+
+function model() {
+  return composeCareerModel(passportToEvidenceCollection(buildDemoPassport()));
+}
+
+describe('Configurable Platform (C1/C6)', () => {
+  it('the demo workspace configuration validates', () => {
+    expect(validateWorkspaceConfig(demoWorkspaceConfig())).toEqual({ valid: true, errors: [] });
+  });
+
+  it('catches a malformed config (unknown section / role / event)', () => {
+    const bad = demoWorkspaceConfig();
+    bad.roles[0].visibleSections = ['not_a_section' as never];
+    bad.automations[0].on = 'not.an.event' as never;
+    const res = validateWorkspaceConfig(bad);
+    expect(res.valid).toBe(false);
+    expect(res.errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('role projection HIDES sections but never alters the underlying facts', () => {
+    const m = model();
+    const recruiter = findRole(demoWorkspaceConfig(), 'recruiter')!;
+    const proj = projectForRole(m, recruiter.roleId, recruiter.visibleSections);
+
+    // Recruiter cannot see raw evidence or growth.
+    expect(proj.hiddenSections).toContain('evidence');
+    expect(proj.hiddenSections).toContain('growth');
+    expect(proj.sections.evidence).toBeUndefined();
+
+    // Visible sections are the SAME facts — pass-through by reference, unchanged.
+    expect(proj.sections.trust).toBe(m.trust);
+    expect(proj.sections.readiness).toBe(m.readiness);
+    // meta decision-grade count is the real one — projection can't inflate it.
+    expect(proj.meta.decisionGradeEvidence).toBe(m.meta.decisionGradeEvidence);
+  });
+
+  it('no role can surface more decision-grade evidence than actually exists', () => {
+    const m = model();
+    const config = demoWorkspaceConfig();
+    for (const role of config.roles) {
+      const proj = projectForRole(m, role.roleId, role.visibleSections);
+      // If trust is visible, its decision-grade count equals the real model's.
+      if (proj.sections.trust) {
+        expect(proj.sections.trust.overall.decisionGradeEvidence).toBe(m.trust.overall.decisionGradeEvidence);
+      }
+      // Visible sections are always a subset of the canonical sections.
+      expect(proj.visibleSections.every((s) => (CAREER_SECTIONS as readonly string[]).includes(s))).toBe(true);
+    }
+  });
+
+  it('workflow steps are gated by REAL decision-grade facts, not configuration', () => {
+    const m = model();
+    const wf = demoWorkspaceConfig().workflows[0];
+    const evaln = evaluateWorkflow(wf, m);
+    expect(evaln.subjectKey).toBe(m.identity.subjectKey);
+    expect(evaln.steps).toHaveLength(3);
+
+    // recognition needs >=1 decision-grade evidence — the demo has it.
+    const recognition = evaln.steps.find((s) => s.stepId === 'recognition')!;
+    expect(recognition.state).toBe(m.meta.decisionGradeEvidence >= 1 ? 'complete' : 'available');
+
+    // A workflow can never invent completion: a step gated on readiness 'ready'
+    // is only complete when readiness is actually 'ready'.
+    const start = evaln.steps.find((s) => s.stepId === 'start')!;
+    if (m.readiness.readiness !== 'ready') expect(start.state).not.toBe('complete');
+  });
+
+  it('automation fires configured actions on real events, fails closed on unknown types', () => {
+    const rules = demoWorkspaceConfig().automations;
+    const fired = evaluateAutomations(rules, {
+      type: 'exchange.verified',
+      tenantId: 'coastal-staffing',
+      subjectKey: 'demo-clinician',
+      payload: {},
+    });
+    expect(fired.map((f) => f.ruleId)).toContain('verified-notify-recruiter');
+
+    // Conditional rule only fires when the payload condition holds.
+    const notReady = evaluateAutomations(rules, {
+      type: 'readiness.changed',
+      tenantId: 'coastal-staffing',
+      subjectKey: 'demo-clinician',
+      payload: { readiness: 'near_ready' },
+    });
+    expect(notReady.find((f) => f.ruleId === 'readiness-ready-route')).toBeUndefined();
+
+    // Unknown event type → nothing fires.
+    expect(
+      evaluateAutomations(rules, { type: 'bogus' as never, tenantId: 't', subjectKey: 's', payload: {} }),
+    ).toHaveLength(0);
+  });
+
+  it('dashboard widgets bound to a hidden section resolve hidden, never fabricated', () => {
+    const m = model();
+    const config = demoWorkspaceConfig();
+    const recruiter = findRole(config, 'recruiter')!;
+    const proj = projectForRole(m, recruiter.roleId, recruiter.visibleSections);
+    const dash = projectDashboard(config.dashboards[0], proj);
+
+    const evidenceWidget = dash.widgets.find((w) => w.widgetId === 'w-evidence')!;
+    expect(evidenceWidget.status).toBe('hidden'); // recruiter can't see evidence
+    expect(evidenceWidget.data).toBeNull();
+
+    const trustWidget = dash.widgets.find((w) => w.widgetId === 'w-trust')!;
+    expect(trustWidget.status).toBe('ok');
+    expect(trustWidget.data).toBe(m.trust); // pass-through, unchanged
+  });
+});

--- a/apps/web/__tests__/workspace-config.test.ts
+++ b/apps/web/__tests__/workspace-config.test.ts
@@ -107,6 +107,11 @@ describe('Configurable Platform (C1/C6)', () => {
     // No appId at all → 401.
     expect((await call('role=clinician')).status).toBe(401);
 
+    // No role enumeration pre-auth: a VALID role and a BOGUS role both return 401
+    // (not 403 unknown_role) when unauthenticated — no oracle for which roles exist.
+    expect((await call('role=clinician')).status).toBe(401);
+    expect((await call('role=does-not-exist')).status).toBe(401);
+
     // Authenticated app, but role NOT granted → 403 (authn passes, authz fails).
     const denied = await call('role=clinician&appId=app-coastal-ats', { 'x-app-key': 'coastal-secret' });
     expect(denied.status).toBe(403);

--- a/apps/web/app/api/workspace-config/[entityId]/route.ts
+++ b/apps/web/app/api/workspace-config/[entityId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { composeCareerModel } from '@vitalcv/domain-evidence';
+import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
+import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+import { demoWorkspaceConfig, findRole, findDashboard } from '@/lib/workspace-config/config';
+import { projectForRole } from '@/lib/workspace-config/roles';
+import { evaluateWorkflow } from '@/lib/workspace-config/workflows';
+import { projectDashboard } from '@/lib/workspace-config/dashboard';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/workspace-config/[entityId]?role=<roleId>&dashboard=<dashboardId>
+ *   — the configurable workspace projection (Wave 1300, C1/C2/C5).
+ *
+ * Resolves the canonical Career Model ONCE, then applies the workspace's role
+ * configuration: a role-scoped view, the configured workflows evaluated against
+ * real facts, and (optionally) a role-scoped dashboard. Configuration only
+ * scopes/gates — it never alters trust or evidence. Unknown role ⇒ 403.
+ */
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ entityId: string }> },
+) {
+  const { entityId } = await context.params;
+  try {
+    const config = demoWorkspaceConfig();
+    const { searchParams } = new URL(req.url);
+    const roleId = searchParams.get('role') ?? 'clinician';
+
+    const role = findRole(config, roleId);
+    if (!role) {
+      return NextResponse.json(
+        { error: 'unknown_role', error_description: `Role "${roleId}" is not defined in this workspace.` },
+        { status: 403, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    // Core platform work happens ONCE; configuration is a pure projection on top.
+    const passport = await resolvePassportRuntimePassport(entityId);
+    const model = composeCareerModel(passportToEvidenceCollection(passport));
+
+    const roleProjection = projectForRole(model, role.roleId, role.visibleSections);
+    const workflows = config.workflows.map((wf) => evaluateWorkflow(wf, model));
+
+    const dashboardId = searchParams.get('dashboard');
+    const dashboardConfig = dashboardId ? findDashboard(config, dashboardId) : null;
+    const dashboard =
+      dashboardConfig && dashboardConfig.roleIds.includes(role.roleId)
+        ? projectDashboard(dashboardConfig, roleProjection)
+        : null;
+
+    return NextResponse.json(
+      {
+        schema: 'vitalcv.workspace-config.v1',
+        workspaceId: config.workspaceId,
+        tenantId: config.tenantId,
+        role: { roleId: role.roleId, label: role.label },
+        projection: roleProjection,
+        workflows,
+        dashboard,
+      },
+      { status: 200, headers: { ETag: `W/"${model.meta.contentHash}"`, 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Workspace projection failed.';
+    return NextResponse.json(
+      { error: 'workspace_unavailable', error_description: detail },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/apps/web/app/api/workspace-config/[entityId]/route.ts
+++ b/apps/web/app/api/workspace-config/[entityId]/route.ts
@@ -3,6 +3,7 @@ import { composeCareerModel } from '@vitalcv/domain-evidence';
 import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
 import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
 import { demoWorkspaceConfig, findRole, findDashboard, isRoleGranted } from '@/lib/workspace-config/config';
+import { authenticateApp, appKeyEnvVar } from '@/lib/workspace-config/auth';
 import { projectForRole } from '@/lib/workspace-config/roles';
 import { evaluateWorkflow } from '@/lib/workspace-config/workflows';
 import { projectDashboard } from '@/lib/workspace-config/dashboard';
@@ -37,11 +38,21 @@ export async function GET(
       );
     }
 
-    // Caller authorization: an app may only assume a role it has been granted.
-    // Without this, any caller could request the broadest role (e.g. clinician).
+    // Caller AUTHENTICATION first: the app must prove its identity with its
+    // configured key, otherwise the appId is just an unverified claim. Fails
+    // closed (401) when the key is missing/unconfigured/mismatched.
+    const appKey = req.headers.get('x-app-key') ?? searchParams.get('appKey') ?? '';
+    if (!authenticateApp(appId, appKey, process.env[appKeyEnvVar(appId)])) {
+      return NextResponse.json(
+        { error: 'app_not_authenticated', error_description: 'A valid appId and matching app key are required.' },
+        { status: 401, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    // Caller AUTHORIZATION: an authenticated app may only assume a granted role.
     if (!isRoleGranted(config, appId, roleId)) {
       return NextResponse.json(
-        { error: 'role_not_granted', error_description: `Application "${appId || '(none)'}" may not assume role "${roleId}".` },
+        { error: 'role_not_granted', error_description: `Application "${appId}" may not assume role "${roleId}".` },
         { status: 403, headers: { 'Cache-Control': 'no-store' } },
       );
     }

--- a/apps/web/app/api/workspace-config/[entityId]/route.ts
+++ b/apps/web/app/api/workspace-config/[entityId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { composeCareerModel } from '@vitalcv/domain-evidence';
 import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
 import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
-import { demoWorkspaceConfig, findRole, findDashboard } from '@/lib/workspace-config/config';
+import { demoWorkspaceConfig, findRole, findDashboard, isRoleGranted } from '@/lib/workspace-config/config';
 import { projectForRole } from '@/lib/workspace-config/roles';
 import { evaluateWorkflow } from '@/lib/workspace-config/workflows';
 import { projectDashboard } from '@/lib/workspace-config/dashboard';
@@ -27,11 +27,21 @@ export async function GET(
     const config = demoWorkspaceConfig();
     const { searchParams } = new URL(req.url);
     const roleId = searchParams.get('role') ?? 'clinician';
+    const appId = searchParams.get('appId')?.trim() ?? '';
 
     const role = findRole(config, roleId);
     if (!role) {
       return NextResponse.json(
         { error: 'unknown_role', error_description: `Role "${roleId}" is not defined in this workspace.` },
+        { status: 403, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    // Caller authorization: an app may only assume a role it has been granted.
+    // Without this, any caller could request the broadest role (e.g. clinician).
+    if (!isRoleGranted(config, appId, roleId)) {
+      return NextResponse.json(
+        { error: 'role_not_granted', error_description: `Application "${appId || '(none)'}" may not assume role "${roleId}".` },
         { status: 403, headers: { 'Cache-Control': 'no-store' } },
       );
     }

--- a/apps/web/app/api/workspace-config/[entityId]/route.ts
+++ b/apps/web/app/api/workspace-config/[entityId]/route.ts
@@ -30,17 +30,11 @@ export async function GET(
     const roleId = searchParams.get('role') ?? 'clinician';
     const appId = searchParams.get('appId')?.trim() ?? '';
 
-    const role = findRole(config, roleId);
-    if (!role) {
-      return NextResponse.json(
-        { error: 'unknown_role', error_description: `Role "${roleId}" is not defined in this workspace.` },
-        { status: 403, headers: { 'Cache-Control': 'no-store' } },
-      );
-    }
-
-    // Caller AUTHENTICATION first: the app must prove its identity with its
-    // configured key, otherwise the appId is just an unverified claim. Fails
-    // closed (401) when the key is missing/unconfigured/mismatched.
+    // Caller AUTHENTICATION FIRST — before anything reveals workspace structure.
+    // The app must prove its identity with its configured key; otherwise the
+    // appId is just an unverified claim. Doing this before any role lookup also
+    // prevents an unauthenticated caller from enumerating role IDs via the
+    // difference between 403 unknown_role and other responses. Fails closed (401).
     const appKey = req.headers.get('x-app-key') ?? searchParams.get('appKey') ?? '';
     if (!authenticateApp(appId, appKey, process.env[appKeyEnvVar(appId)])) {
       return NextResponse.json(
@@ -50,9 +44,19 @@ export async function GET(
     }
 
     // Caller AUTHORIZATION: an authenticated app may only assume a granted role.
+    // Checked before role existence so a non-granted caller learns nothing about
+    // which role IDs exist.
     if (!isRoleGranted(config, appId, roleId)) {
       return NextResponse.json(
         { error: 'role_not_granted', error_description: `Application "${appId}" may not assume role "${roleId}".` },
+        { status: 403, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const role = findRole(config, roleId);
+    if (!role) {
+      return NextResponse.json(
+        { error: 'unknown_role', error_description: `Role "${roleId}" is not defined in this workspace.` },
         { status: 403, headers: { 'Cache-Control': 'no-store' } },
       );
     }

--- a/apps/web/lib/workspace-config/auth.ts
+++ b/apps/web/lib/workspace-config/auth.ts
@@ -1,0 +1,29 @@
+/**
+ * Workspace caller authentication (Wave 1300, security)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Authorization (which role an app may assume) is meaningless if the app's
+ * identity is merely CLAIMED. This authenticates the appId against a per-app
+ * secret configured server-side, BEFORE any role grant is honored — so a caller
+ * cannot simply assert `appId=app-vitalcv-web` to obtain its grants.
+ *
+ * Fails closed: no appId, no presented key, or no configured key ⇒ not
+ * authenticated. Comparison is timing-safe.
+ */
+import { timingSafeEqual } from 'node:crypto';
+
+/** Env var holding a given app's key, e.g. app-coastal-ats → WORKSPACE_APP_KEY_APP_COASTAL_ATS. */
+export function appKeyEnvVar(appId: string): string {
+  return `WORKSPACE_APP_KEY_${appId.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}`;
+}
+
+/**
+ * Authenticate a claimed appId by verifying the presented key against the
+ * configured expected key. Returns false unless all three are present and the
+ * keys match (timing-safe).
+ */
+export function authenticateApp(appId: string, providedKey: string, expectedKey: string | undefined): boolean {
+  if (!appId.trim() || !providedKey || !expectedKey) return false;
+  const a = Buffer.from(providedKey);
+  const b = Buffer.from(expectedKey);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/apps/web/lib/workspace-config/automation.ts
+++ b/apps/web/lib/workspace-config/automation.ts
@@ -1,0 +1,61 @@
+/**
+ * Automation / event engine (Wave 1300, C4)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Configurable triggers → actions over the EXISTING platform event stream
+ * (W900). Rules are declarative: a trigger event type, an optional condition,
+ * and an action. Evaluation is PURE — it returns action DESCRIPTORS to be
+ * carried out by the platform's existing delivery machinery. An automation can
+ * never mutate source evidence, confer decision-grade, or change trust; it can
+ * only describe notifications/routing in response to events that already
+ * happened.
+ */
+import { PLATFORM_EVENT_TYPES, type PlatformEventType, type PlatformEvent } from '@/lib/platform-cloud/events';
+
+export type AutomationActionType = 'notify' | 'route_to_review' | 'tag';
+
+export interface AutomationAction {
+  type: AutomationActionType;
+  /** Free-form target (queue, channel, label) — never provider PII. */
+  target: string;
+}
+
+export interface AutomationRule {
+  ruleId: string;
+  /** Event type that triggers this rule (must be a known platform event). */
+  on: PlatformEventType;
+  /**
+   * Optional payload predicate, expressed declaratively as an equality on a
+   * top-level payload key. Kept intentionally simple (no code execution).
+   */
+  whenPayloadEquals?: { key: string; value: string | number | boolean };
+  action: AutomationAction;
+}
+
+export interface TriggeredAction {
+  ruleId: string;
+  action: AutomationAction;
+  /** The subject the event concerned (carried through, never expanded to PII). */
+  subjectKey: string;
+}
+
+function isKnownType(t: unknown): t is PlatformEventType {
+  return typeof t === 'string' && (PLATFORM_EVENT_TYPES as readonly string[]).includes(t);
+}
+
+function conditionHolds(rule: AutomationRule, event: PlatformEvent): boolean {
+  if (!rule.whenPayloadEquals) return true;
+  const payload = event.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  return (payload as Record<string, unknown>)[rule.whenPayloadEquals.key] === rule.whenPayloadEquals.value;
+}
+
+/**
+ * Evaluate rules against one event, returning the actions to fire. Fails closed:
+ * an unknown event type triggers nothing. Pure — no side effects.
+ */
+export function evaluateAutomations(rules: AutomationRule[], event: PlatformEvent): TriggeredAction[] {
+  if (!isKnownType(event.type)) return [];
+  return rules
+    .filter((rule) => rule.on === event.type && conditionHolds(rule, event))
+    .map((rule) => ({ ruleId: rule.ruleId, action: rule.action, subjectKey: event.subjectKey }));
+}

--- a/apps/web/lib/workspace-config/config.ts
+++ b/apps/web/lib/workspace-config/config.ts
@@ -1,0 +1,150 @@
+/**
+ * Workspace configuration service (Wave 1300, C1)
+ * ──────────────────────────────────────────────────────────────────────────
+ * The declarative configuration that lets one platform serve many healthcare
+ * organizations without forking: per-workspace roles, workflows, automations,
+ * and dashboards. Configuration is DATA — it selects, gates, and routes over
+ * the shared platform services; it never carries business logic or trust facts.
+ *
+ * Validation is strict so a malformed tenant config fails fast rather than
+ * silently mis-scoping a role or binding a widget to a non-existent section.
+ */
+import { CAREER_SECTIONS, type CareerSection } from './roles';
+import type { WorkflowDefinition } from './workflows';
+import type { AutomationRule } from './automation';
+import type { DashboardConfig } from './dashboard';
+import { PLATFORM_EVENT_TYPES } from '@/lib/platform-cloud/events';
+
+export interface WorkspaceRole {
+  roleId: string;
+  label: string;
+  /** Career Model sections this role may see. */
+  visibleSections: CareerSection[];
+}
+
+export interface WorkspaceConfig {
+  workspaceId: string;
+  tenantId: string;
+  roles: WorkspaceRole[];
+  workflows: WorkflowDefinition[];
+  automations: AutomationRule[];
+  dashboards: DashboardConfig[];
+}
+
+export function findRole(config: WorkspaceConfig, roleId: string): WorkspaceRole | null {
+  const id = roleId?.trim();
+  if (!id) return null;
+  return config.roles.find((r) => r.roleId === id) ?? null;
+}
+
+export function findDashboard(config: WorkspaceConfig, dashboardId: string): DashboardConfig | null {
+  return config.dashboards.find((d) => d.dashboardId === dashboardId) ?? null;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const SECTION_SET = new Set<string>(CAREER_SECTIONS);
+const EVENT_SET = new Set<string>(PLATFORM_EVENT_TYPES);
+
+/** Strict structural validation — fail fast on a malformed tenant config. */
+export function validateWorkspaceConfig(config: WorkspaceConfig): ValidationResult {
+  const errors: string[] = [];
+
+  if (!config.workspaceId?.trim()) errors.push('workspaceId is required.');
+  if (!config.tenantId?.trim()) errors.push('tenantId is required.');
+
+  const roleIds = new Set<string>();
+  for (const role of config.roles) {
+    if (roleIds.has(role.roleId)) errors.push(`duplicate roleId "${role.roleId}".`);
+    roleIds.add(role.roleId);
+    for (const s of role.visibleSections) {
+      if (!SECTION_SET.has(s)) errors.push(`role "${role.roleId}" references unknown section "${s}".`);
+    }
+  }
+
+  for (const wf of config.workflows) {
+    if (wf.steps.length === 0) errors.push(`workflow "${wf.workflowId}" has no steps.`);
+  }
+
+  for (const rule of config.automations) {
+    if (!EVENT_SET.has(rule.on)) errors.push(`automation "${rule.ruleId}" triggers on unknown event "${rule.on}".`);
+  }
+
+  for (const dash of config.dashboards) {
+    for (const rid of dash.roleIds) {
+      if (!roleIds.has(rid)) errors.push(`dashboard "${dash.dashboardId}" references unknown role "${rid}".`);
+    }
+    for (const w of dash.widgets) {
+      if (!SECTION_SET.has(w.source)) errors.push(`widget "${w.widgetId}" binds to unknown section "${w.source}".`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** A demo workspace: a clinician self-view, a recruiter view, and a credentialer view. */
+export function demoWorkspaceConfig(): WorkspaceConfig {
+  return {
+    workspaceId: 'mercy-health-workspace',
+    tenantId: 'coastal-staffing',
+    roles: [
+      {
+        roleId: 'clinician',
+        label: 'Clinician (self)',
+        visibleSections: ['evidence', 'trust', 'timeline', 'mobility', 'readiness', 'organizations', 'growth', 'intelligence', 'longitudinal'],
+      },
+      {
+        // A recruiter sees readiness/trust/orgs but NOT raw evidence or growth coaching.
+        roleId: 'recruiter',
+        label: 'Recruiter',
+        visibleSections: ['trust', 'readiness', 'mobility', 'organizations'],
+      },
+      {
+        // A credentialer sees evidence + trust + readiness, not growth/intelligence.
+        roleId: 'credentialer',
+        label: 'Credentialing Specialist',
+        visibleSections: ['evidence', 'trust', 'readiness', 'organizations'],
+      },
+    ],
+    workflows: [
+      {
+        workflowId: 'recognition-to-start',
+        label: 'Recognition → Acceptance → Start',
+        steps: [
+          { stepId: 'recognition', label: 'Recognition', gate: { minDecisionGradeEvidence: 1 } },
+          { stepId: 'acceptance', label: 'Acceptance', gate: { readinessIn: ['near_ready', 'ready'] } },
+          { stepId: 'start', label: 'Start', gate: { readinessIn: ['ready'] } },
+        ],
+      },
+    ],
+    automations: [
+      {
+        ruleId: 'verified-notify-recruiter',
+        on: 'exchange.verified',
+        action: { type: 'notify', target: 'recruiter-queue' },
+      },
+      {
+        ruleId: 'readiness-ready-route',
+        on: 'readiness.changed',
+        whenPayloadEquals: { key: 'readiness', value: 'ready' },
+        action: { type: 'route_to_review', target: 'privileging' },
+      },
+    ],
+    dashboards: [
+      {
+        dashboardId: 'recruiter-dash',
+        label: 'Recruiter Dashboard',
+        roleIds: ['recruiter'],
+        widgets: [
+          { widgetId: 'w-readiness', title: 'Readiness', type: 'summary', source: 'readiness' },
+          { widgetId: 'w-trust', title: 'Trust', type: 'metric', source: 'trust' },
+          // Bound to a section the recruiter cannot see → resolves hidden, not fabricated.
+          { widgetId: 'w-evidence', title: 'Evidence', type: 'list', source: 'evidence' },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/lib/workspace-config/config.ts
+++ b/apps/web/lib/workspace-config/config.ts
@@ -10,7 +10,7 @@
  * silently mis-scoping a role or binding a widget to a non-existent section.
  */
 import { CAREER_SECTIONS, type CareerSection } from './roles';
-import type { WorkflowDefinition } from './workflows';
+import { isFactualGate, type WorkflowDefinition } from './workflows';
 import type { AutomationRule } from './automation';
 import type { DashboardConfig } from './dashboard';
 import { PLATFORM_EVENT_TYPES } from '@/lib/platform-cloud/events';
@@ -22,10 +22,18 @@ export interface WorkspaceRole {
   visibleSections: CareerSection[];
 }
 
+/** Which application/principal may assume which role in this workspace. */
+export interface RoleGrant {
+  appId: string;
+  roleId: string;
+}
+
 export interface WorkspaceConfig {
   workspaceId: string;
   tenantId: string;
   roles: WorkspaceRole[];
+  /** Caller authorization: an app may only assume a role it is granted. */
+  grants: RoleGrant[];
   workflows: WorkflowDefinition[];
   automations: AutomationRule[];
   dashboards: DashboardConfig[];
@@ -35,6 +43,17 @@ export function findRole(config: WorkspaceConfig, roleId: string): WorkspaceRole
   const id = roleId?.trim();
   if (!id) return null;
   return config.roles.find((r) => r.roleId === id) ?? null;
+}
+
+/**
+ * Caller authorization: an application may assume a role ONLY if the workspace
+ * grants it. Fails closed — no appId, or no matching grant ⇒ not authorized.
+ * This stops a caller from simply requesting the broadest role.
+ */
+export function isRoleGranted(config: WorkspaceConfig, appId: string, roleId: string): boolean {
+  const id = appId?.trim();
+  if (!id) return false;
+  return config.grants.some((g) => g.appId === id && g.roleId === roleId);
 }
 
 export function findDashboard(config: WorkspaceConfig, dashboardId: string): DashboardConfig | null {
@@ -67,6 +86,18 @@ export function validateWorkspaceConfig(config: WorkspaceConfig): ValidationResu
 
   for (const wf of config.workflows) {
     if (wf.steps.length === 0) errors.push(`workflow "${wf.workflowId}" has no steps.`);
+    for (const step of wf.steps) {
+      // A step gate must impose a real requirement — never an empty/degenerate
+      // gate that would complete the step without a decision-grade fact.
+      if (!isFactualGate(step.gate)) {
+        errors.push(`workflow "${wf.workflowId}" step "${step.stepId}" has a non-factual gate.`);
+      }
+    }
+  }
+
+  for (const grant of config.grants) {
+    if (!grant.appId?.trim()) errors.push('a role grant is missing appId.');
+    if (!roleIds.has(grant.roleId)) errors.push(`grant references unknown role "${grant.roleId}".`);
   }
 
   for (const rule of config.automations) {
@@ -108,6 +139,13 @@ export function demoWorkspaceConfig(): WorkspaceConfig {
         label: 'Credentialing Specialist',
         visibleSections: ['evidence', 'trust', 'readiness', 'organizations'],
       },
+    ],
+    grants: [
+      // The first-party app may act as the clinician self-view; the partner ATS
+      // is limited to the recruiter role — it can never request the clinician view.
+      { appId: 'app-vitalcv-web', roleId: 'clinician' },
+      { appId: 'app-vitalcv-web', roleId: 'credentialer' },
+      { appId: 'app-coastal-ats', roleId: 'recruiter' },
     ],
     workflows: [
       {

--- a/apps/web/lib/workspace-config/dashboard.ts
+++ b/apps/web/lib/workspace-config/dashboard.ts
@@ -1,0 +1,69 @@
+/**
+ * Dynamic dashboard projections (Wave 1300, C5)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Config-driven dashboards. A dashboard is a list of widgets, each bound to a
+ * Career Model section. Widgets are resolved against a ROLE PROJECTION, so a
+ * widget can only ever show data the role is permitted to see — a widget bound
+ * to a hidden section resolves to `hidden`, never to fabricated data. Widget
+ * values are pass-through; the dashboard never alters or inflates them.
+ *
+ * Pure: a projection over an already role-scoped model.
+ */
+import type { CareerSection, RoleProjection } from './roles';
+
+export type WidgetType = 'summary' | 'list' | 'metric';
+
+export interface WidgetConfig {
+  widgetId: string;
+  title: string;
+  type: WidgetType;
+  /** The Career Model section this widget draws from. */
+  source: CareerSection;
+}
+
+export interface DashboardConfig {
+  dashboardId: string;
+  label: string;
+  /** Roles permitted to view this dashboard. */
+  roleIds: string[];
+  widgets: WidgetConfig[];
+}
+
+export interface ResolvedWidget {
+  widgetId: string;
+  title: string;
+  type: WidgetType;
+  source: CareerSection;
+  /** 'ok' when the role can see the source section, else 'hidden'. */
+  status: 'ok' | 'hidden';
+  /** Section data by reference when visible; null when hidden. */
+  data: unknown;
+}
+
+export interface DashboardProjection {
+  dashboardId: string;
+  label: string;
+  roleId: string;
+  widgets: ResolvedWidget[];
+}
+
+/**
+ * Resolve a dashboard for a role projection. A widget whose source section is
+ * not visible to the role resolves to `hidden` with null data — never invented
+ * content. Visible widgets carry the section data by reference, unchanged.
+ */
+export function projectDashboard(config: DashboardConfig, projection: RoleProjection): DashboardProjection {
+  const visible = new Set(projection.visibleSections);
+  const widgets: ResolvedWidget[] = config.widgets.map((w) => {
+    const isVisible = visible.has(w.source);
+    return {
+      widgetId: w.widgetId,
+      title: w.title,
+      type: w.type,
+      source: w.source,
+      status: isVisible ? 'ok' : 'hidden',
+      data: isVisible ? (projection.sections as Record<CareerSection, unknown>)[w.source] ?? null : null,
+    };
+  });
+  return { dashboardId: config.dashboardId, label: config.label, roleId: projection.roleId, widgets };
+}

--- a/apps/web/lib/workspace-config/roles.ts
+++ b/apps/web/lib/workspace-config/roles.ts
@@ -1,0 +1,87 @@
+/**
+ * Role-based projection engine (Wave 1300, C2)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Projects the canonical Career Model (W1000) for a workspace role. A role
+ * controls VISIBILITY only: which sections a role sees. It can NEVER alter,
+ * fabricate, or elevate the underlying facts — visible sections are passed
+ * through by reference, unchanged. Hiding a section omits it; it never zeroes,
+ * fakes, or inflates trust. No role can see more decision-grade evidence than
+ * actually exists, because the values are the same objects the model produced.
+ *
+ * Pure: a projection over an already-composed model. No trust math, no I/O.
+ */
+import type { CareerModel, CareerIdentity, CareerModelMeta } from '@vitalcv/domain-evidence';
+
+/** The gateable sections of the Career Model. identity + meta are always visible. */
+export type CareerSection =
+  | 'evidence'
+  | 'trust'
+  | 'timeline'
+  | 'mobility'
+  | 'readiness'
+  | 'organizations'
+  | 'growth'
+  | 'intelligence'
+  | 'longitudinal';
+
+export const CAREER_SECTIONS: readonly CareerSection[] = [
+  'evidence',
+  'trust',
+  'timeline',
+  'mobility',
+  'readiness',
+  'organizations',
+  'growth',
+  'intelligence',
+  'longitudinal',
+] as const;
+
+export interface RoleProjection {
+  roleId: string;
+  identity: CareerIdentity;
+  /** Pass-through model meta (content hash, decision-grade counts). */
+  meta: CareerModelMeta;
+  visibleSections: CareerSection[];
+  hiddenSections: CareerSection[];
+  /** Only the visible sections, by reference — values are never modified. */
+  sections: Partial<Pick<CareerModel, CareerSection>>;
+}
+
+function isCareerSection(value: string): value is CareerSection {
+  return (CAREER_SECTIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Project a model for a role. `allowedSections` is the role's visibility grant;
+ * unknown keys are ignored. Visible sections are copied by reference (unchanged);
+ * everything else is reported as hidden. identity + meta always pass through.
+ */
+export function projectForRole(
+  model: CareerModel,
+  roleId: string,
+  allowedSections: readonly string[],
+): RoleProjection {
+  const allowed = new Set(allowedSections.filter(isCareerSection));
+  const visibleSections: CareerSection[] = [];
+  const hiddenSections: CareerSection[] = [];
+  const sections: Partial<Pick<CareerModel, CareerSection>> = {};
+
+  for (const section of CAREER_SECTIONS) {
+    if (allowed.has(section)) {
+      visibleSections.push(section);
+      // Pass-through by reference — the role NEVER changes the values.
+      (sections as Record<CareerSection, unknown>)[section] = model[section];
+    } else {
+      hiddenSections.push(section);
+    }
+  }
+
+  return {
+    roleId,
+    identity: model.identity,
+    meta: model.meta,
+    visibleSections,
+    hiddenSections,
+    sections,
+  };
+}

--- a/apps/web/lib/workspace-config/workflows.ts
+++ b/apps/web/lib/workspace-config/workflows.ts
@@ -51,7 +51,22 @@ export interface WorkflowEvaluation {
   currentStepId: string | null;
 }
 
+/**
+ * A gate is FACTUAL only if it imposes at least one real requirement: needing
+ * >=1 decision-grade evidence, or a non-empty readiness set. An empty gate `{}`
+ * or a degenerate one (`minDecisionGradeEvidence: 0`) is NOT factual — config
+ * must never be able to mark a step complete without a real fact.
+ */
+export function isFactualGate(gate: WorkflowGate): boolean {
+  const hasEvidenceReq = typeof gate.minDecisionGradeEvidence === 'number' && gate.minDecisionGradeEvidence >= 1;
+  const hasReadinessReq = Array.isArray(gate.readinessIn) && gate.readinessIn.length > 0;
+  return hasEvidenceReq || hasReadinessReq;
+}
+
 function gateSatisfied(gate: WorkflowGate, model: CareerModel): boolean {
+  // Defense in depth: a non-factual gate can never be satisfied, so configuration
+  // alone can never force a step to 'complete'. (Validation also rejects these.)
+  if (!isFactualGate(gate)) return false;
   if (
     typeof gate.minDecisionGradeEvidence === 'number' &&
     model.meta.decisionGradeEvidence < gate.minDecisionGradeEvidence

--- a/apps/web/lib/workspace-config/workflows.ts
+++ b/apps/web/lib/workspace-config/workflows.ts
@@ -1,0 +1,112 @@
+/**
+ * Workflow definition engine (Wave 1300, C3)
+ * ──────────────────────────────────────────────────────────────────────────
+ * Workflows are stored as DECLARATIVE configuration and evaluated against the
+ * Career Model. A workflow step's gate is checked against REAL facts — readiness
+ * level and decision-grade evidence count — so configuration can describe a
+ * process but can never confer decision-grade or move a step to "complete" on
+ * evidence that isn't actually checked. This preserves the canonical path
+ * (Recognition → Acceptance → Start) without weakening the honesty contract.
+ *
+ * Pure: evaluation reads the model; it never mutates evidence or fires effects.
+ */
+import type { CareerModel, MobilityReadiness } from '@vitalcv/domain-evidence';
+
+/** Declarative gate for a step. All present conditions must hold. */
+export interface WorkflowGate {
+  /** Minimum decision-grade (checked) evidence required. */
+  minDecisionGradeEvidence?: number;
+  /** Required readiness level(s) — any match satisfies. */
+  readinessIn?: MobilityReadiness[];
+}
+
+export interface WorkflowStep {
+  stepId: string;
+  label: string;
+  gate: WorkflowGate;
+}
+
+export interface WorkflowDefinition {
+  workflowId: string;
+  label: string;
+  steps: WorkflowStep[];
+}
+
+export type StepState = 'complete' | 'available' | 'blocked';
+
+export interface StepEvaluation {
+  stepId: string;
+  label: string;
+  state: StepState;
+  /** Honest reason for the state. */
+  reason: string;
+}
+
+export interface WorkflowEvaluation {
+  workflowId: string;
+  label: string;
+  subjectKey: string;
+  steps: StepEvaluation[];
+  /** First non-complete step id, or null if all complete. */
+  currentStepId: string | null;
+}
+
+function gateSatisfied(gate: WorkflowGate, model: CareerModel): boolean {
+  if (
+    typeof gate.minDecisionGradeEvidence === 'number' &&
+    model.meta.decisionGradeEvidence < gate.minDecisionGradeEvidence
+  ) {
+    return false;
+  }
+  if (gate.readinessIn && gate.readinessIn.length > 0 && !gate.readinessIn.includes(model.readiness.readiness)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Evaluate a workflow against a model. Steps are sequential: a step is
+ * `complete` if its gate holds, `available` if it's the first unmet step whose
+ * gate holds, otherwise `blocked`. A gate is satisfied ONLY by real
+ * decision-grade facts — never by configuration alone.
+ */
+export function evaluateWorkflow(definition: WorkflowDefinition, model: CareerModel): WorkflowEvaluation {
+  const steps: StepEvaluation[] = [];
+  let currentStepId: string | null = null;
+
+  for (const step of definition.steps) {
+    const satisfied = gateSatisfied(step.gate, model);
+
+    let state: StepState;
+    let reason: string;
+    if (satisfied && currentStepId === null) {
+      // Gate holds and all prior steps complete → this step is complete.
+      state = 'complete';
+      reason = 'Gate satisfied by decision-grade facts.';
+    } else if (!satisfied && currentStepId === null) {
+      // First unmet step.
+      state = 'available';
+      reason = describeGate(step.gate, model);
+      currentStepId = step.stepId;
+    } else {
+      // A prior step is unmet → downstream steps are blocked.
+      state = 'blocked';
+      reason = 'Blocked by an earlier incomplete step.';
+    }
+
+    steps.push({ stepId: step.stepId, label: step.label, state, reason });
+  }
+
+  return { workflowId: definition.workflowId, label: definition.label, subjectKey: model.identity.subjectKey, steps, currentStepId };
+}
+
+function describeGate(gate: WorkflowGate, model: CareerModel): string {
+  const parts: string[] = [];
+  if (typeof gate.minDecisionGradeEvidence === 'number') {
+    parts.push(`needs ${gate.minDecisionGradeEvidence} decision-grade evidence (have ${model.meta.decisionGradeEvidence})`);
+  }
+  if (gate.readinessIn && gate.readinessIn.length > 0) {
+    parts.push(`needs readiness in [${gate.readinessIn.join(', ')}] (is ${model.readiness.readiness})`);
+  }
+  return parts.length ? `Available: ${parts.join('; ')}.` : 'Available.';
+}


### PR DESCRIPTION
## W1300 — Configurable Platform

The configuration layer for the Healthcare Workforce OS: **one platform serves many organizations without forking.** Reuses all merged platform services; configuration is **data** (selects/gates/routes), never business logic or trust facts.

### The load-bearing rule
Configuration can **scope, gate, and route** what a role sees — but it can **never alter, fabricate, or elevate** trust or decision-grade. Role projections pass visible sections through **by reference, unchanged**; workflows/automations are gated by **real** decision-grade facts and never mutate source evidence.

### Deliverables
| | |
|---|---|
| **C1 Workspace config** | `config.ts` — roles/workflows/automations/dashboards + strict validation (fails fast on unknown section/role/event/widget) |
| **C2 Role projection** | `roles.ts` — `projectForRole()` scopes visible sections; pass-through by reference; no role surfaces more decision-grade than exists |
| **C3 Workflow engine** | `workflows.ts` — declarative steps gated by real facts (decision-grade count, readiness); config can't confer completion |
| **C4 Automation engine** | `automation.ts` — configurable triggers→actions over W900 events; pure action descriptors; fails closed on unknown types |
| **C5 Dynamic dashboards** | `dashboard.ts` — widgets resolve against the role projection; a widget on a hidden section resolves `hidden`, never fabricated |
| **C6 Integration test** | Workspace→Roles→Workflow→Evidence→Trust→Career→Organization→Automation (7 cases) |
| **C7 Performance** | config is a pure projection over **one** `composeCareerModel` call — core trust derivation runs once, unaffected by tenant config |

### Route
`GET /api/workspace-config/[entityId]?role=<roleId>&dashboard=<dashboardId>`

### Validation
- `workspace-config.test.ts` → 7/7
- `turbo run build --filter @vitalcv/web` → compiled + lint clean; route registered
- No banned strings; lockfile untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)