### PR TITLE
fix(auth): resolve signed-in role via client interstitial — P0 /auth/error dead-end

### DIFF
--- a/apps/web/__tests__/redirect-sanitize.test.ts
+++ b/apps/web/__tests__/redirect-sanitize.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Wave 2B P0 fix — the /auth/resolving interstitial navigates to `redirect_url`
+ * after minting the role cookie. This pins the open-redirect guard.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_POST_RESOLVE_PATH, sanitizeInternalPath } from '@/lib/auth/redirect';
+
+describe('sanitizeInternalPath', () => {
+  it('keeps a same-origin absolute path (with query)', () => {
+    expect(sanitizeInternalPath('/holder')).toBe('/holder');
+    expect(sanitizeInternalPath('/holder/opportunities?apply=abc')).toBe(
+      '/holder/opportunities?apply=abc',
+    );
+    expect(sanitizeInternalPath('/holder/blockers/expiring-license')).toBe(
+      '/holder/blockers/expiring-license',
+    );
+  });
+
+  it('falls back for empty / nullish input', () => {
+    expect(sanitizeInternalPath(null)).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath(undefined)).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath('')).toBe(DEFAULT_POST_RESOLVE_PATH);
+  });
+
+  it('rejects absolute URLs and non-slash values (no open redirect)', () => {
+    expect(sanitizeInternalPath('https://evil.example.com')).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath('http://evil.example.com/x')).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath('evil.example.com')).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath('javascript:alert(1)')).toBe(DEFAULT_POST_RESOLVE_PATH);
+  });
+
+  it('rejects protocol-relative and backslash tricks', () => {
+    expect(sanitizeInternalPath('//evil.example.com')).toBe(DEFAULT_POST_RESOLVE_PATH);
+    expect(sanitizeInternalPath('/\\evil.example.com')).toBe(DEFAULT_POST_RESOLVE_PATH);
+  });
+
+  it('rejects control characters', () => {
+    expect(sanitizeInternalPath(`/holder${String.fromCharCode(10)}x`)).toBe(
+      DEFAULT_POST_RESOLVE_PATH,
+    );
+    expect(sanitizeInternalPath(`/holder${String.fromCharCode(0)}`)).toBe(
+      DEFAULT_POST_RESOLVE_PATH,
+    );
+    expect(sanitizeInternalPath(`/holder${String.fromCharCode(127)}`)).toBe(
+      DEFAULT_POST_RESOLVE_PATH,
+    );
+  });
+
+  it('honors a custom fallback', () => {
+    expect(sanitizeInternalPath(null, '/sign-in')).toBe('/sign-in');
+  });
+});

--- a/apps/web/__tests__/signin-resolution-routes.test.ts
+++ b/apps/web/__tests__/signin-resolution-routes.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Wave 2B P0 fix — route classification for the sign-in role-resolution flow.
+ * The interstitial must be public (else the middleware would loop trying to
+ * authorize the very page that resolves the role), and the protected surfaces
+ * must still require their role.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { UserRole, getRequiredRole, isPublicRoute } from '@/lib/auth/roles';
+
+describe('sign-in resolution routes', () => {
+  it('treats the resolver interstitial as public', () => {
+    expect(isPublicRoute('/auth/resolving')).toBe(true);
+  });
+
+  it('keeps /auth/error public', () => {
+    expect(isPublicRoute('/auth/error')).toBe(true);
+  });
+
+  it('does not gate the interstitial behind a role', () => {
+    expect(getRequiredRole('/auth/resolving')).toBeNull();
+  });
+
+  it('still gates the clinician surface behind CLINICIAN', () => {
+    expect(isPublicRoute('/holder')).toBe(false);
+    expect(getRequiredRole('/holder')).toBe(UserRole.CLINICIAN);
+    expect(getRequiredRole('/holder/readiness')).toBe(UserRole.CLINICIAN);
+  });
+});

--- a/apps/web/app/api/auth/resolve-role/route.ts
+++ b/apps/web/app/api/auth/resolve-role/route.ts
@@ -1,22 +1,31 @@
 /**
- * /api/auth/resolve-role — Clerk role resolution proxy
+ * /api/auth/resolve-role — Clerk role resolution
  *
- * Called by middleware.ts when a Clerk session has no vitalcv.role JWT claim
- * (i.e., first-time users or users whose JWT hasn't refreshed yet).
+ * Called from the BROWSER by the /auth/resolving interstitial (which the
+ * middleware redirects role-less-but-authenticated users to). It:
+ *   1. Identifies the user from the verified Clerk session via auth() — NOT a
+ *      caller-supplied header, so a browser cannot resolve anyone else's role.
+ *   2. Fetches the primary email from Clerk (needed for first-time creation).
+ *   3. Calls backend GET /api/me/role to upsert the User row and get the role.
+ *   4. Mints the signed, short-lived `vitalcv_role` cookie and returns { role }.
  *
- * Flow:
- *   1. Reads x-clerk-user-id from request headers (forwarded by middleware)
- *   2. Fetches primary email from Clerk (needed for user creation)
- *   3. Calls backend GET /api/me/role to upsert User + return role
- *   4. Returns { role: UserRole }
- *
- * Security: This route is only called server-side from middleware (same origin).
- * It never exposes credentials or session data to the browser.
+ * The middleware then reads that cookie on the follow-up navigation. This
+ * replaces the old middleware->self-fetch fallback, which failed inside the
+ * container (it could not reach its own public origin) and dead-ended every
+ * first-time sign-in at /auth/error.
  */
-import { clerkClient } from '@clerk/nextjs/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { UserRole, type UserRoleType } from '@/lib/auth/roles';
+import {
+  ROLE_COOKIE_NAME,
+  ROLE_COOKIE_TTL_SECONDS,
+  signRoleCookie,
+} from '@/lib/auth/roleCookie';
 
 export const runtime = 'nodejs';
+
+const VALID_ROLES = new Set<string>(Object.values(UserRole));
 
 const BACKEND =
   process.env.BACKEND_URL ||
@@ -24,47 +33,58 @@ const BACKEND =
   process.env.NEXT_PUBLIC_API_BASE ||
   'http://localhost:4000';
 
-export async function GET(req: NextRequest) {
-  const clerkUserId = req.headers.get('x-clerk-user-id');
-
-  if (!clerkUserId) {
-    return NextResponse.json({ error: 'Missing x-clerk-user-id' }, { status: 400 });
+export async function GET() {
+  // 1. Authenticated self only — identity comes from the verified session.
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
   }
 
-  // Fetch primary email from Clerk so backend can create the user if needed
+  // 2. Primary email so the backend can create a first-time user.
   let email: string | undefined;
   try {
     const clerk = await clerkClient();
-    const user = await clerk.users.getUser(clerkUserId);
+    const user = await clerk.users.getUser(userId);
     email = user.emailAddresses.find(
       (e) => e.id === user.primaryEmailAddressId,
     )?.emailAddress;
   } catch {
-    // Clerk fetch failed — proceed without email.
-    // ensureWorkspaceUser will still succeed for existing users.
+    // Clerk fetch failed — proceed without email; existing users still resolve.
   }
 
-  // Call backend to ensure User row exists and get their role
+  // 3. Resolve the role from the backend.
+  let role: string;
   try {
-    const headers: Record<string, string> = {
-      'x-clerk-user-id': clerkUserId,
-    };
-    if (email) {
-      headers['x-clerk-user-email'] = email;
-    }
+    const headers: Record<string, string> = { 'x-clerk-user-id': userId };
+    if (email) headers['x-clerk-user-email'] = email;
 
     const res = await fetch(`${BACKEND}/api/me/role`, { headers });
-
     if (!res.ok) {
       const body = await res.text();
       console.error('[resolve-role] backend error', res.status, body);
       return NextResponse.json({ error: 'Failed to resolve role' }, { status: 502 });
     }
-
-    const data = (await res.json()) as { role: string; userId: string };
-    return NextResponse.json({ role: data.role });
+    role = ((await res.json()) as { role: string }).role;
   } catch (err) {
     console.error('[resolve-role] backend unreachable', err);
     return NextResponse.json({ error: 'Backend unavailable' }, { status: 503 });
   }
+
+  // 4. Mint the signed role cookie so the middleware authorizes the follow-up
+  //    navigation from the cookie fast path. Only sign a known role — never
+  //    persist a garbage value that the middleware would reject and loop on.
+  const out = NextResponse.json({ role });
+  if (VALID_ROLES.has(role)) {
+    const cookieValue = await signRoleCookie(role as UserRoleType);
+    if (cookieValue) {
+      out.cookies.set(ROLE_COOKIE_NAME, cookieValue, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: ROLE_COOKIE_TTL_SECONDS,
+      });
+    }
+  }
+  return out;
 }

--- a/apps/web/app/auth/resolving/page.tsx
+++ b/apps/web/app/auth/resolving/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+// /auth/resolving — role-resolution interstitial.
+//
+// The middleware redirects authenticated-but-role-less users here. We resolve
+// the role from the BROWSER (the middleware can't reach its own origin from
+// inside the container), which sets the signed `vitalcv_role` cookie, then
+// navigate back to the original destination — where the middleware now reads
+// the cookie and lets the user through.
+
+import { useEffect, useState } from 'react';
+import { sanitizeInternalPath } from '@/lib/auth/redirect';
+
+const LOOP_GUARD_KEY = 'vcv_role_resolve';
+const LOOP_WINDOW_MS = 20000;
+const LOOP_MAX_ATTEMPTS = 3;
+
+/**
+ * Guard against a pathological redirect loop (cookie set but not honored):
+ * allow a few rapid attempts, then give up to /auth/error. Resets after the
+ * window so a legitimate later re-resolution is not blocked.
+ */
+function tooManyAttempts(): boolean {
+  try {
+    const now = Date.now();
+    const raw = sessionStorage.getItem(LOOP_GUARD_KEY);
+    let state = raw ? (JSON.parse(raw) as { n: number; t: number }) : { n: 0, t: 0 };
+    if (!state || now - state.t > LOOP_WINDOW_MS) state = { n: 0, t: now };
+    state = { n: state.n + 1, t: now };
+    sessionStorage.setItem(LOOP_GUARD_KEY, JSON.stringify(state));
+    return state.n > LOOP_MAX_ATTEMPTS;
+  } catch {
+    return false; // sessionStorage unavailable — don't block resolution
+  }
+}
+
+export default function ResolvingPage() {
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const dest = sanitizeInternalPath(params.get('redirect_url'));
+
+    if (tooManyAttempts()) {
+      window.location.replace('/auth/error');
+      return;
+    }
+
+    let cancelled = false;
+    const stallTimer = setTimeout(() => {
+      if (!cancelled) setStalled(true);
+    }, 6000);
+
+    (async () => {
+      try {
+        const res = await fetch('/api/auth/resolve-role', {
+          credentials: 'same-origin',
+          cache: 'no-store',
+        });
+        if (cancelled) return;
+        if (res.ok) {
+          window.location.replace(dest);
+        } else if (res.status === 401) {
+          window.location.replace(`/sign-in?redirect_url=${encodeURIComponent(dest)}`);
+        } else {
+          window.location.replace('/auth/error');
+        }
+      } catch {
+        if (!cancelled) setStalled(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(stallTimer);
+    };
+  }, []);
+
+  return (
+    <main
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '1rem',
+        textAlign: 'center',
+        padding: '2rem',
+      }}
+    >
+      <p aria-live="polite" style={{ fontSize: '1rem', opacity: 0.8 }}>
+        Signing you in…
+      </p>
+      {stalled && (
+        <p style={{ fontSize: '0.875rem', opacity: 0.7 }}>
+          Taking longer than expected.{' '}
+          <a href="/holder" style={{ textDecoration: 'underline' }}>
+            Continue to your wallet
+          </a>
+          .
+        </p>
+      )}
+      <noscript>
+        <a href="/holder">Continue to your wallet</a>
+      </noscript>
+    </main>
+  );
+}

--- a/apps/web/lib/auth/redirect.ts
+++ b/apps/web/lib/auth/redirect.ts
@@ -1,0 +1,33 @@
+// apps/web/lib/auth/redirect.ts
+//
+// Post-sign-in redirect target sanitization. The role-resolution interstitial
+// reads `redirect_url` from the query and navigates there after minting the
+// role cookie; this guards against open-redirects (protocol-relative //host,
+// absolute http(s):// URLs, backslash tricks, control chars). Pure + isomorphic
+// so it runs in the client interstitial and is unit-testable.
+
+export const DEFAULT_POST_RESOLVE_PATH = '/holder';
+
+/** True if the string contains an ASCII control char (0x00–0x1f or 0x7f). */
+function hasControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * Accept only a same-origin absolute path (starts with a single `/`).
+ * Anything else falls back to the clinician home.
+ */
+export function sanitizeInternalPath(
+  raw: string | null | undefined,
+  fallback: string = DEFAULT_POST_RESOLVE_PATH,
+): string {
+  if (typeof raw !== 'string' || raw.length === 0) return fallback;
+  if (!raw.startsWith('/')) return fallback; // relative path or absolute URL → reject
+  if (raw.startsWith('//') || raw.startsWith('/\\')) return fallback; // protocol-relative
+  if (hasControlChars(raw)) return fallback;
+  return raw;
+}

--- a/apps/web/lib/auth/roles.ts
+++ b/apps/web/lib/auth/roles.ts
@@ -100,6 +100,7 @@ export const PUBLIC_ROUTE_PATTERNS = [
   /^\/clip(\/.*)?$/, // App Clip zero-install verification receipts
   /^\/\.well-known(\/.*)?$/, // OS association manifests (AASA, assetlinks)
   /^\/auth\/error$/,
+  /^\/auth\/resolving$/, // role-resolution interstitial (self-resolves via /api/auth/resolve-role)
   /^\/api(\/.*)?$/, // API routes handle their own auth
 ];
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -7,12 +7,7 @@ import {
   getMismatchRedirect,
   type UserRoleType,
 } from '@/lib/auth/roles';
-import {
-  ROLE_COOKIE_NAME,
-  ROLE_COOKIE_TTL_SECONDS,
-  signRoleCookie,
-  verifyRoleCookie,
-} from '@/lib/auth/roleCookie';
+import { ROLE_COOKIE_NAME, verifyRoleCookie } from '@/lib/auth/roleCookie';
 import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowlist';
 
 /**
@@ -21,35 +16,23 @@ import { checkCorsAllowlist, getAllowedOrigins } from '@/lib/security/corsAllowl
  * Role resolution order, first hit wins:
  *   1. Clerk JWT claim (session.sessionClaims.vitalcv.role) — the fast path
  *      once Clerk session-token customization is enabled.
- *   2. Signed `vitalcv_role` cookie — set after a successful resolve so
- *      subsequent requests skip the backend round-trip.
- *   3. /api/auth/resolve-role backend fallback — upserts the User row and
- *      returns the role. On success we set the cookie and pass the request
- *      through (previously this redirected to ROLE_LANDING "to force a JWT
- *      refresh", which looped forever because the refreshed JWT still carried
- *      no role claim). On failure we redirect to /auth/error.
+ *   2. Signed `vitalcv_role` cookie — set by the resolver so subsequent
+ *      requests skip the backend round-trip.
+ *   3. Neither present → redirect to the /auth/resolving interstitial, which
+ *      calls /api/auth/resolve-role from the BROWSER (reachable), mints the
+ *      signed cookie, and returns the user here.
+ *
+ * Why the interstitial: the middleware must NOT server-fetch its own
+ * `/api/auth/resolve-role` — that self-call fails inside the container (it
+ * can't reach its own public origin), which dead-ended every first-time
+ * sign-in at /auth/error even though the route itself works. Resolving from the
+ * browser sidesteps container networking entirely.
  *
  * Intelligence and investigation API routes attempt Clerk but gracefully
  * degrade when Clerk edge processing fails (missing keys, timeout, etc.).
  * Route handlers use resolveIntelligenceAuthContext() which returns
  * missing_session when Clerk is unavailable.
  */
-
-/** Attach the signed, short-lived role cookie to an outgoing response. */
-async function attachRoleCookie(
-  res: NextResponse,
-  role: UserRoleType,
-): Promise<void> {
-  const value = await signRoleCookie(role);
-  if (!value) return;
-  res.cookies.set(ROLE_COOKIE_NAME, value, {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: ROLE_COOKIE_TTL_SECONDS,
-  });
-}
 
 const isSignInPage = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
 
@@ -89,9 +72,9 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
   let userRole: UserRoleType | undefined =
     session.sessionClaims?.vitalcv?.role as UserRoleType | undefined;
 
-  // 4b. Read role from the signed cookie set by a prior resolve. Avoids the
-  //     backend round-trip on every navigation and works even though the JWT
-  //     carries no role claim.
+  // 4b. Read role from the signed cookie the resolver set on a prior request.
+  //     Avoids the backend round-trip and works even though the JWT carries no
+  //     role claim.
   if (!userRole) {
     const cookieRole = await verifyRoleCookie(
       req.cookies.get(ROLE_COOKIE_NAME)?.value,
@@ -99,53 +82,29 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
     if (cookieRole) userRole = cookieRole;
   }
 
-  // 5. Fallback: no role from JWT or cookie — resolve via backend.
-  let resolvedViaFallback = false;
+  // 5. No role yet → hand off to the client-side resolver interstitial. It
+  //    calls /api/auth/resolve-role from the browser, which mints the signed
+  //    cookie, then returns the user to `redirect_url`. We never self-fetch
+  //    resolve-role from here (that container self-call is what broke).
   if (!userRole) {
-    try {
-      const resolveUrl = new URL('/api/auth/resolve-role', req.nextUrl.origin);
-      const resolveRes = await fetch(resolveUrl, {
-        headers: {
-          'x-clerk-user-id': session.userId,
-        },
-      });
-
-      if (resolveRes.ok) {
-        const data = await resolveRes.json();
-        userRole = data.role as UserRoleType;
-        resolvedViaFallback = Boolean(userRole);
-      }
-    } catch {
-      // Fallback failed — fall through to the /auth/error circuit breaker.
-    }
-
-    if (!userRole) {
-      const errorUrl = req.nextUrl.clone();
-      errorUrl.pathname = '/auth/error';
-      return NextResponse.redirect(errorUrl);
-    }
+    const resolveUrl = req.nextUrl.clone();
+    resolveUrl.pathname = '/auth/resolving';
+    const target = `${pathname}${req.nextUrl.search}`;
+    resolveUrl.search = '';
+    resolveUrl.searchParams.set('redirect_url', target);
+    return NextResponse.redirect(resolveUrl);
   }
 
-  // 6. Check role matches route, then build the response.
-  //    AUTHENTICATED routes accept any authenticated user regardless of role.
-  let res: NextResponse;
+  // 6. Enforce the role. AUTHENTICATED routes accept any signed-in user.
   if (requiredRole !== 'AUTHENTICATED' && userRole !== requiredRole) {
     const redirectUrl = req.nextUrl.clone();
     redirectUrl.pathname = getMismatchRedirect(pathname, userRole);
-    res = NextResponse.redirect(redirectUrl);
-  } else {
-    // 7. Authorized — pass through.
-    res = NextResponse.next();
+    redirectUrl.search = '';
+    return NextResponse.redirect(redirectUrl);
   }
 
-  // 8. Persist the resolved role so the next request uses the cookie fast path
-  //    instead of hitting the backend again (and never loops on a JWT refresh
-  //    that will not carry the claim).
-  if (resolvedViaFallback) {
-    await attachRoleCookie(res, userRole);
-  }
-
-  return res;
+  // 7. Authorized — pass through.
+  return NextResponse.next();
 });
 
 export default async function middleware(req: NextRequest, event: NextFetchEvent) {


### PR DESCRIPTION
> **🔴 P0 — the signed-in clinician flow is still broken in production** despite #503/#504. This restores it. Needs a Railway deploy + a live re-verification (below); the failure does not reproduce locally.

## Proven root cause

Verified against production with a **real active Clerk session** (not 307-inference): authed `/holder` → **307 `/auth/error`, 3/3 consistent**. Isolating each hop:

| Hop | Result |
|---|---|
| Backend `GET /api/me/role` (direct) | ✅ 200 `{role: CLINICIAN}` |
| Web `GET /api/auth/resolve-role` (direct) | ✅ 200 `{role: CLINICIAN}`, <0.7s |
| Forged **signed** `vitalcv_role` cookie + session → `/holder` | ✅ **200 (renders)** |
| Same session **without** the cookie → `/holder` | ❌ 307 → `/auth/error` |

The forged-cookie test proves #503 is deployed and the cookie/role/render path all work. **The only broken hop is the middleware's fallback `fetch(req.nextUrl.origin + '/api/auth/resolve-role')` — it fails inside the Railway container** (a container can't reach its own public origin). Since the `vitalcv_role` cookie is only ever set *after* a successful fallback, a first-time signed-in user can never get it → permanent `/auth/error`.

## Fix — resolve from the browser, not a middleware self-fetch

- **middleware**: when neither the JWT claim nor the signed cookie carries a role, redirect to a new **public** `/auth/resolving` interstitial. The broken container self-fetch is deleted.
- **`/auth/resolving`** (client): calls `/api/auth/resolve-role` — reachable from the *browser* — then navigates to the sanitized `redirect_url`. Loop-guarded (bounded rapid attempts → `/auth/error`).
- **`/api/auth/resolve-role`**: identifies the user via `auth()` (verified session) — **not** a caller-supplied header — and mints the signed `vitalcv_role` cookie itself. The follow-up navigation then authorizes from the cookie fast path.

Net flow: `/holder` (no role) → `/auth/resolving` → browser resolves + sets cookie → `/holder` (cookie present) → **renders**. No container self-call; no loop.

Bonus: the proxy no longer trusts `x-clerk-user-id` from the caller (browser-facing now), closing that spoof vector on the web tier.

## Tests / build

- Open-redirect guard **6/6**, route classification **4/4**, #503 role-cookie **8/8**, route-contract **144/144** — all green.
- Web build green; `/auth/resolving` present in the route manifest; middleware compiles.

## ⚠️ Verification is post-deploy

The container-networking failure **does not reproduce locally**, so local/CI green is necessary but not sufficient. After this deploys to Railway I will **re-run the exact production harness** (mint a real signed-in session → probe `/holder`) and confirm `/holder → 200`, no `/auth/error`, no loop. Do not close the P0 until that passes.

## Interaction with #506 (parked)

The middleware self-fetch that #506 hardened no longer exists. #506 should be reduced to **just** the backend `/api/me/role` transport-auth gate (still valid for direct external calls to `api.vitalcv.com`); its middleware/resolve-role changes are superseded by this PR.

## Merge

Do not merge without external review / Chris approval. Deploy path is Railway (web only — no backend change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)