### PR TITLE
fix(ci): remove phantom gates + placeholder deploy step from monorepo workflow

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -98,25 +98,22 @@ jobs:
         # ("Web Quality"), which triggers on the same web/package paths.
         run: pnpm turbo run test --filter=!@vitalcv/api --filter=!chai-vc-platform-backend --filter=!@vitalcv/web
 
-      - name: Scale integrity gate (W2-PR38A)
-        # Mock-based scale + throughput suite for the replay engine and
-        # runtime trust cohesion. Does NOT need a database — runs Jest
-        # directly with mocked prisma + capsuleEngine. Guards against
-        # silent throughput collapse, governance classification drift,
-        # tamper-evidence regressions, and audit-bundle partial-failure
-        # invisibility. Suite lives under apps/api/backend/src/**/__tests__/scale/.
-        run: pnpm --filter chai-vc-platform-backend run test:scale
+      # REMOVED: "Scale integrity gate (W2-PR38A)" and "NCQA + regulatory
+      # operationalization gate (W2-PR40A)". Both steps referenced suites
+      # that do not exist on main — `test:scale` targets
+      # apps/api/backend/**/__tests__/scale/ (jest: "No tests found",
+      # exit 1) and `ncqa:validate` runs
+      # src/tools/runNcqaValidationGate.ts, which was never merged. The
+      # steps therefore failed on every push and had never passed on
+      # main. Re-add each gate in the SAME PR that lands its suite.
 
-      - name: NCQA + regulatory operationalization gate (W2-PR40A)
-        # Pure-function NCQA validation suite. Asserts the regulatory-export
-        # modules uphold their NCQA semantics: 120-day window constant,
-        # determinism, tamper-detection, traceability coverage, banned-string
-        # absence, and completeness semantics. Fails CI on any drift.
-        # Suite lives in apps/api/backend/src/services/audit/regulatoryExports/.
-        run: pnpm --filter chai-vc-platform-backend run ncqa:validate
-
+  # Build-validation only. The real API deploy is Railway's GitHub
+  # integration (service delightful-essence) triggered directly on push
+  # to main; this job proves the API still builds from a clean checkout.
+  # (Its previous "Deploy to container registry" step was an `echo`
+  # placeholder — removed rather than left pretending to deploy.)
   deploy-api:
-    name: Deploy API
+    name: API build validation
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
@@ -142,12 +139,11 @@ jobs:
       - name: Build API
         run: pnpm turbo run build --filter='@vitalcv/api'
 
-      - name: Deploy to container registry
-        # Add your deployment steps here
-        run: echo "Deploy API to container registry"
-
+  # Build-validation only. The real web deploy is Railway's GitHub
+  # integration (service vitalcv-web, apps/web/Dockerfile) triggered
+  # directly on push to main.
   deploy-web:
-    name: Deploy Web
+    name: Web build validation
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- Layer 2 of the red-main incident (layer 1 fixed in #471). With the web DB test unmasked, `Monorepo CI/CD` now fails at **"Scale integrity gate (W2-PR38A)"**: `jest --testPathPattern='__tests__/scale/'` matches **0 files on main** → "No tests found", exit 1. The next step, **"NCQA gate (W2-PR40A)"**, would fail identically: `src/tools/runNcqaValidationGate.ts` does not exist on main (`git cat-file -e` fails; it exists only in unmerged local trees).
- These gates have **never passed on main** — every run back through 2026-05-28 is red. Removed with an in-file comment requiring each gate to be re-added in the same PR that lands its suite.
- Also removes the `echo "Deploy API to container registry"` placeholder step and renames `Deploy API`/`Deploy Web` jobs to `API build validation`/`Web build validation` — Railway's GitHub integration does the real deploys; these jobs only prove clean-checkout builds. No placeholder pretending to deploy.

## Truth rules
- No product code/copy. This *removes* a fake-deploy claim and two gates guarding nonexistent suites; it does not weaken any real coverage (jest exit-1 on zero matches ≠ coverage).

## Validation
- YAML lint: pass
- `git ls-tree origin/main apps/api/backend | grep scale` → no test files; `ncqa` tool absent from origin/main
- Failure log evidence: run 28549055978 ("No tests found, exiting with code 1", `Pattern: __tests__/scale/ - 0 matches`)