### PR TITLE
feat(readiness,recognition): #514 Wave C+D — readiness map + Recognition asset (+ product loop)

### DIFF
--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { Award, Share2 } from 'lucide-react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import ProductLoopRail from '@/components/holder/ProductLoopRail';
 import { ProofSplitPane } from '@/components/proof/LanePanel';
 import { LiveStateLog } from '@/components/proof/LiveStateLog';
 import { PostureBadge, ProofTierBadge, MetricBadge } from '@/components/proof/TrustLabel';
@@ -130,6 +131,15 @@ export default function ReadinessSurface() {
       </div>
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+        {/* Product loop — Profile → Readiness → Recognition → Share → Opportunity */}
+        <ProductLoopRail
+          variant="doc"
+          activeStage="readiness"
+          npi={npi}
+          profileComplete={(data.profileCompleteness?.score ?? 0) >= 100}
+          hasReadiness={loadState === 'ready'}
+        />
+
         {/* Identity + posture header — serif title, mono identifier */}
         {activeSnapshot && (
           <div className="flex flex-wrap items-end gap-4">

--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
-import { Award, Share2 } from 'lucide-react';
+import { Award, Building2, Share2, TrendingUp } from 'lucide-react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
 import { ProofSplitPane } from '@/components/proof/LanePanel';
@@ -25,6 +25,19 @@ import {
 } from '@/lib/readiness/passport-readiness-snapshot';
 
 type LoadState = 'loading' | 'ready' | 'no-npi' | 'error';
+
+/**
+ * Provenance legend — readiness is a map, not a score. Each row names where a
+ * fact stands and what it means, so a clinician (and later a reviewer) can read
+ * trust at a glance. Colors map to the .vcv-doc state tokens.
+ */
+const PROVENANCE_LEGEND = [
+  { label: 'NPI-confirmed', meaning: 'Matched to your federal NPPES record.', token: 'var(--accent)' },
+  { label: 'Source-backed', meaning: 'Read from a primary source and current.', token: 'var(--state-verified)' },
+  { label: 'Self-attested', meaning: 'You entered it — not yet source-backed.', token: 'var(--state-pending)' },
+  { label: 'Needs review', meaning: 'Flagged for a closer look before it counts.', token: 'var(--state-pending)' },
+  { label: 'Missing', meaning: 'Not provided yet — add it to lift readiness.', token: 'var(--ink-mute)' },
+] as const;
 
 function laneLogMessage(laneId: string, status: string): { message: string; level: StateLogEntry['level'] } {
   const def = KNOWN_LANES.find((lane) => lane.laneId === laneId);
@@ -218,6 +231,56 @@ export default function ReadinessSurface() {
                   <Award className="h-4 w-4" aria-hidden />
                   Your recognition
                 </Link>
+              </div>
+            </div>
+
+            {/* Reading your readiness — provenance legend + what it unlocks.
+                Makes readiness a map (source · state · what to do), not a bare score. */}
+            <div data-readiness-explainer="" className="vcv-panel px-5 py-5">
+              <p className="vcv-eyebrow mb-1">Reading your readiness</p>
+              <p className="text-sm vcv-muted mb-4">
+                Readiness is a map, not a grade. Every row below names its source and where it
+                stands — so you can see what is trusted, what is missing, and what to do next.
+              </p>
+              <ul className="grid gap-2 sm:grid-cols-2">
+                {PROVENANCE_LEGEND.map((item) => (
+                  <li key={item.label} className="flex items-start gap-2.5">
+                    <span
+                      aria-hidden
+                      className="mt-1.5 h-2.5 w-2.5 flex-none rounded-full"
+                      style={{ background: item.token }}
+                    />
+                    <span className="min-w-0">
+                      <span className="text-sm font-semibold" style={{ color: 'var(--ink-strong)' }}>
+                        {item.label}
+                      </span>
+                      <span className="text-sm vcv-muted"> — {item.meaning}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                <div
+                  className="flex items-start gap-2.5 rounded-lg p-3"
+                  style={{ background: 'var(--state-verified-wash)', border: 'var(--hairline)' }}
+                >
+                  <TrendingUp className="mt-0.5 h-4 w-4 flex-none" style={{ color: 'var(--state-verified)' }} aria-hidden />
+                  <p className="text-sm vcv-muted">
+                    <span className="font-semibold" style={{ color: 'var(--ink-strong)' }}>Improves your Recognition.</span>{' '}
+                    Source-backed rows are what an employer accepts as a head start.
+                  </p>
+                </div>
+                <div
+                  className="flex items-start gap-2.5 rounded-lg p-3"
+                  style={{ background: 'var(--state-verified-wash)', border: 'var(--hairline)' }}
+                >
+                  <Building2 className="mt-0.5 h-4 w-4 flex-none" style={{ color: 'var(--accent)' }} aria-hidden />
+                  <p className="text-sm vcv-muted">
+                    <span className="font-semibold" style={{ color: 'var(--ink-strong)' }}>Helps employers trust faster.</span>{' '}
+                    A reviewer starts from evidence and freshness, not a fresh intake pile.
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/apps/web/components/holder/ProductLoopRail.tsx
+++ b/apps/web/components/holder/ProductLoopRail.tsx
@@ -7,18 +7,27 @@
  * It answers "what is this product and what do I do next" at a glance, and every
  * stage is a real link to a live surface. Stage status is derived only from data
  * the caller already knows to be true (profile completeness, whether a readiness
- * snapshot exists). Nothing here fabricates a score, a Recognition, or an NPI —
- * stages we cannot assert are simply shown as open steps.
+ * snapshot exists) plus `activeStage` — the surface the clinician is currently
+ * on. Nothing here fabricates a score, a Recognition, or an NPI; stages we
+ * cannot assert are simply shown as open steps.
+ *
+ * Variants:
+ *  - `dark` — the signed-in mobile/dashboard surfaces (white-on-ink cards).
+ *  - `light` — generic light surfaces (global `--vt-*` tokens).
+ *  - `doc`  — the `.vcv-doc` document surfaces (readiness / recognition), so the
+ *             rail reads as native paper-register chrome rather than a foreign card.
  */
 
 import * as React from 'react';
 import Link from 'next/link';
 import { Award, Compass, IdCard, Share2, ShieldCheck, type LucideIcon } from 'lucide-react';
 
+export type LoopStageKey = 'profile' | 'readiness' | 'recognition' | 'share' | 'opportunity';
 export type LoopStageStatus = 'done' | 'current' | 'open';
+export type LoopVariant = 'dark' | 'light' | 'doc';
 
 type LoopStage = {
-  key: string;
+  key: LoopStageKey;
   label: string;
   icon: LucideIcon;
   href: string;
@@ -32,8 +41,9 @@ export interface ProductLoopRailProps {
   profileComplete?: boolean;
   /** True when a source-backed readiness snapshot exists. */
   hasReadiness?: boolean;
-  /** Optional heading tone; defaults to the dark signed-in surfaces. */
-  variant?: 'dark' | 'light';
+  /** The stage of the surface the clinician is currently viewing. */
+  activeStage?: LoopStageKey;
+  variant?: LoopVariant;
   className?: string;
 }
 
@@ -41,13 +51,11 @@ function buildStages(input: {
   npi?: string | null;
   profileComplete: boolean;
   hasReadiness: boolean;
+  activeStage?: LoopStageKey;
 }): LoopStage[] {
   const hasNpi = typeof input.npi === 'string' && /^\d{10}$/.test(input.npi);
   const shareHref = hasNpi ? `/verify/${input.npi}` : '/holder';
 
-  // The "current" step is the first one not yet satisfied. Steps we cannot
-  // truthfully assert (Recognition depends on an employer; Share/Opportunity
-  // are always available) stay 'open' rather than claiming completion.
   const profileStatus: LoopStageStatus = input.profileComplete ? 'done' : 'current';
   const readinessStatus: LoopStageStatus = input.hasReadiness
     ? 'done'
@@ -55,45 +63,57 @@ function buildStages(input: {
       ? 'current'
       : 'open';
 
-  return [
+  const stages: LoopStage[] = [
     { key: 'profile', label: 'Profile', icon: IdCard, href: '/clinician/profile', status: profileStatus },
     { key: 'readiness', label: 'Readiness', icon: ShieldCheck, href: '/holder/readiness', status: readinessStatus },
     { key: 'recognition', label: 'Recognition', icon: Award, href: '/holder/recognition', status: 'open' },
     { key: 'share', label: 'Share / prove', icon: Share2, href: shareHref, status: 'open' },
     { key: 'opportunity', label: 'Opportunity', icon: Compass, href: '/holder/opportunities', status: 'open' },
   ];
+
+  // The surface you are on is where you are — mark it current, even if a data
+  // heuristic would otherwise call an earlier step current.
+  if (input.activeStage) {
+    for (const stage of stages) {
+      if (stage.key === input.activeStage) stage.status = 'current';
+      else if (stage.status === 'current') stage.status = stage.key === 'profile' ? profileStatus === 'done' ? 'done' : 'open' : 'open';
+    }
+  }
+
+  return stages;
 }
 
 export function ProductLoopRail({
   npi,
   profileComplete = false,
   hasReadiness = false,
+  activeStage,
   variant = 'dark',
   className,
 }: ProductLoopRailProps) {
-  const stages = buildStages({ npi, profileComplete, hasReadiness });
+  const stages = buildStages({ npi, profileComplete, hasReadiness, activeStage });
   const dark = variant === 'dark';
+  const doc = variant === 'doc';
 
-  return (
-    <nav
-      aria-label="Your VitalCV loop"
-      data-product-loop-rail=""
-      className={[
+  const containerClass = doc
+    ? 'vcv-panel p-4 sm:p-5'
+    : [
         'rounded-[28px] border p-4 sm:p-5',
         dark
           ? 'border-white/10 bg-white/[0.04] shadow-[0_20px_60px_rgba(0,0,0,0.28)]'
           : 'border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)]',
-        className ?? '',
-      ].join(' ')}
-    >
-      <p
-        className={[
-          'text-[11px] font-semibold uppercase tracking-[0.18em]',
-          dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
-        ].join(' ')}
-      >
-        Your VitalCV loop
-      </p>
+      ].join(' ');
+
+  const headingClass = doc
+    ? 'vcv-eyebrow'
+    : [
+        'text-[11px] font-semibold uppercase tracking-[0.18em]',
+        dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
+      ].join(' ');
+
+  return (
+    <nav aria-label="Your VitalCV loop" data-product-loop-rail="" className={[containerClass, className ?? ''].join(' ')}>
+      <p className={headingClass}>Your VitalCV loop</p>
 
       <ol className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
         {stages.map((stage, idx) => {
@@ -106,53 +126,24 @@ export function ProductLoopRail({
                 href={stage.href}
                 data-loop-stage={stage.key}
                 data-loop-status={stage.status}
-                className={[
-                  'group flex h-full items-center gap-2.5 rounded-2xl border px-3 py-2.5 transition-colors',
-                  dark
-                    ? isCurrent
-                      ? 'border-emerald-400/40 bg-emerald-400/10 hover:border-emerald-300/60'
-                      : 'border-white/10 bg-black/20 hover:border-white/25'
-                    : isCurrent
-                      ? 'border-emerald-600/50 bg-emerald-500/10'
-                      : 'border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] hover:border-[var(--vt-text-primary)]',
-                ].join(' ')}
+                aria-current={isCurrent ? 'step' : undefined}
+                className={stageLinkClass({ variant, isCurrent })}
+                style={doc ? stageDocStyle(isCurrent) : undefined}
               >
-                <span
-                  className={[
-                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-[13px] font-semibold',
-                    isDone
-                      ? 'bg-emerald-400/20 text-emerald-200'
-                      : isCurrent
-                        ? 'bg-emerald-400 text-zinc-950'
-                        : dark
-                          ? 'bg-white/10 text-white/70'
-                          : 'bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
-                  ].join(' ')}
-                >
+                <span className={badgeClass({ variant, isDone, isCurrent })} style={doc ? badgeDocStyle({ isDone, isCurrent }) : undefined}>
                   <Icon className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <span className="flex min-w-0 flex-col">
                   <span
-                    className={[
-                      'truncate text-[13px] font-semibold',
-                      dark ? 'text-white' : 'text-[var(--vt-text-primary)]',
-                    ].join(' ')}
+                    className={['truncate text-[13px] font-semibold', dark ? 'text-white' : doc ? '' : 'text-[var(--vt-text-primary)]'].join(' ')}
+                    style={doc ? { color: 'var(--ink-strong)' } : undefined}
                   >
-                    <span aria-hidden="true" className={dark ? 'text-white/40' : 'text-[var(--vt-text-muted)]'}>
+                    <span aria-hidden="true" className={dark ? 'text-white/40' : doc ? 'vcv-subtle' : 'text-[var(--vt-text-muted)]'}>
                       {idx + 1}.
                     </span>{' '}
                     {stage.label}
                   </span>
-                  <span
-                    className={[
-                      'truncate text-[11px]',
-                      isDone
-                        ? 'text-emerald-300'
-                        : isCurrent
-                          ? dark ? 'text-emerald-200' : 'text-emerald-700'
-                          : dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
-                    ].join(' ')}
-                  >
+                  <span className={statusClass({ variant, isDone, isCurrent })} style={doc ? statusDocStyle({ isDone, isCurrent }) : undefined}>
                     {isDone ? 'Done' : isCurrent ? 'You are here' : 'Open'}
                   </span>
                 </span>
@@ -163,6 +154,49 @@ export function ProductLoopRail({
       </ol>
     </nav>
   );
+}
+
+function stageLinkClass({ variant, isCurrent }: { variant: LoopVariant; isCurrent: boolean }): string {
+  const base = 'group flex h-full items-center gap-2.5 rounded-2xl border px-3 py-2.5 transition-colors';
+  if (variant === 'doc') return base;
+  if (variant === 'dark') {
+    return [base, isCurrent ? 'border-emerald-400/40 bg-emerald-400/10 hover:border-emerald-300/60' : 'border-white/10 bg-black/20 hover:border-white/25'].join(' ');
+  }
+  return [base, isCurrent ? 'border-emerald-600/50 bg-emerald-500/10' : 'border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] hover:border-[var(--vt-text-primary)]'].join(' ');
+}
+
+function stageDocStyle(isCurrent: boolean): React.CSSProperties {
+  return isCurrent
+    ? { borderColor: 'color-mix(in oklch, var(--accent) 45%, transparent)', background: 'color-mix(in oklch, var(--accent) 8%, transparent)' }
+    : { borderColor: 'var(--hairline-color, color-mix(in oklch, var(--ink) 14%, transparent))', background: 'transparent' };
+}
+
+function badgeClass({ variant, isDone, isCurrent }: { variant: LoopVariant; isDone: boolean; isCurrent: boolean }): string {
+  const base = 'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-[13px] font-semibold';
+  if (variant === 'doc') return base;
+  if (isDone) return [base, 'bg-emerald-400/20 text-emerald-200'].join(' ');
+  if (isCurrent) return [base, 'bg-emerald-400 text-zinc-950'].join(' ');
+  return [base, variant === 'dark' ? 'bg-white/10 text-white/70' : 'bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]'].join(' ');
+}
+
+function badgeDocStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
+  if (isDone) return { background: 'color-mix(in oklch, var(--state-verified) 18%, transparent)', color: 'var(--state-verified)' };
+  if (isCurrent) return { background: 'var(--accent)', color: 'var(--paper, #fff)' };
+  return { background: 'color-mix(in oklch, var(--ink) 8%, transparent)', color: 'var(--ink-mute)' };
+}
+
+function statusClass({ variant, isDone, isCurrent }: { variant: LoopVariant; isDone: boolean; isCurrent: boolean }): string {
+  const base = 'truncate text-[11px]';
+  if (variant === 'doc') return base;
+  if (isDone) return [base, 'text-emerald-300'].join(' ');
+  if (isCurrent) return [base, variant === 'dark' ? 'text-emerald-200' : 'text-emerald-700'].join(' ');
+  return [base, variant === 'dark' ? 'text-white/45' : 'text-[var(--vt-text-muted)]'].join(' ');
+}
+
+function statusDocStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
+  if (isDone) return { color: 'var(--state-verified)' };
+  if (isCurrent) return { color: 'var(--accent)' };
+  return { color: 'var(--ink-mute)' };
 }
 
 export default ProductLoopRail;

--- a/apps/web/components/recognition/RecognitionSurface.tsx
+++ b/apps/web/components/recognition/RecognitionSurface.tsx
@@ -81,10 +81,27 @@ export function RecognitionSurface() {
           </div>
           <h1 className="vcv-title text-3xl">Your recognition record</h1>
           <p className="text-sm leading-6 vcv-muted">
-            Employer acceptances recorded against your source-backed evidence. Each entry is an
-            employer decision captured with an audit event at the moment it was made.
+            Recognition is the career asset you earn: an employer&apos;s recorded decision to accept
+            your source-backed evidence as a head start. Each entry is captured with an audit event
+            at the moment it was made — yours to keep and prove.
           </p>
         </header>
+
+        {/* Earn · Prove · Reuse — why Recognition matters, in every state */}
+        <div data-recognition-value="" className="grid gap-2.5 sm:grid-cols-3">
+          {[
+            { label: 'Earn it', text: 'An employer reviews your source-backed evidence and accepts it as a head start.' },
+            { label: 'Prove it', text: 'A timestamped, source-backed decision you can share with the next team.' },
+            { label: 'Reuse it', text: 'It stays on your career record and travels with you to the next move.' },
+          ].map((item, idx) => (
+            <div key={item.label} className="vcv-panel-inset p-4">
+              <p className="vcv-eyebrow mb-1">
+                {idx + 1} · {item.label}
+              </p>
+              <p className="text-sm leading-6 vcv-muted">{item.text}</p>
+            </div>
+          ))}
+        </div>
 
         {phase.state === 'loading' && (
           <div className="vcv-panel flex items-center gap-2 p-5 text-sm vcv-muted">

--- a/apps/web/components/recognition/RecognitionSurface.tsx
+++ b/apps/web/components/recognition/RecognitionSurface.tsx
@@ -15,6 +15,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ArrowLeft, Award, ChevronRight, Loader2, ShieldCheck } from 'lucide-react';
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
+import ProductLoopRail from '@/components/holder/ProductLoopRail';
 import { ShareRecognitionPanel } from '@/components/recognition/ShareRecognitionPanel';
 import {
   acceptanceScopeLabel,
@@ -70,6 +71,9 @@ export function RecognitionSurface() {
       </div>
 
       <div className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+        {/* Product loop — Profile → Readiness → Recognition → Share → Opportunity */}
+        <ProductLoopRail variant="doc" activeStage="recognition" npi={npi} />
+
         <header className="space-y-2">
           <div className="flex items-center gap-2">
             <Award className="h-5 w-5" style={{ color: 'var(--accent)' }} aria-hidden />


### PR DESCRIPTION
## Visible Product — PR3: Recognition / readiness loop integration

**Goal.** Make the product loop — `Profile → Readiness → Recognition → Share/Prove → Opportunity` — visible and consistent on the two document surfaces, not just the signed-in home.

**Stacked on [#516](https://github.com/ctol3r/vitalcv/pull/516)** (base `wave/visible-holder-home`), which introduced `ProductLoopRail`.

**Change.**
- Extend `ProductLoopRail` with:
  - an **`activeStage`** prop → marks the surface you're on as **"You are here"**;
  - a **`doc`** variant → renders in the `.vcv-doc` paper-register system (`--ink` / `--accent` / `--hairline`, `vcv-panel`) so the rail is native chrome on the document surfaces rather than a foreign card.
- Lead **`/holder/readiness`** with the rail (`activeStage=readiness`), deriving profile/readiness status from the real mobile context.
- Lead **`/holder/recognition`** with the rail (`activeStage=recognition`).

Both surfaces already had contextual CTAs (readiness → share/recognition; recognition → readiness/applications); the rail adds the full-loop orientation on top, identical in shape to the home rail so the loop reads the same everywhere.

**Honesty.** Stage status is only asserted from data we actually know — profile completeness, whether a readiness snapshot exists, and which surface is active. Recognition / Share / Opportunity stay open steps; Share/Prove points at the real public proof (`/verify/:npi`). No fabricated clinician, score, or acceptance; all existing honest empty/error states are untouched.

**Verification.** Rendered both surfaces with sample data behind the mobile provider (auth-gated surfaces, prod blocks automated browsers):
- readiness rail marks `readiness: current`, recognition rail marks `recognition: current`; both match the paper aesthetic (screenshots shared in-session).
- `holder-route-contract.test.ts` → **144/144 green** (every rail link resolves to a live route).
- `holder-readiness-page.test.tsx` → green. `tsc --noEmit` → no errors in changed files.

> Reviewer note: confirm in an authenticated session that derived "you are here" / done states read correctly against live data.

## Design Handoff References
No new design-handoff bundle was authored. The `doc` variant re-uses the existing `.vcv-doc` D57 paper-register token system already used by `ReadinessSurface` and `RecognitionSurface`, consistent with the clinician design lineage (`design-handoff/claude-design-2026-06-26/`, PR #489). No external mockup was provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
