### PR TITLE
fix(truth): 404-gate demo activation/dossier pages behind their demo ids

### DIFF
--- a/apps/web/app/activation/[caseId]/page.tsx
+++ b/apps/web/app/activation/[caseId]/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 import {
   ONBOARD_STATUS_META,
@@ -35,11 +36,15 @@ const TONE_BADGE: Record<string, string> = {
   purple: 'border-purple-500/30 bg-purple-500/10 text-purple-700',
 };
 
+const DEMO_CASE_SLUG = 'demo-001';
+
 export default async function ActivationCasePage({ params }: PageProps) {
-  // The caseId from the URL is intentionally unused in Phase 1 — the
-  // page always renders the demoCase. A later phase wires this to a
-  // real ActivationCase row.
-  await params;
+  // Only the designated demo slug renders. Any other caseId is a 404:
+  // a real case id in the URL must never display fabricated case data.
+  const { caseId } = await params;
+  if (caseId !== DEMO_CASE_SLUG) {
+    notFound();
+  }
   const c = demoCase();
   const counts = computeActivationCounts(c);
   const completion = criticalPathCompletion(c);

--- a/apps/web/app/dossier/[receiptId]/page.tsx
+++ b/apps/web/app/dossier/[receiptId]/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 import {
   VERB_META,
@@ -32,11 +33,14 @@ const TONE_BADGE: Record<string, string> = {
 };
 
 export default async function DossierPage({ params }: PageProps) {
-  // The receiptId from the URL is intentionally unused in Phase 1 —
-  // the page always renders the demoDossier. A later phase wires
-  // this to a real DossierState row.
-  await params;
+  // Only receipt ids that exist inside the demo dossier render. Any other
+  // receiptId is a 404: a real receipt id in the URL must never display
+  // fabricated custody data. (Real receipts render at /receipt/[receiptId].)
+  const { receiptId } = await params;
   const d = demoDossier();
+  if (!d.ledger.some((row) => row.id === receiptId)) {
+    notFound();
+  }
   const counts = computeDossierCounts(d);
   const chainOk = isChainConsistent(d.ledger);
 


### PR DESCRIPTION
## Summary
- `/activation/[caseId]` and `/dossier/[receiptId]` are labeled demo showcases, but they ignored their URL params: ANY id — including a real case or receipt id — rendered the same fabricated demo data under that id's URL. That is a truth hazard (a real receipt id displaying fake custody rows).
- `/activation/[caseId]` now renders only the designated demo slug (`demo-001`); anything else is `notFound()`.
- `/dossier/[receiptId]` now renders only receipt ids that actually exist inside the demo dossier ledger (`r-001`…); anything else is `notFound()`. Real receipts continue to render at `/receipt/[receiptId]`.
- Existing demo labeling (\"Demo dossier — stub signatures\" banner, `· Demo ·` titles) is unchanged; the pages remain reachable as demos with their canonical demo ids.

## Truth rules
- No copy changes beyond code comments; the change strictly narrows what can render.
- Existing tests (activation-page-render uses `demo-001`, dossier-page-render uses `r-002`) pass unchanged — 55/55.

## Validation
- Targeted tests: activation/dossier page-render + data suites — 55/55 passing
- `pnpm turbo run build --filter @vitalcv/web`: 14/14