### PR TITLE
fix(verify): keep employer review notes out of the public acceptance-history read (Wave 2C)

### DIFF
--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -44,6 +44,11 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/trust-proof/1003000126')).toBe(true);
   });
 
+  it('skips tenant context for the public verifier companion reads', () => {
+    expect(shouldSkipTenantContext('/api/passport/npi/1003000126')).toBe(true);
+    expect(shouldSkipTenantContext('/api/employer-review/1003000126/acceptance-history')).toBe(true);
+  });
+
   it('allows the trust-proof read through without organization context', () => {
     const req = createRequest('/api/trust-proof/1003000126');
     const res = createResponse();

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -438,7 +438,8 @@ describe('employer action routes', () => {
         acceptedByOrgId: null,
         acceptedAt: expect.any(String),
         acceptanceScope: 'pilot',
-        acceptanceReason: 'Head start only',
+        // Private notes no longer stand in for a missing acceptance reason.
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
       },
       persistence: expect.objectContaining({
         mode: 'durable_record',
@@ -492,7 +493,7 @@ describe('employer action routes', () => {
       decision: 'PROCEED',
       metadata: expect.objectContaining({
         acceptanceScope: 'pilot',
-        acceptanceReason: 'Head start only',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
       }),
     }));
   });
@@ -623,6 +624,84 @@ describe('employer action routes', () => {
 
     expect(prismaMock.vcvEntity.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.auditEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('never serves private review notes on the anonymous acceptance-history read', async () => {
+    prismaMock.vcvEntity.findFirst.mockResolvedValue({
+      id: 'entity-1',
+      npi: '1234567890',
+    });
+    prismaMock.auditEvent.findMany.mockResolvedValue([
+      {
+        id: 'audit-accept-legacy',
+        createdAt: new Date('2026-03-23T18:00:00.000Z'),
+        metadata: {
+          employerReviewAction: {
+            action: 'accept',
+            employerId: 'employer-1',
+            entityId: 'entity-1',
+            clinicianNpi: '1234567890',
+            requestId: 'req-accept-legacy',
+            attribution: {
+              source: 'organization_context',
+              organizationContextId: 'ctx-1',
+              bundleShareEventId: null,
+              bundleId: null,
+              requestorEntityId: 'org-entity-1',
+              organizationId: 'org-entity-1',
+              organizationName: 'Providence',
+              purposeOfUse: 'Employment review',
+            },
+            persistence: {
+              mode: 'durable_record',
+              target: 'employer_acceptance',
+              acceptanceId: 'accept-legacy',
+              reviewItemId: null,
+              outboxEventId: 'outbox-1',
+              reviewItemCreated: false,
+            },
+            summary: {
+              title: 'Head start accepted',
+              description: 'The employer acceptance was persisted and linked to an audit event.',
+            },
+            details: {
+              staleSources: [],
+              missingDomains: [],
+              reason: null,
+              priority: null,
+            },
+            context: {
+              role: 'Hospitalist',
+              facility: 'Main campus',
+              // Old write path copied these notes into acceptanceReason.
+              notes: 'Salary band flexible for this candidate — internal only.',
+            },
+            acceptance: {
+              acceptedByOrgId: 'org-entity-1',
+              acceptedAt: '2026-03-23T18:00:00.000Z',
+              acceptanceScope: 'pilot',
+              acceptanceReason: 'Salary band flexible for this candidate — internal only.',
+            },
+          },
+        },
+      },
+    ]);
+
+    // No x-clerk-user-id, no x-org-id: this is the anonymous /verify/[npi] read.
+    const response = await request(buildApp())
+      .get('/api/employer-review/1234567890/acceptance-history')
+      .expect(200);
+
+    expect(response.body.history).toEqual([
+      expect.objectContaining({
+        acceptanceId: 'accept-legacy',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      }),
+    ]);
+    const serialized = JSON.stringify(response.body);
+    expect(serialized).not.toContain('Salary band flexible');
+    expect(serialized).not.toContain('Hospitalist');
+    expect(serialized).not.toContain('Main campus');
   });
 
   it('persists refresh requests through the outbox and normalizes the refresh payload', async () => {

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -571,7 +571,8 @@ describe('employer action routes', () => {
           acceptanceId: 'accept-1',
           orgLabel: 'Pilot organization 1',
           isAnonymized: true,
-          acceptedByOrgId: 'org-entity-1',
+          // Raw org id withheld whenever the label is anonymized.
+          acceptedByOrgId: null,
           acceptedAt: '2026-03-23T18:00:00.000Z',
           acceptanceScope: 'pilot',
           acceptanceReason: 'Accepted as head start using VitalCV verification.',
@@ -696,12 +697,14 @@ describe('employer action routes', () => {
       expect.objectContaining({
         acceptanceId: 'accept-legacy',
         acceptanceReason: 'Accepted as head start using VitalCV verification.',
+        acceptedByOrgId: null,
       }),
     ]);
     const serialized = JSON.stringify(response.body);
     expect(serialized).not.toContain('Salary band flexible');
     expect(serialized).not.toContain('Hospitalist');
     expect(serialized).not.toContain('Main campus');
+    expect(serialized).not.toContain('org-entity-1');
   });
 
   it('persists refresh requests through the outbox and normalizes the refresh payload', async () => {

--- a/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
@@ -340,9 +340,11 @@ describe('employerReviewActions service', () => {
       acceptanceId: string;
       notes: string;
       acceptanceReason?: string;
+      acceptanceScope?: string;
+      acceptedAt?: string;
     }) => ({
       id: input.id,
-      createdAt: new Date('2026-03-23T18:00:00.000Z'),
+      createdAt: new Date(input.acceptedAt ?? '2026-03-23T18:00:00.000Z'),
       metadata: {
         employerReviewAction: {
           action: 'accept',
@@ -385,8 +387,8 @@ describe('employerReviewActions service', () => {
           },
           acceptance: {
             acceptedByOrgId: 'org-entity-1',
-            acceptedAt: '2026-03-23T18:00:00.000Z',
-            acceptanceScope: 'pilot',
+            acceptedAt: input.acceptedAt ?? '2026-03-23T18:00:00.000Z',
+            acceptanceScope: input.acceptanceScope ?? 'pilot',
             ...(input.acceptanceReason !== undefined
               ? { acceptanceReason: input.acceptanceReason }
               : {}),
@@ -409,8 +411,18 @@ describe('employerReviewActions service', () => {
       acceptanceId: 'accept-absent',
       notes: 'Budget approved internally.',
     });
+    // Named, non-pilot acceptance: org identity is deliberately public, so the
+    // org id stays. Anonymized entries above must ship acceptedByOrgId: null.
+    const namedScope = buildAcceptanceEvent({
+      id: 'audit-named',
+      acceptanceId: 'accept-named',
+      notes: 'Panel review complete.',
+      acceptanceReason: 'Accepted for full credentialing head start.',
+      acceptanceScope: 'full',
+      acceptedAt: '2026-03-25T18:00:00.000Z',
+    });
 
-    prismaMock.auditEvent.findMany.mockResolvedValue([legacyNotesCopy, reasonAbsent]);
+    prismaMock.auditEvent.findMany.mockResolvedValue([legacyNotesCopy, reasonAbsent, namedScope]);
 
     const history = await loadEmployerAcceptanceHistory({
       entityId: 'entity-1',
@@ -419,18 +431,28 @@ describe('employerReviewActions service', () => {
 
     expect(history.history).toEqual([
       expect.objectContaining({
+        acceptanceId: 'accept-named',
+        orgLabel: 'First Org',
+        isAnonymized: false,
+        acceptedByOrgId: 'org-entity-1',
+        acceptanceReason: 'Accepted for full credentialing head start.',
+      }),
+      expect.objectContaining({
         acceptanceId: 'accept-legacy',
         acceptanceReason: 'Accepted as head start using VitalCV verification.',
+        acceptedByOrgId: null,
       }),
       expect.objectContaining({
         acceptanceId: 'accept-absent',
         acceptanceReason: null,
+        acceptedByOrgId: null,
       }),
     ]);
 
     const serialized = JSON.stringify(history);
     expect(serialized).not.toContain('Great culture fit');
     expect(serialized).not.toContain('Budget approved internally');
+    expect(serialized).not.toContain('Panel review complete');
   });
 
   it('persists bundle fallback attribution onto acceptance audit events using the canonical organization context', async () => {

--- a/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
+++ b/apps/api/backend/src/services/entity/__tests__/employerReviewActions.test.ts
@@ -309,6 +309,130 @@ describe('employerReviewActions service', () => {
     ]);
   });
 
+  it('never copies private review notes into the stored acceptance reason', async () => {
+    await recordEmployerReviewAcceptance({
+      entityId: 'entity-1',
+      employerId: 'employer-1',
+      clinicianNpi: '1234567890',
+      organizationContextId: 'ctx-1',
+      notes: 'Internal fit assessment — do not circulate.',
+    });
+
+    expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        metadata: expect.objectContaining({
+          employerReviewAction: expect.objectContaining({
+            acceptance: expect.objectContaining({
+              acceptanceReason: 'Accepted as head start using VitalCV verification.',
+            }),
+            context: expect.objectContaining({
+              notes: 'Internal fit assessment — do not circulate.',
+            }),
+          }),
+        }),
+      }),
+    }));
+  });
+
+  it('suppresses private notes from the public acceptance history read', async () => {
+    const buildAcceptanceEvent = (input: {
+      id: string;
+      acceptanceId: string;
+      notes: string;
+      acceptanceReason?: string;
+    }) => ({
+      id: input.id,
+      createdAt: new Date('2026-03-23T18:00:00.000Z'),
+      metadata: {
+        employerReviewAction: {
+          action: 'accept',
+          employerId: 'employer-1',
+          entityId: 'entity-1',
+          clinicianNpi: '1234567890',
+          requestId: `req-${input.id}`,
+          attribution: {
+            source: 'organization_context',
+            organizationContextId: 'ctx-1',
+            bundleShareEventId: null,
+            bundleId: null,
+            requestorEntityId: 'org-entity-1',
+            organizationId: 'org-entity-1',
+            organizationName: 'First Org',
+            purposeOfUse: 'Employment review',
+          },
+          persistence: {
+            mode: 'durable_record',
+            target: 'employer_acceptance',
+            acceptanceId: input.acceptanceId,
+            reviewItemId: null,
+            outboxEventId: null,
+            reviewItemCreated: false,
+          },
+          summary: {
+            title: 'Head start accepted',
+            description: 'The employer acceptance was persisted and linked to an audit event.',
+          },
+          details: {
+            staleSources: [],
+            missingDomains: [],
+            reason: null,
+            priority: null,
+          },
+          context: {
+            role: null,
+            facility: null,
+            notes: input.notes,
+          },
+          acceptance: {
+            acceptedByOrgId: 'org-entity-1',
+            acceptedAt: '2026-03-23T18:00:00.000Z',
+            acceptanceScope: 'pilot',
+            ...(input.acceptanceReason !== undefined
+              ? { acceptanceReason: input.acceptanceReason }
+              : {}),
+          },
+        },
+      },
+    });
+
+    // Legacy record: the old write path copied context.notes into
+    // acceptanceReason when the employer gave no explicit reason.
+    const legacyNotesCopy = buildAcceptanceEvent({
+      id: 'audit-legacy',
+      acceptanceId: 'accept-legacy',
+      notes: 'Great culture fit — internal only.',
+      acceptanceReason: 'Great culture fit — internal only.',
+    });
+    // Record with no stored reason at all: history must not fall back to notes.
+    const reasonAbsent = buildAcceptanceEvent({
+      id: 'audit-absent',
+      acceptanceId: 'accept-absent',
+      notes: 'Budget approved internally.',
+    });
+
+    prismaMock.auditEvent.findMany.mockResolvedValue([legacyNotesCopy, reasonAbsent]);
+
+    const history = await loadEmployerAcceptanceHistory({
+      entityId: 'entity-1',
+      clinicianNpi: '1234567890',
+    });
+
+    expect(history.history).toEqual([
+      expect.objectContaining({
+        acceptanceId: 'accept-legacy',
+        acceptanceReason: 'Accepted as head start using VitalCV verification.',
+      }),
+      expect.objectContaining({
+        acceptanceId: 'accept-absent',
+        acceptanceReason: null,
+      }),
+    ]);
+
+    const serialized = JSON.stringify(history);
+    expect(serialized).not.toContain('Great culture fit');
+    expect(serialized).not.toContain('Budget approved internally');
+  });
+
   it('persists bundle fallback attribution onto acceptance audit events using the canonical organization context', async () => {
     const state = await recordEmployerReviewAcceptance({
       entityId: 'entity-1',

--- a/apps/api/backend/src/services/entity/employerReviewActions.ts
+++ b/apps/api/backend/src/services/entity/employerReviewActions.ts
@@ -1353,7 +1353,10 @@ export async function loadEmployerAcceptanceHistory(input: {
       acceptanceId: entry.acceptanceId,
       orgLabel: org.orgLabel,
       isAnonymized: org.isAnonymized,
-      acceptedByOrgId: entry.acceptedByOrgId,
+      // An anonymized label with the raw org id beside it would defeat the
+      // anonymization on this anonymous read; the id ships only when the
+      // organization is already named.
+      acceptedByOrgId: org.isAnonymized ? null : entry.acceptedByOrgId,
       acceptedAt: entry.acceptedAt,
       acceptanceScope: entry.acceptanceScope,
       acceptanceReason: entry.acceptanceReason,

--- a/apps/api/backend/src/services/entity/employerReviewActions.ts
+++ b/apps/api/backend/src/services/entity/employerReviewActions.ts
@@ -35,6 +35,14 @@ export type EmployerReviewPersistenceTarget =
   | 'audit_event';
 export type EmployerAcceptanceScope = 'pilot' | 'full' | 'partial';
 
+/**
+ * Canonical public copy for an acceptance with no employer-provided reason.
+ * Private review notes (context.notes) must never stand in for it: the
+ * acceptance record feeds the anonymous acceptance-history read that renders
+ * on /verify/[npi] and /holder/recognition.
+ */
+export const DEFAULT_ACCEPTANCE_REASON = 'Accepted as head start using VitalCV verification.';
+
 export interface EmployerReviewAcceptanceRecord {
   acceptedByOrgId: string | null;
   acceptedAt: string;
@@ -853,8 +861,7 @@ export async function recordEmployerReviewAcceptance(input: {
     acceptanceScope: normalizeAcceptanceScope(input.acceptanceScope),
     acceptanceReason:
       sanitizeString(input.acceptanceReason, 280)
-      ?? context.notes
-      ?? 'Accepted as head start using VitalCV verification.',
+      ?? DEFAULT_ACCEPTANCE_REASON,
   };
 
   // ── Capture trust snapshot BEFORE transaction — immutable audit record ──
@@ -1262,6 +1269,26 @@ export async function loadEmployerReviewStatus(input: {
   return null;
 }
 
+/**
+ * Acceptance reason as served on the anonymous acceptance-history read.
+ * Records written before the write path stopped copying context.notes into
+ * acceptanceReason may still carry the private note — when the stored reason
+ * matches the note it is suppressed and the canonical copy served instead.
+ */
+function publicAcceptanceReason(metadata: EmployerReviewActionAuditMetadata): string | null {
+  const storedReason = metadata.acceptance?.acceptanceReason ?? null;
+  if (storedReason === null) {
+    return null;
+  }
+
+  const privateNotes = metadata.context.notes ?? null;
+  if (privateNotes !== null && storedReason === privateNotes) {
+    return DEFAULT_ACCEPTANCE_REASON;
+  }
+
+  return storedReason;
+}
+
 export async function loadEmployerAcceptanceHistory(input: {
   entityId: string;
   clinicianNpi: string;
@@ -1302,10 +1329,7 @@ export async function loadEmployerAcceptanceHistory(input: {
       acceptedByOrgId,
       acceptedAt,
       acceptanceScope,
-      acceptanceReason:
-        metadata.acceptance?.acceptanceReason
-        ?? metadata.context.notes
-        ?? null,
+      acceptanceReason: publicAcceptanceReason(metadata),
     }];
   }).sort((left, right) => Date.parse(right.acceptedAt) - Date.parse(left.acceptedAt));
 

--- a/docs/product/public-verifier-authz-map.md
+++ b/docs/product/public-verifier-authz-map.md
@@ -111,10 +111,12 @@ Residual exposures documented as **follow-ups, deliberately not expanded or chan
   dictionary-attackable for low-entropy values (statuses, dates, license/DEA numbers). #490
   accepted the redacted bundle as-is; salting the digests is the right follow-up before any
   further widening of digest exposure.
-- `acceptedByOrgId` (opaque org id) and `acceptanceId` (internal record id) remain in the
-  acceptance-history payload — consumed by holder Recognition evidence surfaces
-  (`lib/recognition/acceptance-evidence.ts`); removing them requires a split public/holder
-  payload. Org display exposure is already governed by the anonymization rule.
+- `acceptedByOrgId` is now **withheld (`null`) whenever the org label is anonymized** — a raw
+  org id beside "Pilot organization N" defeated the anonymization (flagged by the Codex
+  implementation audit; fixed in this wave). It still ships for named, non-pilot acceptances,
+  where org identity is deliberately public; holder Recognition evidence
+  (`lib/recognition/acceptance-evidence.ts`) guards on its presence and degrades gracefully.
+  `acceptanceId` (internal record id) remains as the stable entry key.
 - The backend trusts identity headers (`x-clerk-user-id`, `x-org-id`) set by the web tier;
   `api.vitalcv.com` is directly reachable, so header-attributed (non-anonymous) reads such as
   `/api/employer-review/:id/status` and `/packet` rely on that platform-wide W1300-era model.
@@ -164,11 +166,14 @@ closed, zero PHI on-chain, no banned strings, no bare "Verified" label.
 - `services/entity/__tests__/employerReviewActions.test.ts` —
   write path never copies notes into the stored acceptance reason (notes still persisted for
   org-scoped reads); history read suppresses legacy notes-copies (canonical copy served) and
-  serves `null` (not notes) when no reason was stored; serialized history contains no note text.
+  serves `null` (not notes) when no reason was stored; anonymized entries carry
+  `acceptedByOrgId: null` while named non-pilot entries keep the org id; serialized history
+  contains no note text.
 - `routes/__tests__/employerActions.test.ts` — **anonymous** (no `x-clerk-user-id`, no
   `x-org-id`) NPI-keyed acceptance-history request returns 200 with the canonical copy and the
-  serialized response contains no note/role/facility text; pre-existing tests pin the unknown-NPI
-  404 (no data reflection) and the NPI-format guard against UUID lookups.
+  serialized response contains no note/role/facility text and no raw org id on anonymized
+  entries; pre-existing tests pin the unknown-NPI 404 (no data reflection) and the NPI-format
+  guard against UUID lookups.
 - `middleware/__tests__/tenantGuard.test.ts` — skip-list pins for
   `/api/passport/npi/:npi` and `/api/employer-review/:npi/acceptance-history` (new), for
   `/api/trust-proof/:npi` (#490), and the anonymous-401 pin for protected routes (existing).

--- a/docs/product/public-verifier-authz-map.md
+++ b/docs/product/public-verifier-authz-map.md
@@ -181,11 +181,12 @@ closed, zero PHI on-chain, no banned strings, no bare "Verified" label.
 
 ## 9. Rollback plan
 
-- This wave's change is a **single additive commit**: one service-file fix (three edits), test
-  additions, and this document. No schema changes, no migrations, no config or env changes, no
-  route additions/removals, no tenant-guard changes.
-- **Rollback:** `git revert` of the wave commit restores the previous read/write fallback
-  behavior exactly. Nothing else depends on the new constant or helper.
+- This wave's change is **additive only**: one service-file fix (notes suppression + org-id
+  withholding), test additions, and this document — a short series of commits on the PR branch,
+  landing on `main` as a single squash-merge commit. No schema changes, no migrations, no config
+  or env changes, no route additions/removals, no tenant-guard changes.
+- **Rollback:** `git revert` of the squash-merge commit on `main` restores the previous
+  read/write fallback behavior exactly. Nothing else depends on the new constant or helper.
 - The fix only narrows what the public read serves; org-gated surfaces are untouched, so
   rollback cannot widen or narrow organizational access. The tenant-guard pins added here keep
   protecting `/api/trust-proof` and companions independently of rollback.

--- a/docs/product/public-verifier-authz-map.md
+++ b/docs/product/public-verifier-authz-map.md
@@ -1,0 +1,189 @@
+# Public Verifier Authorization Map — Epic Wave 2C
+
+**Status:** authoritative map of the public verification path (`/verify/[npi]`) and its
+authorization model, produced for Epic Wave 2C (Identity + Public Verifier Repair).
+**Risk tier:** Tier 2 — external review (Codex) or explicit Chris override required before merge.
+
+Wave 2C was dispatched against a production finding ("`/api/trust-proof/:npi` returns
+`401 organization_context_required` for all NPIs, blocking `/verify/[npi]`"). Mapping
+established that **PR #490 (`ddf9c0141`, merged 2026-07-02) already repaired that finding and
+the fix is live in production** (verified by direct probes, §2–§3). The remaining Wave 2C work
+delivered here: this map, one further private-data leak found during mapping and fixed
+(employer review notes served on the anonymous acceptance-history read, §5), and the test
+coverage the wave requires (§8).
+
+---
+
+## 1. Current `/verify/[npi]` route behavior
+
+File: `apps/web/app/verify/[npi]/page.tsx`
+
+- Public Next.js **server component** (`force-dynamic`), no auth required, the share target for
+  Recognition (Recognition Elevation, PRs #484–#488).
+- Fetches two anonymous backend reads (server-side, `Accept: application/json`, 60s revalidate):
+  1. `${BACKEND}/api/passport/npi/:npi` — the `PassportData` contract the page renders
+     (identity, source-coverage lanes, readiness summary). Chosen by #490; the page previously
+     pointed at `/api/trust-proof/:npi`, whose `TrustProofBundle` never matched the page's
+     contract (Defect B in the wave dispatch's terms).
+  2. `${BACKEND}/api/employer-review/:npi/acceptance-history` — Recognition (employer
+     acceptances), NPI-keyed, anonymization-aware org labels.
+- Renders: verdict bar, identity hero, source-coverage lanes, **employer acceptances
+  (Recognition)**, receipt pane, issuer continuity, replay chronology. Failed fetches render a
+  NotFound / system state — never fabricated data.
+- **Production verification (2026-07-02):** `https://vitalcv.com/verify/1234567890` renders the
+  full verifier view anonymously (verdict "Partial coverage", "2 of 4 sources confirmed",
+  source lanes, acceptances section). The wave-dispatch symptom (NotFound for every NPI) is no
+  longer reproducible.
+
+## 2. Current `/api/trust-proof/:npi` behavior
+
+- **Backend** (`apps/api/backend/src/routes/trustProof.ts`, Wave 252): 10-digit NPI validation →
+  `buildTrustProofBundle(npi)` → JSON or PDF. `proofRateLimit`-guarded. The bundle is
+  redacted by design: claims appear only as `claimType` + sha-256 digest (+ optional Merkle
+  path); `credentialClaims.redacted: true`; raw payloads are never serialized.
+- **Authorization:** public read since #490 added `/api/trust-proof/` to the tenant-guard skip
+  list — deliberately, alongside its sibling verifier reads (`/api/trust-state/`,
+  `/api/trust-decision/`). The Wave 251 public profile (`/api/public/profile/npi/:npi`) links to
+  it as the public proof download, and the command-palette PDF download proxies it.
+- **Web proxy** (`apps/web/app/api/trust-proof/[npi]/route.ts`): pass-through, forwards no auth.
+- **Production verification (2026-07-02):** `https://api.vitalcv.com/api/trust-proof/1234567890`
+  returns `200` with the redacted bundle, anonymously.
+
+## 3. The authz gate that caused the original 401 (repaired by #490)
+
+- `apps/api/backend/src/app.ts` mounts `app.use(requireTenantContextOrReadAccess)` (W1300
+  tenant guard) ahead of route registration. Any path not matched by
+  `shouldSkipTenantContext()`'s explicit public prefix list falls through to
+  `requireTenantContext`, which resolves org context from the `x-org-id` header or JWT
+  org/tenant claims (`middleware/organizationContext.ts`) and answers
+  `401 { error: 'organization_context_required' }` when absent.
+- Wave 252 registered `/api/trust-proof/:npi` without adding it to the skip list, so anonymous
+  verifier traffic 401'd. **Root cause was a skip-list omission, not an access decision.**
+  PR #490 added the missing entry (`tenantGuard.ts`) with regression tests pinning both the
+  skip-list entry and the anonymous pass-through.
+
+## 4. Data safe for public verification (what the path serves today)
+
+Only fields that are public record, deliberately-public product surface, or non-reversible
+commitments:
+
+| Field | Basis |
+| --- | --- |
+| NPI | Public identifier (NPPES). |
+| Clinician display name, specialty, provider type | NPPES public registry data. |
+| Recognition summary: accepted-organization count, org labels (real name only for named non-pilot scopes; otherwise "Pilot organization N"), `acceptedAt`, acceptance scope, canonical acceptance copy | Anonymization applied in `loadEmployerAcceptanceHistory` / `buildAcceptanceHistoryOrgLabel`. |
+| Readiness summary: band, status label, score, blockers/gaps as generic phrases, `computedAt` | Same summary Wave 251 serves on the public profile. |
+| Per-source coverage: source label, canonical state (checked / stale / pending / gated / unavailable / review_required), `checkedAt`, source URL | Source-coverage honesty; revoked/suspended stays visible (fails closed, never hidden). |
+| Restricted credential entries | Label + issuer replaced by `"Restricted credential"` / `"Restricted"` at build time (`routes/passport.ts` `inferName`/`inferIssuer`) — redaction is unconditional, not viewer-dependent. |
+| Verification timestamps (`lastCheckedAt`, snapshot `verifiedAt`) | Freshness honesty. |
+| Proof commitments: bundle hash, artifact hashes, claim digests, Merkle roots/paths, snapshot checksum | Non-reversible commitments (see §5 caveat on digest salting). |
+
+## 5. Data that must remain private — and the leak this wave fixed
+
+Must never appear on anonymous surfaces: raw artifact payloads / uploaded documents, employer
+review notes, private organization context, sanctions match detail (wallet-mode only), scoring
+internals beyond the readiness summary, user PII beyond public professional identity.
+
+**Leak found during mapping (fixed in this wave):** employer free-text review notes reached the
+fully public acceptance-history read — rendered on `/verify/[npi]` ("Employer acceptances"
+section) and `/holder/recognition` — through two paths in
+`apps/api/backend/src/services/entity/employerReviewActions.ts`:
+
+1. **Write path:** `recordEmployerReviewAcceptance` stored
+   `acceptanceReason: input.acceptanceReason ?? context.notes ?? <canonical copy>` — when the
+   employer gave no explicit reason but typed private notes (sanitized 500 chars), the notes
+   were persisted into the acceptance record's public-facing reason field.
+2. **Read path:** `loadEmployerAcceptanceHistory` served
+   `acceptanceReason ?? metadata.context.notes ?? null` — falling back to private notes even
+   for records that never copied them.
+
+**Fix (this wave):** the write path now falls back only to the canonical copy
+(`DEFAULT_ACCEPTANCE_REASON`); the read path never touches `context.notes` and additionally
+suppresses legacy records whose stored reason equals the private note (serving the canonical
+copy instead — fails closed). Notes remain stored in `context.notes` for the org-scoped
+review-state reads, which require employer attribution. Regression tests cover both paths and
+the anonymous route (§8).
+
+Residual exposures documented as **follow-ups, deliberately not expanded or changed here**:
+
+- `hashClaim` (`utils/claimHash.ts`) is **unsalted** `sha256("type:value")`. Public claim
+  digests (trust-proof bundle `claims[]`, public-profile `claimHashes[]`) are therefore
+  dictionary-attackable for low-entropy values (statuses, dates, license/DEA numbers). #490
+  accepted the redacted bundle as-is; salting the digests is the right follow-up before any
+  further widening of digest exposure.
+- `acceptedByOrgId` (opaque org id) and `acceptanceId` (internal record id) remain in the
+  acceptance-history payload — consumed by holder Recognition evidence surfaces
+  (`lib/recognition/acceptance-evidence.ts`); removing them requires a split public/holder
+  payload. Org display exposure is already governed by the anonymization rule.
+- The backend trusts identity headers (`x-clerk-user-id`, `x-org-id`) set by the web tier;
+  `api.vitalcv.com` is directly reachable, so header-attributed (non-anonymous) reads such as
+  `/api/employer-review/:id/status` and `/packet` rely on that platform-wide W1300-era model.
+  Unchanged here; belongs to a dedicated authn hardening wave.
+- `/api/passport/npi/:npi` and `/api/employer-review/:id/acceptance-history` carry **no rate
+  limit** (unlike `proofRateLimit` on trust-proof, `publicApiRateLimit` on the public profile).
+  Deliberately not added in this wave: the current limiter keys on the caller and these reads
+  are fetched server-side by the Next.js web tier, so every visitor shares the web egress
+  identity — a naive limit would throttle the whole public verifier surface. Needs
+  client-IP-forwarding keying first.
+
+## 6. Existing proof / packet / passport / share surfaces
+
+| Surface | Access today |
+| --- | --- |
+| `/verify/[npi]` page | Public; the Recognition share target. |
+| `/api/passport/npi/:npi` (passportEntity.ts) | Public ("value before login"), unconditional restricted-label redaction. |
+| `/api/passport/:npi` (+ `/trust`, `/disclose`, `/embed.svg`, `/card.json`) | Public **mode** by default (redacted); wallet mode gated by token; permissive `authMiddleware` tags but never blocks. |
+| `/api/trust-proof/:npi` (Wave 252) | Public since #490; redacted bundle; `proofRateLimit`. |
+| `/api/public/profile/npi/:npi` (Wave 251) | Public, `publicApiRateLimit`, redacted profile; links to trust-proof downloads. |
+| `/api/artifact/bundle/:npi` | Public by skip-list prefix (audit bundle). |
+| `/api/employer-review/:id/acceptance-history` | Public read, NPI- or entity-keyed, anonymization-aware; **notes leak fixed in this wave**. |
+| `/api/employer-review/:id/status`, `/packet` | Header-attributed employer reads (see §5 header-trust caveat). |
+| `/api/employer-review/share-token/:token` | Capability-token-gated packet share. |
+| `/verify/receipt`, `/api/receipts/verify`, `/api/replay/runs/*` | Public receipt/replay verification surfaces. |
+| Wallet passport mode, employer packet export, audit-bundle exports with org context | Authenticated / org-scoped; unchanged. |
+
+## 7. Authorization model (minimal, as it stands after this wave)
+
+1. **Public verification tier** — anonymous, read-only, allowlist-shaped surfaces enumerated in
+   §6: the `/verify/[npi]` page and the reads it composes. Public paths are governed by exactly
+   one mechanism: the tenant-guard skip list (`shouldSkipTenantContext`), pinned by tests. No
+   header-based bypasses, no viewer-conditional payloads on anonymous routes; redaction and
+   anonymization are applied unconditionally at build time.
+2. **Holder tier** — authenticated clinician (wallet passport mode, holder surfaces). Unchanged.
+3. **Organization tier** — org context (`x-org-id` / JWT claims) required by
+   `requireTenantContext` for everything outside the skip list; org-scoped data additionally
+   guarded by `enforceOrganizationMatch`. Unchanged — pinned by tests
+   (`/api/clinician/activate` still answers 401 `organization_context_required` anonymously).
+
+Invariants preserved: audit-first mutation rule (all changed code paths are reads except the
+acceptance write, which already writes its audit event), source-coverage honesty, revoked fails
+closed, zero PHI on-chain, no banned strings, no bare "Verified" label.
+
+## 8. Tests delivered with this wave
+
+- `services/entity/__tests__/employerReviewActions.test.ts` —
+  write path never copies notes into the stored acceptance reason (notes still persisted for
+  org-scoped reads); history read suppresses legacy notes-copies (canonical copy served) and
+  serves `null` (not notes) when no reason was stored; serialized history contains no note text.
+- `routes/__tests__/employerActions.test.ts` — **anonymous** (no `x-clerk-user-id`, no
+  `x-org-id`) NPI-keyed acceptance-history request returns 200 with the canonical copy and the
+  serialized response contains no note/role/facility text; pre-existing tests pin the unknown-NPI
+  404 (no data reflection) and the NPI-format guard against UUID lookups.
+- `middleware/__tests__/tenantGuard.test.ts` — skip-list pins for
+  `/api/passport/npi/:npi` and `/api/employer-review/:npi/acceptance-history` (new), for
+  `/api/trust-proof/:npi` (#490), and the anonymous-401 pin for protected routes (existing).
+- Production probes (2026-07-02, recorded in §1–§2) confirm the deployed path end-to-end.
+
+## 9. Rollback plan
+
+- This wave's change is a **single additive commit**: one service-file fix (three edits), test
+  additions, and this document. No schema changes, no migrations, no config or env changes, no
+  route additions/removals, no tenant-guard changes.
+- **Rollback:** `git revert` of the wave commit restores the previous read/write fallback
+  behavior exactly. Nothing else depends on the new constant or helper.
+- The fix only narrows what the public read serves; org-gated surfaces are untouched, so
+  rollback cannot widen or narrow organizational access. The tenant-guard pins added here keep
+  protecting `/api/trust-proof` and companions independently of rollback.
+- If a regression were suspected in production, the acceptance-history read degrades safely:
+  `/verify/[npi]` renders its "system state" fallback when the endpoint errors, without
+  affecting the rest of the verifier page.


### PR DESCRIPTION
## Epic Wave 2C — Identity + Public Verifier Repair

**Risk tier: 2** — external review (Codex) required before merge.

### What the mapping established

The wave was dispatched against a production finding: `/api/trust-proof/:npi` answering `401 organization_context_required` for all NPIs, blocking `/verify/[npi]`. Mapping (committed as [docs/product/public-verifier-authz-map.md](docs/product/public-verifier-authz-map.md)) established:

- **PR #490 already repaired that finding** (tenant-guard skip-list entry + pointing the page at `/api/passport/npi/:npi`, the endpoint that actually serves the page's `PassportData` contract) — and the fix is **live in production**: `api.vitalcv.com/api/trust-proof/1234567890` → 200 redacted bundle, `vitalcv.com/verify/1234567890` renders the full verifier view anonymously, Recognition section included (probes recorded in the map, 2026-07-02).
- Two further private-data violations remained on the anonymous acceptance-history read; this PR fixes both.

### The leaks this PR fixes

The acceptance-history read is fully anonymous (skip-listed prefix) and renders on `/verify/[npi]` ("Employer acceptances") and `/holder/recognition`.

**1. Employer free-text review notes** reached the payload via two paths in `employerReviewActions.ts`:
- *Write path* — `acceptanceReason: input.acceptanceReason ?? context.notes ?? <canonical copy>`: with no explicit reason, private notes (≤500 chars) were persisted into the acceptance record's public-facing reason.
- *Read path* — `loadEmployerAcceptanceHistory` served `acceptanceReason ?? metadata.context.notes ?? null`.

Fix: both paths stop at the canonical copy (`DEFAULT_ACCEPTANCE_REASON`); the read also suppresses legacy records whose stored reason equals the private note (fails closed to the canonical copy). Notes stay in `context.notes` for the employer-attributed review-state reads.

**2. Raw org id beside the anonymized label** (flagged by the Codex round-1 implementation audit): entries labeled "Pilot organization N" still carried `acceptedByOrgId`, defeating the anonymization. Fix: the id is withheld (`null`) whenever the label is anonymized and ships only for named non-pilot acceptances, where org identity is deliberately public. Holder Recognition evidence guards on presence and degrades gracefully.

No route, schema, or guard changes.

### Required wave outputs

1. **Authz map** — `docs/product/public-verifier-authz-map.md` (current behavior, the original 401 gate, safe-public vs must-stay-private data, all proof/packet/passport/share surfaces, the three-tier authorization model, follow-ups: unsalted claim digests, header-trust model, rate-limit keying).
2. **Route/API change** — the minimal fixes above; #490's repair documented and production-verified rather than re-done.
3. **Tests** (41/41 across the three touched suites):
   - *Public verifier works:* anonymous NPI-keyed acceptance-history route test (no `x-clerk-user-id`, no `x-org-id`) → 200; tenant-guard pins for `/api/passport/npi/:npi`, `/api/employer-review/:npi/acceptance-history`, `/api/trust-proof/:npi`.
   - *Private data not leaked:* serialized anonymous response asserted to contain no note/role/facility text and no raw org id on anonymized entries; write path asserted to never copy notes into the stored reason; legacy notes-copies suppressed; removed fallback pinned (`null`, never notes); named non-pilot entries pin the deliberately-public org id.
   - *Org-only routes remain protected:* existing anonymous-401 pin (`organization_context_required`) unchanged and passing.
   - *Arbitrary IDs reveal nothing:* unknown-NPI 404 with no reflection + NPI-format guard pins (pre-existing, passing).
4. **Rollback plan** — two additive commits; `git revert` restores prior behavior exactly; no migrations/config/env changes; on endpoint error the page renders its system-state fallback (map §9).

### Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)