### PR TITLE
fix(clinician): /holder/blockers/[blockerId] route + contract-test href hardening

### DIFF
--- a/apps/web/__tests__/holder-route-contract.test.ts
+++ b/apps/web/__tests__/holder-route-contract.test.ts
@@ -29,6 +29,9 @@ const SURFACE_FILES = [
   'components/recognition/RecognitionCard.tsx',
   'components/recognition/RecognitionSurface.tsx',
   'components/recognition/ShareRecognitionPanel.tsx',
+  'components/mobile/ClinicianBlockerDetailSurface.tsx',
+  // Data-layer href builders (blocker "Resolve" CTAs are assembled here, not in JSX)
+  'lib/mobile/clinician-state.ts',
 ];
 
 /** Extract internal href path literals (static + template-literal heads). */
@@ -53,6 +56,15 @@ function extractInternalHrefs(source: string): string[] {
   }
   for (const match of source.matchAll(/href:\s*`(\/[^`$]*)\$\{/g)) {
     hrefs.add(`${match[1]}__DYNAMIC__`);
+  }
+  // variable-assigned hrefs: const href = `/path/${expr}` | const somethingHref = '/path'
+  // (this is how lib/mobile/clinician-state.ts builds /holder/blockers/{id} —
+  //  a plain assignment, not an href= attribute or href: object key)
+  for (const match of source.matchAll(/(?:href|Href)\s*=\s*`(\/[^`$]*)\$\{/g)) {
+    hrefs.add(`${match[1]}__DYNAMIC__`);
+  }
+  for (const match of source.matchAll(/(?:href|Href)\s*=\s*["'](\/[^"'#?]*)["']/g)) {
+    hrefs.add(match[1]);
   }
 
   return [...hrefs].filter((href) => href.startsWith('/'));

--- a/apps/web/app/holder/blockers/[blockerId]/page.tsx
+++ b/apps/web/app/holder/blockers/[blockerId]/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import ClinicianBlockerDetailSurface from '@/components/mobile/ClinicianBlockerDetailSurface';
+
+export const metadata: Metadata = {
+  title: 'Blocker',
+  description: 'What is blocking you, why it matters, and the next step to clear it.',
+};
+
+// Detail page for a single readiness/application blocker. Holder home and the
+// applications surface link here via "Resolve blocker" CTAs
+// (lib/mobile/clinician-state.ts builds /holder/blockers/{encodeURIComponent(id)}).
+// Blocker ids contain ':' separators, so the route param must be decoded before
+// the surface looks it up in the shared ClinicianMobileProvider context; the
+// surface calls notFound() when the id is unknown.
+export default async function HolderBlockerDetailPage({
+  params,
+}: {
+  params: Promise<{ blockerId: string }>;
+}) {
+  const { blockerId } = await params;
+  return <ClinicianBlockerDetailSurface blockerId={decodeURIComponent(blockerId)} />;
+}


### PR DESCRIPTION
## Problem (live Golden Path 404)

"Resolve blocker" CTAs on holder home and the applications surface link to `/holder/blockers/{id}` (`lib/mobile/clinician-state.ts:344`), but no route page exists on `main` (only in `_archive/wave119`) — the clinician's **recommended next action 404s in production**. `ClinicianBlockerDetailSurface` already exists with a passing unit test.

The #482 route-contract test missed it: its extractor scans `href=` attributes and `href:` object keys, but this href is a **plain variable assignment** (`const href = \`/holder/blockers/${…}\``).

## Fix (2 files)

1. **`app/holder/blockers/[blockerId]/page.tsx`** — mirrors `holder/applications/[id]`; decodes the param (blocker ids contain `:`); surface handles unknown ids via `notFound()`.
2. **`__tests__/holder-route-contract.test.ts`** — extractor now catches variable-assigned hrefs; scans `clinician-state.ts` + the blocker surface. **Negative control verified:** hiding the page makes the contract fail with `dead links in lib/mobile/clinician-state.ts: /holder/blockers/${…}`; with the page, **13/13 pass**.

## Verification
- Contract test 13/13 ✓ (and proven to catch the regression class)
- `blocker-detail-surface.test.tsx` 1/1 ✓
- `tsc` 0 errors ✓ (remaining worktree errors pre-existing in `intake-types.ts`, untouched)
- Post-merge: Railway auto-deploy → verify `/holder/blockers/x` 307s (not 404) + `pnpm check:deploy` healthy

## Risk tier
**Tier 1** (route wiring + test hardening; no data-layer or copy changes) → self-merge with self-review + Railway verification per the tiered merge policy.

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)