### PR TITLE
feat(holder-home): lead the signed-in home with the VitalCV product loop (Visible Product PR2)

### DIFF
--- a/apps/web/components/holder/ProductLoopRail.tsx
+++ b/apps/web/components/holder/ProductLoopRail.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * ProductLoopRail — the VitalCV clinician loop, made legible on every signed-in
+ * surface: Profile → Readiness → Recognition → Share / Prove → Opportunity.
+ *
+ * It answers "what is this product and what do I do next" at a glance, and every
+ * stage is a real link to a live surface. Stage status is derived only from data
+ * the caller already knows to be true (profile completeness, whether a readiness
+ * snapshot exists). Nothing here fabricates a score, a Recognition, or an NPI —
+ * stages we cannot assert are simply shown as open steps.
+ */
+
+import * as React from 'react';
+import Link from 'next/link';
+import { Award, Compass, IdCard, Share2, ShieldCheck, type LucideIcon } from 'lucide-react';
+
+export type LoopStageStatus = 'done' | 'current' | 'open';
+
+type LoopStage = {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  href: string;
+  status: LoopStageStatus;
+};
+
+export interface ProductLoopRailProps {
+  /** 10-digit NPI, when known — drives the Share/Prove destination. */
+  npi?: string | null;
+  /** True when the profile record is materially complete. */
+  profileComplete?: boolean;
+  /** True when a source-backed readiness snapshot exists. */
+  hasReadiness?: boolean;
+  /** Optional heading tone; defaults to the dark signed-in surfaces. */
+  variant?: 'dark' | 'light';
+  className?: string;
+}
+
+function buildStages(input: {
+  npi?: string | null;
+  profileComplete: boolean;
+  hasReadiness: boolean;
+}): LoopStage[] {
+  const hasNpi = typeof input.npi === 'string' && /^\d{10}$/.test(input.npi);
+  const shareHref = hasNpi ? `/verify/${input.npi}` : '/holder';
+
+  // The "current" step is the first one not yet satisfied. Steps we cannot
+  // truthfully assert (Recognition depends on an employer; Share/Opportunity
+  // are always available) stay 'open' rather than claiming completion.
+  const profileStatus: LoopStageStatus = input.profileComplete ? 'done' : 'current';
+  const readinessStatus: LoopStageStatus = input.hasReadiness
+    ? 'done'
+    : input.profileComplete
+      ? 'current'
+      : 'open';
+
+  return [
+    { key: 'profile', label: 'Profile', icon: IdCard, href: '/clinician/profile', status: profileStatus },
+    { key: 'readiness', label: 'Readiness', icon: ShieldCheck, href: '/holder/readiness', status: readinessStatus },
+    { key: 'recognition', label: 'Recognition', icon: Award, href: '/holder/recognition', status: 'open' },
+    { key: 'share', label: 'Share / prove', icon: Share2, href: shareHref, status: 'open' },
+    { key: 'opportunity', label: 'Opportunity', icon: Compass, href: '/holder/opportunities', status: 'open' },
+  ];
+}
+
+export function ProductLoopRail({
+  npi,
+  profileComplete = false,
+  hasReadiness = false,
+  variant = 'dark',
+  className,
+}: ProductLoopRailProps) {
+  const stages = buildStages({ npi, profileComplete, hasReadiness });
+  const dark = variant === 'dark';
+
+  return (
+    <nav
+      aria-label="Your VitalCV loop"
+      data-product-loop-rail=""
+      className={[
+        'rounded-[28px] border p-4 sm:p-5',
+        dark
+          ? 'border-white/10 bg-white/[0.04] shadow-[0_20px_60px_rgba(0,0,0,0.28)]'
+          : 'border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)]',
+        className ?? '',
+      ].join(' ')}
+    >
+      <p
+        className={[
+          'text-[11px] font-semibold uppercase tracking-[0.18em]',
+          dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
+        ].join(' ')}
+      >
+        Your VitalCV loop
+      </p>
+
+      <ol className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+        {stages.map((stage, idx) => {
+          const Icon = stage.icon;
+          const isDone = stage.status === 'done';
+          const isCurrent = stage.status === 'current';
+          return (
+            <li key={stage.key} className="min-w-0">
+              <Link
+                href={stage.href}
+                data-loop-stage={stage.key}
+                data-loop-status={stage.status}
+                className={[
+                  'group flex h-full items-center gap-2.5 rounded-2xl border px-3 py-2.5 transition-colors',
+                  dark
+                    ? isCurrent
+                      ? 'border-emerald-400/40 bg-emerald-400/10 hover:border-emerald-300/60'
+                      : 'border-white/10 bg-black/20 hover:border-white/25'
+                    : isCurrent
+                      ? 'border-emerald-600/50 bg-emerald-500/10'
+                      : 'border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] hover:border-[var(--vt-text-primary)]',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-[13px] font-semibold',
+                    isDone
+                      ? 'bg-emerald-400/20 text-emerald-200'
+                      : isCurrent
+                        ? 'bg-emerald-400 text-zinc-950'
+                        : dark
+                          ? 'bg-white/10 text-white/70'
+                          : 'bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
+                  ].join(' ')}
+                >
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span className="flex min-w-0 flex-col">
+                  <span
+                    className={[
+                      'truncate text-[13px] font-semibold',
+                      dark ? 'text-white' : 'text-[var(--vt-text-primary)]',
+                    ].join(' ')}
+                  >
+                    <span aria-hidden="true" className={dark ? 'text-white/40' : 'text-[var(--vt-text-muted)]'}>
+                      {idx + 1}.
+                    </span>{' '}
+                    {stage.label}
+                  </span>
+                  <span
+                    className={[
+                      'truncate text-[11px]',
+                      isDone
+                        ? 'text-emerald-300'
+                        : isCurrent
+                          ? dark ? 'text-emerald-200' : 'text-emerald-700'
+                          : dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
+                    ].join(' ')}
+                  >
+                    {isDone ? 'Done' : isCurrent ? 'You are here' : 'Open'}
+                  </span>
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export default ProductLoopRail;

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   Share2,
   ShieldCheck,
+  Sparkles,
   UserRound,
   Wallet,
 } from 'lucide-react';
@@ -309,11 +310,17 @@ export default function ClinicianHomeSurface() {
           ? 'border-sky-400/20 bg-sky-400/10'
           : 'border-emerald-400/20 bg-emerald-400/10'
       }`}>
-        <p className={`text-[11px] uppercase tracking-[0.18em] ${
-          primaryAction.tone === 'sky' ? 'text-sky-100/80' : 'text-emerald-100/80'
-        }`}>
-          {primaryAction.eyebrow}
-        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/80">
+            <Sparkles className="h-3 w-3 text-emerald-300" aria-hidden="true" />
+            MATCHA · Your next step
+          </span>
+          <p className={`text-[11px] uppercase tracking-[0.18em] ${
+            primaryAction.tone === 'sky' ? 'text-sky-100/80' : 'text-emerald-100/80'
+          }`}>
+            {primaryAction.eyebrow}
+          </p>
+        </div>
         <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
             <h2 className="text-2xl font-semibold text-white">{primaryAction.title}</h2>
@@ -321,6 +328,10 @@ export default function ClinicianHomeSurface() {
               primaryAction.tone === 'sky' ? 'text-sky-50/85' : 'text-emerald-50/85'
             }`}>
               {primaryAction.detail}
+            </p>
+            <p className="mt-2 text-xs leading-5 text-white/45">
+              Reasoned from your source-backed readiness signals — VitalCV shows the evidence
+              behind every step and never invents a credential.
             </p>
             {highlightedChange?.occurredAt ? (
               <p className={`mt-3 text-xs ${

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -26,6 +26,7 @@ import { ClinicianStatusBanner } from '@/components/mobile/ClinicianStatusBanner
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { RecognitionCard } from '@/components/recognition/RecognitionCard';
+import ProductLoopRail from '@/components/holder/ProductLoopRail';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
 import { buildClinicianProofSummary } from '@/lib/proof/proof-model';
 
@@ -126,6 +127,7 @@ export default function ClinicianHomeSurface() {
   const shareHref = hasValidNpi ? `/verify/${npi}` : '/holder';
   const completeness = data.profileCompleteness?.score ?? data.workspace?.personProfile?.completeness ?? 0;
   const completedProfileChecks = countCompletedProfileChecks(data.profileCompleteness?.dimensions);
+  const profileComplete = completeness >= 100 || completedProfileChecks >= 5;
   const previousVisitMs = previousVisitAt ? Date.parse(previousVisitAt) : 0;
   const changesSinceLastVisit = previousVisitMs > 0
     ? visibleNotifications.filter((notification) => Date.parse(notification.occurredAt) > previousVisitMs)
@@ -295,6 +297,12 @@ export default function ClinicianHomeSurface() {
       ) : null}
 
       <SelectedOpportunityBanner />
+
+      <ProductLoopRail
+        npi={hasValidNpi ? npi : null}
+        profileComplete={profileComplete}
+        hasReadiness={Boolean(readiness)}
+      />
 
       <section className={`rounded-[28px] border p-5 shadow-[0_20px_60px_rgba(0,0,0,0.24)] ${
         primaryAction.tone === 'sky'


### PR DESCRIPTION
## Visible Product — PR2: Signed-in holder home transformation

**Problem.** The signed-in home (`/holder/home`) already carried every required piece — "Your VitalCV Wallet" identity, readiness score, profile checks, RecognitionCard, next step, opportunities, and a Share/Prove action — but the **product loop was not legible.** A clinician landing here could not see `Profile → Readiness → Recognition → Share/Prove → Opportunity` at a glance, or where they currently stand.

**Change.** Lead the signed-in home with a new reusable **`ProductLoopRail`**:

- Five stages, each a **live link** to its real surface: `/clinician/profile`, `/holder/readiness`, `/holder/recognition`, `/verify/:npi`, `/holder/opportunities`.
- A clear **"You are here"** marker so "what should I do next" is obvious.
- Stage status derived **only from data we can truthfully assert** — profile completeness and whether a readiness snapshot exists. Recognition / Share / Opportunity stay open steps. Nothing fabricates a score, a Recognition, or an NPI; Share/Prove points at the real public proof (`/verify/:npi`), never a demo flow.
- The rail is `variant`-aware (dark for signed-in surfaces, light for document surfaces) so PR3 can place the same loop on readiness and recognition.

This answers the PR2 spec — who am I / how ready / am I recognized / what next / opportunity path / share-prove — and now makes the whole loop the first thing a signed-in clinician sees.

**Verification.** Signed-in surfaces are Clerk-gated (and prod blocks automated browsers), so this was verified via a static render of `ClinicianHomeSurface` with the existing sample dataset:
- `holder-home-page.test.tsx` → green (all identity/readiness/share sections intact).
- `holder-route-contract.test.ts` → **144/144 green** — every rail link resolves to a live route.
- `tsc --noEmit` → no errors in changed files.
- Rail rendered and screenshotted in-session (`1. Profile — You are here`, `2. Readiness — Done`, `3. Recognition`, `4. Share / prove`, `5. Opportunity`).

> Reviewer note: please confirm in an authenticated session (Chris / allowlisted profile) that the rail's derived "you are here" reads correctly against live data.

## Design Handoff References
No new design-handoff bundle was authored. `ProductLoopRail` re-composes the existing signed-in dashboard vocabulary (the `.rounded-[28px]` dark card system already used across `ClinicianHomeSurface`) and lucide iconography, consistent with the clinician design lineage (`design-handoff/claude-design-2026-06-26/`, PR #489). No external mockup was provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
