### PR TITLE
feat(ux): retry on home refresh-error banner + contextual application not-found

### DIFF
--- a/apps/web/app/holder/applications/[id]/not-found.tsx
+++ b/apps/web/app/holder/applications/[id]/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+/**
+ * Contextual not-found for application detail. Reached when the id in the
+ * URL is not in the clinician's live application list — most often because
+ * the application was withdrawn or the link is stale.
+ */
+export default function ApplicationNotFound() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col items-center gap-5 px-4 py-20 text-center sm:px-6">
+      <h1 className="text-2xl font-semibold text-white">This application isn&apos;t in your list</h1>
+      <p className="max-w-md text-sm leading-6 text-white/60">
+        It may have been withdrawn, or the link may be out of date. Your live applications and
+        every employer update are on your updates queue.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href="/holder/applications"
+          className="inline-flex items-center rounded-xl bg-emerald-500 px-6 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400"
+        >
+          Open your applications
+        </Link>
+        <Link
+          href="/holder/opportunities"
+          className="inline-flex items-center rounded-xl border border-white/15 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
+        >
+          Browse live roles
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -258,6 +258,8 @@ export default function ClinicianHomeSurface() {
           tone="error"
           title="Home state could not refresh"
           detail={refreshError}
+          onAction={() => { void refresh(); }}
+          onActionLabel={isRefreshing ? 'Retrying…' : 'Retry now'}
           actionHref="/holder/readiness"
           actionLabel="Open readiness"
         />

--- a/apps/web/components/mobile/ClinicianStatusBanner.tsx
+++ b/apps/web/components/mobile/ClinicianStatusBanner.tsx
@@ -29,29 +29,45 @@ export function ClinicianStatusBanner({
   detail,
   actionHref,
   actionLabel,
+  onAction,
+  onActionLabel,
 }: {
   tone: ClinicianStatusTone;
   title: string;
   detail: string;
   actionHref?: string;
   actionLabel?: string;
+  /** Optional in-place action (e.g. retry) rendered as a button. */
+  onAction?: () => void;
+  onActionLabel?: string;
 }) {
   return (
-    <div className={`rounded-3xl border px-4 py-4 ${TONE_STYLES[tone]}`}>
+    <div className={`rounded-3xl border px-4 py-4 ${TONE_STYLES[tone]}`} role="status" aria-live="polite">
       <div className="flex items-start gap-3">
         <StatusIcon tone={tone} />
         <div className="min-w-0">
           <p className="text-sm font-semibold text-white">{title}</p>
           <p className="mt-1 text-sm leading-6">{detail}</p>
-          {actionHref && actionLabel ? (
-            <Link
-              href={actionHref}
-              className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white transition hover:text-white/80"
-            >
-              {actionLabel}
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          ) : null}
+          <div className="flex flex-wrap items-center gap-4">
+            {onAction && onActionLabel ? (
+              <button
+                type="button"
+                onClick={onAction}
+                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white underline underline-offset-4 transition hover:text-white/80"
+              >
+                {onActionLabel}
+              </button>
+            ) : null}
+            {actionHref && actionLabel ? (
+              <Link
+                href={actionHref}
+                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white transition hover:text-white/80"
+              >
+                {actionLabel}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `ClinicianStatusBanner` gains an optional in-place action (button) alongside the existing link action, plus `role=status`/`aria-live=polite`; holder home's refresh-error banner now offers "Retry now" (calls the provider's `refresh()`, label reflects in-flight state) instead of only a passive link away.
- Add `app/holder/applications/[id]/not-found.tsx`: when an application id isn't in the clinician's list (withdrawn/stale link), the surface's `notFound()` now lands on contextual copy with CTAs to the applications queue and live roles, instead of the generic 404.

## Risk tier
Tier 0/1 (UI cleanup + additive optional prop + additive not-found file). Backwards compatible: existing `ClinicianStatusBanner` call sites are untouched (new props optional). Rollback: revert squash commit.

## Validation
- `pnpm turbo run build --filter @vitalcv/web`: 14/14 post-rebase on latest main
- No copy overclaims; error copy remains system-state framed