### PR TITLE
fix(auth): unblock signed-in clinician role resolution (Wave 2B P0)

### DIFF
--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -57,6 +57,11 @@ export function shouldSkipTenantContext(path: string): boolean {
     || normalized.startsWith('/psv')
     || normalized.startsWith('/identity')
     || normalized.startsWith('/api/identity')
+    // Role bootstrap: resolves a user by Clerk id alone (no org context yet).
+    // Same rationale as /api/identity — a first-time signed-in user has no org
+    // when the middleware asks "what role is this?", so requiring tenant
+    // context here 401s and dead-ends the entire signed-in experience.
+    || normalized === '/api/me/role'
     || normalized.startsWith('/demo')
     || normalized.startsWith('/.well-known')
     || normalized.startsWith('/api/.well-known')

--- a/apps/web/__tests__/role-cookie.test.ts
+++ b/apps/web/__tests__/role-cookie.test.ts
@@ -1,0 +1,67 @@
+// apps/web/__tests__/role-cookie.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ROLE_COOKIE_TTL_SECONDS,
+  signRoleCookie,
+  verifyRoleCookie,
+} from '../lib/auth/roleCookie';
+
+describe('roleCookie sign/verify', () => {
+  beforeEach(() => {
+    vi.stubEnv('ROLE_COOKIE_SECRET', 'test-secret-abc');
+  });
+
+  it('round-trips a signed role', async () => {
+    const value = await signRoleCookie('CLINICIAN');
+    expect(value).toBeTruthy();
+    const role = await verifyRoleCookie(value);
+    expect(role).toBe('CLINICIAN');
+  });
+
+  it('rejects a tampered role', async () => {
+    const value = await signRoleCookie('CLINICIAN');
+    // Swap the role segment but keep the original signature.
+    const forged = value!.replace(/^CLINICIAN\./, 'ADMIN.');
+    expect(await verifyRoleCookie(forged)).toBeNull();
+  });
+
+  it('rejects a tampered signature', async () => {
+    const value = await signRoleCookie('VERIFIER');
+    const forged = `${value!.slice(0, -2)}xy`;
+    expect(await verifyRoleCookie(forged)).toBeNull();
+  });
+
+  it('rejects an expired cookie', async () => {
+    const past = Date.now() - (ROLE_COOKIE_TTL_SECONDS + 60) * 1000;
+    const value = await signRoleCookie('CLINICIAN', ROLE_COOKIE_TTL_SECONDS, past);
+    expect(await verifyRoleCookie(value)).toBeNull();
+  });
+
+  it('rejects an unknown role even if correctly signed structure', async () => {
+    // A signature over a non-role payload must not validate as a role.
+    const value = await signRoleCookie('NOT_A_ROLE' as never);
+    expect(await verifyRoleCookie(value)).toBeNull();
+  });
+
+  it('rejects malformed values', async () => {
+    expect(await verifyRoleCookie(undefined)).toBeNull();
+    expect(await verifyRoleCookie('')).toBeNull();
+    expect(await verifyRoleCookie('a.b')).toBeNull();
+    expect(await verifyRoleCookie('a.b.c.d')).toBeNull();
+  });
+
+  it('returns null when no secret is configured', async () => {
+    vi.stubEnv('ROLE_COOKIE_SECRET', '');
+    vi.stubEnv('CLERK_SECRET_KEY', '');
+    expect(await signRoleCookie('CLINICIAN')).toBeNull();
+    // A previously valid-looking value cannot verify without a secret.
+    expect(await verifyRoleCookie('CLINICIAN.9999999999.sig')).toBeNull();
+  });
+
+  it('falls back to CLERK_SECRET_KEY when ROLE_COOKIE_SECRET is unset', async () => {
+    vi.stubEnv('ROLE_COOKIE_SECRET', '');
+    vi.stubEnv('CLERK_SECRET_KEY', 'clerk-fallback-secret');
+    const value = await signRoleCookie('ISSUER');
+    expect(await verifyRoleCookie(value)).toBe('ISSUER');
+  });
+});

--- a/apps/web/lib/auth/roleCookie.ts
+++ b/apps/web/lib/auth/roleCookie.ts
@@ -1,0 +1,124 @@
+// apps/web/lib/auth/roleCookie.ts
+//
+// Signed, short-lived role cookie used by middleware to break the
+// resolve-role redirect loop WITHOUT depending on Clerk session-token
+// customization.
+//
+// Background: the production Clerk session token carries no `vitalcv.role`
+// claim, so the middleware fast path (session.sessionClaims.vitalcv.role) is
+// always empty and every request falls through to the /api/auth/resolve-role
+// backend round-trip. The old code then redirected to ROLE_LANDING "to force a
+// JWT refresh" — but the refreshed JWT still had no claim, producing an
+// infinite redirect loop.
+//
+// Instead, once resolve-role returns a role we mint an HMAC-signed cookie and
+// pass the request through. Subsequent requests read the cookie (fast, no
+// backend hop) until it expires. If Clerk session-token customization is later
+// enabled, the JWT fast path takes over and this cookie becomes a no-op.
+//
+// Security note: the middleware role check is a routing convenience, not the
+// security boundary — every backend data call independently enforces Clerk auth
+// + tenant context. The HMAC signature still prevents a user from forging a
+// different role and landing in the wrong operator surface.
+//
+// Edge-runtime safe: uses only Web Crypto (crypto.subtle) + TextEncoder, no
+// Node built-ins. Works in Next middleware (edge) and vitest (node ≥ 20).
+
+import { UserRole, type UserRoleType } from './roles';
+
+export const ROLE_COOKIE_NAME = 'vitalcv_role';
+
+/** Default cookie lifetime. Short enough that a role change self-heals quickly. */
+export const ROLE_COOKIE_TTL_SECONDS = 15 * 60; // 15 minutes
+
+const VALID_ROLES = new Set<string>(Object.values(UserRole));
+
+function getSecret(): string {
+  return process.env.ROLE_COOKIE_SECRET || process.env.CLERK_SECRET_KEY || '';
+}
+
+const encoder = new TextEncoder();
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(value: string): Uint8Array | null {
+  try {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+async function hmac(secret: string, data: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return new Uint8Array(signature);
+}
+
+/** Constant-time comparison to avoid signature-timing leaks. */
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) mismatch |= a[i] ^ b[i];
+  return mismatch === 0;
+}
+
+/**
+ * Sign a `role.exp.sig` cookie value. Returns null when no secret is
+ * configured (caller should then simply not set the cookie — the resolve-role
+ * fallback still works, just without caching).
+ */
+export async function signRoleCookie(
+  role: UserRoleType,
+  ttlSeconds: number = ROLE_COOKIE_TTL_SECONDS,
+  nowMs: number = Date.now(),
+): Promise<string | null> {
+  const secret = getSecret();
+  if (!secret) return null;
+  const exp = Math.floor(nowMs / 1000) + ttlSeconds;
+  const payload = `${role}.${exp}`;
+  const signature = await hmac(secret, payload);
+  return `${payload}.${base64UrlEncode(signature)}`;
+}
+
+/**
+ * Verify a role cookie. Returns the role only when the signature is valid, the
+ * value is unexpired, and the role is a known role. Any tampering, expiry, or
+ * missing secret yields null.
+ */
+export async function verifyRoleCookie(
+  value: string | undefined | null,
+  nowMs: number = Date.now(),
+): Promise<UserRoleType | null> {
+  const secret = getSecret();
+  if (!secret || !value) return null;
+
+  const parts = value.split('.');
+  if (parts.length !== 3) return null;
+  const [role, expStr, sigB64] = parts;
+
+  const payload = `${role}.${expStr}`;
+  const expected = await hmac(secret, payload);
+  const provided = base64UrlDecode(sigB64);
+  if (!provided || !timingSafeEqual(expected, provided)) return null;
+
+  const exp = Number(expStr);
+  if (!Number.isFinite(exp) || exp <= Math.floor(nowMs / 1000)) return null;
+
+  if (!VALID_ROLES.has(role)) return null;
+  return role as UserRoleType;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -5,24 +5,51 @@ import {
   isPublicRoute,
   getRequiredRole,
   getMismatchRedirect,
-  ROLE_LANDING,
   type UserRoleType,
 } from '@/lib/auth/roles';
+import {
+  ROLE_COOKIE_NAME,
+  ROLE_COOKIE_TTL_SECONDS,
+  signRoleCookie,
+  verifyRoleCookie,
+} from '@/lib/auth/roleCookie';
 import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowlist';
 
 /**
  * Role-based middleware for VitalCV.
  *
- * Fast path: reads role from Clerk JWT claim (publicMetadata.vitalcv.role).
- * Fallback: if no claim exists, calls /api/auth/resolve-role (Node runtime)
- *           to look up or create the User row in Prisma, then redirects to
- *           force a JWT refresh.
+ * Role resolution order, first hit wins:
+ *   1. Clerk JWT claim (session.sessionClaims.vitalcv.role) — the fast path
+ *      once Clerk session-token customization is enabled.
+ *   2. Signed `vitalcv_role` cookie — set after a successful resolve so
+ *      subsequent requests skip the backend round-trip.
+ *   3. /api/auth/resolve-role backend fallback — upserts the User row and
+ *      returns the role. On success we set the cookie and pass the request
+ *      through (previously this redirected to ROLE_LANDING "to force a JWT
+ *      refresh", which looped forever because the refreshed JWT still carried
+ *      no role claim). On failure we redirect to /auth/error.
  *
  * Intelligence and investigation API routes attempt Clerk but gracefully
  * degrade when Clerk edge processing fails (missing keys, timeout, etc.).
  * Route handlers use resolveIntelligenceAuthContext() which returns
  * missing_session when Clerk is unavailable.
  */
+
+/** Attach the signed, short-lived role cookie to an outgoing response. */
+async function attachRoleCookie(
+  res: NextResponse,
+  role: UserRoleType,
+): Promise<void> {
+  const value = await signRoleCookie(role);
+  if (!value) return;
+  res.cookies.set(ROLE_COOKIE_NAME, value, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: ROLE_COOKIE_TTL_SECONDS,
+  });
+}
 
 const isSignInPage = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
 
@@ -62,7 +89,18 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
   let userRole: UserRoleType | undefined =
     session.sessionClaims?.vitalcv?.role as UserRoleType | undefined;
 
-  // 5. Fallback: no role claim in JWT
+  // 4b. Read role from the signed cookie set by a prior resolve. Avoids the
+  //     backend round-trip on every navigation and works even though the JWT
+  //     carries no role claim.
+  if (!userRole) {
+    const cookieRole = await verifyRoleCookie(
+      req.cookies.get(ROLE_COOKIE_NAME)?.value,
+    );
+    if (cookieRole) userRole = cookieRole;
+  }
+
+  // 5. Fallback: no role from JWT or cookie — resolve via backend.
+  let resolvedViaFallback = false;
   if (!userRole) {
     try {
       const resolveUrl = new URL('/api/auth/resolve-role', req.nextUrl.origin);
@@ -75,9 +113,10 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
       if (resolveRes.ok) {
         const data = await resolveRes.json();
         userRole = data.role as UserRoleType;
+        resolvedViaFallback = Boolean(userRole);
       }
     } catch {
-      // Fallback failed — redirect to error page (circuit breaker)
+      // Fallback failed — fall through to the /auth/error circuit breaker.
     }
 
     if (!userRole) {
@@ -85,24 +124,28 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
       errorUrl.pathname = '/auth/error';
       return NextResponse.redirect(errorUrl);
     }
-
-    // Redirect to role landing to force JWT refresh on next request
-    const landingUrl = req.nextUrl.clone();
-    landingUrl.pathname = ROLE_LANDING[userRole];
-    return NextResponse.redirect(landingUrl);
   }
 
-  // 6. Check role matches route
-  //    AUTHENTICATED routes accept any authenticated user regardless of role
+  // 6. Check role matches route, then build the response.
+  //    AUTHENTICATED routes accept any authenticated user regardless of role.
+  let res: NextResponse;
   if (requiredRole !== 'AUTHENTICATED' && userRole !== requiredRole) {
-    const redirectPath = getMismatchRedirect(pathname, userRole);
     const redirectUrl = req.nextUrl.clone();
-    redirectUrl.pathname = redirectPath;
-    return NextResponse.redirect(redirectUrl);
+    redirectUrl.pathname = getMismatchRedirect(pathname, userRole);
+    res = NextResponse.redirect(redirectUrl);
+  } else {
+    // 7. Authorized — pass through.
+    res = NextResponse.next();
   }
 
-  // 7. Authorized — pass through
-  return NextResponse.next();
+  // 8. Persist the resolved role so the next request uses the cookie fast path
+  //    instead of hitting the backend again (and never loops on a JWT refresh
+  //    that will not carry the claim).
+  if (resolvedViaFallback) {
+    await attachRoleCookie(res, userRole);
+  }
+
+  return res;
 });
 
 export default async function middleware(req: NextRequest, event: NextFetchEvent) {


### PR DESCRIPTION
## The P0

Every authenticated clinician was bounced to `/auth/error` — no `/holder/*` surface was reachable in production. Confirmed end-to-end against a live Clerk session (QA report: `docs/product/signed-in-clinician-qa.md`). This is the single gate blocking the entire signed-in experience.

## Root cause (two coupled defects)

1. **Backend 401.** `GET /api/me/role` sits behind `requireTenantContextOrReadAccess` and was not skip-listed. The role bootstrap legitimately has no org yet, so the guard returned `401 organization_context_required` → `resolve-role` returned `502` → middleware redirected to `/auth/error`.
2. **Infinite loop trap.** The production Clerk session token carries no `vitalcv.role` claim, so the middleware fast path is always empty. The old fallback redirected to `ROLE_LANDING` "to force a JWT refresh" — but the refreshed JWT still had no claim, so fixing only the guard converts `/auth/error` into `ERR_TOO_MANY_REDIRECTS`.

## Fix

- **`tenantGuard.ts`**: skip-list `/api/me/role` (same rationale as `/api/identity` — resolves a user by Clerk id alone, no org needed).
- **`middleware.ts`**: after a successful resolve, mint an HMAC-signed, short-lived `vitalcv_role` cookie and **pass the request through** (render the page) instead of redirect-looping. Subsequent requests read the cookie — no backend hop, no loop.
- **`roleCookie.ts`** (new): edge-safe (Web Crypto) HMAC-SHA256 sign/verify with constant-time compare + expiry. Secret is `ROLE_COOKIE_SECRET` or falls back to `CLERK_SECRET_KEY` — **no new Railway env, no Clerk dashboard change required**.

Forward-compatible: if Clerk session-token customization is enabled later, the JWT fast path takes over and the cookie becomes a no-op.

## Security

The middleware role check is a routing convenience, not the security boundary — every backend data call independently enforces Clerk auth + tenant context. The HMAC signature prevents a user forging a role to land in the wrong operator surface.

## Verification

- `role-cookie.test.ts` — sign/verify roundtrip, tampered role, tampered signature, expiry, unknown role, no-secret, CLERK_SECRET_KEY fallback (8 tests) ✅
- `middleware.test.ts` — route-role matrix + preview fallback (36 tests) ✅
- `pnpm turbo run build --filter @vitalcv/web` — green (middleware compiled) ✅
- **Live signed-in UI pass still required from Chris** — Clerk bot-management blocks automated browsers (see QA report §5 checklist). Acceptance gate: sign in → land on `/holder` (not `/auth/error`, not a redirect loop).

## Tiering

Touches multi-tenant isolation (tenant guard) + auth → **Tier 2**, Codex verify before merge.

## Design Handoff References
No Claude Design handoff file used for this PR.