### PR TITLE
fix(api,web): 404-gate malformed uuid ids across public dynamic routes (Wave 2F follow-up)

### DIFF
--- a/apps/api/backend/src/routes/__tests__/applyShare.test.ts
+++ b/apps/api/backend/src/routes/__tests__/applyShare.test.ts
@@ -301,3 +301,20 @@ describe('NPI format validation', () => {
     expect(NPI_RE.test(npi)).toBe(false);
   });
 });
+
+// ── Malformed share id gate ───────────────────────────────────────────────────
+
+describe('revokeShare — malformed share id', () => {
+  it('rejects a non-uuid shareId before any database lookup', async () => {
+    // BundleShareEvent.id is a Postgres uuid column — an unguarded non-uuid
+    // string makes Prisma throw (a 500) instead of returning null. The guard
+    // must fail closed with the same "not found" validation error, without a
+    // live database in the loop.
+    const { revokeShare } = await import('../../services/distribution/applyShareService');
+
+    for (const bad of ['x', 'not-a-uuid', '../../etc/passwd', '550e8400-e29b-41d4-a716']) {
+      await expect(revokeShare(bad, 'user_123')).rejects.toThrow(ShareValidationError);
+      await expect(revokeShare(bad, 'user_123')).rejects.toThrow('Share not found.');
+    }
+  });
+});

--- a/apps/api/backend/src/routes/__tests__/employerActions.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerActions.test.ts
@@ -174,7 +174,7 @@ function buildPacketFixture() {
     schema: 'vitalcv.employer.packet.v1',
     exportedAt: '2026-03-23T20:00:00.000Z',
     exportedBy: 'employer-1',
-    entityId: 'entity-1',
+    entityId: '11111111-1111-4111-8111-111111111111',
     clinicianNpi: '1234567890',
     displayName: 'Dr. Jane Doe',
     truth: {
@@ -188,7 +188,7 @@ function buildPacketFixture() {
       packetSchema: 'vitalcv.employer.packet.v1',
       exportedAt: '2026-03-23T20:00:00.000Z',
       exportedBy: 'employer-1',
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       clinicianNpi: '1234567890',
       bundleFiles: [
         'packet.json',
@@ -392,11 +392,11 @@ describe('employer action routes', () => {
     createEmployerEvidencePacketZipStreamMock.mockReset();
     issueTrustContainerManifestEntryMock.mockReset();
 
-    buildPassportMock.mockResolvedValue({ entityId: "entity-1", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
+    buildPassportMock.mockResolvedValue({ entityId: "11111111-1111-4111-8111-111111111111", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
     issueTrustContainerManifestEntryMock.mockResolvedValue(buildTrustContainerFixture());
 
     prismaMock.vcvEntity.findUnique.mockResolvedValue({
-      id: 'entity-1',
+      id: '11111111-1111-4111-8111-111111111111',
       npi: '1234567890',
     });
     prismaMock.vcvEntity.findFirst.mockResolvedValue(null);
@@ -424,14 +424,14 @@ describe('employer action routes', () => {
 
   it('persists accept actions with a durable acceptance record and outbox handoff', async () => {
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/accept')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/accept')
       .set('x-clerk-user-id', 'employer-1')
       .send({ role: 'Recruiter', facility: 'Providence', notes: 'Head start only' })
       .expect(201);
 
     expect(response.body.state).toEqual(expect.objectContaining({
       action: 'accept',
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       clinicianNpi: '1234567890',
       auditEventId: 'audit-1',
       acceptance: {
@@ -507,7 +507,7 @@ describe('employer action routes', () => {
           employerReviewAction: {
             action: 'accept',
             employerId: 'employer-1',
-            entityId: 'entity-1',
+            entityId: '11111111-1111-4111-8111-111111111111',
             clinicianNpi: '1234567890',
             requestId: 'req-accept-1',
             attribution: {
@@ -555,7 +555,7 @@ describe('employer action routes', () => {
     ]);
 
     const response = await request(buildApp())
-      .get('/api/employer-review/entity-1/acceptance-history')
+      .get('/api/employer-review/11111111-1111-4111-8111-111111111111/acceptance-history')
       .expect(200);
 
     expect(response.body).toEqual({
@@ -583,7 +583,7 @@ describe('employer action routes', () => {
 
   it('resolves a 10-digit acceptance-history key as a clinician NPI without touching the uuid lookup', async () => {
     prismaMock.vcvEntity.findFirst.mockResolvedValue({
-      id: 'entity-1',
+      id: '11111111-1111-4111-8111-111111111111',
       npi: '1234567890',
     });
 
@@ -627,9 +627,31 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.findMany).not.toHaveBeenCalled();
   });
 
+  it('404s a malformed entity id before it can reach the uuid-typed lookup', async () => {
+    // VcvEntity.id is a Postgres uuid column — an unguarded non-uuid string
+    // makes Prisma throw (a 500) instead of returning null.
+    await request(buildApp())
+      .get('/api/employer-review/not-a-uuid/acceptance-history')
+      .expect(404);
+
+    expect(prismaMock.vcvEntity.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.vcvEntity.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.auditEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('404s a malformed packet entity id before buildPassport runs', async () => {
+    await request(buildApp())
+      .get('/api/employer-review/not-a-uuid/packet?format=json')
+      .set('x-clerk-user-id', 'employer-1')
+      .expect(404);
+
+    expect(buildPassportMock).not.toHaveBeenCalled();
+    expect(prismaMock.vcvEntity.findUnique).not.toHaveBeenCalled();
+  });
+
   it('never serves private review notes on the anonymous acceptance-history read', async () => {
     prismaMock.vcvEntity.findFirst.mockResolvedValue({
-      id: 'entity-1',
+      id: '11111111-1111-4111-8111-111111111111',
       npi: '1234567890',
     });
     prismaMock.auditEvent.findMany.mockResolvedValue([
@@ -640,7 +662,7 @@ describe('employer action routes', () => {
           employerReviewAction: {
             action: 'accept',
             employerId: 'employer-1',
-            entityId: 'entity-1',
+            entityId: '11111111-1111-4111-8111-111111111111',
             clinicianNpi: '1234567890',
             requestId: 'req-accept-legacy',
             attribution: {
@@ -709,7 +731,7 @@ describe('employer action routes', () => {
 
   it('persists refresh requests through the outbox and normalizes the refresh payload', async () => {
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/request-refresh')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/request-refresh')
       .set('x-clerk-user-id', 'employer-1')
       .send({
         staleSources: ['CMS PECOS', 'CMS PECOS', '  OIG LEIE  ', '', 12],
@@ -742,7 +764,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_REFRESH_REQUESTED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         metadata: expect.objectContaining({
           employerReviewAction: expect.objectContaining({
             persistence: expect.objectContaining({
@@ -779,7 +801,7 @@ describe('employer action routes', () => {
     wireTransactionClient({ reviewItemId: 'review-item-1' });
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/route-to-review')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/route-to-review')
       .set('x-clerk-user-id', 'employer-1')
       .send({ reason: 'Manual check required', priority: 'high' })
       .expect(201);
@@ -808,7 +830,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_ROUTED_TO_REVIEW',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         metadata: expect.objectContaining({
           employerReviewAction: expect.objectContaining({
             persistence: expect.objectContaining({
@@ -831,7 +853,7 @@ describe('employer action routes', () => {
     prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce({ id: 'accept-existing' });
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/accept')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/accept')
       .set('x-clerk-user-id', 'employer-1')
       .send({})
       .expect(409);
@@ -845,7 +867,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -868,7 +890,7 @@ describe('employer action routes', () => {
 
   it('fails closed when a BLOCKED passport is accepted from the action route', async () => {
     buildPassportMock.mockResolvedValueOnce({
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       decisionPosture: {
         status: 'BLOCKED',
         blockers: ['OIG exclusion requires review'],
@@ -877,7 +899,7 @@ describe('employer action routes', () => {
     } as never);
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/accept')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/accept')
       .set('x-clerk-user-id', 'employer-1')
       .send({})
       .expect(422);
@@ -892,7 +914,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -908,7 +930,7 @@ describe('employer action routes', () => {
 
   it('generates share-packet bearer tokens with crypto randomness and stores only the token hash', async () => {
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/share-packet')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/share-packet')
       .set('x-clerk-user-id', 'employer-1')
       .send({ npi: '1234567890', organizationContextId: 'ctx-1', bundleId: 'bundle-1' })
       .expect(201);
@@ -944,7 +966,7 @@ describe('employer action routes', () => {
 
   it('rejects share-packet requests when the body NPI does not match the reviewed entity', async () => {
     await request(buildApp())
-      .post('/api/employer-review/entity-1/share-packet')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/share-packet')
       .set('x-clerk-user-id', 'employer-1')
       .send({ npi: '9999999999' })
       .expect(400);
@@ -952,7 +974,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -978,7 +1000,7 @@ describe('employer action routes', () => {
       metadata: {
         schema: 'vitalcv.employer.packet-shared.v1',
         employerId: 'employer-1',
-        entityId: 'entity-1',
+        entityId: '11111111-1111-4111-8111-111111111111',
         clinicianNpi: '1234567890',
         organizationContextId: 'ctx-1',
         bundleId: 'bundle-1',
@@ -1003,11 +1025,11 @@ describe('employer action routes', () => {
     }));
     expect(response.body).toEqual(expect.objectContaining({
       ok: true,
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       clinicianNpi: '1234567890',
       organizationContextId: 'ctx-1',
       bundleId: 'bundle-1',
-      reviewHref: '/review/entity-1?contextId=ctx-1&bundleId=bundle-1',
+      reviewHref: '/review/11111111-1111-4111-8111-111111111111?contextId=ctx-1&bundleId=bundle-1',
       shareEventAuditId: 'audit-share-1',
     }));
   });
@@ -1033,7 +1055,7 @@ describe('employer action routes', () => {
       metadata: {
         schema: 'vitalcv.employer.packet-shared.v1',
         employerId: 'employer-1',
-        entityId: 'entity-1',
+        entityId: '11111111-1111-4111-8111-111111111111',
         clinicianNpi: '1234567890',
         organizationContextId: null,
         bundleId: null,
@@ -1057,7 +1079,7 @@ describe('employer action routes', () => {
     prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce(null);
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/confirm-start')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/confirm-start')
       .set('x-clerk-user-id', 'employer-1')
       .send({
         startedAt: '2026-03-24',
@@ -1076,7 +1098,7 @@ describe('employer action routes', () => {
     prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce(null);
 
     await request(buildApp())
-      .post('/api/employer-review/entity-1/confirm-start')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/confirm-start')
       .set('x-clerk-user-id', 'employer-1')
       .send({
         acceptanceId: 'accept-other-npi',
@@ -1107,7 +1129,7 @@ describe('employer action routes', () => {
         employerReviewAction: {
           action: 'review',
           employerId: 'employer-1',
-          entityId: 'entity-1',
+          entityId: '11111111-1111-4111-8111-111111111111',
           clinicianNpi: '1234567890',
           requestId: 'req-1',
           persistence: {
@@ -1147,7 +1169,7 @@ describe('employer action routes', () => {
     }]);
 
     const response = await request(buildApp())
-      .get('/api/employer-review/entity-1/status')
+      .get('/api/employer-review/11111111-1111-4111-8111-111111111111/status')
       .set('x-clerk-user-id', 'employer-1')
       .expect(200);
 
@@ -1155,7 +1177,7 @@ describe('employer action routes', () => {
       ok: true,
       state: {
         action: 'review',
-        entityId: 'entity-1',
+        entityId: '11111111-1111-4111-8111-111111111111',
         clinicianNpi: '1234567890',
         auditEventId: 'audit-review-1',
         timestamp: '2026-03-23T19:30:00.000Z',
@@ -1199,7 +1221,7 @@ describe('employer action routes', () => {
           employerReviewAction: {
             action: 'accept',
             employerId: 'employer-1',
-            entityId: 'entity-1',
+            entityId: '11111111-1111-4111-8111-111111111111',
             clinicianNpi: '1234567890',
             requestId: 'req-accept-1',
             persistence: {
@@ -1281,7 +1303,7 @@ describe('employer action routes', () => {
     ]);
 
     const response = await request(buildApp())
-      .get('/api/employer-review/entity-1/status')
+      .get('/api/employer-review/11111111-1111-4111-8111-111111111111/status')
       .set('x-clerk-user-id', 'employer-1')
       .expect(200);
 
@@ -1289,7 +1311,7 @@ describe('employer action routes', () => {
       ok: true,
       state: {
         action: 'accept',
-        entityId: 'entity-1',
+        entityId: '11111111-1111-4111-8111-111111111111',
         clinicianNpi: '1234567890',
         auditEventId: 'audit-accept-1',
         timestamp: '2026-03-23T19:46:00.000Z',
@@ -1336,11 +1358,11 @@ describe('employer action routes', () => {
 
   it('emits an audit event when exporting the packet as JSON', async () => {
     const packet = buildPacketFixture();
-    buildPassportMock.mockResolvedValue({ entityId: "entity-1", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
+    buildPassportMock.mockResolvedValue({ entityId: "11111111-1111-4111-8111-111111111111", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
     buildEmployerEvidencePacketMock.mockReturnValue(packet as never);
 
     const response = await request(buildApp())
-      .get('/api/employer-review/entity-1/packet?format=json')
+      .get('/api/employer-review/11111111-1111-4111-8111-111111111111/packet?format=json')
       .set('x-clerk-user-id', 'employer-1')
       .expect(200);
 
@@ -1355,7 +1377,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'ARTIFACT_EXPORTED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           correlationId: expect.any(String),
@@ -1379,7 +1401,7 @@ describe('employer action routes', () => {
   it('streams the packet bundle as ZIP when requested', async () => {
     const packet = buildPacketFixture();
     const zipStream = new PassThrough();
-    buildPassportMock.mockResolvedValue({ entityId: "entity-1", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
+    buildPassportMock.mockResolvedValue({ entityId: "11111111-1111-4111-8111-111111111111", decisionPosture: { status: "READY", blockers: [], missing: [] } } as never);
     buildEmployerEvidencePacketMock.mockReturnValue(packet as never);
     createEmployerEvidencePacketZipStreamMock.mockReturnValue(zipStream);
 
@@ -1388,7 +1410,7 @@ describe('employer action routes', () => {
     });
 
     const response = await request(buildApp())
-      .get('/api/employer-review/entity-1/packet?format=zip')
+      .get('/api/employer-review/11111111-1111-4111-8111-111111111111/packet?format=zip')
       .set('x-clerk-user-id', 'employer-1')
       .buffer(true)
       .parse((res, callback) => {
@@ -1406,7 +1428,7 @@ describe('employer action routes', () => {
 
   it('blocks employer accept when the passport is in BLOCKED posture', async () => {
     buildPassportMock.mockResolvedValueOnce({
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       decisionPosture: {
         status: 'BLOCKED',
         blockers: ['STATE_BOARD access required'],
@@ -1415,7 +1437,7 @@ describe('employer action routes', () => {
     } as never);
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/accept')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/accept')
       .set('x-clerk-user-id', 'employer-1')
       .send({})
       .expect(422);
@@ -1430,7 +1452,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -1448,7 +1470,7 @@ describe('employer action routes', () => {
     process.env.APP_ORIGIN = 'https://app.vitalcv.test';
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/share-packet')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/share-packet')
       .set('x-clerk-user-id', 'employer-1')
       .send({ npi: '1234567890', organizationContextId: 'ctx-1', bundleId: 'bundle-1' })
       .expect(201);
@@ -1468,7 +1490,7 @@ describe('employer action routes', () => {
     expect(metadata).toEqual(expect.objectContaining({
       schema: 'vitalcv.employer.packet-shared.v1',
       employerId: 'employer-1',
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       clinicianNpi: '1234567890',
       organizationContextId: 'ctx-1',
       bundleId: 'bundle-1',
@@ -1487,7 +1509,7 @@ describe('employer action routes', () => {
 
   it('rejects share-packet requests for an NPI that does not match the reviewed entity', async () => {
     await request(buildApp())
-      .post('/api/employer-review/entity-1/share-packet')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/share-packet')
       .set('x-clerk-user-id', 'employer-1')
       .send({ npi: '1111111111' })
       .expect(400);
@@ -1495,7 +1517,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -1512,7 +1534,7 @@ describe('employer action routes', () => {
   it('resolves a valid share token to the review target and scoped context', async () => {
     prismaMock.auditEvent.findFirst.mockResolvedValueOnce({
       id: 'share-audit-1',
-      referenceId: 'entity-1',
+      referenceId: '11111111-1111-4111-8111-111111111111',
       clinicianId: '1234567890',
       createdAt: new Date('2026-03-23T18:00:00.000Z'),
       metadata: {
@@ -1539,11 +1561,11 @@ describe('employer action routes', () => {
     }));
     expect(response.body).toEqual({
       ok: true,
-      entityId: 'entity-1',
+      entityId: '11111111-1111-4111-8111-111111111111',
       clinicianNpi: '1234567890',
       organizationContextId: 'ctx-1',
       bundleId: 'bundle-1',
-      reviewHref: '/review/entity-1?contextId=ctx-1&bundleId=bundle-1',
+      reviewHref: '/review/11111111-1111-4111-8111-111111111111?contextId=ctx-1&bundleId=bundle-1',
       shareEventAuditId: 'share-audit-1',
       sharedAt: '2026-03-23T18:00:00.000Z',
       expiresAt: '2099-03-24T18:00:00.000Z',
@@ -1562,7 +1584,7 @@ describe('employer action routes', () => {
 
     prismaMock.auditEvent.findFirst.mockResolvedValueOnce({
       id: 'share-audit-1',
-      referenceId: 'entity-1',
+      referenceId: '11111111-1111-4111-8111-111111111111',
       clinicianId: '1234567890',
       createdAt: new Date('2026-03-23T18:00:00.000Z'),
       metadata: {
@@ -1578,7 +1600,7 @@ describe('employer action routes', () => {
     prismaMock.employerAcceptance.findFirst.mockResolvedValueOnce(null);
 
     await request(buildApp())
-      .post('/api/employer-review/entity-1/confirm-start')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/confirm-start')
       .set('x-clerk-user-id', 'employer-1')
       .send({
         startedAt: '2026-03-25T18:00:00.000Z',
@@ -1591,7 +1613,7 @@ describe('employer action routes', () => {
     expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         type: 'EMPLOYER_REVIEW_MUTATION_DENIED',
-        referenceId: 'entity-1',
+        referenceId: '11111111-1111-4111-8111-111111111111',
         clinicianId: '1234567890',
         metadata: expect.objectContaining({
           runtimeTrust: expect.objectContaining({
@@ -1612,7 +1634,7 @@ describe('employer action routes', () => {
     });
 
     const response = await request(buildApp())
-      .post('/api/employer-review/entity-1/confirm-start')
+      .post('/api/employer-review/11111111-1111-4111-8111-111111111111/confirm-start')
       .set('x-clerk-user-id', 'employer-1')
       .send({
         startedAt: '2026-03-25T18:00:00.000Z',

--- a/apps/api/backend/src/routes/applications.ts
+++ b/apps/api/backend/src/routes/applications.ts
@@ -42,13 +42,25 @@ function requireClerkUserId(req: Request): string {
   return id;
 }
 
+// Opportunity.id and Application.id are Postgres uuid columns — querying them
+// with a non-uuid string makes Prisma throw (a 500) instead of returning null.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function requireUuidParam(value: string | undefined, label: string): string {
+  const id = value?.trim();
+  if (!id || !UUID_RE.test(id)) {
+    throw new HttpError(404, `${label} not found.`);
+  }
+  return id;
+}
+
 export function registerApplicationRoutes(app: Express): void {
   /* ── Clinician: apply ── */
   app.post(
     '/api/opportunities/:id/apply',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { id: opportunityId } = req.params;
+      const opportunityId = requireUuidParam(req.params.id, 'Opportunity');
       const { npi, coverNote } = req.body as { npi?: string; coverNote?: string };
 
       const application = await applyToOpportunity({ opportunityId, clerkUserId, npi, coverNote });
@@ -71,7 +83,7 @@ export function registerApplicationRoutes(app: Express): void {
     '/api/applications/:appId/withdraw',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { appId } = req.params;
+      const appId = requireUuidParam(req.params.appId, 'Application');
       const updated = await withdrawApplication(appId, clerkUserId);
       res.json(updated);
     }),
@@ -102,7 +114,7 @@ export function registerApplicationRoutes(app: Express): void {
     '/api/opportunities/:id/applications',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { id: opportunityId } = req.params;
+      const opportunityId = requireUuidParam(req.params.id, 'Opportunity');
       const applications = await listApplicationsForOpportunity(opportunityId, clerkUserId);
       res.json(applications);
     }),
@@ -113,7 +125,7 @@ export function registerApplicationRoutes(app: Express): void {
     '/api/applications/:appId/review',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { appId: applicationId } = req.params;
+      const applicationId = requireUuidParam(req.params.appId, 'Application');
       const { status, reviewNote } = req.body as { status?: string; reviewNote?: string };
 
       if (!status || !['REVIEWED', 'ACCEPTED', 'DECLINED'].includes(status)) {
@@ -158,7 +170,7 @@ export function registerApplicationRoutes(app: Express): void {
     '/api/applications/:appId/workflow',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { appId } = req.params;
+      const appId = requireUuidParam(req.params.appId, 'Application');
       const workflowApplication = await getEmployerWorkflowApplication(appId, clerkUserId);
       res.json(workflowApplication);
     }),
@@ -169,7 +181,7 @@ export function registerApplicationRoutes(app: Express): void {
     '/api/applications/:appId/workflow-action',
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
-      const { appId } = req.params;
+      const appId = requireUuidParam(req.params.appId, 'Application');
       const {
         action,
         requests,

--- a/apps/api/backend/src/routes/employerActions.ts
+++ b/apps/api/backend/src/routes/employerActions.ts
@@ -701,7 +701,9 @@ export function registerEmployerActionRoutes(app: Express): void {
       const { entityId } = req.params;
 
       if (!entityId?.trim()) throw new HttpError(400, 'entityId is required.');
-      if (!UUID_RE.test(entityId.trim())) {
+      // Test the raw value — it is what buildPassport and the query below
+      // receive, so a padded uuid must fail here rather than reach Prisma.
+      if (!UUID_RE.test(entityId)) {
         throw new HttpError(404, `Entity ${entityId} not found.`);
       }
 

--- a/apps/api/backend/src/routes/employerActions.ts
+++ b/apps/api/backend/src/routes/employerActions.ts
@@ -64,6 +64,10 @@ function requireClerkUserId(req: Request): string {
   return id;
 }
 
+// VcvEntity.id is a Postgres uuid column — querying it with a non-uuid string
+// makes Prisma throw (a 500) instead of returning null.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function resolvePacketExportFormat(req: Request): 'json' | 'zip' {
   const queryFormat = typeof req.query.format === 'string'
     ? req.query.format.trim().toLowerCase()
@@ -697,6 +701,9 @@ export function registerEmployerActionRoutes(app: Express): void {
       const { entityId } = req.params;
 
       if (!entityId?.trim()) throw new HttpError(400, 'entityId is required.');
+      if (!UUID_RE.test(entityId.trim())) {
+        throw new HttpError(404, `Entity ${entityId} not found.`);
+      }
 
       const [passport, entity] = await Promise.all([
         buildPassport(entityId),

--- a/apps/api/backend/src/routes/opportunities.ts
+++ b/apps/api/backend/src/routes/opportunities.ts
@@ -42,6 +42,10 @@ function requireClerkUserId(req: Request): string {
   return id;
 }
 
+// Opportunity.id is a Postgres uuid column — querying it with a non-uuid
+// string makes Prisma throw (a 500) instead of returning null.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function parsePositiveInt(value: unknown, fallback: number): number {
   const n = typeof value === 'string' ? parseInt(value, 10) : Number(value);
   return Number.isFinite(n) && n >= 0 ? n : fallback;
@@ -221,6 +225,9 @@ export function registerOpportunityRoutes(app: Express): void {
       const opportunityId = req.params.id?.trim();
       if (!opportunityId) {
         throw new HttpError(400, 'Opportunity id is required.');
+      }
+      if (!UUID_RE.test(opportunityId)) {
+        throw new HttpError(404, 'Opportunity not found.');
       }
 
       const opportunity = await getPublicOpportunityById(opportunityId, {

--- a/apps/api/backend/src/routes/passportEntity.ts
+++ b/apps/api/backend/src/routes/passportEntity.ts
@@ -35,6 +35,12 @@ function clerkUserId(req: Request): string | undefined {
   return typeof raw === 'string' ? raw.trim() : undefined;
 }
 
+// Entity/context ids hit Postgres uuid columns — querying them with a
+// non-uuid string makes Prisma throw (a 500) instead of returning null.
+// (The `[0-9a-f-]{36}` route pattern below is looser than a real uuid, so
+// handlers still need this check.)
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function registerPassportEntityRoutes(app: Express): void {
 
   // ── GET /api/passport/entity/:id ────────────────────────────────────────────
@@ -42,6 +48,7 @@ export function registerPassportEntityRoutes(app: Express): void {
     '/api/passport/entity/:id([0-9a-f-]{36})',
     asyncHandler(async (req: Request, res: Response) => {
       const { id } = req.params as { id: string };
+      if (!UUID_RE.test(id)) throw new HttpError(404, 'Entity not found.');
       const passport = await buildPassport(id);
       if (!passport) throw new HttpError(404, 'Entity not found.');
       res.json(passport);
@@ -117,6 +124,12 @@ export function registerPassportEntityRoutes(app: Express): void {
       if (!requestorEntityId || !contextType) {
         throw new HttpError(400, 'requestorEntityId and contextType are required.');
       }
+      if (!UUID_RE.test(requestorEntityId)) {
+        throw new HttpError(404, `Requestor entity ${requestorEntityId} not found.`);
+      }
+      if (subjectEntityIds.some((sid) => !UUID_RE.test(sid))) {
+        throw new HttpError(400, 'subjectEntityIds must be valid entity ids.');
+      }
 
       const context = await createOrgContext({
         requestorEntityId,
@@ -163,6 +176,12 @@ export function registerPassportEntityRoutes(app: Express): void {
 
       if (!entityId || !organizationContextId) {
         throw new HttpError(400, 'entityId and organizationContextId are required.');
+      }
+      // Both ids hit Postgres uuid columns — a non-uuid string makes Prisma
+      // throw (a 500) instead of returning null.
+      if (!UUID_RE.test(entityId)) throw new HttpError(404, 'Entity not found.');
+      if (!UUID_RE.test(organizationContextId)) {
+        throw new HttpError(404, 'Organization context not found.');
       }
 
       // Verify entity exists

--- a/apps/api/backend/src/routes/public.ts
+++ b/apps/api/backend/src/routes/public.ts
@@ -185,7 +185,9 @@ async function handlePublicProfile(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  if (!UUID_RE.test(slug.trim())) {
+  // Test the raw value — it is what the queries below receive, so a padded
+  // uuid must fail here rather than reach Prisma.
+  if (!UUID_RE.test(slug)) {
     res.status(404).json({ error: 'Profile not found' });
     return;
   }

--- a/apps/api/backend/src/routes/public.ts
+++ b/apps/api/backend/src/routes/public.ts
@@ -172,11 +172,21 @@ function extractPublicAuditHashes(claimHashes: unknown): string[] {
 
 // ── Route handler ──────────────────────────────────────────────────────────
 
+// ShareLink.id is a Postgres uuid column — querying it with a non-uuid string
+// makes Prisma throw (a 500) instead of returning null, so a malformed slug
+// must 404 before it reaches the query.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 async function handlePublicProfile(req: Request, res: Response): Promise<void> {
   const { slug } = req.params;
 
   if (typeof slug !== 'string' || slug.trim().length === 0) {
     res.status(400).json({ error: 'Invalid slug' });
+    return;
+  }
+
+  if (!UUID_RE.test(slug.trim())) {
+    res.status(404).json({ error: 'Profile not found' });
     return;
   }
 

--- a/apps/api/backend/src/routes/subscriptions.ts
+++ b/apps/api/backend/src/routes/subscriptions.ts
@@ -25,6 +25,11 @@ function readValidationMessage(error: { issues?: Array<{ message?: string }> }):
   return error.issues?.[0]?.message ?? 'Invalid request payload.';
 }
 
+// Subscription.id and SubscriptionApiKey.id are Postgres uuid columns —
+// querying them with a non-uuid string makes Prisma throw (a 500) instead of
+// returning null.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function registerSubscriptionRoutes(app: Express): void {
 
   // ── POST /api/subscriptions ──────────────────────────────────────
@@ -64,6 +69,10 @@ export function registerSubscriptionRoutes(app: Express): void {
   // ── DELETE /api/subscriptions/:id ───────────────────────────────
   app.delete('/api/subscriptions/:id', async (req: Request, res: Response) => {
     try {
+      if (!UUID_RE.test(req.params.id ?? '')) {
+        res.status(404).json({ error: 'Subscription not found' });
+        return;
+      }
       await cancelSubscription(req.params.id);
       res.json({ canceled: true });
     } catch (err) {
@@ -110,6 +119,10 @@ export function registerSubscriptionRoutes(app: Express): void {
   // ── DELETE /api/api-keys/:keyId ─────────────────────────────────
   app.delete('/api/api-keys/:keyId', async (req: Request, res: Response) => {
     try {
+      if (!UUID_RE.test(req.params.keyId ?? '')) {
+        res.status(404).json({ error: 'API key not found' });
+        return;
+      }
       await revokeApiKey(req.params.keyId);
       res.json({ revoked: true });
     } catch (err) {

--- a/apps/api/backend/src/services/distribution/applyShareService.ts
+++ b/apps/api/backend/src/services/distribution/applyShareService.ts
@@ -423,10 +423,18 @@ export interface RevokeResult {
   revokedAt: string;
 }
 
+// BundleShareEvent.id is a Postgres uuid column — querying it with a non-uuid
+// string makes Prisma throw (a 500) instead of returning null.
+const SHARE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function revokeShare(
   shareId: string,
   clerkUserId: string,
 ): Promise<RevokeResult> {
+  if (!SHARE_ID_RE.test(shareId)) {
+    throw new ShareValidationError('Share not found.');
+  }
+
   const share = await prisma.bundleShareEvent.findUnique({ where: { id: shareId } });
 
   if (!share) {

--- a/apps/api/backend/src/services/entity/employerReviewActions.ts
+++ b/apps/api/backend/src/services/entity/employerReviewActions.ts
@@ -795,7 +795,9 @@ const ENTITY_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 export async function resolveEmployerReviewSubject(
   entityId: string,
 ): Promise<EmployerReviewSubject | null> {
-  if (!entityId.trim() || !ENTITY_UUID_RE.test(entityId.trim())) return null;
+  // Test the raw value — it is what the query below receives, so a padded
+  // uuid must fail here rather than reach Prisma.
+  if (!ENTITY_UUID_RE.test(entityId)) return null;
 
   const entity = await prisma.vcvEntity.findUnique({
     where: { id: entityId },

--- a/apps/api/backend/src/services/entity/employerReviewActions.ts
+++ b/apps/api/backend/src/services/entity/employerReviewActions.ts
@@ -788,10 +788,14 @@ async function writeEmployerReviewAuditEvent(
   });
 }
 
+// VcvEntity.id is a Postgres uuid column — querying it with a non-uuid string
+// makes Prisma throw (a 500) instead of returning null.
+const ENTITY_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function resolveEmployerReviewSubject(
   entityId: string,
 ): Promise<EmployerReviewSubject | null> {
-  if (!entityId.trim()) return null;
+  if (!entityId.trim() || !ENTITY_UUID_RE.test(entityId.trim())) return null;
 
   const entity = await prisma.vcvEntity.findUnique({
     where: { id: entityId },

--- a/apps/web/__tests__/verify-npi-page.test.tsx
+++ b/apps/web/__tests__/verify-npi-page.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * /verify/[npi] — invalid-id 404 gate (Wave 2F route-contract hardening,
+ * public-route unvalidated-id audit).
+ *
+ * Mirrors apply-bundle-page.test.tsx: malformed public ids call notFound()
+ * (→ 404) and never reach the backend. NPIs are 10-digit strings; anything
+ * else cannot resolve. A well-formed NPI the backend does not know keeps its
+ * existing in-page "NPI not found" state (recognition-share-verify.test.tsx
+ * pins the resolvable-NPI states).
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+
+const notFoundMock = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+);
+
+vi.mock('next/navigation', () => ({
+  notFound: notFoundMock,
+}));
+
+import VerifierPage from '../app/verify/[npi]/page';
+
+function renderPage(npi: string) {
+  return VerifierPage({ params: Promise.resolve({ npi }) });
+}
+
+describe('/verify/[npi] — invalid-id path', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    notFoundMock.mockClear();
+  });
+
+  it('404s a malformed NPI without hitting the backend', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    for (const bad of ['x', 'not-a-npi', '123', '12345678901', '../../etc/passwd']) {
+      await expect(renderPage(bad)).rejects.toThrow('NEXT_NOT_FOUND');
+    }
+    expect(notFoundMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the in-page not-found state for a well-formed NPI the backend does not know', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{}', { status: 404 })),
+    );
+
+    const html = renderToStaticMarkup(
+      (await renderPage('1234567890')) as React.ReactElement,
+    );
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(html).toContain('NPI not found');
+    expect(html).toContain('1234567890');
+  });
+});

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -14,6 +14,7 @@
  */
 
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { Eye, ShieldAlert } from 'lucide-react';
 import { ProvenanceStrip } from '@/components/verifier/ProvenanceStrip';
 import { ReceiptVerificationPane } from '@/components/verifier/ReceiptVerificationPane';
@@ -181,6 +182,11 @@ export default async function VerifierPage({
   params: Promise<{ npi: string }>;
 }) {
   const { npi } = await params;
+  // NPIs are 10-digit strings; anything else cannot resolve — 404 before any
+  // backend fetch (Wave 2F route contract: malformed public ids are 404s).
+  if (!/^\d{10}$/.test(npi)) {
+    notFound();
+  }
   const [passport, acceptanceHistory] = await Promise.all([
     fetchPassport(npi),
     fetchAcceptanceHistory(npi),


### PR DESCRIPTION
## Summary

Public-route unvalidated-id audit — the Wave 2F follow-up chipped after PR #500. Same two failure patterns as `/apply/x`:

1. request-supplied ids passed raw into Prisma queries against Postgres uuid columns (Prisma throws P2023 → HTTP 500 instead of null → 404)
2. event handlers rendered in server-component error branches (RSC render crash)

Audited all `apps/api/backend/src/routes/*.ts` Express routes plus every non-archive `apps/web/app/**/[param]` page (4 parallel audit passes; findings verified against `schema.prisma` column types and the `shouldSkipTenantContext` public prefix list before fixing).

## Fixes — public surface (were 500, now 404)

| Route | Column | Guard placement |
|---|---|---|
| `GET /api/public/profile/:slug` | `ShareLink.id` | route (`public.ts`) |
| `GET /api/opportunities/:id` | `Opportunity.id` | route (`opportunities.ts`) |
| `/api/employer-review/:entityId/*` (accept, request-refresh, route-to-review, status, acceptance-history, share-packet, confirm-start) | `VcvEntity.id` | central, in `resolveEmployerReviewSubject` → existing null→404 path |
| `GET /api/employer-review/:entityId/packet` | `VcvEntity.id` | route (bypasses the resolver) |
| `GET /api/passport/entity/:id` | `VcvEntity.id` | route — the `[0-9a-f-]{36}` route regex admits non-uuid strings (36 hex chars, no dashes) |
| `POST /api/opportunities/:id/apply`, `GET /api/opportunities/:id/applications` | `Opportunity.id` | route (`applications.ts`) |
| `DELETE /api/apply/share/:shareId` | `BundleShareEvent.id` | service (`revokeShare`) — 400, matching the existing unknown-share behavior |

## Fixes — authed surface (same class, lower severity)

- `DELETE /api/applications/:appId/withdraw`, `PATCH …/review`, `GET …/workflow`, `POST …/workflow-action` (`Application.id`)
- `DELETE /api/subscriptions/:id`, `DELETE /api/api-keys/:keyId`
- `POST /api/share`, `POST /api/organization-context` (body-supplied entity/context ids → `createOrgContext` queries them raw)

## Fixes — web

- `/verify/[npi]` (public) now `notFound()`s malformed NPIs before any backend fetch, mirroring the `/apply/[bundleId]` gate. Resolvable and well-formed-unknown NPIs keep their existing rendered states (pinned by `recognition-share-verify.test.tsx`).

## Audit findings NOT fixed here (by design)

- **No event-handler (pattern 2) hits found** — the flagged `employer/review/[applicationId]` buttons carry CSS classes only, and `ReceiptVerificationBadge` is `'use client'`.
- The nine `issuer/*/[requestId]` demo pages render static demo data for any id (fake-success, no crash) — authed demo surfaces, out of scope for the 500-class contract.
- Wave 2C follow-ups (unsalted claim digests, header-trust authn, rate-limit keying) remain tracked separately.

## Tests

- `employerActions.test.ts`: migrated off the non-uuid `entity-1` fixture (impossible in production — it would P2023; the suite only passed because Prisma is mocked) + 2 new malformed-id gates asserting the uuid lookup is never reached
- `applyShare.test.ts`: malformed `shareId` rejection gate
- `apps/web/__tests__/verify-npi-page.test.tsx`: mirror of `apply-bundle-page.test.tsx` — malformed NPI → `notFound()` with zero fetches; well-formed unknown keeps the in-page state
- Backend suites 63/63 green (employerActions, applyShare, publicProfile); web targeted vitest 14/14; holder route-contract 144/144; backend `tsc --noEmit` clean

## Verification (curl vs local dev servers, backend + web)

All malformed-id probes: `404` (or `400` for apply-share, `401`-before-guard preserved on tenant-gated routes). Well-formed unknown uuids still traverse the real DB query path to `404` — no resolvable-path regression. `/verify/x` → 404, `/verify/1234567890` → 200, control `/apply/x` → 404.

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)