### PR TITLE
feat(identity): provenance-honest clinician identity surface (Wave 2G)

### DIFF
--- a/apps/web/__tests__/clinician-identity-surface.test.tsx
+++ b/apps/web/__tests__/clinician-identity-surface.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * WAVE-2G — clinician identity surface contract.
+ *
+ * Pins the provenance honesty of /clinician/identity:
+ *   - the personal record derives from real session + PersonProfile
+ *     inputs (the hardcoded sample binding is gone),
+ *   - NPPES-copied values are labeled stored copies, never proofed
+ *     identity,
+ *   - missing data is UNKNOWN/unverified, and
+ *   - the page keeps its truth-contract strings.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RoleProvider } from '@/components/auth/RoleContext';
+import { ClinicianIdentityPanel, PanelBody } from '@/components/identity/ClinicianIdentityPanel';
+import {
+  buildClinicianIdentitySurface,
+  explainNpiBindingStatus,
+  type ClinicianIdentitySurfaceModel,
+} from '@/lib/identity/clinicianIdentitySurface';
+import type { ClinicianNpiBindingStatus } from '@/lib/identity/identityProofingPolicy';
+import { isCoherentProvenance } from '@/lib/clinician-profile/profileTypes';
+import { PROVENANCE_META } from '@/lib/profile/provenance';
+import type { WorkspacePersonProfile } from '@/types/workspace';
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({ isLoaded: true, isSignedIn: false, user: null }),
+}));
+
+function profileFixture(
+  overrides: Partial<WorkspacePersonProfile> = {},
+): WorkspacePersonProfile {
+  return {
+    id: 'pp_1',
+    userId: 'user_1',
+    npi: '1033806195',
+    npiType: 'TYPE_1',
+    firstName: 'Connor',
+    lastName: 'Kilch',
+    specialty: 'Family Medicine',
+    stateOfPractice: 'MI',
+    workAuthStatus: null,
+    resumeUrl: null,
+    linkedinUrl: null,
+    portfolioUrl: null,
+    completeness: 30,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function allFields(model: ClinicianIdentitySurfaceModel) {
+  return model.sections.flatMap((section) => section.fields);
+}
+
+function fieldById(model: ClinicianIdentitySurfaceModel, id: string) {
+  const field = allFields(model).find((candidate) => candidate.id === id);
+  if (!field) throw new Error(`missing field: ${id}`);
+  return field;
+}
+
+describe('buildClinicianIdentitySurface', () => {
+  it('signed-out: policy-only view with a sign-in gap and nothing source-backed', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: false,
+      accountEmail: null,
+      personProfile: null,
+    });
+
+    expect(model.audience).toBe('signed_out');
+    expect(model.bindingStatus).toBe('unbound');
+    expect(model.gaps.map((gap) => gap.id)).toEqual(['sign_in']);
+    expect(model.gaps[0].href).toBe('/sign-in');
+    for (const field of allFields(model)) {
+      expect(field.confidence).not.toBe('source-backed');
+      expect(field.value).toBeNull();
+      expect(field.provenance).toBe('UNKNOWN');
+    }
+  });
+
+  it('signed-in without an NPI binding: unbound + claim gap routed to /get-ready', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: 'doc@example.com',
+      personProfile: null,
+    });
+
+    expect(model.audience).toBe('signed_in');
+    expect(model.bindingStatus).toBe('unbound');
+    const claimGap = model.gaps.find((gap) => gap.id === 'claim_npi');
+    expect(claimGap?.href).toBe('/get-ready');
+    // Account identity is present but never source-backed.
+    expect(fieldById(model, 'account_email').value).toBe('doc@example.com');
+    expect(fieldById(model, 'account_email').confidence).toBe('self-attested');
+    // With no bound NPI, nothing may present as source-backed.
+    for (const field of allFields(model)) {
+      expect(field.confidence).not.toBe('source-backed');
+    }
+  });
+
+  it('signed-in with a claimed NPI: foundation_ready with NPPES stored-copy labels', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: 'doc@example.com',
+      personProfile: profileFixture(),
+    });
+
+    expect(model.bindingStatus).toBe('foundation_ready');
+    expect(model.gaps.find((gap) => gap.id === 'claim_npi')).toBeUndefined();
+
+    const npiField = fieldById(model, 'npi');
+    expect(npiField.value).toBe('1033806195');
+    expect(npiField.provenance).toBe('VERIFIED');
+    expect(npiField.confidence).toBe('source-backed');
+    expect(npiField.sourceLabel).toContain('NPPES');
+    expect(npiField.changePolicy).toBe('source_of_record');
+
+    const nameField = fieldById(model, 'name_on_file');
+    expect(nameField.value).toBe('Connor Kilch');
+    expect(nameField.limitationNote).toContain('Stored copy');
+    expect(nameField.changePolicy).toBe('source_of_record');
+
+    expect(fieldById(model, 'npi_type').value).toBe('Individual (Type 1)');
+    expect(fieldById(model, 'specialty').changePolicy).toBe('source_of_record');
+    expect(fieldById(model, 'state_of_practice').changePolicy).toBe('source_of_record');
+  });
+
+  it('omits gov-id/liveness evaluator inputs so an unproofed claim is never demoted to gov_id_required', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: null,
+      personProfile: profileFixture(),
+    });
+
+    // Passing governmentIdVerified: false into the policy evaluator
+    // would assert a failed check that never ran; the surface must not.
+    expect(model.bindingStatus).toBe('foundation_ready');
+    expect(model.bindingStatus).not.toBe('gov_id_required');
+    expect(model.bindingStatus).not.toBe('liveness_required');
+  });
+
+  it('NPI without a stored name stays self_attested and surfaces a refresh gap', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: null,
+      personProfile: profileFixture({ firstName: null, lastName: null }),
+    });
+
+    expect(model.bindingStatus).toBe('self_attested');
+    const gap = model.gaps.find((candidate) => candidate.id === 'name_missing');
+    expect(gap?.href).toBe('/get-ready');
+    expect(fieldById(model, 'name_on_file').value).toBeNull();
+    expect(fieldById(model, 'name_on_file').provenance).toBe('UNKNOWN');
+  });
+
+  it('a profile without an NPI never labels identity fields source-backed', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: null,
+      personProfile: profileFixture({ npi: null, npiType: null }),
+    });
+
+    const nameField = fieldById(model, 'name_on_file');
+    expect(nameField.provenance).toBe('USER_ENTERED');
+    expect(nameField.confidence).toBe('self-attested');
+    for (const field of allFields(model)) {
+      expect(field.confidence).not.toBe('source-backed');
+    }
+  });
+
+  it('missing values normalize to UNKNOWN + unverified and every field stays coherent', () => {
+    const models = [
+      buildClinicianIdentitySurface({ isSignedIn: false, accountEmail: null, personProfile: null }),
+      buildClinicianIdentitySurface({ isSignedIn: true, accountEmail: null, personProfile: null }),
+      buildClinicianIdentitySurface({
+        isSignedIn: true,
+        accountEmail: 'doc@example.com',
+        personProfile: profileFixture({ workAuthStatus: null, specialty: null }),
+      }),
+    ];
+
+    for (const model of models) {
+      for (const field of allFields(model)) {
+        expect(isCoherentProvenance(field.provenance, field.confidence)).toBe(true);
+        if (field.value === null) {
+          expect(field.provenance).toBe('UNKNOWN');
+          expect(field.confidence).toBe('unverified');
+        }
+      }
+    }
+
+    const workAuth = fieldById(models[2], 'work_auth_status');
+    expect(workAuth.provenance).toBe('UNKNOWN');
+    expect(workAuth.confidence).toBe('unverified');
+    expect(workAuth.changePolicy).toBe('editable_profile');
+  });
+
+  it('never renders the bare status label "Verified" and explains every binding status', () => {
+    const model = buildClinicianIdentitySurface({
+      isSignedIn: true,
+      accountEmail: 'doc@example.com',
+      personProfile: profileFixture(),
+    });
+
+    for (const field of allFields(model)) {
+      expect(PROVENANCE_META[field.provenance].label.toLowerCase()).not.toBe('verified');
+    }
+
+    const statuses: ClinicianNpiBindingStatus[] = [
+      'unbound',
+      'self_attested',
+      'foundation_ready',
+      'gov_id_required',
+      'liveness_required',
+      'unavailable',
+    ];
+    for (const status of statuses) {
+      const explanation = explainNpiBindingStatus(status);
+      expect(explanation.length).toBeGreaterThan(20);
+      expect(explanation.toLowerCase()).not.toMatch(/^verified\b/);
+    }
+    expect(explainNpiBindingStatus('foundation_ready')).toContain(
+      'NPI lookup is not government-ID identity proofing',
+    );
+  });
+});
+
+describe('ClinicianIdentityPanel (static render, Clerk disabled)', () => {
+  it('renders the signed-out record shell with a sign-in path', () => {
+    const markup = renderToStaticMarkup(
+      <RoleProvider initialUserId={null} initialClerkRole={null}>
+        <ClinicianIdentityPanel />
+      </RoleProvider>,
+    );
+
+    expect(markup).toContain('Your identity record');
+    expect(markup).toContain('/sign-in');
+    expect(markup).not.toContain('foundation_ready');
+  });
+
+  it('renders the signed-in record with binding status, badges, and change policies', () => {
+    const markup = renderToStaticMarkup(
+      <PanelBody
+        isSignedIn
+        accountEmail="doc@example.com"
+        personProfile={profileFixture()}
+        onRefresh={async () => {}}
+      />,
+    );
+
+    expect(markup).toContain('foundation_ready');
+    expect(markup).toContain('Connor Kilch');
+    expect(markup).toContain('1033806195');
+    expect(markup).toContain('NPPES');
+    expect(markup).toContain('Source-confirmed');
+    expect(markup).toContain('Requires source-of-record correction');
+    expect(markup).toContain('Reload record');
+    expect(markup).not.toContain('>Verified<');
+  });
+});
+
+describe('/clinician/identity page copy invariants', () => {
+  const pagePath = resolve(__dirname, '..', 'app', 'clinician', 'identity', 'page.tsx');
+  const panelPath = resolve(__dirname, '..', 'components', 'identity', 'ClinicianIdentityPanel.tsx');
+  const libPath = resolve(__dirname, '..', 'lib', 'identity', 'clinicianIdentitySurface.ts');
+  const pageSrc = readFileSync(pagePath, 'utf-8');
+
+  it('keeps the NPI-vs-identity-proofing disclaimer and mounts the personal record panel', () => {
+    expect(pageSrc).toContain('NPI lookup is not government-ID identity proofing.');
+    expect(pageSrc).toContain('ClinicianIdentityPanel');
+  });
+
+  it('no longer renders a hardcoded sample binding', () => {
+    expect(pageSrc).not.toContain('Sample binding');
+    expect(pageSrc).not.toContain('sampleBinding');
+  });
+
+  it('links the claim flow, verification policy, profile, and readiness surfaces', () => {
+    for (const href of ['/get-ready', '/clinician/identity/verification', '/clinician/profile', '/holder/readiness']) {
+      expect(pageSrc).toContain(href);
+    }
+  });
+
+  it('page, panel, and surface lib avoid proofing overclaims and banned phrases', () => {
+    const banned = [
+      'guaranteed verification',
+      'instant credentialing',
+      'complete credentialing',
+      'legally accepted',
+      'risk transferred',
+      'hipaa compliant',
+      'soc2 certified',
+      'government id verified',
+      'liveness verified',
+      'biometric verified',
+      'automatically verified',
+    ];
+    for (const path of [pagePath, panelPath, libPath]) {
+      const src = readFileSync(path, 'utf-8').toLowerCase();
+      for (const phrase of banned) expect(src).not.toContain(phrase);
+      expect(src).not.toMatch(/\bial2\b/);
+      expect(src).not.toMatch(/\bial3\b/);
+    }
+  });
+});

--- a/apps/web/app/clinician/identity/page.tsx
+++ b/apps/web/app/clinician/identity/page.tsx
@@ -1,24 +1,44 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
+import { ClinicianIdentityPanel } from '@/components/identity/ClinicianIdentityPanel';
 import {
   buildIdentityProofingFoundationPolicy,
-  evaluateClinicianNpiBindingReadiness,
   explainIdentityProofingStatus,
 } from '@/lib/identity/identityProofingPolicy';
 
 export const metadata: Metadata = {
   title: 'Clinician Identity · VitalCV',
   description:
-    'Identity proofing policy and clinician-to-NPI binding status. NPI lookup is not government-ID identity proofing.',
+    'Your identity record with the origin of every value, plus the identity proofing policy. NPI lookup is not government-ID identity proofing.',
 };
+
+const RELATED_SURFACES = [
+  {
+    href: '/clinician/identity/verification',
+    label: 'Planned proofing controls',
+    detail: 'Government ID and liveness controls — planned, not live in this build.',
+  },
+  {
+    href: '/clinician/profile',
+    label: 'Full profile',
+    detail: 'Every profile field with its origin labeled.',
+  },
+  {
+    href: '/get-ready',
+    label: 'Claim or refresh your NPI',
+    detail: 'Resolve your NPI against NPPES and link it to your account.',
+  },
+  {
+    href: '/holder/readiness',
+    label: 'Readiness snapshot',
+    detail: 'Live source-check status and freshness for your record.',
+  },
+] as const;
 
 export default function ClinicianIdentityPage() {
   const policy = buildIdentityProofingFoundationPolicy();
-  const sampleBinding = evaluateClinicianNpiBindingReadiness({
-    identifierResolved: true,
-    selfAttestedName: true,
-  });
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:py-12">
@@ -27,7 +47,7 @@ export default function ClinicianIdentityPage() {
           Clinician identity
         </p>
         <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
-          Identity proofing policy and NPI binding
+          Your identity record and how it is sourced
         </h1>
         <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
           <strong>NPI lookup is not government-ID identity proofing.</strong>{' '}
@@ -38,28 +58,7 @@ export default function ClinicianIdentityPage() {
         </p>
       </header>
 
-      <section
-        aria-labelledby="binding-status-heading"
-        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
-      >
-        <h2 id="binding-status-heading" className="text-base font-semibold sm:text-lg">
-          NPI binding status
-        </h2>
-        <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-          <div>
-            <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-              Sample binding (identifier resolved + self-attested name)
-            </dt>
-            <dd className="mt-1 font-mono">{sampleBinding}</dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-              Highest readiness this foundation can return
-            </dt>
-            <dd className="mt-1 text-muted-foreground">foundation_ready (not "verified")</dd>
-          </div>
-        </dl>
-      </section>
+      <ClinicianIdentityPanel />
 
       <section
         aria-labelledby="policy-summary-heading"
@@ -73,6 +72,11 @@ export default function ClinicianIdentityPage() {
         </p>
         <p className="mt-2 text-xs text-muted-foreground">
           {explainIdentityProofingStatus(policy.status)}
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          The strongest NPI-link status this surface reports is{' '}
+          <span className="font-mono">foundation_ready</span> — a documented,
+          self-attested link, never a proofed identity.
         </p>
       </section>
 
@@ -134,6 +138,28 @@ export default function ClinicianIdentityPage() {
                 </span>
               </p>
               <p className="mt-1 text-xs text-muted-foreground">{req.explanation}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="related-surfaces-heading"
+        className="mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
+      >
+        <h2 id="related-surfaces-heading" className="text-base font-semibold sm:text-lg">
+          Related surfaces
+        </h2>
+        <ul className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {RELATED_SURFACES.map((surface) => (
+            <li key={surface.href} className="text-sm">
+              <Link
+                href={surface.href}
+                className="font-medium underline underline-offset-4"
+              >
+                {surface.label}
+              </Link>
+              <p className="mt-1 text-xs text-muted-foreground">{surface.detail}</p>
             </li>
           ))}
         </ul>

--- a/apps/web/components/identity/ClinicianIdentityPanel.tsx
+++ b/apps/web/components/identity/ClinicianIdentityPanel.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+/**
+ * WAVE-2G — signed-in identity record panel for /clinician/identity.
+ *
+ * Client island: reads the session + PersonProfile through the same
+ * RoleContext the holder surfaces use (no new fetch paths), feeds the
+ * pure clinicianIdentitySurface transform, and renders each field with
+ * its provenance badge, source label, and change policy. Display-only:
+ * no mutations, no auth logic, no new identity flows.
+ */
+
+import Link from 'next/link';
+import * as React from 'react';
+import { useUser } from '@clerk/nextjs';
+
+import { useRoleContext } from '@/components/auth/RoleContext';
+import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
+import {
+  buildClinicianIdentitySurface,
+  type ClinicianIdentitySurfaceModel,
+  type IdentityChangePolicy,
+  type IdentitySurfaceField,
+} from '@/lib/identity/clinicianIdentitySurface';
+import { PROVENANCE_META } from '@/lib/profile/provenance';
+import type { WorkspacePersonProfile } from '@/types/workspace';
+
+const CHANGE_POLICY_LABEL: Record<IdentityChangePolicy, string> = {
+  editable_profile: 'You can update this',
+  account_managed: 'Managed in account settings',
+  source_of_record: 'Requires source-of-record correction',
+  not_editable: 'Not editable',
+};
+
+function panelClassName(): string {
+  return 'mb-6 rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5';
+}
+
+export function ClinicianIdentityPanel() {
+  const role = useRoleContext();
+
+  if (!role.isLoaded) {
+    return (
+      <section aria-busy="true" aria-labelledby="identity-record-heading" className={panelClassName()}>
+        <h2 id="identity-record-heading" className="text-base font-semibold sm:text-lg">
+          Your identity record
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">Loading your identity record…</p>
+      </section>
+    );
+  }
+
+  const personProfile = role.workspace?.personProfile ?? null;
+
+  if (!CLERK_PROVIDER_ENABLED) {
+    return (
+      <PanelBody
+        isSignedIn={role.isSignedIn}
+        accountEmail={null}
+        personProfile={personProfile}
+        onRefresh={role.refresh}
+      />
+    );
+  }
+
+  return (
+    <ClerkEmailBridge
+      isSignedIn={role.isSignedIn}
+      personProfile={personProfile}
+      onRefresh={role.refresh}
+    />
+  );
+}
+
+/**
+ * Mounted only when the Clerk provider is enabled, so the useUser hook
+ * always runs under ClerkProvider. Supplies the account email; nothing
+ * else about auth is read or changed here.
+ */
+function ClerkEmailBridge(props: {
+  isSignedIn: boolean;
+  personProfile: WorkspacePersonProfile | null;
+  onRefresh: () => Promise<void>;
+}) {
+  const { user } = useUser();
+  return (
+    <PanelBody
+      isSignedIn={props.isSignedIn}
+      accountEmail={user?.primaryEmailAddress?.emailAddress ?? null}
+      personProfile={props.personProfile}
+      onRefresh={props.onRefresh}
+    />
+  );
+}
+
+/** Exported for static-render tests; not part of the page API. */
+export function PanelBody(props: {
+  isSignedIn: boolean;
+  accountEmail: string | null;
+  personProfile: WorkspacePersonProfile | null;
+  onRefresh: () => Promise<void>;
+}) {
+  const model = buildClinicianIdentitySurface({
+    isSignedIn: props.isSignedIn,
+    accountEmail: props.accountEmail,
+    personProfile: props.personProfile,
+  });
+
+  if (model.audience === 'signed_out') {
+    return (
+      <section aria-labelledby="identity-record-heading" className={panelClassName()}>
+        <h2 id="identity-record-heading" className="text-base font-semibold sm:text-lg">
+          Your identity record
+        </h2>
+        <GapList model={model} />
+        <p className="mt-3 text-xs text-muted-foreground">
+          The policy below applies to every account; your own record appears here once you sign in.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="identity-record-heading" className={panelClassName()}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <h2 id="identity-record-heading" className="text-base font-semibold sm:text-lg">
+          Your identity record
+        </h2>
+        <button
+          type="button"
+          onClick={() => void props.onRefresh()}
+          className="rounded-md border border-[var(--vt-border,_rgba(0,0,0,0.12))] px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          Reload record
+        </button>
+      </div>
+
+      <div className="mt-3 rounded-lg border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface-muted,_rgba(0,0,0,0.02))] p-3">
+        <p className="text-xs uppercase tracking-wider text-muted-foreground">NPI link status</p>
+        <p className="mt-1 font-mono text-sm">{model.bindingStatus}</p>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{model.bindingExplanation}</p>
+      </div>
+
+      <GapList model={model} />
+
+      {model.sections.map((section) => (
+        <div key={section.id} className="mt-5">
+          <h3 className="text-sm font-semibold">{section.title}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">{section.summary}</p>
+          <ul className="mt-2 divide-y divide-[var(--vt-border,_rgba(0,0,0,0.06))]">
+            {section.fields.map((field) => (
+              <FieldRow key={field.id} field={field} />
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function GapList({ model }: { model: ClinicianIdentitySurfaceModel }) {
+  if (model.gaps.length === 0) return null;
+
+  return (
+    <ul className="mt-3 space-y-2">
+      {model.gaps.map((gap) => (
+        <li
+          key={gap.id}
+          className="rounded-lg border border-amber-500/25 bg-amber-500/5 p-3 text-sm"
+        >
+          <p className="font-medium">{gap.label}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{gap.description}</p>
+          <Link
+            href={gap.href}
+            className="mt-2 inline-flex items-center text-xs font-semibold underline underline-offset-4"
+          >
+            {gap.cta} →
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function FieldRow({ field }: { field: IdentitySurfaceField }) {
+  const meta = PROVENANCE_META[field.provenance];
+
+  return (
+    <li className="py-3 text-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="font-medium">{field.label}</p>
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${meta.badgeClass}`}
+          aria-label={`Origin: ${meta.label}`}
+          title={meta.description}
+        >
+          {meta.label}
+        </span>
+      </div>
+      <p className="mt-1 font-mono text-sm">{field.value ?? 'Not on file'}</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {field.sourceLabel}
+        <span className="ml-2 text-muted-foreground/70">({field.confidence})</span>
+      </p>
+      {field.limitationNote && (
+        <p className="mt-1 text-[11px] text-muted-foreground/80">{field.limitationNote}</p>
+      )}
+      <p className="mt-1 text-[11px] text-muted-foreground/80">
+        <span className="font-medium">{CHANGE_POLICY_LABEL[field.changePolicy]}.</span>{' '}
+        {field.changeNote}
+      </p>
+    </li>
+  );
+}

--- a/apps/web/lib/identity/clinicianIdentitySurface.ts
+++ b/apps/web/lib/identity/clinicianIdentitySurface.ts
@@ -1,0 +1,367 @@
+/**
+ * WAVE-2G — clinician identity surface model.
+ *
+ * Pure transform: no fetches, no DB access, no audit writes. Takes the
+ * account-session facts (Clerk via RoleContext) and the stored
+ * PersonProfile (GET /api/me/workspaces) and derives a provenance-honest
+ * model of the identity VitalCV holds: what each value is, where it came
+ * from, what is missing, what the clinician can change, and what must be
+ * corrected at the source of record instead.
+ *
+ * Truth invariants:
+ *   1. Reuses the 5-tier provenance vocabulary (lib/profile/provenance)
+ *      plus the confidence axis (lib/clinician-profile/profileTypes).
+ *      No new identity vocabulary is introduced.
+ *   2. Binding readiness comes from evaluateClinicianNpiBindingReadiness.
+ *      Its ceiling is `foundation_ready`; nothing here may present a
+ *      binding as identity-proofed.
+ *   3. PersonProfile identity fields (name, specialty, state) are only
+ *      written by the NPI claim flow today, which copies them from
+ *      NPPES. They are therefore labeled source-backed *stored copies*
+ *      when an NPI is bound — with an explicit limitation note — and
+ *      self-attested otherwise. If a profile edit path ships later, the
+ *      writer must pass real per-field provenance instead.
+ *   4. No field may carry the bare status label "Verified".
+ */
+
+import {
+  evaluateClinicianNpiBindingReadiness,
+  type ClinicianNpiBindingStatus,
+} from '@/lib/identity/identityProofingPolicy';
+import {
+  isCoherentProvenance,
+  type ProfileFieldConfidence,
+} from '@/lib/clinician-profile/profileTypes';
+import type { ProfileProvenance } from '@/lib/profile/provenance';
+import type { WorkspacePersonProfile } from '@/types/workspace';
+
+/** How (or whether) the clinician can change a given identity value. */
+export type IdentityChangePolicy =
+  | 'editable_profile'
+  | 'account_managed'
+  | 'source_of_record'
+  | 'not_editable';
+
+export interface IdentitySurfaceField {
+  id: string;
+  label: string;
+  /** Display value; null means nothing is on file. */
+  value: string | null;
+  provenance: ProfileProvenance;
+  confidence: ProfileFieldConfidence;
+  /** Where the stored value came from (plain language, no overclaim). */
+  sourceLabel: string;
+  changePolicy: IdentityChangePolicy;
+  /** One line: how to change this value, or why it cannot be changed here. */
+  changeNote: string;
+  /** Optional honesty caveat rendered next to the source label. */
+  limitationNote?: string;
+}
+
+export interface IdentitySurfaceSection {
+  id: 'account' | 'npi_binding' | 'profile_identity';
+  title: string;
+  /** Plain-language framing for the section; never claims proofing. */
+  summary: string;
+  fields: IdentitySurfaceField[];
+}
+
+export interface IdentitySurfaceGap {
+  id: 'sign_in' | 'claim_npi' | 'name_missing' | 'profile_fields';
+  label: string;
+  description: string;
+  href: string;
+  cta: string;
+}
+
+export interface ClinicianIdentitySurfaceModel {
+  audience: 'signed_out' | 'signed_in';
+  bindingStatus: ClinicianNpiBindingStatus;
+  bindingExplanation: string;
+  sections: IdentitySurfaceSection[];
+  gaps: IdentitySurfaceGap[];
+}
+
+export interface ClinicianIdentitySurfaceInput {
+  isSignedIn: boolean;
+  /** Primary email from the sign-in provider, when the caller has it. */
+  accountEmail: string | null;
+  personProfile: WorkspacePersonProfile | null;
+}
+
+const STORED_COPY_NOTE =
+  'Stored copy from your NPI claim. Live source freshness appears in your readiness snapshot.';
+
+/**
+ * Plain-language explanation for each binding status. The strongest
+ * status is explained as a self-attested link — never as proofing.
+ */
+export function explainNpiBindingStatus(status: ClinicianNpiBindingStatus): string {
+  switch (status) {
+    case 'unbound':
+      return 'No NPI is linked to this account. Claiming your NPI resolves it against NPPES and creates the link.';
+    case 'self_attested':
+      return 'An NPI is on file but no name record accompanies it, so the link rests on the claim alone.';
+    case 'foundation_ready':
+      return 'Your NPI was resolved against NPPES and you attested it is yours. This is a self-attested link — NPI lookup is not government-ID identity proofing, and foundation_ready is the strongest status this surface reports.';
+    case 'gov_id_required':
+      return 'This link needs government-ID proofing, which is a planned control and not live in this build.';
+    case 'liveness_required':
+      return 'This link needs a liveness check, which is a planned control and not live in this build.';
+    case 'unavailable':
+      return 'Binding evaluation is unavailable in this environment.';
+  }
+}
+
+interface FieldSpec {
+  id: string;
+  label: string;
+  value: string | null;
+  provenance: ProfileProvenance;
+  confidence: ProfileFieldConfidence;
+  sourceLabel: string;
+  changePolicy: IdentityChangePolicy;
+  changeNote: string;
+  limitationNote?: string;
+}
+
+/**
+ * Normalizes a field so missing values are honestly UNKNOWN/unverified
+ * and the provenance–confidence pair is always coherent, regardless of
+ * what the caller claimed.
+ */
+function buildField(spec: FieldSpec): IdentitySurfaceField {
+  const missing = spec.value === null || spec.value.trim().length === 0;
+  const provenance: ProfileProvenance = missing ? 'UNKNOWN' : spec.provenance;
+  let confidence: ProfileFieldConfidence = missing ? 'unverified' : spec.confidence;
+  if (!isCoherentProvenance(provenance, confidence)) {
+    confidence = 'unverified';
+  }
+
+  return {
+    id: spec.id,
+    label: spec.label,
+    value: missing ? null : spec.value,
+    provenance,
+    confidence,
+    sourceLabel: missing ? 'No data on file' : spec.sourceLabel,
+    changePolicy: spec.changePolicy,
+    changeNote: spec.changeNote,
+    ...(spec.limitationNote && !missing ? { limitationNote: spec.limitationNote } : {}),
+  };
+}
+
+function formatNpiType(npiType: WorkspacePersonProfile['npiType']): string | null {
+  if (npiType === 'TYPE_1') return 'Individual (Type 1)';
+  if (npiType === 'TYPE_2') return 'Organization (Type 2)';
+  return null;
+}
+
+function joinName(profile: WorkspacePersonProfile | null): string | null {
+  const parts = [profile?.firstName, profile?.lastName].filter(
+    (part): part is string => Boolean(part && part.trim().length > 0),
+  );
+  return parts.length > 0 ? parts.join(' ') : null;
+}
+
+export function buildClinicianIdentitySurface(
+  input: ClinicianIdentitySurfaceInput,
+): ClinicianIdentitySurfaceModel {
+  const profile = input.isSignedIn ? input.personProfile : null;
+  const npi = profile?.npi ?? null;
+  const npiBound = Boolean(npi);
+  const name = joinName(profile);
+
+  // Real inputs replace the old hardcoded sample: the identifier is
+  // resolved iff an NPI is stored (the claim flow resolves it against
+  // NPPES before storing), and the name is the claim-flow attestation.
+  // governmentIdVerified / livenessVerified are omitted on purpose —
+  // passing literal false would assert a failed check that never ran.
+  const bindingStatus: ClinicianNpiBindingStatus = input.isSignedIn
+    ? evaluateClinicianNpiBindingReadiness({
+        identifierResolved: npiBound,
+        selfAttestedName: Boolean(name),
+      })
+    : 'unbound';
+
+  // NPPES-copied fields: the claim flow is the only PersonProfile
+  // writer today, so a bound NPI means these values were copied from
+  // NPPES. Without a bound NPI nothing about them is source-backed.
+  const nppesCopied = npiBound;
+  const nppesProvenance: ProfileProvenance = nppesCopied ? 'VERIFIED' : 'USER_ENTERED';
+  const nppesConfidence: ProfileFieldConfidence = nppesCopied ? 'source-backed' : 'self-attested';
+  const nppesSourceLabel = nppesCopied
+    ? 'NPPES (CMS registry) — copied at claim'
+    : 'Supplied without a source-of-record check';
+
+  const sections: IdentitySurfaceSection[] = [
+    {
+      id: 'account',
+      title: 'Account identity',
+      summary:
+        'Your sign-in account authenticates this session. It does not prove clinical identity, and it is separate from your NPI record.',
+      fields: [
+        buildField({
+          id: 'account_session',
+          label: 'Account session',
+          value: input.isSignedIn ? 'Signed in' : null,
+          provenance: 'USER_ENTERED',
+          confidence: 'self-attested',
+          sourceLabel: 'Sign-in provider session',
+          changePolicy: 'account_managed',
+          changeNote:
+            'Sign-in credentials (email, password, passkeys) are managed in your account settings, not on this page.',
+        }),
+        buildField({
+          id: 'account_email',
+          label: 'Account email',
+          value: input.isSignedIn ? input.accountEmail : null,
+          provenance: 'USER_ENTERED',
+          confidence: 'self-attested',
+          sourceLabel: 'Sign-in provider account',
+          changePolicy: 'account_managed',
+          changeNote:
+            'Change your email through account settings. It identifies your account, not your clinical record.',
+        }),
+      ],
+    },
+    {
+      id: 'npi_binding',
+      title: 'NPI record',
+      summary:
+        'The federal identifier this account claims. NPPES resolves the identifier; it does not bind a person to it.',
+      fields: [
+        buildField({
+          id: 'npi',
+          label: 'NPI',
+          value: npi,
+          provenance: 'VERIFIED',
+          confidence: 'source-backed',
+          sourceLabel: 'NPPES (CMS registry) — resolved at claim',
+          changePolicy: 'source_of_record',
+          changeNote:
+            'An NPI cannot be edited in place. If this is not your NPI, re-run the claim flow. If the NPPES record itself is wrong, correct it with CMS first.',
+          limitationNote: STORED_COPY_NOTE,
+        }),
+        buildField({
+          id: 'npi_type',
+          label: 'NPI type',
+          value: formatNpiType(profile?.npiType ?? null),
+          provenance: 'VERIFIED',
+          confidence: 'source-backed',
+          sourceLabel: 'NPPES (CMS registry) — resolved at claim',
+          changePolicy: 'source_of_record',
+          changeNote: 'Set by the NPPES record for your NPI; it cannot be edited here.',
+          limitationNote: STORED_COPY_NOTE,
+        }),
+      ],
+    },
+    {
+      id: 'profile_identity',
+      title: 'Profile identity',
+      summary:
+        'Identity fields stored on your VitalCV profile, with the origin of each value labeled.',
+      fields: [
+        buildField({
+          id: 'name_on_file',
+          label: 'Name on file',
+          value: name,
+          provenance: nppesProvenance,
+          confidence: nppesConfidence,
+          sourceLabel: nppesSourceLabel,
+          changePolicy: 'source_of_record',
+          changeNote:
+            'If your legal name changed, update your NPPES record with CMS first — VitalCV refreshes from the source rather than accepting a typed override.',
+          limitationNote: nppesCopied ? STORED_COPY_NOTE : undefined,
+        }),
+        buildField({
+          id: 'specialty',
+          label: 'Specialty',
+          value: profile?.specialty ?? null,
+          provenance: nppesProvenance,
+          confidence: nppesConfidence,
+          sourceLabel: nppesCopied
+            ? 'NPPES primary taxonomy — copied at claim'
+            : nppesSourceLabel,
+          changePolicy: 'source_of_record',
+          changeNote:
+            'Specialty follows your NPPES taxonomy. Correct it at the source; a typed override would not be source-backed.',
+          limitationNote: nppesCopied ? STORED_COPY_NOTE : undefined,
+        }),
+        buildField({
+          id: 'state_of_practice',
+          label: 'State of practice',
+          value: profile?.stateOfPractice ?? null,
+          provenance: nppesProvenance,
+          confidence: nppesConfidence,
+          sourceLabel: nppesSourceLabel,
+          changePolicy: 'source_of_record',
+          changeNote:
+            'Copied from your NPPES practice location at claim. Update NPPES to change it.',
+          limitationNote: nppesCopied ? STORED_COPY_NOTE : undefined,
+        }),
+        buildField({
+          id: 'work_auth_status',
+          label: 'Work authorization status',
+          value: profile?.workAuthStatus ?? null,
+          provenance: 'USER_ENTERED',
+          confidence: 'self-attested',
+          sourceLabel: 'Entered on your profile',
+          changePolicy: 'editable_profile',
+          changeNote:
+            'You can update this on your profile. It stays self-attested until a source-backed check exists for it.',
+        }),
+      ],
+    },
+  ];
+
+  const gaps: IdentitySurfaceGap[] = [];
+  if (!input.isSignedIn) {
+    gaps.push({
+      id: 'sign_in',
+      label: 'No account session',
+      description:
+        'Sign in to see the identity record VitalCV holds for you. This page shows only the policy until then.',
+      href: '/sign-in',
+      cta: 'Sign in',
+    });
+  } else if (!npiBound) {
+    gaps.push({
+      id: 'claim_npi',
+      label: 'No NPI linked',
+      description:
+        'No NPI binding is loaded for this account. Claim your NPI to resolve it against NPPES and start your source-backed record.',
+      href: '/get-ready',
+      cta: 'Claim your NPI',
+    });
+  } else {
+    if (!name) {
+      gaps.push({
+        id: 'name_missing',
+        label: 'No name stored with your NPI',
+        description:
+          'Your NPI is linked but no name record accompanies it. Re-running the claim flow refreshes it from NPPES.',
+        href: '/get-ready',
+        cta: 'Refresh from NPPES',
+      });
+    }
+    if (!profile?.specialty || !profile?.stateOfPractice) {
+      gaps.push({
+        id: 'profile_fields',
+        label: 'Profile identity fields incomplete',
+        description:
+          'Specialty or state of practice is missing. Review your profile to see every field and its origin.',
+        href: '/clinician/profile',
+        cta: 'Review profile',
+      });
+    }
+  }
+
+  return {
+    audience: input.isSignedIn ? 'signed_in' : 'signed_out',
+    bindingStatus,
+    bindingExplanation: explainNpiBindingStatus(bindingStatus),
+    sections,
+    gaps,
+  };
+}


### PR DESCRIPTION
## EPIC WAVE 2G — Clinician Identity Policy Surface

`/clinician/identity` was flagged as a policy stub: it rendered the identity-proofing policy plus a **hardcoded sample binding** (`identifierResolved: true, selfAttestedName: true`) — a signed-in clinician learned nothing about their own record. It is now a provenance-honest identity surface.

### What a clinician now sees
- **What VitalCV has on file** — account identity (session/email), NPI record, and profile identity fields (name, specialty, state of practice, work authorization).
- **What source confirmed it** — every field carries the existing 5-tier provenance badge (`PROVENANCE_META`) plus the confidence axis; NPPES-copied values are labeled *stored copy from your NPI claim* with a pointer to the readiness snapshot for live freshness, never presented as a live check.
- **What is missing** — gap cards route to `/sign-in`, `/get-ready` (claim/refresh NPI), or `/clinician/profile`.
- **What they can update vs. cannot** — per-field change policy: *You can update this* (work auth), *Managed in account settings* (email/session), *Requires source-of-record correction* (NPI, NPPES name/specialty/state → fix at CMS, then refresh).
- **What requires source verification** — binding status comes from the real `evaluateClinicianNpiBindingReadiness` inputs; ceiling stays `foundation_ready`, explained as a self-attested link. Planned gov-ID/liveness controls link to `/clinician/identity/verification`.

### How (smallest implementation)
- `apps/web/lib/identity/clinicianIdentitySurface.ts` — **pure transform** (no fetches, no writes) from `(isSignedIn, accountEmail, WorkspacePersonProfile | null)` to the labeled model. Reuses `ProfileProvenance` + `ProfileFieldConfidence` + `isCoherentProvenance`; introduces **no new identity vocabulary**.
- `apps/web/components/identity/ClinicianIdentityPanel.tsx` — client island on the existing `RoleContext` (identical resolution path to holder surfaces; no new API routes). Clerk `useUser` mounts only when `CLERK_PROVIDER_ENABLED`; signed-out and Clerk-disabled render the policy-only shell.
- Page rework keeps **every pinned truth string** (foundation-sweep-2/4 suites pass unchanged): the NPI-vs-identity-proofing disclaimer, no IAL-token claims, no banned phrases, no bare `Verified` label.

### Explicitly not done (per wave constraints)
No new identity system; no Clerk/auth/session logic changes (read-only context consumption); no NPI verification semantics changes; no public exposure of private data (panel renders only the signed-in user's own record, via the same authed workspace fetch holder pages use).

### Risk tier
**Tier 1 — display-only.** New pure lib + client island + page rework; zero mutation paths, zero auth-logic changes.

### Verification
- Full `apps/web` vitest: **204 files / 1787 tests passed** (includes 14 new cases: real-input binding statuses, stored-copy labeling, UNKNOWN/unverified normalization, provenance coherence, evaluator-input guard against false `gov_id_required` demotion, signed-out + signed-in static renders, page copy invariants).
- `pnpm turbo run build --filter @vitalcv/web`: 14/14 tasks green (typecheck + lint enforced by `next.config.mjs`).
- Dev-server browser pass on the worktree (`:3030`): signed-out shell renders panel + policy + links; no server errors; console errors limited to pre-existing PostHog token noise.

### Design Handoff References
No Claude Design handoff file used for this PR.
(`design-handoff/claude-design-2026-06-26/vitalcv/project/Identity Hook D54.html` was reviewed and found out of scope — it designs the public NPI claim funnel, not this policy/record surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Tier + rollback
Tier: 1 — clinician-facing display-only surface (new pure lib + client island + page rework; no auth/session logic, no mutations, no schema/config surfaces).
Rollback: revert the single squash commit. No data, env, or deploy surfaces are touched; the page falls back to the prior policy-stub render.
