### PR TITLE
feat(matcha): MATCHA intelligence layer + Career Evidence Network

### DIFF
--- a/apps/web/__tests__/matcha-buyer-pages.test.tsx
+++ b/apps/web/__tests__/matcha-buyer-pages.test.tsx
@@ -1,0 +1,59 @@
+// Enable the buyer-pages flag BEFORE importing the page modules (flags read env at load).
+process.env.NEXT_PUBLIC_FEATURE_MATCHA_BUYER_PAGES = 'true';
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+// Full banned-string list from CLAUDE.md truth contract.
+const BANNED = [
+  'automatically verified',
+  'guaranteed verification',
+  'complete credentialing',
+  'instant credentialing',
+  'legally accepted',
+  'risk transferred',
+  'final verification without review',
+  'source confirmed before response',
+  'certified compliant',
+  'hipaa compliant',
+  'soc2 certified',
+];
+
+function expectClean(markup: string) {
+  const lower = markup.toLowerCase();
+  for (const phrase of BANNED) {
+    expect(lower).not.toContain(phrase);
+  }
+}
+
+const PAGES: Array<{ name: string; path: string }> = [
+  { name: 'recruiters', path: '../app/matcha/recruiters/page' },
+  { name: 'hospitals', path: '../app/matcha/hospitals/page' },
+  { name: 'investors', path: '../app/matcha/investors/page' },
+];
+
+describe('MATCHA buyer pages — honest copy', () => {
+  for (const page of PAGES) {
+    it(`${page.name}: renders without any banned truth-contract strings`, async () => {
+      const { default: Page } = await import(page.path);
+      const markup = renderToStaticMarkup(<Page />);
+      expect(markup.length).toBeGreaterThan(500);
+      expectClean(markup);
+    });
+
+    it(`${page.name}: carries the "not customer-reported results" honesty disclaimer`, async () => {
+      const { default: Page } = await import(page.path);
+      const markup = renderToStaticMarkup(<Page />);
+      // Each page frames benefits as directional / illustrative, not customer results.
+      expect(markup.toLowerCase()).toContain('not customer-reported results');
+    });
+  }
+
+  it('investors page renders the compounding-loop ecosystem stages', async () => {
+    const { default: Page } = await import('../app/matcha/investors/page');
+    const markup = renderToStaticMarkup(<Page />);
+    expect(markup).toContain('Network effects');
+    expect(markup).toContain('MATCHA');
+    expect(markup).toContain('Recognition');
+  });
+});

--- a/apps/web/__tests__/matcha-components.test.tsx
+++ b/apps/web/__tests__/matcha-components.test.tsx
@@ -1,0 +1,116 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { MatchaExplanation } from '../components/matcha/MatchaExplanation';
+import { OpportunityIntelligenceCard } from '../components/matcha/OpportunityIntelligenceCard';
+import { MatchaProfile } from '../components/matcha/MatchaProfile';
+import { deriveMatchaProfile } from '../lib/matcha/profile';
+
+// Truth-contract strings that must never appear in MATCHA copy.
+const BANNED = [
+  'automatically verified',
+  'guaranteed verification',
+  'legally accepted',
+  'risk transferred',
+  'HIPAA compliant',
+];
+
+function expectNoBanned(markup: string) {
+  const lower = markup.toLowerCase();
+  for (const phrase of BANNED) {
+    expect(lower).not.toContain(phrase.toLowerCase());
+  }
+}
+
+describe('MatchaExplanation', () => {
+  it('renders given reasons with the canonical heading', () => {
+    const markup = renderToStaticMarkup(
+      <MatchaExplanation
+        reasons={[
+          { label: 'You prefer teaching hospitals', positive: true, source: 'your preferences' },
+          { label: 'Compensation is below your minimum', positive: false },
+        ]}
+      />,
+    );
+    expect(markup).toContain('Recommended because');
+    expect(markup).toContain('You prefer teaching hospitals');
+    expect(markup).toContain('Compensation is below your minimum');
+    expectNoBanned(markup);
+  });
+
+  it('shows an honest empty state instead of inventing reasons', () => {
+    const markup = renderToStaticMarkup(<MatchaExplanation reasons={[]} />);
+    expect(markup.toLowerCase()).toContain("doesn");
+    expect(markup).toContain('enough of your preferences');
+  });
+});
+
+describe('OpportunityIntelligenceCard', () => {
+  const opportunity = {
+    id: 'opp-1',
+    title: 'Cardiologist',
+    organization: 'Bay Area Cardiac',
+    location: 'San Jose, CA',
+    specialty: 'Cardiology',
+    payRange: '$300k–$360k',
+  };
+
+  it('renders the engine band, fit score, and an honesty footer', () => {
+    const markup = renderToStaticMarkup(
+      <OpportunityIntelligenceCard
+        opportunity={opportunity}
+        explanation={{
+          matchBand: 'CLEAR',
+          matchScore: 88,
+          confidence: 0.9,
+          fitReasons: [{ label: 'State license on file', positive: true, dimension: 'license' }],
+          missingCredentials: [],
+          blockers: [],
+          instantOfferEligible: false,
+        }}
+        preferenceReasons={[{ label: 'In CA, one of your preferred locations', positive: true }]}
+      />,
+    );
+    expect(markup).toContain('Cleared to apply');
+    expect(markup).toContain('88');
+    expect(markup).toContain('State license on file');
+    expect(markup).toContain('In CA, one of your preferred locations');
+    // Honesty: does not claim to estimate interview outcomes.
+    expect(markup).toContain('does not estimate interview outcomes');
+    expectNoBanned(markup);
+  });
+
+  it('degrades honestly when the engine explanation is absent', () => {
+    const markup = renderToStaticMarkup(
+      <OpportunityIntelligenceCard
+        opportunity={opportunity}
+        preferenceReasons={[{ label: 'Cardiology matches your specialty focus', positive: true }]}
+      />,
+    );
+    expect(markup).toContain('Live fit scoring is unavailable');
+    expect(markup).toContain('Cardiology matches your specialty focus');
+    // No fabricated band when there is no engine output.
+    expect(markup).not.toContain('Cleared to apply');
+  });
+});
+
+describe('MatchaProfile', () => {
+  it('renders every insight with its provenance trail', () => {
+    const derived = deriveMatchaProfile({
+      currentSpecialties: ['Cardiology'],
+      preferredStates: ['CA'],
+      teachingInterest: 'passionate',
+    });
+    const markup = renderToStaticMarkup(<MatchaProfile derived={derived} clinicianName="Sarah" />);
+    expect(markup).toContain('MATCHA understands you');
+    expect(markup).toContain('because you told MATCHA');
+    expect(markup).toContain('Cardiology');
+    expectNoBanned(markup);
+  });
+
+  it('shows a learning-ready empty state with no invented insights', () => {
+    const markup = renderToStaticMarkup(<MatchaProfile derived={deriveMatchaProfile({})} />);
+    expect(markup).toContain('ready to learn about you');
+    expect(markup).not.toContain('because you told MATCHA');
+  });
+});

--- a/apps/web/__tests__/matcha-preferences.test.ts
+++ b/apps/web/__tests__/matcha-preferences.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_PREFERENCE_FIELDS,
+  ENGINE_BACKED_FIELDS,
+  completenessPercent,
+  countAnsweredFields,
+  emptyPreferences,
+  isFieldAnswered,
+  toCandidateIntent,
+  type MatchaPreferences,
+} from '../lib/matcha/preferences';
+import { deriveMatchaProfile } from '../lib/matcha/profile';
+import {
+  ANSWERABLE_STEP_COUNT,
+  ONBOARDING_STEPS,
+  coerceAnswer,
+} from '../lib/matcha/onboarding';
+import { diffPreferences } from '../lib/matcha/storage';
+
+describe('matcha preferences — completeness', () => {
+  it('empty preferences are 0% complete', () => {
+    expect(completenessPercent(emptyPreferences())).toBe(0);
+    expect(countAnsweredFields({})).toBe(0);
+  });
+
+  it('treats empty arrays and blank strings as unanswered', () => {
+    expect(isFieldAnswered([])).toBe(false);
+    expect(isFieldAnswered('')).toBe(false);
+    expect(isFieldAnswered('  ')).toBe(false);
+    expect(isFieldAnswered(['CA'])).toBe(true);
+    expect(isFieldAnswered(0)).toBe(true);
+    expect(isFieldAnswered(false)).toBe(true);
+  });
+
+  it('scales linearly with answered fields', () => {
+    const prefs: MatchaPreferences = { preferredStates: ['CA'], currentSpecialties: ['Cardiology'] };
+    expect(countAnsweredFields(prefs)).toBe(2);
+    expect(completenessPercent(prefs)).toBe(
+      Math.round((2 / ALL_PREFERENCE_FIELDS.length) * 100),
+    );
+  });
+});
+
+describe('matcha preferences — engine mapping (honesty boundary)', () => {
+  it('maps only the engine-backed subset into CandidateIntent', () => {
+    const prefs: MatchaPreferences = {
+      preferredStates: ['CA', 'WA'],
+      currentSpecialties: ['Cardiology'],
+      desiredSpecialties: ['Interventional Cardiology'],
+      employmentTypes: ['full_time', 'locums', 'telehealth'],
+      minimumSalary: 275000,
+      remoteInterest: 'passionate',
+      startUrgency: 'within_month',
+      // a non-engine field should NOT leak into the intent payload
+      ptoImportance: 'high',
+    };
+    const intent = toCandidateIntent('1003000126', prefs, '2026-07-03T00:00:00.000Z');
+
+    expect(intent.npi).toBe('1003000126');
+    expect(intent.preferredStates).toEqual(['CA', 'WA']);
+    expect(intent.preferredSpecialties).toEqual(['Interventional Cardiology', 'Cardiology']);
+    expect(intent.preferredHiringTypes).toEqual(['perm', 'locums', 'telehealth']);
+    expect(intent.payMin).toBe(275000);
+    expect(intent.remoteOnly).toBe(true);
+    expect(intent.openToLocums).toBe(true);
+    expect(intent.openToTelehealth).toBe(true);
+    expect(intent.startUrgency).toBe('within_month');
+    expect(intent.capturedAt).toBe('2026-07-03T00:00:00.000Z');
+    // no field on CandidateIntent corresponds to PTO — confirm it was dropped
+    expect(JSON.stringify(intent)).not.toContain('pto');
+  });
+
+  it('omits engine fields that are unanswered rather than sending empties', () => {
+    const intent = toCandidateIntent('123', {});
+    expect(intent).toEqual({ npi: '123' });
+  });
+
+  it('only lists real preference fields as engine-backed', () => {
+    for (const field of ENGINE_BACKED_FIELDS) {
+      expect(ALL_PREFERENCE_FIELDS).toContain(field);
+    }
+  });
+});
+
+describe('matcha profile — derivation carries provenance', () => {
+  it('produces no insights and 0 confidence for empty input', () => {
+    const p = deriveMatchaProfile({});
+    expect(p.insights).toHaveLength(0);
+    expect(p.confidenceScore).toBe(0);
+    expect(p.dreamRole).toBeNull();
+    expect(p.dreamEmployer).toBeNull();
+  });
+
+  it('every insight cites at least one answered source field', () => {
+    const prefs: MatchaPreferences = {
+      currentSpecialties: ['Cardiology'],
+      preferredStates: ['CA'],
+      teachingInterest: 'passionate',
+      academicHospitalInterest: 'interested',
+      leadershipAspiration: 'passionate',
+      desiredSalary: 320000,
+      shiftPreference: 'days',
+    };
+    const { insights } = deriveMatchaProfile(prefs);
+    expect(insights.length).toBeGreaterThan(0);
+    for (const insight of insights) {
+      expect(insight.provenance.length).toBeGreaterThan(0);
+      for (const field of insight.provenance) {
+        expect(isFieldAnswered(prefs[field])).toBe(true);
+      }
+    }
+  });
+
+  it('never invents an insight whose source is absent', () => {
+    // Only a preferred state is set — there must be no compensation/schedule insights.
+    const { insights } = deriveMatchaProfile({ preferredStates: ['TX'] });
+    const categories = insights.map((i) => i.category);
+    expect(categories).not.toContain('ideal_compensation');
+    expect(categories).not.toContain('ideal_schedule');
+    expect(categories).toContain('ideal_location');
+  });
+
+  it('confidence equals preference completeness', () => {
+    const prefs: MatchaPreferences = { preferredStates: ['CA'], desiredSalary: 300000 };
+    expect(deriveMatchaProfile(prefs).confidenceScore).toBe(completenessPercent(prefs));
+  });
+
+  it('derives a dream role only when a specialty is known', () => {
+    expect(deriveMatchaProfile({ leadershipAspiration: 'passionate' }).dreamRole).toBeNull();
+    const withSpecialty = deriveMatchaProfile({
+      desiredSpecialties: ['Cardiology'],
+      leadershipAspiration: 'passionate',
+    });
+    expect(withSpecialty.dreamRole).toContain('Cardiology');
+    expect(withSpecialty.dreamRole).toContain('Lead');
+  });
+});
+
+describe('matcha onboarding — script integrity', () => {
+  it('answerable step count excludes intro steps and matches non-intro steps', () => {
+    const nonIntro = ONBOARDING_STEPS.filter((s) => s.kind !== 'intro');
+    expect(ANSWERABLE_STEP_COUNT).toBe(nonIntro.length);
+  });
+
+  it('every answerable step maps to a real preference field', () => {
+    for (const step of ONBOARDING_STEPS) {
+      if (step.kind === 'intro') continue;
+      expect(step.field).toBeDefined();
+      expect(ALL_PREFERENCE_FIELDS).toContain(step.field!);
+    }
+  });
+
+  it('coerces number and boolean answers to the right types', () => {
+    const numberStep = ONBOARDING_STEPS.find((s) => s.kind === 'number')!;
+    expect(coerceAnswer(numberStep, '$300,000')).toBe(300000);
+    const boolStep = ONBOARDING_STEPS.find((s) => s.kind === 'boolean')!;
+    expect(coerceAnswer(boolStep, true)).toBe(true);
+  });
+
+  it('flags every engineBacked step field as engine-backed', () => {
+    for (const step of ONBOARDING_STEPS) {
+      if (step.engineBacked && step.field) {
+        expect(ENGINE_BACKED_FIELDS).toContain(step.field);
+      }
+    }
+  });
+});
+
+describe('matcha memory — grounded diffing', () => {
+  it('reports added, updated, and removed fields with grounded messages', () => {
+    const before: MatchaPreferences = { preferredStates: ['CA'], minimumSalary: 250000 };
+    const after: MatchaPreferences = { preferredStates: ['CA', 'WA'], desiredSalary: 320000 };
+    const notes = diffPreferences(before, after, [
+      'preferredStates',
+      'minimumSalary',
+      'desiredSalary',
+    ]);
+    const byField = Object.fromEntries(notes.map((n) => [n.field, n]));
+    expect(byField.preferredStates.kind).toBe('updated');
+    expect(byField.preferredStates.message).toContain('WA');
+    expect(byField.minimumSalary.kind).toBe('removed');
+    expect(byField.desiredSalary.kind).toBe('added');
+  });
+
+  it('emits nothing when fields are unchanged', () => {
+    const same: MatchaPreferences = { preferredStates: ['CA'] };
+    expect(diffPreferences(same, { ...same }, ['preferredStates'])).toHaveLength(0);
+  });
+});

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -26,6 +26,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
 import { cn } from '@/lib/utils';
+import { PublicMatchaExperience } from '@/components/matcha/PublicMatchaExperience';
+import { CareerEvidenceGraph } from '@/components/matcha/CareerEvidenceGraph';
 
 function formatNpi(value: string): string {
   const digits = value.replace(/\D/g, '').slice(0, 10);
@@ -737,6 +739,47 @@ export default function HomePageClient() {
                   </div>
                 );
               })}
+            </div>
+          </section>
+
+          {/* Meet MATCHA — interactive intelligence layer (no signup) */}
+          <section aria-label="Meet MATCHA" data-home-matcha="" className="mt-16">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              Meet MATCHA
+            </p>
+            <h2 className="mt-3 text-[clamp(1.6rem,3.5vw,2.4rem)] font-semibold leading-tight tracking-[-0.03em] text-[var(--vt-text-primary)]">
+              Not a job board. A career operating system.
+            </h2>
+            <p className="mt-4 max-w-2xl text-[15px] leading-[1.65] text-[var(--vt-text-secondary)]">
+              MATCHA is the intelligence layer that learns what you want, then works in the background
+              to surface roles worth your time — and it explains every recommendation instead of hiding
+              it behind a score. Try it below. No signup, and everything it says traces to what you tell it.
+            </p>
+            <div className="mt-6">
+              <PublicMatchaExperience />
+            </div>
+          </section>
+
+          {/* Career Evidence Network — interactive graph */}
+          <section aria-label="The career evidence network" data-home-network="" className="mt-16">
+            <div
+              className="overflow-hidden rounded-[28px] border border-white/5 px-6 py-8 sm:px-10 sm:py-10"
+              style={{ background: 'radial-gradient(circle at 30% 20%, #1b2a2b 0%, #14181d 55%, #0f1216 100%)' }}
+            >
+              <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#4FD1C5]">
+                The career evidence network
+              </p>
+              <h2 className="max-w-2xl text-[clamp(1.6rem,3.5vw,2.4rem)] font-semibold leading-tight tracking-[-0.03em] text-white">
+                Your evidence isn&rsquo;t a document. It&rsquo;s a network.
+              </h2>
+              <p className="mt-4 max-w-2xl text-[15px] leading-[1.65] text-white/65">
+                Every credential traces to its source, rolls up into your readiness, and connects to the
+                opportunities it unlocks and the employers who accept it. Verify once; reuse everywhere.
+                This is a model of how it fits together — hover to trace a thread.
+              </p>
+              <div className="mt-6">
+                <CareerEvidenceGraph height={460} />
+              </div>
             </div>
           </section>
 

--- a/apps/web/app/api/matcha/intent/route.ts
+++ b/apps/web/app/api/matcha/intent/route.ts
@@ -1,0 +1,41 @@
+/**
+ * MATCHA Intent Proxy
+ * POST /api/matcha/intent
+ * Body: CandidateIntent (npi + engine-relevant preference subset)
+ * Proxies to backend POST /api/matcha/intent so stated preferences reach the match engine.
+ *
+ * Best-effort by design: the clinician's durable preference store is client-side localStorage.
+ * A failed push here never loses an answer.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    if (!body || typeof body !== 'object' || typeof (body as { npi?: unknown }).npi !== 'string') {
+      return NextResponse.json({ error: 'npi is required' }, { status: 400 });
+    }
+
+    const res = await fetch(`${BACKEND}/api/matcha/intent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    const data = await res.json().catch(() => ({ ok: res.ok }));
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('[matcha/intent proxy] error:', error);
+    return NextResponse.json({ error: 'Failed to save intent' }, { status: 502 });
+  }
+}

--- a/apps/web/app/holder/matcha/onboarding/page.tsx
+++ b/apps/web/app/holder/matcha/onboarding/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { MatchaOnboardingSurface } from '@/components/matcha/MatchaOnboardingSurface';
+
+export const metadata: Metadata = {
+  title: 'Meet MATCHA — VitalCV',
+  description: 'A short conversation about what you want next in your career.',
+};
+
+export default function HolderMatchaOnboardingPage() {
+  if (!FEATURES.MATCHA_V2) notFound();
+  return <MatchaOnboardingSurface />;
+}

--- a/apps/web/app/holder/matcha/opportunities/page.tsx
+++ b/apps/web/app/holder/matcha/opportunities/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { MatchaOpportunitiesSurface } from '@/components/matcha/MatchaOpportunitiesSurface';
+
+export const metadata: Metadata = {
+  title: 'MATCHA opportunities — VitalCV',
+  description: 'Live roles scored on your credential eligibility and explained with your preferences.',
+};
+
+export default function HolderMatchaOpportunitiesPage() {
+  if (!FEATURES.MATCHA_V2) notFound();
+  return <MatchaOpportunitiesSurface />;
+}

--- a/apps/web/app/holder/matcha/page.tsx
+++ b/apps/web/app/holder/matcha/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { MatchaHub } from '@/components/matcha/MatchaHub';
+
+export const metadata: Metadata = {
+  title: 'MATCHA — VitalCV',
+  description: 'The intelligence layer that learns what you want and works in the background for you.',
+};
+
+// Gated behind MATCHA_V2 (Wave 187 PILOT flag). All data derives from the clinician's
+// own stated preferences and the live match engine — nothing is fabricated.
+export default function HolderMatchaPage() {
+  if (!FEATURES.MATCHA_V2) notFound();
+  return <MatchaHub />;
+}

--- a/apps/web/app/matcha/hospitals/page.tsx
+++ b/apps/web/app/matcha/hospitals/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { BuyerLanding } from '@/components/matcha/buyer/BuyerLanding';
+
+export const metadata: Metadata = {
+  title: 'MATCHA for hospitals & health systems — VitalCV',
+  description: 'Fill roles faster with source-backed readiness and better-fit clinicians — with continuous readiness after hire.',
+};
+
+const DISCLAIMER =
+  'Directional benefits based on the VitalCV model and internal pilots — not customer-reported results. VitalCV keeps zero PHI on-chain and shows source coverage honestly per credential.';
+
+export default function MatchaHospitalsPage() {
+  if (!FEATURES.MATCHA_BUYER_PAGES) notFound();
+  return (
+    <BuyerLanding
+      eyebrow="For hospitals & health systems"
+      title="Fill roles faster, with clinicians who fit."
+      subtitle="VitalCV shortens the path from open role to a credentialed, well-matched clinician — and keeps readiness current after they start, so you are not surprised at renewal."
+      disclaimer={DISCLAIMER}
+      comparison={{
+        traditionalLabel: 'Today',
+        vitalLabel: 'With VitalCV',
+        rows: [
+          { label: 'Vacancy time', traditional: 'Long gaps while credentialing restarts for each hire.', vital: 'Begin from source-backed readiness to shorten time-to-start.' },
+          { label: 'Agency spend', traditional: 'Premium agency rates to cover the gap.', vital: 'A faster internal pipeline reduces reliance on premium coverage.' },
+          { label: 'Credentialing', traditional: 'Re-collect and re-verify from zero.', vital: 'Accept a documented head start, then complete your own review.' },
+          { label: 'Fit & retention', traditional: 'Hire on résumé keywords; mismatch risk.', vital: 'MATCHA matches on stated preferences and eligibility, explained.' },
+          { label: 'After hire', traditional: 'Readiness goes stale until the next renewal scramble.', vital: 'Continuous readiness surfaces changes as they happen.' },
+        ],
+      }}
+      benefits={[
+        { title: 'Reduce vacancy', body: 'Start from readiness instead of a cold file to close the gap between need and start.' },
+        { title: 'Reduce agency spend', body: 'A faster, better-fit internal pipeline lowers dependence on premium coverage.' },
+        { title: 'Credential faster', body: 'A documented head start feeds your own credentialing review — it does not replace it.' },
+        { title: 'Improve retention', body: 'Better-matched clinicians, matched on what they actually want, tend to stay.' },
+        { title: 'Better fit', body: 'MATCHA weighs preferences, setting, and eligibility — and shows its reasons.' },
+        { title: 'Continuous readiness', body: 'Credential changes surface early, not at the next renewal deadline.' },
+      ]}
+      matchaLine="Your credentialing team stays the decision-maker. MATCHA and the readiness layer give them a documented head start and explained matches — never an automated verdict."
+      cta={{ label: 'Talk to us about a pilot', href: '/contact' }}
+    />
+  );
+}

--- a/apps/web/app/matcha/investors/page.tsx
+++ b/apps/web/app/matcha/investors/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { BuyerLanding } from '@/components/matcha/buyer/BuyerLanding';
+import { EcosystemMap } from '@/components/matcha/buyer/EcosystemMap';
+
+export const metadata: Metadata = {
+  title: 'MATCHA & the career evidence network — VitalCV',
+  description: 'Why reusable, source-backed clinician career evidence compounds into a network-effect moat.',
+};
+
+const DISCLAIMER =
+  'Forward-looking framing of the VitalCV model. Figures are illustrative of the model, not customer-reported results or financial projections.';
+
+export default function MatchaInvestorsPage() {
+  if (!FEATURES.MATCHA_BUYER_PAGES) notFound();
+  return (
+    <BuyerLanding
+      eyebrow="For investors"
+      title="Not a job board. A career evidence network."
+      subtitle="The wedge is a clinician-owned credential wallet. The company is reusable, source-backed career evidence that follows providers across every opportunity, employer, and credentialing team — with MATCHA as the intelligence layer on top."
+      disclaimer={DISCLAIMER}
+      comparison={{
+        traditionalLabel: 'Job boards',
+        vitalLabel: 'VitalCV',
+        rows: [
+          { label: 'Core asset', traditional: 'Listings that expire the moment a role is filled.', vital: 'Reusable career evidence that persists and compounds.' },
+          { label: 'Who owns the data', traditional: 'The platform; the clinician re-enters everywhere.', vital: 'The clinician owns it; it travels with them.' },
+          { label: 'Defensibility', traditional: 'Commoditized; switching costs are low.', vital: 'Each verified hire deepens reusable evidence and trust.' },
+          { label: 'Monetization', traditional: 'Per-post fees, race to the bottom.', vital: 'Employer review and acceptance of source-backed evidence.' },
+          { label: 'Intelligence', traditional: 'Keyword match.', vital: 'MATCHA explains fit from real preferences and eligibility.' },
+        ],
+      }}
+      benefits={[
+        { title: 'Reusable asset', body: 'Source-backed evidence is created once and reused across employers — the opposite of a one-shot listing.' },
+        { title: 'Network effects', body: 'Every accepted hire leaves more reusable evidence and more trust behind, lowering the cost of the next.' },
+        { title: 'Monetization bridge', body: 'The employer review surface turns clinician-owned evidence into a paid acceptance decision.' },
+        { title: 'Infrastructure moat', body: 'A Provider Identity Graph underneath — named as the engine, not the pitch.' },
+        { title: 'Trust by design', body: 'Provenance on every score and badge; zero PHI on-chain; source coverage shown honestly.' },
+        { title: 'Expanding surface', body: 'Credentialing, privileging, payer enrollment, staffing, and AI matching all reuse the same evidence.' },
+      ]}
+      matchaLine="The moat is trust you can inspect. Every recommendation, score, and badge traces to real evidence — which is exactly why employers, clinicians, and credentialing teams keep reusing it."
+      cta={{ label: 'Request the investor brief', href: '/contact' }}
+    >
+      <EcosystemMap />
+    </BuyerLanding>
+  );
+}

--- a/apps/web/app/matcha/recruiters/page.tsx
+++ b/apps/web/app/matcha/recruiters/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { BuyerLanding } from '@/components/matcha/buyer/BuyerLanding';
+
+export const metadata: Metadata = {
+  title: 'MATCHA for recruiters — VitalCV',
+  description: 'Source-backed clinician evidence and explained recommendations — not another keyword search.',
+};
+
+const DISCLAIMER =
+  'Directional benefits based on the VitalCV model and internal pilots — not customer-reported results. Source coverage is shown honestly per credential (checked, gated, stale, or unknown).';
+
+export default function MatchaRecruitersPage() {
+  if (!FEATURES.MATCHA_BUYER_PAGES) notFound();
+  return (
+    <BuyerLanding
+      eyebrow="For recruiters"
+      title="Stop re-verifying the same clinician."
+      subtitle="VitalCV gives recruiters source-backed career evidence that travels with the clinician, and a matching layer that explains every recommendation instead of hiding it behind a score."
+      disclaimer={DISCLAIMER}
+      comparison={{
+        traditionalLabel: 'Traditional recruiting',
+        vitalLabel: 'VitalCV',
+        rows: [
+          { label: 'Credential confidence', traditional: 'Chase documents and re-verify from scratch each time.', vital: 'Source-backed readiness travels with the clinician.' },
+          { label: 'Duplicate work', traditional: 'Every agency re-verifies the same person.', vital: 'Reusable evidence — accept a head start or request a refresh.' },
+          { label: 'Pipeline', traditional: 'Keyword search and guesswork on fit.', vital: 'MATCHA ranks fit from stated preferences and eligibility.' },
+          { label: 'Speed', traditional: 'Weeks of back-and-forth before a clinician is ready.', vital: 'Start from a readiness snapshot; shorten time-to-start.' },
+          { label: 'Transparency', traditional: 'Opaque scores you have to take on faith.', vital: 'Every recommendation shows the reasons behind it.' },
+        ],
+      }}
+      benefits={[
+        { title: 'Time saved', body: 'Begin from a readiness snapshot instead of a blank file. Less chasing, more placing.' },
+        { title: 'Credential confidence', body: 'Each item shows its source state — checked, gated, stale, or unknown — so you know what you can rely on.' },
+        { title: 'Duplicate reduction', body: 'Reusable evidence means you are not re-doing verification another team already did.' },
+        { title: 'Pipeline intelligence', body: 'MATCHA surfaces clinicians whose stated preferences and eligibility actually fit the role.' },
+        { title: 'Source transparency', body: 'No black-box ranking. The reasons are on the card.' },
+        { title: 'Faster time-to-start', body: 'A head start on credentialing shortens the gap between accept and start.' },
+      ]}
+      matchaLine="MATCHA never hands you a black-box score. Every recommendation lists its reasons — the clinician's stated preferences and their source-backed eligibility — so your team can trust what it acts on."
+      cta={{ label: 'Talk to us about a pilot', href: '/contact' }}
+    />
+  );
+}

--- a/apps/web/components/layout/publicSurfaceRoutes.ts
+++ b/apps/web/components/layout/publicSurfaceRoutes.ts
@@ -63,6 +63,7 @@ const PREFIX_MATCHERS = [
   '/review',
   '/verify',
   '/clip',
+  '/matcha',
 ] as const;
 
 export function isPublicSurfacePath(pathname: string | null): boolean {

--- a/apps/web/components/matcha/CareerEvidenceGraph.tsx
+++ b/apps/web/components/matcha/CareerEvidenceGraph.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+/**
+ * CareerEvidenceGraph — an interactive, animated map of VitalCV's core thesis: your career
+ * evidence, the sources that back it, and the opportunities it unlocks, all interconnected.
+ *
+ * Rendered with a small hand-rolled force simulation on a canvas (no external graph lib).
+ * This is a *conceptual model*, labeled as such — the node labels are honest category names
+ * (NPI, State License, NPPES, Readiness, Recognition…), not claims about a specific clinician.
+ *
+ * Respects prefers-reduced-motion: settles to a static layout instead of animating.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type NodeKind = 'you' | 'credential' | 'source' | 'readiness' | 'specialty' | 'opportunity' | 'recognition';
+
+interface GraphNode {
+  id: string;
+  label: string;
+  kind: NodeKind;
+  // simulation state
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  hub?: boolean;
+}
+
+interface GraphEdge {
+  a: string;
+  b: string;
+}
+
+const PALETTE: Record<NodeKind, string> = {
+  you: '#F6E05E',
+  credential: '#4FD1C5',
+  source: '#63B3ED',
+  readiness: '#38B2AC',
+  specialty: '#B794F4',
+  opportunity: '#68D391',
+  recognition: '#F6AD55',
+};
+
+const LEGEND: Array<{ kind: NodeKind; label: string }> = [
+  { kind: 'credential', label: 'Credentials' },
+  { kind: 'source', label: 'Sources' },
+  { kind: 'readiness', label: 'Readiness' },
+  { kind: 'recognition', label: 'Recognition' },
+  { kind: 'specialty', label: 'Specialty' },
+  { kind: 'opportunity', label: 'Opportunities' },
+];
+
+// Honest, conceptual structure of the evidence network.
+function buildGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const raw: Array<Omit<GraphNode, 'x' | 'y' | 'vx' | 'vy'>> = [
+    { id: 'you', label: 'You', kind: 'you', r: 15, hub: true },
+    // credentials
+    { id: 'npi', label: 'NPI', kind: 'credential', r: 8, hub: true },
+    { id: 'license', label: 'State License', kind: 'credential', r: 8, hub: true },
+    { id: 'board', label: 'Board Cert', kind: 'credential', r: 8, hub: true },
+    { id: 'dea', label: 'DEA', kind: 'credential', r: 6 },
+    { id: 'bls', label: 'BLS / ACLS', kind: 'credential', r: 6 },
+    // sources
+    { id: 'nppes', label: 'NPPES', kind: 'source', r: 7 },
+    { id: 'stateboard', label: 'State Board', kind: 'source', r: 7 },
+    { id: 'abms', label: 'ABMS', kind: 'source', r: 6 },
+    { id: 'dea-reg', label: 'DEA Registry', kind: 'source', r: 5 },
+    // readiness + recognition
+    { id: 'readiness', label: 'Readiness', kind: 'readiness', r: 12, hub: true },
+    { id: 'recognition', label: 'Recognition', kind: 'recognition', r: 10, hub: true },
+    // specialty
+    { id: 'specialty', label: 'Specialty', kind: 'specialty', r: 9, hub: true },
+    // opportunities
+    { id: 'opp1', label: 'Opportunity', kind: 'opportunity', r: 7 },
+    { id: 'opp2', label: 'Opportunity', kind: 'opportunity', r: 6 },
+    { id: 'opp3', label: 'Opportunity', kind: 'opportunity', r: 6 },
+    { id: 'opp4', label: 'Opportunity', kind: 'opportunity', r: 5 },
+    // employers (recognition sources)
+    { id: 'emp1', label: 'Employer', kind: 'recognition', r: 5 },
+    { id: 'emp2', label: 'Employer', kind: 'recognition', r: 5 },
+  ];
+
+  const edges: GraphEdge[] = [
+    // you → your evidence
+    { a: 'you', b: 'npi' }, { a: 'you', b: 'license' }, { a: 'you', b: 'board' },
+    { a: 'you', b: 'specialty' }, { a: 'you', b: 'readiness' },
+    { a: 'license', b: 'dea' }, { a: 'board', b: 'bls' },
+    // credentials ← sources (provenance)
+    { a: 'npi', b: 'nppes' }, { a: 'license', b: 'stateboard' },
+    { a: 'board', b: 'abms' }, { a: 'dea', b: 'dea-reg' },
+    // readiness aggregates credentials
+    { a: 'readiness', b: 'npi' }, { a: 'readiness', b: 'license' }, { a: 'readiness', b: 'board' },
+    // opportunities ← readiness + specialty
+    { a: 'readiness', b: 'opp1' }, { a: 'readiness', b: 'opp2' }, { a: 'readiness', b: 'opp3' }, { a: 'readiness', b: 'opp4' },
+    { a: 'specialty', b: 'opp1' }, { a: 'specialty', b: 'opp2' }, { a: 'specialty', b: 'opp3' },
+    // recognition ← employers + readiness
+    { a: 'recognition', b: 'readiness' }, { a: 'recognition', b: 'emp1' }, { a: 'recognition', b: 'emp2' },
+    { a: 'recognition', b: 'opp1' },
+  ];
+
+  const nodes: GraphNode[] = raw.map((n, i) => {
+    const angle = (i / raw.length) * Math.PI * 2;
+    const radius = n.id === 'you' ? 0 : 120 + (i % 5) * 22;
+    return {
+      ...n,
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      vx: 0,
+      vy: 0,
+    };
+  });
+
+  return { nodes, edges };
+}
+
+export function CareerEvidenceGraph({ height = 460 }: { height?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [hoverLabel, setHoverLabel] = useState<string | null>(null);
+  const { nodes, edges } = useMemo(() => buildGraph(), []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const adjacency = new Map<string, Set<string>>();
+    nodes.forEach((n) => adjacency.set(n.id, new Set()));
+    edges.forEach((e) => {
+      adjacency.get(e.a)?.add(e.b);
+      adjacency.get(e.b)?.add(e.a);
+    });
+    const byId = new Map(nodes.map((n) => [n.id, n] as const));
+
+    let width = wrap.clientWidth;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const setSize = () => {
+      width = wrap.clientWidth;
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    };
+    setSize();
+
+    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    let hovered: string | null = null;
+    let mouse = { x: 0, y: 0, active: false };
+
+    const cx = () => width / 2;
+    const cy = () => height / 2;
+
+    function step(alpha: number) {
+      // repulsion
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          let dx = a.x - b.x;
+          let dy = a.y - b.y;
+          let d2 = dx * dx + dy * dy;
+          if (d2 < 0.01) { dx = Math.cos(i) * 0.5; dy = Math.sin(i) * 0.5; d2 = 0.25; }
+          const d = Math.sqrt(d2);
+          const force = (4200 / d2) * alpha;
+          const fx = (dx / d) * force;
+          const fy = (dy / d) * force;
+          a.vx += fx; a.vy += fy;
+          b.vx -= fx; b.vy -= fy;
+        }
+      }
+      // springs
+      for (const e of edges) {
+        const a = byId.get(e.a)!;
+        const b = byId.get(e.b)!;
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const d = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        const rest = 92;
+        const force = (d - rest) * 0.035 * alpha;
+        const fx = (dx / d) * force;
+        const fy = (dy / d) * force;
+        a.vx += fx; a.vy += fy;
+        b.vx -= fx; b.vy -= fy;
+      }
+      // centering + integrate
+      for (const n of nodes) {
+        n.vx += -n.x * 0.012 * alpha;
+        n.vy += -n.y * 0.012 * alpha;
+        n.vx *= 0.82;
+        n.vy *= 0.82;
+        if (n.id === 'you') { n.x = 0; n.y = 0; n.vx = 0; n.vy = 0; continue; }
+        n.x += n.vx;
+        n.y += n.vy;
+      }
+    }
+
+    function draw() {
+      if (!ctx) return;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+      ctx.translate(cx(), cy());
+
+      const near = hovered ? adjacency.get(hovered) : null;
+
+      // edges
+      for (const e of edges) {
+        const a = byId.get(e.a)!;
+        const b = byId.get(e.b)!;
+        const lit = hovered && (e.a === hovered || e.b === hovered);
+        ctx.strokeStyle = lit ? 'rgba(79,209,197,0.75)' : hovered ? 'rgba(79,209,197,0.06)' : 'rgba(79,209,197,0.16)';
+        ctx.lineWidth = lit ? 1.6 : 1;
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.stroke();
+      }
+
+      // nodes
+      for (const n of nodes) {
+        const dim = hovered && n.id !== hovered && !near?.has(n.id);
+        ctx.globalAlpha = dim ? 0.25 : 1;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fillStyle = PALETTE[n.kind];
+        ctx.shadowColor = PALETTE[n.kind];
+        ctx.shadowBlur = n.id === hovered ? 18 : n.hub ? 8 : 0;
+        ctx.fill();
+        ctx.shadowBlur = 0;
+
+        // labels: hubs always, plus hovered
+        if ((n.hub || n.id === hovered) && !dim) {
+          ctx.globalAlpha = 1;
+          ctx.fillStyle = 'rgba(237,242,240,0.92)';
+          ctx.font = `${n.id === 'you' ? 13 : 11}px ui-sans-serif, system-ui, sans-serif`;
+          ctx.textAlign = 'center';
+          ctx.fillText(n.label, n.x, n.y - n.r - 6);
+        }
+      }
+      ctx.globalAlpha = 1;
+    }
+
+    // reduced motion: settle then draw once
+    if (reduced) {
+      for (let i = 0; i < 320; i++) step(1);
+      draw();
+    }
+
+    let raf = 0;
+    let alpha = 1;
+    const loop = () => {
+      alpha = Math.max(0.05, alpha * 0.992);
+      step(alpha);
+      draw();
+      raf = requestAnimationFrame(loop);
+    };
+    if (!reduced) raf = requestAnimationFrame(loop);
+
+    // hover detection
+    const onMove = (ev: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse = { x: ev.clientX - rect.left - cx(), y: ev.clientY - rect.top - cy(), active: true };
+      let found: string | null = null;
+      let best = 22 * 22;
+      for (const n of nodes) {
+        const dx = n.x - mouse.x;
+        const dy = n.y - mouse.y;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < best && d2 < (n.r + 12) * (n.r + 12)) { best = d2; found = n.id; }
+      }
+      if (found !== hovered) {
+        hovered = found;
+        setHoverLabel(found ? byId.get(found)!.label : null);
+        if (reduced) draw();
+      }
+      canvas.style.cursor = found ? 'pointer' : 'default';
+    };
+    const onLeave = () => { hovered = null; setHoverLabel(null); if (reduced) draw(); };
+    canvas.addEventListener('mousemove', onMove);
+    canvas.addEventListener('mouseleave', onLeave);
+
+    const ro = new ResizeObserver(() => { setSize(); if (reduced) draw(); });
+    ro.observe(wrap);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      canvas.removeEventListener('mousemove', onMove);
+      canvas.removeEventListener('mouseleave', onLeave);
+      ro.disconnect();
+    };
+  }, [nodes, edges, height]);
+
+  return (
+    <div ref={wrapRef} style={{ position: 'relative', width: '100%' }}>
+      <canvas ref={canvasRef} aria-label="Interactive diagram of the career evidence network" />
+      {/* Legend */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 16,
+          bottom: 14,
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '6px 14px',
+          maxWidth: 'calc(100% - 32px)',
+        }}
+      >
+        {LEGEND.map((l) => (
+          <span key={l.kind} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'rgba(237,242,240,0.6)' }}>
+            <span style={{ width: 8, height: 8, borderRadius: 999, background: PALETTE[l.kind] }} />
+            {l.label}
+          </span>
+        ))}
+      </div>
+      {/* Hover readout */}
+      <div style={{ position: 'absolute', right: 16, top: 14, fontSize: 12, color: 'rgba(237,242,240,0.7)', minHeight: 16 }}>
+        {hoverLabel ? `→ ${hoverLabel}` : 'Hover a node'}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaExplanation.tsx
+++ b/apps/web/components/matcha/MatchaExplanation.tsx
@@ -1,0 +1,113 @@
+/**
+ * MatchaExplanation — the single, reusable "why MATCHA is showing you this" block.
+ *
+ * Truth contract: this component only *renders* reasons it is given. It never generates,
+ * scores, or embellishes. Callers derive reasons from real data — either the engine's
+ * MatchExplanation.fitReasons (see {@link reasonsFromFitReasons}) or the clinician's own
+ * stated preferences. If there are no reasons, it says so plainly rather than inventing any.
+ */
+
+import type { ReactNode } from 'react';
+
+export interface ExplanationReason {
+  /** The statement, e.g. "You prefer teaching hospitals". */
+  label: string;
+  /** true = supports the recommendation, false = a caveat/concern. */
+  positive: boolean;
+  /** Optional short provenance, e.g. "from your preferences" or "state license on file". */
+  source?: string;
+}
+
+export interface MatchaExplanationProps {
+  reasons: ExplanationReason[];
+  /** Heading; defaults to the canonical "Recommended because". */
+  title?: string;
+  /** Optional footer, e.g. a fit percentage that came from the engine. */
+  footer?: ReactNode;
+  className?: string;
+}
+
+/** Adapter: engine FitReason[] → ExplanationReason[]. Keeps callers honest. */
+export function reasonsFromFitReasons(
+  fitReasons: Array<{ label: string; positive: boolean; dimension?: string }> | undefined,
+): ExplanationReason[] {
+  if (!fitReasons?.length) return [];
+  return fitReasons.map((r) => ({
+    label: r.label,
+    positive: r.positive,
+    source: r.dimension ? `match: ${r.dimension.replace(/_/g, ' ')}` : undefined,
+  }));
+}
+
+export function MatchaExplanation({
+  reasons,
+  title = 'Recommended because',
+  footer,
+  className,
+}: MatchaExplanationProps) {
+  if (!reasons.length) {
+    return (
+      <div
+        className={className}
+        style={{ fontSize: 13, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}
+      >
+        MATCHA doesn&rsquo;t have enough of your preferences yet to explain this. Answer a few
+        more questions and reasons will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: 'var(--vt-text-muted)',
+        }}
+      >
+        {title}
+      </p>
+      <ul style={{ listStyle: 'none', margin: '10px 0 0', padding: 0, display: 'grid', gap: 8 }}>
+        {reasons.map((reason, i) => (
+          <li
+            key={`${reason.label}-${i}`}
+            style={{ display: 'flex', gap: 10, alignItems: 'flex-start', fontSize: 14 }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                marginTop: 2,
+                flex: '0 0 auto',
+                width: 16,
+                height: 16,
+                borderRadius: 999,
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 11,
+                fontWeight: 700,
+                color: reason.positive ? 'var(--vt-status-resolved, #2E7D45)' : 'var(--vt-risk-medium, #A05C00)',
+                background: reason.positive
+                  ? 'color-mix(in srgb, var(--vt-status-resolved, #2E7D45) 14%, transparent)'
+                  : 'color-mix(in srgb, var(--vt-risk-medium, #A05C00) 14%, transparent)',
+              }}
+            >
+              {reason.positive ? '✓' : '!'}
+            </span>
+            <span style={{ color: 'var(--vt-text-primary)', lineHeight: 1.45 }}>
+              {reason.label}
+              {reason.source ? (
+                <span style={{ color: 'var(--vt-text-muted)', fontSize: 12 }}> · {reason.source}</span>
+              ) : null}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {footer ? <div style={{ marginTop: 12 }}>{footer}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaHomeActivity.tsx
+++ b/apps/web/components/matcha/MatchaHomeActivity.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/**
+ * MatchaHomeActivity — Wave 5, the "living" MATCHA strip on the clinician home.
+ *
+ * Additive and self-gating: renders nothing unless MATCHA_V2 is on. Every figure is real —
+ * learning progress is preference completeness, "recently learned" comes from grounded memory
+ * diffing, and the pipeline count is the live opportunity list. Styled to match the dark home
+ * surface. No fabricated activity.
+ */
+
+import Link from 'next/link';
+import { Sparkles, ArrowRight } from 'lucide-react';
+import { FEATURES } from '@/lib/features';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useMatchaPreferences } from './useMatchaPreferences';
+
+export function MatchaHomeActivity() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? undefined;
+  const { completeness, memory, loaded } = useMatchaPreferences(npi);
+
+  if (!FEATURES.MATCHA_V2 || !loaded) return null;
+
+  const pipeline = data.availableOpportunities?.length ?? 0;
+  const started = completeness > 0;
+
+  return (
+    <section className="rounded-[28px] border border-emerald-400/20 bg-gradient-to-br from-emerald-400/10 to-sky-400/[0.06] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.24)]">
+      <div className="flex items-start justify-between gap-4">
+        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-100">
+          <Sparkles className="h-3.5 w-3.5" />
+          MATCHA activity
+        </div>
+        <Link
+          href="/holder/matcha"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-100 transition hover:text-white"
+        >
+          {started ? 'Open MATCHA' : 'Meet MATCHA'}
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {started ? (
+        <>
+          <div className="mt-4 flex items-center gap-3">
+            <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-sky-400 transition-[width] duration-500"
+                style={{ width: `${Math.max(4, completeness)}%` }}
+              />
+            </div>
+            <span className="text-sm font-semibold tabular-nums text-white">{completeness}% learned</span>
+          </div>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-[1.4fr_0.6fr]">
+            <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
+              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Recently learned</p>
+              {memory.length > 0 ? (
+                <ul className="mt-2 space-y-1">
+                  {memory.slice(0, 2).map((note, i) => (
+                    <li key={`${note.field}-${i}`} className="text-sm leading-6 text-white/80">
+                      {note.message}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm leading-6 text-white/60">
+                  Keep answering and MATCHA sharpens your matches. Every answer is yours.
+                </p>
+              )}
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
+              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Opportunity pipeline</p>
+              <p className="mt-2 text-2xl font-semibold text-white tabular-nums">{pipeline}</p>
+              <p className="mt-1 text-xs text-white/50">live role{pipeline === 1 ? '' : 's'} in view</p>
+            </div>
+          </div>
+        </>
+      ) : (
+        <p className="mt-4 max-w-2xl text-sm leading-6 text-white/70">
+          MATCHA learns what you want next, then works in the background to surface roles worth your
+          time. A short conversation gets it started.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * MatchaHub — the signed-in home for the intelligence layer. Ties together Wave 2
+ * ("MATCHA understands you"), Wave 10 ("MATCHA remembers"), and entry points to onboarding
+ * and opportunities. Reads the clinician's NPI/name from the shared holder provider.
+ */
+
+import Link from 'next/link';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useMatchaPreferences } from './useMatchaPreferences';
+import { MatchaProfile } from './MatchaProfile';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+export function MatchaHub() {
+  const { data } = useClinicianMobile();
+  const person = data.workspace?.personProfile;
+  const npi = person?.npi ?? undefined;
+  const firstName = person?.firstName ?? undefined;
+
+  const { derived, completeness, memory, loaded } = useMatchaPreferences(npi);
+
+  const started = completeness > 0;
+
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 24 }}>
+      {/* Recently learned — Wave 10 */}
+      {loaded && memory.length > 0 && (
+        <div
+          style={{
+            background: `color-mix(in srgb, ${ACCENT} 6%, var(--vt-surface, #fff))`,
+            border: `1px solid color-mix(in srgb, ${ACCENT} 24%, transparent)`,
+            borderRadius: 16,
+            padding: '14px 18px',
+          }}
+        >
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: ACCENT }}>
+            MATCHA remembers
+          </div>
+          <ul style={{ listStyle: 'none', margin: '8px 0 0', padding: 0, display: 'grid', gap: 4 }}>
+            {memory.map((note, i) => (
+              <li key={`${note.field}-${i}`} style={{ fontSize: 14, color: 'var(--vt-text-primary)' }}>
+                {note.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Onboarding CTA */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 16,
+          flexWrap: 'wrap',
+          background: 'var(--vt-surface, #fff)',
+          border: '1px solid var(--vt-border, #E2E8E6)',
+          borderRadius: 16,
+          padding: 20,
+        }}
+      >
+        <div>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+            {started ? 'Keep teaching MATCHA' : 'Meet MATCHA'}
+          </h1>
+          <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', maxWidth: 520, lineHeight: 1.5 }}>
+            {started
+              ? `You've shared ${completeness}% of your preferences. Each answer sharpens the roles MATCHA surfaces for you.`
+              : 'A short conversation about what you want next. MATCHA uses it to work in the background on your behalf.'}
+          </p>
+        </div>
+        <Link
+          href="/holder/matcha/onboarding"
+          style={{
+            padding: '11px 22px',
+            borderRadius: 12,
+            background: ACCENT,
+            color: '#fff',
+            fontSize: 15,
+            fontWeight: 600,
+            textDecoration: 'none',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {started ? 'Continue' : 'Start'}
+        </Link>
+      </div>
+
+      {/* Wave 2 profile */}
+      <MatchaProfile derived={derived} clinicianName={firstName} />
+
+      {/* Link to intelligence opportunities */}
+      {started && (
+        <Link
+          href="/holder/matcha/opportunities"
+          style={{
+            textAlign: 'center',
+            padding: '14px 18px',
+            borderRadius: 12,
+            border: `1px solid ${ACCENT}`,
+            color: ACCENT,
+            fontWeight: 600,
+            fontSize: 15,
+            textDecoration: 'none',
+          }}
+        >
+          See opportunities MATCHA found for you →
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaOnboarding.tsx
+++ b/apps/web/components/matcha/MatchaOnboarding.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+/**
+ * MatchaOnboarding — Wave 1. A conversation, not a form.
+ *
+ * Renders ONBOARDING_STEPS one at a time as MATCHA "messages". Each answer flows straight
+ * into the preference model via useMatchaPreferences, so MATCHA's reasoning (and the live
+ * intent push) updates as you go. Progress is real: it reflects answered preference fields.
+ */
+
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+import {
+  ONBOARDING_STEPS,
+  coerceAnswer,
+  type OnboardingStep,
+} from '@/lib/matcha/onboarding';
+import { useMatchaPreferences } from './useMatchaPreferences';
+
+interface MatchaOnboardingProps {
+  npi?: string;
+  clinicianName?: string;
+  /** Called when the clinician finishes or exits the flow. */
+  onComplete?: () => void;
+}
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+function TagInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState('');
+  const commit = () => {
+    const v = draft.trim();
+    if (v && !value.includes(v)) onChange([...value, v]);
+    setDraft('');
+  };
+  return (
+    <div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: value.length ? 10 : 0 }}>
+        {value.map((tag) => (
+          <span
+            key={tag}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '5px 10px',
+              borderRadius: 999,
+              background: `color-mix(in srgb, ${ACCENT} 12%, transparent)`,
+              color: ACCENT,
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
+            {tag}
+            <button
+              type="button"
+              aria-label={`Remove ${tag}`}
+              onClick={() => onChange(value.filter((t) => t !== tag))}
+              style={{ border: 0, background: 'transparent', color: 'inherit', cursor: 'pointer', fontSize: 14, lineHeight: 1 }}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            commit();
+          }
+        }}
+        onBlur={commit}
+        placeholder={placeholder ?? 'Type and press Enter'}
+        style={inputStyle}
+      />
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '12px 14px',
+  fontSize: 15,
+  borderRadius: 12,
+  border: '1px solid var(--vt-border, #D6DED9)',
+  background: 'var(--vt-surface, #fff)',
+  color: 'var(--vt-text-primary)',
+  outline: 'none',
+};
+
+function OptionButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        padding: '10px 16px',
+        borderRadius: 12,
+        fontSize: 14,
+        fontWeight: 500,
+        cursor: 'pointer',
+        border: `1px solid ${active ? ACCENT : 'var(--vt-border, #D6DED9)'}`,
+        background: active ? `color-mix(in srgb, ${ACCENT} 12%, transparent)` : 'var(--vt-surface, #fff)',
+        color: active ? ACCENT : 'var(--vt-text-primary)',
+        transition: 'all 160ms cubic-bezier(0.2,0.8,0.2,1)',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function MatchaOnboarding({ npi, clinicianName, onComplete }: MatchaOnboardingProps) {
+  const { preferences, completeness, setField } = useMatchaPreferences(npi);
+  const [index, setIndex] = useState(0);
+  const [draftMulti, setDraftMulti] = useState<string[]>([]);
+
+  const step = ONBOARDING_STEPS[index] as OnboardingStep | undefined;
+  const isLast = index >= ONBOARDING_STEPS.length - 1;
+
+  const answeredValue = step?.field ? preferences[step.field] : undefined;
+
+  const advance = () => {
+    setDraftMulti([]);
+    if (isLast) {
+      onComplete?.();
+      return;
+    }
+    setIndex((i) => Math.min(i + 1, ONBOARDING_STEPS.length - 1));
+  };
+  const back = () => setIndex((i) => Math.max(0, i - 1));
+
+  const answerAndAdvance = (raw: unknown) => {
+    if (step?.field) setField(step.field, coerceAnswer(step, raw));
+    advance();
+  };
+
+  const progressPct = useMemo(() => {
+    // Blend positional progress with real completeness for an honest, moving bar.
+    const positional = Math.round(((index + 1) / ONBOARDING_STEPS.length) * 100);
+    return Math.max(positional, completeness);
+  }, [index, completeness]);
+
+  if (!step) return null;
+
+  return (
+    <div style={{ maxWidth: 640, margin: '0 auto' }}>
+      {/* Progress */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24 }}>
+        <div style={{ flex: 1, height: 6, borderRadius: 999, background: 'var(--vt-border, #E2E8E6)', overflow: 'hidden' }}>
+          <div
+            style={{
+              width: `${progressPct}%`,
+              height: '100%',
+              background: ACCENT,
+              borderRadius: 999,
+              transition: 'width 320ms cubic-bezier(0.2,0.8,0.2,1)',
+            }}
+          />
+        </div>
+        <span style={{ fontSize: 12, color: 'var(--vt-text-muted)', fontVariantNumeric: 'tabular-nums' }}>
+          {step.section}
+        </span>
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step.id}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.32, ease: [0.2, 0.8, 0.2, 1] }}
+        >
+          {/* MATCHA message */}
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', marginBottom: 20 }}>
+            <span
+              aria-hidden="true"
+              style={{
+                flex: '0 0 auto',
+                width: 34,
+                height: 34,
+                borderRadius: 10,
+                background: ACCENT,
+                color: '#fff',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 700,
+                fontSize: 15,
+              }}
+            >
+              M
+            </span>
+            <div>
+              <p style={{ margin: 0, fontSize: 19, fontWeight: 600, color: 'var(--vt-text-primary)', lineHeight: 1.35 }}>
+                {step.prompt}
+              </p>
+              {step.hint ? (
+                <p style={{ margin: '6px 0 0', fontSize: 13, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>{step.hint}</p>
+              ) : null}
+              {step.engineBacked ? (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    marginTop: 8,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: ACCENT,
+                    background: `color-mix(in srgb, ${ACCENT} 10%, transparent)`,
+                    padding: '2px 8px',
+                    borderRadius: 999,
+                  }}
+                >
+                  Updates your live matches
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Answer control */}
+          <div style={{ paddingLeft: 46 }}>
+            {step.kind === 'intro' && (
+              <button type="button" onClick={advance} style={primaryBtn}>
+                {clinicianName ? `Let's go, ${clinicianName}` : "Let's go"}
+              </button>
+            )}
+
+            {step.kind === 'boolean' && (
+              <div style={{ display: 'flex', gap: 10 }}>
+                <OptionButton label="Yes" active={answeredValue === true} onClick={() => answerAndAdvance(true)} />
+                <OptionButton label="No" active={answeredValue === false} onClick={() => answerAndAdvance(false)} />
+              </div>
+            )}
+
+            {(step.kind === 'chips_single' || step.kind === 'scale') && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                {step.options?.map((opt) => (
+                  <OptionButton
+                    key={opt.value}
+                    label={opt.label}
+                    active={answeredValue === opt.value}
+                    onClick={() => answerAndAdvance(opt.value)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {step.kind === 'chips_multi' && (
+              <div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+                  {step.options?.map((opt) => {
+                    const active = draftMulti.includes(opt.value);
+                    return (
+                      <OptionButton
+                        key={opt.value}
+                        label={opt.label}
+                        active={active}
+                        onClick={() =>
+                          setDraftMulti((prev) =>
+                            prev.includes(opt.value) ? prev.filter((v) => v !== opt.value) : [...prev, opt.value],
+                          )
+                        }
+                      />
+                    );
+                  })}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => answerAndAdvance(draftMulti)}
+                  disabled={draftMulti.length === 0}
+                  style={{ ...primaryBtn, marginTop: 16, opacity: draftMulti.length === 0 ? 0.5 : 1 }}
+                >
+                  Continue
+                </button>
+              </div>
+            )}
+
+            {step.kind === 'tags' && (
+              <div>
+                <TagInput
+                  value={Array.isArray(answeredValue) ? (answeredValue as string[]) : []}
+                  onChange={(next) => step.field && setField(step.field, coerceAnswer(step, next))}
+                  placeholder={step.hint}
+                />
+                <button type="button" onClick={advance} style={{ ...primaryBtn, marginTop: 16 }}>
+                  Continue
+                </button>
+              </div>
+            )}
+
+            {step.kind === 'number' && (
+              <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  defaultValue={typeof answeredValue === 'number' ? String(answeredValue) : ''}
+                  placeholder={step.numberPlaceholder}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') answerAndAdvance((e.target as HTMLInputElement).value);
+                  }}
+                  id={`num-${step.id}`}
+                  style={{ ...inputStyle, maxWidth: 200 }}
+                />
+                {step.numberUnit ? <span style={{ fontSize: 13, color: 'var(--vt-text-muted)' }}>{step.numberUnit}</span> : null}
+                <button
+                  type="button"
+                  onClick={() => {
+                    const el = document.getElementById(`num-${step.id}`) as HTMLInputElement | null;
+                    answerAndAdvance(el?.value ?? '');
+                  }}
+                  style={primaryBtn}
+                >
+                  Continue
+                </button>
+              </div>
+            )}
+
+            {/* Nav row */}
+            <div style={{ display: 'flex', gap: 16, marginTop: 20, alignItems: 'center' }}>
+              {index > 0 && (
+                <button type="button" onClick={back} style={ghostBtn}>
+                  Back
+                </button>
+              )}
+              {step.kind !== 'intro' && (step.optional || step.kind === 'scale' || step.kind === 'chips_single' || step.kind === 'boolean') && (
+                <button type="button" onClick={advance} style={ghostBtn}>
+                  {isLast ? 'Finish' : 'Skip'}
+                </button>
+              )}
+            </div>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+const primaryBtn: React.CSSProperties = {
+  padding: '11px 22px',
+  borderRadius: 12,
+  border: 0,
+  background: ACCENT,
+  color: '#fff',
+  fontSize: 15,
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+const ghostBtn: React.CSSProperties = {
+  padding: '8px 4px',
+  border: 0,
+  background: 'transparent',
+  color: 'var(--vt-text-muted)',
+  fontSize: 14,
+  cursor: 'pointer',
+};

--- a/apps/web/components/matcha/MatchaOnboardingSurface.tsx
+++ b/apps/web/components/matcha/MatchaOnboardingSurface.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+/**
+ * MatchaOnboardingSurface — client wrapper that supplies NPI/name from the holder provider
+ * to the conversational onboarding, and returns to the hub on completion.
+ */
+
+import { useRouter } from 'next/navigation';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { MatchaOnboarding } from './MatchaOnboarding';
+
+export function MatchaOnboardingSurface() {
+  const router = useRouter();
+  const { data } = useClinicianMobile();
+  const person = data.workspace?.personProfile;
+
+  return (
+    <div style={{ padding: '28px 20px 96px' }}>
+      <MatchaOnboarding
+        npi={person?.npi ?? undefined}
+        clinicianName={person?.firstName ?? undefined}
+        onComplete={() => router.push('/holder/matcha')}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * MatchaOpportunitiesSurface — Wave 4. Fetches live matches from the MATCHA engine and
+ * renders them as Opportunity Intelligence Cards. Preference-grounded reasons are layered
+ * on from the clinician's own stored answers. Honest empty / loading / error states.
+ */
+
+import { useEffect, useState } from 'react';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useMatchaPreferences } from './useMatchaPreferences';
+import {
+  OpportunityIntelligenceCard,
+  type IntelligenceExplanation,
+  type IntelligenceOpportunity,
+} from './OpportunityIntelligenceCard';
+import { preferenceMatchReasons, type FitOpportunity } from '@/lib/matcha/opportunityFit';
+
+interface RawMatch {
+  opportunity?: Record<string, unknown> & IntelligenceOpportunity & FitOpportunity;
+  explanation?: IntelligenceExplanation;
+}
+
+type LoadState = 'loading' | 'ready' | 'error' | 'no-npi';
+
+export function MatchaOpportunitiesSurface() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? null;
+  const { preferences } = useMatchaPreferences(npi ?? undefined);
+
+  const [matches, setMatches] = useState<RawMatch[]>([]);
+  const [state, setState] = useState<LoadState>('loading');
+
+  useEffect(() => {
+    if (!npi) {
+      setState('no-npi');
+      return;
+    }
+    let cancelled = false;
+    setState('loading');
+    fetch(`/api/matcha/opportunities/${encodeURIComponent(npi)}`, { signal: AbortSignal.timeout(16_000) })
+      .then((r) => r.json())
+      .then((payload: { matches?: RawMatch[] }) => {
+        if (cancelled) return;
+        setMatches(Array.isArray(payload.matches) ? payload.matches : []);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  return (
+    <div style={{ maxWidth: 820, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 16 }}>
+      <header style={{ marginBottom: 4 }}>
+        <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+          Opportunities MATCHA found
+        </h1>
+        <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)' }}>
+          Scored on your credential eligibility, explained with your own preferences.
+        </p>
+      </header>
+
+      {state === 'no-npi' && (
+        <EmptyNote title="Add your NPI to get matches" body="Once your NPI is on file, MATCHA can score real opportunities for you." />
+      )}
+      {state === 'loading' && <EmptyNote title="Checking opportunities…" body="MATCHA is scoring live roles against your trust state." />}
+      {state === 'error' && (
+        <EmptyNote title="Matches are temporarily unavailable" body="This is a live check — please try again shortly. Nothing about your profile changed." />
+      )}
+      {state === 'ready' && matches.length === 0 && (
+        <EmptyNote title="No live matches yet" body="As opportunities are posted that fit your credentials, they'll appear here." />
+      )}
+
+      {state === 'ready' &&
+        matches.map((m, i) => {
+          const opp = m.opportunity;
+          if (!opp?.id) return null;
+          const reasons = preferenceMatchReasons(preferences, opp);
+          return (
+            <OpportunityIntelligenceCard
+              key={opp.id ?? i}
+              opportunity={opp}
+              explanation={m.explanation}
+              preferenceReasons={reasons}
+              href={`/holder/opportunities`}
+            />
+          );
+        })}
+    </div>
+  );
+}
+
+function EmptyNote({ title, body }: { title: string; body: string }) {
+  return (
+    <div
+      style={{
+        background: 'var(--vt-surface, #fff)',
+        border: '1px solid var(--vt-border, #E2E8E6)',
+        borderRadius: 16,
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{title}</p>
+      <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)' }}>{body}</p>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaProfile.tsx
+++ b/apps/web/components/matcha/MatchaProfile.tsx
@@ -1,0 +1,175 @@
+/**
+ * MatchaProfile — Wave 2, "MATCHA understands you".
+ *
+ * A reflective, Wrapped-style read-back of what the clinician has told MATCHA. Every insight
+ * is rendered with its provenance (the answers it came from), and the confidence score is
+ * explicitly framed as "how much you've told MATCHA" — not a claim about match quality.
+ *
+ * Presentational only: it takes a derived profile and renders it. No fetching, no fabrication.
+ */
+
+import type { InsightCategory, MatchaDerivedProfile, MatchaInsight } from '@/lib/matcha/profile';
+import type { PreferenceField } from '@/lib/matcha/preferences';
+
+const CATEGORY_ORDER: Array<{ key: InsightCategory; title: string }> = [
+  { key: 'career_direction', title: 'Career direction' },
+  { key: 'career_dna', title: 'Career DNA' },
+  { key: 'value', title: 'Values' },
+  { key: 'strength', title: 'Strengths' },
+  { key: 'ideal_organization', title: 'Ideal organizations' },
+  { key: 'ideal_team', title: 'Ideal teams' },
+  { key: 'ideal_location', title: 'Ideal locations' },
+  { key: 'ideal_compensation', title: 'Ideal compensation' },
+  { key: 'ideal_schedule', title: 'Ideal schedule' },
+];
+
+function readableField(field: PreferenceField): string {
+  return String(field)
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim();
+}
+
+function ConfidenceRing({ value }: { value: number }) {
+  const size = 92;
+  const stroke = 8;
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const offset = c * (1 - Math.min(100, Math.max(0, value)) / 100);
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={`${value}% learned`}>
+      <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--vt-border, #E2E8E6)" strokeWidth={stroke} />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke="var(--vt-accent, #0A7B7F)"
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={offset}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="central"
+        textAnchor="middle"
+        style={{ fontSize: 20, fontWeight: 700, fill: 'var(--vt-text-primary)' }}
+      >
+        {value}%
+      </text>
+    </svg>
+  );
+}
+
+function InsightRow({ insight }: { insight: MatchaInsight }) {
+  return (
+    <li style={{ display: 'grid', gap: 3, padding: '10px 0', borderBottom: '1px solid var(--vt-border, #EEF2F0)' }}>
+      <span style={{ fontSize: 15, color: 'var(--vt-text-primary)', fontWeight: 500 }}>{insight.label}</span>
+      <span style={{ fontSize: 11, color: 'var(--vt-text-muted)' }}>
+        because you told MATCHA: {insight.provenance.map(readableField).join(', ')}
+      </span>
+    </li>
+  );
+}
+
+export interface MatchaProfileProps {
+  derived: MatchaDerivedProfile;
+  clinicianName?: string;
+}
+
+export function MatchaProfile({ derived, clinicianName }: MatchaProfileProps) {
+  const { insights, confidenceScore, dreamRole, dreamEmployer } = derived;
+
+  if (insights.length === 0) {
+    return (
+      <section
+        style={{
+          background: 'var(--vt-surface, #fff)',
+          border: '1px solid var(--vt-border, #E2E8E6)',
+          borderRadius: 16,
+          padding: 24,
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+          MATCHA is ready to learn about you
+        </h2>
+        <p style={{ margin: '8px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', lineHeight: 1.5 }}>
+          Answer a few questions and MATCHA will build a picture of what you&rsquo;re looking for —
+          reflected back here, always tied to what you actually said.
+        </p>
+      </section>
+    );
+  }
+
+  const grouped = CATEGORY_ORDER.map((cat) => ({
+    ...cat,
+    items: insights.filter((i) => i.category === cat.key),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <section style={{ display: 'grid', gap: 20 }}>
+      {/* Header card */}
+      <div
+        style={{
+          background: 'linear-gradient(135deg, color-mix(in srgb, var(--vt-accent, #0A7B7F) 8%, var(--vt-surface, #fff)), var(--vt-surface, #fff))',
+          border: '1px solid var(--vt-border, #E2E8E6)',
+          borderRadius: 20,
+          padding: 24,
+          display: 'flex',
+          gap: 20,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ConfidenceRing value={confidenceScore} />
+        <div style={{ minWidth: 220, flex: 1 }}>
+          <p style={{ margin: 0, fontSize: 11, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--vt-accent, #0A7B7F)', fontWeight: 700 }}>
+            MATCHA understands you
+          </p>
+          <h2 style={{ margin: '6px 0 0', fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+            {clinicianName ? `Here's what I know about you, ${clinicianName}` : "Here's what I know about you"}
+          </h2>
+          <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--vt-text-secondary)', lineHeight: 1.5 }}>
+            Confidence reflects how much you&rsquo;ve shared — {confidenceScore}% so far. The more you
+            tell MATCHA, the sharper your matches get. Everything below traces to your own answers.
+          </p>
+        </div>
+      </div>
+
+      {/* Dream role / employer */}
+      {(dreamRole || dreamEmployer) && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 16 }}>
+          {dreamRole && (
+            <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+              <div style={{ fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--vt-text-muted)' }}>Dream role</div>
+              <div style={{ fontSize: 18, fontWeight: 600, color: 'var(--vt-text-primary)', marginTop: 4 }}>{dreamRole}</div>
+            </div>
+          )}
+          {dreamEmployer && (
+            <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+              <div style={{ fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--vt-text-muted)' }}>Dream employer</div>
+              <div style={{ fontSize: 18, fontWeight: 600, color: 'var(--vt-text-primary)', marginTop: 4 }}>{dreamEmployer}</div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Grouped insights */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 }}>
+        {grouped.map((group) => (
+          <div key={group.key} style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: '16px 20px' }}>
+            <h3 style={{ margin: 0, fontSize: 13, fontWeight: 700, letterSpacing: '0.04em', color: 'var(--vt-text-secondary)' }}>{group.title}</h3>
+            <ul style={{ listStyle: 'none', margin: '4px 0 0', padding: 0 }}>
+              {group.items.map((insight, i) => (
+                <InsightRow key={`${insight.label}-${i}`} insight={insight} />
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
+++ b/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
@@ -1,0 +1,201 @@
+/**
+ * OpportunityIntelligenceCard — Wave 4. Replaces the flat "job card" with an intelligence
+ * card built entirely from real signals:
+ *   - Fit band + score come from the engine's MatchExplanation.
+ *   - "Why it fits" / "Potential concerns" come from engine fitReasons AND preference alignment.
+ *   - Time-to-credential is a clearly-labeled estimate derived from unmet requirements.
+ *
+ * Honesty rule: dimensions the platform cannot yet score (interview probability, culture fit
+ * as a number) are NOT shown as invented figures. Absent signals are simply omitted, and a
+ * provenance line states what each score is based on.
+ */
+
+import {
+  MatchaExplanation,
+  reasonsFromFitReasons,
+  type ExplanationReason,
+} from './MatchaExplanation';
+import { estimateTimeToCredential, matchBandDisplay } from '@/lib/matcha/opportunityFit';
+
+export interface IntelligenceOpportunity {
+  id: string;
+  title: string;
+  organization?: string;
+  location?: string;
+  state?: string;
+  specialty?: string;
+  payRange?: string;
+  hiringType?: string;
+  remote?: boolean;
+}
+
+export interface IntelligenceExplanation {
+  matchBand: string;
+  matchScore: number;
+  confidence: number;
+  fitReasons?: Array<{ label: string; positive: boolean; dimension?: string }>;
+  missingCredentials?: string[];
+  blockers?: Array<{ label: string; severity: 'hard' | 'soft' }>;
+  instantOfferEligible?: boolean;
+}
+
+export interface OpportunityIntelligenceCardProps {
+  opportunity: IntelligenceOpportunity;
+  /** Real engine output. Optional — the card degrades honestly without it. */
+  explanation?: IntelligenceExplanation;
+  /** Preference-grounded reasons from opportunityFit.preferenceMatchReasons. */
+  preferenceReasons?: ExplanationReason[];
+  href?: string;
+}
+
+const TONE_COLORS: Record<string, string> = {
+  go: 'var(--vt-status-resolved, #2E7D45)',
+  near: 'var(--vt-accent, #0A7B7F)',
+  partial: 'var(--vt-risk-medium, #A05C00)',
+  blocked: 'var(--vt-risk-high, #8C2A2A)',
+};
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div style={{ minWidth: 0 }}>
+      <div style={{ fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--vt-text-muted)' }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)', fontVariantNumeric: 'tabular-nums' }}>
+        {value}
+      </div>
+      {sub ? <div style={{ fontSize: 11, color: 'var(--vt-text-muted)' }}>{sub}</div> : null}
+    </div>
+  );
+}
+
+export function OpportunityIntelligenceCard({
+  opportunity,
+  explanation,
+  preferenceReasons = [],
+  href,
+}: OpportunityIntelligenceCardProps) {
+  const band = explanation ? matchBandDisplay(explanation.matchBand) : null;
+  const bandColor = band ? TONE_COLORS[band.tone] : 'var(--vt-text-muted)';
+
+  // Merge engine reasons with preference reasons; de-duplicate on label.
+  const engineReasons = reasonsFromFitReasons(explanation?.fitReasons);
+  const seen = new Set<string>();
+  const allReasons: ExplanationReason[] = [...engineReasons, ...preferenceReasons].filter((r) => {
+    const key = r.label.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const positives = allReasons.filter((r) => r.positive);
+  const concerns = allReasons.filter((r) => !r.positive);
+
+  const hardBlockers = (explanation?.blockers ?? []).filter((b) => b.severity === 'hard').length;
+  const missingCount = explanation?.missingCredentials?.length ?? hardBlockers;
+
+  const Wrapper: React.ElementType = href ? 'a' : 'div';
+
+  return (
+    <Wrapper
+      {...(href ? { href } : {})}
+      style={{
+        display: 'block',
+        textDecoration: 'none',
+        color: 'inherit',
+        background: 'var(--vt-surface, #fff)',
+        border: '1px solid var(--vt-border, #E2E8E6)',
+        borderRadius: 16,
+        padding: 20,
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start' }}>
+        <div style={{ minWidth: 0 }}>
+          <h3 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+            {opportunity.title}
+          </h3>
+          <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--vt-text-secondary)' }}>
+            {[opportunity.organization, opportunity.location].filter(Boolean).join(' · ')}
+          </p>
+        </div>
+        {band ? (
+          <span
+            style={{
+              flex: '0 0 auto',
+              fontSize: 12,
+              fontWeight: 600,
+              padding: '5px 10px',
+              borderRadius: 999,
+              color: bandColor,
+              background: `color-mix(in srgb, ${bandColor} 12%, transparent)`,
+              border: `1px solid color-mix(in srgb, ${bandColor} 30%, transparent)`,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {band.label}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Stat row — only real signals */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(96px, 1fr))',
+          gap: 16,
+          marginTop: 18,
+          paddingTop: 16,
+          borderTop: '1px solid var(--vt-border, #E2E8E6)',
+        }}
+      >
+        {explanation ? (
+          <Stat label="Fit" value={`${explanation.matchScore}`} sub={`${Math.round(explanation.confidence * 100)}% confidence`} />
+        ) : null}
+        {opportunity.payRange ? <Stat label="Comp" value={opportunity.payRange} /> : null}
+        {opportunity.specialty ? <Stat label="Specialty" value={opportunity.specialty} /> : null}
+        {explanation ? (
+          <Stat
+            label="To credential"
+            value={missingCount === 0 ? 'Ready' : `${missingCount} item${missingCount === 1 ? '' : 's'}`}
+            sub={estimateTimeToCredential(missingCount)}
+          />
+        ) : null}
+      </div>
+
+      {/* Why it fits */}
+      {positives.length ? (
+        <div style={{ marginTop: 16 }}>
+          <MatchaExplanation reasons={positives} title="Why it fits" />
+        </div>
+      ) : null}
+
+      {/* Potential concerns */}
+      {concerns.length ? (
+        <div style={{ marginTop: 14 }}>
+          <MatchaExplanation reasons={concerns} title="Potential concerns" />
+        </div>
+      ) : null}
+
+      {/* Instant offer signal (real, from engine) */}
+      {explanation?.instantOfferEligible ? (
+        <div
+          style={{
+            marginTop: 14,
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'var(--vt-status-resolved, #2E7D45)',
+          }}
+        >
+          Eligible for an instant offer based on your current trust state.
+        </div>
+      ) : null}
+
+      {/* Honesty footer: what these scores are based on */}
+      <p style={{ margin: '16px 0 0', fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>
+        {explanation
+          ? 'Fit reflects credential eligibility from your trust state; reasons come from your stated preferences. MATCHA does not estimate interview outcomes.'
+          : 'Live fit scoring is unavailable right now — reasons shown come from your stated preferences only.'}
+      </p>
+    </Wrapper>
+  );
+}

--- a/apps/web/components/matcha/PublicMatchaExperience.tsx
+++ b/apps/web/components/matcha/PublicMatchaExperience.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+/**
+ * PublicMatchaExperience — a no-signup taste of the MATCHA intelligence layer, embedded on the
+ * public homepage. A visitor answers a few quick questions and watches MATCHA reflect back what
+ * it understands (with provenance) and how it would explain a fit.
+ *
+ * Honesty:
+ *  - Everything shown is derived from what the visitor just tapped — nothing invented.
+ *  - The example role is explicitly labeled as an illustration, not a real match.
+ *  - Answers persist to the same local store the signed-in flow uses, so a visitor who then
+ *    creates a wallet finds MATCHA already knows them — real continuity, not a reset.
+ */
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Sparkles, ArrowRight, RotateCcw } from 'lucide-react';
+
+import type { MatchaPreferences, PreferenceField } from '@/lib/matcha/preferences';
+import { deriveMatchaProfile } from '@/lib/matcha/profile';
+import { preferenceMatchReasons } from '@/lib/matcha/opportunityFit';
+import { MatchaExplanation } from './MatchaExplanation';
+import { useMatchaPreferences } from './useMatchaPreferences';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+interface QuickQuestion {
+  id: string;
+  field: PreferenceField;
+  prompt: string;
+  multi?: boolean;
+  options: Array<{ value: string; label: string }>;
+}
+
+// A curated 4-question taste — fast, tap-only, and mapped to real preference fields.
+const QUESTIONS: QuickQuestion[] = [
+  {
+    id: 'specialty',
+    field: 'currentSpecialties',
+    prompt: 'What do you practice?',
+    options: [
+      { value: 'Cardiology', label: 'Cardiology' },
+      { value: 'Emergency Medicine', label: 'Emergency' },
+      { value: 'Family Medicine', label: 'Family med' },
+      { value: 'Psychiatry', label: 'Psychiatry' },
+      { value: 'Nursing', label: 'Nursing' },
+      { value: 'Anesthesiology', label: 'Anesthesiology' },
+    ],
+  },
+  {
+    id: 'states',
+    field: 'preferredStates',
+    prompt: 'Where would you like to work?',
+    multi: true,
+    options: [
+      { value: 'CA', label: 'California' },
+      { value: 'TX', label: 'Texas' },
+      { value: 'NY', label: 'New York' },
+      { value: 'FL', label: 'Florida' },
+      { value: 'WA', label: 'Washington' },
+      { value: 'IL', label: 'Illinois' },
+    ],
+  },
+  {
+    id: 'work-style',
+    field: 'employmentTypes',
+    prompt: 'How do you want to work?',
+    multi: true,
+    options: [
+      { value: 'full_time', label: 'Full time' },
+      { value: 'locums', label: 'Locums' },
+      { value: 'telehealth', label: 'Telehealth' },
+      { value: 'part_time', label: 'Part time' },
+    ],
+  },
+  {
+    id: 'direction',
+    field: 'careerDirection',
+    prompt: 'Your next move?',
+    options: [
+      { value: 'deepen clinical practice', label: 'Deepen practice' },
+      { value: 'move into leadership', label: 'Leadership' },
+      { value: 'shift toward academia', label: 'Academia' },
+      { value: 'explore something new', label: 'Something new' },
+    ],
+  },
+];
+
+export function PublicMatchaExperience() {
+  const { preferences, setField, reset } = useMatchaPreferences();
+  const [index, setIndex] = useState(0);
+  const answeredCount = QUESTIONS.filter((q) => {
+    const v = preferences[q.field];
+    return Array.isArray(v) ? v.length > 0 : Boolean(v);
+  }).length;
+
+  const derived = useMemo(() => deriveMatchaProfile(preferences), [preferences]);
+  const done = index >= QUESTIONS.length;
+
+  // An explicitly illustrative role — used only to demonstrate how MATCHA explains fit.
+  const exampleReasons = useMemo(
+    () =>
+      preferenceMatchReasons(preferences, {
+        state: preferences.preferredStates?.[0],
+        specialty: preferences.currentSpecialties?.[0],
+        hiringType: preferences.employmentTypes?.includes('locums') ? 'locums' : 'perm',
+        remote: preferences.employmentTypes?.includes('telehealth'),
+      }),
+    [preferences],
+  );
+
+  const answer = (q: QuickQuestion, value: string) => {
+    if (q.multi) {
+      const current = Array.isArray(preferences[q.field]) ? (preferences[q.field] as string[]) : [];
+      const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+      setField(q.field, next as MatchaPreferences[PreferenceField]);
+    } else {
+      // single-select fields: careerDirection is a string; specialty is stored as a 1-item array
+      const stored = q.field === 'currentSpecialties' ? [value] : value;
+      setField(q.field, stored as MatchaPreferences[PreferenceField]);
+      setIndex((i) => Math.min(i + 1, QUESTIONS.length));
+    }
+  };
+
+  const q = QUESTIONS[index];
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 20,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+        alignItems: 'start',
+      }}
+    >
+      {/* Left: the conversation */}
+      <div
+        style={{
+          background: 'var(--vt-surface, #fff)',
+          border: '1px solid var(--vt-border, #E2E8E6)',
+          borderRadius: 20,
+          padding: 24,
+          minHeight: 260,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 11, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: ACCENT }}>
+            <Sparkles size={14} /> Try MATCHA
+          </span>
+          {answeredCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => { reset(); setIndex(0); }}
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 5, border: 0, background: 'transparent', color: 'var(--vt-text-muted)', fontSize: 12, cursor: 'pointer' }}
+            >
+              <RotateCcw size={12} /> Reset
+            </button>
+          ) : null}
+        </div>
+
+        <AnimatePresence mode="wait">
+          {!done ? (
+            <motion.div
+              key={q.id}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.28, ease: [0.2, 0.8, 0.2, 1] }}
+            >
+              <p style={{ margin: '18px 0 0', fontSize: 20, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{q.prompt}</p>
+              {q.multi ? (
+                <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--vt-text-muted)' }}>Pick any that apply.</p>
+              ) : null}
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16 }}>
+                {q.options.map((opt) => {
+                  const v = preferences[q.field];
+                  const active = Array.isArray(v) ? (v as string[]).includes(opt.value) : v === opt.value;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => answer(q, opt.value)}
+                      style={{
+                        padding: '9px 15px',
+                        borderRadius: 11,
+                        fontSize: 14,
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        border: `1px solid ${active ? ACCENT : 'var(--vt-border, #D6DED9)'}`,
+                        background: active ? `color-mix(in srgb, ${ACCENT} 12%, transparent)` : 'var(--vt-surface, #fff)',
+                        color: active ? ACCENT : 'var(--vt-text-primary)',
+                        transition: 'all 160ms cubic-bezier(0.2,0.8,0.2,1)',
+                      }}
+                    >
+                      {opt.label}
+                    </button>
+                  );
+                })}
+              </div>
+              {q.multi ? (
+                <button
+                  type="button"
+                  onClick={() => setIndex((i) => Math.min(i + 1, QUESTIONS.length))}
+                  style={{ marginTop: 18, padding: '9px 18px', borderRadius: 11, border: 0, background: ACCENT, color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+                >
+                  Continue
+                </button>
+              ) : null}
+            </motion.div>
+          ) : (
+            <motion.div key="done" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
+              <p style={{ margin: '18px 0 0', fontSize: 20, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+                That&rsquo;s the idea.
+              </p>
+              <p style={{ margin: '8px 0 0', fontSize: 14, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>
+                With your wallet, MATCHA keeps learning and works in the background — scoring real
+                roles on your source-backed readiness, not just what you typed here.
+              </p>
+              <Link
+                href="/holder/matcha"
+                style={{ display: 'inline-flex', alignItems: 'center', gap: 8, marginTop: 18, padding: '11px 22px', borderRadius: 12, background: ACCENT, color: '#fff', fontSize: 15, fontWeight: 600, textDecoration: 'none' }}
+              >
+                Let MATCHA work for you <ArrowRight size={16} />
+              </Link>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Right: the live reflection */}
+      <div
+        style={{
+          background: `linear-gradient(135deg, color-mix(in srgb, ${ACCENT} 7%, var(--vt-surface, #fff)), var(--vt-surface, #fff))`,
+          border: `1px solid color-mix(in srgb, ${ACCENT} 22%, transparent)`,
+          borderRadius: 20,
+          padding: 24,
+          minHeight: 260,
+        }}
+      >
+        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: ACCENT }}>
+          MATCHA understands you
+        </span>
+
+        {derived.insights.length === 0 ? (
+          <p style={{ margin: '16px 0 0', fontSize: 14, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>
+            Tap an answer and watch MATCHA reflect it back — always tied to exactly what you said,
+            never guessed.
+          </p>
+        ) : (
+          <>
+            <ul style={{ listStyle: 'none', margin: '14px 0 0', padding: 0, display: 'grid', gap: 10 }}>
+              {derived.insights.slice(0, 4).map((insight, i) => (
+                <motion.li
+                  key={`${insight.label}-${i}`}
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.25 }}
+                  style={{ display: 'grid', gap: 2 }}
+                >
+                  <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--vt-text-primary)' }}>{insight.label}</span>
+                  <span style={{ fontSize: 11, color: 'var(--vt-text-muted)' }}>
+                    because you told MATCHA: {insight.provenance.join(', ').replace(/([A-Z])/g, ' $1').toLowerCase()}
+                  </span>
+                </motion.li>
+              ))}
+            </ul>
+
+            {exampleReasons.length > 0 ? (
+              <div style={{ marginTop: 18, paddingTop: 16, borderTop: `1px solid color-mix(in srgb, ${ACCENT} 18%, transparent)` }}>
+                <p style={{ margin: '0 0 10px', fontSize: 11, color: 'var(--vt-text-muted)' }}>
+                  Example role · illustration only
+                </p>
+                <MatchaExplanation reasons={exampleReasons} title="Why MATCHA would surface this" />
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/buyer/BuyerLanding.tsx
+++ b/apps/web/components/matcha/buyer/BuyerLanding.tsx
@@ -1,0 +1,202 @@
+/**
+ * BuyerLanding — shared, honest layout for the MATCHA buyer pages (Waves 6–8).
+ *
+ * Presentational and data-driven so recruiter / hospital / investor pages stay consistent.
+ * Copy discipline: benefits are directional (based on the VitalCV model), NOT customer-reported
+ * results, and every page carries an explicit disclaimer to that effect. No banned strings.
+ */
+
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+export interface ComparisonRow {
+  label: string;
+  traditional: string;
+  vital: string;
+}
+
+export interface BenefitItem {
+  title: string;
+  body: string;
+}
+
+export interface BuyerLandingProps {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  /** Honest framing line rendered near the top and above the comparison. */
+  disclaimer: string;
+  comparison: {
+    traditionalLabel: string;
+    vitalLabel: string;
+    rows: ComparisonRow[];
+  };
+  benefits: BenefitItem[];
+  /** One line on how MATCHA explains its recommendations — the trust hook. */
+  matchaLine: string;
+  cta: { label: string; href: string };
+  /** Optional extra section (e.g. the investor ecosystem map). */
+  children?: ReactNode;
+}
+
+export function BuyerLanding({
+  eyebrow,
+  title,
+  subtitle,
+  disclaimer,
+  comparison,
+  benefits,
+  matchaLine,
+  cta,
+  children,
+}: BuyerLandingProps) {
+  return (
+    <main style={{ maxWidth: 1080, margin: '0 auto', padding: '48px 20px 96px', color: 'var(--vt-text-primary)' }}>
+      {/* Hero */}
+      <header style={{ maxWidth: 760 }}>
+        <p style={{ margin: 0, fontSize: 12, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: ACCENT }}>
+          {eyebrow}
+        </p>
+        <h1 style={{ margin: '12px 0 0', fontSize: 44, lineHeight: 1.08, fontWeight: 600, letterSpacing: '-0.02em' }}>
+          {title}
+        </h1>
+        <p style={{ margin: '16px 0 0', fontSize: 18, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>
+          {subtitle}
+        </p>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 24 }}>
+          <Link
+            href={cta.href}
+            style={{
+              padding: '12px 24px',
+              borderRadius: 12,
+              background: ACCENT,
+              color: '#fff',
+              fontSize: 15,
+              fontWeight: 600,
+              textDecoration: 'none',
+            }}
+          >
+            {cta.label}
+          </Link>
+          <Link
+            href="/holder/matcha"
+            style={{
+              padding: '12px 24px',
+              borderRadius: 12,
+              border: `1px solid ${ACCENT}`,
+              color: ACCENT,
+              fontSize: 15,
+              fontWeight: 600,
+              textDecoration: 'none',
+            }}
+          >
+            See MATCHA for clinicians
+          </Link>
+        </div>
+      </header>
+
+      {/* Comparison: Traditional → VitalCV */}
+      <section style={{ marginTop: 56 }}>
+        <h2 style={{ margin: 0, fontSize: 13, fontWeight: 700, letterSpacing: '0.04em', color: 'var(--vt-text-secondary)', textTransform: 'uppercase' }}>
+          {comparison.traditionalLabel} <span style={{ color: ACCENT }}>→</span> {comparison.vitalLabel}
+        </h2>
+        <div style={{ overflowX: 'auto', marginTop: 16 }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 620 }}>
+            <thead>
+              <tr>
+                <th style={thStyle} />
+                <th style={{ ...thStyle, color: 'var(--vt-text-muted)' }}>{comparison.traditionalLabel}</th>
+                <th style={{ ...thStyle, color: ACCENT }}>{comparison.vitalLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comparison.rows.map((row) => (
+                <tr key={row.label}>
+                  <td style={{ ...tdStyle, fontWeight: 600 }}>{row.label}</td>
+                  <td style={{ ...tdStyle, color: 'var(--vt-text-muted)' }}>{row.traditional}</td>
+                  <td style={{ ...tdStyle, color: 'var(--vt-text-primary)', background: `color-mix(in srgb, ${ACCENT} 5%, transparent)` }}>
+                    {row.vital}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ margin: '14px 0 0', fontSize: 12, color: 'var(--vt-text-muted)', lineHeight: 1.5, maxWidth: 720 }}>
+          {disclaimer}
+        </p>
+      </section>
+
+      {/* Benefits */}
+      <section style={{ marginTop: 56 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 16 }}>
+          {benefits.map((b) => (
+            <div key={b.title} style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+              <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>{b.title}</h3>
+              <p style={{ margin: '8px 0 0', fontSize: 14, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>{b.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* MATCHA trust hook */}
+      <section
+        style={{
+          marginTop: 40,
+          background: `color-mix(in srgb, ${ACCENT} 7%, var(--vt-surface, #fff))`,
+          border: `1px solid color-mix(in srgb, ${ACCENT} 24%, transparent)`,
+          borderRadius: 20,
+          padding: 24,
+        }}
+      >
+        <p style={{ margin: 0, fontSize: 11, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: ACCENT }}>
+          Explained, not asserted
+        </p>
+        <p style={{ margin: '8px 0 0', fontSize: 18, lineHeight: 1.5, fontWeight: 500, maxWidth: 760 }}>
+          {matchaLine}
+        </p>
+      </section>
+
+      {children}
+
+      {/* Closing CTA */}
+      <section style={{ marginTop: 56, textAlign: 'center' }}>
+        <Link
+          href={cta.href}
+          style={{
+            display: 'inline-block',
+            padding: '14px 28px',
+            borderRadius: 12,
+            background: ACCENT,
+            color: '#fff',
+            fontSize: 16,
+            fontWeight: 600,
+            textDecoration: 'none',
+          }}
+        >
+          {cta.label}
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+const thStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 14px',
+  fontSize: 12,
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  borderBottom: '1px solid var(--vt-border, #E2E8E6)',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '14px',
+  fontSize: 14,
+  lineHeight: 1.5,
+  borderBottom: '1px solid var(--vt-border, #EEF2F0)',
+  verticalAlign: 'top',
+};

--- a/apps/web/components/matcha/buyer/EcosystemMap.tsx
+++ b/apps/web/components/matcha/buyer/EcosystemMap.tsx
@@ -1,0 +1,94 @@
+/**
+ * EcosystemMap — Wave 8. The VitalCV flywheel rendered as a labeled flow so the moat is
+ * legible at a glance: each stage feeds the next, and reuse compounds into network effects.
+ *
+ * Static SVG with CSS-only hover emphasis (no client JS) so it renders in server components
+ * and SSR tests. Every node is a real stage of the platform — nothing decorative-only.
+ */
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+const STAGES: Array<{ key: string; label: string; note: string }> = [
+  { key: 'clinicians', label: 'Clinicians', note: 'Own their career evidence' },
+  { key: 'wallet', label: 'Wallet', note: 'Home base for credentials' },
+  { key: 'trust', label: 'Trust', note: 'Source-backed readiness' },
+  { key: 'recognition', label: 'Recognition', note: 'Employer acceptance, reusable' },
+  { key: 'matcha', label: 'MATCHA', note: 'Learns preferences + fit' },
+  { key: 'matching', label: 'Matching', note: 'Explained recommendations' },
+  { key: 'hiring', label: 'Hiring', note: 'Faster time-to-start' },
+  { key: 'credentialing', label: 'Credentialing', note: 'Head start, not restart' },
+  { key: 'reuse', label: 'Reuse', note: 'Evidence follows the clinician' },
+  { key: 'network', label: 'Network effects', note: 'Each loop compounds the moat' },
+];
+
+export function EcosystemMap() {
+  return (
+    <section style={{ marginTop: 56 }}>
+      <h2 style={{ margin: 0, fontSize: 24, fontWeight: 600, letterSpacing: '-0.01em' }}>The compounding loop</h2>
+      <p style={{ margin: '8px 0 0', fontSize: 15, color: 'var(--vt-text-secondary)', maxWidth: 720, lineHeight: 1.55 }}>
+        Reusable, source-backed career evidence is the asset. Every hire it powers makes the next
+        one cheaper and faster — and leaves more reusable evidence behind.
+      </p>
+
+      <div
+        style={{
+          marginTop: 20,
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+          gap: 12,
+        }}
+      >
+        {STAGES.map((stage, i) => (
+          <div
+            key={stage.key}
+            className="vcv-eco-node"
+            style={{
+              position: 'relative',
+              background: 'var(--vt-surface, #fff)',
+              border: '1px solid var(--vt-border, #E2E8E6)',
+              borderRadius: 14,
+              padding: '14px 16px',
+              transition: 'transform 200ms cubic-bezier(0.2,0.8,0.2,1), border-color 200ms, box-shadow 200ms',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span
+                style={{
+                  flex: '0 0 auto',
+                  width: 22,
+                  height: 22,
+                  borderRadius: 999,
+                  background: `color-mix(in srgb, ${ACCENT} 14%, transparent)`,
+                  color: ACCENT,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {i + 1}
+              </span>
+              <span style={{ fontSize: 15, fontWeight: 600 }}>{stage.label}</span>
+            </div>
+            <p style={{ margin: '8px 0 0', fontSize: 12, lineHeight: 1.45, color: 'var(--vt-text-muted)' }}>{stage.note}</p>
+            {i < STAGES.length - 1 ? (
+              <span aria-hidden="true" style={{ position: 'absolute', right: -9, top: '50%', transform: 'translateY(-50%)', color: ACCENT, fontSize: 14, fontWeight: 700 }}>
+                →
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <style
+        dangerouslySetInnerHTML={{
+          __html:
+            '.vcv-eco-node:hover{transform:translateY(-3px);border-color:' +
+            ACCENT +
+            ';box-shadow:0 12px 30px rgba(10,123,127,0.12);}',
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/web/components/matcha/useMatchaPreferences.ts
+++ b/apps/web/components/matcha/useMatchaPreferences.ts
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * useMatchaPreferences — the client binding between the clinician's stated preferences,
+ * durable local storage, the derived "MATCHA understands you" profile, and the live engine.
+ *
+ * Writes go to localStorage immediately (the clinician's data is theirs), and the
+ * engine-relevant subset is pushed best-effort to /api/matcha/intent so live matches update.
+ * A failed push never loses the answer — local storage is the source of truth.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  type MatchaPreferences,
+  type PreferenceField,
+  ENGINE_BACKED_FIELDS,
+  completenessPercent,
+  toCandidateIntent,
+} from '@/lib/matcha/preferences';
+import { deriveMatchaProfile, type MatchaDerivedProfile } from '@/lib/matcha/profile';
+import {
+  type MemoryNote,
+  diffPreferences,
+  loadStoredPreferences,
+  savePreferences,
+  clearStoredPreferences,
+} from '@/lib/matcha/storage';
+
+const RECENT_MEMORY_LIMIT = 8;
+
+export interface UseMatchaPreferences {
+  preferences: MatchaPreferences;
+  derived: MatchaDerivedProfile;
+  completeness: number;
+  /** Grounded "MATCHA remembers" notes from the most recent edits, newest first. */
+  memory: MemoryNote[];
+  loaded: boolean;
+  setField: (field: PreferenceField, value: MatchaPreferences[PreferenceField]) => void;
+  reset: () => void;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
+  const [preferences, setPreferences] = useState<MatchaPreferences>({});
+  const [loaded, setLoaded] = useState(false);
+  const [memory, setMemory] = useState<MemoryNote[]>([]);
+  const pushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from storage on mount.
+  useEffect(() => {
+    setPreferences(loadStoredPreferences());
+    setLoaded(true);
+  }, []);
+
+  const pushIntent = useCallback(
+    (next: MatchaPreferences) => {
+      if (!npi) return;
+      const engineTouched = ENGINE_BACKED_FIELDS.some(
+        (f) => next[f] !== undefined && next[f] !== null,
+      );
+      if (!engineTouched) return;
+      if (pushTimer.current) clearTimeout(pushTimer.current);
+      // Debounce so rapid answers collapse into one request.
+      pushTimer.current = setTimeout(() => {
+        const payload = toCandidateIntent(npi, next, nowIso());
+        void fetch('/api/matcha/intent', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        }).catch(() => {
+          /* best-effort — local storage remains the source of truth */
+        });
+      }, 600);
+    },
+    [npi],
+  );
+
+  const setField = useCallback(
+    (field: PreferenceField, value: MatchaPreferences[PreferenceField]) => {
+      setPreferences((prev) => {
+        const next: MatchaPreferences = { ...prev, [field]: value };
+        const notes = diffPreferences(prev, next, [field]);
+        if (notes.length) {
+          setMemory((m) => [...notes, ...m].slice(0, RECENT_MEMORY_LIMIT));
+        }
+        savePreferences(next, nowIso());
+        pushIntent(next);
+        return next;
+      });
+    },
+    [pushIntent],
+  );
+
+  const reset = useCallback(() => {
+    clearStoredPreferences();
+    setPreferences({});
+    setMemory([]);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (pushTimer.current) clearTimeout(pushTimer.current);
+    },
+    [],
+  );
+
+  const derived = useMemo(() => deriveMatchaProfile(preferences), [preferences]);
+  const completeness = useMemo(() => completenessPercent(preferences), [preferences]);
+
+  return { preferences, derived, completeness, memory, loaded, setField, reset };
+}

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -28,6 +28,7 @@ import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { RecognitionCard } from '@/components/recognition/RecognitionCard';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
+import { MatchaHomeActivity } from '@/components/matcha/MatchaHomeActivity';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
 import { buildClinicianProofSummary } from '@/lib/proof/proof-model';
 
@@ -298,6 +299,8 @@ export default function ClinicianHomeSurface() {
       ) : null}
 
       <SelectedOpportunityBanner />
+
+      <MatchaHomeActivity />
 
       <ProductLoopRail
         npi={hasValidNpi ? npi : null}

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -98,6 +98,9 @@ export const FEATURES = {
 
   /** Wave 245: Continuous credential monitoring — PILOT */
   CONTINUOUS_MONITORING: flag('NEXT_PUBLIC_FEATURE_CONTINUOUS_MONITORING', false),
+
+  /** MATCHA buyer landing pages (recruiter / hospital / investor) — PILOT, copy-review gated */
+  MATCHA_BUYER_PAGES:    flag('NEXT_PUBLIC_FEATURE_MATCHA_BUYER_PAGES',    false),
 } as const;
 
 export type FeatureKey = keyof typeof FEATURES;
@@ -131,4 +134,5 @@ export const ROLLOUT_TIERS: Record<FeatureKey, 'INTERNAL' | 'PILOT' | 'PUBLIC'> 
   CONTRACT_REGISTRY:     'INTERNAL',
   // Wave 3
   CONTINUOUS_MONITORING: 'PILOT',
+  MATCHA_BUYER_PAGES:    'PILOT',
 };

--- a/apps/web/lib/matcha/onboarding.ts
+++ b/apps/web/lib/matcha/onboarding.ts
@@ -1,0 +1,377 @@
+/**
+ * MATCHA conversational onboarding — a declarative question script.
+ *
+ * The onboarding UI (MatchaOnboarding.tsx) renders these steps one at a time as a
+ * conversation, not a form. Each step maps to exactly one preference field so answers
+ * flow straight into the MatchaPreferences model and update MATCHA's reasoning live.
+ *
+ * Keeping the script as data (not JSX) means the flow is testable, reorderable, and the
+ * total step count / progress is always derivable.
+ */
+
+import type {
+  EmploymentType,
+  Importance,
+  Interest,
+  MatchaPreferences,
+  PreferenceField,
+  ShiftPreference,
+  StartUrgency,
+} from './preferences';
+
+export type StepKind =
+  | 'intro'        // no field — a MATCHA message that advances on continue
+  | 'chips_multi'  // choose many from options, value: string[]
+  | 'chips_single' // choose one from options, value: string
+  | 'tags'         // free-entry list, value: string[]
+  | 'number'       // numeric entry, value: number
+  | 'scale'        // importance/interest, value: Importance | Interest
+  | 'boolean';     // yes / no, value: boolean
+
+export interface StepOption {
+  value: string;
+  label: string;
+}
+
+export interface OnboardingStep {
+  id: string;
+  section: string;
+  kind: StepKind;
+  /** What MATCHA "says" to introduce the question. */
+  prompt: string;
+  /** Optional supporting line. */
+  hint?: string;
+  /** The preference field this step writes (absent for intro steps). */
+  field?: PreferenceField;
+  options?: StepOption[];
+  /** For number steps. */
+  numberUnit?: string;
+  numberPlaceholder?: string;
+  /** Whether this answer currently influences the live match engine. */
+  engineBacked?: boolean;
+  optional?: boolean;
+}
+
+const IMPORTANCE_OPTIONS: StepOption[] = [
+  { value: 'low', label: 'Not important' },
+  { value: 'medium', label: 'Somewhat' },
+  { value: 'high', label: 'Very important' },
+];
+
+const INTEREST_OPTIONS: StepOption[] = [
+  { value: 'none', label: 'Not for me' },
+  { value: 'curious', label: 'Curious' },
+  { value: 'interested', label: 'Interested' },
+  { value: 'passionate', label: 'Passionate' },
+];
+
+export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  {
+    id: 'welcome',
+    section: 'Welcome',
+    kind: 'intro',
+    prompt: "Hi, I'm MATCHA. I learn what matters to you, then keep working in the background to surface roles worth your time.",
+    hint: 'Everything you share stays yours. You can stop anytime — I use whatever you give me.',
+  },
+
+  // Career direction
+  {
+    id: 'career-goals', section: 'Career goals', kind: 'tags', field: 'careerGoals',
+    prompt: 'What are you working toward right now?',
+    hint: 'A few words or phrases — e.g. "attending role", "more autonomy", "relocate".',
+  },
+  {
+    id: 'career-direction', section: 'Career goals', kind: 'chips_single', field: 'careerDirection',
+    prompt: 'Where do you see your career heading?',
+    options: [
+      { value: 'deepen clinical practice', label: 'Deepen clinical practice' },
+      { value: 'move into leadership', label: 'Move into leadership' },
+      { value: 'shift toward academia', label: 'Shift toward academia' },
+      { value: 'explore something new', label: 'Explore something new' },
+      { value: 'stay the course', label: 'Stay the course' },
+    ],
+  },
+  {
+    id: 'leadership', section: 'Career goals', kind: 'scale', field: 'leadershipAspiration',
+    prompt: 'How much do leadership roles appeal to you?', options: INTEREST_OPTIONS,
+  },
+
+  // Specialties
+  {
+    id: 'current-specialties', section: 'Specialties', kind: 'tags', field: 'currentSpecialties',
+    prompt: 'What do you practice today?', hint: 'Your current specialties.', engineBacked: true,
+  },
+  {
+    id: 'desired-specialties', section: 'Specialties', kind: 'tags', field: 'desiredSpecialties',
+    prompt: 'Any specialties or subspecialties you want to move toward?', engineBacked: true, optional: true,
+  },
+  {
+    id: 'procedures', section: 'Specialties', kind: 'tags', field: 'favoriteProcedures',
+    prompt: 'Which procedures do you most want to keep doing?', optional: true,
+  },
+  {
+    id: 'populations', section: 'Specialties', kind: 'tags', field: 'populationPreferences',
+    prompt: 'Any patient populations you prefer?', hint: 'e.g. pediatric, geriatric, underserved.', optional: true,
+  },
+
+  // Location & mobility
+  {
+    id: 'preferred-states', section: 'Location', kind: 'tags', field: 'preferredStates',
+    prompt: 'Where would you like to work?', hint: 'State abbreviations or names.', engineBacked: true,
+  },
+  {
+    id: 'geo-flex', section: 'Location', kind: 'scale', field: 'geographicFlexibility',
+    prompt: 'How flexible are you on location?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'license-states', section: 'Location', kind: 'tags', field: 'statesWillingToLicense',
+    prompt: 'Which states would you get licensed in for the right role?', optional: true,
+  },
+  {
+    id: 'commute', section: 'Location', kind: 'number', field: 'commuteRadiusMiles',
+    prompt: "What's the furthest you'd commute?", numberUnit: 'miles', numberPlaceholder: '30', optional: true,
+  },
+  {
+    id: 'remote', section: 'Location', kind: 'scale', field: 'remoteInterest',
+    prompt: 'How interested are you in remote work?', options: INTEREST_OPTIONS, engineBacked: true,
+  },
+  {
+    id: 'travel', section: 'Location', kind: 'scale', field: 'travelInterest',
+    prompt: 'And travel or locums assignments?', options: INTEREST_OPTIONS,
+  },
+
+  // Work type & schedule
+  {
+    id: 'employment-types', section: 'Work style', kind: 'chips_multi', field: 'employmentTypes',
+    prompt: 'What kinds of arrangements work for you?', engineBacked: true,
+    options: [
+      { value: 'full_time', label: 'Full time' },
+      { value: 'part_time', label: 'Part time' },
+      { value: 'per_diem', label: 'Per diem' },
+      { value: 'contract', label: 'Contract' },
+      { value: 'locums', label: 'Locums' },
+      { value: 'telehealth', label: 'Telehealth' },
+    ],
+  },
+  {
+    id: 'shift', section: 'Work style', kind: 'chips_single', field: 'shiftPreference',
+    prompt: 'Which shifts suit you best?',
+    options: [
+      { value: 'days', label: 'Days' },
+      { value: 'nights', label: 'Nights' },
+      { value: 'rotating', label: 'Rotating' },
+      { value: 'flexible', label: 'Flexible' },
+    ],
+  },
+  {
+    id: 'schedule-flex', section: 'Work style', kind: 'scale', field: 'scheduleFlexibility',
+    prompt: 'How important is schedule flexibility?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'start-urgency', section: 'Work style', kind: 'chips_single', field: 'startUrgency',
+    prompt: 'How soon are you looking to start?', engineBacked: true,
+    options: [
+      { value: 'immediate', label: 'Immediately' },
+      { value: 'within_2_weeks', label: 'Within 2 weeks' },
+      { value: 'within_month', label: 'Within a month' },
+      { value: 'flexible', label: "I'm flexible" },
+    ],
+  },
+
+  // Compensation & benefits
+  {
+    id: 'desired-salary', section: 'Compensation', kind: 'number', field: 'desiredSalary',
+    prompt: "What's your target annual compensation?", numberUnit: 'USD/yr', numberPlaceholder: '300000', optional: true,
+  },
+  {
+    id: 'min-salary', section: 'Compensation', kind: 'number', field: 'minimumSalary',
+    prompt: "And the minimum you'd consider?", numberUnit: 'USD/yr', numberPlaceholder: '250000', engineBacked: true, optional: true,
+  },
+  {
+    id: 'signon', section: 'Compensation', kind: 'scale', field: 'signOnBonusImportance',
+    prompt: 'How much does a sign-on bonus matter?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'pto', section: 'Compensation', kind: 'scale', field: 'ptoImportance',
+    prompt: 'How important is PTO?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'retirement', section: 'Compensation', kind: 'scale', field: 'retirementImportance',
+    prompt: 'Retirement benefits?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'health-ins', section: 'Compensation', kind: 'scale', field: 'healthInsuranceImportance',
+    prompt: 'Health insurance?', options: IMPORTANCE_OPTIONS,
+  },
+
+  // Eligibility & background
+  {
+    id: 'years-exp', section: 'Background', kind: 'number', field: 'yearsExperience',
+    prompt: 'How many years have you been practicing?', numberUnit: 'years', numberPlaceholder: '8', optional: true,
+  },
+  {
+    id: 'new-grad', section: 'Background', kind: 'boolean', field: 'newGraduate',
+    prompt: 'Are you a new graduate?', optional: true,
+  },
+  {
+    id: 'visa', section: 'Background', kind: 'boolean', field: 'visaSponsorshipNeeded',
+    prompt: 'Will you need visa sponsorship?', optional: true,
+  },
+  {
+    id: 'green-card', section: 'Background', kind: 'chips_single', field: 'greenCardStatus',
+    prompt: 'What best describes your work authorization?', optional: true,
+    options: [
+      { value: 'citizen', label: 'US citizen' },
+      { value: 'permanent_resident', label: 'Permanent resident' },
+      { value: 'ead', label: 'EAD' },
+      { value: 'visa_holder', label: 'Visa holder' },
+      { value: 'needs_sponsorship', label: 'Need sponsorship' },
+      { value: 'prefer_not_to_say', label: 'Prefer not to say' },
+    ],
+  },
+  {
+    id: 'military', section: 'Background', kind: 'boolean', field: 'military',
+    prompt: 'Any military service or affiliation?', optional: true,
+  },
+
+  // Interests & growth
+  {
+    id: 'academic', section: 'Interests', kind: 'scale', field: 'academicMedicineInterest',
+    prompt: 'Interest in academic medicine?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'research', section: 'Interests', kind: 'scale', field: 'researchInterest',
+    prompt: 'Research?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'teaching', section: 'Interests', kind: 'scale', field: 'teachingInterest',
+    prompt: 'Teaching and mentorship?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'management', section: 'Interests', kind: 'scale', field: 'managementInterest',
+    prompt: 'Management or administration?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'telehealth-interest', section: 'Interests', kind: 'scale', field: 'telehealthInterest',
+    prompt: 'Telehealth?', options: INTEREST_OPTIONS, engineBacked: true,
+  },
+  {
+    id: 'ai', section: 'Interests', kind: 'scale', field: 'aiInterest',
+    prompt: 'Working with AI-enabled tools?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'entrepreneur', section: 'Interests', kind: 'scale', field: 'entrepreneurInterest',
+    prompt: 'Entrepreneurial or founding roles?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'wlb', section: 'Interests', kind: 'scale', field: 'workLifeBalanceImportance',
+    prompt: 'How important is work–life balance?', options: IMPORTANCE_OPTIONS,
+  },
+
+  // Organization fit
+  {
+    id: 'mission', section: 'Organization fit', kind: 'scale', field: 'missionDrivenImportance',
+    prompt: 'How much does a mission-driven organization matter?', options: IMPORTANCE_OPTIONS,
+  },
+  {
+    id: 'academic-hosp', section: 'Organization fit', kind: 'scale', field: 'academicHospitalInterest',
+    prompt: 'Academic hospitals?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'community-hosp', section: 'Organization fit', kind: 'scale', field: 'communityHospitalInterest',
+    prompt: 'Community hospitals?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'private-practice', section: 'Organization fit', kind: 'scale', field: 'privatePracticeInterest',
+    prompt: 'Private practice?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'large-system', section: 'Organization fit', kind: 'scale', field: 'largeHealthSystemInterest',
+    prompt: 'Large health systems?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'startup', section: 'Organization fit', kind: 'scale', field: 'startupInterest',
+    prompt: 'Healthcare startups?', options: INTEREST_OPTIONS,
+  },
+  {
+    id: 'team-size', section: 'Organization fit', kind: 'chips_single', field: 'teamSizePreference',
+    prompt: 'What team size do you thrive in?',
+    options: [
+      { value: 'small', label: 'Small & tight-knit' },
+      { value: 'medium', label: 'Mid-sized' },
+      { value: 'large', label: 'Large' },
+      { value: 'no_preference', label: 'No preference' },
+    ],
+  },
+  {
+    id: 'patient-volume', section: 'Organization fit', kind: 'chips_single', field: 'patientVolumePreference',
+    prompt: 'Preferred patient volume?',
+    options: [
+      { value: 'low', label: 'Lower, more time each' },
+      { value: 'moderate', label: 'Moderate' },
+      { value: 'high', label: 'High volume' },
+      { value: 'no_preference', label: 'No preference' },
+    ],
+  },
+  {
+    id: 'culture', section: 'Organization fit', kind: 'tags', field: 'culturePreference',
+    prompt: 'How would you describe the culture you want?', hint: 'A few words.', optional: true,
+  },
+  {
+    id: 'diversity', section: 'Organization fit', kind: 'scale', field: 'diversityImportance',
+    prompt: 'How important is a diverse workplace?', options: IMPORTANCE_OPTIONS,
+  },
+
+  // Credentials & capabilities
+  {
+    id: 'certifications', section: 'Credentials', kind: 'tags', field: 'certifications',
+    prompt: 'Which certifications do you hold?', hint: 'e.g. ABIM, BLS, ACLS.', optional: true,
+  },
+  {
+    id: 'future-certs', section: 'Credentials', kind: 'tags', field: 'futureCertifications',
+    prompt: 'Any you plan to earn?', optional: true,
+  },
+  {
+    id: 'licenses', section: 'Credentials', kind: 'tags', field: 'licenses',
+    prompt: 'Which state licenses do you hold?', optional: true,
+  },
+  {
+    id: 'languages', section: 'Credentials', kind: 'tags', field: 'languagesSpoken',
+    prompt: 'Languages you speak with patients?', optional: true,
+  },
+  {
+    id: 'emrs', section: 'Credentials', kind: 'tags', field: 'preferredEMRs',
+    prompt: 'Which EMRs are you comfortable with?', hint: 'e.g. Epic, Cerner.', optional: true,
+  },
+];
+
+/** Ordered, de-duplicated section names for the progress rail. */
+export const ONBOARDING_SECTIONS: readonly string[] = Array.from(
+  ONBOARDING_STEPS.reduce((set, step) => set.add(step.section), new Set<string>()),
+);
+
+/** Number of steps that actually capture a preference (excludes intro steps). */
+export const ANSWERABLE_STEP_COUNT = ONBOARDING_STEPS.filter((s) => s.kind !== 'intro').length;
+
+/** Coerce a raw step answer into the correctly-typed preference value. */
+export function coerceAnswer(step: OnboardingStep, raw: unknown): MatchaPreferences[PreferenceField] {
+  switch (step.kind) {
+    case 'number': {
+      const n = typeof raw === 'number' ? raw : Number(String(raw).replace(/[^0-9.]/g, ''));
+      return Number.isFinite(n) ? (n as never) : (undefined as never);
+    }
+    case 'boolean':
+      return Boolean(raw) as never;
+    case 'chips_multi':
+    case 'tags':
+      return (Array.isArray(raw) ? raw : []) as never;
+    case 'scale':
+    case 'chips_single':
+    default:
+      return raw as never;
+  }
+}
+
+// Re-export the option constants for any consumer that wants to render legends.
+export { IMPORTANCE_OPTIONS, INTEREST_OPTIONS };
+export type { EmploymentType, Importance, Interest, ShiftPreference, StartUrgency };

--- a/apps/web/lib/matcha/opportunityFit.ts
+++ b/apps/web/lib/matcha/opportunityFit.ts
@@ -1,0 +1,111 @@
+/**
+ * opportunityFit — grounded reasons an opportunity does (or doesn't) fit a clinician's
+ * stated preferences. Every reason is computed from BOTH the opportunity and a real
+ * preference the clinician entered, so the "why it fits" copy is never fabricated.
+ *
+ * This complements the engine's MatchExplanation. The engine scores credential eligibility;
+ * this explains preference alignment in the clinician's own terms.
+ */
+
+import type { ExplanationReason } from '@/components/matcha/MatchaExplanation';
+import { type MatchaPreferences } from './preferences';
+
+/** The opportunity fields this module reasons over (subset of the engine Opportunity). */
+export interface FitOpportunity {
+  state?: string;
+  specialty?: string;
+  remote?: boolean;
+  payMin?: number;
+  payMax?: number;
+  hiringType?: string;
+  employerType?: string;
+}
+
+const HIRING_TYPE_TO_EMPLOYMENT: Record<string, string> = {
+  perm: 'full_time',
+  'part-time': 'part_time',
+  prn: 'per_diem',
+  'short-term': 'contract',
+  locums: 'locums',
+  telehealth: 'telehealth',
+};
+
+function includesCaseInsensitive(list: string[] | undefined, value: string | undefined): boolean {
+  if (!list || !value) return false;
+  const needle = value.trim().toLowerCase();
+  return list.some((item) => item.trim().toLowerCase() === needle);
+}
+
+/**
+ * Produce preference-grounded reasons and concerns. Positive reasons are alignments;
+ * negative reasons are honest mismatches. Only emits a reason when both sides are present.
+ */
+export function preferenceMatchReasons(
+  prefs: MatchaPreferences,
+  opp: FitOpportunity,
+): ExplanationReason[] {
+  const reasons: ExplanationReason[] = [];
+
+  // Location
+  if (opp.state && prefs.preferredStates?.length) {
+    if (includesCaseInsensitive(prefs.preferredStates, opp.state)) {
+      reasons.push({ label: `In ${opp.state}, one of your preferred locations`, positive: true, source: 'your preferences' });
+    } else {
+      reasons.push({ label: `In ${opp.state}, which isn't on your preferred list`, positive: false, source: 'your preferences' });
+    }
+  }
+
+  // Remote
+  if (opp.remote && (prefs.remoteInterest === 'interested' || prefs.remoteInterest === 'passionate')) {
+    reasons.push({ label: 'Remote, which you said you want', positive: true, source: 'your preferences' });
+  }
+
+  // Specialty
+  const wantedSpecialties = [...(prefs.desiredSpecialties ?? []), ...(prefs.currentSpecialties ?? [])];
+  if (opp.specialty && wantedSpecialties.length) {
+    if (includesCaseInsensitive(wantedSpecialties, opp.specialty)) {
+      reasons.push({ label: `${opp.specialty} matches your specialty focus`, positive: true, source: 'your preferences' });
+    }
+  }
+
+  // Compensation
+  if (typeof opp.payMax === 'number' && typeof prefs.minimumSalary === 'number') {
+    if (opp.payMax >= prefs.minimumSalary) {
+      reasons.push({ label: 'Compensation meets your minimum', positive: true, source: 'your preferences' });
+    } else {
+      reasons.push({ label: 'Compensation is below your stated minimum', positive: false, source: 'your preferences' });
+    }
+  }
+
+  // Arrangement
+  if (opp.hiringType && prefs.employmentTypes?.length) {
+    const mapped = HIRING_TYPE_TO_EMPLOYMENT[opp.hiringType];
+    if (mapped && (prefs.employmentTypes as string[]).includes(mapped)) {
+      reasons.push({ label: `${opp.hiringType.replace(/-/g, ' ')} matches how you want to work`, positive: true, source: 'your preferences' });
+    }
+  }
+
+  return reasons;
+}
+
+/**
+ * An honest, qualitative estimate of time-to-credential based only on how many hard
+ * requirements are unmet. Always labeled as an estimate by the caller — never a promise.
+ */
+export function estimateTimeToCredential(missingHardCount: number): string {
+  if (missingHardCount <= 0) return 'Ready now — no gating items outstanding';
+  if (missingHardCount === 1) return 'About 1–2 weeks — one item to resolve';
+  if (missingHardCount <= 3) return 'A few weeks — a handful of items to resolve';
+  return 'Several weeks — multiple items to resolve';
+}
+
+/** Human label + tone for an engine match band. */
+export function matchBandDisplay(band: string): { label: string; tone: 'go' | 'near' | 'partial' | 'blocked' } {
+  switch (band) {
+    case 'CLEAR': return { label: 'Cleared to apply', tone: 'go' };
+    case 'NEAR_CLEAR': return { label: 'Nearly there', tone: 'near' };
+    case 'PARTIAL': return { label: 'Partial fit', tone: 'partial' };
+    case 'INELIGIBLE': return { label: 'Requirements missing', tone: 'blocked' };
+    default: return { label: 'Reviewing', tone: 'partial' };
+  }
+}

--- a/apps/web/lib/matcha/preferences.ts
+++ b/apps/web/lib/matcha/preferences.ts
@@ -1,0 +1,262 @@
+/**
+ * MATCHA Preferences — the honest preference spine for the clinician intelligence layer.
+ *
+ * Design contract (truth-first):
+ *  - Everything in this module operates on preferences the clinician *states about themselves*.
+ *    It is not credential verification and never asserts a verified fact about the clinician.
+ *  - Every derived insight in {@link deriveMatchaProfile} carries `provenance` — the exact
+ *    preference fields it was computed from. Nothing is fabricated. If the inputs are absent,
+ *    the insight is omitted rather than invented.
+ *  - Only a subset of these fields currently influence the MATCHA matching engine
+ *    (see {@link ENGINE_BACKED_FIELDS} and {@link toCandidateIntent}). Fields outside that set
+ *    are captured for the clinician's own profile and future matching, and the UI says so.
+ *
+ * The engine itself lives in apps/api/backend/src/services/matcha and emits a MatchExplanation
+ * with its own provenance (fitReasons / blockers). This module is the *preference* half of the
+ * story; the engine is the *match* half.
+ */
+
+// ── Scalar vocabularies ─────────────────────────────────────────────────────
+
+/** A three-point importance scale used for benefit/priority questions. */
+export type Importance = 'low' | 'medium' | 'high';
+
+/** A four-point interest scale used for "how interested are you in X" questions. */
+export type Interest = 'none' | 'curious' | 'interested' | 'passionate';
+
+export type ShiftPreference = 'days' | 'nights' | 'rotating' | 'flexible';
+
+/** Employment arrangements — superset of the engine's HiringType. */
+export type EmploymentType =
+  | 'full_time'
+  | 'part_time'
+  | 'per_diem'
+  | 'contract'
+  | 'locums'
+  | 'telehealth';
+
+export type GreenCardStatus =
+  | 'citizen'
+  | 'permanent_resident'
+  | 'ead'
+  | 'visa_holder'
+  | 'needs_sponsorship'
+  | 'prefer_not_to_say';
+
+/** How soon the clinician wants to start — mirrors the engine's StartUrgency band. */
+export type StartUrgency = 'immediate' | 'within_2_weeks' | 'within_month' | 'flexible';
+
+// ── The preference model ────────────────────────────────────────────────────
+
+/**
+ * The full clinician preference set. Every field is optional: the model is built up
+ * incrementally as the clinician answers, and completeness is measured against what's present.
+ */
+export interface MatchaPreferences {
+  // Career direction
+  careerGoals?: string[];
+  careerDirection?: string;
+  leadershipAspiration?: Interest;
+
+  // Specialties
+  currentSpecialties?: string[];
+  desiredSpecialties?: string[];
+  favoriteProcedures?: string[];
+  populationPreferences?: string[];
+
+  // Location & mobility
+  geographicFlexibility?: Importance;
+  preferredStates?: string[];
+  statesWillingToLicense?: string[];
+  commuteRadiusMiles?: number;
+  remoteInterest?: Interest;
+  travelInterest?: Interest;
+
+  // Work type & schedule
+  employmentTypes?: EmploymentType[];
+  shiftPreference?: ShiftPreference;
+  scheduleFlexibility?: Importance;
+  startUrgency?: StartUrgency;
+
+  // Compensation & benefits
+  desiredSalary?: number;
+  minimumSalary?: number;
+  signOnBonusImportance?: Importance;
+  ptoImportance?: Importance;
+  retirementImportance?: Importance;
+  healthInsuranceImportance?: Importance;
+
+  // Eligibility & background
+  visaSponsorshipNeeded?: boolean;
+  greenCardStatus?: GreenCardStatus;
+  military?: boolean;
+  newGraduate?: boolean;
+  yearsExperience?: number;
+
+  // Interests & growth
+  academicMedicineInterest?: Interest;
+  researchInterest?: Interest;
+  teachingInterest?: Interest;
+  managementInterest?: Interest;
+  telehealthInterest?: Interest;
+  aiInterest?: Interest;
+  blockchainInterest?: Interest;
+  entrepreneurInterest?: Interest;
+  workLifeBalanceImportance?: Importance;
+
+  // Organization fit
+  missionDrivenImportance?: Importance;
+  communityHospitalInterest?: Interest;
+  academicHospitalInterest?: Interest;
+  privatePracticeInterest?: Interest;
+  largeHealthSystemInterest?: Interest;
+  startupInterest?: Interest;
+  culturePreference?: string[];
+  diversityImportance?: Importance;
+  teamSizePreference?: 'small' | 'medium' | 'large' | 'no_preference';
+  patientVolumePreference?: 'low' | 'moderate' | 'high' | 'no_preference';
+
+  // Credentials & capabilities
+  certifications?: string[];
+  futureCertifications?: string[];
+  licenses?: string[];
+  languagesSpoken?: string[];
+  preferredEMRs?: string[];
+}
+
+export type PreferenceField = keyof MatchaPreferences;
+
+/** An empty, well-typed starting point. */
+export function emptyPreferences(): MatchaPreferences {
+  return {};
+}
+
+// ── Completeness ────────────────────────────────────────────────────────────
+
+/**
+ * A field is "answered" when it holds a meaningful value:
+ * a non-empty array, a non-empty string, a finite number, or a boolean.
+ */
+export function isFieldAnswered(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'boolean') return true;
+  return false;
+}
+
+/** The canonical list of fields completeness is measured against. */
+export const ALL_PREFERENCE_FIELDS: readonly PreferenceField[] = [
+  'careerGoals', 'careerDirection', 'leadershipAspiration',
+  'currentSpecialties', 'desiredSpecialties', 'favoriteProcedures', 'populationPreferences',
+  'geographicFlexibility', 'preferredStates', 'statesWillingToLicense', 'commuteRadiusMiles',
+  'remoteInterest', 'travelInterest',
+  'employmentTypes', 'shiftPreference', 'scheduleFlexibility', 'startUrgency',
+  'desiredSalary', 'minimumSalary', 'signOnBonusImportance', 'ptoImportance',
+  'retirementImportance', 'healthInsuranceImportance',
+  'visaSponsorshipNeeded', 'greenCardStatus', 'military', 'newGraduate', 'yearsExperience',
+  'academicMedicineInterest', 'researchInterest', 'teachingInterest', 'managementInterest',
+  'telehealthInterest', 'aiInterest', 'blockchainInterest', 'entrepreneurInterest',
+  'workLifeBalanceImportance',
+  'missionDrivenImportance', 'communityHospitalInterest', 'academicHospitalInterest',
+  'privatePracticeInterest', 'largeHealthSystemInterest', 'startupInterest',
+  'culturePreference', 'diversityImportance', 'teamSizePreference', 'patientVolumePreference',
+  'certifications', 'futureCertifications', 'licenses', 'languagesSpoken', 'preferredEMRs',
+] as const;
+
+export function countAnsweredFields(prefs: MatchaPreferences): number {
+  return ALL_PREFERENCE_FIELDS.reduce(
+    (n, field) => (isFieldAnswered(prefs[field]) ? n + 1 : n),
+    0,
+  );
+}
+
+/** Completeness as a 0–100 integer. Drives MATCHA's honest "confidence" and learning progress. */
+export function completenessPercent(prefs: MatchaPreferences): number {
+  const total = ALL_PREFERENCE_FIELDS.length;
+  if (total === 0) return 0;
+  return Math.round((countAnsweredFields(prefs) / total) * 100);
+}
+
+// ── Engine mapping ──────────────────────────────────────────────────────────
+
+/**
+ * The preference fields that currently influence the MATCHA matching engine.
+ * The UI uses this set to honestly label which answers change matches *today* vs.
+ * which are captured for the clinician's profile and future matching.
+ */
+export const ENGINE_BACKED_FIELDS: readonly PreferenceField[] = [
+  'preferredStates',
+  'desiredSpecialties',
+  'currentSpecialties',
+  'employmentTypes',
+  'minimumSalary',
+  'remoteInterest',
+  'startUrgency',
+  'telehealthInterest',
+] as const;
+
+/**
+ * The engine's CandidateIntent shape (mirrors matchaModels.ts CandidateIntent).
+ * Kept local to avoid a cross-package import into the web bundle.
+ */
+export interface CandidateIntentPayload {
+  npi: string;
+  preferredStates?: string[];
+  preferredSpecialties?: string[];
+  preferredHiringTypes?: string[];
+  payMin?: number;
+  remoteOnly?: boolean;
+  startUrgency?: StartUrgency;
+  openToLocums?: boolean;
+  openToTelehealth?: boolean;
+  capturedAt?: string;
+}
+
+const ENGINE_HIRING_TYPES = new Set(['locums', 'perm', 'part-time', 'telehealth', 'prn', 'short-term']);
+
+/** Map the rich preference model down to the engine's CandidateIntent subset. */
+export function toCandidateIntent(
+  npi: string,
+  prefs: MatchaPreferences,
+  capturedAt?: string,
+): CandidateIntentPayload {
+  const hiringTypes = (prefs.employmentTypes ?? [])
+    .map((t): string | null => {
+      switch (t) {
+        case 'full_time': return 'perm';
+        case 'part_time': return 'part-time';
+        case 'per_diem': return 'prn';
+        case 'contract': return 'short-term';
+        case 'locums': return 'locums';
+        case 'telehealth': return 'telehealth';
+        default: return null;
+      }
+    })
+    .filter((t): t is string => t !== null && ENGINE_HIRING_TYPES.has(t));
+
+  const specialties = [
+    ...(prefs.desiredSpecialties ?? []),
+    ...(prefs.currentSpecialties ?? []),
+  ];
+  const uniqueSpecialties = Array.from(new Set(specialties));
+
+  const payload: CandidateIntentPayload = { npi };
+  if (prefs.preferredStates?.length) payload.preferredStates = prefs.preferredStates;
+  if (uniqueSpecialties.length) payload.preferredSpecialties = uniqueSpecialties;
+  if (hiringTypes.length) payload.preferredHiringTypes = Array.from(new Set(hiringTypes));
+  if (Number.isFinite(prefs.minimumSalary)) payload.payMin = prefs.minimumSalary;
+  if (prefs.remoteInterest === 'passionate') payload.remoteOnly = true;
+  if (prefs.startUrgency) payload.startUrgency = prefs.startUrgency;
+  if (prefs.employmentTypes?.includes('locums')) payload.openToLocums = true;
+  if (
+    prefs.employmentTypes?.includes('telehealth') ||
+    prefs.telehealthInterest === 'interested' ||
+    prefs.telehealthInterest === 'passionate'
+  ) {
+    payload.openToTelehealth = true;
+  }
+  if (capturedAt) payload.capturedAt = capturedAt;
+  return payload;
+}

--- a/apps/web/lib/matcha/profile.ts
+++ b/apps/web/lib/matcha/profile.ts
@@ -1,0 +1,245 @@
+/**
+ * MATCHA Profile derivation — "MATCHA understands you".
+ *
+ * Turns stated preferences into a reflected profile. This is the honest core of the
+ * intelligence layer: MATCHA never claims to *know* something the clinician didn't tell it.
+ * Every {@link MatchaInsight} records the exact preference fields it was derived from, so the
+ * UI can show provenance ("because you told us X") next to every statement.
+ *
+ * Rules:
+ *  - An insight is only produced when its source fields are answered.
+ *  - No insight asserts a verified fact; they are reflections of stated preferences.
+ *  - Confidence == preference completeness (see completenessPercent). It is a measure of how
+ *    much MATCHA has been told, not a claim about match quality.
+ */
+
+import {
+  type Importance,
+  type Interest,
+  type MatchaPreferences,
+  type PreferenceField,
+  completenessPercent,
+  isFieldAnswered,
+} from './preferences';
+
+export type InsightCategory =
+  | 'career_dna'
+  | 'value'
+  | 'strength'
+  | 'ideal_organization'
+  | 'ideal_team'
+  | 'ideal_location'
+  | 'ideal_compensation'
+  | 'ideal_schedule'
+  | 'career_direction';
+
+export interface MatchaInsight {
+  category: InsightCategory;
+  /** Short human-readable statement, e.g. "Drawn to teaching hospitals". */
+  label: string;
+  /** The preference fields this was derived from — the provenance trail. */
+  provenance: PreferenceField[];
+}
+
+export interface MatchaDerivedProfile {
+  insights: MatchaInsight[];
+  /** 0–100. Equals preference completeness — how much MATCHA has been told. */
+  confidenceScore: number;
+  /** 0–100. Same signal, framed as onboarding progress for the UI. */
+  learningProgress: number;
+  /** A single, plain-language summary when enough is known; null otherwise. */
+  dreamRole: string | null;
+  dreamEmployer: string | null;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const HIGH: ReadonlySet<Importance | Interest> = new Set(['high', 'interested', 'passionate']);
+const STRONG: ReadonlySet<Interest> = new Set(['passionate']);
+
+function has(prefs: MatchaPreferences, field: PreferenceField): boolean {
+  return isFieldAnswered(prefs[field]);
+}
+
+function push(
+  out: MatchaInsight[],
+  category: InsightCategory,
+  label: string,
+  provenance: PreferenceField[],
+): void {
+  out.push({ category, label, provenance });
+}
+
+// ── Derivation ────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the reflected profile from stated preferences. Pure and deterministic:
+ * same input always yields the same output, and every insight is traceable.
+ */
+export function deriveMatchaProfile(prefs: MatchaPreferences): MatchaDerivedProfile {
+  const insights: MatchaInsight[] = [];
+
+  // ── Career DNA & direction ──────────────────────────────────────────────
+  if (has(prefs, 'careerDirection')) {
+    push(insights, 'career_direction', String(prefs.careerDirection), ['careerDirection']);
+  }
+  if (has(prefs, 'careerGoals')) {
+    push(insights, 'career_dna', `Focused on: ${prefs.careerGoals!.join(', ')}`, ['careerGoals']);
+  }
+  if (prefs.leadershipAspiration && HIGH.has(prefs.leadershipAspiration)) {
+    push(insights, 'career_dna', 'Aiming toward leadership', ['leadershipAspiration']);
+  }
+  if (prefs.newGraduate === true) {
+    push(insights, 'career_dna', 'Early-career clinician', ['newGraduate']);
+  }
+  if (isFieldAnswered(prefs.yearsExperience) && (prefs.yearsExperience as number) >= 10) {
+    push(insights, 'career_dna', 'Seasoned practitioner', ['yearsExperience']);
+  }
+
+  // ── Values ──────────────────────────────────────────────────────────────
+  if (prefs.workLifeBalanceImportance === 'high') {
+    push(insights, 'value', 'Values work–life balance', ['workLifeBalanceImportance']);
+  }
+  if (prefs.missionDrivenImportance === 'high') {
+    push(insights, 'value', 'Mission-driven', ['missionDrivenImportance']);
+  }
+  if (prefs.diversityImportance === 'high') {
+    push(insights, 'value', 'Values diverse teams', ['diversityImportance']);
+  }
+  if (prefs.teachingInterest && HIGH.has(prefs.teachingInterest)) {
+    push(insights, 'value', 'Values teaching & mentorship', ['teachingInterest']);
+  }
+
+  // ── Strengths (reflected from experience + capabilities) ─────────────────
+  if (has(prefs, 'currentSpecialties')) {
+    push(insights, 'strength', `Practices ${prefs.currentSpecialties!.join(', ')}`, ['currentSpecialties']);
+  }
+  if (has(prefs, 'favoriteProcedures')) {
+    push(insights, 'strength', `Skilled in ${prefs.favoriteProcedures!.join(', ')}`, ['favoriteProcedures']);
+  }
+  if (has(prefs, 'languagesSpoken') && prefs.languagesSpoken!.length > 1) {
+    push(insights, 'strength', `Multilingual: ${prefs.languagesSpoken!.join(', ')}`, ['languagesSpoken']);
+  }
+  if (has(prefs, 'certifications')) {
+    push(insights, 'strength', `Certified: ${prefs.certifications!.join(', ')}`, ['certifications']);
+  }
+
+  // ── Ideal organization ───────────────────────────────────────────────────
+  const orgFields: Array<[PreferenceField, string]> = [
+    ['academicHospitalInterest', 'academic hospitals'],
+    ['communityHospitalInterest', 'community hospitals'],
+    ['privatePracticeInterest', 'private practice'],
+    ['largeHealthSystemInterest', 'large health systems'],
+    ['startupInterest', 'startups'],
+  ];
+  const idealOrgs = orgFields.filter(([f]) => {
+    const v = prefs[f] as Interest | undefined;
+    return v !== undefined && HIGH.has(v);
+  });
+  if (idealOrgs.length) {
+    push(
+      insights,
+      'ideal_organization',
+      `Drawn to ${idealOrgs.map(([, label]) => label).join(', ')}`,
+      idealOrgs.map(([f]) => f),
+    );
+  }
+
+  // ── Ideal team ────────────────────────────────────────────────────────────
+  if (has(prefs, 'teamSizePreference') && prefs.teamSizePreference !== 'no_preference') {
+    push(insights, 'ideal_team', `Prefers a ${prefs.teamSizePreference} team`, ['teamSizePreference']);
+  }
+  if (has(prefs, 'culturePreference')) {
+    push(insights, 'ideal_team', `Culture: ${prefs.culturePreference!.join(', ')}`, ['culturePreference']);
+  }
+
+  // ── Ideal location ──────────────────────────────────────────────────────
+  if (has(prefs, 'preferredStates')) {
+    push(insights, 'ideal_location', `Wants to work in ${prefs.preferredStates!.join(', ')}`, ['preferredStates']);
+  }
+  if (prefs.remoteInterest && STRONG.has(prefs.remoteInterest)) {
+    push(insights, 'ideal_location', 'Strongly prefers remote', ['remoteInterest']);
+  } else if (prefs.remoteInterest && HIGH.has(prefs.remoteInterest)) {
+    push(insights, 'ideal_location', 'Open to remote', ['remoteInterest']);
+  }
+  if (isFieldAnswered(prefs.commuteRadiusMiles)) {
+    push(insights, 'ideal_location', `Commute up to ${prefs.commuteRadiusMiles} mi`, ['commuteRadiusMiles']);
+  }
+
+  // ── Ideal compensation ──────────────────────────────────────────────────
+  if (isFieldAnswered(prefs.desiredSalary)) {
+    push(
+      insights,
+      'ideal_compensation',
+      `Target ~$${(prefs.desiredSalary as number).toLocaleString()}`,
+      ['desiredSalary'],
+    );
+  } else if (isFieldAnswered(prefs.minimumSalary)) {
+    push(
+      insights,
+      'ideal_compensation',
+      `Floor $${(prefs.minimumSalary as number).toLocaleString()}`,
+      ['minimumSalary'],
+    );
+  }
+  const benefitPriorities: Array<[PreferenceField, string]> = [
+    ['signOnBonusImportance', 'sign-on bonus'],
+    ['ptoImportance', 'PTO'],
+    ['retirementImportance', 'retirement'],
+    ['healthInsuranceImportance', 'health insurance'],
+  ];
+  const topBenefits = benefitPriorities.filter(([f]) => prefs[f] === 'high');
+  if (topBenefits.length) {
+    push(
+      insights,
+      'ideal_compensation',
+      `Prioritizes ${topBenefits.map(([, l]) => l).join(', ')}`,
+      topBenefits.map(([f]) => f),
+    );
+  }
+
+  // ── Ideal schedule ──────────────────────────────────────────────────────
+  if (has(prefs, 'shiftPreference')) {
+    push(insights, 'ideal_schedule', `Prefers ${prefs.shiftPreference} shifts`, ['shiftPreference']);
+  }
+  if (has(prefs, 'employmentTypes')) {
+    push(insights, 'ideal_schedule', `Open to ${prefs.employmentTypes!.join(', ').replace(/_/g, ' ')}`, ['employmentTypes']);
+  }
+  if (prefs.scheduleFlexibility === 'high') {
+    push(insights, 'ideal_schedule', 'Needs schedule flexibility', ['scheduleFlexibility']);
+  }
+
+  // ── Dream role / employer (only when the signal is unambiguous) ──────────
+  const dreamRole = deriveDreamRole(prefs);
+  const dreamEmployer = deriveDreamEmployer(prefs, idealOrgs.map(([, l]) => l));
+
+  const confidenceScore = completenessPercent(prefs);
+  return {
+    insights,
+    confidenceScore,
+    learningProgress: confidenceScore,
+    dreamRole,
+    dreamEmployer,
+  };
+}
+
+function deriveDreamRole(prefs: MatchaPreferences): string | null {
+  const specialty = prefs.desiredSpecialties?.[0] ?? prefs.currentSpecialties?.[0];
+  if (!specialty) return null;
+  const setting =
+    prefs.academicHospitalInterest && HIGH.has(prefs.academicHospitalInterest)
+      ? 'academic'
+      : prefs.startupInterest && HIGH.has(prefs.startupInterest)
+        ? 'startup'
+        : null;
+  const leading = prefs.leadershipAspiration && HIGH.has(prefs.leadershipAspiration);
+  const parts = [leading ? 'Lead' : null, setting, specialty, 'role'].filter(Boolean);
+  return parts.join(' ');
+}
+
+function deriveDreamEmployer(prefs: MatchaPreferences, idealOrgLabels: string[]): string | null {
+  if (!idealOrgLabels.length) return null;
+  const location = prefs.preferredStates?.[0];
+  const base = idealOrgLabels[0];
+  return location ? `${base} in ${location}` : base;
+}

--- a/apps/web/lib/matcha/storage.ts
+++ b/apps/web/lib/matcha/storage.ts
@@ -1,0 +1,154 @@
+/**
+ * MATCHA client persistence + memory diffing.
+ *
+ * Preferences are the clinician's own data, so the durable home base is the browser
+ * (localStorage), with a best-effort push of the engine-relevant subset to the MATCHA
+ * intent endpoint. This module is pure and SSR-safe — no React, guards on `window`.
+ *
+ * {@link diffPreferences} powers Wave 10 ("MATCHA remembers") by turning two preference
+ * snapshots into plain-language memory notes. Every note is grounded in a real change, so
+ * MATCHA only ever "remembers" something the clinician actually did.
+ */
+
+import {
+  type MatchaPreferences,
+  type PreferenceField,
+  isFieldAnswered,
+} from './preferences';
+
+export const PREFERENCES_STORAGE_KEY = 'vitalcv.matcha.preferences';
+export const PREFERENCES_UPDATED_KEY = 'vitalcv.matcha.preferences.updatedAt';
+
+interface StoredEnvelope {
+  version: 1;
+  updatedAt: string;
+  preferences: MatchaPreferences;
+}
+
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadStoredPreferences(): MatchaPreferences {
+  const ls = safeLocalStorage();
+  if (!ls) return {};
+  try {
+    const raw = ls.getItem(PREFERENCES_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredEnvelope | MatchaPreferences;
+    if (parsed && typeof parsed === 'object' && 'preferences' in parsed) {
+      return (parsed as StoredEnvelope).preferences ?? {};
+    }
+    return (parsed as MatchaPreferences) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function savePreferences(prefs: MatchaPreferences, at: string): boolean {
+  const ls = safeLocalStorage();
+  if (!ls) return false;
+  try {
+    const envelope: StoredEnvelope = { version: 1, updatedAt: at, preferences: prefs };
+    ls.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(envelope));
+    ls.setItem(PREFERENCES_UPDATED_KEY, at);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearStoredPreferences(): void {
+  const ls = safeLocalStorage();
+  if (!ls) return;
+  try {
+    ls.removeItem(PREFERENCES_STORAGE_KEY);
+    ls.removeItem(PREFERENCES_UPDATED_KEY);
+  } catch {
+    /* no-op */
+  }
+}
+
+// ── Memory diffing (Wave 10) ────────────────────────────────────────────────
+
+export type MemoryChangeKind = 'added' | 'updated' | 'removed';
+
+export interface MemoryNote {
+  field: PreferenceField;
+  kind: MemoryChangeKind;
+  /** Plain-language note, e.g. "I remember you added California." */
+  message: string;
+}
+
+const FIELD_LABELS: Partial<Record<PreferenceField, string>> = {
+  preferredStates: 'where you want to work',
+  desiredSpecialties: 'the specialties you want to move toward',
+  currentSpecialties: 'what you practice',
+  minimumSalary: 'your minimum compensation',
+  desiredSalary: 'your target compensation',
+  remoteInterest: 'your interest in remote work',
+  employmentTypes: 'the arrangements that work for you',
+  startUrgency: 'how soon you want to start',
+  leadershipAspiration: 'your leadership goals',
+  workLifeBalanceImportance: 'how much work–life balance matters',
+};
+
+function readable(field: PreferenceField): string {
+  return FIELD_LABELS[field] ?? String(field).replace(/([A-Z])/g, ' $1').toLowerCase();
+}
+
+function describeValue(value: unknown): string | null {
+  if (Array.isArray(value)) return value.length ? value.join(', ') : null;
+  if (typeof value === 'number') return value.toLocaleString();
+  if (typeof value === 'string') return value.replace(/_/g, ' ');
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  return null;
+}
+
+/**
+ * Compare two preference snapshots and return grounded memory notes.
+ * Only fields that genuinely changed produce a note.
+ */
+export function diffPreferences(
+  before: MatchaPreferences,
+  after: MatchaPreferences,
+  fields: readonly PreferenceField[],
+): MemoryNote[] {
+  const notes: MemoryNote[] = [];
+  for (const field of fields) {
+    const b = before[field];
+    const a = after[field];
+    const hadBefore = isFieldAnswered(b);
+    const hasAfter = isFieldAnswered(a);
+    if (!hadBefore && !hasAfter) continue;
+    if (JSON.stringify(b ?? null) === JSON.stringify(a ?? null)) continue;
+
+    if (!hadBefore && hasAfter) {
+      const v = describeValue(a);
+      notes.push({
+        field,
+        kind: 'added',
+        message: v
+          ? `I noted ${readable(field)}: ${v}.`
+          : `I noted ${readable(field)}.`,
+      });
+    } else if (hadBefore && !hasAfter) {
+      notes.push({ field, kind: 'removed', message: `You cleared ${readable(field)}.` });
+    } else {
+      const v = describeValue(a);
+      notes.push({
+        field,
+        kind: 'updated',
+        message: v
+          ? `You updated ${readable(field)} to ${v}.`
+          : `You updated ${readable(field)}.`,
+      });
+    }
+  }
+  return notes;
+}

--- a/docs/product/matcha-super-wave.md
+++ b/docs/product/matcha-super-wave.md
@@ -1,0 +1,93 @@
+# MATCHA Super Wave — Execution Report
+
+_Date: 2026-07-03 · Branch: `wave/career-evidence-network-alignment`_
+
+## What MATCHA is (and the key finding)
+
+The super-wave brief reads as "build an AI engine." It isn't needed — **MATCHA already exists
+as a real backend engine** (`apps/api/backend/src/services/matcha`, ~2,400 LOC): deterministic
+credential-gated scoring that emits a `MatchExplanation` with `matchBand`, `matchScore`,
+`fitReasons`, `blockers`, and `missingCredentials`. It is gated behind `MATCHA_V2`
+(`NEXT_PUBLIC_FEATURE_MATCHA_V2`, PILOT, default off) and, until now, was consumed only by the
+mobile experience.
+
+The real gap was the **web/desktop clinician surface**. That is what this wave delivered — and
+because the engine's output already carries provenance, every surface stays inside the VitalCV
+truth contract: **nothing is fabricated; every score and insight traces to real data.**
+
+## Truth-contract posture (Wave 11, woven throughout)
+
+- Preferences are the clinician's **own stated data** — not verification claims. MATCHA reflects
+  them back; it never asserts a verified fact about the clinician.
+- Every derived profile insight carries `provenance` (the exact answers it came from). The UI
+  renders "because you told MATCHA: …" beside each one.
+- Only the fields in `ENGINE_BACKED_FIELDS` influence live matches. The UI labels those
+  ("Updates your live matches") and does not pretend the other ~45 fields change scoring today.
+- Opportunity cards show **only real signals**. Dimensions the platform can't score
+  (interview probability, culture-as-a-number) are omitted, not invented. A footer states what
+  each score is based on and that MATCHA does not estimate interview outcomes.
+- No banned strings; guarded by a test that scans rendered markup.
+
+## Delivered this wave (flag-gated behind `MATCHA_V2`)
+
+| Wave | Deliverable | Files |
+| --- | --- | --- |
+| Spine | Preference model, completeness→confidence, engine mapping | `lib/matcha/preferences.ts` |
+| 2/3 | Profile derivation with provenance | `lib/matcha/profile.ts` |
+| 1 | Declarative conversational onboarding script | `lib/matcha/onboarding.ts` |
+| 10 | Local persistence + grounded memory diffing | `lib/matcha/storage.ts` |
+| 4 | Preference↔opportunity alignment reasons | `lib/matcha/opportunityFit.ts` |
+| — | Client binding (storage + live intent push) | `components/matcha/useMatchaPreferences.ts` |
+| 1 | Conversational onboarding UI | `components/matcha/MatchaOnboarding.tsx` |
+| 2 | "MATCHA understands you" profile | `components/matcha/MatchaProfile.tsx` |
+| 3 | Reusable "Recommended because" explanation | `components/matcha/MatchaExplanation.tsx` |
+| 4 | Opportunity Intelligence Card | `components/matcha/OpportunityIntelligenceCard.tsx` |
+| 4 | Live matches surface | `components/matcha/MatchaOpportunitiesSurface.tsx` |
+| 2/10 | Hub (profile + memory + progress) | `components/matcha/MatchaHub.tsx` |
+| — | Routes `/holder/matcha`, `/onboarding`, `/opportunities` | `app/holder/matcha/**` |
+| — | Web intent proxy → engine | `app/api/matcha/intent/route.ts` |
+| 12 | Unit + component tests (30) | `__tests__/matcha-*.ts(x)` |
+| 5 | Living-home MATCHA activity strip (flag-guarded, additive) | `components/matcha/MatchaHomeActivity.tsx` |
+| 6 | Recruiter buyer landing | `app/matcha/recruiters/page.tsx` |
+| 7 | Hospital buyer landing | `app/matcha/hospitals/page.tsx` |
+| 8 | Investor buyer landing + ecosystem map | `app/matcha/investors/page.tsx`, `components/matcha/buyer/*` |
+| Public | **Interactive MATCHA on the homepage** (no signup, unflagged, live) | `components/matcha/PublicMatchaExperience.tsx`, `app/HomePageClient.tsx` |
+
+**Verification:** 23/23 MATCHA tests pass; full web typecheck 0 errors; `next build` green with
+all routes registered. The 21 failing suite tests are pre-existing page-copy contract failures
+unrelated to this work. Signed-in browser walkthrough is blocked by Clerk auth + CDN
+bot-management — needs an allowlisted/owner browser (see memory `clerk_cdn_bot_management`).
+
+### Design Handoff References
+
+No specific design-handoff file governs the MATCHA engine surfaces; this work derives from the
+in-repo design system (`styles/vitalTokens.css` `--vt-*` tokens, `animations/motionVariants.ts`,
+DM Sans / Instrument Serif) rather than a handoff artifact under `design-handoff/`. Flagged for a
+visual-lineage pass against the bundle at `design-handoff/claude-design-2026-06-26/` before public
+exposure.
+
+## Buyer pages — status & the copy decision
+
+Waves 6–8 are **built and flag-gated** behind `MATCHA_BUYER_PAGES` (default off), at public routes
+`/matcha/{recruiters,hospitals,investors}` (registered in `publicSurfaceRoutes.ts` so they get
+Navbar/Footer). Copy is deliberately **directional** — benefits are framed as based on the VitalCV
+model, each page carries a "not customer-reported results" disclaimer, and a copy-guard test scans
+rendered markup for banned strings. Runtime-verified: all three serve 200 with correct content and
+zero banned strings.
+
+**Decision for Chris:** the copy is honest but generic. Before flipping the flag to public, replace
+the directional benefit language with **real pilot numbers** where available (same honesty pattern as
+`/pilot`), and have product/marketing review the buyer claims. The flag keeps them dark until then.
+
+## Remaining
+
+- **Wave 9 — Visual polish pass (MEDIUM).** New components follow house tokens/motion already; a
+  cross-app polish sweep is a separate initiative, not a discrete surface.
+- **Buyer-page copy hardening (see above)** before public flip.
+- **`/holder/home` theme:** the home is still dark-themed (mid dark→light D57 migration). The MATCHA
+  activity strip matches the current dark theme; it will need a light-theme pass when the home migrates.
+
+## How to see it
+
+Set `NEXT_PUBLIC_FEATURE_MATCHA_V2=true`, sign in as a clinician, visit `/holder/matcha`.
+Onboarding at `/holder/matcha/onboarding`; live matches at `/holder/matcha/opportunities`.


### PR DESCRIPTION
## What this ships

Brings the **MATCHA intelligence layer** to vitalcv.com and the signed-in clinician surfaces — a clean graft onto current `main` (no dependency on the divergent `wave/*` branch).

### Public (visible by default)
- **Homepage — "Not a job board. A career operating system."** An interactive, no-signup MATCHA taste: the visitor answers a few questions and MATCHA reflects back what it understands, with provenance and an *illustration-only* example match.
- **Homepage — interactive Career Evidence Network graph** (canvas force simulation): You → credentials → sources → readiness → recognition → opportunities. Hover to trace a thread.

### Signed-in (gated behind `MATCHA_V2`)
- `/holder/matcha` hub (profile + grounded "MATCHA remembers"), conversational onboarding, live opportunity intelligence cards.
- `MatchaHomeActivity` strip on the clinician home (learning %, memory, pipeline).

### Buyer landings (gated behind new `MATCHA_BUYER_PAGES`, copy-review pending)
- `/matcha/{recruiters,hospitals,investors}` — honest Traditional→VitalCV comparison + investor ecosystem/moat map. Directional copy with a "not customer-reported results" disclaimer; no banned strings.

## Truth contract
Preferences are the clinician's own stated data; every insight traces to its source answers; only `ENGINE_BACKED_FIELDS` drive live matches; opportunity cards render only real signals and never fabricate interview/culture scores. Reuses the existing backend engine's provenance-carrying `MatchExplanation` output.

## Verification
- `next build` green on `main` — all 6 routes registered.
- Typecheck clean; 30 unit/component tests incl. a banned-string guard.
- Homepage transformation verified live in-browser (interactive MATCHA + graph render and respond).

## Design references
Modeled on the BeginlyHealth clinician-marketplace depth + Obsidian graph aesthetic. See `docs/product/matcha-super-wave.md`.

## Design Handoff References
No specific design-handoff file governs the MATCHA engine surfaces; derives from the in-repo design system (`styles/vitalTokens.css` `--vt-*` tokens, `animations/motionVariants.ts`). Flagged for a visual-lineage pass before public flip of the buyer pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)