### PR TITLE
fix(verify): restore public verifier surface — passport-contract read + redacted trust-proof

### DIFF
--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -40,6 +40,21 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/clinician/activate')).toBe(false);
   });
 
+  it('skips tenant context for public verifier reads (trust proof)', () => {
+    expect(shouldSkipTenantContext('/api/trust-proof/1003000126')).toBe(true);
+  });
+
+  it('allows the trust-proof read through without organization context', () => {
+    const req = createRequest('/api/trust-proof/1003000126');
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireTenantContextOrReadAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it('allows health probes through without organization context', () => {
     const req = createRequest('/health');
     const res = createResponse();

--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -75,6 +75,7 @@ export function shouldSkipTenantContext(path: string): boolean {
     || normalized.startsWith('/api/apply/')
     || normalized.startsWith('/api/trust-state/')
     || normalized.startsWith('/api/trust-decision/')
+    || normalized.startsWith('/api/trust-proof/')
     || normalized.startsWith('/api/verify')
     || normalized.startsWith('/api/verifier/accept')
     || normalized.startsWith('/api/pilot')

--- a/apps/web/__tests__/recognition-share-verify.test.tsx
+++ b/apps/web/__tests__/recognition-share-verify.test.tsx
@@ -119,7 +119,7 @@ describe('/verify/[npi] acceptance panel', () => {
   }) {
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/api/trust-proof/')) return routes.passport();
+      if (url.includes('/api/passport/npi/')) return routes.passport();
       if (url.includes('/acceptance-history')) return routes.acceptance();
       throw new Error(`Unexpected fetch: ${url}`);
     }));

--- a/apps/web/__tests__/verifier/replay-chronology-label.test.tsx
+++ b/apps/web/__tests__/verifier/replay-chronology-label.test.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import { ReplayChronologyPanel } from '../../components/verifier/ReplayChronologyPanel';
+import type { LaneSnapshot } from '../../components/proof/trust-types';
 
 describe('ReplayChronologyPanel status labels', () => {
   it('renders verified lanes as SOURCE-BACKED, never the bare VERIFIED label', () => {
@@ -21,6 +22,26 @@ describe('ReplayChronologyPanel status labels', () => {
           {
             laneId: 'NPPES_API',
             status: 'verified',
+            checkedAt: Date.UTC(2026, 5, 30, 12, 0, 0),
+            source: 'https://npiregistry.cms.hhs.gov',
+            receiptId: 'rcpt-12345678',
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('SOURCE-BACKED');
+    expect(html).not.toMatch(/·\s*VERIFIED/);
+    expect(html).not.toMatch(/>\s*VERIFIED\s*</);
+  });
+
+  it('normalizes unmapped runtime status casing instead of falling back to the bare label', () => {
+    const html = renderToStaticMarkup(
+      <ReplayChronologyPanel
+        lanes={[
+          {
+            laneId: 'NPPES_API',
+            status: 'VERIFIED' as LaneSnapshot['status'],
             checkedAt: Date.UTC(2026, 5, 30, 12, 0, 0),
             source: 'https://npiregistry.cms.hhs.gov',
             receiptId: 'rcpt-12345678',

--- a/apps/web/__tests__/verifier/replay-chronology-label.test.tsx
+++ b/apps/web/__tests__/verifier/replay-chronology-label.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * ReplayChronologyPanel status-label truth contract.
+ *
+ * CLAUDE.md bans the bare word "Verified" as a status label. The panel's
+ * verified lane state must render with the ProvenanceStrip vocabulary
+ * ('SOURCE-BACKED'), never as bare 'VERIFIED'. The banned-verified-label
+ * sweep only catches the exact-case literal 'Verified', so this pins the
+ * all-caps render site directly.
+ */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ReplayChronologyPanel } from '../../components/verifier/ReplayChronologyPanel';
+
+describe('ReplayChronologyPanel status labels', () => {
+  it('renders verified lanes as SOURCE-BACKED, never the bare VERIFIED label', () => {
+    const html = renderToStaticMarkup(
+      <ReplayChronologyPanel
+        lanes={[
+          {
+            laneId: 'NPPES_API',
+            status: 'verified',
+            checkedAt: Date.UTC(2026, 5, 30, 12, 0, 0),
+            source: 'https://npiregistry.cms.hhs.gov',
+            receiptId: 'rcpt-12345678',
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('SOURCE-BACKED');
+    expect(html).not.toMatch(/·\s*VERIFIED/);
+    expect(html).not.toMatch(/>\s*VERIFIED\s*</);
+  });
+});

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -111,10 +111,16 @@ function checksToLaneSnapshots(
 
 // ── Data fetching ──────────────────────────────────────────────────────────────
 
+/**
+ * Public passport read. /api/passport/npi/:npi is anonymous by design
+ * (value before login) and serves the PassportData contract this page
+ * renders — coverage states and readiness only, restricted credential
+ * labels redacted for unauthenticated viewers.
+ */
 async function fetchPassport(npi: string): Promise<PassportData | null> {
   try {
     const res = await fetch(
-      `${BACKEND}/api/trust-proof/${encodeURIComponent(npi)}`,
+      `${BACKEND}/api/passport/npi/${encodeURIComponent(npi)}`,
       {
         headers: { Accept: 'application/json' },
         next: { revalidate: 60 }, // 60s cache; verifier read is non-real-time

--- a/apps/web/components/verifier/ReplayChronologyPanel.tsx
+++ b/apps/web/components/verifier/ReplayChronologyPanel.tsx
@@ -70,14 +70,18 @@ function buildEvents(lanes: LaneSnapshot[], prior: LaneSnapshot[]): RunEvent[] {
     .filter((l) => l.checkedAt !== null)
     .map((l) => {
       const def = KNOWN_LANES.find((d) => d.laneId === l.laneId);
+      // Normalize before label/color lookups so a runtime status like
+      // 'VERIFIED' resolves through STATUS_LABEL instead of falling back
+      // to the banned bare label via toUpperCase().
+      const status = String(l.status).trim().toLowerCase();
       return {
         isoTs: toIsoFull(l.checkedAt),
         tsMs: l.checkedAt ?? 0,
         lane: def?.displayName ?? l.laneId,
         source: l.source ?? def?.source ?? l.laneId,
-        status: l.status,
+        status,
         receiptId: l.receiptId,
-        tier: l.status === 'verified' ? 'T3' : 'T1',
+        tier: status === 'verified' ? 'T3' : 'T1',
       };
     })
     .sort((a, b) => b.tsMs - a.tsMs);

--- a/apps/web/components/verifier/ReplayChronologyPanel.tsx
+++ b/apps/web/components/verifier/ReplayChronologyPanel.tsx
@@ -30,8 +30,10 @@ function shortId(id: string | null | undefined, len = 8): string {
   return id.slice(0, len);
 }
 
+// Truth contract: never the bare word "Verified" as a status label —
+// 'SOURCE-BACKED' matches the ProvenanceStrip vocabulary for this state.
 const STATUS_LABEL: Record<string, string> = {
-  verified: 'VERIFIED',
+  verified: 'SOURCE-BACKED',
   in_progress: 'IN PROGRESS',
   not_checked: 'NOT CHECKED',
   stale: 'STALE',


### PR DESCRIPTION
## Problem

Production `/verify/[npi]` renders **"NPI not found" for every NPI**, taking down the entire public verification surface — including the "Employer acceptances" section shipped in #487. Root cause: the page's passport fetch hits `GET /api/trust-proof/:npi`, which returns `401 {"error":"organization_context_required"}` on api.vitalcv.com. The W1300 tenant guard (`app.use(requireTenantContextOrReadAccess)`) default-denies any path not in the `shouldSkipTenantContext` allowlist, and `/api/trust-proof/` was never added — sibling public verifier reads (`/api/trust-state/`, `/api/passport/`, `/api/employer-review/`) all were.

## Fix (Tier 2)

**1. Point `/verify/[npi]` at the source that is legitimately public and contract-correct** — `GET /api/passport/npi/:npi` ([passportEntity.ts](apps/api/backend/src/routes/passportEntity.ts): "Auth: anonymous for GET (value before login)").
- Already in the tenant-guard skip list; the `/api/passport` `authMiddleware` is annotate-only (never blocks).
- Serves the literal `PassportData` contract the page casts to. The trust-proof bundle never did (no `identity`, no `sourceCoverage`) — even pre-W1300 the page rendered without a name or lanes. After this change the page renders identity, per-lane coverage, and readiness.
- Anonymous viewers get redacted credential labels (`"Restricted credential"`) — read-only design preserved, no raw claims.

**2. Restore the unauthenticated read-only trust-proof read** — add `/api/trust-proof/` to `shouldSkipTenantContext`.
- The bundle is redacted by design: claim digests + merkle proofs only, `credentialClaims: { redacted: true, selectiveDisclosure: true }`; `rawPayload` is consumed internally for hashing and never serialized.
- Route is `proofRateLimit`-guarded.
- Unbreaks the command-palette trust-proof PDF download ([commands.ts:40](apps/web/lib/command/commands.ts) → web proxy `/api/trust-proof/[npi]` → backend), which 401s in production today.

## Tests

- `apps/api/backend`: `tenantGuard.test.ts` — trust-proof path skips org context; write routes stay protected (6/6 pass).
- `apps/web`: `recognition-share-verify.test.tsx` fetch stub now pins `/api/passport/npi/` (stub throws on any unexpected URL, so the page fetching anything else fails the suite) (4/4 pass).
- Banned-strings gate (`banned-verified-label.test.ts`) pass; typecheck (web + backend) pass.

## Local verification against production API

Dev server with `BACKEND_URL=https://api.vitalcv.com`: `/verify/1003000126` renders the verifier view — verdict bar ("Partial coverage, 3 of 4 sources confirmed"), identity "ARDALAN ENKESHAFI, M.D.", 4 source-coverage lanes (NPPES/OIG/PECOS source-backed, STATE_BOARD stale), and "Employer acceptances" with the honest zero-state. No "NPI not found".

## Post-merge production verification (before closing)

- `curl https://vitalcv.com/verify/1003000126` → verifier view markers present, "NPI not found" absent, "Employer acceptances" present.
- `curl https://api.vitalcv.com/api/trust-proof/1003000126` → no longer 401.

## Design Handoff References

No Claude Design handoff file used for this PR.

(Production incident fix — restores surfaces whose design lineage is #487 and the verifier reading mode wave; no new design surface introduced. design-handoff/claude-design-2026-06-26/ remains unavailable for ingestion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)