### PR TITLE
feat(holder-home): make the signed-in home an identity-forward VitalCV Wallet

### DIFF
--- a/apps/web/__tests__/holder-home-page.test.tsx
+++ b/apps/web/__tests__/holder-home-page.test.tsx
@@ -270,7 +270,12 @@ describe('/holder/home page', () => {
       </ClinicianMobileProvider>,
     );
 
-    expect(markup).toContain('Keep moving');
+    // Identity-forward wallet header: who you are + how to share/prove.
+    expect(markup).toContain('Your VitalCV Wallet');
+    expect(markup).toContain('Ada Lovelace');
+    expect(markup).toContain('NPI 1234567890');
+    expect(markup).toContain('Share / prove');
+    expect(markup).toContain('href="/verify/1234567890"');
     expect(markup).toContain('Readiness');
     expect(markup).toContain('What&#x27;s left');
     expect(markup).toContain('Recent changes');

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -9,9 +9,10 @@ import {
   History,
   RefreshCw,
   Settings,
+  Share2,
   ShieldCheck,
-  Sparkles,
   UserRound,
+  Wallet,
 } from 'lucide-react';
 import {
   ApplicationList,
@@ -58,7 +59,7 @@ function resumeLabel(path: string | null): { title: string; href: string } | nul
   }
 
   if (path.startsWith('/holder')) {
-    return { title: 'Return to your your readiness', href: path };
+    return { title: 'Return to your readiness', href: path };
   }
 
   return { title: 'Continue where you left off', href: path };
@@ -114,7 +115,15 @@ export default function ClinicianHomeSurface() {
   } = useClinicianMobile();
   const resume = resumeLabel(resumePath);
   const readiness = data.trustState;
-  const npi = data.workspace?.personProfile?.npi ?? 'unknown';
+  const profile = data.workspace?.personProfile;
+  const npi = profile?.npi ?? 'unknown';
+  const hasValidNpi = /^\d{10}$/.test(npi);
+  const fullName = [profile?.firstName, profile?.lastName].filter(Boolean).join(' ').trim();
+  const displayName = fullName || 'Your VitalCV Wallet';
+  // Share the real, public, source-backed proof (what an employer actually
+  // reads) — never the demo-backed presentation flow. Falls back to the wallet
+  // when no NPI is bound yet.
+  const shareHref = hasValidNpi ? `/verify/${npi}` : '/holder';
   const completeness = data.profileCompleteness?.score ?? data.workspace?.personProfile?.completeness ?? 0;
   const completedProfileChecks = countCompletedProfileChecks(data.profileCompleteness?.dimensions);
   const previousVisitMs = previousVisitAt ? Date.parse(previousVisitAt) : 0;
@@ -139,10 +148,10 @@ export default function ClinicianHomeSurface() {
       }
     : {
         eyebrow: data.recommendedAction?.kind === 'finish_onboarding' ? 'Start here' : 'Next step',
-        title: data.recommendedAction?.title ?? 'Open your your readiness',
+        title: data.recommendedAction?.title ?? 'Open your readiness',
         detail: highlightedChange
-          ? `${data.recommendedAction?.description ?? 'Keep your verified identity ready to share.'} Latest: ${highlightedChange.title}.`
-          : data.recommendedAction?.description ?? 'Keep your verified identity ready to share.',
+          ? `${data.recommendedAction?.description ?? 'Keep your source-backed identity ready to share.'} Latest: ${highlightedChange.title}.`
+          : data.recommendedAction?.description ?? 'Keep your source-backed identity ready to share.',
         href: data.recommendedAction?.href ?? '/holder',
         label: data.recommendedAction?.kind === 'resolve_gap'
           ? data.recommendedAction.ctaLabel
@@ -229,29 +238,48 @@ export default function ClinicianHomeSurface() {
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
-      <header className="flex items-start justify-between gap-4">
-        <div>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
           <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-100">
-            <Sparkles className="h-3.5 w-3.5" />
-            Active
+            <Wallet className="h-3.5 w-3.5" />
+            Your VitalCV Wallet
           </div>
-          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white">
-            Keep moving
+          <h1 className="mt-4 truncate text-3xl font-semibold tracking-tight text-white">
+            {displayName}
           </h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/65">
-            Pick up where you left off and take the next clear step.
+          <p className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm leading-6 text-white/65">
+            {hasValidNpi ? (
+              <span className="font-mono text-white/50">NPI {npi}</span>
+            ) : (
+              <span>Add your NPI to build your source-backed readiness.</span>
+            )}
+            {profile?.specialty ? (
+              <>
+                <span aria-hidden="true" className="text-white/25">·</span>
+                <span>{profile.specialty}</span>
+              </>
+            ) : null}
           </p>
         </div>
 
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          disabled={isRefreshing}
-          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href={shareHref}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/50 hover:bg-emerald-400/15"
+          >
+            <Share2 className="h-4 w-4" />
+            {hasValidNpi ? 'Share / prove' : 'Set up sharing'}
+          </Link>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={isRefreshing}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </div>
       </header>
 
       {refreshError ? (

--- a/apps/web/lib/mobile/clinician-state.ts
+++ b/apps/web/lib/mobile/clinician-state.ts
@@ -783,8 +783,8 @@ export function buildRecommendedAction(input: {
 
   return {
     kind: 'view_passport',
-    title: 'Review your your readiness',
-    description: 'Keep your verified identity and credential evidence ready to share.',
+    title: 'Review your readiness',
+    description: 'Keep your source-backed identity and credential evidence ready to share.',
     href: '/holder',
     ctaLabel: 'Open passport',
   };


### PR DESCRIPTION
## Summary

The signed-in clinician home (`/holder/home`) opened with a generic "Keep moving / Active" header — a clinician could not immediately see **who they are** or **how to share/prove** their evidence. The body already renders readiness, recognition, profile completeness, next action, and the opportunity path; this makes identity and share/prove first-class.

- **Header → "Your VitalCV Wallet"**: eyebrow with a wallet mark, the clinician's name (`personProfile.firstName/lastName`), `NPI · specialty`, replacing "Keep moving / Active".
- **Share / prove action**: a prominent header button that opens the clinician's **real, public, source-backed** proof — `/verify/:npi` (what an employer actually reads). It deliberately does **not** route to `CredentialPresentationActions`, which is still demo-backed (`cred-demo-001…`).
- **Honest empty state**: when no NPI is bound, the header says "Add your NPI to build your source-backed readiness." and the action becomes "Set up sharing" → `/holder`.
- **Copy fixes**: the "your your readiness" typo on this surface *and* in the recommended-action data that feeds it (`clinician-state.ts`); "verified identity" → "source-backed identity" (truth alignment).

Only `/holder/home` (and its data source) changes. This surface is currently unreachable in production because the signed-in flow dead-ends (holder 0/6 in release-verify); PR #507 restores it, and this refresh is what a clinician then lands on.

## Truth rules (what is NOT claimed)

- No status label is the bare word `Verified`; no banned strings (grep clean over both source files).
- Share target is the public source-backed view, not a fabricated/demo presentation.
- No fake data, no demo clinician; empty/no-NPI state is honest.
- No auth, API, or runtime change.

## Validation

- `holder-home-page.test.tsx`: **1/1** (updated to assert the new identity header + `/verify/:npi` share href instead of "Keep moving").
- `holder-route-contract.test.ts`: **144/144** (the added `/verify/:npi` link is a real route; the contract scan would fail on a dead link).
- `pnpm turbo run build --filter @vitalcv/web`: 14/14.
- Truth-contract grep over the diff: clean.

## Tier

**Tier 1 (clinician-facing surface).** Self-mergeable with heightened review per the release-manager routine. Rollback = revert the squash commit (presentational + copy only; no state, no schema).

## Design Handoff References

No Claude Design handoff file used for this PR. The change stays within the surface's existing dark clinician-home visual language (Tailwind tokens already in `ClinicianHomeSurface.tsx`); it is an IA/copy change, not a new design import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
