### PR TITLE
feat(matcha): employer candidate pool

### DIFF
--- a/apps/web/__tests__/matcha-pool.test.ts
+++ b/apps/web/__tests__/matcha-pool.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bandDescriptor,
+  buildPoolQuery,
+  formatAvailability,
+  readinessLabel,
+} from '../lib/matcha/pool';
+
+const NOW = Date.parse('2026-07-04T00:00:00.000Z');
+
+describe('pool — filters & query', () => {
+  it('builds a query only from set filters', () => {
+    expect(buildPoolQuery({})).toBe('');
+    expect(buildPoolQuery({ specialty: 'Cardiology', trustBand: 'L2' })).toBe('specialty=Cardiology&trustBand=L2');
+    expect(buildPoolQuery({ state: 'CA', urgency: 'immediate' })).toBe('state=CA&urgency=immediate');
+  });
+
+  it('ignores blank filter values', () => {
+    expect(buildPoolQuery({ specialty: '   ', state: '' })).toBe('');
+  });
+});
+
+describe('pool — honest trust-band descriptors', () => {
+  it('describes source coverage without a bare "verified" claim', () => {
+    expect(bandDescriptor('L1').label).toBe('L1');
+    expect(bandDescriptor('L3').blurb).toBe('Comprehensive source coverage');
+    const all = ['L1', 'L2', 'L3', 'L0', undefined].map((b) => bandDescriptor(b).blurb.toLowerCase());
+    for (const blurb of all) {
+      expect(blurb).not.toBe('verified');
+      expect(blurb).not.toContain('automatically verified');
+    }
+  });
+
+  it('falls back to L0 for unknown bands', () => {
+    expect(bandDescriptor(undefined).label).toBe('L0');
+    expect(bandDescriptor('weird').label).toBe('L0');
+  });
+});
+
+describe('pool — availability & readiness formatting', () => {
+  it('reads absent or past availability as "Available now"', () => {
+    expect(formatAvailability(undefined, NOW)).toBe('Available now');
+    expect(formatAvailability('2026-06-01T00:00:00.000Z', NOW)).toBe('Available now');
+    expect(formatAvailability('not-a-date', NOW)).toBe('Available now');
+  });
+
+  it('formats a future availability date', () => {
+    expect(formatAvailability('2026-09-01T00:00:00.000Z', NOW)).toContain('Available');
+    expect(formatAvailability('2026-09-01T00:00:00.000Z', NOW)).not.toBe('Available now');
+  });
+
+  it('labels readiness honestly, guarding non-numbers', () => {
+    expect(readinessLabel(82)).toBe('Readiness 82/100');
+    expect(readinessLabel(undefined)).toBe('Readiness pending');
+    expect(readinessLabel(Number.NaN)).toBe('Readiness pending');
+  });
+});

--- a/apps/web/app/api/marketplace/pool/route.ts
+++ b/apps/web/app/api/marketplace/pool/route.ts
@@ -1,0 +1,30 @@
+/**
+ * GET /api/marketplace/pool — employer-facing credential-ready clinician pool.
+ * Proxies to backend GET /api/marketplace/pool (Clerk-gated). Forwards the caller's
+ * Clerk user id so the backend can authorize. Returns PHI-free pool entries only
+ * (NPI, specialty, locations, trust band, readiness score, availability, passport URL).
+ */
+
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { BACKEND_URL } from '@/lib/backend-url';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const qs = req.nextUrl.searchParams.toString();
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/marketplace/pool${qs ? `?${qs}` : ''}`, {
+      headers: { 'x-clerk-user-id': session.userId },
+      signal: AbortSignal.timeout(16_000),
+    });
+    const data = await res.json().catch(() => ({ error: 'Invalid response from backend', pool: [] }));
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch candidate pool', pool: [] }, { status: 502 });
+  }
+}

--- a/apps/web/app/employer/candidates/page.tsx
+++ b/apps/web/app/employer/candidates/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { FEATURES } from '@/lib/features';
+import { CandidatePoolSurface } from '@/components/matcha/employer/CandidatePoolSurface';
+
+export const metadata: Metadata = {
+  title: 'Credential-ready clinicians — VitalCV',
+  description: 'Browse a pool of clinicians with source-backed readiness and start a review.',
+};
+
+export default function EmployerCandidatesPage() {
+  if (!FEATURES.MATCHA_V2) notFound();
+  return <CandidatePoolSurface />;
+}

--- a/apps/web/components/matcha/employer/CandidateCard.tsx
+++ b/apps/web/components/matcha/employer/CandidateCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+/**
+ * CandidateCard — one credential-ready clinician in the employer pool.
+ *
+ * PHI-free: shows NPI, specialty, locations, trust band (source coverage), readiness score, and
+ * availability only. "Request review" wires into the real monetization flow: it POSTs to
+ * /api/request-review and navigates to the returned review surface. Honest errors (e.g. an
+ * employer workspace isn't set up yet) surface inline rather than failing silently.
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { MapPin, FileText, ArrowRight } from 'lucide-react';
+import {
+  bandDescriptor,
+  formatAvailability,
+  readinessLabel,
+  type PoolCandidate,
+} from '@/lib/matcha/pool';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+export function CandidateCard({ candidate, now }: { candidate: PoolCandidate; now: number }) {
+  const router = useRouter();
+  const [requesting, setRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const band = bandDescriptor(candidate.trustBand);
+  const locations = (candidate.locations ?? []).filter(Boolean);
+  const passportHref = candidate.passportUrl ?? `/p/${candidate.npi}`;
+
+  async function requestReview() {
+    setRequesting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/request-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ npi: candidate.npi }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { reviewUrl?: string; error?: string };
+      if (!res.ok || !data.reviewUrl) {
+        setError(data.error ?? 'Set up your employer workspace to request a review.');
+        return;
+      }
+      if (data.reviewUrl.startsWith('/')) router.push(data.reviewUrl);
+      else window.location.href = data.reviewUrl;
+    } catch {
+      setError('Could not start a review just now. Please try again.');
+    } finally {
+      setRequesting(false);
+    }
+  }
+
+  return (
+    <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
+        <div style={{ minWidth: 0 }}>
+          <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+            {candidate.specialty || 'Clinician'}
+          </h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--vt-text-muted)', fontVariantNumeric: 'tabular-nums' }}>
+            NPI {candidate.npi}
+          </p>
+        </div>
+        <span
+          title={band.blurb}
+          style={{
+            flex: '0 0 auto',
+            display: 'inline-flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 2,
+            padding: '6px 12px',
+            borderRadius: 12,
+            border: `1px solid color-mix(in srgb, ${ACCENT} 30%, transparent)`,
+            background: `color-mix(in srgb, ${ACCENT} 10%, transparent)`,
+          }}
+        >
+          <span style={{ fontSize: 15, fontWeight: 700, color: ACCENT }}>{band.label}</span>
+          <span style={{ fontSize: 10, color: 'var(--vt-text-muted)' }}>{band.blurb}</span>
+        </span>
+      </div>
+
+      <div style={{ marginTop: 14, display: 'flex', flexWrap: 'wrap', gap: 14, fontSize: 13, color: 'var(--vt-text-secondary)' }}>
+        <span style={{ fontWeight: 600, color: 'var(--vt-text-primary)' }}>{readinessLabel(candidate.readinessScore)}</span>
+        <span>{formatAvailability(candidate.availableFrom, now)}</span>
+        {locations.length ? (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <MapPin size={13} aria-hidden="true" /> {locations.join(', ')}
+          </span>
+        ) : null}
+      </div>
+
+      <div style={{ marginTop: 16, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <a
+          href={passportHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '9px 15px', borderRadius: 10, fontSize: 13, fontWeight: 600, textDecoration: 'none', border: '1px solid var(--vt-border, #D6DED9)', color: 'var(--vt-text-primary)' }}
+        >
+          <FileText size={14} aria-hidden="true" /> View passport
+        </a>
+        <button
+          type="button"
+          onClick={requestReview}
+          disabled={requesting}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '9px 15px', borderRadius: 10, fontSize: 13, fontWeight: 600, cursor: requesting ? 'default' : 'pointer', border: 0, background: ACCENT, color: '#fff', opacity: requesting ? 0.7 : 1 }}
+        >
+          {requesting ? 'Starting…' : 'Request review'} <ArrowRight size={14} aria-hidden="true" />
+        </button>
+      </div>
+
+      {error ? (
+        <p style={{ margin: '10px 0 0', fontSize: 12, color: 'var(--vt-risk-high, #8C2A2A)', lineHeight: 1.5 }}>{error}</p>
+      ) : null}
+
+      <p style={{ margin: '14px 0 0', fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>
+        PHI-free — identity, specialty, and source-backed readiness only. Trust band reflects source
+        coverage, not a hiring decision.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
+++ b/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * CandidatePoolSurface — the employer's MATCHA talent pool. Filter credential-ready clinicians by
+ * specialty / state / trust band, then lead into the existing review flow. Honest empty, error,
+ * and unauthorized states — no fabricated candidates.
+ */
+
+import { useMemo, useState } from 'react';
+import { useCandidatePool } from './useCandidatePool';
+import { CandidateCard } from './CandidateCard';
+import type { TrustBand } from '@/lib/matcha/pool';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+const BANDS: TrustBand[] = ['L1', 'L2', 'L3'];
+
+const inputStyle: React.CSSProperties = {
+  padding: '10px 12px',
+  fontSize: 14,
+  borderRadius: 10,
+  border: '1px solid var(--vt-border, #D6DED9)',
+  background: 'var(--vt-surface, #fff)',
+  color: 'var(--vt-text-primary)',
+  outline: 'none',
+  minWidth: 0,
+};
+
+export function CandidatePoolSurface() {
+  const { filters, setFilters, candidates, state } = useCandidatePool();
+  const [specialty, setSpecialty] = useState('');
+  const [stateFilter, setStateFilter] = useState('');
+  const now = useMemo(() => Date.now(), [candidates]);
+
+  function applyFilters() {
+    setFilters({ ...filters, specialty: specialty || undefined, state: stateFilter || undefined });
+  }
+
+  return (
+    <div style={{ maxWidth: 860, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+      <header>
+        <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>
+          Credential-ready clinicians
+        </h1>
+        <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)', lineHeight: 1.55 }}>
+          A pool of clinicians with source-backed readiness, ranked by trust band. Start a review to
+          see the full proof packet — you begin from a head start, not a blank file.
+        </p>
+      </header>
+
+      {/* Filters */}
+      <div style={{ display: 'grid', gap: 10 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr)) auto', gap: 10 }}>
+          <input style={inputStyle} placeholder="Specialty (e.g. Cardiology)" value={specialty} onChange={(e) => setSpecialty(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && applyFilters()} />
+          <input style={inputStyle} placeholder="State (e.g. CA)" value={stateFilter} onChange={(e) => setStateFilter(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && applyFilters()} />
+          <button type="button" onClick={applyFilters} style={{ padding: '10px 18px', borderRadius: 10, border: 0, background: ACCENT, color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+            Search
+          </button>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 12, color: 'var(--vt-text-muted)' }}>Min trust band:</span>
+          {BANDS.map((b) => {
+            const active = filters.trustBand === b;
+            return (
+              <button
+                key={b}
+                type="button"
+                onClick={() => setFilters({ ...filters, trustBand: active ? undefined : b })}
+                aria-pressed={active}
+                style={{ padding: '5px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, cursor: 'pointer', border: `1px solid ${active ? ACCENT : 'var(--vt-border, #D6DED9)'}`, background: active ? `color-mix(in srgb, ${ACCENT} 12%, transparent)` : 'var(--vt-surface, #fff)', color: active ? ACCENT : 'var(--vt-text-primary)' }}
+              >
+                {b}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* States */}
+      {state === 'loading' && <Note title="Finding credential-ready clinicians…" body="Checking live trust state for the pool." />}
+      {state === 'unauthorized' && <Note title="Employer sign-in required" body="Sign in with your employer workspace to view the candidate pool." />}
+      {state === 'error' && <Note title="The pool is temporarily unavailable" body="This is a live query — please try again shortly." />}
+      {state === 'ready' && candidates.length === 0 && (
+        <Note title="No candidates match yet" body="Broaden your filters, or check back as more clinicians reach credential readiness." />
+      )}
+
+      {state === 'ready' && candidates.length > 0 && (
+        <div style={{ display: 'grid', gap: 12 }}>
+          {candidates.map((c) => (
+            <CandidateCard key={c.npi} candidate={c} now={now} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Note({ title, body }: { title: string; body: string }) {
+  return (
+    <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 24, textAlign: 'center' }}>
+      <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{title}</p>
+      <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)' }}>{body}</p>
+    </div>
+  );
+}

--- a/apps/web/components/matcha/employer/useCandidatePool.ts
+++ b/apps/web/components/matcha/employer/useCandidatePool.ts
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * useCandidatePool — fetches the credential-ready clinician pool for employers, with filters.
+ * Honest states: loading / ready / error / unauthorized (the pool API is Clerk-gated).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { buildPoolQuery, type PoolCandidate, type PoolFilters } from '@/lib/matcha/pool';
+
+export type PoolLoadState = 'loading' | 'ready' | 'error' | 'unauthorized';
+
+export function useCandidatePool(initial: PoolFilters = {}) {
+  const [filters, setFilters] = useState<PoolFilters>(initial);
+  const [candidates, setCandidates] = useState<PoolCandidate[]>([]);
+  const [state, setState] = useState<PoolLoadState>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    const qs = buildPoolQuery(filters);
+    fetch(`/api/marketplace/pool${qs ? `?${qs}` : ''}`, { signal: AbortSignal.timeout(16_000) })
+      .then(async (r) => {
+        if (r.status === 401) {
+          if (!cancelled) setState('unauthorized');
+          return null;
+        }
+        const payload = (await r.json().catch(() => ({}))) as { pool?: PoolCandidate[] };
+        if (cancelled) return null;
+        setCandidates(Array.isArray(payload.pool) ? payload.pool : []);
+        setState('ready');
+        return null;
+      })
+      .catch(() => {
+        if (!cancelled) setState('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, reloadKey]);
+
+  return { filters, setFilters, candidates, state, reload };
+}

--- a/apps/web/lib/matcha/pool.ts
+++ b/apps/web/lib/matcha/pool.ts
@@ -1,0 +1,66 @@
+/**
+ * Employer candidate pool — the hiring side of MATCHA.
+ *
+ * A pool entry is PHI-free by construction (NPI, specialty, locations, trust band, readiness
+ * score, availability, passport URL — the exact fields the backend /api/marketplace/pool returns).
+ * Trust-band descriptors describe *source coverage* honestly and never assert a bare "verified"
+ * status. This module is pure and testable; the fetching hook + UI live in components/matcha/employer.
+ */
+
+export type TrustBand = 'L1' | 'L2' | 'L3';
+
+export interface PoolCandidate {
+  npi: string;
+  specialty?: string;
+  locations?: string[];
+  trustBand?: TrustBand | string;
+  readinessScore?: number;
+  availableFrom?: string;
+  urgency?: string;
+  passportUrl?: string;
+}
+
+export interface PoolFilters {
+  specialty?: string;
+  state?: string;
+  trustBand?: TrustBand;
+  urgency?: string;
+}
+
+/** Honest, source-coverage descriptors for each trust band. No bare "verified" claims. */
+export const BAND_DESCRIPTOR: Record<TrustBand, { label: string; blurb: string }> = {
+  L1: { label: 'L1', blurb: 'Identity established' },
+  L2: { label: 'L2', blurb: 'Multiple sources checked' },
+  L3: { label: 'L3', blurb: 'Comprehensive source coverage' },
+};
+
+export function bandDescriptor(band: string | undefined): { label: string; blurb: string } {
+  if (band === 'L1' || band === 'L2' || band === 'L3') return BAND_DESCRIPTOR[band];
+  return { label: 'L0', blurb: 'Coverage in progress' };
+}
+
+/** Build the query string for the pool endpoint from filter selections. */
+export function buildPoolQuery(filters: PoolFilters): string {
+  const params = new URLSearchParams();
+  if (filters.specialty?.trim()) params.set('specialty', filters.specialty.trim());
+  if (filters.state?.trim()) params.set('state', filters.state.trim());
+  if (filters.trustBand) params.set('trustBand', filters.trustBand);
+  if (filters.urgency?.trim()) params.set('urgency', filters.urgency.trim());
+  return params.toString();
+}
+
+/** Human-readable availability. Absent / past dates read as "Available now". */
+export function formatAvailability(availableFrom: string | undefined, now: number): string {
+  if (!availableFrom) return 'Available now';
+  const t = Date.parse(availableFrom);
+  if (!Number.isFinite(t)) return 'Available now';
+  if (t <= now) return 'Available now';
+  const d = new Date(t);
+  return `Available ${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
+}
+
+/** A short, honest readiness phrase for a 0–100 score. */
+export function readinessLabel(score: number | undefined): string {
+  if (typeof score !== 'number' || !Number.isFinite(score)) return 'Readiness pending';
+  return `Readiness ${Math.round(score)}/100`;
+}


### PR DESCRIPTION
## What this adds

The **hiring side of MATCHA** — the credential-ready clinician pool employers were missing, leading into the existing review flow (no duplication of the review surface).

- **`/employer/candidates`** (gated behind `MATCHA_V2`): filter by specialty / state / trust band; honest loading / unauthorized / error / empty states.
- **`CandidateCard`** — PHI-free (NPI, specialty, locations, trust band, readiness score, availability). **Request review** POSTs to the real `/api/request-review` and navigates to the review surface; **View passport** opens the public `/p/:npi`. Honest inline error when an employer workspace isn't set up.
- **`/api/marketplace/pool`** proxy (Clerk-gated) → backend pool; forwards the Clerk user id like the existing `candidates` proxy.
- **`lib/matcha/pool.ts`** — pure query/format/band helpers. Trust-band descriptors describe *source coverage* honestly — **no bare "verified" label** (banned string).

## Truth contract
Pool entries are PHI-free by construction (the backend returns only NPI/specialty/locations/band/readiness/availability). Trust band reflects source coverage, not a hiring decision — the card says so.

## Verification
- Typecheck clean; `next build` green (both routes registered).
- 7 tests (query building, honest band descriptors incl. a no-"verified" guard, availability/readiness formatting).

## Follow-up
Link `/employer/candidates` from the employer dashboard once `MATCHA_V2` is flipped on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)