### PR TITLE
feat(home): lead the public homepage with the clinician career-evidence loop

### DIFF
--- a/apps/web/__tests__/home-npi-role-doors.test.tsx
+++ b/apps/web/__tests__/home-npi-role-doors.test.tsx
@@ -1,11 +1,14 @@
 /**
- * home-npi-role-doors.test.tsx — Wave I coverage.
+ * home-npi-role-doors.test.tsx — Visible Product Wave coverage.
  *
  * Asserts the homepage renders:
- *   - the canonical NPI-first headline + subhead,
- *   - "Look up an NPI" as the primary CTA label,
+ *   - the Career Evidence Network eyebrow + clinician-value headline + subhead,
+ *   - "Check readiness" as the primary NPI CTA label,
  *   - a "Sign in" secondary link,
- *   - four role doors (Verifier / Clinician / Employer / Issuer)
+ *   - the five-step "how it works" loop,
+ *   - the "what you get" value cards (wallet / readiness / recognition /
+ *     proof / opportunities / time-to-start),
+ *   - four role doors (Clinician / Verifier / Employer / Issuer)
  *     each with the documented action label,
  *   - a three-column proof strip (Source / State / Review boundary),
  *   - a trust footer row (Status / Source attribution / Trust),
@@ -59,20 +62,26 @@ function assertNoBannedPhrases(html: string): void {
   }
 }
 
-describe('HomePageClient — NPI-first hero', () => {
-  it('renders the canonical hero headline and subhead', () => {
+describe('HomePageClient — clinician-value hero', () => {
+  it('renders the network eyebrow and clinician-value headline', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
-    expect(html).toContain('Look up an NPI.');
-    expect(html).toContain('data-home-hero-subhead');
-    expect(html).toContain(
-      'See what is source-backed, what is gated, and what still needs institution review.',
-    );
+    expect(html).toContain('data-home-eyebrow');
+    expect(html).toContain('The Provider Career Evidence Network');
+    expect(html).toContain('Your clinical career evidence, in one wallet you own.');
   });
 
-  it('renders "Look up an NPI" as the primary CTA label', () => {
+  it('renders the NPI-first subhead', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-hero-subhead');
+    expect(html).toContain('Start with your NPI.');
+    expect(html).toContain('employer-ready proof packet');
+    expect(html).toContain('reusable for every move');
+  });
+
+  it('renders "Check readiness" as the primary CTA label', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
     expect(html).toContain('data-home-primary-cta');
-    expect(html).toMatch(/Look up an NPI[^<]*<svg/);
+    expect(html).toMatch(/Check readiness[^<]*<svg/);
   });
 
   it('renders a "Sign in" secondary link', () => {
@@ -80,6 +89,54 @@ describe('HomePageClient — NPI-first hero', () => {
     expect(html).toContain('data-home-secondary-cta');
     expect(html).toContain('href="/sign-in"');
     expect(html).toContain('>Sign in<');
+  });
+});
+
+describe('HomePageClient — how-it-works loop', () => {
+  it('renders the five loop steps', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-loop');
+    for (const n of ['1', '2', '3', '4', '5']) {
+      expect(html).toContain(`data-home-loop-step="${n}"`);
+    }
+  });
+
+  it('names the canonical clinician path in the loop copy', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('Start with your NPI');
+    expect(html).toContain('We check primary sources');
+    expect(html).toContain('Get your readiness snapshot');
+    expect(html).toContain('Share an employer-ready packet');
+    expect(html).toContain('Get accepted as a head start');
+  });
+});
+
+describe('HomePageClient — value cards', () => {
+  it('renders the six value cards', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-value');
+    for (const key of [
+      'wallet',
+      'readiness',
+      'recognition',
+      'proof',
+      'opportunities',
+      'time-to-start',
+    ]) {
+      expect(html).toContain(`data-home-value-card="${key}"`);
+    }
+  });
+
+  it('communicates the clinician product in the value copy', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('A free career wallet you own');
+    expect(html).toContain('NPI-first readiness');
+    expect(html).toContain('VitalCV Recognition');
+    expect(html).toContain('Shareable proof');
+    expect(html).toContain('Opportunity matching');
+    expect(html).toContain('Start working faster');
+    // MATCHA named as the matching engine (a substrate, not the headline).
+    expect(html).toContain('MATCHA');
   });
 });
 
@@ -95,8 +152,8 @@ describe('HomePageClient — role doors', () => {
 
   it('each role door advertises its canonical action label', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
-    expect(html).toContain('Look up an NPI'); // verifier (also matches the primary CTA above the doors)
     expect(html).toContain('Claim my NPI record'); // clinician
+    expect(html).toContain('Look up an NPI'); // verifier
     expect(html).toContain('Review a passport'); // employer
     expect(html).toContain('Connect a source'); // issuer
   });

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -4,7 +4,16 @@ import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { SignedIn } from '@clerk/nextjs';
-import { ArrowRight, Fingerprint, Zap } from 'lucide-react';
+import {
+  ArrowRight,
+  Award,
+  Compass,
+  Fingerprint,
+  Share2,
+  ShieldCheck,
+  Wallet,
+  Zap,
+} from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
@@ -18,13 +27,107 @@ function formatNpi(value: string): string {
 }
 
 /**
- * Role doors — four entry points keyed off operator role.
- *
- * Each door is a calm card with a single action. Doors share a flat
- * visual treatment (no gradients, no hover lift, no shadow-stack drama)
- * so the NPI lookup above remains the unambiguous primary action.
+ * The loop — the canonical clinician path, stated plainly so a first-time
+ * visitor can see what VitalCV does end to end. Mirrors the doctrine path
+ * NPI → Source checks → Readiness → Proof packet → Employer review →
+ * Accepted as a head start → Start → Reuse. Kept honest: employer review is
+ * a head start, never a final credentialing decision.
+ */
+const LOOP_STEPS = [
+  {
+    n: '1',
+    title: 'Start with your NPI',
+    text: 'No account required to look. Your NPI is the key to everything below.',
+  },
+  {
+    n: '2',
+    title: 'We check primary sources',
+    text: 'Each field names its source and shows state — source-backed, gated, or stale.',
+  },
+  {
+    n: '3',
+    title: 'Get your readiness snapshot',
+    text: 'A source-backed picture of where you stand, in your own wallet.',
+  },
+  {
+    n: '4',
+    title: 'Share an employer-ready packet',
+    text: 'Send proof that shows what is source-backed and what still needs review.',
+  },
+  {
+    n: '5',
+    title: 'Get accepted as a head start',
+    text: 'When an employer accepts it, that becomes your VitalCV Recognition — then reuse the same wallet for your next move.',
+  },
+] as const;
+
+/**
+ * Value cards — the eight things VitalCV gives a clinician, grouped so each
+ * card carries a single clear idea and (where a real public route exists) a
+ * single action. No card links to a route that does not exist.
+ */
+const VALUE_CARDS = [
+  {
+    key: 'wallet',
+    icon: Wallet,
+    title: 'A free career wallet you own',
+    text: 'A clinician-owned home for your identity, credentials, and evidence. Free to start, and yours to keep across every job.',
+    href: '/get-ready',
+    cta: 'Start your wallet',
+  },
+  {
+    key: 'readiness',
+    icon: ShieldCheck,
+    title: 'NPI-first readiness',
+    text: 'Enter your NPI and VitalCV reads primary sources to build a source-backed readiness snapshot — honest about what is checked, gated, or stale.',
+    href: '#npi',
+    cta: 'Check your readiness',
+  },
+  {
+    key: 'recognition',
+    icon: Award,
+    title: 'VitalCV Recognition',
+    text: 'When an employer accepts your evidence as a head start, the acceptance is recorded as Recognition on your career record — a head start, not a final credentialing decision.',
+    href: '/trust',
+    cta: 'How Recognition works',
+  },
+  {
+    key: 'proof',
+    icon: Share2,
+    title: 'Shareable proof',
+    text: 'Share a proof packet an employer can read in minutes. Every row names its source and shows its state, so review starts from evidence.',
+    href: '/trust/attribution',
+    cta: 'See what a packet shows',
+  },
+  {
+    key: 'opportunities',
+    icon: Compass,
+    title: 'Opportunity matching',
+    text: 'MATCHA matches your source-backed evidence to open roles, and you apply with your VitalCV — no re-uploading the same documents for every application.',
+    href: '/get-ready',
+    cta: 'Find your path',
+  },
+  {
+    key: 'time-to-start',
+    icon: Zap,
+    title: 'Start working faster',
+    text: 'Evidence that is ready before day one shortens Time-to-Start. Reuse the same wallet for the next opportunity instead of starting over.',
+    href: null,
+    cta: null,
+  },
+] as const;
+
+/**
+ * Role doors — four entry points keyed off operator role. Clinician leads.
+ * Each door is a calm card with a single action.
  */
 const ROLE_DOORS = [
+  {
+    role: 'Clinician',
+    action: 'Claim my NPI record',
+    href: '/onboarding',
+    blurb: 'Open the wallet tied to your NPI and see your readiness.',
+  },
   {
     role: 'Verifier',
     action: 'Look up an NPI',
@@ -32,15 +135,9 @@ const ROLE_DOORS = [
     blurb: 'See what is source-backed about a clinician.',
   },
   {
-    role: 'Clinician',
-    action: 'Claim my NPI record',
-    href: '/onboarding',
-    blurb: 'Open the snapshot tied to your NPI.',
-  },
-  {
     role: 'Employer',
     action: 'Review a passport',
-    href: '/employers',
+    href: '/pilot',
     blurb: 'Reviewer-ready head start, not a final credentialing decision.',
   },
   {
@@ -124,31 +221,42 @@ export default function HomePageClient() {
                 href="/holder"
                 className="ml-1 font-semibold underline underline-offset-4 transition-opacity hover:opacity-80"
               >
-                Go to Workspace
+                Go to your wallet
               </Link>
             </p>
           </div>
         </SignedIn>
       )}
 
-      <main className="relative mx-auto flex min-h-screen w-full max-w-5xl items-start px-6 py-16 sm:py-20">
+      <main className="relative mx-auto w-full max-w-5xl px-6 py-16 sm:py-20">
         <div className="w-full">
 
-          {/* Hero — NPI-first lookup with trust-bounded headline */}
+          {/* Hero — clinician value, NPI-first entry */}
           <section aria-label="NPI lookup" data-home-hero="" className="max-w-3xl">
             <div className="space-y-5">
-              <h1 className="text-[clamp(2.5rem,6vw,4rem)] leading-[0.96] font-semibold tracking-[-0.04em] text-[var(--vt-text-primary)]">
-                Look up an NPI.
+              <p
+                data-home-eyebrow=""
+                className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--vt-text-muted)]"
+              >
+                The Provider Career Evidence Network
+              </p>
+              <h1 className="text-[clamp(2.4rem,5.6vw,3.75rem)] leading-[0.98] font-semibold tracking-[-0.04em] text-[var(--vt-text-primary)]">
+                Your clinical career evidence, in one wallet you own.
               </h1>
               <p
                 data-home-hero-subhead=""
                 className="max-w-2xl text-[18px] leading-[1.6] text-[var(--vt-text-secondary)]"
               >
-                See what is source-backed, what is gated, and what still needs institution review.
+                Start with your NPI. VitalCV reads primary sources, builds your
+                readiness snapshot, and gives you an employer-ready proof packet —
+                free for clinicians, and reusable for every move.
               </p>
             </div>
 
-            <Card className="mt-8 max-w-2xl border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_96%,white)] shadow-[0_1px_0_rgba(255,255,255,0.72),0_18px_48px_rgba(15,23,42,0.05)]">
+            <Card
+              id="npi"
+              className="mt-8 max-w-2xl scroll-mt-24 border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_96%,white)] shadow-[0_1px_0_rgba(255,255,255,0.72),0_18px_48px_rgba(15,23,42,0.05)]"
+            >
               <CardContent className="space-y-5 px-5 py-5 sm:px-6 sm:py-6">
                 <form
                   className="space-y-2"
@@ -158,7 +266,7 @@ export default function HomePageClient() {
                   }}
                 >
                   <label
-                    htmlFor="npi"
+                    htmlFor="npi-input"
                     className="text-[11px] font-medium uppercase tracking-[0.2em] text-[var(--vt-text-muted)]"
                   >
                     NPI
@@ -176,7 +284,7 @@ export default function HomePageClient() {
                       <Fingerprint size={18} aria-hidden="true" />
                     </div>
                     <Input
-                      id="npi"
+                      id="npi-input"
                       type="text"
                       inputMode="numeric"
                       autoComplete="off"
@@ -203,7 +311,7 @@ export default function HomePageClient() {
                           : 'cursor-not-allowed bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
                       )}
                     >
-                      Look up an NPI
+                      Check readiness
                       <ArrowRight size={16} aria-hidden="true" />
                     </button>
                   </div>
@@ -236,11 +344,82 @@ export default function HomePageClient() {
             </Card>
           </section>
 
-          {/* Role doors — four calm entry points */}
+          {/* The loop — what VitalCV does, end to end */}
+          <section aria-label="How VitalCV works" data-home-loop="" className="mt-16">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              How it works
+            </p>
+            <ol className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+              {LOOP_STEPS.map((step) => (
+                <li
+                  key={step.n}
+                  data-home-loop-step={step.n}
+                  className="flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
+                >
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--vt-text-primary)] text-[12px] font-semibold text-[var(--vt-bg)]">
+                    {step.n}
+                  </span>
+                  <p className="text-sm font-semibold leading-snug text-[var(--vt-text-primary)]">
+                    {step.title}
+                  </p>
+                  <p className="text-[12px] leading-relaxed text-[var(--vt-text-secondary)]">
+                    {step.text}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* Value cards — the clinician's answer to "what do I get?" */}
+          <section
+            aria-label="What VitalCV gives clinicians"
+            data-home-value=""
+            className="mt-16"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              What you get
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {VALUE_CARDS.map((card) => {
+                const Icon = card.icon;
+                return (
+                  <div
+                    key={card.key}
+                    data-home-value-card={card.key}
+                    className="flex flex-col gap-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-5 py-5"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="flex h-9 w-9 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
+                    >
+                      <Icon size={17} />
+                    </span>
+                    <p className="text-[15px] font-semibold leading-snug text-[var(--vt-text-primary)]">
+                      {card.title}
+                    </p>
+                    <p className="text-[13px] leading-relaxed text-[var(--vt-text-secondary)]">
+                      {card.text}
+                    </p>
+                    {card.href && card.cta ? (
+                      <Link
+                        href={card.href}
+                        className="mt-auto inline-flex items-center gap-1.5 pt-1 text-[13px] font-semibold text-[var(--vt-text-primary)] underline-offset-4 transition-opacity hover:opacity-80"
+                      >
+                        {card.cta}
+                        <ArrowRight size={14} aria-hidden="true" />
+                      </Link>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Role doors — four calm entry points, clinician first */}
           <section
             aria-label="Role-specific entry points"
             data-home-role-doors=""
-            className="mt-14"
+            className="mt-16"
           >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
               By role
@@ -271,7 +450,7 @@ export default function HomePageClient() {
           <section
             aria-label="What every passport row carries"
             data-home-proof-strip=""
-            className="mt-14"
+            className="mt-16"
           >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
               Every row carries
@@ -298,7 +477,7 @@ export default function HomePageClient() {
           <nav
             aria-label="Trust footer"
             data-home-trust-footer=""
-            className="mt-14 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-[var(--vt-border-subtle)] pt-6 text-[12px] text-[var(--vt-text-muted)]"
+            className="mt-16 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-[var(--vt-border-subtle)] pt-6 text-[12px] text-[var(--vt-text-muted)]"
           >
             <span className="text-[11px] font-semibold uppercase tracking-[0.18em]">
               Trust


### PR DESCRIPTION
## Summary

The live public homepage led with the verifier mechanic — a bare "Look up an NPI." headline — so a first-time visitor could not tell what VitalCV *is* for a clinician. This refresh keeps the NPI-first entry (and the working `/passport` handoff) but reframes the page around the clinician career-evidence loop, so a normal visitor understands the product in one scroll.

What a visitor now sees, in order:

- **Hero** — eyebrow "The Provider Career Evidence Network", headline "Your clinical career evidence, in one wallet you own.", and an NPI-first subhead. The NPI lookup card is unchanged in behavior (submits to `/passport?npi=…`); the primary button reads **Check readiness**.
- **How it works** — a five-step loop naming the canonical path: NPI → source checks (source-backed / gated / stale) → readiness snapshot → employer-ready packet → accepted as a head start → VitalCV Recognition → reuse the wallet.
- **What you get** — six value cards communicating: a free clinician-owned wallet, NPI-first readiness, VitalCV Recognition, shareable proof, opportunity matching (MATCHA named as the engine), and Time-to-Start / reuse.
- **By role / proof strip / trust footer** — retained; clinician door now leads.

Every CTA points at a route that exists and returns non-404 in production: `/get-ready` (200), `/trust` (200), `/trust/attribution`, `/pilot` (employers), `/passport`, `/sign-in`, `/onboarding`, `#npi`. No card links to `/explore` (404 in prod).

## Truth rules (what is NOT claimed)

- No status label is the bare word `Verified`; the string "verified" appears only as the `--vt-state-verified` CSS token inside the `SignedIn` banner (not rendered copy).
- No banned strings (`automatically verified`, `guaranteed verification`, `instant/complete credentialing`, `legally accepted`, `HIPAA compliant`, `SOC2 certified`, etc.) — grep clean.
- Recognition is described as "a head start, not a final credentialing decision"; the proof strip keeps "Institution review remains the final step."
- Source-coverage honesty preserved: copy says fields are "source-backed, gated, or stale," never "verified."
- No fake data, no demo clinician, no employer platform, no auth change.

## Validation

- Targeted vitest `home-npi-role-doors.test.tsx`: **16/16** (rewritten to match the intentional copy change + new loop/value sections; banned-phrase scan intact).
- `pnpm turbo run build --filter @vitalcv/web`: green (see CI).
- Truth-contract grep over the diff: clean.
- No other test pins the old headline (`postrelease-truth-cleanup` is quarantined in `vitest.config`).

## Tier

**Tier 1 (product / public copy surface).** Self-mergeable with heightened review per the release-manager routine: single presentational file + its test, no API/auth/runtime changes. Rollback = revert the squash commit (pure copy/markup, no state).

## Design Handoff References

No Claude Design handoff file used for this PR. The refresh reuses the existing homepage design system (the `--vt-*` token set and card/strip components already in `HomePageClient.tsx`); it is a copy/IA change within that established visual language, not a new design import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
