### PR TITLE
feat(profile): Wave 2B — profile editing depth (provenance, save states, completeness guidance)

### DIFF
--- a/apps/web/__tests__/clinician-profile-surface.test.tsx
+++ b/apps/web/__tests__/clinician-profile-surface.test.tsx
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+/**
+ * ProfileSurface — Wave 2B profile editing depth.
+ *
+ * Truth contract under test:
+ *   - identity header fields carry per-field provenance (registry-hydrated
+ *     fields are source-confirmed; nothing missing is ever source-confirmed)
+ *   - completeness guidance is filled-ness only, renders the backend
+ *     dimension breakdown as done/missing with a fix destination
+ *   - save is disabled with no changes; editing after a save clears the
+ *     stale "Saved" state; a save that clears a previously saved field is
+ *     blocked with an honest explanation (the intake API cannot clear)
+ *   - a failed lookup renders as a system state, never as a finding
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProfileSurface from '../app/clinician/profile/ProfileSurface';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NPI = '1234567890';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function workspacePayload() {
+  return {
+    userId: 'u1',
+    personProfile: {
+      npi: NPI,
+      firstName: 'Test',
+      lastName: 'Clinician',
+      specialty: 'Internal Medicine',
+      stateOfPractice: 'CA',
+      workAuthStatus: 'authorized',
+      resumeUrl: null,
+      linkedinUrl: 'https://linkedin.com/in/test',
+      portfolioUrl: null,
+      completeness: 55,
+    },
+  };
+}
+
+function completenessPayload() {
+  return {
+    userId: 'u1',
+    score: 55,
+    dimensions: {
+      npiVerified: true,
+      resumeUploaded: false,
+      linksAdded: true,
+      workAuthProvided: true,
+      credentialsImported: false,
+    },
+  };
+}
+
+function acceptanceHistoryPayload() {
+  return {
+    ok: true,
+    summary: {
+      acceptedOrganizationCount: 1,
+      hasPriorAcceptances: true,
+      headline: 'Accepted by 1 organization.',
+      trustCopy:
+        'This clinician has already been accepted using VitalCV verification. Each acceptance remains scoped to the organization and scope shown below.',
+    },
+    history: [
+      {
+        acceptanceId: 'accept-1',
+        orgLabel: 'Pilot organization 1',
+        isAnonymized: true,
+        acceptedByOrgId: 'org-entity-1',
+        acceptedAt: '2026-03-23T18:00:00.000Z',
+        acceptanceScope: 'pilot',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      },
+    ],
+  };
+}
+
+/** Routes every fetch the surface makes; records profile save POSTs. */
+function installFetchMock(options?: { failSaves?: boolean }) {
+  const savePosts: string[] = [];
+  const mock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/me/workspaces')) return jsonResponse(workspacePayload());
+    if (url.includes('/api/profile/completeness')) return jsonResponse(completenessPayload());
+    if (url.includes('/acceptance-history')) return jsonResponse(acceptanceHistoryPayload());
+    if (url.includes('/api/passport/')) return jsonResponse({ error: 'unavailable' }, 503);
+    if (
+      url.includes('/api/profile/links') ||
+      url.includes('/api/profile/resume/upload') ||
+      url.includes('/api/profile/work-auth')
+    ) {
+      savePosts.push(url);
+      if (options?.failSaves) return jsonResponse({ error: 'backend unavailable' }, 503);
+      return jsonResponse({ ok: true });
+    }
+    throw new Error(`Unmocked fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', mock);
+  return { mock, savePosts };
+}
+
+async function flushEffects() {
+  // Several rounds: workspace load → ready render → passport/completeness/
+  // recognition effects → their state commits.
+  for (let i = 0; i < 6; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/** Submit the profile form the way jsdom supports across versions. */
+function submitForm(container: HTMLElement) {
+  const form = container.querySelector('form') as HTMLFormElement;
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+}
+
+describe('ProfileSurface (Wave 2B editing depth)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function renderSurface() {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<ProfileSurface />);
+    });
+    await flushEffects();
+  }
+
+  it('renders per-field identity provenance from the registry-hydrated profile', async () => {
+    installFetchMock();
+    await renderSurface();
+
+    const section = container.querySelector('[data-testid="identity-provenance"]');
+    expect(section).not.toBeNull();
+    expect(section!.textContent).toContain('Where your identity data comes from');
+    expect(section!.textContent).toContain('Internal Medicine');
+    // Hydrated fields carry the source-confirmed chip; nothing shows a bare "Verified".
+    expect(section!.querySelectorAll('[data-provenance="VERIFIED"]').length).toBe(4);
+    expect(section!.textContent).toContain('Source-confirmed');
+    expect(section!.textContent).not.toMatch(/\bVerified\b/);
+  });
+
+  it('renders completeness guidance with done/missing rows and fix destinations', async () => {
+    installFetchMock();
+    await renderSurface();
+
+    const checklist = container.querySelector('[data-testid="completeness-checklist"]');
+    expect(checklist).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="completeness-npiVerified"]')?.getAttribute('data-complete'),
+    ).toBe('true');
+    const credentials = container.querySelector('[data-testid="completeness-credentialsImported"]');
+    expect(credentials?.getAttribute('data-complete')).toBe('false');
+    expect(credentials?.textContent).toContain('Missing');
+    expect(credentials?.querySelector('a')?.getAttribute('href')).toBe('/holder#evidence-upload');
+    const resume = container.querySelector('[data-testid="completeness-resumeUploaded"]');
+    expect(resume?.querySelector('a')?.getAttribute('href')).toBe('#self-attested');
+    // Filled-ness-only framing stays pinned.
+    expect(container.textContent).toContain('it is not verification');
+  });
+
+  it('shows recorded employer acceptances with a link to the recognition record', async () => {
+    installFetchMock();
+    await renderSurface();
+
+    const recognition = container.querySelector('[data-testid="profile-recognition"]');
+    expect(recognition).not.toBeNull();
+    expect(recognition!.textContent).toContain('Accepted by 1 organization.');
+    const link = Array.from(recognition!.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === '/holder/recognition',
+    );
+    expect(link).toBeDefined();
+  });
+
+  it('renders the passport failure as a system state, not a finding', async () => {
+    installFetchMock();
+    await renderSurface();
+    expect(container.textContent).toContain(
+      'Your source-backed profile sections are temporarily unavailable.',
+    );
+    expect(container.textContent).toContain('not a finding about your credentials');
+  });
+
+  it('disables save with no changes and tracks dirty state on edit', async () => {
+    installFetchMock();
+    await renderSurface();
+
+    const button = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(container.textContent).toContain('No unsaved changes.');
+
+    const linkedin = container.querySelector('#profile-linkedin') as HTMLInputElement;
+    await act(async () => {
+      setInputValue(linkedin, 'linkedin.com/in/updated');
+    });
+    expect(container.textContent).toContain('Unsaved changes.');
+    expect((container.querySelector('button[type="submit"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('blocks a save that clears a previously saved field, with honest copy', async () => {
+    const { savePosts } = installFetchMock();
+    await renderSurface();
+
+    const linkedin = container.querySelector('#profile-linkedin') as HTMLInputElement;
+    await act(async () => {
+      setInputValue(linkedin, '');
+    });
+    const button = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    await act(async () => {
+      submitForm(container);
+    });
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('Removing a saved value is not supported on this surface yet');
+    expect(alert?.textContent).toContain('LinkedIn');
+    expect(savePosts).toEqual([]);
+    expect(container.querySelector('button[type="submit"]')?.textContent).toContain('Retry save');
+  });
+
+  it('saves only the changed field and reports a failed save with a retry affordance', async () => {
+    const { savePosts } = installFetchMock({ failSaves: true });
+    await renderSurface();
+
+    const linkedin = container.querySelector('#profile-linkedin') as HTMLInputElement;
+    await act(async () => {
+      setInputValue(linkedin, 'linkedin.com/in/updated');
+    });
+    await act(async () => {
+      submitForm(container);
+    });
+    await flushEffects();
+
+    expect(savePosts).toHaveLength(1);
+    expect(savePosts[0]).toContain('/api/profile/links');
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('system state');
+    expect(container.querySelector('button[type="submit"]')?.textContent).toContain('Retry save');
+
+    // Editing again clears the failed-save state back to a plain save.
+    await act(async () => {
+      setInputValue(linkedin, 'linkedin.com/in/updated-again');
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('button[type="submit"]')?.textContent).toContain(
+      'Save self-attested fields',
+    );
+  });
+
+  it('completes a successful save and returns to a clean, saved state', async () => {
+    const { savePosts } = installFetchMock();
+    await renderSurface();
+
+    const workAuth = container.querySelector('#profile-work-auth') as HTMLSelectElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLSelectElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(workAuth, 'visa_required');
+      workAuth.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    const button = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    await act(async () => {
+      submitForm(container);
+    });
+    await flushEffects();
+
+    expect(savePosts.some((url) => url.includes('/api/profile/work-auth'))).toBe(true);
+    // The reload resets the form to the saved profile; the save reads as done.
+    expect(container.textContent).toContain('Saved as self-attested.');
+    expect((container.querySelector('button[type="submit"]') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('marks the editable section and the read-only projections honestly', async () => {
+    installFetchMock();
+    await renderSurface();
+    expect(container.textContent).toContain('Editable');
+    expect(container.textContent).toContain('Self-attested');
+    expect(container.textContent).toContain('Not provided');
+    expect(container.textContent).toContain(
+      'User-entered information is not verified until source-backed evidence is attached.',
+    );
+  });
+});

--- a/apps/web/__tests__/holder-route-contract.test.ts
+++ b/apps/web/__tests__/holder-route-contract.test.ts
@@ -20,6 +20,7 @@ const APP_ROOT = join(WEB_ROOT, 'app');
 const SURFACE_FILES = [
   'app/holder/page.tsx',
   'app/holder/readiness/ReadinessSurface.tsx',
+  'app/clinician/profile/ProfileSurface.tsx',
   'components/mobile/ClinicianHomeSurface.tsx',
   'components/mobile/ClinicianOpportunitiesSurface.tsx',
   'components/mobile/ClinicianApplicationsSurface.tsx',

--- a/apps/web/app/clinician/profile/ProfileSurface.tsx
+++ b/apps/web/app/clinician/profile/ProfileSurface.tsx
@@ -11,48 +11,86 @@
  * presented as verified.
  *
  *   checking → signed_out | no_npi | load_error | ready
+ *
+ * Wave 2B (profile editing depth):
+ *   - per-field provenance chips on the identity header (registry-hydrated
+ *     fields are source-confirmed; a bare NPI stays user-entered)
+ *   - dirty tracking: save is disabled with no changes, "Saved" clears the
+ *     moment the form is edited again, and a failed save offers a retry
+ *   - clearing a saved field is blocked with an honest explanation (the
+ *     intake API cannot clear values yet)
+ *   - completeness guidance: the backend dimension breakdown renders as a
+ *     what's-done / what's-missing checklist. Filled-ness only — completing
+ *     the checklist is never presented as verification.
+ *   - recorded employer acceptances (recognition) surface with a link to the
+ *     full recognition record
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { AlertCircle, ChevronRight, Loader2, UserRound } from 'lucide-react';
+import {
+  AlertCircle,
+  Award,
+  CheckCircle2,
+  ChevronRight,
+  CircleDashed,
+  Loader2,
+  UserRound,
+} from 'lucide-react';
 import { ClinicianProfileSections } from '@/components/profile/ClinicianProfileSections';
 import { isPassportData, type PassportData } from '@/lib/trust/passport-contract';
+import { PROVENANCE_META, type ProfileProvenance } from '@/lib/profile/provenance';
 import {
+  fetchAcceptanceRecognition,
+  type AcceptanceRecognitionResult,
+} from '@/lib/recognition/acceptance-recognition';
+import {
+  COMPLETENESS_DIMENSIONS,
   WORK_AUTH_OPTIONS,
   completenessStatement,
+  computeProfileFormDiff,
+  describeClearedFieldsBlock,
+  describeIdentityFields,
   describeProfileSaveError,
   displayName,
+  extractCompletenessBreakdown,
   extractPersonProfile,
   isWorkAuthStatus,
   resumeFileNameFromUrl,
   validateProfileUrl,
+  type CompletenessBreakdown,
+  type ProfileFormValues,
   type WorkspacePersonProfile,
 } from '@/lib/clinician-profile/liveProfile';
 
 type Phase = 'checking' | 'signed_out' | 'no_npi' | 'load_error' | 'ready';
 
-interface LinkFormState {
-  linkedinUrl: string;
-  portfolioUrl: string;
-  resumeUrl: string;
-  workAuthStatus: string;
-}
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+type CompletenessState =
+  | { status: 'loading' }
+  | { status: 'ready'; breakdown: CompletenessBreakdown }
+  | { status: 'unavailable' };
+
+type RecognitionState = { state: 'loading' } | AcceptanceRecognitionResult;
+
+const EMPTY_FORM: ProfileFormValues = {
+  linkedinUrl: '',
+  portfolioUrl: '',
+  resumeUrl: '',
+  workAuthStatus: '',
+};
 
 export default function ProfileSurface() {
   const [phase, setPhase] = useState<Phase>('checking');
   const [profile, setProfile] = useState<WorkspacePersonProfile | null>(null);
   const [passport, setPassport] = useState<PassportData | null>(null);
   const [passportUnavailable, setPassportUnavailable] = useState(false);
-  const [form, setForm] = useState<LinkFormState>({
-    linkedinUrl: '',
-    portfolioUrl: '',
-    resumeUrl: '',
-    workAuthStatus: '',
-  });
-  const [saving, setSaving] = useState(false);
+  const [completeness, setCompleteness] = useState<CompletenessState>({ status: 'loading' });
+  const [recognition, setRecognition] = useState<RecognitionState>({ state: 'loading' });
+  const [form, setForm] = useState<ProfileFormValues>(EMPTY_FORM);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [saveDone, setSaveDone] = useState(false);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -94,6 +132,23 @@ export default function ProfileSurface() {
     }
   }, []);
 
+  const loadCompleteness = useCallback(async (cancelled?: () => boolean) => {
+    try {
+      const res = await fetch('/api/profile/completeness', { cache: 'no-store' });
+      if (cancelled?.()) return;
+      if (!res.ok) {
+        setCompleteness({ status: 'unavailable' });
+        return;
+      }
+      const payload: unknown = await res.json();
+      if (cancelled?.()) return;
+      const breakdown = extractCompletenessBreakdown(payload);
+      setCompleteness(breakdown ? { status: 'ready', breakdown } : { status: 'unavailable' });
+    } catch {
+      if (!cancelled?.()) setCompleteness({ status: 'unavailable' });
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     void loadWorkspace(() => cancelled);
@@ -103,6 +158,15 @@ export default function ProfileSurface() {
   }, [loadWorkspace]);
 
   const npi = profile?.npi ?? null;
+
+  useEffect(() => {
+    if (phase !== 'ready') return;
+    let cancelled = false;
+    void loadCompleteness(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [phase, loadCompleteness]);
 
   useEffect(() => {
     if (!npi) return;
@@ -130,17 +194,42 @@ export default function ProfileSurface() {
       }
     }
 
+    async function loadRecognition() {
+      setRecognition({ state: 'loading' });
+      const result = await fetchAcceptanceRecognition(npi as string);
+      if (!cancelled) setRecognition(result);
+    }
+
     void loadPassport();
+    void loadRecognition();
     return () => {
       cancelled = true;
     };
   }, [npi]);
 
+  const diff = useMemo(
+    () => (profile ? computeProfileFormDiff(profile, form) : null),
+    [profile, form],
+  );
+
+  function updateForm(patch: Partial<ProfileFormValues>) {
+    setForm((f) => ({ ...f, ...patch }));
+    // Editing again invalidates the last save outcome.
+    setSaveState((s) => (s === 'saving' ? s : 'idle'));
+    setSaveError(null);
+  }
+
   async function saveSelfAttested(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!profile) return;
+    if (!profile || !diff) return;
     setSaveError(null);
-    setSaveDone(false);
+
+    if (diff.clearedFields.length > 0) {
+      setSaveState('error');
+      setSaveError(describeClearedFieldsBlock(diff.clearedFields));
+      return;
+    }
+    if (!diff.dirty) return;
 
     const linkedin = validateProfileUrl(form.linkedinUrl);
     const portfolio = validateProfileUrl(form.portfolioUrl);
@@ -151,36 +240,37 @@ export default function ProfileSurface() {
       ['Resume', resume],
     ] as const) {
       if (!v.ok) {
+        setSaveState('error');
         setSaveError(`${label}: ${v.reason}`);
         return;
       }
     }
     if (form.workAuthStatus && !isWorkAuthStatus(form.workAuthStatus)) {
+      setSaveState('error');
       setSaveError('Choose a work authorization option from the list.');
       return;
     }
 
-    setSaving(true);
+    setSaveState('saving');
     try {
       const requests: Array<Promise<Response>> = [];
 
-      const linksChanged =
-        (linkedin.url ?? '') !== (profile.linkedinUrl ?? '') ||
-        (portfolio.url ?? '') !== (profile.portfolioUrl ?? '');
-      if (linksChanged && (linkedin.url || portfolio.url)) {
+      if (diff.linksChanged) {
+        const linkedinChanged = linkedin.url && linkedin.url !== (profile.linkedinUrl ?? '');
+        const portfolioChanged = portfolio.url && portfolio.url !== (profile.portfolioUrl ?? '');
         requests.push(
           fetch('/api/profile/links', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              ...(linkedin.url ? { linkedinUrl: linkedin.url } : {}),
-              ...(portfolio.url ? { portfolioUrl: portfolio.url } : {}),
+              ...(linkedinChanged ? { linkedinUrl: linkedin.url } : {}),
+              ...(portfolioChanged ? { portfolioUrl: portfolio.url } : {}),
             }),
           }),
         );
       }
 
-      if (resume.url && resume.url !== (profile.resumeUrl ?? '')) {
+      if (diff.resumeChanged && resume.url) {
         requests.push(
           fetch('/api/profile/resume/upload', {
             method: 'POST',
@@ -193,7 +283,7 @@ export default function ProfileSurface() {
         );
       }
 
-      if (form.workAuthStatus && form.workAuthStatus !== (profile.workAuthStatus ?? '')) {
+      if (diff.workAuthChanged && form.workAuthStatus) {
         requests.push(
           fetch('/api/profile/work-auth', {
             method: 'POST',
@@ -203,28 +293,26 @@ export default function ProfileSurface() {
         );
       }
 
-      if (requests.length === 0) {
-        setSaveDone(true);
-        return;
-      }
-
       const responses = await Promise.all(requests);
       const failed = responses.find((r) => !r.ok);
       if (!mountedRef.current) return;
       if (failed) {
         const body: unknown = await failed.json().catch(() => null);
         if (!mountedRef.current) return;
+        setSaveState('error');
         setSaveError(describeProfileSaveError(failed.status, body));
         return;
       }
 
-      setSaveDone(true);
-      await loadWorkspace(() => !mountedRef.current);
+      setSaveState('saved');
+      await Promise.allSettled([
+        loadWorkspace(() => !mountedRef.current),
+        loadCompleteness(() => !mountedRef.current),
+      ]);
     } catch {
       if (!mountedRef.current) return;
+      setSaveState('error');
       setSaveError(describeProfileSaveError(0, null));
-    } finally {
-      if (mountedRef.current) setSaving(false);
     }
   }
 
@@ -295,6 +383,10 @@ export default function ProfileSurface() {
 
   /* ── Ready ── */
   const name = displayName(profile);
+  const identityFields = describeIdentityFields(profile);
+  const saving = saveState === 'saving';
+  const saveDisabled = saving || !diff?.dirty;
+
   return (
     <Shell wide>
       {/* Identity header — from the NPPES-bootstrapped PersonProfile */}
@@ -306,10 +398,6 @@ export default function ProfileSurface() {
           <div>
             <h1 className="text-2xl font-bold text-foreground">{name ?? 'Your professional profile'}</h1>
             <p className="mt-0.5 font-mono text-sm tracking-wide text-zinc-500">NPI {profile.npi}</p>
-            <p className="mt-1 text-sm text-zinc-400">
-              {[profile.specialty, profile.stateOfPractice].filter(Boolean).join(' · ') ||
-                'Specialty and state not listed in your registry record.'}
-            </p>
             <p className="mt-1 text-xs text-zinc-600">
               Identity fields come from your NPPES registry record at connect time.
             </p>
@@ -323,33 +411,168 @@ export default function ProfileSurface() {
         </Link>
       </header>
 
-      {/* Completeness — filled-ness only */}
-      {profile.completeness !== null && (
-        <section
-          aria-labelledby="completeness-heading"
-          className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
-        >
-          <h2 id="completeness-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
-            Profile completeness
+      {/* Where each identity field came from */}
+      <section
+        aria-labelledby="identity-provenance-heading"
+        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+        data-testid="identity-provenance"
+      >
+        <h2 id="identity-provenance-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+          Where your identity data comes from
+        </h2>
+        <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+          {identityFields.map((field) => (
+            <div key={field.key} className="rounded-xl border border-zinc-800/80 bg-zinc-950/40 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-xs uppercase tracking-[0.12em] text-zinc-500">{field.label}</dt>
+                <ProvenanceChip provenance={field.provenance} />
+              </div>
+              <dd className="mt-1.5">
+                <p className="text-sm text-foreground/90">{field.value ?? 'Not on file'}</p>
+                <p className="mt-1 text-xs leading-relaxed text-zinc-600">{field.note}</p>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      {/* Completeness — filled-ness only, with what's-missing guidance */}
+      <section
+        aria-labelledby="completeness-heading"
+        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+      >
+        <h2 id="completeness-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+          Profile completeness
+        </h2>
+        {(() => {
+          const score =
+            completeness.status === 'ready' ? completeness.breakdown.score : profile.completeness;
+          if (score === null) return null;
+          return (
+            <>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800" role="presentation">
+                <div
+                  className="h-full rounded-full bg-emerald-500 transition-all"
+                  style={{ width: `${Math.max(0, Math.min(100, score))}%` }}
+                />
+              </div>
+              <p className="mt-2 text-sm text-zinc-400">{completenessStatement(score)}</p>
+            </>
+          );
+        })()}
+
+        {completeness.status === 'loading' && (
+          <p className="mt-3 animate-pulse font-mono text-xs text-zinc-600" role="status" aria-live="polite">
+            Loading what&apos;s complete and what&apos;s missing…
+          </p>
+        )}
+        {completeness.status === 'unavailable' && (
+          <p className="mt-3 text-xs text-zinc-500">
+            The completeness breakdown is temporarily unavailable. This is a system state — not a
+            finding about your profile.
+          </p>
+        )}
+        {completeness.status === 'ready' && (
+          <ul className="mt-4 space-y-3" data-testid="completeness-checklist">
+            {COMPLETENESS_DIMENSIONS.map((dim) => {
+              const done = completeness.breakdown.dimensions[dim.key];
+              return (
+                <li
+                  key={dim.key}
+                  className="flex items-start gap-3"
+                  data-testid={`completeness-${dim.key}`}
+                  data-complete={done}
+                >
+                  {done ? (
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" aria-hidden />
+                  ) : (
+                    <CircleDashed className="mt-0.5 h-4 w-4 shrink-0 text-zinc-600" aria-hidden />
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm text-foreground/90">
+                      {dim.label}
+                      <span className="ml-2 text-xs text-zinc-600">
+                        {done ? 'Done' : 'Missing'} · {dim.weight} of 100 points
+                      </span>
+                    </p>
+                    {!done && (
+                      <p className="mt-0.5 text-xs leading-relaxed text-zinc-500">
+                        {dim.whyItMatters}{' '}
+                        <a href={dim.fixHref} className="font-semibold text-emerald-400 hover:text-emerald-300">
+                          {dim.fixLabel}
+                        </a>
+                      </p>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Recorded employer acceptances */}
+      <section
+        aria-labelledby="recognition-heading"
+        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+        data-testid="profile-recognition"
+      >
+        <div className="flex items-center gap-2">
+          <Award className="h-4 w-4 text-emerald-400" aria-hidden />
+          <h2 id="recognition-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+            Employer recognition
           </h2>
-          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800" role="presentation">
-            <div
-              className="h-full rounded-full bg-emerald-500 transition-all"
-              style={{ width: `${Math.max(0, Math.min(100, profile.completeness))}%` }}
-            />
-          </div>
-          <p className="mt-2 text-sm text-zinc-400">{completenessStatement(profile.completeness)}</p>
-        </section>
-      )}
+        </div>
+        {recognition.state === 'loading' && (
+          <p className="mt-2 animate-pulse font-mono text-xs text-zinc-600" role="status" aria-live="polite">
+            Checking your recognition record…
+          </p>
+        )}
+        {recognition.state === 'recognized' && (
+          <p className="mt-2 text-sm text-zinc-300">
+            {recognition.recognition.summary.headline} Each acceptance is an employer decision
+            recorded with an audit event.
+          </p>
+        )}
+        {recognition.state === 'none_recorded' && (
+          <p className="mt-2 text-sm text-zinc-400">
+            No employer acceptances recorded yet. When an employer accepts your evidence as a head
+            start, it shows up here.
+          </p>
+        )}
+        {recognition.state === 'unavailable' && (
+          <p className="mt-2 text-xs text-zinc-500">
+            Your recognition record is temporarily unavailable. This is a system state — not a
+            finding about your record.
+          </p>
+        )}
+        {recognition.state !== 'loading' && (
+          <Link
+            href="/holder/recognition"
+            className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-400 transition hover:text-emerald-300"
+          >
+            View your recognition record <ChevronRight className="h-4 w-4" aria-hidden />
+          </Link>
+        )}
+      </section>
 
       {/* Self-attested fields — editable */}
-      <section aria-labelledby="self-attested-heading" className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
-        <div className="flex items-center justify-between gap-3">
+      <section
+        id="self-attested"
+        aria-labelledby="self-attested-heading"
+        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 id="self-attested-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
             Career links &amp; work authorization
           </h2>
-          <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-500">
-            Self-attested
+          <span className="flex items-center gap-2">
+            <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-emerald-500">
+              Editable
+            </span>
+            <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-500">
+              Self-attested
+            </span>
           </span>
         </div>
         <p className="mt-2 text-xs leading-relaxed text-zinc-500">
@@ -362,34 +585,40 @@ export default function ProfileSurface() {
             label="LinkedIn"
             placeholder="linkedin.com/in/you"
             value={form.linkedinUrl}
+            savedValue={profile.linkedinUrl}
             disabled={saving}
-            onChange={(v) => setForm((f) => ({ ...f, linkedinUrl: v }))}
+            onChange={(v) => updateForm({ linkedinUrl: v })}
           />
           <FormField
             id="profile-portfolio"
             label="Portfolio / website"
             placeholder="example.com"
             value={form.portfolioUrl}
+            savedValue={profile.portfolioUrl}
             disabled={saving}
-            onChange={(v) => setForm((f) => ({ ...f, portfolioUrl: v }))}
+            onChange={(v) => updateForm({ portfolioUrl: v })}
           />
           <FormField
             id="profile-resume"
             label="Resume link"
             placeholder="Link to your hosted resume (PDF or doc)"
             value={form.resumeUrl}
+            savedValue={profile.resumeUrl}
             disabled={saving}
-            onChange={(v) => setForm((f) => ({ ...f, resumeUrl: v }))}
+            onChange={(v) => updateForm({ resumeUrl: v })}
           />
           <div>
-            <label htmlFor="profile-work-auth" className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
-              Work authorization
-            </label>
+            <span className="flex items-center justify-between gap-2">
+              <label htmlFor="profile-work-auth" className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+                Work authorization
+              </label>
+              <FieldStateChip savedValue={profile.workAuthStatus} />
+            </span>
             <select
               id="profile-work-auth"
               value={form.workAuthStatus}
               disabled={saving}
-              onChange={(e) => setForm((f) => ({ ...f, workAuthStatus: e.target.value }))}
+              onChange={(e) => updateForm({ workAuthStatus: e.target.value })}
               className="mt-2 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm text-foreground focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-900"
             >
               <option value="">Not stated</option>
@@ -403,13 +632,15 @@ export default function ProfileSurface() {
           <div className="sm:col-span-2 flex flex-wrap items-center gap-3">
             <button
               type="submit"
-              disabled={saving}
+              disabled={saveDisabled}
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Saving…
                 </>
+              ) : saveState === 'error' ? (
+                'Retry save'
               ) : (
                 'Save self-attested fields'
               )}
@@ -417,9 +648,15 @@ export default function ProfileSurface() {
             <p aria-live="polite" className="text-sm">
               {saveError ? (
                 <span role="alert" className="text-red-400">{saveError}</span>
-              ) : saveDone ? (
+              ) : saving ? (
+                <span className="text-zinc-400">Saving your self-attested fields…</span>
+              ) : saveState === 'saved' && !diff?.dirty ? (
                 <span className="text-emerald-400">Saved as self-attested.</span>
-              ) : null}
+              ) : diff?.dirty ? (
+                <span className="text-amber-400">Unsaved changes.</span>
+              ) : (
+                <span className="text-zinc-600">No unsaved changes.</span>
+              )}
             </p>
           </div>
         </form>
@@ -427,7 +664,14 @@ export default function ProfileSurface() {
 
       {/* Passport-backed profile sections */}
       {passport ? (
-        <ClinicianProfileSections passport={passport} />
+        <>
+          <p className="text-xs leading-relaxed text-zinc-600">
+            The sections below are read projections from your passport and registry sources —
+            uploads and source checks keep them current. Direct editing of these sections ships in
+            later waves.
+          </p>
+          <ClinicianProfileSections passport={passport} />
+        </>
       ) : passportUnavailable ? (
         <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
           <p className="text-sm text-zinc-300">Your source-backed profile sections are temporarily unavailable.</p>
@@ -441,6 +685,34 @@ export default function ProfileSurface() {
         </div>
       )}
     </Shell>
+  );
+}
+
+function ProvenanceChip({ provenance }: { provenance: ProfileProvenance }) {
+  const meta = PROVENANCE_META[provenance];
+  return (
+    <span
+      title={meta.description}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] ${meta.badgeClass}`}
+      data-provenance={provenance}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+/** Chip for an editable field: saved self-attested value vs nothing on file. */
+function FieldStateChip({ savedValue }: { savedValue: string | null }) {
+  return savedValue ? (
+    <ProvenanceChip provenance="USER_ENTERED" />
+  ) : (
+    <span
+      className="inline-flex items-center rounded-full border border-zinc-700 bg-zinc-800/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-zinc-500"
+      data-provenance="NOT_PROVIDED"
+      title="Nothing saved for this field yet. Anything you enter is stored as self-attested."
+    >
+      Not provided
+    </span>
   );
 }
 
@@ -487,6 +759,7 @@ function FormField({
   label,
   placeholder,
   value,
+  savedValue,
   disabled,
   onChange,
 }: {
@@ -494,14 +767,18 @@ function FormField({
   label: string;
   placeholder: string;
   value: string;
+  savedValue: string | null;
   disabled: boolean;
   onChange: (value: string) => void;
 }) {
   return (
     <div>
-      <label htmlFor={id} className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
-        {label}
-      </label>
+      <span className="flex items-center justify-between gap-2">
+        <label htmlFor={id} className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+          {label}
+        </label>
+        <FieldStateChip savedValue={savedValue} />
+      </span>
       <input
         id={id}
         type="text"

--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -11,7 +11,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ShieldCheck, ChevronRight, Loader2, AlertCircle, Upload } from 'lucide-react';
+import { ShieldCheck, ChevronRight, Loader2, AlertCircle, Upload, UserRound } from 'lucide-react';
 import { WalletPassport } from '@/components/wallet/WalletPassport';
 import { CredentialWallet } from '@/components/wallet/CredentialWallet';
 import { CredentialPresentationActions } from '@/components/clinician/CredentialPresentationActions';
@@ -137,13 +137,22 @@ export default function HolderPage() {
             Welcome back, <span className="text-zinc-300 font-medium">{profile.firstName}</span>
           </p>
         )}
-        <a
-          href="#evidence-upload"
-          className="inline-flex min-h-[44px] w-full items-center justify-center gap-1.5 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-300 transition hover:border-emerald-700 hover:bg-emerald-950/30 hover:text-emerald-300 sm:w-auto"
-        >
-          <Upload className="h-3.5 w-3.5" />
-          Upload Credential
-        </a>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+          <Link
+            href="/clinician/profile"
+            className="inline-flex min-h-[44px] w-full items-center justify-center gap-1.5 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-300 transition hover:border-emerald-700 hover:bg-emerald-950/30 hover:text-emerald-300 sm:w-auto"
+          >
+            <UserRound className="h-3.5 w-3.5" />
+            Professional profile
+          </Link>
+          <a
+            href="#evidence-upload"
+            className="inline-flex min-h-[44px] w-full items-center justify-center gap-1.5 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-300 transition hover:border-emerald-700 hover:bg-emerald-950/30 hover:text-emerald-300 sm:w-auto"
+          >
+            <Upload className="h-3.5 w-3.5" />
+            Upload Credential
+          </a>
+        </div>
       </div>
 
       {/* Trust State */}

--- a/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
+++ b/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
@@ -1,14 +1,46 @@
 import { describe, expect, it } from 'vitest';
 import {
+  COMPLETENESS_DIMENSIONS,
   WORK_AUTH_OPTIONS,
   completenessStatement,
+  computeProfileFormDiff,
+  describeClearedFieldsBlock,
+  describeIdentityFields,
   describeProfileSaveError,
   displayName,
+  extractCompletenessBreakdown,
   extractPersonProfile,
   isWorkAuthStatus,
   resumeFileNameFromUrl,
   validateProfileUrl,
+  type ProfileFormValues,
+  type WorkspacePersonProfile,
 } from '@/lib/clinician-profile/liveProfile';
+
+function baseProfile(overrides: Partial<WorkspacePersonProfile> = {}): WorkspacePersonProfile {
+  return {
+    npi: '1234567890',
+    firstName: 'Test',
+    lastName: 'Clinician',
+    specialty: 'Internal Medicine',
+    stateOfPractice: 'CA',
+    workAuthStatus: 'authorized',
+    resumeUrl: 'https://example.com/cv.pdf',
+    linkedinUrl: 'https://linkedin.com/in/test',
+    portfolioUrl: null,
+    completeness: 55,
+    ...overrides,
+  };
+}
+
+function formFromProfile(profile: WorkspacePersonProfile): ProfileFormValues {
+  return {
+    linkedinUrl: profile.linkedinUrl ?? '',
+    portfolioUrl: profile.portfolioUrl ?? '',
+    resumeUrl: profile.resumeUrl ?? '',
+    workAuthStatus: profile.workAuthStatus ?? '',
+  };
+}
 
 describe('extractPersonProfile', () => {
   it('extracts the PersonProfile fields the surface consumes', () => {
@@ -89,6 +121,169 @@ describe('describeProfileSaveError', () => {
   });
   it('frames system failures as system states', () => {
     expect(describeProfileSaveError(503, null)).toContain('system state');
+  });
+});
+
+describe('computeProfileFormDiff', () => {
+  it('is clean when the form mirrors the saved profile', () => {
+    const profile = baseProfile();
+    const diff = computeProfileFormDiff(profile, formFromProfile(profile));
+    expect(diff.dirty).toBe(false);
+    expect(diff.clearedFields).toEqual([]);
+  });
+
+  it('is clean when a URL differs only by scheme normalization', () => {
+    const profile = baseProfile();
+    const diff = computeProfileFormDiff(profile, {
+      ...formFromProfile(profile),
+      linkedinUrl: 'linkedin.com/in/test',
+    });
+    expect(diff.dirty).toBe(false);
+    expect(diff.linksChanged).toBe(false);
+  });
+
+  it('flags changed links, resume, and work auth independently', () => {
+    const profile = baseProfile();
+    const form = formFromProfile(profile);
+
+    const links = computeProfileFormDiff(profile, { ...form, portfolioUrl: 'example.org' });
+    expect(links).toMatchObject({ dirty: true, linksChanged: true, resumeChanged: false });
+
+    const resume = computeProfileFormDiff(profile, { ...form, resumeUrl: 'example.com/new-cv.pdf' });
+    expect(resume).toMatchObject({ dirty: true, resumeChanged: true, linksChanged: false });
+
+    const workAuth = computeProfileFormDiff(profile, { ...form, workAuthStatus: 'visa_required' });
+    expect(workAuth).toMatchObject({ dirty: true, workAuthChanged: true });
+  });
+
+  it('reports cleared saved fields instead of treating them as changes to send', () => {
+    const profile = baseProfile();
+    const diff = computeProfileFormDiff(profile, {
+      ...formFromProfile(profile),
+      linkedinUrl: '',
+      workAuthStatus: '',
+    });
+    expect(diff.dirty).toBe(true);
+    expect(diff.clearedFields).toEqual(['LinkedIn', 'Work authorization']);
+    expect(diff.linksChanged).toBe(false);
+    expect(diff.workAuthChanged).toBe(false);
+  });
+
+  it('never reports a never-saved empty field as cleared', () => {
+    const profile = baseProfile({ portfolioUrl: null });
+    const diff = computeProfileFormDiff(profile, formFromProfile(profile));
+    expect(diff.clearedFields).toEqual([]);
+  });
+
+  it('cleared-fields copy names the fields and is honest about the limitation', () => {
+    const copy = describeClearedFieldsBlock(['LinkedIn', 'Resume link']);
+    expect(copy).toContain('LinkedIn');
+    expect(copy).toContain('Resume link');
+    expect(copy).toContain('not supported on this surface yet');
+  });
+});
+
+describe('extractCompletenessBreakdown', () => {
+  const validDimensions = {
+    npiVerified: true,
+    resumeUploaded: false,
+    linksAdded: true,
+    workAuthProvided: false,
+    credentialsImported: false,
+  };
+
+  it('parses the backend completeness payload', () => {
+    const parsed = extractCompletenessBreakdown({
+      userId: 'u1',
+      score: 55,
+      dimensions: validDimensions,
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.score).toBe(55);
+    expect(parsed?.dimensions.npiVerified).toBe(true);
+    expect(parsed?.dimensions.resumeUploaded).toBe(false);
+  });
+
+  it('rejects malformed payloads rather than guessing', () => {
+    expect(extractCompletenessBreakdown(null)).toBeNull();
+    expect(extractCompletenessBreakdown({})).toBeNull();
+    expect(extractCompletenessBreakdown({ score: '55', dimensions: validDimensions })).toBeNull();
+    expect(
+      extractCompletenessBreakdown({
+        score: 55,
+        dimensions: { ...validDimensions, credentialsImported: 'yes' },
+      }),
+    ).toBeNull();
+    const { credentialsImported: _dropped, ...missingKey } = validDimensions;
+    expect(extractCompletenessBreakdown({ score: 55, dimensions: missingKey })).toBeNull();
+  });
+
+  it('bounds out-of-range scores', () => {
+    expect(extractCompletenessBreakdown({ score: 140, dimensions: validDimensions })?.score).toBe(100);
+    expect(extractCompletenessBreakdown({ score: -3, dimensions: validDimensions })?.score).toBe(0);
+  });
+});
+
+describe('COMPLETENESS_DIMENSIONS', () => {
+  it('mirrors the backend weights and sums to 100', () => {
+    const total = COMPLETENESS_DIMENSIONS.reduce((sum, d) => sum + d.weight, 0);
+    expect(total).toBe(100);
+    expect(COMPLETENESS_DIMENSIONS.map((d) => d.key).sort()).toEqual([
+      'credentialsImported',
+      'linksAdded',
+      'npiVerified',
+      'resumeUploaded',
+      'workAuthProvided',
+    ]);
+  });
+
+  it('every dimension has a fix destination', () => {
+    for (const dim of COMPLETENESS_DIMENSIONS) {
+      expect(dim.fixHref.length).toBeGreaterThan(0);
+      expect(dim.fixLabel.length).toBeGreaterThan(0);
+      expect(dim.fixHref.startsWith('/') || dim.fixHref.startsWith('#')).toBe(true);
+    }
+  });
+
+  it('guidance copy is filled-ness only — never a verification claim', () => {
+    for (const dim of COMPLETENESS_DIMENSIONS) {
+      const copy = `${dim.label} ${dim.whyItMatters}`.toLowerCase();
+      expect(copy).not.toContain('verified');
+      expect(copy).not.toContain('guaranteed');
+      expect(copy).not.toContain('instant');
+    }
+  });
+});
+
+describe('describeIdentityFields', () => {
+  it('marks registry-hydrated fields as source-backed', () => {
+    const fields = describeIdentityFields(baseProfile());
+    const byKey = Object.fromEntries(fields.map((f) => [f.key, f]));
+    expect(byKey.name.provenance).toBe('VERIFIED');
+    expect(byKey.npi.provenance).toBe('VERIFIED');
+    expect(byKey.specialty.provenance).toBe('VERIFIED');
+    expect(byKey.stateOfPractice.provenance).toBe('VERIFIED');
+  });
+
+  it('keeps a bare NPI user-entered when the registry never hydrated', () => {
+    const fields = describeIdentityFields(
+      baseProfile({ firstName: null, lastName: null, specialty: null, stateOfPractice: null }),
+    );
+    const byKey = Object.fromEntries(fields.map((f) => [f.key, f]));
+    expect(byKey.name.provenance).toBe('UNKNOWN');
+    expect(byKey.npi.provenance).toBe('USER_ENTERED');
+    expect(byKey.npi.note).toContain('hydration has not completed');
+    expect(byKey.specialty.provenance).toBe('UNKNOWN');
+    expect(byKey.stateOfPractice.provenance).toBe('UNKNOWN');
+  });
+
+  it('never labels a missing value as source-backed', () => {
+    const fields = describeIdentityFields(baseProfile({ specialty: null }));
+    for (const field of fields) {
+      if (field.value === null) {
+        expect(field.provenance).not.toBe('VERIFIED');
+      }
+    }
   });
 });
 

--- a/apps/web/lib/clinician-profile/liveProfile.ts
+++ b/apps/web/lib/clinician-profile/liveProfile.ts
@@ -16,6 +16,8 @@
  * completeness is filled-ness only — it never implies verification.
  */
 
+import type { ProfileProvenance } from '@/lib/profile/provenance';
+
 export const WORK_AUTH_OPTIONS = [
   { value: 'authorized', label: 'Authorized to work in the U.S.' },
   { value: 'visa_required', label: 'Visa sponsorship required' },
@@ -111,6 +113,81 @@ export function resumeFileNameFromUrl(url: string): string {
   return 'resume-link';
 }
 
+/** Editable form values on the live profile surface. */
+export interface ProfileFormValues {
+  linkedinUrl: string;
+  portfolioUrl: string;
+  resumeUrl: string;
+  workAuthStatus: string;
+}
+
+export interface ProfileFormDiff {
+  /** True when any field differs from the saved profile. */
+  dirty: boolean;
+  linksChanged: boolean;
+  resumeChanged: boolean;
+  workAuthChanged: boolean;
+  /**
+   * Labels of previously saved fields the form now leaves empty. The intake
+   * API only writes non-empty values (it cannot clear a saved field), so a
+   * save with cleared fields must be blocked with an honest explanation
+   * instead of silently leaving the old value in place.
+   */
+  clearedFields: string[];
+}
+
+function normalizedUrlOrRaw(raw: string): string {
+  const v = validateProfileUrl(raw);
+  return v.ok ? (v.url ?? '') : raw.trim();
+}
+
+/**
+ * Compares the form against the saved profile. URL fields compare on their
+ * normalized form so "linkedin.com/in/you" is not "dirty" against a saved
+ * "https://linkedin.com/in/you".
+ */
+export function computeProfileFormDiff(
+  profile: WorkspacePersonProfile,
+  form: ProfileFormValues,
+): ProfileFormDiff {
+  const savedLinkedin = profile.linkedinUrl ?? '';
+  const savedPortfolio = profile.portfolioUrl ?? '';
+  const savedResume = profile.resumeUrl ?? '';
+  const savedWorkAuth = profile.workAuthStatus ?? '';
+
+  const nextLinkedin = normalizedUrlOrRaw(form.linkedinUrl);
+  const nextPortfolio = normalizedUrlOrRaw(form.portfolioUrl);
+  const nextResume = normalizedUrlOrRaw(form.resumeUrl);
+  const nextWorkAuth = form.workAuthStatus;
+
+  const clearedFields: string[] = [];
+  if (savedLinkedin && nextLinkedin === '') clearedFields.push('LinkedIn');
+  if (savedPortfolio && nextPortfolio === '') clearedFields.push('Portfolio');
+  if (savedResume && nextResume === '') clearedFields.push('Resume link');
+  if (savedWorkAuth && nextWorkAuth === '') clearedFields.push('Work authorization');
+
+  const linksChanged =
+    (nextLinkedin !== savedLinkedin && nextLinkedin !== '') ||
+    (nextPortfolio !== savedPortfolio && nextPortfolio !== '');
+  const resumeChanged = nextResume !== savedResume && nextResume !== '';
+  const workAuthChanged = nextWorkAuth !== savedWorkAuth && nextWorkAuth !== '';
+
+  return {
+    dirty: linksChanged || resumeChanged || workAuthChanged || clearedFields.length > 0,
+    linksChanged,
+    resumeChanged,
+    workAuthChanged,
+    clearedFields,
+  };
+}
+
+/** Copy for a blocked save when the form clears previously saved fields. */
+export function describeClearedFieldsBlock(clearedFields: string[]): string {
+  return `Removing a saved value is not supported on this surface yet (${clearedFields.join(
+    ', ',
+  )}). Restore the previous value or enter a replacement.`;
+}
+
 export function describeProfileSaveError(status: number, body: unknown): string {
   const message =
     body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string'
@@ -132,4 +209,176 @@ export function describeProfileSaveError(status: number, body: unknown): string 
 export function completenessStatement(score: number): string {
   const bounded = Math.max(0, Math.min(100, Math.round(score)));
   return `${bounded}% of profile fields are filled in. Completeness measures filled-ness only — it is not verification.`;
+}
+
+/* ── Completeness guidance (GET /api/profile/completeness) ──────────────── */
+
+/** Boolean dimension breakdown computed by the backend intake service. */
+export interface CompletenessDimensions {
+  npiVerified: boolean;
+  resumeUploaded: boolean;
+  linksAdded: boolean;
+  workAuthProvided: boolean;
+  credentialsImported: boolean;
+}
+
+export interface CompletenessBreakdown {
+  score: number;
+  dimensions: CompletenessDimensions;
+}
+
+const DIMENSION_KEYS = [
+  'npiVerified',
+  'resumeUploaded',
+  'linksAdded',
+  'workAuthProvided',
+  'credentialsImported',
+] as const;
+
+/** Defensive parse of the completeness endpoint payload. */
+export function extractCompletenessBreakdown(payload: unknown): CompletenessBreakdown | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as { score?: unknown; dimensions?: unknown };
+  if (typeof p.score !== 'number' || !p.dimensions || typeof p.dimensions !== 'object') {
+    return null;
+  }
+  const raw = p.dimensions as Record<string, unknown>;
+  const dimensions = {} as CompletenessDimensions;
+  for (const key of DIMENSION_KEYS) {
+    if (typeof raw[key] !== 'boolean') return null;
+    dimensions[key] = raw[key] as boolean;
+  }
+  return { score: Math.max(0, Math.min(100, Math.round(p.score))), dimensions };
+}
+
+export interface CompletenessDimensionMeta {
+  key: keyof CompletenessDimensions;
+  /** Filled-ness label. Must never read as a verification claim. */
+  label: string;
+  /** Points this dimension adds to the 0–100 score (mirrors backend weights). */
+  weight: number;
+  whyItMatters: string;
+  /** Where the clinician goes to fill this dimension. */
+  fixHref: string;
+  fixLabel: string;
+}
+
+/**
+ * Mirrors the backend intake-service dimension weights (30/20/10/15/25).
+ * Copy rule: every line is about filled-ness and reviewer usefulness —
+ * completing a dimension never implies a source check passed.
+ */
+export const COMPLETENESS_DIMENSIONS: readonly CompletenessDimensionMeta[] = [
+  {
+    key: 'npiVerified',
+    label: 'NPI connected',
+    weight: 30,
+    whyItMatters:
+      'Your NPPES registry record anchors your profile and is where every source check starts.',
+    fixHref: '/get-ready',
+    fixLabel: 'Connect your NPI',
+  },
+  {
+    key: 'credentialsImported',
+    label: 'Credential evidence attached',
+    weight: 25,
+    whyItMatters:
+      'Uploaded credential documents are what source checks and employer review run against.',
+    fixHref: '/holder#evidence-upload',
+    fixLabel: 'Upload evidence',
+  },
+  {
+    key: 'resumeUploaded',
+    label: 'Resume attached',
+    weight: 20,
+    whyItMatters:
+      'Reviewers line up your stated employment history against source-backed checks faster with a resume on file.',
+    fixHref: '#self-attested',
+    fixLabel: 'Add your resume link below',
+  },
+  {
+    key: 'workAuthProvided',
+    label: 'Work authorization stated',
+    weight: 15,
+    whyItMatters:
+      'Employers ask about work authorization early — stating it now avoids a stall later in an application.',
+    fixHref: '#self-attested',
+    fixLabel: 'Choose a status below',
+  },
+  {
+    key: 'linksAdded',
+    label: 'Career links added',
+    weight: 10,
+    whyItMatters:
+      'LinkedIn or a portfolio gives reviewers self-attested context beyond your registry fields.',
+    fixHref: '#self-attested',
+    fixLabel: 'Add links below',
+  },
+];
+
+/* ── Identity field provenance (NPPES-bootstrapped header) ──────────────── */
+
+export type IdentityFieldKey = 'name' | 'npi' | 'specialty' | 'stateOfPractice';
+
+export interface IdentityFieldDescriptor {
+  key: IdentityFieldKey;
+  label: string;
+  value: string | null;
+  provenance: ProfileProvenance;
+  note: string;
+}
+
+/**
+ * Provenance for the PersonProfile identity header.
+ *
+ * Name / specialty / state only ever come from the NPPES lookup at connect
+ * time, so a present value is source-backed. The NPI row is only
+ * source-confirmed when the registry lookup actually hydrated (name present);
+ * otherwise it is the number the clinician entered, awaiting registry
+ * hydration — USER_ENTERED, never presented as confirmed.
+ */
+export function describeIdentityFields(
+  profile: WorkspacePersonProfile,
+): IdentityFieldDescriptor[] {
+  const name = displayName(profile);
+  const registryHydrated = name !== null;
+
+  return [
+    {
+      key: 'name',
+      label: 'Name',
+      value: name,
+      provenance: registryHydrated ? 'VERIFIED' : 'UNKNOWN',
+      note: registryHydrated
+        ? 'From your NPPES registry record at connect time.'
+        : 'Not returned by the registry lookup yet.',
+    },
+    {
+      key: 'npi',
+      label: 'NPI',
+      value: profile.npi,
+      provenance: registryHydrated ? 'VERIFIED' : 'USER_ENTERED',
+      note: registryHydrated
+        ? 'Matched to your NPPES registry record at connect time.'
+        : 'Entered at connect. Registry hydration has not completed for this NPI.',
+    },
+    {
+      key: 'specialty',
+      label: 'Specialty',
+      value: profile.specialty,
+      provenance: profile.specialty ? 'VERIFIED' : 'UNKNOWN',
+      note: profile.specialty
+        ? 'NPPES primary taxonomy. A specialty claim, not a board-certification claim.'
+        : 'Not listed in your registry record.',
+    },
+    {
+      key: 'stateOfPractice',
+      label: 'State of practice',
+      value: profile.stateOfPractice,
+      provenance: profile.stateOfPractice ? 'VERIFIED' : 'UNKNOWN',
+      note: profile.stateOfPractice
+        ? 'Practice address state from your NPPES registry record.'
+        : 'Not listed in your registry record.',
+    },
+  ];
 }


### PR DESCRIPTION
## Mission (EPIC WAVE 2B)

Make the Professional Profile feel real, editable, and trustworthy: *"This is my professional identity, and I can improve it."*

## Gap map (produced before building)

| Area | Found | Action |
|---|---|---|
| Route + data | `/clinician/profile` live; PersonProfile persisted (Postgres via intake service, audited, Clerk-auth'd) | Kept — no second profile system created |
| Entry points | Holder home quick action exists; `/holder` wallet had none | Added wallet header link |
| Save states | One coarse form save; stale "Saved" after re-edit; "Saved" shown when nothing changed; no retry affordance | Dirty tracking, save disabled when clean, `Retry save` on error |
| Clearing values | UI treated empty as "clear" but backend `ingestLinks` only writes non-empty values — silent no-op | Cleared-field saves blocked with honest copy |
| Provenance | 5-tier vocabulary + legend existed; identity header had prose only; no per-field labels | Identity provenance grid: Source-confirmed (NPPES-hydrated) / User-entered (bare NPI) / Unknown; per-field Self-attested / Not provided chips on editable fields |
| Completeness | Bar + % only; backend dimension breakdown endpoint unused | Done/missing checklist with why-it-matters + fix links (weights mirror backend 30/25/20/15/10) |
| Employer-accepted | Recognition data existed but invisible on profile | Recognition strip via existing public acceptance-history read → `/holder/recognition` |
| Fake values | None found on the live path (demo values are seed/test fixtures only) | Nothing to remove |
| Dead sections | 8 of 16 passport sections permanently empty with no edit path | Labelled honestly as read projections; editing deferred (needs schema — out of 2B scope) |

## Truth contract

- User-entered values never presented as verified; missing values never Source-confirmed
- Completeness copy stays filled-ness-only ("it is not verification" pinned in tests)
- Failed lookups render as system states, never findings
- No banned strings; no bare "Verified" label (suite green)

## Tests

- `lib/clinician-profile/__tests__/liveProfile.test.ts`: 27 tests (form diff/cleared-field detection, completeness parsing, dimension metadata truth, identity provenance rules)
- `__tests__/clinician-profile-surface.test.tsx`: 9 jsdom tests (provenance chips, checklist, recognition, save/dirty/retry/blocked-clear lifecycle, system states)
- `ProfileSurface.tsx` added to holder route-contract coverage
- Full web suite: 1802 passed / 0 failed; `turbo build --filter @vitalcv/web` green

## Design Handoff References

- `design-handoff/claude-design-2026-06-26/vitalcv/project/Clinician Profile.html` — "Provenance footer per section — what makes this true" → identity provenance grid + per-field source notes
- `design-handoff/claude-design-2026-06-26/vitalcv/project/wave1000/view-profile.jsx` — "Identity anchored at NPPES" → Source-confirmed chips gated on registry hydration

## Tier

Tier 1 (web-only surface + tests; no schema, no auth, no trust-model change) → Fable self-review + self-merge + Railway production verification per tiered merge policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)