### PR TITLE
fix(ui): route navbar Sign In to /sign-in and clear remaining 'your your' typo

### DIFF
--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Holder Page — Clinician Your readiness
+ * Holder Page — Clinician wallet & passport
  *
  * Loads the logged-in clinician's real NPI from their workspace profile.
  * If no NPI is set up yet, shows an onboarding empty state → /get-ready.

--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -78,7 +78,7 @@ export default function HolderPage() {
             <ShieldCheck className="h-7 w-7 text-emerald-400" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-foreground mb-2">Set up your your readiness</h1>
+            <h1 className="text-2xl font-bold text-foreground mb-2">Set up your readiness</h1>
             <p className="text-zinc-400 leading-relaxed text-sm">
               Verify your NPI to activate your clinician profile. Takes 2 minutes.
               VitalCV pulls your credentials directly from public registries — no document uploads required to get started.

--- a/apps/web/components/documents/CredentialReview.tsx
+++ b/apps/web/components/documents/CredentialReview.tsx
@@ -185,7 +185,7 @@ export function CredentialReview({ documentId, documentType, fields, onBack }: C
             }}
           >
             Your {documentType.replace(/_/g, ' ')} has been queued for primary-source verification.
-            You&apos;ll see the result in your your readiness.
+            You&apos;ll see the result in your readiness.
           </p>
         </div>
 

--- a/apps/web/components/documents/CredentialReview.tsx
+++ b/apps/web/components/documents/CredentialReview.tsx
@@ -205,7 +205,7 @@ export function CredentialReview({ documentId, documentType, fields, onBack }: C
             boxShadow: '0 0 20px rgba(16,185,129,0.3)',
           }}
         >
-          View your Your readiness →
+          View your readiness →
         </Link>
       </div>
     );

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -78,7 +78,7 @@ export default function Navbar() {
         <div className="hidden md:flex items-center gap-2 shrink-0">
           <ThemeToggle />
           <Link
-            href="/passport"
+            href="/sign-in"
             className="rounded-full border border-border px-4 py-1.5 text-sm font-medium text-muted-foreground hover:border-foreground/30 hover:text-foreground transition"
           >
             Sign In
@@ -126,7 +126,7 @@ export default function Navbar() {
           </ul>
           <div className="mt-4 flex gap-2 border-t border-border pt-4">
             <Link
-              href="/passport"
+              href="/sign-in"
               onClick={closeMenu}
               className="flex-1 rounded-xl border border-border py-2.5 text-center text-sm font-medium text-muted-foreground"
             >

--- a/apps/web/components/prequalify/PrequalifyModal.tsx
+++ b/apps/web/components/prequalify/PrequalifyModal.tsx
@@ -62,7 +62,7 @@ type StepId = (typeof STEPS)[number]['id'];
 
 function StepRole({ onNext }: { onNext: (role: Role) => void }) {
   const options: Array<{ role: Role; icon: typeof BriefcaseMedical; title: string; body: string; color: string }> = [
-    { role: 'CLINICIAN', icon: BriefcaseMedical, title: "I'm a Clinician", body: "Build your your readiness, get matched, unlock instant offers.", color: 'ring-vt-success/40 hover:ring-vt-success/80' },
+    { role: 'CLINICIAN', icon: BriefcaseMedical, title: "I'm a Clinician", body: "Build your readiness, get matched, unlock instant offers.", color: 'ring-vt-success/40 hover:ring-vt-success/80' },
     { role: 'VERIFIER',  icon: Building2,         title: "I'm an Employer",  body: "Publish roles, receive prequalified candidates, hire faster.",   color: 'ring-vt-info/40 hover:ring-vt-info/80' },
     { role: 'BOTH',      icon: Layers3,           title: "I'm Both",         body: "Switch between clinician and employer without logging out.",     color: 'ring-vt-warning/40 hover:ring-vt-warning/80' },
   ];


### PR DESCRIPTION
## Summary

Two small public-surface correctness fixes found during the visible-product pass:

- **Navbar "Sign In" → `/sign-in`** (was `/passport`, both desktop and mobile). `/passport` is the NPI-lookup surface and is unprotected, so it never prompts sign-in — a visitor clicking "Sign In" landed on a passport lookup instead of the sign-in page. `/sign-in` is the correct, live destination.
- **Kill the "your your readiness" typo** in the three remaining spots: `app/holder/page.tsx` (no-NPI wallet state), `components/prequalify/PrequalifyModal.tsx`, `components/documents/CredentialReview.tsx`. (The two occurrences on the `/holder/home` surface and its data are fixed in #511; this PR does not touch those files, so the two merge without conflict.)

## Truth rules

- No banned strings, no bare `Verified`, no fake data, no claim changes — pure link/copy correctness.
- No auth **logic** change: only a navigation `href` on the "Sign In" button. Middleware, roles, and session handling are untouched.

## Validation

- `pnpm turbo run build --filter @vitalcv/web`: 14/14.
- No test pins the navbar `/passport` link or the typo strings.
- Grep confirms zero `your your` remain across `app`/`components`/`lib` once this + #511 land.

## Tier

**Tier 0 (copy + one nav href).** Self-mergeable. Rollback = revert (no state, no logic).

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
