### PR TITLE
feat(recognition): Recognition card on holder home surfaces

### DIFF
--- a/apps/web/__tests__/holder-route-contract.test.ts
+++ b/apps/web/__tests__/holder-route-contract.test.ts
@@ -26,6 +26,7 @@ const SURFACE_FILES = [
   'components/mobile/ClinicianApplicationDetailSurface.tsx',
   'components/mobile/ClinicianPanels.tsx',
   'components/clinician/MobileBottomNav.tsx',
+  'components/recognition/RecognitionCard.tsx',
 ];
 
 /** Extract internal href path literals (static + template-literal heads). */

--- a/apps/web/__tests__/recognition-card.test.tsx
+++ b/apps/web/__tests__/recognition-card.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+/**
+ * Recognition card + acceptance-recognition helper.
+ *
+ * Truth contract: the card renders only real acceptance-history payloads;
+ * a failed lookup is presented as a system state, never as a finding; an
+ * empty record says exactly that. Copy pins the holder-facing recognition
+ * vocabulary ("employer acceptances", "head start") — no bare "Verified".
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecognitionCard } from '../components/recognition/RecognitionCard';
+import { fetchAcceptanceRecognition } from '../lib/recognition/acceptance-recognition';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function acceptanceHistoryPayload() {
+  return {
+    ok: true,
+    summary: {
+      acceptedOrganizationCount: 1,
+      hasPriorAcceptances: true,
+      headline: 'Accepted by 1 organization',
+      trustCopy:
+        'This clinician has already been accepted using VitalCV verification. Each acceptance remains scoped to the organization and scope shown below.',
+    },
+    history: [
+      {
+        acceptanceId: 'accept-1',
+        orgLabel: 'Pilot organization 1',
+        isAnonymized: true,
+        acceptedByOrgId: 'org-entity-1',
+        acceptedAt: '2026-03-23T18:00:00.000Z',
+        acceptanceScope: 'pilot',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      },
+    ],
+  };
+}
+
+describe('fetchAcceptanceRecognition', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns recognized with the normalized payload when acceptances exist', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(acceptanceHistoryPayload()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAcceptanceRecognition('1234567890');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/employer-review/1234567890/acceptance-history',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+    expect(result.state).toBe('recognized');
+    if (result.state === 'recognized') {
+      expect(result.recognition.summary.headline).toBe('Accepted by 1 organization');
+      expect(result.recognition.history).toHaveLength(1);
+    }
+  });
+
+  it('maps an empty record and an unknown NPI (404) to none_recorded', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      ok: true,
+      summary: {
+        acceptedOrganizationCount: 0,
+        hasPriorAcceptances: false,
+        headline: 'No prior acceptances',
+        trustCopy: null,
+      },
+      history: [],
+    })));
+    expect((await fetchAcceptanceRecognition('1234567890')).state).toBe('none_recorded');
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'not_found' }, 404)));
+    expect((await fetchAcceptanceRecognition('9999999999')).state).toBe('none_recorded');
+  });
+
+  it('maps server failures, malformed payloads, and network errors to unavailable — never a finding', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'boom' }, 500)));
+    expect((await fetchAcceptanceRecognition('1234567890')).state).toBe('unavailable');
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ ok: true, summary: {}, history: 'nope' })));
+    expect((await fetchAcceptanceRecognition('1234567890')).state).toBe('unavailable');
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    expect((await fetchAcceptanceRecognition('1234567890')).state).toBe('unavailable');
+  });
+});
+
+describe('RecognitionCard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderCard(npi: string) {
+    await act(async () => {
+      root.render(<RecognitionCard npi={npi} />);
+    });
+  }
+
+  it('renders the real acceptance record with headline, latest entry, and scope', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(acceptanceHistoryPayload())));
+
+    await renderCard('1234567890');
+
+    expect(container.textContent).toContain('Recognition');
+    expect(container.textContent).toContain('Accepted by 1 organization');
+    expect(container.textContent).toContain('Pilot organization 1');
+    expect(container.textContent).toContain('Pilot scope');
+    const link = container.querySelector('a[href="/holder/applications"]');
+    expect(link).not.toBeNull();
+  });
+
+  it('renders an honest empty state when nothing is recorded', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'not_found' }, 404)));
+
+    await renderCard('1234567890');
+
+    expect(container.textContent).toContain('No employer acceptances recorded yet');
+    expect(container.textContent).toContain('accepts your evidence as a head start');
+    expect(container.querySelector('a[href="/holder/readiness"]')).not.toBeNull();
+  });
+
+  it('renders a system-state message (not a finding) when the lookup fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    await renderCard('1234567890');
+
+    expect(container.textContent).toContain('Recognition status is temporarily unavailable');
+    expect(container.textContent).toContain('not a finding about your record');
+  });
+
+  it('never renders a bare Verified label in any state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(acceptanceHistoryPayload())));
+
+    await renderCard('1234567890');
+
+    const text = container.textContent ?? '';
+    expect(/\bVerified\b/.test(text)).toBe(false);
+  });
+});

--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -18,6 +18,7 @@ import { CredentialPresentationActions } from '@/components/clinician/Credential
 import EvidenceUploadPanel from '@/components/mobile/EvidenceUploadPanel';
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { TrustStatePanel } from '@/components/trust-state/TrustStatePanel';
+import { RecognitionCard } from '@/components/recognition/RecognitionCard';
 
 type WorkspaceProfile = {
   npi?: string | null;
@@ -148,6 +149,11 @@ export default function HolderPage() {
       {/* Trust State */}
       <div className="mx-auto max-w-3xl px-4 pb-0 pt-4 sm:px-6">
         <TrustStatePanel npi={npi!} />
+      </div>
+
+      {/* Recognition — employer acceptance record */}
+      <div className="mx-auto max-w-3xl px-4 pb-0 pt-4 sm:px-6">
+        <RecognitionCard npi={npi!} />
       </div>
 
       {/* Passport */}

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -24,6 +24,7 @@ import type { MobileQuickAction } from '@/components/mobile/ClinicianPanels';
 import { ClinicianStatusBanner } from '@/components/mobile/ClinicianStatusBanner';
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { RecognitionCard } from '@/components/recognition/RecognitionCard';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
 import { buildClinicianProofSummary } from '@/lib/proof/proof-model';
 
@@ -370,6 +371,8 @@ export default function ClinicianHomeSurface() {
           </div>
         </div>
       </section>
+
+      {/^\d{10}$/.test(npi) && <RecognitionCard npi={npi} />}
 
       <section className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
         <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">

--- a/apps/web/components/recognition/RecognitionCard.tsx
+++ b/apps/web/components/recognition/RecognitionCard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+/**
+ * Recognition card — the holder-facing answer to "Am I recognized?".
+ *
+ * Renders the clinician's employer acceptance record (the product form of the
+ * canonical Recognition → Acceptance → Start path) from the public
+ * acceptance-history read. States are honest: a lookup failure is a system
+ * state, never a finding about the record, and an empty record says exactly
+ * that — no demo data, no synthesized recognition.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Award, ChevronRight, Loader2 } from 'lucide-react';
+import {
+  acceptanceScopeLabel,
+  fetchAcceptanceRecognition,
+  formatAcceptedAt,
+  type AcceptanceRecognitionResult,
+} from '@/lib/recognition/acceptance-recognition';
+
+type Phase = { state: 'loading' } | AcceptanceRecognitionResult;
+
+export function RecognitionCard({ npi }: { npi: string }) {
+  const [phase, setPhase] = useState<Phase>({ state: 'loading' });
+
+  const load = useCallback(async () => {
+    setPhase({ state: 'loading' });
+    setPhase(await fetchAcceptanceRecognition(npi));
+  }, [npi]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section
+      aria-label="Recognition"
+      className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Recognition</p>
+        <Award className="h-4 w-4 text-emerald-400" aria-hidden />
+      </div>
+
+      {phase.state === 'loading' && (
+        <div className="mt-3 flex items-center gap-2 text-sm text-zinc-500">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Checking your acceptance record…
+        </div>
+      )}
+
+      {phase.state === 'unavailable' && (
+        <div className="mt-3 space-y-2">
+          <p className="text-sm font-medium text-zinc-200">
+            Recognition status is temporarily unavailable
+          </p>
+          <p className="text-sm leading-6 text-zinc-400">
+            This is a system state — not a finding about your record. Try again shortly.
+          </p>
+          <button
+            onClick={() => { void load(); }}
+            className="rounded-lg border border-zinc-700 px-4 py-1.5 text-sm text-zinc-300 transition hover:text-white"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {phase.state === 'none_recorded' && (
+        <div className="mt-3 space-y-2">
+          <p className="text-base font-semibold text-zinc-100">
+            No employer acceptances recorded yet
+          </p>
+          <p className="text-sm leading-6 text-zinc-400">
+            When an employer accepts your evidence as a head start, the acceptance is
+            recorded here and stays part of your career record.
+          </p>
+          <Link
+            href="/holder/readiness"
+            className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+          >
+            Keep your readiness current <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+          </Link>
+        </div>
+      )}
+
+      {phase.state === 'recognized' && (
+        <RecognizedBody recognition={phase.recognition} />
+      )}
+    </section>
+  );
+}
+
+function RecognizedBody({
+  recognition,
+}: {
+  recognition: Extract<AcceptanceRecognitionResult, { state: 'recognized' }>['recognition'];
+}) {
+  const latest = recognition.history[0] ?? null;
+  const latestDate = latest ? formatAcceptedAt(latest.acceptedAt) : null;
+
+  return (
+    <div className="mt-3 space-y-3">
+      <p className="text-lg font-semibold text-zinc-100">{recognition.summary.headline}</p>
+
+      {latest && (
+        <p className="text-sm leading-6 text-zinc-400">
+          Most recent: <span className="text-zinc-200">{latest.orgLabel}</span>
+          {' · '}
+          {acceptanceScopeLabel(latest.acceptanceScope)}
+          {latestDate ? ` · ${latestDate}` : ''}
+        </p>
+      )}
+
+      {recognition.summary.trustCopy && (
+        <p className="text-sm leading-6 text-zinc-500">{recognition.summary.trustCopy}</p>
+      )}
+
+      <Link
+        href="/holder/applications"
+        className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+      >
+        View your applications <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/lib/recognition/acceptance-recognition.ts
+++ b/apps/web/lib/recognition/acceptance-recognition.ts
@@ -1,0 +1,71 @@
+/**
+ * Clinician-facing read of the employer acceptance chain (the product form of
+ * Recognition → Acceptance → Start). Wraps the existing public
+ * acceptance-history endpoint — no new trust model, no new storage; the same
+ * anonymized entries the employer review surface renders.
+ */
+
+import {
+  normalizeEmployerAcceptanceHistoryResponse,
+  type EmployerAcceptanceHistoryEntry,
+  type EmployerAcceptanceHistoryResponse,
+} from '@/lib/employer-review-actions';
+
+export type AcceptanceRecognitionResult =
+  /** At least one employer acceptance is recorded. */
+  | { state: 'recognized'; recognition: EmployerAcceptanceHistoryResponse }
+  /** The record exists (or the NPI is unknown to the backend) with no acceptances. */
+  | { state: 'none_recorded' }
+  /** System state — the lookup failed; never presented as a finding. */
+  | { state: 'unavailable' };
+
+/**
+ * Fetch acceptance recognition for a clinician NPI via the public
+ * acceptance-history read. A 404 means the backend has no entity for the NPI
+ * yet — indistinguishable, for the holder, from "nothing recorded".
+ */
+export async function fetchAcceptanceRecognition(
+  npi: string,
+  init?: RequestInit,
+): Promise<AcceptanceRecognitionResult> {
+  try {
+    const res = await fetch(
+      `/api/employer-review/${encodeURIComponent(npi)}/acceptance-history`,
+      { cache: 'no-store', ...init },
+    );
+
+    if (res.status === 404) return { state: 'none_recorded' };
+    if (!res.ok) return { state: 'unavailable' };
+
+    const recognition = normalizeEmployerAcceptanceHistoryResponse(await res.json());
+    if (!recognition) return { state: 'unavailable' };
+    if (!recognition.summary.hasPriorAcceptances) return { state: 'none_recorded' };
+
+    return { state: 'recognized', recognition };
+  } catch {
+    return { state: 'unavailable' };
+  }
+}
+
+const SCOPE_LABELS: Record<EmployerAcceptanceHistoryEntry['acceptanceScope'], string> = {
+  pilot: 'Pilot scope',
+  full: 'Full scope',
+  partial: 'Partial scope',
+};
+
+export function acceptanceScopeLabel(
+  scope: EmployerAcceptanceHistoryEntry['acceptanceScope'],
+): string {
+  return SCOPE_LABELS[scope];
+}
+
+export function formatAcceptedAt(acceptedAt: string): string | null {
+  const parsed = Date.parse(acceptedAt);
+  if (Number.isNaN(parsed)) return null;
+
+  return new Date(parsed).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}


### PR DESCRIPTION
## Mission — Recognition Elevation (PR B of 5)

**Risk tier: 1** (web UI, additive, no backend changes) — self-merge after tests/build/production verification per tiered merge policy.

Map: `docs/product/recognition-elevation-map.md` (landed in #484).

## What

- **`RecognitionCard`** (`components/recognition/`): the holder-facing answer to *"Am I recognized?"* — reads the real employer acceptance chain via the public `acceptance-history` endpoint (NPI key enabled by #484). Four honest states:
  - **recognized** — backend headline ("Accepted by N organization(s)"), latest acceptance (anonymized org label, scope, date), backend trust copy
  - **none recorded** — "No employer acceptances recorded yet" + how recognition happens ("accepts your evidence as a head start")
  - **unavailable** — explicitly a system state, "not a finding about your record", with retry
  - loading
- **`lib/recognition/acceptance-recognition.ts`**: shared fetch + state mapping reusing the existing `normalizeEmployerAcceptanceHistoryResponse` contract (no new trust model). 404 (NPI unknown to backend) maps to *none recorded* — indistinguishable for the holder, and correct.
- Mounted on **`/holder`** (under the trust panel) and **`/holder/home`** (after the readiness/momentum section, only when a real 10-digit NPI is present).
- `RecognitionCard.tsx` added to the **holder route-contract test** surfaces so its links can never dead-end.

## Rules compliance

- No demo data — renders only the live acceptance-history payload; empty and failure states are explicit.
- No new trust model — one existing endpoint, one existing normalizer.
- Copy: no banned strings, no bare "Verified" (test-pinned in `recognition-card.test.tsx`).

## Verification

- New `recognition-card.test.tsx`: 7 tests (helper state mapping ×3, rendered states ×3, bare-Verified guard).
- Full web suite: **1753 passed / 4 skipped**, including holder route contract (now 9 surface files).
- `pnpm turbo run build --filter @vitalcv/web`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design Handoff References

No Claude Design handoff file used for this PR.

(Audited against design-handoff/claude-design-2026-06-26 after ingestion — see docs/design/claude-design-handoff-index.md. No handoff file specifies a clinician-side recognition record surface; no conflict found. Future alignment candidate: the signed-artifact register from "vitalcv/project/Trust State Visual System.html" for acceptance entries.)
