### PR TITLE
feat(clinician): live source-backed readiness (replace demo snapshot)

### DIFF
--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -46,6 +46,19 @@ export default function ReadinessSurface() {
   const [logEntries, setLogEntries] = useState<StateLogEntry[]>([]);
   const [loadState, setLoadState] = useState<LoadState>('loading');
 
+  // Synchronous reset on identity change (React "adjust state during render"
+  // pattern): React re-renders immediately with cleared state, so not one
+  // frame of a prior clinician's readiness, limitations, or state log can
+  // ever be shown for a different NPI.
+  const [renderedNpi, setRenderedNpi] = useState(npi);
+  if (renderedNpi !== npi) {
+    setRenderedNpi(npi);
+    setSnapshot(null);
+    setLimitations([]);
+    setLogEntries([]);
+    setLoadState(npi ? 'loading' : 'no-npi');
+  }
+
   const addLog = useCallback((message: string, level: StateLogEntry['level'] = 'info') => {
     setLogEntries((prev) => [...prev, { ts: Date.now(), message, level }]);
   }, []);
@@ -100,6 +113,12 @@ export default function ReadinessSurface() {
     };
   }, [npi, name, addLog]);
 
+  // Render-time identity guard: a snapshot is only valid for the NPI it was
+  // built from. On NPI change (or disappearance) the effect resets state a
+  // tick later — this guard makes sure not even one frame of another
+  // clinician's readiness can render in the gap.
+  const activeSnapshot = snapshot && snapshot.npi === npi ? snapshot : null;
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Top bar */}
@@ -111,17 +130,17 @@ export default function ReadinessSurface() {
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6">
         {/* Posture header */}
-        {snapshot && (
+        {activeSnapshot && (
           <div className="flex flex-wrap items-center gap-4">
             <div>
-              <h1 className="text-2xl font-extrabold text-slate-900">{snapshot.name}</h1>
-              <p className="font-mono text-sm text-slate-500 mt-0.5 tracking-wide">NPI {snapshot.npi}</p>
+              <h1 className="text-2xl font-extrabold text-slate-900">{activeSnapshot.name}</h1>
+              <p className="font-mono text-sm text-slate-500 mt-0.5 tracking-wide">NPI {activeSnapshot.npi}</p>
             </div>
             <div className="flex flex-wrap items-center gap-2 ml-auto">
-              <PostureBadge posture={snapshot.posture} size="md" />
-              <ProofTierBadge tier={snapshot.proofTier} />
-              {snapshot.score !== null
-                ? <MetricBadge label={`${snapshot.score}% readiness`} type="measured" />
+              <PostureBadge posture={activeSnapshot.posture} size="md" />
+              <ProofTierBadge tier={activeSnapshot.proofTier} />
+              {activeSnapshot.score !== null
+                ? <MetricBadge label={`${activeSnapshot.score}% readiness`} type="measured" />
                 : <MetricBadge label="score unavailable" type="unverified" />}
             </div>
           </div>
@@ -156,22 +175,22 @@ export default function ReadinessSurface() {
         )}
 
         {/* Split pane */}
-        {snapshot && loadState === 'ready' && (
+        {activeSnapshot && loadState === 'ready' && (
           <>
             <ProofSplitPane
-              lanes={snapshot.lanes}
-              npi={snapshot.npi}
-              name={snapshot.name}
-              score={snapshot.score}
-              generatedAt={snapshot.generatedAt}
-              proofTier={snapshot.proofTier}
+              lanes={activeSnapshot.lanes}
+              npi={activeSnapshot.npi}
+              name={activeSnapshot.name}
+              score={activeSnapshot.score}
+              generatedAt={activeSnapshot.generatedAt}
+              proofTier={activeSnapshot.proofTier}
               limitations={limitations}
             />
 
-            {snapshot.nextStep && (
+            {activeSnapshot.nextStep && (
               <div className="bg-white border border-slate-200 rounded-xl px-5 py-4">
                 <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">Next Step</p>
-                <p className="text-sm text-slate-700">{snapshot.nextStep}</p>
+                <p className="text-sm text-slate-700">{activeSnapshot.nextStep}</p>
               </div>
             )}
 

--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -54,11 +54,18 @@ export default function ReadinessSurface() {
     let cancelled = false;
 
     async function load() {
+      // Reset all readiness state whenever the identity changes so a prior
+      // clinician's snapshot can never linger while (or after) a new NPI loads.
+      setSnapshot(null);
+      setLimitations([]);
+      setLogEntries([]);
+
       if (!npi) {
         setLoadState('no-npi');
         return;
       }
 
+      setLoadState('loading');
       addLog('Loading source-backed readiness…');
       try {
         const res = await fetch(`/api/passport/${encodeURIComponent(npi)}`, { cache: 'no-store' });

--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -44,7 +44,7 @@ export default function ReadinessSurface() {
   const [snapshot, setSnapshot] = useState<ReadinessSnapshot | null>(null);
   const [limitations, setLimitations] = useState<string[]>([]);
   const [logEntries, setLogEntries] = useState<StateLogEntry[]>([]);
-  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [loadState, setLoadState] = useState<LoadState>(npi ? 'loading' : 'no-npi');
 
   // Synchronous reset on identity change (React "adjust state during render"
   // pattern): React re-renders immediately with cleared state, so not one

--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -1,93 +1,97 @@
 'use client';
 /**
- * Readiness Surface — wave-133: UI/UX Unfreeze
+ * Readiness Surface — live source-backed readiness for the signed-in clinician.
  *
- * Split-pane architecture:
- *   LEFT:  source lanes quick scan
- *   RIGHT: deep inspection (claims, receipts, limitations)
- *
- * Live state log replaces spinners.
- * Typography: monospace for IDs/hashes, tabular for scores.
- * Colors only for state — no decoration.
+ * Reads the clinician's NPI/name from the shared mobile context, fetches their
+ * real passport (/api/passport/:npi — the same source the wallet/packet use),
+ * and maps its source coverage into the readiness lanes. No demo data: when the
+ * NPI is missing or the passport can't be loaded it shows an honest empty/error
+ * state instead of a fabricated snapshot.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { ProofSplitPane } from '@/components/proof/LanePanel';
-import { LiveStateLog, buildStateLog } from '@/components/proof/LiveStateLog';
+import { LiveStateLog } from '@/components/proof/LiveStateLog';
 import { PostureBadge, ProofTierBadge, MetricBadge } from '@/components/proof/TrustLabel';
-import type { ReadinessSnapshot, StateLogEntry, LaneSnapshot } from '@/components/proof/trust-types';
+import { KNOWN_LANES, type ReadinessSnapshot, type StateLogEntry } from '@/components/proof/trust-types';
+import { isPassportData } from '@/lib/trust/passport-contract';
+import {
+  buildReadinessLimitations,
+  buildReadinessSnapshotFromPassport,
+} from '@/lib/readiness/passport-readiness-snapshot';
 
-// ─── Demo/fallback state for when no API is wired ─────────────────
-// Replace with real API call in production
+type LoadState = 'loading' | 'ready' | 'no-npi' | 'error';
 
-function buildDemoSnapshot(): ReadinessSnapshot {
-  const now = Date.now();
-  return {
-    npi: '1457128589',
-    name: 'MACIE MILLER',
-    posture: 'partial',
-    score: 25,
-    proofTier: 'partial',
-    generatedAt: now,
-    nextStep: 'OIG exclusions and state license require institutional access to verify.',
-    lanes: [
-      { laneId: 'nppes_identity',   status: 'verified',        checkedAt: now,   value: 'Active — Behavior Technician',    source: 'NPPES', receiptId: `rcpt-nppes-${now}` },
-      { laneId: 'oig_exclusions',   status: 'access_required', checkedAt: null,  value: null, source: 'OIG LEIE', receiptId: null },
-      { laneId: 'state_license',    status: 'access_required', checkedAt: null,  value: null, source: 'State Board', receiptId: null },
-      { laneId: 'employment_history', status: 'not_checked',   checkedAt: null,  value: null, source: 'The Work Number', receiptId: null },
-    ],
-  };
+function laneLogMessage(laneId: string, status: string): { message: string; level: StateLogEntry['level'] } {
+  const def = KNOWN_LANES.find((lane) => lane.laneId === laneId);
+  const name = def?.displayName ?? laneId;
+  const level: StateLogEntry['level'] =
+    status === 'verified' ? 'info' : status === 'adverse' ? 'error' : 'warn';
+  const label = status.replace(/_/g, ' ');
+  return { message: `${name} — ${label}`, level };
 }
 
-const DEMO_LIMITATIONS = [
-  'NPPES identity verified against live CMS registry.',
-  'OIG exclusions: integration not yet wired — access_required.',
-  'State license: no state-board source attached for this clinician; board API not wired.',
-  'Score reflects identity lane only (25% = 1 of 4 tracked lanes).',
-];
-
-// ─── Surface ──────────────────────────────────────────────────────
-
 export default function ReadinessSurface() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? null;
+  const name =
+    [data.workspace?.personProfile?.firstName, data.workspace?.personProfile?.lastName]
+      .filter(Boolean)
+      .join(' ') || 'Your profile';
+
   const [snapshot, setSnapshot] = useState<ReadinessSnapshot | null>(null);
+  const [limitations, setLimitations] = useState<string[]>([]);
   const [logEntries, setLogEntries] = useState<StateLogEntry[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
 
   const addLog = useCallback((message: string, level: StateLogEntry['level'] = 'info') => {
-    setLogEntries(prev => [...prev, { ts: Date.now(), message, level }]);
+    setLogEntries((prev) => [...prev, { ts: Date.now(), message, level }]);
   }, []);
 
   useEffect(() => {
     let cancelled = false;
 
     async function load() {
-      addLog('Initializing readiness check…');
-      await delay(150);
-      if (cancelled) return;
+      if (!npi) {
+        setLoadState('no-npi');
+        return;
+      }
 
-      addLog('Fetching NPPES identity…');
-      await delay(300);
-      if (cancelled) return;
+      addLog('Loading source-backed readiness…');
+      try {
+        const res = await fetch(`/api/passport/${encodeURIComponent(npi)}`, { cache: 'no-store' });
+        if (!res.ok) throw new Error(`passport ${res.status}`);
+        const payload: unknown = await res.json();
+        if (cancelled) return;
 
-      // In production: fetch from /api/manifest
-      // For now: demo snapshot
-      const snap = buildDemoSnapshot();
-      if (cancelled) return;
+        if (!isPassportData(payload)) {
+          throw new Error('passport payload invalid');
+        }
 
-      addLog('NPPES identity — verified', 'info');
-      addLog('OIG exclusions — institutional access required', 'warn');
-      addLog('State license — institutional access required', 'warn');
-      addLog('Employment history — not checked this session', 'info');
-      addLog(`Readiness snapshot generated at ${new Date(snap.generatedAt).toLocaleTimeString()}`);
+        const snap = buildReadinessSnapshotFromPassport(payload, { npi, name });
+        snap.lanes.forEach((lane) => {
+          const { message, level } = laneLogMessage(lane.laneId, lane.status);
+          addLog(message, level);
+        });
+        addLog(`Readiness snapshot generated at ${new Date(snap.generatedAt).toLocaleTimeString()}`);
 
-      setSnapshot(snap);
-      setLoading(false);
+        setSnapshot(snap);
+        setLimitations(buildReadinessLimitations(snap));
+        setLoadState('ready');
+      } catch {
+        if (cancelled) return;
+        addLog('Could not load source-backed readiness.', 'error');
+        setLoadState('error');
+      }
     }
 
-    load();
-    return () => { cancelled = true; };
-  }, [addLog]);
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [npi, name, addLog]);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -95,13 +99,10 @@ export default function ReadinessSurface() {
       <div className="bg-slate-900 text-slate-300 text-xs px-6 py-2 flex items-center justify-between">
         <Link href="/holder/home" className="text-slate-400 hover:text-white transition-colors">← Dashboard</Link>
         <span className="font-mono uppercase tracking-widest font-bold">Readiness</span>
-        <span className="font-mono text-slate-500 text-[10px]">
-          {snapshot ? `v${Date.now().toString(36).slice(-6)}` : '…'}
-        </span>
+        <span className="font-mono text-slate-500 text-[10px]">{npi ? `NPI ${npi}` : '…'}</span>
       </div>
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6">
-
         {/* Posture header */}
         {snapshot && (
           <div className="flex flex-wrap items-center gap-4">
@@ -113,25 +114,42 @@ export default function ReadinessSurface() {
               <PostureBadge posture={snapshot.posture} size="md" />
               <ProofTierBadge tier={snapshot.proofTier} />
               {snapshot.score !== null
-                ? <MetricBadge label={`${snapshot.score}% coverage`} type="measured" />
-                : <MetricBadge label="score unavailable" type="unverified" />
-              }
+                ? <MetricBadge label={`${snapshot.score}% readiness`} type="measured" />
+                : <MetricBadge label="score unavailable" type="unverified" />}
             </div>
           </div>
         )}
 
-        {/* Live state log */}
-        <LiveStateLog entries={logEntries} maxHeight={160} />
+        {/* No NPI — honest CTA, not demo */}
+        {loadState === 'no-npi' && (
+          <div className="bg-white border border-slate-200 rounded-xl p-8 text-center space-y-3">
+            <p className="text-sm text-slate-700">Add your NPI to see your source-backed readiness.</p>
+            <Link href="/get-ready" className="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 transition-colors">
+              Connect your NPI →
+            </Link>
+          </div>
+        )}
 
-        {/* Loading state */}
-        {loading && (
+        {/* Live state log */}
+        {loadState !== 'no-npi' && <LiveStateLog entries={logEntries} maxHeight={160} />}
+
+        {/* Loading */}
+        {loadState === 'loading' && (
           <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
             <p className="font-mono text-sm text-slate-500 animate-pulse">Checking sources…</p>
           </div>
         )}
 
+        {/* Error — honest, not demo */}
+        {loadState === 'error' && (
+          <div className="bg-white border border-rose-200 rounded-xl p-8 text-center space-y-2">
+            <p className="text-sm text-rose-700">Source-backed readiness is temporarily unavailable.</p>
+            <p className="text-xs text-slate-500">This is a system state — not a finding about your credentials. Try again shortly.</p>
+          </div>
+        )}
+
         {/* Split pane */}
-        {snapshot && !loading && (
+        {snapshot && loadState === 'ready' && (
           <>
             <ProofSplitPane
               lanes={snapshot.lanes}
@@ -140,10 +158,9 @@ export default function ReadinessSurface() {
               score={snapshot.score}
               generatedAt={snapshot.generatedAt}
               proofTier={snapshot.proofTier}
-              limitations={DEMO_LIMITATIONS}
+              limitations={limitations}
             />
 
-            {/* Next step */}
             {snapshot.nextStep && (
               <div className="bg-white border border-slate-200 rounded-xl px-5 py-4">
                 <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">Next Step</p>
@@ -151,22 +168,21 @@ export default function ReadinessSurface() {
               </div>
             )}
 
-            {/* Limitations block */}
-            <div className="bg-amber-50 border border-amber-200 rounded-xl px-5 py-4">
-              <p className="text-xs font-bold uppercase tracking-widest text-amber-700 mb-3">Limitations</p>
-              <ul className="space-y-1">
-                {DEMO_LIMITATIONS.map((l, i) => (
-                  <li key={i} className="text-xs text-amber-800 flex gap-2">
-                    <span className="flex-shrink-0 text-amber-400">·</span>{l}
-                  </li>
-                ))}
-              </ul>
-            </div>
+            {limitations.length > 0 && (
+              <div className="bg-amber-50 border border-amber-200 rounded-xl px-5 py-4">
+                <p className="text-xs font-bold uppercase tracking-widest text-amber-700 mb-3">Limitations</p>
+                <ul className="space-y-1">
+                  {limitations.map((limitation, index) => (
+                    <li key={index} className="text-xs text-amber-800 flex gap-2">
+                      <span className="flex-shrink-0 text-amber-400">·</span>{limitation}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </>
         )}
       </div>
     </div>
   );
 }
-
-function delay(ms: number) { return new Promise(r => setTimeout(r, ms)); }

--- a/apps/web/lib/readiness/__tests__/passport-readiness-snapshot.test.ts
+++ b/apps/web/lib/readiness/__tests__/passport-readiness-snapshot.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  buildReadinessLimitations,
+  buildReadinessSnapshotFromPassport,
+} from '@/lib/readiness/passport-readiness-snapshot';
+
+function passport(checks: Array<{ sourceId: string; state: string; reason?: string; checkedAt?: string | null }>, score = 62): PassportData {
+  return {
+    sourceCoverage: {
+      checks: checks.map((c) => ({
+        sourceId: c.sourceId,
+        state: c.state,
+        reason: c.reason ?? 'reason',
+        checkedAt: c.checkedAt ?? null,
+      })),
+    },
+    readiness: { score, gaps: ['Resolve OIG access'] },
+  } as unknown as PassportData;
+}
+
+describe('buildReadinessSnapshotFromPassport', () => {
+  it('maps real source coverage to lanes conservatively (only checked → verified)', () => {
+    const snap = buildReadinessSnapshotFromPassport(
+      passport([
+        { sourceId: 'NPPES_API', state: 'checked', checkedAt: '2026-06-01T00:00:00.000Z' },
+        { sourceId: 'OIG_LEIE', state: 'accessRequired' },
+        { sourceId: 'STATE_BOARD', state: 'stale' },
+        { sourceId: 'PECOS_PUBLIC', state: 'reviewRequired' },
+      ]),
+      { npi: '1234567890', name: 'Dr. Test Clinician' },
+    );
+
+    const byLane = Object.fromEntries(snap.lanes.map((l) => [l.laneId, l.status]));
+    expect(byLane.nppes_identity).toBe('verified');
+    expect(byLane.oig_exclusions).toBe('access_required');
+    expect(byLane.state_license).toBe('stale');
+    expect(byLane.pecos_enrollment).toBe('review_required');
+    // sources with no check stay honestly not_checked
+    expect(byLane.employment_history).toBe('not_checked');
+    expect(byLane.board_cert).toBe('not_checked');
+
+    expect(snap.npi).toBe('1234567890');
+    expect(snap.score).toBe(62);
+    // required lanes (nppes/oig/state_license) not all verified → partial; stale present → degraded
+    expect(snap.proofTier).toBe('partial');
+    expect(snap.posture).toBe('degraded');
+    expect(snap.nextStep).toBe('Resolve OIG access');
+  });
+
+  it('never lets previewOnly/synthetic states read as verified', () => {
+    const snap = buildReadinessSnapshotFromPassport(
+      passport([{ sourceId: 'NPPES_API', state: 'previewOnly' }]),
+      { npi: '1', name: 'x' },
+    );
+    expect(snap.lanes.find((l) => l.laneId === 'nppes_identity')?.status).toBe('not_checked');
+    expect(snap.proofTier).toBe('none');
+    expect(snap.posture).toBe('unchecked');
+  });
+
+  it('reaches decision_grade only when all required lanes are checked', () => {
+    const snap = buildReadinessSnapshotFromPassport(
+      passport([
+        { sourceId: 'NPPES_API', state: 'checked' },
+        { sourceId: 'OIG_LEIE', state: 'checked' },
+        { sourceId: 'STATE_BOARD', state: 'checked' },
+      ]),
+      { npi: '1', name: 'x' },
+    );
+    expect(snap.proofTier).toBe('decision_grade');
+    expect(snap.posture).toBe('decision_grade');
+  });
+
+  it('derives honest limitations from non-verified lanes only', () => {
+    const snap = buildReadinessSnapshotFromPassport(
+      passport([{ sourceId: 'NPPES_API', state: 'checked' }]),
+      { npi: '1', name: 'x' },
+    );
+    const limitations = buildReadinessLimitations(snap);
+    expect(limitations.some((l) => l.startsWith('NPPES Identity'))).toBe(false);
+    expect(limitations.some((l) => l.startsWith('OIG Exclusions'))).toBe(true);
+  });
+});

--- a/apps/web/lib/readiness/passport-readiness-snapshot.ts
+++ b/apps/web/lib/readiness/passport-readiness-snapshot.ts
@@ -1,0 +1,143 @@
+/**
+ * passport-readiness-snapshot — maps the clinician's REAL passport source
+ * coverage (the same data the wallet/packet render) into the ReadinessSnapshot
+ * shape the /holder/readiness surface consumes. Replaces the hardcoded
+ * buildDemoSnapshot().
+ *
+ * Truth contract: this never upgrades a state. Canonical coverage states map
+ * conservatively to the surface's SourceStatus — only `checked` becomes
+ * `verified`; everything non-decision-grade reads as not-checked / gated /
+ * stale / review-required honestly. `previewOnly` (synthetic) is treated as
+ * not_checked so demo payloads can never present as real verification.
+ */
+
+import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  findPassportSourceCoverageChecks,
+  sourceCoverageStateLabel,
+  type PassportSourceCoverageState,
+} from '@/lib/trust/source-coverage';
+import {
+  KNOWN_LANES,
+  type LaneSnapshot,
+  type ReadinessPosture,
+  type ReadinessSnapshot,
+  type SourceStatus,
+} from '@/components/proof/trust-types';
+
+// Source-id aliases per canonical lane. `findPassportSourceCoverageChecks`
+// fuzzy-matches (normalized substring both ways), so these map the launch-spine
+// source ids (NPPES_API, OIG_LEIE, PECOS_PUBLIC, STATE_BOARD) + phase-2 sources.
+const LANE_ALIASES: Record<string, string[]> = {
+  nppes_identity: ['nppes'],
+  oig_exclusions: ['oig', 'leie'],
+  state_license: ['stateboard'],
+  employment_history: ['worknumber', 'employment'],
+  board_cert: ['abms', 'boardcert', 'specialtyboard'],
+  pecos_enrollment: ['pecos'],
+};
+
+// Conservative canonical-state → surface-status mapping. Never upgrades.
+const STATE_TO_STATUS: Record<PassportSourceCoverageState, SourceStatus> = {
+  checked: 'verified',
+  stale: 'stale',
+  pending: 'in_progress',
+  gated: 'access_required',
+  unavailable: 'unavailable',
+  accessRequired: 'access_required',
+  reviewRequired: 'review_required',
+  notDecisionGrade: 'not_checked',
+  previewOnly: 'not_checked',
+};
+
+const REQUIRED_LANE_IDS = KNOWN_LANES.filter((lane) => lane.isRequired).map((lane) => lane.laneId);
+
+function parseTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function derivePosture(lanes: LaneSnapshot[], proofTier: ReadinessSnapshot['proofTier']): ReadinessPosture {
+  if (lanes.some((lane) => lane.status === 'adverse')) return 'blocked';
+  if (proofTier === 'decision_grade') return 'decision_grade';
+  if (lanes.some((lane) => lane.status === 'stale')) return 'degraded';
+  if (lanes.some((lane) => lane.status === 'in_progress')) return 'checking';
+  if (proofTier === 'partial') return 'partial';
+  return 'unchecked';
+}
+
+export function buildReadinessSnapshotFromPassport(
+  passport: PassportData,
+  opts: { npi: string; name: string },
+): ReadinessSnapshot {
+  const report = passport.sourceCoverage;
+
+  const lanes: LaneSnapshot[] = KNOWN_LANES.map((lane) => {
+    const aliases = LANE_ALIASES[lane.laneId] ?? [lane.shortName.toLowerCase()];
+    const check = findPassportSourceCoverageChecks(report, aliases)[0] ?? null;
+
+    if (!check) {
+      return {
+        laneId: lane.laneId,
+        status: 'not_checked',
+        checkedAt: null,
+        value: null,
+        source: lane.source,
+        receiptId: null,
+      };
+    }
+
+    return {
+      laneId: lane.laneId,
+      status: STATE_TO_STATUS[check.state] ?? 'not_checked',
+      checkedAt: parseTimestamp(check.checkedAt),
+      value: sourceCoverageStateLabel(check.state),
+      source: lane.source,
+      receiptId: check.proof?.receiptIds?.[0] ?? null,
+    };
+  });
+
+  const verifiedRequired = lanes.filter(
+    (lane) => REQUIRED_LANE_IDS.includes(lane.laneId) && lane.status === 'verified',
+  ).length;
+  const anyVerified = lanes.some((lane) => lane.status === 'verified');
+  const proofTier: ReadinessSnapshot['proofTier'] =
+    verifiedRequired === REQUIRED_LANE_IDS.length ? 'decision_grade' : anyVerified ? 'partial' : 'none';
+
+  const posture = derivePosture(lanes, proofTier);
+  const score = typeof passport.readiness?.score === 'number' ? Math.round(passport.readiness.score) : null;
+  const nextStep = passport.readiness?.gaps?.[0] ?? null;
+
+  return {
+    npi: opts.npi,
+    name: opts.name,
+    posture,
+    score,
+    lanes,
+    generatedAt: Date.now(),
+    proofTier,
+    nextStep,
+  };
+}
+
+const STATUS_LIMITATION_LABEL: Record<SourceStatus, string> = {
+  verified: 'verified',
+  in_progress: 'a check is currently running',
+  not_checked: 'not checked yet',
+  stale: 'previously verified but now stale — refresh recommended',
+  unavailable: 'source temporarily unreachable',
+  access_required: 'requires institutional access not yet configured',
+  review_required: 'returned data that requires human review',
+  adverse: 'returned an adverse finding (blocker)',
+};
+
+/** Honest, source-backed limitations derived from the real (non-verified) lanes. */
+export function buildReadinessLimitations(snapshot: ReadinessSnapshot): string[] {
+  return snapshot.lanes
+    .filter((lane) => lane.status !== 'verified')
+    .map((lane) => {
+      const def = KNOWN_LANES.find((known) => known.laneId === lane.laneId);
+      return `${def?.displayName ?? lane.laneId}: ${STATUS_LIMITATION_LABEL[lane.status]}.`;
+    });
+}


### PR DESCRIPTION
## Golden Path step: *Achieve Credential Readiness*

`/holder/readiness` (the "Ready" nav tab) rendered a **hardcoded demo snapshot** — NPI `1457128589` / "MACIE MILLER" with fabricated lanes — for **every** clinician. By the success metric (no demo data on the journey), this was a Golden-Path interruption.

## Change

The surface now reads the signed-in clinician's NPI/name from the shared mobile context and fetches their **real passport** (`/api/passport/:npi` — the same source the wallet and Career Packet already use), mapping its source coverage into the readiness lanes.

- **`lib/readiness/passport-readiness-snapshot.ts`** — pure mapper `PassportData.sourceCoverage → ReadinessSnapshot`. **Conservative by truth contract:** only canonical `checked` → `verified`; `gated`/`stale`/`reviewRequired`/`previewOnly` never upgrade; `proofTier` is `decision_grade` only when all required lanes are checked.
- **Unit-tested** (4 cases), including *"previewOnly/synthetic never reads as verified."*
- **Honest states, no demo fallback:** no NPI → connect-NPI CTA; load failure → "temporarily unavailable (system state, not a finding)."

Reuses existing components (`ProofSplitPane`, badges, `LiveStateLog`) and the existing `@vitalcv/trust-state` source-coverage helpers — no duplicate data path, no new screens.

## Verified
- `tsc` 0 errors · lint clean · **vitest 4/4** on the mapper.
- Authed render verifies on the Railway deployment (Clerk unavailable in local dev).

## Journey impact
Removes demo data from the "Achieve Credential Readiness" step — a clinician now sees their *real* source-backed readiness. Next per journey order: Professional Profile editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)