### PR TITLE
feat(recognition): Present VitalCV Recognition — share panel + public verifier acceptances

### DIFF
--- a/apps/web/__tests__/holder-route-contract.test.ts
+++ b/apps/web/__tests__/holder-route-contract.test.ts
@@ -28,6 +28,7 @@ const SURFACE_FILES = [
   'components/clinician/MobileBottomNav.tsx',
   'components/recognition/RecognitionCard.tsx',
   'components/recognition/RecognitionSurface.tsx',
+  'components/recognition/ShareRecognitionPanel.tsx',
 ];
 
 /** Extract internal href path literals (static + template-literal heads). */

--- a/apps/web/__tests__/recognition-share-verify.test.tsx
+++ b/apps/web/__tests__/recognition-share-verify.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+/**
+ * Share Recognition + public verifier acceptance panel.
+ *
+ * Truth contract: the share panel always shows the full link it hands out
+ * (nothing hidden), the verifier page renders acceptances from the real
+ * backend payload only, and a failed acceptance lookup is a system state —
+ * never rendered as "no acceptances".
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ShareRecognitionPanel } from '../components/recognition/ShareRecognitionPanel';
+import VerifierPage from '../app/verify/[npi]/page';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function acceptanceHistoryPayload() {
+  return {
+    ok: true,
+    summary: {
+      acceptedOrganizationCount: 1,
+      hasPriorAcceptances: true,
+      headline: 'Accepted by 1 organization',
+      trustCopy:
+        'This clinician has already been accepted using VitalCV verification. Each acceptance remains scoped to the organization and scope shown below.',
+    },
+    history: [
+      {
+        acceptanceId: 'accept-1',
+        orgLabel: 'Pilot organization 1',
+        isAnonymized: true,
+        acceptedByOrgId: 'org-entity-1',
+        acceptedAt: '2026-03-23T18:00:00.000Z',
+        acceptanceScope: 'pilot',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      },
+    ],
+  };
+}
+
+function minimalPassport() {
+  return {
+    entityId: 'entity-1',
+    npi: '1234567890',
+    identity: {
+      displayName: 'Ada Lovelace',
+      specialty: 'Cardiology',
+      entityType: 'PERSON',
+      status: 'A',
+    },
+    sourceCoverage: { checks: [] },
+    readiness: { status: 'PARTIAL', score: 62 },
+    lastCheckedAt: '2026-06-30T12:00:00.000Z',
+  };
+}
+
+describe('ShareRecognitionPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows the full verifier link, an open action, and copies via the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await act(async () => {
+      root.render(<ShareRecognitionPanel npi="1234567890" />);
+    });
+
+    expect(container.textContent).toContain('Present VitalCV Recognition');
+    expect(container.textContent).toContain('without creating an account');
+
+    const input = container.querySelector<HTMLInputElement>('input[readonly]');
+    expect(input?.value).toContain('/verify/1234567890');
+
+    const openLink = container.querySelector('a[target="_blank"]');
+    expect(openLink?.getAttribute('href')).toBe('/verify/1234567890');
+
+    const copyButton = [...container.querySelectorAll('button')]
+      .find((b) => b.textContent?.includes('Copy link'));
+    expect(copyButton).toBeTruthy();
+    await act(async () => {
+      copyButton!.click();
+    });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/verify/1234567890'));
+    expect(container.textContent).toContain('Copied');
+  });
+});
+
+describe('/verify/[npi] acceptance panel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubBackend(routes: {
+    passport: () => Response;
+    acceptance: () => Response | Promise<Response>;
+  }) {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/trust-proof/')) return routes.passport();
+      if (url.includes('/acceptance-history')) return routes.acceptance();
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+  }
+
+  async function renderPage() {
+    const element = await VerifierPage({ params: Promise.resolve({ npi: '1234567890' }) });
+    return renderToStaticMarkup(element);
+  }
+
+  it('renders recorded acceptances from the backend payload', async () => {
+    stubBackend({
+      passport: () => jsonResponse(minimalPassport()),
+      acceptance: () => jsonResponse(acceptanceHistoryPayload()),
+    });
+
+    const html = await renderPage();
+
+    expect(html).toContain('Employer acceptances');
+    expect(html).toContain('Accepted by 1 organization');
+    expect(html).toContain('Pilot organization 1');
+    expect(html).toContain('Pilot scope');
+  });
+
+  it('renders an honest zero-state when no acceptances are recorded', async () => {
+    stubBackend({
+      passport: () => jsonResponse(minimalPassport()),
+      acceptance: () => jsonResponse({
+        ok: true,
+        summary: {
+          acceptedOrganizationCount: 0,
+          hasPriorAcceptances: false,
+          headline: 'No prior acceptances',
+          trustCopy: null,
+        },
+        history: [],
+      }),
+    });
+
+    const html = await renderPage();
+
+    expect(html).toContain('No employer acceptances recorded for this NPI.');
+  });
+
+  it('renders a system-state line — never a zero-state — when the acceptance lookup fails', async () => {
+    stubBackend({
+      passport: () => jsonResponse(minimalPassport()),
+      acceptance: () => jsonResponse({ error: 'boom' }, 500),
+    });
+
+    const html = await renderPage();
+
+    expect(html).toContain('Acceptance record temporarily unavailable');
+    expect(html).toContain('not a finding about this clinician');
+    expect(html).not.toContain('No employer acceptances recorded');
+  });
+});

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -21,6 +21,11 @@ import { IssuerContinuityPanel } from '@/components/verifier/IssuerContinuityPan
 import { ReplayChronologyPanel } from '@/components/verifier/ReplayChronologyPanel';
 import type { LaneSnapshot } from '@/components/proof/trust-types';
 import type { PassportData } from '@/lib/trust/passport-contract';
+import {
+  normalizeEmployerAcceptanceHistoryResponse,
+  type EmployerAcceptanceHistoryResponse,
+} from '@/lib/employer-review-actions';
+import { acceptanceScopeLabel, formatAcceptedAt } from '@/lib/recognition/acceptance-recognition';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -122,6 +127,30 @@ async function fetchPassport(npi: string): Promise<PassportData | null> {
   }
 }
 
+/**
+ * Recorded employer acceptances (Recognition → Acceptance → Start, middle
+ * step). Public read, same anonymized payload the review surface shows.
+ * Null means the lookup failed — rendered as a system state, never as an
+ * empty record.
+ */
+async function fetchAcceptanceHistory(
+  npi: string,
+): Promise<EmployerAcceptanceHistoryResponse | null> {
+  try {
+    const res = await fetch(
+      `${BACKEND}/api/employer-review/${encodeURIComponent(npi)}/acceptance-history`,
+      {
+        headers: { Accept: 'application/json' },
+        next: { revalidate: 60 },
+      },
+    );
+    if (!res.ok) return null;
+    return normalizeEmployerAcceptanceHistoryResponse(await res.json());
+  } catch {
+    return null;
+  }
+}
+
 // ── Metadata ──────────────────────────────────────────────────────────────────
 
 export async function generateMetadata({
@@ -146,7 +175,10 @@ export default async function VerifierPage({
   params: Promise<{ npi: string }>;
 }) {
   const { npi } = await params;
-  const passport = await fetchPassport(npi);
+  const [passport, acceptanceHistory] = await Promise.all([
+    fetchPassport(npi),
+    fetchAcceptanceHistory(npi),
+  ]);
 
   if (!passport) {
     return <NotFound npi={npi} />;
@@ -255,6 +287,11 @@ export default async function VerifierPage({
           <ProvenanceStrip lanes={lanes} />
         </Section>
 
+        {/* ── Section: Employer acceptances (Recognition) ────────────────── */}
+        <Section title="Employer acceptances">
+          <AcceptancePanel history={acceptanceHistory} />
+        </Section>
+
         {/* ── Section: Receipt Verification ─────────────────────────────── */}
         <Section title="Verification receipt">
           {firstReceiptLane ? (
@@ -327,6 +364,57 @@ function EmptyState({ message }: { message: string }) {
   return (
     <div className="border border-dashed border-gray-200 rounded px-3 py-4 text-sm text-gray-400 text-center">
       {message}
+    </div>
+  );
+}
+
+/**
+ * Recorded employer acceptances for the reviewed NPI. Three explicit states:
+ * entries, an honest zero-state, and a system-state line when the lookup
+ * failed (never rendered as "no acceptances").
+ */
+function AcceptancePanel({
+  history,
+}: {
+  history: EmployerAcceptanceHistoryResponse | null;
+}) {
+  if (!history) {
+    return (
+      <EmptyState message="Acceptance record temporarily unavailable. This is a system state — not a finding about this clinician." />
+    );
+  }
+
+  if (!history.summary.hasPriorAcceptances) {
+    return <EmptyState message="No employer acceptances recorded for this NPI." />;
+  }
+
+  return (
+    <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
+      <div className="px-4 py-3">
+        <p className="text-sm font-semibold text-gray-900">{history.summary.headline}</p>
+        {history.summary.trustCopy && (
+          <p className="mt-1 text-xs leading-5 text-gray-500">{history.summary.trustCopy}</p>
+        )}
+      </div>
+      {history.history.map((entry, index) => (
+        <div
+          key={entry.acceptanceId ?? `${entry.acceptedAt}-${index}`}
+          className="px-4 py-3 flex flex-wrap items-center justify-between gap-2"
+        >
+          <div>
+            <p className="text-sm text-gray-800">{entry.orgLabel}</p>
+            {entry.acceptanceReason && (
+              <p className="mt-0.5 text-xs text-gray-500">{entry.acceptanceReason}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            <span className="border border-gray-200 rounded-full px-2 py-0.5">
+              {acceptanceScopeLabel(entry.acceptanceScope)}
+            </span>
+            {formatAcceptedAt(entry.acceptedAt) && <span>{formatAcceptedAt(entry.acceptedAt)}</span>}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/components/recognition/RecognitionSurface.tsx
+++ b/apps/web/components/recognition/RecognitionSurface.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Award, ChevronRight, Loader2, ShieldCheck } from 'lucide-react';
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
+import { ShareRecognitionPanel } from '@/components/recognition/ShareRecognitionPanel';
 import {
   acceptanceScopeLabel,
   fetchAcceptanceRecognition,
@@ -194,6 +195,10 @@ export function RecognitionSurface() {
               ))}
             </section>
           </>
+        )}
+
+        {'npi' in phase && phase.npi && (
+          <ShareRecognitionPanel npi={phase.npi} />
         )}
 
         <section

--- a/apps/web/components/recognition/ShareRecognitionPanel.tsx
+++ b/apps/web/components/recognition/ShareRecognitionPanel.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * Share panel — the holder-facing answer to "How do I share or prove it?".
+ *
+ * "Present VitalCV Recognition" (canonical holder-facing verb, MASTER_PROMPT
+ * copy discipline): hands the clinician the existing public verifier link for
+ * their NPI. No new tokens, no new backend — the /verify/[npi] surface is
+ * already public and read-only, and shows recorded acceptances alongside
+ * source-backed status. The link is shown in full so the clinician always
+ * sees exactly what they are sharing.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, Copy, ExternalLink, Send } from 'lucide-react';
+
+export function ShareRecognitionPanel({ npi }: { npi: string }) {
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState<'idle' | 'copied' | 'manual'>('idle');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Origin is only knowable client-side; render the full URL once mounted.
+    setShareUrl(`${window.location.origin}/verify/${encodeURIComponent(npi)}`);
+  }, [npi]);
+
+  async function copyLink() {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied('copied');
+    } catch {
+      inputRef.current?.select();
+      setCopied('manual');
+    }
+  }
+
+  return (
+    <section
+      aria-label="Present VitalCV Recognition"
+      className="space-y-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+    >
+      <div className="flex items-center gap-2">
+        <Send className="h-4 w-4 text-emerald-400" aria-hidden />
+        <h2 className="text-sm font-semibold text-zinc-200">Present VitalCV Recognition</h2>
+      </div>
+      <p className="text-sm leading-6 text-zinc-400">
+        Anyone with this link can open your read-only verifier view — your source-backed
+        status and any recorded acceptances — without creating an account. Nothing is
+        shared until you send the link.
+      </p>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          ref={inputRef}
+          readOnly
+          value={shareUrl ?? 'Preparing link…'}
+          aria-label="Your verifier link"
+          onFocus={(event) => { event.currentTarget.select(); }}
+          className="min-w-0 flex-1 rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 font-mono text-xs text-zinc-300"
+        />
+        <div className="flex gap-2">
+          <button
+            onClick={() => { void copyLink(); }}
+            disabled={!shareUrl}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 transition hover:border-emerald-700 hover:text-emerald-300 disabled:opacity-50"
+          >
+            {copied === 'copied'
+              ? (<><Check className="h-3.5 w-3.5" aria-hidden /> Copied</>)
+              : (<><Copy className="h-3.5 w-3.5" aria-hidden /> Copy link</>)}
+          </button>
+          <a
+            href={`/verify/${encodeURIComponent(npi)}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 transition hover:border-emerald-700 hover:text-emerald-300"
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden /> Open
+          </a>
+        </div>
+      </div>
+
+      {copied === 'manual' && (
+        <p className="text-xs text-zinc-500">
+          Copy didn&apos;t reach your clipboard — the link is selected above, copy it manually.
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Mission — Recognition Elevation (PR D of 5, buckets 3+4)

**Risk tier: 1** (web UI, additive, reuses existing public surfaces) — self-merge after tests/build/production verification.

Follows #484 → #485 → #486. Map: `docs/product/recognition-elevation-map.md`.

## What

**Share Recognition (bucket 3)** — `ShareRecognitionPanel` on `/holder/recognition`:
- Section titled **"Present VitalCV Recognition"** (the frozen holder-facing copy discipline, MASTER_PROMPT §3)
- Hands out the **existing public `/verify/[npi]` link** — no new tokens, no new backend, and the full URL is always visible so the clinician sees exactly what they share
- Copy-to-clipboard with an honest manual fallback, plus an Open action
- Rendered whenever the NPI is resolved (including the empty-record state — presenting a record with zero acceptances is legitimate; the verifier shows the state as it is)

**Verification surface (bucket 4)** — `/verify/[npi]` gains an **Employer acceptances** section:
- Server-side fetch of the same NPI-keyed public acceptance-history read (#484)
- Three explicit states: recorded entries (org label / scope / date / reason), an honest zero-state, and a **system-state line when the lookup fails — never rendered as "no acceptances"**
- Recipients see Recognition without an account; the whole page stays read-only

## Rules compliance

No demo data, no new trust model, no new infrastructure (existing route, existing normalizer, existing public surface registration for `/verify/**`). No banned strings; no bare "Verified".

## Verification

- `recognition-share-verify.test.tsx`: 4 tests — share panel link + clipboard, verifier acceptances render, zero-state, failure-as-system-state (asserts it does NOT claim "no acceptances")
- Full web suite: **1764 passed / 4 skipped**; `ShareRecognitionPanel` pinned in the holder route contract (12 surface files)
- `pnpm turbo run build --filter @vitalcv/web`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design Handoff References

No Claude Design handoff file used for this PR.

(Audited post-ingestion: the /verify/[npi] page this PR extends follows "vitalcv/project/Verifier Reading Mode.html" — verdict bar, provenance strip, issuer continuity, replay lineage. The Employer acceptances section added here is consistent with that design's section grammar but is not specified by it; "vitalcv/project/Acceptance Proof.html" governs the employer-side accept moment, outside this PR's scope. See docs/design/claude-design-handoff-index.md.)
