### PR TITLE
fix(auth): backend transport-auth gate for /api/me/role (Wave 2B, trimmed post-#507) — DO NOT MERGE until backend env rollout

### DIFF
--- a/apps/api/backend/src/auth/__tests__/internalRoleAuth.test.ts
+++ b/apps/api/backend/src/auth/__tests__/internalRoleAuth.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Wave 2B follow-up — transport-auth gate for GET /api/me/role.
+ *
+ * Verifies both the P0-safe default (enforcement off = no-op) and the
+ * fail-closed behavior when armed. Pure unit test — no DB, no Express app.
+ */
+import { isInternalRoleCallAuthorized } from '../internalRoleAuth';
+
+describe('isInternalRoleCallAuthorized', () => {
+  const SECRET = 'super-secret-value';
+
+  describe('enforcement OFF (default)', () => {
+    it('authorizes regardless of the provided/expected secret (no-op)', () => {
+      expect(isInternalRoleCallAuthorized(undefined, SECRET, false)).toBe(true);
+      expect(isInternalRoleCallAuthorized('anything', SECRET, false)).toBe(true);
+      expect(isInternalRoleCallAuthorized('anything', undefined, false)).toBe(true);
+      expect(isInternalRoleCallAuthorized(undefined, undefined, false)).toBe(true);
+    });
+  });
+
+  describe('enforcement ON (armed)', () => {
+    it('accepts an exactly matching secret', () => {
+      expect(isInternalRoleCallAuthorized(SECRET, SECRET, true)).toBe(true);
+    });
+
+    it('rejects a wrong secret', () => {
+      expect(isInternalRoleCallAuthorized('nope', SECRET, true)).toBe(false);
+    });
+
+    it('rejects a missing secret (external caller)', () => {
+      expect(isInternalRoleCallAuthorized(undefined, SECRET, true)).toBe(false);
+      expect(isInternalRoleCallAuthorized(null, SECRET, true)).toBe(false);
+      expect(isInternalRoleCallAuthorized('', SECRET, true)).toBe(false);
+    });
+
+    it('fails closed when armed but the server secret is unconfigured', () => {
+      expect(isInternalRoleCallAuthorized('anything', undefined, true)).toBe(false);
+      expect(isInternalRoleCallAuthorized('anything', null, true)).toBe(false);
+      expect(isInternalRoleCallAuthorized('anything', '', true)).toBe(false);
+    });
+  });
+});

--- a/apps/api/backend/src/auth/internalRoleAuth.ts
+++ b/apps/api/backend/src/auth/internalRoleAuth.ts
@@ -1,0 +1,40 @@
+/**
+ * internalRoleAuth.ts — transport-auth for GET /api/me/role (Wave 2B follow-up).
+ *
+ * Closes the residual documented in #504: `api.vitalcv.com/api/me/role` is
+ * internet-reachable and header-trusting (skip-listed from the tenant guard by
+ * #503 so signed-in role resolution works). #504 already blocked the account
+ * *takeover* path in ensureWorkspaceUser; this gate additionally requires the
+ * shared internal `MONITORING_SECRET` so only our own web tier — which has
+ * Clerk-verified the session — can reach the route at all, closing the residual
+ * role-disclosure and email pre-squat vectors.
+ *
+ * Rollout safety: gated behind `ENFORCE_ME_ROLE_INTERNAL_AUTH`. Default OFF, so
+ * shipping the code is a no-op and cannot re-break the just-recovered signed-in
+ * P0. It is armed only after `MONITORING_SECRET` is confirmed on BOTH the web
+ * and backend tiers. See docs/product/me-role-transport-auth.md.
+ *
+ * Pure and dependency-free so both the flag and the secret comparison are unit
+ * testable without Prisma or a live Express app.
+ */
+
+/**
+ * Decide whether an internal call to /api/me/role is authorized.
+ *
+ * - enforce=false  → always authorized (P0-safe default; secret ignored).
+ * - enforce=true   → authorized only when a non-empty secret is configured AND
+ *                    the provided value matches it exactly (fails closed).
+ */
+export function isInternalRoleCallAuthorized(
+  providedSecret: string | undefined | null,
+  expectedSecret: string | undefined | null,
+  enforce: boolean,
+): boolean {
+  if (!enforce) {
+    return true;
+  }
+  if (!expectedSecret || !providedSecret) {
+    return false;
+  }
+  return providedSecret === expectedSecret;
+}

--- a/apps/api/backend/src/routes/role.ts
+++ b/apps/api/backend/src/routes/role.ts
@@ -16,9 +16,16 @@
 import type { Express, NextFunction, Request, Response } from 'express';
 import { ensureWorkspaceUser } from '../services/workspace/workspaceService';
 import { inferRoleFromNpi } from '../services/auth/roleInferenceService';
+import { isInternalRoleCallAuthorized } from '../auth/internalRoleAuth';
 import { HttpError } from '../utils/httpError';
 import { log } from '../obs/logger';
 import prisma from '../graphql/prisma_client';
+
+// Transport-auth for this internet-reachable route (Wave 2B follow-up to #504).
+// Default OFF so shipping is a no-op; armed only after MONITORING_SECRET is set
+// on both web + backend tiers. See docs/product/me-role-transport-auth.md.
+const MONITORING_SECRET = process.env.MONITORING_SECRET?.trim();
+const ENFORCE_INTERNAL_AUTH = process.env.ENFORCE_ME_ROLE_INTERNAL_AUTH === 'true';
 
 function asyncHandler(
   fn: (req: Request, res: Response, next: NextFunction) => Promise<void>,
@@ -39,12 +46,21 @@ export function registerRoleRoutes(app: Express): void {
    * GET /api/me/role
    *
    * Returns { role: UserRole, userId: string, inferred?: boolean }
-   * Requires: x-clerk-user-id header
+   * Requires: x-clerk-user-id header; x-monitoring-secret when enforcement is on
    * Optional: x-clerk-user-email header (needed for first-time user creation)
    */
   app.get(
     '/api/me/role',
     asyncHandler(async (req: Request, res: Response) => {
+      // ── Transport-auth gate (must run before any DB access) ──────────────
+      // Only our own web tier holds MONITORING_SECRET. When enforcement is off
+      // (default) this is a no-op so the signed-in P0 fix cannot regress.
+      const providedSecret = getHeaderValue(req.headers['x-monitoring-secret']);
+      if (!isInternalRoleCallAuthorized(providedSecret, MONITORING_SECRET, ENFORCE_INTERNAL_AUTH)) {
+        res.status(403).json({ error: 'forbidden' });
+        return;
+      }
+
       const clerkUserId = getHeaderValue(req.headers['x-clerk-user-id'])?.trim();
       if (!clerkUserId) {
         throw new HttpError(401, 'Missing x-clerk-user-id header.');

--- a/apps/web/app/api/auth/resolve-role/route.ts
+++ b/apps/web/app/api/auth/resolve-role/route.ts
@@ -6,13 +6,23 @@
  *   1. Identifies the user from the verified Clerk session via auth() — NOT a
  *      caller-supplied header, so a browser cannot resolve anyone else's role.
  *   2. Fetches the primary email from Clerk (needed for first-time creation).
- *   3. Calls backend GET /api/me/role to upsert the User row and get the role.
+ *   3. Calls backend GET /api/me/role — forwarding the internal MONITORING_SECRET
+ *      so the backend transport-auth gate accepts the call once armed — to
+ *      upsert the User row and get the role.
  *   4. Mints the signed, short-lived `vitalcv_role` cookie and returns { role }.
  *
  * The middleware then reads that cookie on the follow-up navigation. This
  * replaces the old middleware->self-fetch fallback, which failed inside the
  * container (it could not reach its own public origin) and dead-ended every
  * first-time sign-in at /auth/error.
+ *
+ * Transport-auth (Wave 2B follow-up to #504): the backend /api/me/role route is
+ * internet-reachable and header-trusting. When ENFORCE_ME_ROLE_INTERNAL_AUTH is
+ * armed on the backend, it requires the shared MONITORING_SECRET; this proxy
+ * (the only legitimate caller) forwards it. Forwarding is harmless when the
+ * gate is off. This proxy needs NO inbound secret gate of its own: identity
+ * here comes from the verified Clerk session (auth()), not a trusted header.
+ * See docs/product/me-role-transport-auth.md.
  */
 import { auth, clerkClient } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
@@ -32,6 +42,11 @@ const BACKEND =
   process.env.NEXT_PUBLIC_BACKEND_URL ||
   process.env.NEXT_PUBLIC_API_BASE ||
   'http://localhost:4000';
+
+// Shared internal secret forwarded to the backend so its transport-auth gate
+// accepts this call when armed. Empty string when unset — harmless while the
+// backend gate is off; must be set on both tiers before arming enforcement.
+const INTERNAL_SECRET = process.env.MONITORING_SECRET?.trim() ?? '';
 
 export async function GET() {
   // 1. Authenticated self only — identity comes from the verified session.
@@ -55,7 +70,12 @@ export async function GET() {
   // 3. Resolve the role from the backend.
   let role: string;
   try {
-    const headers: Record<string, string> = { 'x-clerk-user-id': userId };
+    const headers: Record<string, string> = {
+      'x-clerk-user-id': userId,
+      // Forward the internal secret so the backend gate accepts the call when
+      // armed. Ignored by the backend when enforcement is off.
+      'x-monitoring-secret': INTERNAL_SECRET,
+    };
     if (email) headers['x-clerk-user-email'] = email;
 
     const res = await fetch(`${BACKEND}/api/me/role`, { headers });

--- a/docs/product/me-role-transport-auth.md
+++ b/docs/product/me-role-transport-auth.md
@@ -1,0 +1,101 @@
+# `/api/me/role` backend transport-auth gate (Wave 2B follow-up to #504)
+
+Closes the residual that #503/#504 explicitly deferred. **Reviewable, not
+merged.** Arming it is a coordinated, reversible env change — read the rollout
+before merging.
+
+> **Scope note (trimmed after #507).** This PR originally also gated the web
+> `/api/auth/resolve-role` proxy and had the middleware forward a secret to it.
+> #507 changed the architecture: the middleware no longer self-fetches
+> resolve-role (it redirects to the `/auth/resolving` interstitial), and
+> resolve-role now identifies the caller from the verified Clerk session via
+> `auth()` — not a trusted header. That already closes the web-proxy vector, and
+> an inbound secret gate on a **browser-called** endpoint would re-break the P0.
+> So this PR is now **backend-gate-only**: the sole remaining change is the
+> backend `GET /api/me/role` gate plus resolve-role forwarding the secret
+> *outbound* to the backend.
+
+## Background / threat model
+
+`#503` skip-listed `GET /api/me/role` from the backend tenant guard so signed-in
+role resolution works. That also made it reachable on the internet-facing
+`api.vitalcv.com`, where it trusts the caller-supplied `x-clerk-user-id` /
+`x-clerk-user-email` headers.
+
+- `#504` closed the **account-takeover** path (email→row rebind is now
+  allowlisted to platform placeholder rows only; real accounts → 409).
+- `#507` closed the **web proxy** vector: `/api/auth/resolve-role` is now
+  authenticated by the Clerk session (`auth()`), so an external caller cannot use
+  it to resolve anyone's role.
+- **Residual, still open — the backend route only:** `api.vitalcv.com/api/me/role`
+  remains header-trusting, so two lower-severity vectors persist there:
+  1. **Role disclosure** — given a known Clerk id, an external caller learns that
+     user's VitalCV role.
+  2. **Email pre-squat DoS** — an external caller can create a placeholder-free
+     `User` row for a victim's email, so the victim later 409s on first sign-in.
+
+Both are closed by requiring the shared internal `MONITORING_SECRET` (already
+used by ~20 backend internal routes) on the backend route, so only our own web
+tier — which resolve-role gates with a verified session — can reach it.
+
+## Design — why a flag, not a hard requirement
+
+The #504 author deferred this precisely because a hard secret requirement "needs
+env coordination … would re-break [the signed-in P0] if mis-set." So backend
+enforcement is behind **`ENFORCE_ME_ROLE_INTERNAL_AUTH`**, default **off**:
+
+| Component | Off (default) | On (armed) |
+| --- | --- | --- |
+| Backend `GET /api/me/role` | serves as today | 403 unless `x-monitoring-secret` matches |
+| Web `/api/auth/resolve-role` | `auth()`-gated (session); **forwards** `x-monitoring-secret` to the backend (harmless when off) | same — no inbound flag; identity is the verified session, not a header |
+| Web middleware | not involved (redirects to `/auth/resolving`; never calls resolve-role) | same |
+
+**Merging this PR changes no behavior** — the backend flag is off and the
+outbound header is ignored, so it cannot regress the P0. The gate is armed only
+after the secret is confirmed on both tiers.
+
+The backend predicate is pure and unit-tested:
+`apps/api/backend/src/auth/internalRoleAuth.ts`
+(`enforce=false` → always allow; `enforce=true` → fail-closed exact match).
+
+## Rollout runbook (in order)
+
+1. **Merge + deploy** this PR. No-op (flag off). Confirm the signed-in flow is
+   unchanged: sign in → `/auth/resolving` → `/holder`.
+2. **Set `MONITORING_SECRET` on the web service** to the **same value** the
+   backend already uses, so resolve-role forwards a matching secret. Redeploy
+   web. Still a no-op (backend flag off), but the secret now flows end-to-end.
+3. **Verify the secret path works** while still unenforced — sign in and confirm
+   `/holder` still loads (the resolve-role→backend call now carries the secret).
+4. **Arm it:** set `ENFORCE_ME_ROLE_INTERNAL_AUTH=true` on the **backend**
+   service. Redeploy backend. (No flag needed on web — it has no inbound gate.)
+5. **Verify enforcement:**
+   - Signed-in flow still works: sign in → `/holder` (not `/auth/error`).
+   - External backend call is now blocked:
+     ```bash
+     curl -s -o /dev/null -w '%{http_code}\n' \
+       -H 'x-clerk-user-id: user_anything' https://api.vitalcv.com/api/me/role
+     # expect 403 (was 200/404)
+     ```
+   - The web proxy already rejects unauthenticated external callers (independent
+     of this flag, via #507):
+     ```bash
+     curl -s -o /dev/null -w '%{http_code}\n' \
+       -H 'x-clerk-user-id: user_anything' https://vitalcv.com/api/auth/resolve-role
+     # expect 401 (no verified session)
+     ```
+
+## Rollback
+
+Set `ENFORCE_ME_ROLE_INTERNAL_AUTH=false` (or unset it) on the backend and
+redeploy — instant return to the current, working behavior. No code revert
+needed. If mid-rollout the signed-in flow ever dead-ends at `/auth/error`, the
+cause is almost always the web `MONITORING_SECRET` not matching the backend —
+fix the env or disarm the flag.
+
+## Note on the JWT fast path (optional, separate)
+
+`#503`/`#507` resolve the loop with a signed cookie, not the Clerk session-token
+claim, so this system works with no Clerk dashboard change. Enabling the
+`vitalcv.role` session-token claim later is a pure optimization (fewer backend
+hops) and is independent of this gate.


### PR DESCRIPTION
**Tier 2 hardening. DO NOT MERGE** until: `MONITORING_SECRET` is set on both web + backend, `ENFORCE_ME_ROLE_INTERNAL_AUTH` staged on the backend, and Chris approves the rollout. Merging with the flag off is a no-op.

## Trimmed post-#507 (2026-07-03)

This PR was **rebuilt on current `main`** after the signed-in P0 was fixed by #507 and verified closed in production. The previous version predated #507 and would have **reverted the interstitial fix and re-broken the P0** if merged. It also gated the web `/api/auth/resolve-role` proxy and had the middleware forward a secret — both now obsolete:

- #507 moved resolve-role identity to the **verified Clerk session (`auth()`)**, so the web proxy is no longer header-trusting → its inbound secret gate is unnecessary, and would be **harmful** (it's browser-called now; a browser can't send `MONITORING_SECRET`).
- #507's middleware **no longer calls resolve-role** (it redirects to `/auth/resolving`), so there's nothing to forward a secret from.

So this PR is now **backend-gate-only**.

## What it does

| File | Change |
|---|---|
| `apps/api/backend/src/auth/internalRoleAuth.ts` (+test) | Pure fail-closed predicate: `enforce=false` → allow; `enforce=true` → exact-match required |
| `apps/api/backend/src/routes/role.ts` | Gate `GET /api/me/role` behind `ENFORCE_ME_ROLE_INTERNAL_AUTH` (default off), before any DB access |
| `apps/web/app/api/auth/resolve-role/route.ts` | Forward `x-monitoring-secret` **outbound** to the backend (harmless when the gate is off). No inbound gate — identity is `auth()`. |
| `docs/product/me-role-transport-auth.md` | Threat model + staged rollout + rollback runbook |

**Closes the residual from #504** (backend `/api/me/role` role-disclosure + email pre-squat DoS) once armed. No behavior change until the backend flag is armed and the secret is set on both tiers.

## Verification

- Backend predicate unit test: **5/5 pass** (`internalRoleAuth.test.ts`, `enforce` off/on × match/miss/missing/unconfigured).
- Web typecheck: **green** (13/13 turbo tasks).
- No changes to `middleware.ts` and no `internalCallAuth` web predicate (dropped as obsolete).

## Rollback

Set `ENFORCE_ME_ROLE_INTERNAL_AUTH=false` (or unset) on the backend and redeploy — instant return to current behavior, no code revert. Full runbook: `docs/product/me-role-transport-auth.md`.
