### PR TITLE
fix(ci): exclude @vitalcv/web from monorepo test lane (no postgres service)

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -87,7 +87,16 @@ jobs:
         # test coverage lives in .github/workflows/ci-preflight.yml
         # (see the "backend tests" step there); the deploy-api job in
         # this file only builds the backend, it does not test it.
-        run: pnpm turbo run test --filter=!@vitalcv/api --filter=!chai-vc-platform-backend
+        #
+        # @vitalcv/web is excluded for the same class of reason: this job
+        # has no postgres service, but the dummy DATABASE_URL above (kept
+        # for other packages' env validation) un-skips the web suite's
+        # real-Postgres tests (__tests__/verifier-worklist-db.test.ts
+        # skips only when DATABASE_URL is unset), which then fail with
+        # P1001 — red on every push to main since PR #469. The full web
+        # suite runs without DATABASE_URL in .github/workflows/ci.yml
+        # ("Web Quality"), which triggers on the same web/package paths.
+        run: pnpm turbo run test --filter=!@vitalcv/api --filter=!chai-vc-platform-backend --filter=!@vitalcv/web
 
       - name: Scale integrity gate (W2-PR38A)
         # Mock-based scale + throughput suite for the replay engine and


### PR DESCRIPTION
## Summary
- Monorepo CI/CD has been red on every push to main since PR #469: the "Run tests (non-backend packages)" step exports a dummy `DATABASE_URL` (kept for other packages' env validation) but the job has **no postgres service container**, so `apps/web/__tests__/verifier-worklist-db.test.ts` un-skips (its skip guard is `!process.env.DATABASE_URL`), hits nothing at localhost:5432, and fails with Prisma P1001.
- Fix: add `--filter=!@vitalcv/web` to the turbo test invocation in this lane, with an explanatory comment mirroring the existing backend-exclusion rationale.

## Coverage honesty
- No web test coverage is lost: the full `@vitalcv/web` suite runs (currently green, 194 files / 1710 tests) without `DATABASE_URL` in `.github/workflows/ci.yml` ("Web Quality"), which triggers on the same `apps/web/**` / `packages/**` paths.
- The real-Postgres web DB test still has no CI lane with an actual database — same state as before this PR; it was only ever running here by accident and failing.

## Truth rules
- No product code or copy changes. Workflow-only.

## Validation
- YAML lint: pass
- Root cause verified from the failed run log of main push 2280251b2 (run 28528787270): `PrismaClientInitializationError: Can't reach database server at localhost:5432` in `verifier-worklist-db.test.ts`, 194/195 other web files green.