### PR TITLE
fix(web): install full workspace graph in Docker deps stage

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -14,16 +14,18 @@ WORKDIR /app
 RUN npm i -g pnpm@10.6.1
 
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/web/package.json apps/web/
-# Skip postinstall in the deps layer — the Prisma schema isn't
-# copied yet. `prisma generate` runs in the build stage via the
-# package.json `build` script (`prisma generate && next build`).
+# Copy the FULL workspace manifest + source set so pnpm can resolve the
+# COMPLETE workspace graph — inter-package symlinks (e.g. crs -> psv) plus
+# every selected package's node_modules. A web-only manifest leaves the
+# transitively-built workspace packages that `turbo run build` compiles
+# with no links (TS2307) and no build tooling. `--filter @vitalcv/web...`
+# still scopes the install to web's dependency closure, not all apps.
+# --ignore-scripts skips postinstalls (prisma generate) here; the web
+# `build` script (`prisma generate && next build`) runs it in the build stage.
+COPY . .
 RUN pnpm install --frozen-lockfile --filter @vitalcv/web... --ignore-scripts
 
-FROM base AS build
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+FROM deps AS build
 ENV NEXT_TELEMETRY_DISABLED=1
 # NEXT_PUBLIC_* vars are baked into the client bundle at build time.
 # Default to the production API host so a build without an explicit


### PR DESCRIPTION
## Summary

The `vitalcv-web` Docker build fails on `main`: `pnpm turbo run build --filter @vitalcv/web` cannot compile the workspace packages web now depends on. Root cause is a **partial manifest set** in the Dockerfile `deps` stage — it copied only `apps/web/package.json`, so pnpm never saw the other workspace packages' manifests and produced neither their build tooling nor their inter-package symlinks.

**Fix is one file, `apps/web/Dockerfile`:** copy the full workspace context before installing, and build `FROM deps` so per-package `node_modules` survive. `--filter @vitalcv/web...` still scopes the install to web's closure (14 of 41 projects).

```diff
 FROM base AS deps
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY apps/web/package.json apps/web/
+COPY . .
 RUN pnpm install --frozen-lockfile --filter @vitalcv/web... --ignore-scripts

-FROM base AS build
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+FROM deps AS build
```

## Reproduction timeline

1. **Observed:** `deps` stage runs `pnpm install --frozen-lockfile --filter @vitalcv/web... --ignore-scripts`, then `pnpm turbo run build --filter @vitalcv/web` fails — `@vitalcv/wallet-sdk` / `@vitalcv/verifier-sdk` "cannot execute tsup".
2. **Graph check:** on `main`, `apps/web/package.json` declares `@vitalcv/wallet-sdk` + `@vitalcv/verifier-sdk` as `workspace:*`; `turbo run build --filter @vitalcv/web` compiles 12 workspace packages from source (crs, psv, ingest, trust-state, 4× domain, 3× sdk, web).
3. **Tooling placement:** `tsup` is a devDependency of the 4 SDK packages and is **not** hoisted at the workspace root; `typescript` **is** root-hoisted (that's why `tsc`-built packages survive and only `tsup`-built ones break).
4. **Dockerfile detail:** the `deps` stage copies only root manifests + `apps/web/package.json`. pnpm therefore never installs the SDKs' devDeps and never links `crs`→`psv`.
5. **Reproduced** the exact failure in a clean local `docker build` (see below).

## Experimental evidence — why the `tsup` root-hoist was discarded

I first hypothesized the fix was hoisting `tsup` into the root `package.json` (mirroring `typescript`). Testing disproved it as the right/minimal fix:

- **With `tsup` hoisted to root, Dockerfile unchanged:** the three SDKs built, but the build then failed at `@vitalcv/crs` with `TS2307: Cannot find module '@vitalcv/psv'` — a *second* failure the tsup error had masked. So the hoist alone does **not** produce a green build.
- **With the Dockerfile fix and NO package.json change:** full build is **14/14 green**. This proves that once the manifests are present, `--filter @vitalcv/web...` installs each in-scope package's devDeps (tsup included) — the hoist is redundant.

Conclusion: the `deps`-stage manifest set is the single root cause; the `package.json`/lockfile edits were removed. Final diff is Dockerfile-only.

## Before / after Docker validation (local, `origin/main` @ `9c4c49c`)

| Stage | Command | Result |
|---|---|---|
| **Original failure** | `docker build --target build` (unmodified `main`) | ❌ `sh: tsup: not found` — wallet/verifier/issuer-sdk; `Tasks: 0 successful, 7 total` |
| **Intermediate (tsup-hoist experiment)** | hoist `tsup` to root, Dockerfile unchanged | ❌ SDKs pass, then `@vitalcv/crs:build: TS2307: Cannot find module '@vitalcv/psv'`; `7 successful, 11 total` |
| **Final green (this PR)** | full `docker build` of `apps/web/Dockerfile` | ✅ `Tasks: 14 successful, 14 total`; `@vitalcv/web:build > prisma generate && next build` → `✓ Compiled successfully`; runtime stage COPYs OK; **exit 0** |
| **Control** | final Dockerfile fix with NO package.json change | ✅ `14 successful, 14 total` — fix is self-contained |

## Scope

- One file: `apps/web/Dockerfile` (+10 / −8). No unrelated cleanup.
- **Trade-off noted:** `COPY . .` in `deps` busts the install-layer cache on any source change (warm `pnpm install` ≈ 13s). Manifest-only cache granularity can be restored later with `COPY --parents **/package.json ./` (`# syntax=docker/dockerfile:1.7-labs`) — an optimization, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
