### PR TITLE
feat(design): D57 light-document system + readiness surface lineage

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -10,6 +10,7 @@
 @import '../styles/blueprint-overrides.css';
 @import '../styles/graph.css';
 @import '../styles/intelligence.css';
+@import '../styles/clinician-doc.css';
 /* glue.css superseded by antigravity.css (imported in layout.tsx) */
 
 @custom-variant dark (&:is(.dark *));

--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -120,21 +120,21 @@ export default function ReadinessSurface() {
   const activeSnapshot = snapshot && snapshot.npi === npi ? snapshot : null;
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Top bar */}
-      <div className="bg-slate-900 text-slate-300 text-xs px-6 py-2 flex items-center justify-between">
-        <Link href="/holder/home" className="text-slate-400 hover:text-white transition-colors">← Dashboard</Link>
-        <span className="font-mono uppercase tracking-widest font-bold">Readiness</span>
-        <span className="font-mono text-slate-500 text-[10px]">{npi ? `NPI ${npi}` : '…'}</span>
+    <div className="vcv-doc min-h-screen">
+      {/* Top bar — signed-artifact register (D57 dark op-bar) */}
+      <div className="vcv-register text-xs px-6 py-2 flex items-center justify-between">
+        <Link href="/holder/home" className="vcv-mono transition-opacity hover:opacity-80">← Dashboard</Link>
+        <span className="vcv-eyebrow">Readiness</span>
+        <span className="vcv-mono text-[10px] opacity-70">{npi ? `NPI ${npi}` : '…'}</span>
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6">
-        {/* Posture header */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+        {/* Identity + posture header — serif title, mono identifier */}
         {activeSnapshot && (
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-wrap items-end gap-4">
             <div>
-              <h1 className="text-2xl font-extrabold text-slate-900">{activeSnapshot.name}</h1>
-              <p className="font-mono text-sm text-slate-500 mt-0.5 tracking-wide">NPI {activeSnapshot.npi}</p>
+              <h1 className="vcv-title text-3xl">{activeSnapshot.name}</h1>
+              <p className="vcv-mono text-sm vcv-muted mt-1">NPI {activeSnapshot.npi}</p>
             </div>
             <div className="flex flex-wrap items-center gap-2 ml-auto">
               <PostureBadge posture={activeSnapshot.posture} size="md" />
@@ -148,9 +148,9 @@ export default function ReadinessSurface() {
 
         {/* No NPI — honest CTA, not demo */}
         {loadState === 'no-npi' && (
-          <div className="bg-white border border-slate-200 rounded-xl p-8 text-center space-y-3">
-            <p className="text-sm text-slate-700">Add your NPI to see your source-backed readiness.</p>
-            <Link href="/get-ready" className="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 transition-colors">
+          <div className="vcv-panel p-8 text-center space-y-3">
+            <p className="text-sm" style={{ color: 'var(--ink)' }}>Add your NPI to see your source-backed readiness.</p>
+            <Link href="/get-ready" className="vcv-cta inline-flex items-center px-4 py-2 text-sm">
               Connect your NPI →
             </Link>
           </div>
@@ -161,16 +161,19 @@ export default function ReadinessSurface() {
 
         {/* Loading */}
         {loadState === 'loading' && (
-          <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
-            <p className="font-mono text-sm text-slate-500 animate-pulse">Checking sources…</p>
+          <div className="vcv-panel p-8 text-center">
+            <p className="vcv-mono text-sm vcv-muted animate-pulse">Checking sources…</p>
           </div>
         )}
 
         {/* Error — honest, not demo */}
         {loadState === 'error' && (
-          <div className="bg-white border border-rose-200 rounded-xl p-8 text-center space-y-2">
-            <p className="text-sm text-rose-700">Source-backed readiness is temporarily unavailable.</p>
-            <p className="text-xs text-slate-500">This is a system state — not a finding about your credentials. Try again shortly.</p>
+          <div
+            className="vcv-panel p-8 text-center space-y-2"
+            style={{ borderColor: 'color-mix(in oklch, var(--state-blocked) 30%, transparent)' }}
+          >
+            <p className="text-sm" style={{ color: 'var(--state-blocked)' }}>Source-backed readiness is temporarily unavailable.</p>
+            <p className="text-xs vcv-subtle">This is a system state — not a finding about your credentials. Try again shortly.</p>
           </div>
         )}
 
@@ -188,19 +191,22 @@ export default function ReadinessSurface() {
             />
 
             {activeSnapshot.nextStep && (
-              <div className="bg-white border border-slate-200 rounded-xl px-5 py-4">
-                <p className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-2">Next Step</p>
-                <p className="text-sm text-slate-700">{activeSnapshot.nextStep}</p>
+              <div className="vcv-panel px-5 py-4">
+                <p className="vcv-eyebrow mb-2">Next Step</p>
+                <p className="text-sm" style={{ color: 'var(--ink)' }}>{activeSnapshot.nextStep}</p>
               </div>
             )}
 
             {limitations.length > 0 && (
-              <div className="bg-amber-50 border border-amber-200 rounded-xl px-5 py-4">
-                <p className="text-xs font-bold uppercase tracking-widest text-amber-700 mb-3">Limitations</p>
+              <div
+                className="vcv-panel px-5 py-4"
+                style={{ background: 'var(--state-pending-wash)', borderColor: 'color-mix(in oklch, var(--state-pending) 30%, transparent)' }}
+              >
+                <p className="vcv-eyebrow mb-3" style={{ color: 'var(--state-pending)' }}>Limitations</p>
                 <ul className="space-y-1">
                   {limitations.map((limitation, index) => (
-                    <li key={index} className="text-xs text-amber-800 flex gap-2">
-                      <span className="flex-shrink-0 text-amber-400">·</span>{limitation}
+                    <li key={index} className="text-xs flex gap-2" style={{ color: 'var(--state-pending)' }}>
+                      <span className="flex-shrink-0" style={{ color: 'var(--state-pending)', opacity: 0.6 }}>·</span>{limitation}
                     </li>
                   ))}
                 </ul>

--- a/apps/web/styles/clinician-doc.css
+++ b/apps/web/styles/clinician-doc.css
@@ -1,0 +1,156 @@
+/*
+ * clinician-doc.css — VitalCV "document" design system for signed-in clinician
+ * surfaces, ported faithfully from the Claude Design handoff D57 Visual System
+ * (design-handoff/claude-design-2026-06-26/vitalcv/project/VitalCV Visual
+ * System.html) and its Readiness Report / Clinician Profile / Acceptance Proof
+ * lineage. See docs/design/design-lineage-policy.md.
+ *
+ * Namespaced under `.vcv-doc` so it never leaks into the dark app chrome or the
+ * operator/intelligence surfaces. Wrap a clinician surface's root in
+ * `.vcv-doc` and its children inherit the paper/ink substrate, the single
+ * indigo accent, the six trust-state colors, hairline rules, document-grade
+ * radii, and the serif-title / mono-proof typography.
+ *
+ * Design commitments (D57): off-white paper, near-black ink, ONE accent used
+ * surgically, states paired with soft washes (never neon), 1px hairline rules,
+ * nothing rounder than 10px, monospace for proof/identifiers.
+ */
+
+.vcv-doc {
+  /* Paper substrate */
+  --paper: oklch(98.5% 0.004 85);
+  --paper-warm: oklch(97% 0.008 85);
+  --paper-inset: oklch(95% 0.008 85);
+  --paper-edge: oklch(92% 0.008 85);
+
+  /* Ink scale */
+  --ink: oklch(18% 0.012 265);
+  --ink-strong: oklch(12% 0.012 265);
+  --ink-mute: oklch(46% 0.010 265);
+  --ink-subtle: oklch(62% 0.008 265);
+  --ink-ghost: oklch(78% 0.006 265);
+
+  /* One accent, used surgically */
+  --accent: oklch(38% 0.14 274);
+  --accent-ink: oklch(28% 0.10 274);
+  --accent-wash: oklch(94% 0.025 274);
+  --accent-edge: oklch(82% 0.06 274);
+
+  /* Six trust states — ink + soft wash pairs */
+  --state-verified: oklch(46% 0.10 152);
+  --state-verified-wash: oklch(94% 0.03 152);
+  --state-pending: oklch(54% 0.10 78);
+  --state-pending-wash: oklch(95% 0.04 78);
+  --state-blocked: oklch(48% 0.16 25);
+  --state-blocked-wash: oklch(94% 0.04 25);
+  --state-contradicted: oklch(42% 0.14 305);
+  --state-contradicted-wash: oklch(94% 0.03 305);
+  --state-unknown: oklch(58% 0.008 265);
+  --state-unknown-wash: oklch(94% 0.005 265);
+
+  /* Document-grade radii — nothing over 10px */
+  --r-2: 4px;
+  --r-3: 6px;
+  --r-4: 8px;
+  --r-5: 10px;
+
+  /* Hairline + soft elevation */
+  --hairline: 1px solid var(--paper-edge);
+  --shadow-1: 0 0.5px 0 rgba(15, 23, 42, 0.04), 0 1px 6px -1px rgba(15, 23, 42, 0.06);
+
+  /* Typography — system stacks exposed by the root layout */
+  --doc-serif: var(--font-serif, ui-serif, Georgia, 'Iowan Old Style', serif);
+  --doc-sans: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  --doc-mono: var(--font-mono, ui-monospace, 'Geist Mono', monospace);
+
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--doc-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Structure ─────────────────────────────────────────────────────────── */
+
+.vcv-panel {
+  background: #fff;
+  border: var(--hairline);
+  border-radius: var(--r-4);
+  box-shadow: var(--shadow-1);
+}
+
+.vcv-panel-inset {
+  background: var(--paper-warm);
+  border: var(--hairline);
+  border-radius: var(--r-4);
+}
+
+/* Signed-artifact register — inverted ink card for verdicts and ledger rows
+   (D11 "the row is the proof": no confetti, no green checks). */
+.vcv-register {
+  background: var(--ink-strong);
+  color: var(--paper);
+  border-radius: var(--r-4);
+}
+.vcv-register .vcv-eyebrow { color: color-mix(in oklch, var(--paper) 55%, transparent); }
+.vcv-register .vcv-mono { color: var(--paper); }
+
+/* ── Typography ────────────────────────────────────────────────────────── */
+
+.vcv-title {
+  font-family: var(--doc-serif);
+  color: var(--ink-strong);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.vcv-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.vcv-mono {
+  font-family: var(--doc-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+
+.vcv-muted { color: var(--ink-mute); }
+.vcv-subtle { color: var(--ink-subtle); }
+
+/* ── Accent action ─────────────────────────────────────────────────────── */
+
+.vcv-cta {
+  background: var(--accent);
+  color: #fff;
+  border-radius: var(--r-3);
+  font-weight: 600;
+  transition: background 0.15s ease;
+}
+.vcv-cta:hover { background: var(--accent-ink); }
+
+.vcv-link { color: var(--accent); }
+.vcv-link:hover { color: var(--accent-ink); }
+
+/* ── State chips — ink text on soft wash, hairline edge ────────────────── */
+
+.vcv-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: var(--r-2);
+  border: 1px solid transparent;
+}
+.vcv-chip[data-state='verified'] { color: var(--state-verified); background: var(--state-verified-wash); border-color: color-mix(in oklch, var(--state-verified) 25%, transparent); }
+.vcv-chip[data-state='pending'] { color: var(--state-pending); background: var(--state-pending-wash); border-color: color-mix(in oklch, var(--state-pending) 25%, transparent); }
+.vcv-chip[data-state='blocked'] { color: var(--state-blocked); background: var(--state-blocked-wash); border-color: color-mix(in oklch, var(--state-blocked) 25%, transparent); }
+.vcv-chip[data-state='contradicted'] { color: var(--state-contradicted); background: var(--state-contradicted-wash); border-color: color-mix(in oklch, var(--state-contradicted) 25%, transparent); }
+.vcv-chip[data-state='unknown'] { color: var(--state-unknown); background: var(--state-unknown-wash); border-color: color-mix(in oklch, var(--state-unknown) 25%, transparent); }


### PR DESCRIPTION
First surface of the **dark→light clinician redesign** (item 4; direction confirmed with Chris — adopt the handoff's light paper-and-ink document aesthetic).

## What

- **`apps/web/styles/clinician-doc.css`** — a `.vcv-doc`-namespaced design layer ported faithfully from the handoff's **D57 Visual System**: off-white paper substrate, near-black ink scale, one indigo accent used surgically, the six trust-state ink/wash pairs, 1px hairline rules, document-grade radii (≤10px), serif-title / mono-proof typography (via the app's existing system-font vars). Namespaced so it never leaks into the dark app chrome or operator surfaces, and reusable across the remaining clinician surfaces (`/holder`, recognition, profile).
- **`/holder/readiness`** restyled onto it — verdict-register top bar, serif identity title, mono NPI, hairline panels, state-wash limitations.

## Truth-contract safety

Only the **visual frame** changed. All data logic, the honest empty/loading/error states, the NPI identity guard, and **every copy string** are untouched — no banned strings introduced, no asserted copy altered.

## Verification

- `holder-readiness-page` + `holder-route-contract` + `clinician-profile-sections`: **156 tests green**.
- `pnpm turbo run build --filter @vitalcv/web`: green (CSS + TS compile).
- Live UI is auth-gated (Clerk bot-block), so a rendered preview of the aesthetic accompanies this for direction review.

## Tiering

UI-only, no logic/auth/security change → **Tier 1**.

## Design Handoff References
- `design-handoff/claude-design-2026-06-26/vitalcv/project/VitalCV Visual System.html` (D57 — canonical tokens)
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Readiness Report.html` (readiness layout: verdict-first, source coverage, mono proof)