### PR TITLE
feat(matcha): clinician dashboard — greeting, next actions, opportunity snapshot

### DIFF
--- a/apps/web/__tests__/matcha-next-actions.test.ts
+++ b/apps/web/__tests__/matcha-next-actions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveNextActions, type NextActionInput } from '../lib/matcha/nextActions';
+
+const CATS: NextActionInput['categories'] = [
+  { category: 'personal', answered: 5, total: 17, percent: 29 },
+  { category: 'professional', answered: 2, total: 19, percent: 11 },
+  { category: 'place', answered: 10, total: 16, percent: 63 },
+];
+
+describe('deriveNextActions — grounded in real gaps', () => {
+  it('leads with adding an NPI when missing', () => {
+    const actions = deriveNextActions({ hasNpi: false, completeness: 40, categories: CATS, newMatches: 0, savedMatches: 0 });
+    expect(actions[0].id).toBe('add-npi');
+    expect(actions[0].primary).toBe(true);
+    expect(actions[0].href).toBe('/holder');
+  });
+
+  it('surfaces new matches with a correct count and pluralization', () => {
+    const one = deriveNextActions({ hasNpi: true, completeness: 40, categories: CATS, newMatches: 1, savedMatches: 0 });
+    expect(one.find((a) => a.id === 'review-matches')?.label).toContain('1 new match');
+    const many = deriveNextActions({ hasNpi: true, completeness: 40, categories: CATS, newMatches: 3, savedMatches: 0 });
+    expect(many.find((a) => a.id === 'review-matches')?.label).toContain('3 new matches');
+  });
+
+  it('nudges the thinnest match-question category', () => {
+    const actions = deriveNextActions({ hasNpi: true, completeness: 40, categories: CATS, newMatches: 0, savedMatches: 0 });
+    // professional is thinnest (11%)
+    expect(actions.some((a) => a.id === 'answer-professional')).toBe(true);
+  });
+
+  it('asks the clinician to start when nothing is answered', () => {
+    const actions = deriveNextActions({ hasNpi: true, completeness: 0, categories: [], newMatches: 0, savedMatches: 0 });
+    expect(actions.some((a) => a.id === 'meet-matcha')).toBe(true);
+  });
+
+  it('de-duplicates by href and caps at four', () => {
+    const actions = deriveNextActions({ hasNpi: true, completeness: 30, categories: CATS, newMatches: 2, savedMatches: 4 });
+    const hrefs = actions.map((a) => a.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+    expect(actions.length).toBeLessThanOrEqual(4);
+  });
+
+  it('falls back to a single neutral action when everything is in good shape', () => {
+    const full: NextActionInput['categories'] = CATS.map((c) => ({ ...c, percent: 100 }));
+    const actions = deriveNextActions({ hasNpi: true, completeness: 100, categories: full, newMatches: 0, savedMatches: 0 });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].id).toBe('browse');
+  });
+});

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -1,18 +1,34 @@
 'use client';
 
 /**
- * MatchaHub — the signed-in home for the intelligence layer. Ties together Wave 2
- * ("MATCHA understands you"), Wave 10 ("MATCHA remembers"), and entry points to onboarding
- * and opportunities. Reads the clinician's NPI/name from the shared holder provider.
+ * MatchaHub — the signed-in MATCHA dashboard. Ties together the greeting, honest "what to do
+ * next", the opportunity snapshot (New/Saved/Connected/Declined + top matches), the match-question
+ * categories, "MATCHA understands you" (profile), and "MATCHA remembers" (memory). Every figure is
+ * real — completeness, category progress, action counts, and engine match scores.
  */
 
 import Link from 'next/link';
+import { useMemo } from 'react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { useMatchaPreferences } from './useMatchaPreferences';
+import { useMatchaOpportunities } from './useMatchaOpportunities';
+import { useOpportunityActions } from './useOpportunityActions';
 import { MatchaProfile } from './MatchaProfile';
+import { OpportunityCard } from './OpportunityCard';
 import { CATEGORY_META, CATEGORY_ORDER, allCategoryProgress } from '@/lib/matcha/categories';
+import { deriveNextActions } from '@/lib/matcha/nextActions';
+import { BUCKET_LABEL, BUCKET_ORDER } from '@/lib/matcha/opportunityActions';
+import { preferenceMatchReasons } from '@/lib/matcha/opportunityFit';
 
 const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+      {children}
+    </div>
+  );
+}
 
 export function MatchaHub() {
   const { data } = useClinicianMobile();
@@ -23,11 +39,73 @@ export function MatchaHub() {
   const { preferences, derived, completeness, memory, loaded } = useMatchaPreferences(npi);
   const categoryProgress = allCategoryProgress(preferences);
 
+  const { matches, state: oppState } = useMatchaOpportunities(npi ?? null);
+  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions();
+
+  const oppIds = useMemo(
+    () => matches.map((m) => m.opportunity?.id).filter((id): id is string => Boolean(id)),
+    [matches],
+  );
+  const bucketCounts = counts(oppIds);
+
+  const nextActions = deriveNextActions({
+    hasNpi: Boolean(npi),
+    completeness,
+    categories: categoryProgress,
+    newMatches: bucketCounts.new,
+    savedMatches: bucketCounts.saved,
+  });
+
+  const topMatches = useMemo(
+    () =>
+      [...matches]
+        .filter((m) => m.opportunity?.id)
+        .sort((a, b) => (b.explanation?.matchScore ?? 0) - (a.explanation?.matchScore ?? 0))
+        .slice(0, 2),
+    [matches],
+  );
+
   const started = completeness > 0;
+  const hasMatches = oppState === 'ready' && matches.length > 0;
 
   return (
     <div style={{ maxWidth: 960, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 24 }}>
-      {/* Recently learned — Wave 10 */}
+      {/* Greeting + what to do next */}
+      <Panel>
+        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>
+          {firstName ? `Welcome back, ${firstName}.` : 'Welcome to MATCHA.'}
+        </h1>
+        <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', lineHeight: 1.5 }}>
+          {started
+            ? `MATCHA is ${completeness}% tuned to you. Here's where to take it next.`
+            : "Let's get MATCHA working for you — a few answers is all it takes to start."}
+        </p>
+        <div style={{ marginTop: 16, display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+          {nextActions.map((a) => (
+            <Link
+              key={a.id}
+              href={a.href}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '10px 16px',
+                borderRadius: 999,
+                fontSize: 13,
+                fontWeight: 600,
+                textDecoration: 'none',
+                border: `1px solid ${a.primary ? ACCENT : 'var(--vt-border, #D6DED9)'}`,
+                background: a.primary ? ACCENT : 'var(--vt-surface, #fff)',
+                color: a.primary ? '#fff' : 'var(--vt-text-primary)',
+              }}
+            >
+              {a.label} →
+            </Link>
+          ))}
+        </div>
+      </Panel>
+
+      {/* Recently learned — memory */}
       {loaded && memory.length > 0 && (
         <div
           style={{
@@ -50,49 +128,43 @@ export function MatchaHub() {
         </div>
       )}
 
-      {/* Onboarding CTA */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: 16,
-          flexWrap: 'wrap',
-          background: 'var(--vt-surface, #fff)',
-          border: '1px solid var(--vt-border, #E2E8E6)',
-          borderRadius: 16,
-          padding: 20,
-        }}
-      >
-        <div>
-          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
-            {started ? 'Keep teaching MATCHA' : 'Meet MATCHA'}
-          </h1>
-          <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', maxWidth: 520, lineHeight: 1.5 }}>
-            {started
-              ? `You've shared ${completeness}% of your preferences. Each answer sharpens the roles MATCHA surfaces for you.`
-              : 'A short conversation about what you want next. MATCHA uses it to work in the background on your behalf.'}
-          </p>
-        </div>
-        <Link
-          href="/holder/matcha/onboarding"
-          style={{
-            padding: '11px 22px',
-            borderRadius: 12,
-            background: ACCENT,
-            color: '#fff',
-            fontSize: 15,
-            fontWeight: 600,
-            textDecoration: 'none',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {started ? 'Continue' : 'Start'}
-        </Link>
-      </div>
+      {/* Opportunity snapshot — counters + top matches */}
+      {hasMatches && actionsLoaded && (
+        <Panel>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
+            <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Your opportunities</h2>
+            <Link href="/holder/matcha/opportunities" style={{ fontSize: 13, fontWeight: 600, color: ACCENT, textDecoration: 'none' }}>
+              View all →
+            </Link>
+          </div>
+          <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+            {BUCKET_ORDER.map((b) => (
+              <div key={b} style={{ border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 12, padding: '12px 10px', textAlign: 'center' }}>
+                <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--vt-text-primary)', fontVariantNumeric: 'tabular-nums' }}>{bucketCounts[b]}</div>
+                <div style={{ fontSize: 11, color: 'var(--vt-text-muted)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>{BUCKET_LABEL[b]}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 16, display: 'grid', gap: 12 }}>
+            {topMatches.map((m, i) => {
+              const opp = m.opportunity!;
+              return (
+                <OpportunityCard
+                  key={opp.id ?? i}
+                  opportunity={opp}
+                  explanation={m.explanation}
+                  preferenceReasons={preferenceMatchReasons(preferences, opp)}
+                  bucket={bucketOf(opp.id)}
+                  onSetStatus={(status) => setStatus(opp.id, status)}
+                />
+              );
+            })}
+          </div>
+        </Panel>
+      )}
 
       {/* Match questions — Personal / Professional / Place */}
-      <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+      <Panel>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
           <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Match questions</h2>
           <Link href="/holder/matcha/assessment" style={{ fontSize: 13, fontWeight: 600, color: ACCENT, textDecoration: 'none' }}>
@@ -122,27 +194,17 @@ export function MatchaHub() {
             );
           })}
         </div>
-      </div>
+      </Panel>
 
-      {/* Wave 2 profile */}
+      {/* MATCHA understands you — profile */}
       <MatchaProfile derived={derived} clinicianName={firstName} />
 
-      {/* Link to intelligence opportunities */}
-      {started && (
+      {!started && (
         <Link
-          href="/holder/matcha/opportunities"
-          style={{
-            textAlign: 'center',
-            padding: '14px 18px',
-            borderRadius: 12,
-            border: `1px solid ${ACCENT}`,
-            color: ACCENT,
-            fontWeight: 600,
-            fontSize: 15,
-            textDecoration: 'none',
-          }}
+          href="/holder/matcha/onboarding"
+          style={{ textAlign: 'center', padding: '14px 18px', borderRadius: 12, background: ACCENT, color: '#fff', fontWeight: 600, fontSize: 15, textDecoration: 'none' }}
         >
-          See opportunities MATCHA found for you →
+          Start with MATCHA →
         </Link>
       )}
     </div>

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -6,61 +6,27 @@
  * on from the clinician's own stored answers. Honest empty / loading / error states.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { useMatchaPreferences } from './useMatchaPreferences';
-import {
-  type IntelligenceExplanation,
-  type IntelligenceOpportunity,
-} from './OpportunityIntelligenceCard';
 import { OpportunityCard } from './OpportunityCard';
 import { useOpportunityActions } from './useOpportunityActions';
+import { useMatchaOpportunities } from './useMatchaOpportunities';
 import { BUCKET_LABEL, BUCKET_ORDER } from '@/lib/matcha/opportunityActions';
-import { preferenceMatchReasons, type FitOpportunity } from '@/lib/matcha/opportunityFit';
-
-interface RawMatch {
-  opportunity?: Record<string, unknown> & IntelligenceOpportunity & FitOpportunity;
-  explanation?: IntelligenceExplanation;
-}
-
-type LoadState = 'loading' | 'ready' | 'error' | 'no-npi';
+import { preferenceMatchReasons } from '@/lib/matcha/opportunityFit';
 
 export function MatchaOpportunitiesSurface() {
   const { data } = useClinicianMobile();
   const npi = data.workspace?.personProfile?.npi ?? null;
   const { preferences } = useMatchaPreferences(npi ?? undefined);
   const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions();
-
-  const [matches, setMatches] = useState<RawMatch[]>([]);
-  const [state, setState] = useState<LoadState>('loading');
+  const { matches, state } = useMatchaOpportunities(npi);
 
   const ids = useMemo(
     () => matches.map((m) => m.opportunity?.id).filter((id): id is string => Boolean(id)),
     [matches],
   );
   const bucketCounts = counts(ids);
-
-  useEffect(() => {
-    if (!npi) {
-      setState('no-npi');
-      return;
-    }
-    let cancelled = false;
-    setState('loading');
-    fetch(`/api/matcha/opportunities/${encodeURIComponent(npi)}`, { signal: AbortSignal.timeout(16_000) })
-      .then((r) => r.json())
-      .then((payload: { matches?: RawMatch[] }) => {
-        if (cancelled) return;
-        setMatches(Array.isArray(payload.matches) ? payload.matches : []);
-        setState('ready');
-      })
-      .catch(() => {
-        if (!cancelled) setState('error');
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [npi]);
 
   return (
     <div style={{ maxWidth: 820, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 16 }}>

--- a/apps/web/components/matcha/useMatchaOpportunities.ts
+++ b/apps/web/components/matcha/useMatchaOpportunities.ts
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * useMatchaOpportunities — fetches live matches from the MATCHA engine for an NPI.
+ * Shared by the opportunities surface and the dashboard so the fetch lives in one place.
+ */
+
+import { useEffect, useState } from 'react';
+import type {
+  IntelligenceExplanation,
+  IntelligenceOpportunity,
+} from './OpportunityIntelligenceCard';
+import type { FitOpportunity } from '@/lib/matcha/opportunityFit';
+
+export interface RawMatch {
+  opportunity?: Record<string, unknown> & IntelligenceOpportunity & FitOpportunity;
+  explanation?: IntelligenceExplanation;
+}
+
+export type MatchLoadState = 'loading' | 'ready' | 'error' | 'no-npi';
+
+export function useMatchaOpportunities(npi: string | null | undefined) {
+  const [matches, setMatches] = useState<RawMatch[]>([]);
+  const [state, setState] = useState<MatchLoadState>('loading');
+
+  useEffect(() => {
+    if (!npi) {
+      setState('no-npi');
+      setMatches([]);
+      return;
+    }
+    let cancelled = false;
+    setState('loading');
+    fetch(`/api/matcha/opportunities/${encodeURIComponent(npi)}`, { signal: AbortSignal.timeout(16_000) })
+      .then((r) => r.json())
+      .then((payload: { matches?: RawMatch[] }) => {
+        if (cancelled) return;
+        setMatches(Array.isArray(payload.matches) ? payload.matches : []);
+        setState('ready');
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  return { matches, state };
+}

--- a/apps/web/lib/matcha/nextActions.ts
+++ b/apps/web/lib/matcha/nextActions.ts
@@ -1,0 +1,83 @@
+/**
+ * "What to do next" — derives the clinician's most useful next steps from real MATCHA state.
+ *
+ * Pure and honest: every suggestion is grounded in an actual gap (no NPI, unreviewed matches,
+ * a thin match-question category, a low overall completeness). If everything is in good shape,
+ * it falls back to a single neutral suggestion rather than inventing urgency.
+ */
+
+import { CATEGORY_META, type MatchCategory } from './categories';
+
+export interface NextActionInput {
+  hasNpi: boolean;
+  completeness: number;
+  categories: Array<{ category: MatchCategory; answered: number; total: number; percent: number }>;
+  newMatches: number;
+  savedMatches: number;
+}
+
+export interface NextAction {
+  id: string;
+  label: string;
+  href: string;
+  primary: boolean;
+}
+
+const ASSESS = '/holder/matcha/assessment';
+const OPPS = '/holder/matcha/opportunities';
+
+export function deriveNextActions(input: NextActionInput): NextAction[] {
+  const actions: NextAction[] = [];
+
+  if (!input.hasNpi) {
+    actions.push({ id: 'add-npi', label: 'Add your NPI to unlock matches', href: '/holder', primary: true });
+  }
+
+  if (input.newMatches > 0) {
+    actions.push({
+      id: 'review-matches',
+      label: `Review ${input.newMatches} new match${input.newMatches === 1 ? '' : 'es'}`,
+      href: OPPS,
+      primary: true,
+    });
+  }
+
+  if (input.completeness === 0) {
+    actions.push({ id: 'meet-matcha', label: 'Answer your first match questions', href: '/holder/matcha/onboarding', primary: actions.length === 0 });
+  } else {
+    // Nudge the thinnest category first.
+    const thinnest = [...input.categories]
+      .filter((c) => c.percent < 100)
+      .sort((a, b) => a.percent - b.percent)[0];
+    if (thinnest) {
+      actions.push({
+        id: `answer-${thinnest.category}`,
+        label: `Answer more ${CATEGORY_META[thinnest.category].label} questions`,
+        href: ASSESS,
+        primary: actions.length === 0,
+      });
+    }
+  }
+
+  if (input.savedMatches > 0) {
+    actions.push({ id: 'revisit-saved', label: 'Revisit your saved opportunities', href: OPPS, primary: false });
+  }
+
+  if (input.completeness > 0 && input.completeness < 60) {
+    actions.push({ id: 'sharpen', label: 'Sharpen your profile for better matches', href: ASSESS, primary: false });
+  }
+
+  // De-duplicate by href, keep first (highest priority), cap at 4.
+  const seen = new Set<string>();
+  const deduped = actions.filter((a) => {
+    if (seen.has(a.href)) return false;
+    seen.add(a.href);
+    return true;
+  });
+
+  if (deduped.length === 0) {
+    deduped.push({ id: 'browse', label: 'Browse your opportunities', href: OPPS, primary: true });
+  }
+
+  return deduped.slice(0, 4);
+}


### PR DESCRIPTION
## What this adds

Turns the `/holder/matcha` hub into a real **clinician dashboard** (BeginlyHealth-style) — every figure grounded in real state.

- **Greeting** ("Welcome back, {name}") + a MATCHA-tuned completeness line.
- **What to do next** — honest, derived suggestions (`deriveNextActions`): add NPI, review N new matches, answer the thinnest match-question category, sharpen profile. Falls back to a single neutral action when nothing is pressing.
- **Opportunity snapshot** — New / Saved / Connected / Declined counters + the top 2 matches (by engine score) as interactive `OpportunityCard`s.
- **Shared `useMatchaOpportunities` hook** — the opportunities surface is refactored onto it, removing duplicate fetch logic.

## Truth contract
No fabricated numbers or urgency. Next actions come only from actual gaps; counts come from the clinician's own actions; match scores come from the engine.

## Verification
- Typecheck clean; `next build` green.
- 6 new tests for next-action derivation (counts/pluralization, thinnest-category nudge, dedup + cap, neutral fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)