### PR TITLE
feat(readiness): add share-proof + recognition CTA to close the readiness loop

### DIFF
--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import { Award, Share2 } from 'lucide-react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { ProofSplitPane } from '@/components/proof/LanePanel';
 import { LiveStateLog } from '@/components/proof/LiveStateLog';
@@ -180,6 +181,36 @@ export default function ReadinessSurface() {
         {/* Split pane */}
         {activeSnapshot && loadState === 'ready' && (
           <>
+            {/* Share / prove + recognition — close the readiness → proof → recognition loop */}
+            <div
+              data-readiness-share=""
+              className="vcv-panel flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <p className="vcv-eyebrow mb-1">Share your evidence</p>
+                <p className="text-sm vcv-muted">
+                  Send the public, source-backed view an employer can read — or see where you have been recognized.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href={`/verify/${activeSnapshot.npi}`}
+                  className="vcv-cta inline-flex items-center gap-1.5 px-4 py-2 text-sm"
+                >
+                  <Share2 className="h-4 w-4" aria-hidden />
+                  Share proof
+                </Link>
+                <Link
+                  href="/holder/recognition"
+                  className="vcv-link inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 text-sm"
+                  style={{ borderColor: 'color-mix(in oklch, var(--accent) 32%, transparent)' }}
+                >
+                  <Award className="h-4 w-4" aria-hidden />
+                  Your recognition
+                </Link>
+              </div>
+            </div>
+
             <ProofSplitPane
               lanes={activeSnapshot.lanes}
               npi={activeSnapshot.npi}


### PR DESCRIPTION
## Summary

The signed-in readiness surface (`/holder/readiness`) showed a source-backed snapshot but offered no way to act on it — a clinician could see they were ready but not share it or check their recognition. This adds a share/prove + recognition strip that closes the **readiness → proof → recognition** loop.

When a real snapshot is loaded, a strip appears above the proof split-pane:

- **Share proof** → `/verify/:npi` — the real, public, source-backed view an employer reads (the same target PR #511 uses on the home surface). Not a demo/fabricated presentation.
- **Your recognition** → `/holder/recognition` — the employer-acceptance record.

Copy: "Send the public, source-backed view an employer can read — or see where you have been recognized." Styled in the surface's existing D57 light-document system (`.vcv-cta`, `.vcv-link`, `.vcv-panel`). It only renders in the `ready` state, so no share affordance is shown when there is no NPI or the passport can't load (honest states preserved).

Like the rest of the signed-in surfaces, `/holder/readiness` is currently unreachable in production until the auth fix (#507); this is what a clinician then acts on.

## Truth rules (what is NOT claimed)

- Share target is the public source-backed proof, never a demo presentation.
- No banned strings, no bare `Verified`, no fake data.
- No API, auth, or data change — a presentational CTA strip only.

## Validation

- `pnpm turbo run build --filter @vitalcv/web`: 14/14 (adds `Award`/`Share2` imports, both used).
- Truth-contract grep over the diff: clean.
- `/verify/:npi` and `/holder/recognition` are both real routes (route-contract suite already guards them).

## Tier

**Tier 1 (clinician-facing surface).** Self-mergeable with heightened review. Rollback = revert (presentational only).

## Design Handoff References

`design-handoff/claude-design-2026-06-26/vitalcv/project/Readiness Report.html` informs the readiness surface's D57 lineage; this PR reuses that established `.vcv-*` system for the added strip rather than importing new design. No other handoff file was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
