### PR TITLE
feat(recognition): recorded acceptances project into the career timeline

### DIFF
--- a/apps/web/__tests__/recognition-timeline.test.ts
+++ b/apps/web/__tests__/recognition-timeline.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Recognition in the Professional Memory timeline.
+ *
+ * Truth contract: recorded employer acceptances (and only recorded ones)
+ * project into the timeline as acceptance-class career events with
+ * recognitionImpact 'acceptance'; a failed acceptance read yields honest
+ * omission — a valid timeline with an empty recognition lane, never
+ * fabricated events.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  buildEvidenceCollection,
+  projectEvidenceToGraph,
+  projectTimeline,
+  propagateTrust,
+} from '@vitalcv/domain-evidence';
+import { acceptanceHistoryToEvidenceObjects } from '../lib/recognition/acceptance-evidence';
+import { assertPassportData } from '../lib/trust/passport-contract';
+
+const resolveMock = vi.fn();
+vi.mock('@/lib/trust/passport-runtime', () => ({
+  resolvePassportRuntimePassport: resolveMock,
+}));
+
+function acceptanceHistoryPayload() {
+  return {
+    ok: true as const,
+    summary: {
+      acceptedOrganizationCount: 1,
+      hasPriorAcceptances: true,
+      headline: 'Accepted by 1 organization',
+      trustCopy: null,
+    },
+    history: [
+      {
+        acceptanceId: 'accept-1',
+        orgLabel: 'Pilot organization 1',
+        isAnonymized: true,
+        acceptedByOrgId: 'org-entity-1',
+        acceptedAt: '2026-03-23T18:00:00.000Z',
+        acceptanceScope: 'pilot' as const,
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      },
+    ],
+  };
+}
+
+// Minimal valid PassportData (same shape the W240 route tests use).
+function buildPassportPayload(npi: string) {
+  return {
+    entityId: npi,
+    npi,
+    identity: { displayName: 'Ada Lovelace', specialty: 'Cardiology', entityType: 'PERSON', status: 'ACTIVE', npi },
+    authority: {
+      credentials: [
+        {
+          id: 'lic-ca', domain: 'California Medical Board', type: 'STATE_LICENSE', status: 'ACTIVE',
+          verificationLevel: 'PRIMARY_SOURCE', stale: false, confidenceLabel: 'HIGH', claimConfidenceLabel: 'HIGH',
+          dataFreshness: 'fresh', dataFreshnessLabel: 'Fresh', reviewRequired: false, jurisdiction: 'CA',
+          verifiedAt: '2026-03-23T12:00:00.000Z', sourceId: 'STATE_BOARD',
+        },
+      ],
+      summary: { active: 1, expired: 0, stale: 0, missing: [] },
+    },
+    training: { records: [], hasDegree: true, degreeVerified: true, hasResidency: true, fellowshipCount: 0 },
+    standing: {
+      exclusionClear: true, exclusionStatus: 'CLEAR', exclusionCheckedAt: '2026-03-23T12:00:00.000Z',
+      licensureStatus: 'verified', deaStatus: 'unknown', pecosStatus: 'enrolled', pecosEnrollmentStatus: 'ENROLLED',
+      enrollmentSourceLabel: 'CMS PECOS', enrollmentDataFreshness: 'Quarterly',
+      enrollmentNote: 'Current PECOS enrollment found.', enrollmentObservedAt: '2026-03-20T00:00:00.000Z',
+      negativeFindings: [],
+    },
+    readiness: { status: 'PARTIAL', score: 70, level: 'L2', blockers: [], gaps: [], estimatedStartDays: 14, nextActions: [] },
+    sources: { checked: ['NPPES_API'], lastFetch: { NPPES_API: '2026-03-23T12:00:00.000Z' } },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', reason: 'NPPES identity checked', checkedAt: '2026-03-23T12:00:00.000Z' },
+      ],
+    },
+    trustPosture: {
+      band: 'L2', bandLabel: 'Moderate trust', score: 70, dimensions: [],
+      freshness: { state: 'partial', label: 'Partial source coverage', items: [] },
+      safeToRelyOnNow: [], missingItems: [], gatedItems: [], reviewRequiredItems: [], staleItems: [], blockers: [],
+    },
+    lastCheckedAt: '2026-03-23T12:00:00.000Z',
+  };
+}
+
+describe('acceptanceHistoryToEvidenceObjects', () => {
+  it('produces collection-valid acceptance evidence with an accepted_by relationship', () => {
+    const { objects, relationships } = acceptanceHistoryToEvidenceObjects(
+      '1234567890',
+      acceptanceHistoryPayload(),
+    );
+
+    expect(objects).toHaveLength(1);
+    expect(objects[0].evidenceClass).toBe('acceptance');
+    expect(objects[0].decisionGrade).toBe(true);
+    expect(objects[0].label).toBe('Accepted as head start — Pilot organization 1');
+    expect(objects[0].checkedAt).toBe('2026-03-23T18:00:00.000Z');
+    expect(objects[0].provenance.artifactIds).toEqual(['accept-1']);
+    expect(relationships).toEqual([
+      {
+        from: 'acceptance:accept-1',
+        to: 'org-entity-1',
+        type: 'accepted_by',
+        confidence: null,
+        observedAt: '2026-03-23T18:00:00.000Z',
+      },
+    ]);
+
+    // Must satisfy the collection's decisionGrade invariant (throws otherwise).
+    const collection = buildEvidenceCollection({
+      subjectKey: '1234567890',
+      generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+      objects,
+      relationships,
+    });
+    expect(collection.byClass.acceptance).toHaveLength(1);
+  });
+
+  it('projects into the timeline recognition lane with recognitionImpact acceptance', () => {
+    const { objects, relationships } = acceptanceHistoryToEvidenceObjects(
+      '1234567890',
+      acceptanceHistoryPayload(),
+    );
+    const collection = buildEvidenceCollection({
+      subjectKey: '1234567890',
+      generatedFor: { displayName: 'Ada Lovelace', npi: '1234567890' },
+      objects,
+      relationships,
+    });
+    const graph = projectEvidenceToGraph(collection);
+    const trust = propagateTrust(graph);
+    const timeline = projectTimeline(collection, graph, trust);
+
+    expect(timeline.recognition).toHaveLength(1);
+    expect(timeline.recognition[0].type).toBe('acceptance');
+    expect(timeline.recognition[0].recognitionImpact).toBe('acceptance');
+    expect(timeline.recognition[0].label).toBe('Accepted as head start — Pilot organization 1');
+  });
+});
+
+describe('GET /api/timeline/[entityId] recognition merge', () => {
+  const ctx = (entityId: string) => ({ params: Promise.resolve({ entityId }) });
+  const req = () => new NextRequest('http://localhost/api/timeline/test');
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resolveMock.mockReset();
+  });
+
+  it('merges recorded acceptances into the projection for NPI subjects', async () => {
+    resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload('1234567890')));
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/employer-review/1234567890/acceptance-history')) {
+        return new Response(JSON.stringify(acceptanceHistoryPayload()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    const { GET } = await import('../app/api/timeline/[entityId]/route');
+    const res = await GET(req(), ctx('1234567890'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.schema).toBe('vitalcv.timeline.v1');
+    expect(body.recognition).toHaveLength(1);
+    expect(body.recognition[0].recognitionImpact).toBe('acceptance');
+    expect(body.recognition[0].label).toBe('Accepted as head start — Pilot organization 1');
+    // The acceptance also appears in the main event stream.
+    expect(body.events.some((e: { type: string }) => e.type === 'acceptance')).toBe(true);
+  });
+
+  it('projects an honest timeline without recognition events when the acceptance read fails', async () => {
+    resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload('1234567890')));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ error: 'boom' }), { status: 500 })));
+
+    const { GET } = await import('../app/api/timeline/[entityId]/route');
+    const res = await GET(req(), ctx('1234567890'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.recognition).toEqual([]);
+    expect(body.events.some((e: { type: string }) => e.type === 'acceptance')).toBe(false);
+  });
+
+  it('skips the acceptance read entirely for non-NPI subjects', async () => {
+    resolveMock.mockResolvedValue(assertPassportData(buildPassportPayload('1234567890')));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { GET } = await import('../app/api/timeline/[entityId]/route');
+    const res = await GET(req(), ctx('entity-1'));
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/timeline/[entityId]/route.ts
+++ b/apps/web/app/api/timeline/[entityId]/route.ts
@@ -1,13 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
+  buildEvidenceCollection,
   projectEvidenceToGraph,
   projectTimeline,
   propagateTrust,
 } from '@vitalcv/domain-evidence';
 import { resolvePassportRuntimePassport } from '@/lib/trust/passport-runtime';
 import { passportToEvidenceCollection } from '@/lib/evidence/passport-to-evidence';
+import { BACKEND_URL } from '@/lib/backend-url';
+import {
+  acceptanceHistoryToEvidenceObjects,
+  fetchAcceptanceHistoryForTimeline,
+} from '@/lib/recognition/acceptance-evidence';
 
 export const runtime = 'nodejs';
+
+const NPI_PATTERN = /^\d{10}$/;
 
 /**
  * GET /api/timeline/[entityId] — read-only Professional Memory timeline (Wave 225).
@@ -17,6 +25,12 @@ export const runtime = 'nodejs';
  * trustHistory, recognition, and reputation, so the sub-views documented in
  * docs/wave225/C4-memory-api-contracts.md are filters over this single read.
  * No persistence, no ML, recruiter surfaces untouched.
+ *
+ * Recognition: for NPI subjects, recorded employer acceptances (the canonical
+ * Recognition → Acceptance → Start middle step) are merged in as
+ * acceptance-class evidence before projection, so they appear as career
+ * events with recognitionImpact 'acceptance'. If the acceptance read fails,
+ * the timeline projects without them — honest omission, never fabrication.
  */
 export async function GET(
   _req: NextRequest,
@@ -25,8 +39,25 @@ export async function GET(
   const { entityId } = await context.params;
 
   try {
-    const passport = await resolvePassportRuntimePassport(entityId);
-    const collection = passportToEvidenceCollection(passport);
+    const [passport, acceptanceHistory] = await Promise.all([
+      resolvePassportRuntimePassport(entityId),
+      NPI_PATTERN.test(entityId.trim())
+        ? fetchAcceptanceHistoryForTimeline(BACKEND_URL, entityId.trim())
+        : Promise.resolve(null),
+    ]);
+
+    let collection = passportToEvidenceCollection(passport);
+
+    if (acceptanceHistory) {
+      const acceptance = acceptanceHistoryToEvidenceObjects(entityId.trim(), acceptanceHistory);
+      collection = buildEvidenceCollection({
+        subjectKey: collection.subjectKey,
+        generatedFor: collection.generatedFor,
+        objects: [...collection.objects, ...acceptance.objects],
+        relationships: [...collection.relationships, ...acceptance.relationships],
+      });
+    }
+
     const graph = projectEvidenceToGraph(collection);
     const trust = propagateTrust(graph);
     const timeline = projectTimeline(collection, graph, trust);

--- a/apps/web/lib/recognition/acceptance-evidence.ts
+++ b/apps/web/lib/recognition/acceptance-evidence.ts
@@ -1,0 +1,113 @@
+/**
+ * Acceptance history → evidence objects for the Professional Memory timeline.
+ *
+ * Pure transform (no I/O): each recorded employer acceptance becomes an
+ * `acceptance`-class EvidenceObject, the shape the Wave 225 projection stack
+ * was designed for (see packages/domain-evidence timeline tests). Status is
+ * 'checked' because an acceptance is a recorded employer decision backed by
+ * a non-repudiable audit event — not an inference. The projector derives
+ * recognitionImpact 'acceptance' from the class, which is what surfaces these
+ * events in the timeline's recognition lane.
+ */
+
+import type { EvidenceObject, EvidenceRelationship } from '@vitalcv/domain-evidence';
+import { isDecisionGradeStatus } from '@vitalcv/domain-evidence';
+import {
+  normalizeEmployerAcceptanceHistoryResponse,
+  type EmployerAcceptanceHistoryEntry,
+  type EmployerAcceptanceHistoryResponse,
+} from '@/lib/employer-review-actions';
+
+const ACCEPTANCE_STATUS = 'checked' as const;
+
+function entryEvidenceId(entry: EmployerAcceptanceHistoryEntry, index: number): string {
+  return `acceptance:${entry.acceptanceId ?? `${entry.acceptedAt}:${index}`}`;
+}
+
+export function acceptanceHistoryToEvidenceObjects(
+  npi: string,
+  history: EmployerAcceptanceHistoryResponse,
+): { objects: EvidenceObject[]; relationships: EvidenceRelationship[] } {
+  const objects: EvidenceObject[] = [];
+  const relationships: EvidenceRelationship[] = [];
+
+  history.history.forEach((entry, index) => {
+    const evidenceId = entryEvidenceId(entry, index);
+
+    objects.push({
+      evidenceId,
+      subjectKey: npi,
+      evidenceClass: 'acceptance',
+      label: `Accepted as head start — ${entry.orgLabel}`,
+      value: {
+        orgLabel: entry.orgLabel,
+        acceptanceScope: entry.acceptanceScope,
+        isAnonymized: entry.isAnonymized,
+      },
+      status: ACCEPTANCE_STATUS,
+      source: {
+        sourceId: 'EMPLOYER_REVIEW',
+        sourceLabel: 'Employer review — recorded acceptance',
+        laneType: null,
+        governance: null,
+      },
+      trustTier: null,
+      decisionGrade: isDecisionGradeStatus(ACCEPTANCE_STATUS),
+      observedAt: entry.acceptedAt,
+      checkedAt: entry.acceptedAt,
+      expiresAt: null,
+      freshnessWindowHours: null,
+      integrityHash: null,
+      provenance: {
+        artifactIds: entry.acceptanceId ? [entry.acceptanceId] : [],
+        receiptIds: [],
+        sourceUrl: null,
+        checksum: null,
+        parserVersion: null,
+      },
+      lifecycle: 'active',
+      supersedes: null,
+      supersededBy: null,
+    });
+
+    if (entry.acceptedByOrgId) {
+      relationships.push({
+        from: evidenceId,
+        to: entry.acceptedByOrgId,
+        type: 'accepted_by',
+        confidence: null,
+        observedAt: entry.acceptedAt,
+      });
+    }
+  });
+
+  return { objects, relationships };
+}
+
+/**
+ * Server-side read of the acceptance record for an NPI. Returns null on any
+ * failure or when nothing is recorded — the timeline then simply projects
+ * without acceptance events (honest omission, never fabricated entries).
+ */
+export async function fetchAcceptanceHistoryForTimeline(
+  backendUrl: string,
+  npi: string,
+): Promise<EmployerAcceptanceHistoryResponse | null> {
+  try {
+    const res = await fetch(
+      `${backendUrl}/api/employer-review/${encodeURIComponent(npi)}/acceptance-history`,
+      {
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+        signal: AbortSignal.timeout(8000),
+      },
+    );
+    if (!res.ok) return null;
+
+    const parsed = normalizeEmployerAcceptanceHistoryResponse(await res.json());
+    if (!parsed || !parsed.summary.hasPriorAcceptances) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Mission — Recognition Elevation (PR E of 5, bucket 5)

**Risk tier: 2** (touches the trust/timeline projection input) — Codex verification before merge.

Follows #484 → #485 → #486 → #487. Map: `docs/product/recognition-elevation-map.md`.

## What

- **`lib/recognition/acceptance-evidence.ts`**: pure transform — each recorded employer acceptance becomes an `acceptance`-class `EvidenceObject` (status `'checked'`: it is a recorded, audit-event-backed employer decision, not an inference) plus an `accepted_by` relationship. Exactly the shape the Wave 225 projector's own tests fixture for this class.
- **`/api/timeline/[entityId]`**: for NPI subjects, fetches the acceptance record (NPI-keyed public read, #484) in parallel with the passport and merges it into the evidence collection via `buildEvidenceCollection` (decision-grade invariant enforced) before graph → trust → timeline projection. `/activity/[npi]` and `/holder/timeline` now actually show the recognition events their metadata has promised since Wave 300.
- Failure honesty: acceptance read fails → timeline projects **without** recognition events (omission, never fabrication). Non-NPI subjects skip the read entirely.

## Trust semantics (for the verifier)

- No new trust model: the `acceptance` evidence class, `recognitionImpact` derivation, ACCEPTED_BY graph edges, and professional/institutional trust dimensions all pre-exist in `packages/domain-evidence` (Waves 220–228); this PR only feeds them real data.
- Trust impact of an acceptance event follows the existing `statusTrustScore` rule for `'checked'` evidence — same rule every other checked evidence object uses; no special-casing, no inflation.
- Route stays read-only, no persistence, 8s timeout + catch on the acceptance read.

## Verification

- `recognition-timeline.test.ts`: 5 tests — transform validity vs the collection invariant, projection into the recognition lane, route merge for NPI subjects, honest omission on failed reads, no fetch for non-NPI subjects.
- Existing `evidence-routes.test.ts` (W240 hardening): untouched, 8/8 green.
- Full web suite: **1764 passed / 4 skipped**; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design Handoff References

No Claude Design handoff file used for this PR.

(Audited post-ingestion: this PR feeds real acceptance data into the projection stack specified by "vitalcv/project/Career Evidence Graph W220.html" and "vitalcv/project/Professional Memory System W225.html" (D1-D3) — the system those designs describe, already implemented in packages/domain-evidence. The W225 D4 "Professional Recognition Event" (third-party conferred honors) is a distinct, not-yet-implemented concept and is NOT what this PR materializes. See docs/design/claude-design-handoff-index.md.)
