### PR TITLE
feat(recognition): /holder/recognition detail surface

### DIFF
--- a/apps/web/__tests__/holder-route-contract.test.ts
+++ b/apps/web/__tests__/holder-route-contract.test.ts
@@ -27,6 +27,7 @@ const SURFACE_FILES = [
   'components/mobile/ClinicianPanels.tsx',
   'components/clinician/MobileBottomNav.tsx',
   'components/recognition/RecognitionCard.tsx',
+  'components/recognition/RecognitionSurface.tsx',
 ];
 
 /** Extract internal href path literals (static + template-literal heads). */

--- a/apps/web/__tests__/recognition-card.test.tsx
+++ b/apps/web/__tests__/recognition-card.test.tsx
@@ -129,7 +129,7 @@ describe('RecognitionCard', () => {
     expect(container.textContent).toContain('Accepted by 1 organization');
     expect(container.textContent).toContain('Pilot organization 1');
     expect(container.textContent).toContain('Pilot scope');
-    const link = container.querySelector('a[href="/holder/applications"]');
+    const link = container.querySelector('a[href="/holder/recognition"]');
     expect(link).not.toBeNull();
   });
 

--- a/apps/web/__tests__/recognition-surface.test.tsx
+++ b/apps/web/__tests__/recognition-surface.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+/**
+ * /holder/recognition surface — full recognition record.
+ *
+ * Truth contract: only real acceptance-history payloads render; the meaning
+ * explainer never overstates (scoped to the accepting organization, anchored
+ * to source checks); failures are system states; no bare "Verified".
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecognitionSurface } from '../components/recognition/RecognitionSurface';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function workspacesPayload(npi: string | null) {
+  return { personProfile: npi ? { npi, firstName: 'Ada' } : null };
+}
+
+function acceptanceHistoryPayload() {
+  return {
+    ok: true,
+    summary: {
+      acceptedOrganizationCount: 2,
+      hasPriorAcceptances: true,
+      headline: 'Accepted by 2 organizations',
+      trustCopy:
+        'This clinician has already been accepted using VitalCV verification. Each acceptance remains scoped to the organization and scope shown below.',
+    },
+    history: [
+      {
+        acceptanceId: 'accept-2',
+        orgLabel: 'Providence',
+        isAnonymized: false,
+        acceptedByOrgId: 'org-entity-2',
+        acceptedAt: '2026-05-11T12:00:00.000Z',
+        acceptanceScope: 'full',
+        acceptanceReason: null,
+      },
+      {
+        acceptanceId: 'accept-1',
+        orgLabel: 'Pilot organization 1',
+        isAnonymized: true,
+        acceptedByOrgId: 'org-entity-1',
+        acceptedAt: '2026-03-23T18:00:00.000Z',
+        acceptanceScope: 'pilot',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      },
+    ],
+  };
+}
+
+function stubFetchByUrl(routes: Record<string, () => Response | Promise<Response>>) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [prefix, respond] of Object.entries(routes)) {
+      if (url.startsWith(prefix)) return respond();
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }));
+}
+
+describe('RecognitionSurface', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderSurface() {
+    await act(async () => {
+      root.render(<RecognitionSurface />);
+    });
+  }
+
+  it('renders the full acceptance record with every entry, scope, and the meaning explainer', async () => {
+    stubFetchByUrl({
+      '/api/me/workspaces': () => jsonResponse(workspacesPayload('1234567890')),
+      '/api/employer-review/1234567890/acceptance-history': () =>
+        jsonResponse(acceptanceHistoryPayload()),
+    });
+
+    await renderSurface();
+
+    expect(container.textContent).toContain('Your recognition record');
+    expect(container.textContent).toContain('Accepted by 2 organizations');
+    expect(container.textContent).toContain('Providence');
+    expect(container.textContent).toContain('Full scope');
+    expect(container.textContent).toContain('Pilot organization 1');
+    expect(container.textContent).toContain('Pilot scope');
+    expect(container.textContent).toContain('Accepted as head start using VitalCV verification.');
+    // Meaning explainer: scoped, audit-recorded, canonical sequence.
+    expect(container.textContent).toContain('What an acceptance means');
+    expect(container.textContent).toContain('scoped to the accepting organization');
+    expect(container.textContent).toContain('does not replace another organization');
+    expect(container.textContent).toContain('Recognition, then acceptance, then start');
+    expect(container.querySelector('a[href="/holder"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/holder/applications"]')).not.toBeNull();
+  });
+
+  it('renders the honest empty state when nothing is recorded', async () => {
+    stubFetchByUrl({
+      '/api/me/workspaces': () => jsonResponse(workspacesPayload('1234567890')),
+      '/api/employer-review/1234567890/acceptance-history': () =>
+        jsonResponse({ error: 'not_found' }, 404),
+    });
+
+    await renderSurface();
+
+    expect(container.textContent).toContain('No employer acceptances recorded yet');
+    expect(container.textContent).toContain('accepts it as a head start');
+    expect(container.querySelector('a[href="/holder/readiness"]')).not.toBeNull();
+  });
+
+  it('routes a missing NPI to the readiness setup path', async () => {
+    stubFetchByUrl({
+      '/api/me/workspaces': () => jsonResponse(workspacesPayload(null)),
+    });
+
+    await renderSurface();
+
+    expect(container.textContent).toContain('Set up your readiness first');
+    expect(container.querySelector('a[href="/get-ready"]')).not.toBeNull();
+  });
+
+  it('presents lookup failures as system states, never findings', async () => {
+    stubFetchByUrl({
+      '/api/me/workspaces': () => jsonResponse(workspacesPayload('1234567890')),
+      '/api/employer-review/1234567890/acceptance-history': () =>
+        jsonResponse({ error: 'boom' }, 500),
+    });
+
+    await renderSurface();
+
+    expect(container.textContent).toContain('Recognition status is temporarily unavailable');
+    expect(container.textContent).toContain('not a finding about your record');
+  });
+
+  it('never renders a bare Verified label', async () => {
+    stubFetchByUrl({
+      '/api/me/workspaces': () => jsonResponse(workspacesPayload('1234567890')),
+      '/api/employer-review/1234567890/acceptance-history': () =>
+        jsonResponse(acceptanceHistoryPayload()),
+    });
+
+    await renderSurface();
+
+    expect(/\bVerified\b/.test(container.textContent ?? '')).toBe(false);
+  });
+});

--- a/apps/web/app/holder/recognition/page.tsx
+++ b/apps/web/app/holder/recognition/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import { RecognitionSurface } from '@/components/recognition/RecognitionSurface';
+
+export const metadata: Metadata = {
+  title: 'Recognition · VitalCV',
+  description:
+    'Your recognition record — employer acceptances recorded against your source-backed evidence, with what each acceptance means.',
+};
+
+export default function HolderRecognitionPage() {
+  return <RecognitionSurface />;
+}

--- a/apps/web/components/recognition/RecognitionCard.tsx
+++ b/apps/web/components/recognition/RecognitionCard.tsx
@@ -119,10 +119,10 @@ function RecognizedBody({
       )}
 
       <Link
-        href="/holder/applications"
+        href="/holder/recognition"
         className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
       >
-        View your applications <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+        View your recognition record <ChevronRight className="h-3.5 w-3.5" aria-hidden />
       </Link>
     </div>
   );

--- a/apps/web/components/recognition/RecognitionSurface.tsx
+++ b/apps/web/components/recognition/RecognitionSurface.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+/**
+ * Recognition surface — /holder/recognition.
+ *
+ * The clinician-facing answer to "What does my recognition mean?". Renders the
+ * full employer acceptance record (canonical Recognition → Acceptance → Start
+ * path, middle step) from the public acceptance-history read, plus a plain
+ * explanation of what an acceptance is and is not. Honest states throughout:
+ * lookup failures are system states, empty records say exactly that, and no
+ * entry is ever synthesized.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Award, ChevronRight, Loader2, ShieldCheck } from 'lucide-react';
+import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
+import {
+  acceptanceScopeLabel,
+  fetchAcceptanceRecognition,
+  formatAcceptedAt,
+  type AcceptanceRecognitionResult,
+} from '@/lib/recognition/acceptance-recognition';
+
+type Phase =
+  | { state: 'loading' }
+  | { state: 'no_npi' }
+  | { state: 'profile_error' }
+  | (AcceptanceRecognitionResult & { npi?: string });
+
+export function RecognitionSurface() {
+  const [phase, setPhase] = useState<Phase>({ state: 'loading' });
+
+  const load = useCallback(async () => {
+    setPhase({ state: 'loading' });
+    try {
+      const res = await fetch('/api/me/workspaces');
+      if (!res.ok) {
+        setPhase({ state: 'profile_error' });
+        return;
+      }
+      const data = await res.json() as { personProfile?: { npi?: string | null } | null };
+      const npi = data.personProfile?.npi ?? null;
+      if (!npi) {
+        setPhase({ state: 'no_npi' });
+        return;
+      }
+      setPhase({ ...(await fetchAcceptanceRecognition(npi)), npi });
+    } catch {
+      setPhase({ state: 'profile_error' });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-foreground">
+      <div className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+        <Link
+          href="/holder"
+          className="inline-flex items-center gap-1.5 text-sm text-zinc-500 transition hover:text-zinc-300"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden /> Back to your readiness
+        </Link>
+
+        <header className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Award className="h-5 w-5 text-emerald-400" aria-hidden />
+            <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Recognition</p>
+          </div>
+          <h1 className="text-2xl font-bold text-foreground">Your recognition record</h1>
+          <p className="text-sm leading-6 text-zinc-400">
+            Employer acceptances recorded against your source-backed evidence. Each entry is an
+            employer decision captured with an audit event at the moment it was made.
+          </p>
+        </header>
+
+        {phase.state === 'loading' && (
+          <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5 text-sm text-zinc-500">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            Loading your acceptance record…
+          </div>
+        )}
+
+        {phase.state === 'profile_error' && (
+          <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <p className="text-sm font-medium text-zinc-200">Couldn&apos;t load your profile</p>
+            <p className="text-sm leading-6 text-zinc-400">
+              This is a system state — not a finding about your record. Try again shortly.
+            </p>
+            <button
+              onClick={() => { void load(); }}
+              className="rounded-lg border border-zinc-700 px-4 py-1.5 text-sm text-zinc-300 transition hover:text-white"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {phase.state === 'no_npi' && (
+          <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <p className="text-sm font-medium text-zinc-200">Set up your readiness first</p>
+            <p className="text-sm leading-6 text-zinc-400">
+              Recognition builds on your NPI-anchored evidence. Verify your NPI to activate your
+              clinician profile, and acceptances will be recorded here.
+            </p>
+            <Link
+              href="/get-ready"
+              className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+            >
+              Verify my NPI <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+            </Link>
+          </div>
+        )}
+
+        {phase.state === 'unavailable' && (
+          <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <p className="text-sm font-medium text-zinc-200">
+              Recognition status is temporarily unavailable
+            </p>
+            <p className="text-sm leading-6 text-zinc-400">
+              This is a system state — not a finding about your record. Try again shortly.
+            </p>
+            <button
+              onClick={() => { void load(); }}
+              className="rounded-lg border border-zinc-700 px-4 py-1.5 text-sm text-zinc-300 transition hover:text-white"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+
+        {phase.state === 'none_recorded' && (
+          <div className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <p className="text-base font-semibold text-zinc-100">
+              No employer acceptances recorded yet
+            </p>
+            <p className="text-sm leading-6 text-zinc-400">
+              When an employer reviews your evidence and accepts it as a head start, the
+              acceptance is recorded here and stays part of your career record. Keeping your
+              readiness current is what makes that decision easy.
+            </p>
+            <Link
+              href="/holder/readiness"
+              className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+            >
+              Review your readiness <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+            </Link>
+          </div>
+        )}
+
+        {phase.state === 'recognized' && (
+          <>
+            <section
+              aria-label="Acceptance summary"
+              className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-5"
+            >
+              <p className="text-lg font-semibold text-zinc-100">
+                {phase.recognition.summary.headline}
+              </p>
+              {phase.recognition.summary.trustCopy && (
+                <p className="mt-2 text-sm leading-6 text-zinc-400">
+                  {phase.recognition.summary.trustCopy}
+                </p>
+              )}
+            </section>
+
+            <section aria-label="Acceptance history" className="space-y-3">
+              <h2 className="text-xs uppercase tracking-wider text-zinc-500">
+                Recorded acceptances
+              </h2>
+              {phase.recognition.history.map((entry, index) => (
+                <div
+                  key={entry.acceptanceId ?? `${entry.acceptedAt}-${index}`}
+                  className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-zinc-100">{entry.orgLabel}</p>
+                    <span className="rounded-full border border-zinc-700 px-2.5 py-0.5 text-xs text-zinc-400">
+                      {acceptanceScopeLabel(entry.acceptanceScope)}
+                    </span>
+                  </div>
+                  {formatAcceptedAt(entry.acceptedAt) && (
+                    <p className="mt-1 text-xs text-zinc-500">
+                      Accepted {formatAcceptedAt(entry.acceptedAt)}
+                    </p>
+                  )}
+                  {entry.acceptanceReason && (
+                    <p className="mt-2 text-sm leading-6 text-zinc-400">{entry.acceptanceReason}</p>
+                  )}
+                </div>
+              ))}
+            </section>
+          </>
+        )}
+
+        <section
+          aria-label="What recognition means"
+          className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5"
+        >
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-emerald-400" aria-hidden />
+            <h2 className="text-sm font-semibold text-zinc-200">What an acceptance means</h2>
+          </div>
+          <ul className="space-y-2 text-sm leading-6 text-zinc-400">
+            <li>
+              An employer reviewed your source-backed evidence and accepted it as a head start —
+              a decision recorded with an audit event at the moment it was made.
+            </li>
+            <li>
+              Each acceptance is scoped to the accepting organization. It gives that team a
+              recorded starting point; it does not replace another organization&apos;s own review.
+            </li>
+            <li>
+              Recognition, then acceptance, then start is the canonical sequence. Your record here
+              is that middle step, and it stays anchored to the source checks behind it.
+            </li>
+          </ul>
+          <Link
+            href="/holder/applications"
+            className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+          >
+            View your applications <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+          </Link>
+        </section>
+
+        <ClinicianSupportCard
+          topic="recognition-record"
+          detail="If an acceptance you expect is missing here, refresh once, then contact support with your NPI and the organization involved."
+          primaryHref="/holder/readiness"
+          primaryLabel="Review readiness"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
     setupFiles: ['./test/setup.ts'],
     exclude: [...configDefaults.exclude, 'tests/**', ...STALE_TEST_FILES],
   },
+  // Match Next's automatic JSX runtime so components without a `React` import
+  // (the app's prevailing style) also render under jsdom tests.
+  esbuild: { jsx: 'automatic' },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Mission — Recognition Elevation (PR C of 5)

**Risk tier: 1** (web UI, additive) — self-merge after tests/build/production verification.

Follows #484 (NPI read enabler) and #485 (home card). Map: `docs/product/recognition-elevation-map.md`.

## What

- **`/holder/recognition`** — the clinician-facing recognition record (`RecognitionSurface`):
  - full acceptance history (anonymized org label, scope chip, date, acceptance reason when recorded)
  - summary block with the backend headline + trust copy
  - **"What an acceptance means"** explainer, honesty-first: recorded with an audit event at decision time; scoped to the accepting organization ("does not replace another organization's own review"); the middle step of the canonical Recognition → Acceptance → Start sequence
  - honest empty / no-NPI / system-state failure states (never presented as findings)
- Home card's CTA now deep-links to the record ("View your recognition record").
- Both recognition components are pinned in the **holder route-contract test** (11 surface files).
- **vitest config**: `esbuild: { jsx: 'automatic' }` — tests now compile JSX the way the Next build does, so components written without a `React` import (the app's prevailing style) render under jsdom. This unblocked rendering `ClinicianSupportCard`/`SupportActionButton` inside the new surface's tests and removes the footgun repo-wide.

## Rules compliance

No demo data; no new trust model (same public acceptance-history read); no banned strings; no bare "Verified" (test-pinned).

## Verification

- `recognition-surface.test.tsx`: 5 tests (full record render, empty state, no-NPI path, system-state failure, bare-Verified guard).
- Full web suite: **1759 passed / 4 skipped** (net +5, zero regressions from the JSX runtime change).
- `pnpm turbo run build --filter @vitalcv/web`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design Handoff References

No Claude Design handoff file used for this PR.

(Audited against design-handoff/claude-design-2026-06-26 after ingestion — see docs/design/claude-design-handoff-index.md. No handoff file specifies a clinician-side recognition record surface; no conflict found. Future alignment candidate: the signed-artifact register from "vitalcv/project/Trust State Visual System.html" for acceptance entries.)
