### PR TITLE
fix(apply): 404-gate /apply/[bundleId] for invalid bundle ids (Wave 2F)

### DIFF
--- a/apps/api/backend/src/services/distribution/applyBundle.ts
+++ b/apps/api/backend/src/services/distribution/applyBundle.ts
@@ -207,6 +207,17 @@ export async function generateApplyBundle(
   return bundle;
 }
 
+// ── Bundle id validation ──────────────────────────────────────────────────────
+
+// Bundle ids are randomUUID() values stored in VerificationArtifact.id, a
+// Postgres uuid column — querying it with a non-uuid string makes Prisma
+// throw (a 500) instead of returning null.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidBundleId(bundleId: string): boolean {
+  return UUID_RE.test(bundleId);
+}
+
 // ── Core: verify bundle ───────────────────────────────────────────────────────
 
 export async function verifyBundle(
@@ -214,6 +225,10 @@ export async function verifyBundle(
   signature: string,
 ): Promise<{ valid: boolean; bundle?: ApplyBundle }> {
   log('info', 'apply_bundle_verify', { bundleId });
+
+  if (!isValidBundleId(bundleId)) {
+    return { valid: false };
+  }
 
   const artifact = await prisma.verificationArtifact.findFirst({
     where: { id: bundleId, source: 'APPLY_BUNDLE' },
@@ -247,6 +262,7 @@ export async function verifyBundle(
 // ── Core: retrieve bundle by ID ───────────────────────────────────────────────
 
 export async function getApplyBundle(bundleId: string): Promise<ApplyBundle | null> {
+  if (!isValidBundleId(bundleId)) return null;
   const artifact = await prisma.verificationArtifact.findFirst({
     where: { id: bundleId, source: 'APPLY_BUNDLE' },
   });

--- a/apps/web/__tests__/apply-bundle-page.test.tsx
+++ b/apps/web/__tests__/apply-bundle-page.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * /apply/[bundleId] — invalid-id 404 gate (Wave 2F route-contract hardening).
+ *
+ * Production regression: /apply/x returned HTTP 500. Two causes:
+ *   1. A non-uuid bundleId reached the backend, whose Postgres uuid column
+ *      query throws → backend 500 → page fell into its 'error' branch.
+ *   2. The 'error' branch rendered a <button onClick> inside a server
+ *      component, crashing the RSC render into a 500 of its own.
+ *
+ * Contract: malformed or unresolvable bundle ids call notFound() (→ 404 via
+ * not-found.tsx) and never fetch; expired/error states render anchors only.
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+
+const notFoundMock = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+);
+
+vi.mock('next/navigation', () => ({
+  notFound: notFoundMock,
+}));
+
+vi.mock('@/components/apply/ApplyBundleView', () => ({
+  ApplyBundleView: ({ bundle }: { bundle: { bundleId: string } }) => (
+    <div data-testid="apply-bundle-view">{bundle.bundleId}</div>
+  ),
+}));
+
+import ApplyBundlePage from '../app/apply/[bundleId]/page';
+import ApplyBundleNotFound from '../app/apply/[bundleId]/not-found';
+import { isValidBundleId } from '../lib/apply/bundle-id';
+
+const VALID_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function renderPage(bundleId: string) {
+  return ApplyBundlePage({ params: Promise.resolve({ bundleId }) });
+}
+
+describe('isValidBundleId', () => {
+  it('accepts randomUUID-shaped ids', () => {
+    expect(isValidBundleId(VALID_ID)).toBe(true);
+    expect(isValidBundleId(VALID_ID.toUpperCase())).toBe(true);
+  });
+
+  it('rejects everything else', () => {
+    for (const bad of ['x', '', 'demo-001', '123e4567', `${VALID_ID}/extra`, '../../etc/passwd']) {
+      expect(isValidBundleId(bad)).toBe(false);
+    }
+  });
+});
+
+describe('/apply/[bundleId] — invalid-id path', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    notFoundMock.mockClear();
+  });
+
+  it('404s a malformed bundleId without hitting the backend', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(renderPage('x')).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('404s a well-formed bundleId the backend does not know', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 404 })));
+
+    await expect(renderPage(VALID_ID)).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the expired state (not a 404, not a crash) on backend 410', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 410 })));
+
+    const html = renderToStaticMarkup((await renderPage(VALID_ID)) as React.ReactElement);
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(html).toContain('This link has expired');
+  });
+
+  it('renders the anchor-only error state when the backend is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('backend down')));
+
+    const html = renderToStaticMarkup((await renderPage(VALID_ID)) as React.ReactElement);
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(html).toContain('Connection interrupted');
+    // Retry must be a plain anchor — a <button onClick> here is an RSC
+    // render crash (the original production 500).
+    expect(html).toContain(`href="/apply/${VALID_ID}"`);
+    expect(html).not.toContain('<button');
+  });
+
+  it('renders the bundle view for a resolvable bundle', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ bundleId: VALID_ID, expiresAt: '2999-01-01T00:00:00.000Z' }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const html = renderToStaticMarkup((await renderPage(VALID_ID)) as React.ReactElement);
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(html).toContain('data-testid="apply-bundle-view"');
+    expect(html).toContain(VALID_ID);
+  });
+});
+
+describe('/apply/[bundleId] — not-found boundary', () => {
+  it('renders contextual copy with a recovery path and no bundle data', () => {
+    const html = renderToStaticMarkup(<ApplyBundleNotFound />);
+    expect(html).toContain('Link not found');
+    expect(html).toContain('This link is invalid or has been revoked.');
+    expect(html).toContain('href="/passport"');
+  });
+});

--- a/apps/web/app/api/apply/bundle/[bundleId]/route.ts
+++ b/apps/web/app/api/apply/bundle/[bundleId]/route.ts
@@ -2,6 +2,7 @@
  * Wave 246: Apply-with-VitalCV — GET /api/apply/bundle/:bundleId proxy
  */
 import { NextRequest, NextResponse } from 'next/server';
+import { isValidBundleId } from '@/lib/apply/bundle-id';
 export const runtime = 'nodejs';
 
 const B =
@@ -15,6 +16,13 @@ export async function GET(
   { params }: { params: Promise<{ bundleId: string }> },
 ) {
   const { bundleId } = await params;
-  const res = await fetch(`${B}/api/apply/bundle/${bundleId}`);
-  return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
+  if (!isValidBundleId(bundleId)) {
+    return NextResponse.json({ error: 'Bundle not found.' }, { status: 404 });
+  }
+  try {
+    const res = await fetch(`${B}/api/apply/bundle/${bundleId}`);
+    return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'Upstream unavailable.' }, { status: 502 });
+  }
 }

--- a/apps/web/app/apply/[bundleId]/not-found.tsx
+++ b/apps/web/app/apply/[bundleId]/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+/**
+ * Contextual 404 for apply bundle links. Reached when the bundleId in the
+ * URL is malformed or doesn't resolve to a live bundle — most often a
+ * mistyped, revoked, or fabricated link. Must never render bundle data.
+ */
+export default function ApplyBundleNotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-ops-gradient px-4 text-foreground">
+      <div className="w-full max-w-sm text-center space-y-4">
+        <div className="text-5xl">🔍</div>
+        <h1 className="text-xl font-bold text-foreground">Link not found</h1>
+        <p className="text-sm text-muted-foreground">This link is invalid or has been revoked.</p>
+        <div className="flex flex-col gap-2 pt-2">
+          <Link
+            href="/passport"
+            className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-muted border border-border px-6 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+          >
+            Start a new NPI lookup
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/apply/[bundleId]/page.tsx
+++ b/apps/web/app/apply/[bundleId]/page.tsx
@@ -2,11 +2,15 @@
  * Wave 246: Apply-with-VitalCV — Public Bundle View Page
  *
  * Server component. Fetches the bundle from the backend and renders
- * ApplyBundleView. Shows an expiry/error message if the bundle is invalid.
+ * ApplyBundleView. Malformed or unresolvable bundle ids 404 via notFound()
+ * (see not-found.tsx); expired links and backend failures render
+ * contextual error states.
  */
 
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { ApplyBundleView } from '@/components/apply/ApplyBundleView';
+import { isValidBundleId } from '@/lib/apply/bundle-id';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -95,10 +99,17 @@ async function fetchBundle(bundleId: string): Promise<BundleResult> {
 
 export default async function ApplyBundlePage({ params }: Props) {
   const { bundleId } = await params;
+  if (!isValidBundleId(bundleId)) {
+    notFound();
+  }
+
   const result = await fetchBundle(bundleId);
 
   if (!result.ok) {
-    return <BundleErrorView reason={result.reason} />;
+    if (result.reason === 'not_found') {
+      notFound();
+    }
+    return <BundleErrorView reason={result.reason} retryHref={`/apply/${bundleId}`} />;
   }
 
   return <ApplyBundleView bundle={result.bundle} />;
@@ -106,7 +117,9 @@ export default async function ApplyBundlePage({ params }: Props) {
 
 // ── Error states ──────────────────────────────────────────────────────────────
 
-function BundleErrorView({ reason }: { reason: 'expired' | 'not_found' | 'error' }) {
+function BundleErrorView({ reason, retryHref }: { reason: 'expired' | 'error'; retryHref: string }) {
+  // This is a server component: anchors only, no event handlers. An onClick
+  // here crashes the RSC render and turns every error state into a 500.
   const messages = {
     expired: {
       emoji: '⏱',
@@ -117,21 +130,12 @@ function BundleErrorView({ reason }: { reason: 'expired' | 'not_found' | 'error'
       secondaryLabel: 'Start a new NPI lookup',
       secondaryHref: '/passport',
     },
-    not_found: {
-      emoji: '🔍',
-      title: 'Link not found',
-      body: 'This link is invalid or has been revoked.',
-      primaryLabel: 'Start a new NPI lookup',
-      primaryHref: '/passport',
-      secondaryLabel: null,
-      secondaryHref: null,
-    },
     error: {
       emoji: '⚠️',
       title: 'Connection interrupted',
       body: 'We could not load this passport right now. Try again in a moment.',
       primaryLabel: 'Try again',
-      primaryHref: null, // reload
+      primaryHref: retryHref,
       secondaryLabel: 'Start a new NPI lookup',
       secondaryHref: '/passport',
     },
@@ -146,29 +150,18 @@ function BundleErrorView({ reason }: { reason: 'expired' | 'not_found' | 'error'
         <h1 className="text-xl font-bold text-foreground">{msg.title}</h1>
         <p className="text-sm text-muted-foreground">{msg.body}</p>
         <div className="flex flex-col gap-2 pt-2">
-          {msg.primaryHref ? (
-            <a
-              href={msg.primaryHref}
-              className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-muted border border-border px-6 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
-            >
-              {msg.primaryLabel}
-            </a>
-          ) : (
-            <button
-              onClick={() => window.location.reload()}
-              className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-muted border border-border px-6 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
-            >
-              {msg.primaryLabel}
-            </button>
-          )}
-          {msg.secondaryHref && (
-            <a
-              href={msg.secondaryHref}
-              className="inline-flex h-11 w-full items-center justify-center rounded-xl border border-white/6 px-6 text-sm text-foreground/70 transition-colors hover:text-foreground"
-            >
-              {msg.secondaryLabel}
-            </a>
-          )}
+          <a
+            href={msg.primaryHref}
+            className="inline-flex h-11 w-full items-center justify-center rounded-xl bg-muted border border-border px-6 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+          >
+            {msg.primaryLabel}
+          </a>
+          <a
+            href={msg.secondaryHref}
+            className="inline-flex h-11 w-full items-center justify-center rounded-xl border border-white/6 px-6 text-sm text-foreground/70 transition-colors hover:text-foreground"
+          >
+            {msg.secondaryLabel}
+          </a>
         </div>
       </div>
     </div>

--- a/apps/web/lib/apply/bundle-id.ts
+++ b/apps/web/lib/apply/bundle-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Apply bundle id validation.
+ *
+ * Bundle ids are backend randomUUID() values stored in
+ * VerificationArtifact.id, a Postgres uuid column. A non-uuid id can never
+ * resolve — and querying the uuid column with one makes the backend throw —
+ * so malformed ids must be rejected before any fetch.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidBundleId(bundleId: string): boolean {
+  return UUID_RE.test(bundleId);
+}


### PR DESCRIPTION
## Problem

Production issue found during Wave 2F route-contract hardening: `https://vitalcv.com/apply/x` returns **HTTP 500** (unhandled error) instead of a 404 gate when the bundleId doesn't exist. Confirmed live before the fix: both `/apply/x` and `/api/apply/bundle/x` → 500.

Two stacked causes:

1. **Backend 500 instead of 404** — bundle ids are `randomUUID()` values stored in `VerificationArtifact.id`, a Postgres uuid column. Querying it with a non-uuid string (`x`) makes Prisma throw, so `GET /api/apply/bundle/x` 500ed.
2. **Page 500 on any backend failure** — the page's `error` branch rendered `<button onClick={() => window.location.reload()}>` inside a **server component**, which crashes the RSC render. So the backend 500 became a page 500.

## Fix (mirrors PR #478's demo-route 404 gates for `/activation/[caseId]` and `/dossier/[receiptId]`)

- `apps/web/lib/apply/bundle-id.ts` — `isValidBundleId()` uuid-shape validator shared by page and proxy route.
- `apps/web/app/apply/[bundleId]/page.tsx` — malformed ids `notFound()` **before any backend round-trip**; backend 404s also `notFound()`. Error states (`expired`, backend failure) render anchors only — no event handlers in the server component. "Try again" is now a link back to the same apply URL.
- `apps/web/app/apply/[bundleId]/not-found.tsx` — contextual 404 copy (invalid/revoked link → "Start a new NPI lookup" → `/passport`), modeled on `apps/web/app/holder/applications/[id]/not-found.tsx`.
- `apps/web/app/api/apply/bundle/[bundleId]/route.ts` — same uuid guard (404 for malformed ids without hitting upstream); upstream fetch failure now returns 502 instead of crashing the route.
- `apps/api/backend/src/services/distribution/applyBundle.ts` — `getApplyBundle`/`verifyBundle` return null/`{valid:false}` for non-uuid ids instead of letting Prisma throw (defense in depth for the direct backend endpoint).

## Tests

`apps/web/__tests__/apply-bundle-page.test.tsx` (8 tests, all passing):
- malformed id → `notFound()` called, **fetch never called**
- well-formed but unknown id (backend 404) → `notFound()`
- backend 410 → expired view (not a 404, not a crash)
- backend unreachable → anchor-only error view (no `<button` in markup — the original RSC crash vector)
- resolvable bundle → renders bundle view
- not-found boundary renders contextual copy + recovery link
- `isValidBundleId` accept/reject cases

Full web vitest suite: 32 pre-existing failures on main, unchanged by this PR (baseline-verified by stash-run). Lint clean on all touched files.

## Local verification (dev server)

```
/apply/x                                        404
/apply/demo-001                                 404
/apply/123e4567-e89b-42d3-a456-426614174000     200 (error view — backend down locally, no crash)
/api/apply/bundle/x                             404
```

## Post-deploy verification

```
curl -s -o /dev/null -w '%{http_code}' https://vitalcv.com/apply/x   # expect 404
```

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)