### PR TITLE
fix(deploy): remove broken startCommand override — restore Railway web deploys

### DIFF
--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -1,27 +1,28 @@
-# Railway service config for `apps/web`.
+# Railway service config for `apps/web` (config-as-code, applied via the
+# service's "config file path" = /apps/web/railway.toml).
 #
-# This is the canonical web-app deployment config. The root
-# `railway.toml` deploys `apps/api/backend`; this file deploys
-# `apps/web` and is consumed when the Railway service's root
-# directory is set to `apps/web` in the Railway dashboard.
+# The vitalcv-web service builds with apps/web/Dockerfile (multi-stage
+# deps → build → runtime). The runtime stage sets WORKDIR /app/apps/web
+# and CMD ["pnpm", "start"], which honors Railway's $PORT.
 #
-# Build chain: pnpm install (root) → pnpm turbo build --filter
-# @vitalcv/web. Turbo handles the workspace dep build order
-# (trust-state, ingest, etc.) before next build runs.
-#
-# Start: Next.js listens on $PORT provided by Railway, binds 0.0.0.0.
+# Do NOT set deploy.startCommand here. A startCommand overrides the
+# Docker CMD but keeps the image's WORKDIR (/app/apps/web) — the
+# previous "cd apps/web && pnpm start" resolved to the nonexistent
+# /app/apps/web/apps/web, so every container exited instantly with no
+# logs and the deployment FAILED (no web deploy succeeded after
+# 2026-05-25 / 1d1b81756, the last deploy before startCommand was
+# added). The Docker CMD is already correct on its own.
 #
 # Health check: /api/health returns JSON `{status:'ok'}`. The route
-# never throws; backend probe failures map to backend:'unreachable'
-# in the response body, not a 5xx.
+# never throws; backend probe failures map to backend:'degraded' or
+# 'unreachable' in the response body, not a 5xx.
 
 [build]
-builder = "NIXPACKS"
-buildCommand = "cd ../.. && pnpm install --frozen-lockfile && pnpm turbo run build --filter @vitalcv/web"
+builder = "DOCKERFILE"
+dockerfilePath = "/apps/web/Dockerfile"
 
 [deploy]
-startCommand = "cd apps/web && pnpm start"
 healthcheckPath = "/api/health"
-healthcheckTimeout = 60
+healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- **Production web has not deployed successfully since 2026-05-25** (`1d1b81756`). Every deployment since — including both July 1 attempts at #469 and #470 — is `FAILED`, and vitalcv.com is serving a 5-week-old build (SHA drift incident, confirmed by `pnpm check:deploy`).
- Root cause: `3804b1cd8` added `deploy.startCommand = "cd apps/web && pnpm start"` to `apps/web/railway.toml`. Railway applies this config file to the vitalcv-web service (visible as `configFile: /apps/web/railway.toml` in the deployment `serviceManifest`) **on top of the Docker image**, whose runtime stage already sets `WORKDIR /app/apps/web`. The override runs `cd apps/web` *from* `/app/apps/web` → nonexistent path → container exits instantly with zero logs → deployment `FAILED` while the stale build keeps serving.
- Fix: drop `startCommand` (the Docker `CMD ["pnpm","start"]` is already correct — it is exactly what the last successful deployment ran), declare `builder = "DOCKERFILE"` to match the service's real manifest (the old `NIXPACKS` + `buildCommand` lines were dashboard-overridden dead config), and restore `healthcheckTimeout = 120` from the last-known-good config.

## Evidence (reproduced locally in the exact image)
Built `apps/web/Dockerfile` from this branch (clean origin/main worktree + this change), then:
```
$ docker run --rm <img> sh -c 'cd apps/web && pnpm start'   # what Railway runs today
sh: cd: line 0: can't cd to apps/web: No such file or directory

$ docker run -d -p 3100:3000 <img>                           # default CMD (this PR's behavior)
GET /api/health -> 200  {"status":"ok","service":"web",...}
```
Railway deployment history (`railway deployment list -s vitalcv-web`): last SUCCESS 2026-05-25 (`1d1b81756`, config had **no** startCommand); all subsequent deploys FAILED with deploy logs containing only `Stopping Container`.

## Truth rules
- Config-only change; no product code, no copy, no claims. Does not touch the Dockerfile that #470 fixed (that fix is good — the image builds and pushes; it was the start override that killed the container).

## Validation
- Full `docker build` of `apps/web/Dockerfile`: exit 0, 14/14 turbo tasks
- Container boots with default CMD; `/api/health` → 200
- Old startCommand reproduces the exact production failure signature