### PR TITLE
feat(matcha): opportunity actions + honest livability

### DIFF
--- a/apps/web/__tests__/matcha-opportunity-actions.test.ts
+++ b/apps/web/__tests__/matcha-opportunity-actions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bucketFor,
+  statusCounts,
+  type OpportunityActionMap,
+} from '../lib/matcha/opportunityActions';
+import { livabilityLookupUrl, locationLabel } from '../lib/matcha/livability';
+
+describe('opportunity actions — buckets & counts', () => {
+  it('treats an unacted opportunity as new', () => {
+    expect(bucketFor({}, 'opp1')).toBe('new');
+  });
+
+  it('reflects recorded status', () => {
+    const map: OpportunityActionMap = { opp1: 'saved', opp2: 'declined' };
+    expect(bucketFor(map, 'opp1')).toBe('saved');
+    expect(bucketFor(map, 'opp2')).toBe('declined');
+  });
+
+  it('counts new as ids with no recorded action, restricted to the given ids', () => {
+    const map: OpportunityActionMap = { opp1: 'saved', opp2: 'connected', ghost: 'declined' };
+    const counts = statusCounts(map, ['opp1', 'opp2', 'opp3', 'opp4']);
+    expect(counts).toEqual({ new: 2, saved: 1, connected: 1, declined: 0 });
+    // 'ghost' is not among the shown ids, so it does not inflate declined
+  });
+
+  it('is all-new for an empty action map', () => {
+    expect(statusCounts({}, ['a', 'b', 'c'])).toEqual({ new: 3, saved: 0, connected: 0, declined: 0 });
+  });
+});
+
+describe('livability — honest external lookups', () => {
+  it('builds an external search URL scoped to category + location', () => {
+    const url = livabilityLookupUrl('cost_of_living', 'Oakland, CA');
+    expect(url).toContain('https://www.google.com/search?q=');
+    expect(decodeURIComponent(url)).toContain('Cost of living in Oakland, CA');
+  });
+
+  it('composes and de-duplicates the location label', () => {
+    expect(locationLabel({ location: 'Oakland, CA', state: 'CA' })).toBe('Oakland, CA');
+    expect(locationLabel({ location: 'Austin', state: 'TX' })).toBe('Austin, TX');
+    expect(locationLabel({})).toBeNull();
+  });
+});

--- a/apps/web/components/matcha/Livability.tsx
+++ b/apps/web/components/matcha/Livability.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+/**
+ * Livability — honest relocation context for an opportunity.
+ *
+ * Renders category tiles that link to external lookups scoped to the location. VitalCV does not
+ * estimate these figures; the copy says so. Remote roles show a distinct, honest note instead of
+ * relocation data.
+ */
+
+import { MapPin, ExternalLink, Laptop } from 'lucide-react';
+import {
+  LIVABILITY_CATEGORIES,
+  livabilityLookupUrl,
+  locationLabel,
+} from '@/lib/matcha/livability';
+
+export interface LivabilityProps {
+  location?: string;
+  state?: string;
+  remote?: boolean;
+}
+
+export function Livability({ location, state, remote }: LivabilityProps) {
+  const label = locationLabel({ location, state });
+
+  if (remote) {
+    return (
+      <div style={{ marginTop: 16, padding: '14px 16px', borderRadius: 12, border: '1px solid var(--vt-border, #E2E8E6)', background: 'var(--vt-surface-subtle, #EDF2F0)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+          <Laptop size={15} aria-hidden="true" /> Remote role
+        </div>
+        <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--vt-text-secondary)', lineHeight: 1.5 }}>
+          No relocation needed — live where you like. {label ? `Team based in ${label}.` : ''}
+        </p>
+      </div>
+    );
+  }
+
+  if (!label) return null;
+
+  return (
+    <div style={{ marginTop: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+        <MapPin size={15} aria-hidden="true" style={{ color: 'var(--vt-accent, #0A7B7F)' }} />
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Livability — {label}</span>
+      </div>
+      <p style={{ margin: '0 0 10px', fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>
+        Relocation context from external sources. VitalCV doesn&rsquo;t estimate these figures.
+      </p>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8 }}>
+        {LIVABILITY_CATEGORIES.map((cat) => (
+          <a
+            key={cat.key}
+            href={livabilityLookupUrl(cat.key, label)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: 'block',
+              textDecoration: 'none',
+              border: '1px solid var(--vt-border, #E2E8E6)',
+              borderRadius: 10,
+              padding: '10px 12px',
+              background: 'var(--vt-surface, #fff)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{cat.label}</span>
+              <ExternalLink size={12} aria-hidden="true" style={{ color: 'var(--vt-text-muted)', flex: '0 0 auto' }} />
+            </div>
+            <span style={{ fontSize: 11, color: 'var(--vt-text-muted)' }}>{cat.hint}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -6,14 +6,16 @@
  * on from the clinician's own stored answers. Honest empty / loading / error states.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { useMatchaPreferences } from './useMatchaPreferences';
 import {
-  OpportunityIntelligenceCard,
   type IntelligenceExplanation,
   type IntelligenceOpportunity,
 } from './OpportunityIntelligenceCard';
+import { OpportunityCard } from './OpportunityCard';
+import { useOpportunityActions } from './useOpportunityActions';
+import { BUCKET_LABEL, BUCKET_ORDER } from '@/lib/matcha/opportunityActions';
 import { preferenceMatchReasons, type FitOpportunity } from '@/lib/matcha/opportunityFit';
 
 interface RawMatch {
@@ -27,9 +29,16 @@ export function MatchaOpportunitiesSurface() {
   const { data } = useClinicianMobile();
   const npi = data.workspace?.personProfile?.npi ?? null;
   const { preferences } = useMatchaPreferences(npi ?? undefined);
+  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions();
 
   const [matches, setMatches] = useState<RawMatch[]>([]);
   const [state, setState] = useState<LoadState>('loading');
+
+  const ids = useMemo(
+    () => matches.map((m) => m.opportunity?.id).filter((id): id is string => Boolean(id)),
+    [matches],
+  );
+  const bucketCounts = counts(ids);
 
   useEffect(() => {
     if (!npi) {
@@ -64,6 +73,18 @@ export function MatchaOpportunitiesSurface() {
         </p>
       </header>
 
+      {/* Status counters — New / Saved / Connected / Declined */}
+      {state === 'ready' && matches.length > 0 && actionsLoaded && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+          {BUCKET_ORDER.map((b) => (
+            <div key={b} style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 12, padding: '12px 10px', textAlign: 'center' }}>
+              <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--vt-text-primary)', fontVariantNumeric: 'tabular-nums' }}>{bucketCounts[b]}</div>
+              <div style={{ fontSize: 11, color: 'var(--vt-text-muted)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>{BUCKET_LABEL[b]}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
       {state === 'no-npi' && (
         <EmptyNote title="Add your NPI to get matches" body="Once your NPI is on file, MATCHA can score real opportunities for you." />
       )}
@@ -81,12 +102,13 @@ export function MatchaOpportunitiesSurface() {
           if (!opp?.id) return null;
           const reasons = preferenceMatchReasons(preferences, opp);
           return (
-            <OpportunityIntelligenceCard
+            <OpportunityCard
               key={opp.id ?? i}
               opportunity={opp}
               explanation={m.explanation}
               preferenceReasons={reasons}
-              href={`/holder/opportunities`}
+              bucket={bucketOf(opp.id)}
+              onSetStatus={(status) => setStatus(opp.id, status)}
             />
           );
         })}

--- a/apps/web/components/matcha/OpportunityCard.tsx
+++ b/apps/web/components/matcha/OpportunityCard.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+/**
+ * OpportunityCard — interactive wrapper around OpportunityIntelligenceCard.
+ * Adds the clinician's Save / Connect / Decline actions and the honest Livability section.
+ * Status is owned by the surface (one shared action map) and passed in.
+ */
+
+import { Bookmark, Check, X } from 'lucide-react';
+import {
+  OpportunityIntelligenceCard,
+  type IntelligenceExplanation,
+  type IntelligenceOpportunity,
+} from './OpportunityIntelligenceCard';
+import { Livability } from './Livability';
+import type { ExplanationReason } from './MatchaExplanation';
+import type { OpportunityBucket, OpportunityStatus } from '@/lib/matcha/opportunityActions';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+const GREEN = 'var(--vt-status-resolved, #2E7D45)';
+const MUTED_BORDER = 'var(--vt-border, #D6DED9)';
+
+interface ActionDef {
+  status: OpportunityStatus;
+  label: string;
+  activeLabel: string;
+  icon: typeof Bookmark;
+  color: string;
+}
+
+const ACTIONS: ActionDef[] = [
+  { status: 'saved', label: 'Save', activeLabel: 'Saved', icon: Bookmark, color: ACCENT },
+  { status: 'connected', label: 'Connect', activeLabel: 'Connected', icon: Check, color: GREEN },
+  { status: 'declined', label: 'Decline', activeLabel: 'Declined', icon: X, color: 'var(--vt-text-muted, #5A6472)' },
+];
+
+export interface OpportunityCardProps {
+  opportunity: IntelligenceOpportunity;
+  explanation?: IntelligenceExplanation;
+  preferenceReasons?: ExplanationReason[];
+  bucket: OpportunityBucket;
+  onSetStatus: (status: OpportunityStatus) => void;
+}
+
+export function OpportunityCard({ opportunity, explanation, preferenceReasons, bucket, onSetStatus }: OpportunityCardProps) {
+  const declined = bucket === 'declined';
+  return (
+    <div style={{ opacity: declined ? 0.6 : 1, transition: 'opacity 200ms' }}>
+      <OpportunityIntelligenceCard
+        opportunity={opportunity}
+        explanation={explanation}
+        preferenceReasons={preferenceReasons}
+      >
+        {/* Action bar */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
+          {ACTIONS.map((a) => {
+            const active = bucket === a.status;
+            const Icon = a.icon;
+            return (
+              <button
+                key={a.status}
+                type="button"
+                onClick={() => onSetStatus(a.status)}
+                aria-pressed={active}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  padding: '8px 14px',
+                  borderRadius: 10,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  border: `1px solid ${active ? a.color : MUTED_BORDER}`,
+                  background: active ? `color-mix(in srgb, ${a.color} 12%, transparent)` : 'var(--vt-surface, #fff)',
+                  color: active ? a.color : 'var(--vt-text-primary)',
+                  transition: 'all 150ms cubic-bezier(0.2,0.8,0.2,1)',
+                }}
+              >
+                <Icon size={14} aria-hidden="true" />
+                {active ? a.activeLabel : a.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Livability */}
+        <Livability location={opportunity.location} state={opportunity.state} remote={opportunity.remote} />
+      </OpportunityIntelligenceCard>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
+++ b/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
@@ -46,6 +46,8 @@ export interface OpportunityIntelligenceCardProps {
   /** Preference-grounded reasons from opportunityFit.preferenceMatchReasons. */
   preferenceReasons?: ExplanationReason[];
   href?: string;
+  /** Interactive content injected before the honesty footer (action bar, livability). */
+  children?: React.ReactNode;
 }
 
 const TONE_COLORS: Record<string, string> = {
@@ -74,6 +76,7 @@ export function OpportunityIntelligenceCard({
   explanation,
   preferenceReasons = [],
   href,
+  children,
 }: OpportunityIntelligenceCardProps) {
   const band = explanation ? matchBandDisplay(explanation.matchBand) : null;
   const bandColor = band ? TONE_COLORS[band.tone] : 'var(--vt-text-muted)';
@@ -189,6 +192,9 @@ export function OpportunityIntelligenceCard({
           Eligible for an instant offer based on your current trust state.
         </div>
       ) : null}
+
+      {/* Interactive slot: action bar + livability */}
+      {children}
 
       {/* Honesty footer: what these scores are based on */}
       <p style={{ margin: '16px 0 0', fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>

--- a/apps/web/components/matcha/useOpportunityActions.ts
+++ b/apps/web/components/matcha/useOpportunityActions.ts
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * useOpportunityActions — React state over the clinician's Save/Connect/Decline decisions,
+ * backed by localStorage. Toggling a status off returns the opportunity to "new".
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  type OpportunityActionMap,
+  type OpportunityBucket,
+  type OpportunityStatus,
+  bucketFor,
+  loadOpportunityActions,
+  persistOpportunityActions,
+  statusCounts,
+} from '@/lib/matcha/opportunityActions';
+
+export function useOpportunityActions() {
+  const [map, setMap] = useState<OpportunityActionMap>({});
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setMap(loadOpportunityActions());
+    setLoaded(true);
+  }, []);
+
+  const setStatus = useCallback((id: string, status: OpportunityStatus) => {
+    setMap((prev) => {
+      const next = { ...prev };
+      if (next[id] === status) {
+        delete next[id]; // toggle back to "new"
+      } else {
+        next[id] = status;
+      }
+      persistOpportunityActions(next);
+      return next;
+    });
+  }, []);
+
+  const bucketOf = useCallback((id: string): OpportunityBucket => bucketFor(map, id), [map]);
+  const counts = useCallback((ids: readonly string[]) => statusCounts(map, ids), [map]);
+
+  return { loaded, bucketOf, setStatus, counts };
+}

--- a/apps/web/lib/matcha/livability.ts
+++ b/apps/web/lib/matcha/livability.ts
@@ -1,0 +1,46 @@
+/**
+ * Livability lookups — honest relocation context for an opportunity.
+ *
+ * Truth rule: VitalCV does NOT fabricate cost-of-living, weather, walk-score, or school figures.
+ * Instead, each category links out to a real external lookup scoped to the opportunity's location.
+ * The UI states plainly that these are external sources, not VitalCV estimates. When the role is
+ * remote, relocation context is not asserted at all.
+ */
+
+export interface LivabilityCategory {
+  key: string;
+  label: string;
+  /** What the external lookup covers. */
+  hint: string;
+}
+
+export const LIVABILITY_CATEGORIES: readonly LivabilityCategory[] = [
+  { key: 'cost_of_living', label: 'Cost of living', hint: 'Overall affordability index' },
+  { key: 'housing', label: 'Housing', hint: 'Home prices & rent' },
+  { key: 'schools', label: 'Schools', hint: 'Ratings & districts' },
+  { key: 'commute', label: 'Commute', hint: 'Transit & drive times' },
+  { key: 'safety', label: 'Safety', hint: 'Crime & safety data' },
+  { key: 'weather', label: 'Weather', hint: 'Climate & seasons' },
+  { key: 'things_to_do', label: 'Things to do', hint: 'Amenities & recreation' },
+];
+
+/** Build an honest external search URL for a category + location. */
+export function livabilityLookupUrl(categoryKey: string, location: string): string {
+  const cat = LIVABILITY_CATEGORIES.find((c) => c.key === categoryKey);
+  const term = cat ? cat.label : '';
+  const query = `${term} in ${location}`.trim();
+  return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+}
+
+/** Compose a readable location string from opportunity fields. */
+export function locationLabel(input: { location?: string; state?: string }): string | null {
+  const loc = input.location?.trim();
+  const st = input.state?.trim();
+  if (loc && st) {
+    // Don't append the state if the location already references it (e.g. "Oakland, CA" + "CA").
+    const escaped = st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const alreadyHasState = new RegExp(`\\b${escaped}\\b`, 'i').test(loc);
+    return alreadyHasState ? loc : `${loc}, ${st}`;
+  }
+  return loc || st || null;
+}

--- a/apps/web/lib/matcha/opportunityActions.ts
+++ b/apps/web/lib/matcha/opportunityActions.ts
@@ -1,0 +1,75 @@
+/**
+ * Opportunity actions — the clinician's own Save / Connect / Decline decisions.
+ *
+ * These are real user actions, persisted locally (the clinician owns them). "New" is simply an
+ * opportunity that hasn't been acted on yet. Pure + SSR-safe; the React hook lives in
+ * components/matcha/useOpportunityActions.ts.
+ */
+
+export type OpportunityStatus = 'saved' | 'connected' | 'declined';
+export type OpportunityBucket = 'new' | OpportunityStatus;
+
+export type OpportunityActionMap = Record<string, OpportunityStatus>;
+
+export const OPPORTUNITY_ACTIONS_KEY = 'vitalcv.matcha.opportunity-actions';
+
+export const BUCKET_ORDER: readonly OpportunityBucket[] = ['new', 'saved', 'connected', 'declined'];
+
+export const BUCKET_LABEL: Record<OpportunityBucket, string> = {
+  new: 'New',
+  saved: 'Saved',
+  connected: 'Connected',
+  declined: 'Declined',
+};
+
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadOpportunityActions(): OpportunityActionMap {
+  const ls = safeLocalStorage();
+  if (!ls) return {};
+  try {
+    const raw = ls.getItem(OPPORTUNITY_ACTIONS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as OpportunityActionMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function persistOpportunityActions(map: OpportunityActionMap): void {
+  const ls = safeLocalStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(OPPORTUNITY_ACTIONS_KEY, JSON.stringify(map));
+  } catch {
+    /* no-op */
+  }
+}
+
+/** The bucket an opportunity falls in — acted-on status, or 'new' if untouched. */
+export function bucketFor(map: OpportunityActionMap, id: string): OpportunityBucket {
+  return map[id] ?? 'new';
+}
+
+/**
+ * Count opportunities per bucket across a known set of ids. "new" = ids with no recorded action;
+ * saved/connected/declined come from recorded actions (restricted to the given ids).
+ */
+export function statusCounts(
+  map: OpportunityActionMap,
+  ids: readonly string[],
+): Record<OpportunityBucket, number> {
+  const counts: Record<OpportunityBucket, number> = { new: 0, saved: 0, connected: 0, declined: 0 };
+  for (const id of ids) {
+    counts[bucketFor(map, id)] += 1;
+  }
+  return counts;
+}


### PR DESCRIPTION
## What this adds

Enriches the Opportunity Intelligence cards toward BeginlyHealth depth — inside the truth contract.

- **Save / Connect / Decline** per opportunity, persisted locally (the clinician owns these); toggling off returns to **New**. A **New / Saved / Connected / Declined** counter bar sits above the list.
- **Livability** section: honest relocation context. VitalCV does **not** fabricate cost-of-living / weather / school figures — each category links to an external lookup scoped to the location, and the copy says so. Remote roles show a "no relocation needed" note instead.
- `OpportunityIntelligenceCard` gains a `children` slot so the action bar + livability compose inside the card without touching its scored, tested core.

## Truth contract
No fabricated numbers. Actions are the clinician's own; livability points to external sources rather than inventing figures in-app.

## Verification
- Typecheck clean; `next build` green.
- 6 new tests (bucket counts + livability URL/label, incl. a de-dup fix for "Oakland, CA" + "CA").

🤖 Generated with [Claude Code](https://claude.com/claude-code)