### PR TITLE
feat(profile): live professional profile — real workspace + passport data, self-attested edits

### DIFF
--- a/apps/web/app/clinician/profile/ProfileSurface.tsx
+++ b/apps/web/app/clinician/profile/ProfileSurface.tsx
@@ -13,7 +13,7 @@
  *   checking → signed_out | no_npi | load_error | ready
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { AlertCircle, ChevronRight, Loader2, UserRound } from 'lucide-react';
 import { ClinicianProfileSections } from '@/components/profile/ClinicianProfileSections';
@@ -53,6 +53,14 @@ export default function ProfileSurface() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveDone, setSaveDone] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const loadWorkspace = useCallback(async (cancelled?: () => boolean) => {
     try {
@@ -202,18 +210,21 @@ export default function ProfileSurface() {
 
       const responses = await Promise.all(requests);
       const failed = responses.find((r) => !r.ok);
+      if (!mountedRef.current) return;
       if (failed) {
         const body: unknown = await failed.json().catch(() => null);
+        if (!mountedRef.current) return;
         setSaveError(describeProfileSaveError(failed.status, body));
         return;
       }
 
       setSaveDone(true);
-      await loadWorkspace();
+      await loadWorkspace(() => !mountedRef.current);
     } catch {
+      if (!mountedRef.current) return;
       setSaveError(describeProfileSaveError(0, null));
     } finally {
-      setSaving(false);
+      if (mountedRef.current) setSaving(false);
     }
   }
 

--- a/apps/web/app/clinician/profile/ProfileSurface.tsx
+++ b/apps/web/app/clinician/profile/ProfileSurface.tsx
@@ -1,0 +1,506 @@
+'use client';
+
+/**
+ * ProfileSurface — the live professional profile for the signed-in clinician.
+ *
+ * Reads the real workspace PersonProfile (bound at /get-ready via the NPPES
+ * bootstrap) and the clinician's live passport, renders the provenance-honest
+ * profile sections (ClinicianProfileSections), and lets the clinician save
+ * SELF-ATTESTED fields (career links, resume link, work authorization)
+ * through the existing intake endpoints. User-entered information is never
+ * presented as verified.
+ *
+ *   checking → signed_out | no_npi | load_error | ready
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertCircle, ChevronRight, Loader2, UserRound } from 'lucide-react';
+import { ClinicianProfileSections } from '@/components/profile/ClinicianProfileSections';
+import { isPassportData, type PassportData } from '@/lib/trust/passport-contract';
+import {
+  WORK_AUTH_OPTIONS,
+  completenessStatement,
+  describeProfileSaveError,
+  displayName,
+  extractPersonProfile,
+  isWorkAuthStatus,
+  resumeFileNameFromUrl,
+  validateProfileUrl,
+  type WorkspacePersonProfile,
+} from '@/lib/clinician-profile/liveProfile';
+
+type Phase = 'checking' | 'signed_out' | 'no_npi' | 'load_error' | 'ready';
+
+interface LinkFormState {
+  linkedinUrl: string;
+  portfolioUrl: string;
+  resumeUrl: string;
+  workAuthStatus: string;
+}
+
+export default function ProfileSurface() {
+  const [phase, setPhase] = useState<Phase>('checking');
+  const [profile, setProfile] = useState<WorkspacePersonProfile | null>(null);
+  const [passport, setPassport] = useState<PassportData | null>(null);
+  const [passportUnavailable, setPassportUnavailable] = useState(false);
+  const [form, setForm] = useState<LinkFormState>({
+    linkedinUrl: '',
+    portfolioUrl: '',
+    resumeUrl: '',
+    workAuthStatus: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveDone, setSaveDone] = useState(false);
+
+  const loadWorkspace = useCallback(async (cancelled?: () => boolean) => {
+    try {
+      const res = await fetch('/api/me/workspaces', { cache: 'no-store' });
+      if (cancelled?.()) return;
+      if (res.status === 401) {
+        setPhase('signed_out');
+        return;
+      }
+      if (!res.ok) {
+        setPhase('load_error');
+        return;
+      }
+      const payload: unknown = await res.json();
+      if (cancelled?.()) return;
+      const person = extractPersonProfile(payload);
+      if (!person || !person.npi) {
+        setPhase('no_npi');
+        return;
+      }
+      setProfile(person);
+      setForm({
+        linkedinUrl: person.linkedinUrl ?? '',
+        portfolioUrl: person.portfolioUrl ?? '',
+        resumeUrl: person.resumeUrl ?? '',
+        workAuthStatus: person.workAuthStatus ?? '',
+      });
+      setPhase('ready');
+    } catch {
+      if (!cancelled?.()) setPhase('load_error');
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadWorkspace(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [loadWorkspace]);
+
+  const npi = profile?.npi ?? null;
+
+  useEffect(() => {
+    if (!npi) return;
+    let cancelled = false;
+
+    async function loadPassport() {
+      setPassport(null);
+      setPassportUnavailable(false);
+      try {
+        const res = await fetch(`/api/passport/${encodeURIComponent(npi as string)}`, { cache: 'no-store' });
+        if (cancelled) return;
+        if (!res.ok) {
+          setPassportUnavailable(true);
+          return;
+        }
+        const payload: unknown = await res.json();
+        if (cancelled) return;
+        if (isPassportData(payload)) {
+          setPassport(payload);
+        } else {
+          setPassportUnavailable(true);
+        }
+      } catch {
+        if (!cancelled) setPassportUnavailable(true);
+      }
+    }
+
+    void loadPassport();
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  async function saveSelfAttested(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!profile) return;
+    setSaveError(null);
+    setSaveDone(false);
+
+    const linkedin = validateProfileUrl(form.linkedinUrl);
+    const portfolio = validateProfileUrl(form.portfolioUrl);
+    const resume = validateProfileUrl(form.resumeUrl);
+    for (const [label, v] of [
+      ['LinkedIn', linkedin],
+      ['Portfolio', portfolio],
+      ['Resume', resume],
+    ] as const) {
+      if (!v.ok) {
+        setSaveError(`${label}: ${v.reason}`);
+        return;
+      }
+    }
+    if (form.workAuthStatus && !isWorkAuthStatus(form.workAuthStatus)) {
+      setSaveError('Choose a work authorization option from the list.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const requests: Array<Promise<Response>> = [];
+
+      const linksChanged =
+        (linkedin.url ?? '') !== (profile.linkedinUrl ?? '') ||
+        (portfolio.url ?? '') !== (profile.portfolioUrl ?? '');
+      if (linksChanged && (linkedin.url || portfolio.url)) {
+        requests.push(
+          fetch('/api/profile/links', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              ...(linkedin.url ? { linkedinUrl: linkedin.url } : {}),
+              ...(portfolio.url ? { portfolioUrl: portfolio.url } : {}),
+            }),
+          }),
+        );
+      }
+
+      if (resume.url && resume.url !== (profile.resumeUrl ?? '')) {
+        requests.push(
+          fetch('/api/profile/resume/upload', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              fileName: resumeFileNameFromUrl(resume.url),
+              fileUrl: resume.url,
+            }),
+          }),
+        );
+      }
+
+      if (form.workAuthStatus && form.workAuthStatus !== (profile.workAuthStatus ?? '')) {
+        requests.push(
+          fetch('/api/profile/work-auth', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workAuthStatus: form.workAuthStatus }),
+          }),
+        );
+      }
+
+      if (requests.length === 0) {
+        setSaveDone(true);
+        return;
+      }
+
+      const responses = await Promise.all(requests);
+      const failed = responses.find((r) => !r.ok);
+      if (failed) {
+        const body: unknown = await failed.json().catch(() => null);
+        setSaveError(describeProfileSaveError(failed.status, body));
+        return;
+      }
+
+      setSaveDone(true);
+      await loadWorkspace();
+    } catch {
+      setSaveError(describeProfileSaveError(0, null));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  /* ── Checking ── */
+  if (phase === 'checking') {
+    return (
+      <Shell>
+        <div className="flex flex-col items-center gap-3 py-16" role="status" aria-live="polite">
+          <Loader2 className="h-7 w-7 animate-spin text-zinc-500" aria-hidden />
+          <p className="text-sm text-zinc-500">Loading your profile…</p>
+        </div>
+      </Shell>
+    );
+  }
+
+  /* ── Signed out ── */
+  if (phase === 'signed_out') {
+    return (
+      <Shell>
+        <EmptyCard
+          title="Sign in to see your profile"
+          body="Your professional profile is bound to your VitalCV account."
+          ctaHref="/sign-in?redirect_url=%2Fclinician%2Fprofile"
+          ctaLabel="Sign in to continue"
+        />
+      </Shell>
+    );
+  }
+
+  /* ── No NPI yet ── */
+  if (phase === 'no_npi') {
+    return (
+      <Shell>
+        <EmptyCard
+          title="Connect your NPI to start your profile"
+          body="Your profile begins from your public NPPES registry record. Connecting takes about a minute."
+          ctaHref="/get-ready"
+          ctaLabel="Connect your NPI"
+        />
+      </Shell>
+    );
+  }
+
+  /* ── Load error ── */
+  if (phase === 'load_error' || !profile) {
+    return (
+      <Shell>
+        <div className="space-y-4 py-10 text-center">
+          <AlertCircle className="mx-auto h-8 w-8 text-red-400" aria-hidden />
+          <p className="font-medium text-foreground">Couldn&apos;t load your profile</p>
+          <p className="text-sm text-zinc-400">
+            This is a system state — not a finding about your profile. Try again shortly.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setPhase('checking');
+              void loadWorkspace();
+            }}
+            className="rounded-lg border border-zinc-700 px-5 py-2 text-sm text-zinc-300 transition hover:text-foreground"
+          >
+            Try again
+          </button>
+        </div>
+      </Shell>
+    );
+  }
+
+  /* ── Ready ── */
+  const name = displayName(profile);
+  return (
+    <Shell wide>
+      {/* Identity header — from the NPPES-bootstrapped PersonProfile */}
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900">
+            <UserRound className="h-6 w-6 text-emerald-400" aria-hidden />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">{name ?? 'Your professional profile'}</h1>
+            <p className="mt-0.5 font-mono text-sm tracking-wide text-zinc-500">NPI {profile.npi}</p>
+            <p className="mt-1 text-sm text-zinc-400">
+              {[profile.specialty, profile.stateOfPractice].filter(Boolean).join(' · ') ||
+                'Specialty and state not listed in your registry record.'}
+            </p>
+            <p className="mt-1 text-xs text-zinc-600">
+              Identity fields come from your NPPES registry record at connect time.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/holder/readiness"
+          className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-300 transition hover:border-emerald-800 hover:text-emerald-300"
+        >
+          Your readiness <ChevronRight className="h-4 w-4" aria-hidden />
+        </Link>
+      </header>
+
+      {/* Completeness — filled-ness only */}
+      {profile.completeness !== null && (
+        <section
+          aria-labelledby="completeness-heading"
+          className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+        >
+          <h2 id="completeness-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+            Profile completeness
+          </h2>
+          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800" role="presentation">
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-all"
+              style={{ width: `${Math.max(0, Math.min(100, profile.completeness))}%` }}
+            />
+          </div>
+          <p className="mt-2 text-sm text-zinc-400">{completenessStatement(profile.completeness)}</p>
+        </section>
+      )}
+
+      {/* Self-attested fields — editable */}
+      <section aria-labelledby="self-attested-heading" className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+        <div className="flex items-center justify-between gap-3">
+          <h2 id="self-attested-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+            Career links &amp; work authorization
+          </h2>
+          <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-500">
+            Self-attested
+          </span>
+        </div>
+        <p className="mt-2 text-xs leading-relaxed text-zinc-500">
+          These fields are entered by you and shared with employers as self-attested information.
+          User-entered information is not verified until source-backed evidence is attached.
+        </p>
+        <form onSubmit={saveSelfAttested} className="mt-4 grid gap-4 sm:grid-cols-2" noValidate>
+          <FormField
+            id="profile-linkedin"
+            label="LinkedIn"
+            placeholder="linkedin.com/in/you"
+            value={form.linkedinUrl}
+            disabled={saving}
+            onChange={(v) => setForm((f) => ({ ...f, linkedinUrl: v }))}
+          />
+          <FormField
+            id="profile-portfolio"
+            label="Portfolio / website"
+            placeholder="example.com"
+            value={form.portfolioUrl}
+            disabled={saving}
+            onChange={(v) => setForm((f) => ({ ...f, portfolioUrl: v }))}
+          />
+          <FormField
+            id="profile-resume"
+            label="Resume link"
+            placeholder="Link to your hosted resume (PDF or doc)"
+            value={form.resumeUrl}
+            disabled={saving}
+            onChange={(v) => setForm((f) => ({ ...f, resumeUrl: v }))}
+          />
+          <div>
+            <label htmlFor="profile-work-auth" className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+              Work authorization
+            </label>
+            <select
+              id="profile-work-auth"
+              value={form.workAuthStatus}
+              disabled={saving}
+              onChange={(e) => setForm((f) => ({ ...f, workAuthStatus: e.target.value }))}
+              className="mt-2 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm text-foreground focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-900"
+            >
+              <option value="">Not stated</option>
+              {WORK_AUTH_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="sm:col-span-2 flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Saving…
+                </>
+              ) : (
+                'Save self-attested fields'
+              )}
+            </button>
+            <p aria-live="polite" className="text-sm">
+              {saveError ? (
+                <span role="alert" className="text-red-400">{saveError}</span>
+              ) : saveDone ? (
+                <span className="text-emerald-400">Saved as self-attested.</span>
+              ) : null}
+            </p>
+          </div>
+        </form>
+      </section>
+
+      {/* Passport-backed profile sections */}
+      {passport ? (
+        <ClinicianProfileSections passport={passport} />
+      ) : passportUnavailable ? (
+        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+          <p className="text-sm text-zinc-300">Your source-backed profile sections are temporarily unavailable.</p>
+          <p className="mt-1 text-xs text-zinc-500">
+            This is a system state — not a finding about your credentials. Your self-attested fields above still save normally.
+          </p>
+        </section>
+      ) : (
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-8 text-center" role="status" aria-live="polite">
+          <p className="animate-pulse font-mono text-sm text-zinc-500">Loading source-backed sections…</p>
+        </div>
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
+  return (
+    <div className="min-h-screen bg-zinc-950 px-4 py-8 sm:px-6">
+      <div className={`mx-auto flex w-full flex-col gap-5 ${wide ? 'max-w-4xl' : 'max-w-md'}`}>{children}</div>
+    </div>
+  );
+}
+
+function EmptyCard({
+  title,
+  body,
+  ctaHref,
+  ctaLabel,
+}: {
+  title: string;
+  body: string;
+  ctaHref: string;
+  ctaLabel: string;
+}) {
+  return (
+    <div className="space-y-5 py-10 text-center">
+      <div className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900">
+        <UserRound className="h-7 w-7 text-emerald-400" aria-hidden />
+      </div>
+      <div>
+        <h1 className="mb-2 text-2xl font-bold text-foreground">{title}</h1>
+        <p className="text-sm leading-relaxed text-zinc-400">{body}</p>
+      </div>
+      <Link
+        href={ctaHref}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-7 py-3.5 text-sm font-semibold text-black transition hover:bg-emerald-400"
+      >
+        {ctaLabel} <ChevronRight className="h-4 w-4" aria-hidden />
+      </Link>
+    </div>
+  );
+}
+
+function FormField({
+  id,
+  label,
+  placeholder,
+  value,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  placeholder: string;
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="text"
+        autoComplete="off"
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-2 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm text-foreground placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-900"
+      />
+    </div>
+  );
+}

--- a/apps/web/app/clinician/profile/page.tsx
+++ b/apps/web/app/clinician/profile/page.tsx
@@ -1,232 +1,59 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
 import { PROVENANCE_META, type ProfileProvenance } from '@/lib/profile/provenance';
+import ProfileSurface from './ProfileSurface';
 
 export const metadata: Metadata = {
-  title: 'Clinician Profile · VitalCV',
+  title: 'Professional Profile · VitalCV',
   description:
-    'Your clinician profile. User-entered information is not verified until source-backed evidence is attached.',
+    'Your live professional profile. User-entered information is not verified until source-backed evidence is attached.',
 };
 
-interface SectionDef {
-  key: string;
-  title: string;
-  fields: ReadonlyArray<{ label: string; provenance: ProfileProvenance; placeholder: string }>;
-}
-
-const SECTIONS: ReadonlyArray<SectionDef> = [
-  {
-    key: 'identity',
-    title: 'Identity, contact, locations',
-    fields: [
-      { label: 'Legal name', provenance: 'USER_ENTERED', placeholder: 'As it appears on government ID' },
-      { label: 'NPI', provenance: 'UNKNOWN', placeholder: '10-digit NPI' },
-      { label: 'Primary email', provenance: 'USER_ENTERED', placeholder: 'you@example.org' },
-      { label: 'Practice locations', provenance: 'USER_ENTERED', placeholder: 'City, state' },
-    ],
-  },
-  {
-    key: 'medical_school',
-    title: 'Medical school',
-    fields: [
-      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'School name' },
-      { label: 'Degree', provenance: 'USER_ENTERED', placeholder: 'MD, DO, MBBS, …' },
-      { label: 'Graduation year', provenance: 'USER_ENTERED', placeholder: 'YYYY' },
-    ],
-  },
-  {
-    key: 'residency',
-    title: 'Residency',
-    fields: [
-      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'Program name' },
-      { label: 'Specialty', provenance: 'USER_ENTERED', placeholder: 'e.g., Internal Medicine' },
-      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
-    ],
-  },
-  {
-    key: 'fellowship',
-    title: 'Fellowship',
-    fields: [
-      { label: 'Institution', provenance: 'USER_ENTERED', placeholder: 'Program name' },
-      { label: 'Specialty', provenance: 'USER_ENTERED', placeholder: 'Subspecialty area' },
-      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
-    ],
-  },
-  {
-    key: 'training_programs',
-    title: 'Other training programs',
-    fields: [
-      { label: 'Program', provenance: 'USER_ENTERED', placeholder: 'Name + institution' },
-      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
-    ],
-  },
-  {
-    key: 'specialty',
-    title: 'Specialty and subspecialty',
-    fields: [
-      { label: 'Specialty', provenance: 'INFERRED', placeholder: 'NPPES taxonomy or self-attested' },
-      { label: 'Subspecialty', provenance: 'USER_ENTERED', placeholder: 'Free-text' },
-      { label: 'Board certified', provenance: 'UNKNOWN', placeholder: 'Pending source-backed check' },
-    ],
-  },
-  {
-    key: 'current_employer',
-    title: 'Current employer',
-    fields: [
-      { label: 'Employer', provenance: 'USER_ENTERED', placeholder: 'Organization name' },
-      { label: 'Title', provenance: 'USER_ENTERED', placeholder: 'Your role' },
-      { label: 'Start date', provenance: 'USER_ENTERED', placeholder: 'YYYY-MM-DD' },
-    ],
-  },
-  {
-    key: 'employer_history',
-    title: 'Employer history',
-    fields: [
-      { label: 'Employer', provenance: 'USER_ENTERED', placeholder: 'Prior organization' },
-      { label: 'Title', provenance: 'USER_ENTERED', placeholder: 'Role' },
-      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
-    ],
-  },
-  {
-    key: 'affiliations',
-    title: 'Affiliations',
-    fields: [
-      { label: 'Organization', provenance: 'USER_ENTERED', placeholder: 'Hospital, society, etc.' },
-      { label: 'Type', provenance: 'USER_ENTERED', placeholder: 'Privileges, member, …' },
-      { label: 'Years', provenance: 'USER_ENTERED', placeholder: 'YYYY–YYYY' },
-    ],
-  },
-  {
-    key: 'research',
-    title: 'Research',
-    fields: [
-      { label: 'Topic', provenance: 'USER_ENTERED', placeholder: 'Area of research' },
-      { label: 'Role', provenance: 'USER_ENTERED', placeholder: 'PI, co-author, …' },
-    ],
-  },
-  {
-    key: 'publications',
-    title: 'Publications',
-    fields: [
-      { label: 'Title', provenance: 'INFERRED', placeholder: 'PubMed import is candidate-grade until source-backed' },
-      { label: 'Journal', provenance: 'INFERRED', placeholder: 'PubMed-derived' },
-      { label: 'Year', provenance: 'INFERRED', placeholder: 'YYYY' },
-    ],
-  },
+const LEGEND_ORDER: ReadonlyArray<ProfileProvenance> = [
+  'VERIFIED',
+  'USER_ENTERED',
+  'INFERRED',
+  'UNKNOWN',
+  'CONFLICT',
 ];
 
-function ProvenanceBadge({ provenance }: { provenance: ProfileProvenance }) {
-  const meta = PROVENANCE_META[provenance];
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${meta.badgeClass}`}
-      aria-label={`Provenance: ${meta.label}`}
-      title={meta.description}
-    >
-      {meta.label}
-    </span>
-  );
-}
-
+/**
+ * Server shell: renders the live client surface plus the provenance legend.
+ * Truth rule pinned by tests: user-entered information is not verified until
+ * source-backed evidence is attached, and every field carries a provenance
+ * badge from the shared PROVENANCE_META vocabulary.
+ */
 export default function ClinicianProfilePage() {
-  // Foundation shell: sections render with placeholders and provenance
-  // badges. No client state. Filled-ness summary is computed below from
-  // the static defs (everything is currently empty / unknown).
-  const totalFields = SECTIONS.reduce((s, sec) => s + sec.fields.length, 0);
-  const filledFields = 0;
-  const sourceBackedFields = 0;
-  const completionPercent = totalFields === 0 ? 0 : Math.round((filledFields / totalFields) * 100);
-
   return (
-    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
-      <header className="mb-8 sm:mb-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          Clinician profile
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
-          Your credential record
-        </h1>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          <strong>User-entered information is not verified until source-backed
-          evidence is attached.</strong> Provenance badges show where each field
-          stands today.
-        </p>
-
-        <section
-          aria-labelledby="completion-summary-heading"
-          className="mt-5 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
-        >
-          <h2 id="completion-summary-heading" className="text-sm font-semibold">
-            Profile completion summary
+    <div className="bg-zinc-950">
+      <ProfileSurface />
+      <aside
+        aria-labelledby="provenance-legend-heading"
+        className="mx-auto w-full max-w-4xl px-4 pb-12 sm:px-6"
+      >
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+          <h2 id="provenance-legend-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+            How to read provenance badges
           </h2>
-          <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Filled</dt>
-              <dd className="mt-1 font-mono">
-                {filledFields} / {totalFields} ({completionPercent}%)
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Source-backed</dt>
-              <dd className="mt-1 font-mono">{sourceBackedFields} / {totalFields}</dd>
-            </div>
-            <div>
-              <dt className="text-xs uppercase tracking-wider text-muted-foreground">Verified credentialing</dt>
-              <dd className="mt-1 text-muted-foreground">Not asserted by completion alone.</dd>
-            </div>
+          <dl className="mt-3 space-y-2">
+            {LEGEND_ORDER.map((key) => {
+              const meta = PROVENANCE_META[key];
+              return (
+                <div key={key} className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
+                  <dt>
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] ${meta.badgeClass}`}
+                    >
+                      {meta.label}
+                    </span>
+                  </dt>
+                  <dd className="text-xs leading-relaxed text-zinc-500">{meta.description}</dd>
+                </div>
+              );
+            })}
           </dl>
-        </section>
-      </header>
-
-      <div className="space-y-5">
-        {SECTIONS.map((section) => (
-          <section
-            key={section.key}
-            aria-labelledby={`section-${section.key}-heading`}
-            className="rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
-          >
-            <h2 id={`section-${section.key}-heading`} className="text-base font-semibold sm:text-lg">
-              {section.title}
-            </h2>
-            <dl className="mt-3 space-y-3">
-              {section.fields.map((field) => {
-                const fieldId = `${section.key}-${field.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
-                return (
-                  <div key={fieldId} className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-                    <div className="flex flex-1 items-center gap-2">
-                      <dt>
-                        <label htmlFor={fieldId} className="text-sm font-medium">
-                          {field.label}
-                        </label>
-                      </dt>
-                      <ProvenanceBadge provenance={field.provenance} />
-                    </div>
-                    <dd className="flex-1">
-                      <input
-                        id={fieldId}
-                        type="text"
-                        readOnly
-                        placeholder={field.placeholder}
-                        aria-describedby={`${fieldId}-help`}
-                        className="w-full rounded-lg border border-[var(--vt-border,_rgba(0,0,0,0.12))] bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-offset-2"
-                      />
-                      <p id={`${fieldId}-help`} className="mt-1 text-[11px] text-muted-foreground">
-                        {PROVENANCE_META[field.provenance].description}
-                      </p>
-                    </dd>
-                  </div>
-                );
-              })}
-            </dl>
-          </section>
-        ))}
-      </div>
-
-      <p className="mt-8 text-xs leading-relaxed text-muted-foreground">
-        This is the foundation shell. Editing flow, source-backed import wiring,
-        and verification gating ship in subsequent waves. <strong>User-entered
-        information is not verified until source-backed evidence is attached.</strong>
-      </p>
-    </main>
+        </div>
+      </aside>
+    </div>
   );
 }

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   ShieldCheck,
   Sparkles,
+  UserRound,
 } from 'lucide-react';
 import {
   ApplicationList,
@@ -196,6 +197,14 @@ export default function ClinicianHomeSurface() {
       href: '/holder/applications',
       icon: BellRing,
       tone: 'amber',
+    },
+    {
+      id: 'open-profile',
+      label: 'Professional profile',
+      description: 'Review your profile record and add self-attested career links and work authorization.',
+      href: '/clinician/profile',
+      icon: UserRound,
+      tone: 'zinc',
     },
   ];
 

--- a/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
+++ b/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WORK_AUTH_OPTIONS,
+  completenessStatement,
+  describeProfileSaveError,
+  displayName,
+  extractPersonProfile,
+  isWorkAuthStatus,
+  resumeFileNameFromUrl,
+  validateProfileUrl,
+} from '@/lib/clinician-profile/liveProfile';
+
+describe('extractPersonProfile', () => {
+  it('extracts the PersonProfile fields the surface consumes', () => {
+    const profile = extractPersonProfile({
+      userId: 'u1',
+      personProfile: {
+        npi: '1234567890',
+        firstName: 'Test',
+        lastName: 'Clinician',
+        specialty: 'Internal Medicine',
+        stateOfPractice: 'CA',
+        workAuthStatus: 'authorized',
+        resumeUrl: 'https://example.com/cv.pdf',
+        linkedinUrl: 'https://linkedin.com/in/test',
+        portfolioUrl: null,
+        completeness: 55,
+        extraneous: 'ignored',
+      },
+    });
+    expect(profile).not.toBeNull();
+    expect(profile?.npi).toBe('1234567890');
+    expect(profile?.completeness).toBe(55);
+    expect(profile?.portfolioUrl).toBeNull();
+    expect(displayName(profile!)).toBe('Test Clinician');
+  });
+
+  it('returns null for signed-out/malformed payloads and empty strings', () => {
+    expect(extractPersonProfile(null)).toBeNull();
+    expect(extractPersonProfile({})).toBeNull();
+    expect(extractPersonProfile({ personProfile: null })).toBeNull();
+    const empty = extractPersonProfile({ personProfile: { npi: '' } });
+    expect(empty?.npi).toBeNull();
+  });
+});
+
+describe('validateProfileUrl', () => {
+  it('treats empty input as a valid clear', () => {
+    expect(validateProfileUrl('')).toEqual({ ok: true, url: null, reason: null });
+    expect(validateProfileUrl('   ')).toEqual({ ok: true, url: null, reason: null });
+  });
+
+  it('normalizes scheme-less links to https', () => {
+    const v = validateProfileUrl('linkedin.com/in/you');
+    expect(v.ok).toBe(true);
+    expect(v.url).toBe('https://linkedin.com/in/you');
+  });
+
+  it('rejects non-http(s) schemes and domain-less input', () => {
+    expect(validateProfileUrl('javascript:alert(1)').ok).toBe(false);
+    expect(validateProfileUrl('ftp://example.com/cv').ok).toBe(false);
+    expect(validateProfileUrl('localhost').ok).toBe(false);
+  });
+});
+
+describe('resumeFileNameFromUrl', () => {
+  it('uses the URL tail when present', () => {
+    expect(resumeFileNameFromUrl('https://example.com/files/My%20CV.pdf')).toBe('My CV.pdf');
+  });
+  it('falls back to a generic name for bare domains', () => {
+    expect(resumeFileNameFromUrl('https://example.com/')).toBe('resume-link');
+  });
+});
+
+describe('work auth', () => {
+  it('accepts only the backend-allowed statuses', () => {
+    for (const option of WORK_AUTH_OPTIONS) {
+      expect(isWorkAuthStatus(option.value)).toBe(true);
+    }
+    expect(isWorkAuthStatus('citizen')).toBe(false);
+    expect(isWorkAuthStatus('')).toBe(false);
+  });
+});
+
+describe('describeProfileSaveError', () => {
+  it('maps auth expiry and validation failures distinctly', () => {
+    expect(describeProfileSaveError(401, null)).toContain('Sign in again');
+    expect(describeProfileSaveError(400, { error: 'fileName and fileUrl are required.' })).toContain('fileName');
+  });
+  it('frames system failures as system states', () => {
+    expect(describeProfileSaveError(503, null)).toContain('system state');
+  });
+});
+
+describe('completenessStatement', () => {
+  it('is filled-ness only and never a verification claim', () => {
+    const statement = completenessStatement(55);
+    expect(statement).toContain('55%');
+    expect(statement).toContain('not verification');
+    expect(statement.toLowerCase()).not.toContain('verified');
+  });
+  it('bounds out-of-range scores', () => {
+    expect(completenessStatement(140)).toContain('100%');
+    expect(completenessStatement(-5)).toContain('0%');
+  });
+});

--- a/apps/web/lib/clinician-profile/liveProfile.ts
+++ b/apps/web/lib/clinician-profile/liveProfile.ts
@@ -1,0 +1,135 @@
+/**
+ * liveProfile — pure helpers for the live /clinician/profile surface.
+ *
+ * Data flow: GET /api/me/workspaces returns the full workspace payload whose
+ * `personProfile` is the backend PersonProfile row (bound at /get-ready via
+ * the NPPES bootstrap). The surface renders that record plus the clinician's
+ * live passport (ClinicianProfileSections) and writes self-attested fields
+ * through the existing intake proxies:
+ *
+ *   POST /api/profile/links      { linkedinUrl?, portfolioUrl? }
+ *   POST /api/profile/work-auth  { workAuthStatus: 'authorized'|'visa_required'|'other' }
+ *   POST /api/profile/resume/upload { fileName, fileUrl }
+ *
+ * Truth contract: everything the clinician types here is SELF-ATTESTED.
+ * Nothing in this module may present a user-entered value as verified, and
+ * completeness is filled-ness only — it never implies verification.
+ */
+
+export const WORK_AUTH_OPTIONS = [
+  { value: 'authorized', label: 'Authorized to work in the U.S.' },
+  { value: 'visa_required', label: 'Visa sponsorship required' },
+  { value: 'other', label: 'Other / prefer to explain later' },
+] as const;
+
+export type WorkAuthStatus = (typeof WORK_AUTH_OPTIONS)[number]['value'];
+
+export function isWorkAuthStatus(value: unknown): value is WorkAuthStatus {
+  return WORK_AUTH_OPTIONS.some((option) => option.value === value);
+}
+
+/** The PersonProfile fields this surface consumes from /api/me/workspaces. */
+export interface WorkspacePersonProfile {
+  npi: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  specialty: string | null;
+  stateOfPractice: string | null;
+  workAuthStatus: string | null;
+  resumeUrl: string | null;
+  linkedinUrl: string | null;
+  portfolioUrl: string | null;
+  completeness: number | null;
+}
+
+export function extractPersonProfile(payload: unknown): WorkspacePersonProfile | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const raw = (payload as { personProfile?: unknown }).personProfile;
+  if (!raw || typeof raw !== 'object') return null;
+  const p = raw as Record<string, unknown>;
+
+  const str = (key: string): string | null =>
+    typeof p[key] === 'string' && (p[key] as string).length > 0 ? (p[key] as string) : null;
+
+  return {
+    npi: str('npi'),
+    firstName: str('firstName'),
+    lastName: str('lastName'),
+    specialty: str('specialty'),
+    stateOfPractice: str('stateOfPractice'),
+    workAuthStatus: str('workAuthStatus'),
+    resumeUrl: str('resumeUrl'),
+    linkedinUrl: str('linkedinUrl'),
+    portfolioUrl: str('portfolioUrl'),
+    completeness: typeof p.completeness === 'number' ? (p.completeness as number) : null,
+  };
+}
+
+export function displayName(profile: WorkspacePersonProfile): string | null {
+  const name = [profile.firstName, profile.lastName].filter(Boolean).join(' ').trim();
+  return name.length > 0 ? name : null;
+}
+
+export interface UrlValidation {
+  ok: boolean;
+  /** Normalized URL when ok (https:// prefixed when scheme was omitted). */
+  url: string | null;
+  reason: string | null;
+}
+
+/** Validates a self-attested link. Empty input is valid-and-null (clearing). */
+export function validateProfileUrl(raw: string): UrlValidation {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, url: null, reason: null };
+  }
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return { ok: false, url: null, reason: 'Enter a valid link (for example, linkedin.com/in/you).' };
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return { ok: false, url: null, reason: 'Links must use http or https.' };
+  }
+  if (!parsed.hostname.includes('.')) {
+    return { ok: false, url: null, reason: 'That link is missing a domain (for example, example.com).' };
+  }
+  return { ok: true, url: parsed.toString(), reason: null };
+}
+
+/** Derives an honest file name for a resume attached by URL. */
+export function resumeFileNameFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const tail = parsed.pathname.split('/').filter(Boolean).pop();
+    if (tail && tail.length <= 120) return decodeURIComponent(tail);
+  } catch {
+    // fall through to the generic name
+  }
+  return 'resume-link';
+}
+
+export function describeProfileSaveError(status: number, body: unknown): string {
+  const message =
+    body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string'
+      ? (body as { error: string }).error
+      : null;
+  if (status === 401) {
+    return 'Your session expired. Sign in again to save your profile.';
+  }
+  if (status === 400 || status === 422) {
+    return message ?? 'That value could not be saved. Check it and try again.';
+  }
+  return 'Saving is temporarily unavailable. This is a system state — your entries were not lost; try again shortly.';
+}
+
+/**
+ * Completeness copy: filled-ness only. This string is asserted in tests to
+ * keep the surface from ever presenting completeness as verification.
+ */
+export function completenessStatement(score: number): string {
+  const bounded = Math.max(0, Math.min(100, Math.round(score)));
+  return `${bounded}% of profile fields are filled in. Completeness measures filled-ness only — it is not verification.`;
+}


### PR DESCRIPTION
## Summary
- Replace the read-only `/clinician/profile` foundation shell (hardcoded placeholder sections, `readOnly` inputs, no data) with a live surface:
  - Reads the signed-in clinician's real workspace `PersonProfile` (bound at `/get-ready` via the NPPES bootstrap) through `GET /api/me/workspaces`.
  - Renders the existing provenance-honest `ClinicianProfileSections` (16 sections, tested) from the clinician's live passport — first production consumer of that component.
  - Lets the clinician SAVE self-attested fields through the existing intake endpoints: career links (`POST /api/profile/links`), resume link (`POST /api/profile/resume/upload`), work authorization (`POST /api/profile/work-auth`). Only changed fields are submitted.
  - Completeness bar driven by the backend completeness score, worded as filled-ness only.
- Full state coverage: checking / signed-out (redirect back after sign-in) / no-NPI (CTA to `/get-ready`) / load-error / ready, plus a degraded card when the passport is temporarily unavailable (editing still works). `aria-live` save status, labeled inputs, `role=alert` errors.
- New pure helpers in `lib/clinician-profile/liveProfile.ts` (payload extraction, URL validation incl. scheme normalization + `javascript:` rejection, error copy, completeness statement) — 17 unit tests.
- Server page keeps the pinned truth literals ('User-entered information is not verified until source-backed evidence is attached.', `PROVENANCE_META`) and now renders a provenance-badge legend.
- Reachability: added a "Professional profile" quick action to the holder home surface — the profile is no longer an orphaned route.

## Truth rules
- Every editable field is explicitly labeled Self-attested; user-entered values are never presented as verified.
- Completeness copy states it measures filled-ness only, never verification (test-asserted).
- Identity header states its source: the NPPES registry record at connect time.
- No banned strings; no bare 'Verified' label.

## Validation
- Targeted tests: liveProfile (17) + clinician-profile-foundation pins + clinician-profile-sections + foundation-sweep-5 — 74/74 passing
- `pnpm turbo run build --filter @vitalcv/web`: 14/14
- Truth scan over diff scope: clean