### PR TITLE
feat(matcha): Personal/Professional/Place match questions

### DIFF
--- a/apps/web/__tests__/matcha-categories.test.ts
+++ b/apps/web/__tests__/matcha-categories.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { ALL_PREFERENCE_FIELDS, type MatchaPreferences } from '../lib/matcha/preferences';
+import {
+  CATEGORY_ORDER,
+  FIELD_CATEGORY,
+  allCategoryProgress,
+  categoryFields,
+  categoryProgress,
+  stepsForCategory,
+} from '../lib/matcha/categories';
+
+describe('matcha categories — every field is categorized exactly once', () => {
+  it('maps every preference field to a category', () => {
+    for (const field of ALL_PREFERENCE_FIELDS) {
+      expect(FIELD_CATEGORY[field]).toBeDefined();
+      expect(CATEGORY_ORDER).toContain(FIELD_CATEGORY[field]);
+    }
+  });
+
+  it('has no category entries for non-existent fields', () => {
+    for (const field of Object.keys(FIELD_CATEGORY)) {
+      expect(ALL_PREFERENCE_FIELDS).toContain(field);
+    }
+  });
+
+  it('partitions all fields across the three categories with no overlap', () => {
+    const buckets = CATEGORY_ORDER.map((c) => categoryFields(c));
+    const flat = buckets.flat();
+    // no field appears in two categories
+    expect(new Set(flat).size).toBe(flat.length);
+    // every field is covered
+    expect(flat.length).toBe(ALL_PREFERENCE_FIELDS.length);
+  });
+});
+
+describe('matcha categories — progress', () => {
+  it('reports 0 for empty preferences', () => {
+    for (const p of allCategoryProgress({})) {
+      expect(p.answered).toBe(0);
+      expect(p.percent).toBe(0);
+      expect(p.total).toBeGreaterThan(0);
+    }
+  });
+
+  it('counts answered fields within the right category', () => {
+    // preferredStates is a Place field; currentSpecialties is Professional.
+    const prefs: MatchaPreferences = { preferredStates: ['CA'], currentSpecialties: ['Cardiology'] };
+    const place = categoryProgress(prefs, 'place');
+    const professional = categoryProgress(prefs, 'professional');
+    const personal = categoryProgress(prefs, 'personal');
+    expect(place.answered).toBe(1);
+    expect(professional.answered).toBe(1);
+    expect(personal.answered).toBe(0);
+  });
+
+  it('percent equals answered/total rounded', () => {
+    const prefs: MatchaPreferences = { careerGoals: ['attending'] };
+    const personal = categoryProgress(prefs, 'personal');
+    expect(personal.percent).toBe(Math.round((personal.answered / personal.total) * 100));
+  });
+});
+
+describe('matcha categories — steps', () => {
+  it('returns only steps whose field belongs to the category', () => {
+    for (const cat of CATEGORY_ORDER) {
+      const steps = stepsForCategory(cat);
+      expect(steps.length).toBeGreaterThan(0);
+      for (const step of steps) {
+        expect(step.field).toBeDefined();
+        expect(FIELD_CATEGORY[step.field!]).toBe(cat);
+        expect(step.kind).not.toBe('intro');
+      }
+    }
+  });
+});

--- a/apps/web/app/holder/matcha/assessment/page.tsx
+++ b/apps/web/app/holder/matcha/assessment/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { MatchaAssessment } from '@/components/matcha/MatchaAssessment';
+
+export const metadata: Metadata = {
+  title: 'Match questions — VitalCV',
+  description: 'Answer Personal, Professional, and Place match questions to sharpen how MATCHA matches you.',
+};
+
+export default function HolderMatchaAssessmentPage() {
+  if (!FEATURES.MATCHA_V2) notFound();
+  return <MatchaAssessment />;
+}

--- a/apps/web/components/matcha/MatchaAssessment.tsx
+++ b/apps/web/components/matcha/MatchaAssessment.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * MatchaAssessment — the browsable Personal / Professional / Place match-question surface.
+ *
+ * Answer as many as you like; the more you answer, the sharper the match. Per-category and
+ * overall completeness are real (answered / total). Every question writes straight into the
+ * MatchaPreferences spine and updates MATCHA's reasoning live. Honest throughout — the copy
+ * says answering improves matching, and only engine-backed fields are labeled as such.
+ */
+
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useMatchaPreferences } from './useMatchaPreferences';
+import { MatchaStepInput } from './MatchaStepInput';
+import {
+  CATEGORY_META,
+  CATEGORY_ORDER,
+  allCategoryProgress,
+  stepsForCategory,
+  type MatchCategory,
+} from '@/lib/matcha/categories';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+function ProgressBar({ percent }: { percent: number }) {
+  return (
+    <div style={{ height: 6, borderRadius: 999, background: 'var(--vt-border, #E2E8E6)', overflow: 'hidden' }}>
+      <div style={{ width: `${Math.max(2, percent)}%`, height: '100%', background: ACCENT, borderRadius: 999, transition: 'width 320ms cubic-bezier(0.2,0.8,0.2,1)' }} />
+    </div>
+  );
+}
+
+export function MatchaAssessment() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? undefined;
+  const { preferences, completeness, setField } = useMatchaPreferences(npi);
+  const [open, setOpen] = useState<MatchCategory | null>('personal');
+
+  const progress = allCategoryProgress(preferences);
+  const totalAnswered = progress.reduce((n, p) => n + p.answered, 0);
+  const totalQuestions = progress.reduce((n, p) => n + p.total, 0);
+
+  return (
+    <div style={{ maxWidth: 760, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+      {/* Header */}
+      <header>
+        <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Match questions</h1>
+        <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', lineHeight: 1.55 }}>
+          Answer as many as you like across three areas. The more MATCHA knows, the sharper your
+          matches — and everything you enter stays yours.
+        </p>
+        <div style={{ marginTop: 14, display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div style={{ flex: 1 }}><ProgressBar percent={completeness} /></div>
+          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-text-primary)', fontVariantNumeric: 'tabular-nums' }}>
+            {totalAnswered}/{totalQuestions} answered
+          </span>
+        </div>
+      </header>
+
+      {/* Category sections */}
+      {CATEGORY_ORDER.map((cat) => {
+        const meta = CATEGORY_META[cat];
+        const prog = progress.find((p) => p.category === cat)!;
+        const steps = stepsForCategory(cat);
+        const isOpen = open === cat;
+        return (
+          <section key={cat} style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, overflow: 'hidden' }}>
+            <button
+              type="button"
+              onClick={() => setOpen(isOpen ? null : cat)}
+              aria-expanded={isOpen}
+              style={{ width: '100%', display: 'flex', alignItems: 'center', gap: 14, padding: '18px 20px', background: 'transparent', border: 0, cursor: 'pointer', textAlign: 'left' }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{meta.label}</span>
+                  <span style={{ fontSize: 12, color: 'var(--vt-text-muted)', fontVariantNumeric: 'tabular-nums' }}>{prog.answered}/{prog.total}</span>
+                </div>
+                <p style={{ margin: '4px 0 10px', fontSize: 13, color: 'var(--vt-text-secondary)' }}>{meta.blurb}</p>
+                <ProgressBar percent={prog.percent} />
+              </div>
+              <ChevronDown size={18} style={{ flex: '0 0 auto', color: 'var(--vt-text-muted)', transform: isOpen ? 'rotate(180deg)' : 'none', transition: 'transform 200ms' }} />
+            </button>
+
+            {isOpen && (
+              <div style={{ borderTop: '1px solid var(--vt-border, #EEF2F0)', padding: '8px 20px 20px' }}>
+                {steps.map((step) => (
+                  <div key={step.id} style={{ padding: '16px 0', borderBottom: '1px solid var(--vt-border, #F1F5F3)' }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10 }}>
+                      <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--vt-text-primary)' }}>{step.prompt}</span>
+                      {step.engineBacked ? (
+                        <span style={{ fontSize: 10, fontWeight: 600, color: ACCENT, background: `color-mix(in srgb, ${ACCENT} 10%, transparent)`, padding: '1px 6px', borderRadius: 999, whiteSpace: 'nowrap' }}>
+                          affects matches
+                        </span>
+                      ) : null}
+                    </div>
+                    <MatchaStepInput step={step} value={preferences[step.field!]} onChange={(v) => setField(step.field!, v)} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { useMatchaPreferences } from './useMatchaPreferences';
 import { MatchaProfile } from './MatchaProfile';
+import { CATEGORY_META, CATEGORY_ORDER, allCategoryProgress } from '@/lib/matcha/categories';
 
 const ACCENT = 'var(--vt-accent, #0A7B7F)';
 
@@ -19,7 +20,8 @@ export function MatchaHub() {
   const npi = person?.npi ?? undefined;
   const firstName = person?.firstName ?? undefined;
 
-  const { derived, completeness, memory, loaded } = useMatchaPreferences(npi);
+  const { preferences, derived, completeness, memory, loaded } = useMatchaPreferences(npi);
+  const categoryProgress = allCategoryProgress(preferences);
 
   const started = completeness > 0;
 
@@ -87,6 +89,39 @@ export function MatchaHub() {
         >
           {started ? 'Continue' : 'Start'}
         </Link>
+      </div>
+
+      {/* Match questions — Personal / Professional / Place */}
+      <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
+          <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Match questions</h2>
+          <Link href="/holder/matcha/assessment" style={{ fontSize: 13, fontWeight: 600, color: ACCENT, textDecoration: 'none' }}>
+            Answer more →
+          </Link>
+        </div>
+        <p style={{ margin: '6px 0 14px', fontSize: 13, color: 'var(--vt-text-secondary)' }}>
+          The more you answer across these three areas, the sharper MATCHA&rsquo;s matches.
+        </p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>
+          {CATEGORY_ORDER.map((cat) => {
+            const prog = categoryProgress.find((p) => p.category === cat)!;
+            return (
+              <Link
+                key={cat}
+                href="/holder/matcha/assessment"
+                style={{ display: 'block', textDecoration: 'none', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 12, padding: '14px 16px' }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{CATEGORY_META[cat].label}</span>
+                  <span style={{ fontSize: 12, color: 'var(--vt-text-muted)', fontVariantNumeric: 'tabular-nums' }}>{prog.answered}/{prog.total}</span>
+                </div>
+                <div style={{ marginTop: 10, height: 5, borderRadius: 999, background: 'var(--vt-border, #E2E8E6)', overflow: 'hidden' }}>
+                  <div style={{ width: `${Math.max(2, prog.percent)}%`, height: '100%', background: ACCENT, borderRadius: 999 }} />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
       </div>
 
       {/* Wave 2 profile */}

--- a/apps/web/components/matcha/MatchaStepInput.tsx
+++ b/apps/web/components/matcha/MatchaStepInput.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * MatchaStepInput — a controlled input for a single onboarding/assessment step.
+ *
+ * Renders the right control for the step kind (chips, scale, tags, number, boolean) and reports
+ * changes via onChange. Unlike the linear onboarding flow, this does not auto-advance — it's the
+ * shared control used by the browsable Personal/Professional/Place assessment.
+ */
+
+import { useState } from 'react';
+import type { MatchaPreferences, PreferenceField } from '@/lib/matcha/preferences';
+import { coerceAnswer, type OnboardingStep } from '@/lib/matcha/onboarding';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  fontSize: 14,
+  borderRadius: 10,
+  border: '1px solid var(--vt-border, #D6DED9)',
+  background: 'var(--vt-surface, #fff)',
+  color: 'var(--vt-text-primary)',
+  outline: 'none',
+};
+
+function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        padding: '8px 13px',
+        borderRadius: 10,
+        fontSize: 13,
+        fontWeight: 500,
+        cursor: 'pointer',
+        border: `1px solid ${active ? ACCENT : 'var(--vt-border, #D6DED9)'}`,
+        background: active ? `color-mix(in srgb, ${ACCENT} 12%, transparent)` : 'var(--vt-surface, #fff)',
+        color: active ? ACCENT : 'var(--vt-text-primary)',
+        transition: 'all 150ms cubic-bezier(0.2,0.8,0.2,1)',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function TagInput({ value, onChange, placeholder }: { value: string[]; onChange: (v: string[]) => void; placeholder?: string }) {
+  const [draft, setDraft] = useState('');
+  const commit = () => {
+    const v = draft.trim();
+    if (v && !value.includes(v)) onChange([...value, v]);
+    setDraft('');
+  };
+  return (
+    <div>
+      {value.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}>
+          {value.map((tag) => (
+            <span key={tag} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 9px', borderRadius: 999, background: `color-mix(in srgb, ${ACCENT} 12%, transparent)`, color: ACCENT, fontSize: 12, fontWeight: 500 }}>
+              {tag}
+              <button type="button" aria-label={`Remove ${tag}`} onClick={() => onChange(value.filter((t) => t !== tag))} style={{ border: 0, background: 'transparent', color: 'inherit', cursor: 'pointer', fontSize: 13, lineHeight: 1 }}>×</button>
+            </span>
+          ))}
+        </div>
+      )}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); commit(); } }}
+        onBlur={commit}
+        placeholder={placeholder ?? 'Type and press Enter'}
+        style={inputStyle}
+      />
+    </div>
+  );
+}
+
+export interface MatchaStepInputProps {
+  step: OnboardingStep;
+  value: MatchaPreferences[PreferenceField];
+  onChange: (value: MatchaPreferences[PreferenceField]) => void;
+}
+
+export function MatchaStepInput({ step, value, onChange }: MatchaStepInputProps) {
+  switch (step.kind) {
+    case 'boolean':
+      return (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Chip label="Yes" active={value === true} onClick={() => onChange(true as never)} />
+          <Chip label="No" active={value === false} onClick={() => onChange(false as never)} />
+        </div>
+      );
+
+    case 'scale':
+    case 'chips_single':
+      return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {step.options?.map((opt) => (
+            <Chip
+              key={opt.value}
+              label={opt.label}
+              active={value === opt.value}
+              onClick={() => onChange(opt.value as never)}
+            />
+          ))}
+        </div>
+      );
+
+    case 'chips_multi': {
+      const arr = Array.isArray(value) ? (value as string[]) : [];
+      return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {step.options?.map((opt) => {
+            const active = arr.includes(opt.value);
+            return (
+              <Chip
+                key={opt.value}
+                label={opt.label}
+                active={active}
+                onClick={() => onChange((active ? arr.filter((v) => v !== opt.value) : [...arr, opt.value]) as never)}
+              />
+            );
+          })}
+        </div>
+      );
+    }
+
+    case 'tags':
+      return (
+        <TagInput
+          value={Array.isArray(value) ? (value as string[]) : []}
+          onChange={(v) => onChange(coerceAnswer(step, v))}
+          placeholder={step.hint}
+        />
+      );
+
+    case 'number':
+      return (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input
+            type="text"
+            inputMode="numeric"
+            defaultValue={typeof value === 'number' ? String(value) : ''}
+            placeholder={step.numberPlaceholder}
+            onBlur={(e) => onChange(coerceAnswer(step, e.target.value))}
+            onKeyDown={(e) => { if (e.key === 'Enter') onChange(coerceAnswer(step, (e.target as HTMLInputElement).value)); }}
+            style={{ ...inputStyle, maxWidth: 180 }}
+          />
+          {step.numberUnit ? <span style={{ fontSize: 13, color: 'var(--vt-text-muted)' }}>{step.numberUnit}</span> : null}
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}

--- a/apps/web/lib/matcha/categories.ts
+++ b/apps/web/lib/matcha/categories.ts
@@ -1,0 +1,146 @@
+/**
+ * MATCHA match-question categories — Personal / Professional / Place.
+ *
+ * Mirrors the three-bucket "Match Questions" model clinicians expect: answer as many as you
+ * like, and the more you answer, the sharper the match. Every preference field maps to exactly
+ * one category, so per-category completeness is well-defined and honest (answered / total).
+ *
+ * This is a pure re-view of the existing MatchaPreferences spine — no new data, no fabrication.
+ */
+
+import {
+  type MatchaPreferences,
+  type PreferenceField,
+  ALL_PREFERENCE_FIELDS,
+  isFieldAnswered,
+} from './preferences';
+import { ONBOARDING_STEPS, type OnboardingStep } from './onboarding';
+
+export type MatchCategory = 'personal' | 'professional' | 'place';
+
+export interface CategoryMeta {
+  key: MatchCategory;
+  label: string;
+  blurb: string;
+}
+
+export const CATEGORY_META: Record<MatchCategory, CategoryMeta> = {
+  personal: {
+    key: 'personal',
+    label: 'Personal',
+    blurb: 'Who you are, what you value, and where your career is headed.',
+  },
+  professional: {
+    key: 'professional',
+    label: 'Professional',
+    blurb: 'Your practice, credentials, and the terms you work under.',
+  },
+  place: {
+    key: 'place',
+    label: 'Place',
+    blurb: 'Where you want to work and the kind of setting that fits.',
+  },
+};
+
+export const CATEGORY_ORDER: readonly MatchCategory[] = ['personal', 'professional', 'place'];
+
+/** Every preference field mapped to exactly one category. */
+export const FIELD_CATEGORY: Record<PreferenceField, MatchCategory> = {
+  // Personal — identity, values, background, growth
+  careerGoals: 'personal',
+  careerDirection: 'personal',
+  leadershipAspiration: 'personal',
+  yearsExperience: 'personal',
+  newGraduate: 'personal',
+  visaSponsorshipNeeded: 'personal',
+  greenCardStatus: 'personal',
+  military: 'personal',
+  languagesSpoken: 'personal',
+  workLifeBalanceImportance: 'personal',
+  academicMedicineInterest: 'personal',
+  researchInterest: 'personal',
+  teachingInterest: 'personal',
+  managementInterest: 'personal',
+  aiInterest: 'personal',
+  blockchainInterest: 'personal',
+  entrepreneurInterest: 'personal',
+
+  // Professional — practice, credentials, work terms, compensation
+  currentSpecialties: 'professional',
+  desiredSpecialties: 'professional',
+  favoriteProcedures: 'professional',
+  populationPreferences: 'professional',
+  certifications: 'professional',
+  futureCertifications: 'professional',
+  licenses: 'professional',
+  preferredEMRs: 'professional',
+  employmentTypes: 'professional',
+  shiftPreference: 'professional',
+  scheduleFlexibility: 'professional',
+  startUrgency: 'professional',
+  telehealthInterest: 'professional',
+  desiredSalary: 'professional',
+  minimumSalary: 'professional',
+  signOnBonusImportance: 'professional',
+  ptoImportance: 'professional',
+  retirementImportance: 'professional',
+  healthInsuranceImportance: 'professional',
+
+  // Place — location, mobility, organization type & culture
+  preferredStates: 'place',
+  statesWillingToLicense: 'place',
+  geographicFlexibility: 'place',
+  commuteRadiusMiles: 'place',
+  remoteInterest: 'place',
+  travelInterest: 'place',
+  missionDrivenImportance: 'place',
+  communityHospitalInterest: 'place',
+  academicHospitalInterest: 'place',
+  privatePracticeInterest: 'place',
+  largeHealthSystemInterest: 'place',
+  startupInterest: 'place',
+  teamSizePreference: 'place',
+  patientVolumePreference: 'place',
+  culturePreference: 'place',
+  diversityImportance: 'place',
+};
+
+/** The preference fields belonging to a category. */
+export function categoryFields(category: MatchCategory): PreferenceField[] {
+  return ALL_PREFERENCE_FIELDS.filter((f) => FIELD_CATEGORY[f] === category);
+}
+
+/** The onboarding steps (question definitions) for a category, in script order. */
+export function stepsForCategory(category: MatchCategory): OnboardingStep[] {
+  return ONBOARDING_STEPS.filter(
+    (s) => s.kind !== 'intro' && s.field !== undefined && FIELD_CATEGORY[s.field] === category,
+  );
+}
+
+export interface CategoryProgress {
+  category: MatchCategory;
+  answered: number;
+  total: number;
+  percent: number;
+}
+
+/** Per-category completeness — answered vs total fields in that category. */
+export function categoryProgress(
+  prefs: MatchaPreferences,
+  category: MatchCategory,
+): CategoryProgress {
+  const fields = categoryFields(category);
+  const answered = fields.reduce((n, f) => (isFieldAnswered(prefs[f]) ? n + 1 : n), 0);
+  const total = fields.length;
+  return {
+    category,
+    answered,
+    total,
+    percent: total === 0 ? 0 : Math.round((answered / total) * 100),
+  };
+}
+
+/** Progress for all three categories, in canonical order. */
+export function allCategoryProgress(prefs: MatchaPreferences): CategoryProgress[] {
+  return CATEGORY_ORDER.map((c) => categoryProgress(prefs, c));
+}


### PR DESCRIPTION
## What this adds

The three-bucket **Personal / Professional / Place** match-question model (BeginlyHealth-style), built on top of the MATCHA preference spine shipped in #518.

- **`lib/matcha/categories.ts`** — every preference field maps to exactly one category, with honest per-category and overall completeness (answered / total). A test asserts the mapping is a clean partition (every field categorized exactly once, no overlap).
- **`MatchaStepInput`** — shared controlled input (chips / scale / tags / number / boolean), so onboarding and the assessment render questions identically.
- **`MatchaAssessment` + `/holder/matcha/assessment`** (gated behind `MATCHA_V2`) — a browsable "answer as many as you like" surface with live per-category progress. Only engine-backed questions are labeled "affects matches."
- **`MatchaHub`** — adds a three-tile Match Questions widget with per-category progress.

## Truth contract
A pure re-view of the clinician's own stated preferences — no new data, no fabrication. Copy is honest ("the more you answer, the sharper your matches").

## Verification
- Typecheck clean; `next build` green (route registered).
- 7 new tests (clean-partition + progress math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)