### PR TITLE
fix(clinician): add missing /holder route pages (Roles, Updates, application detail)

### DIFF
--- a/apps/web/app/holder/applications/[id]/page.tsx
+++ b/apps/web/app/holder/applications/[id]/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import ClinicianApplicationDetailSurface from '@/components/mobile/ClinicianApplicationDetailSurface';
+
+export const metadata: Metadata = {
+  title: 'Application',
+  description: 'Your application status, timeline, and readiness snapshot.',
+};
+
+// Detail page for a single application. ApplyModal redirects here on a
+// successful apply (/holder/applications/{id}); the surface reads the
+// application from the shared ClinicianMobileProvider and calls notFound()
+// when the id is unknown.
+export default async function HolderApplicationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <ClinicianApplicationDetailSurface applicationId={id} />;
+}

--- a/apps/web/app/holder/applications/page.tsx
+++ b/apps/web/app/holder/applications/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+import ClinicianApplicationsSurface from '@/components/mobile/ClinicianApplicationsSurface';
+
+export const metadata: Metadata = {
+  title: 'Applications',
+  description: 'Track your applications and where each one stands.',
+};
+
+// Renders the "Updates" tab of the clinician bottom nav. Data comes from the
+// shared ClinicianMobileProvider loaded in app/holder/layout.tsx.
+export default function HolderApplicationsPage() {
+  return <ClinicianApplicationsSurface />;
+}

--- a/apps/web/app/holder/opportunities/page.tsx
+++ b/apps/web/app/holder/opportunities/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+import ClinicianOpportunitiesSurface from '@/components/mobile/ClinicianOpportunitiesSurface';
+
+export const metadata: Metadata = {
+  title: 'Opportunities',
+  description: 'Roles matched to your VitalCV readiness.',
+};
+
+// Renders the "Roles" tab of the clinician bottom nav. Data comes from the
+// shared ClinicianMobileProvider loaded in app/holder/layout.tsx.
+export default function HolderOpportunitiesPage() {
+  return <ClinicianOpportunitiesSurface />;
+}


### PR DESCRIPTION
## Problem (live defect on `main`)

The clinician bottom-nav (`MobileBottomNav`) and `ApplyModal` link to routes that have **no page file on `main`**, so they 404:

- **`/holder/opportunities`** — the "Roles" nav tab → 404
- **`/holder/applications`** — the "Updates" nav tab → 404
- **`/holder/applications/[id]`** — where `ApplyModal` redirects after a successful apply → **404 (post-apply dead-end)**

Two of the five primary clinician nav tabs are dead, and applying to a job lands the clinician on a 404.

## Fix

The surfaces and data pipeline already exist on `main` — only the route pages were missing:
- `ClinicianOpportunitiesSurface`, `ClinicianApplicationsSurface`, `ClinicianApplicationDetailSurface` (all read shared context)
- `ClinicianMobileProvider` (loaded once in `app/holder/layout.tsx` via `loadClinicianMobileData`)

This adds the three route pages, mirroring `app/holder/home/page.tsx`. No new components, no data changes — pure wiring.

## Verified
- All three routes now resolve **307 → sign-in** (identical to the working `/holder/home`), no longer 404.
- `tsc` 0 errors; lint clean.
- Authed render verifies on the Railway deployment (Clerk is unavailable in local dev).

## Customer value
Completes the core clinician loop — **browse roles → apply → track applications** — closing two dead nav tabs and the post-apply dead-end. P1 Clinician Career Platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)