### PR TITLE
feat(matcha): AI cover-letter generator (real Claude call)

### DIFF
--- a/apps/web/__tests__/matcha-cover-letter.test.ts
+++ b/apps/web/__tests__/matcha-cover-letter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCoverLetterMessages,
+  summarizeProfileForLetter,
+} from '../lib/matcha/coverLetter';
+import type { MatchaPreferences } from '../lib/matcha/preferences';
+
+describe('cover letter — profile summary is grounded in stated preferences only', () => {
+  it('includes only answered preference fields', () => {
+    const prefs: MatchaPreferences = {
+      currentSpecialties: ['Cardiology'],
+      preferredStates: ['CA'],
+      workLifeBalanceImportance: 'high',
+      teachingInterest: 'passionate',
+    };
+    const summary = summarizeProfileForLetter(prefs, 'Alex');
+    expect(summary).toContain('Name: Alex');
+    expect(summary).toContain('Cardiology');
+    expect(summary).toContain('CA');
+    expect(summary).toContain('work–life balance');
+    expect(summary).toContain('teaching');
+    // nothing about credentials/licenses (not a preference field)
+    expect(summary.toLowerCase()).not.toContain('license');
+    expect(summary.toLowerCase()).not.toContain('board cert');
+  });
+
+  it('returns an empty string when nothing is answered', () => {
+    expect(summarizeProfileForLetter({})).toBe('');
+  });
+
+  it('omits low-interest values', () => {
+    const summary = summarizeProfileForLetter({ teachingInterest: 'none', researchInterest: 'curious' });
+    expect(summary).not.toContain('teaching');
+    expect(summary).not.toContain('research');
+  });
+});
+
+describe('cover letter — prompt forbids fabrication', () => {
+  it('system prompt bans inventing credentials and verification claims', () => {
+    const { system } = buildCoverLetterMessages({ profileSummary: 'Practices: Cardiology', opportunity: {} });
+    const lower = system.toLowerCase();
+    expect(lower).toContain('do not invent');
+    expect(lower).toContain('credential');
+    expect(lower).toContain('license');
+    expect(lower).toContain('verified');
+  });
+
+  it('user message carries the opportunity and the profile as the only facts', () => {
+    const { user } = buildCoverLetterMessages({
+      profileSummary: 'Practices: Cardiology\nPrefers to work in: CA',
+      opportunity: { title: 'Cardiologist', organization: 'Bay Health', specialty: 'Cardiology', location: 'Oakland, CA' },
+    });
+    expect(user).toContain('Cardiologist');
+    expect(user).toContain('Bay Health');
+    expect(user).toContain('Oakland, CA');
+    expect(user).toContain('the only facts you may use');
+    expect(user).toContain('Practices: Cardiology');
+  });
+
+  it('handles an empty profile without breaking', () => {
+    const { user } = buildCoverLetterMessages({ profileSummary: '', opportunity: { title: 'Nurse' } });
+    expect(user).toContain('keep the letter general');
+  });
+});

--- a/apps/web/app/api/matcha/cover-letter/route.ts
+++ b/apps/web/app/api/matcha/cover-letter/route.ts
@@ -1,0 +1,84 @@
+/**
+ * POST /api/matcha/cover-letter — generate an AI cover-letter DRAFT for an opportunity.
+ *
+ * Body: { opportunity: {title, organization, specialty, location}, profileSummary: string }
+ * Returns: { draft } on success, { configured: false } when no model key is set (honest —
+ * the UI shows an "AI drafting isn't enabled here" state rather than failing), or { error }.
+ *
+ * Calls the Anthropic Messages API directly (no SDK dependency). Model defaults to
+ * claude-opus-4-8; override with COVER_LETTER_MODEL. The draft is grounded only in the provided
+ * facts (see lib/matcha/coverLetter.ts) and is clearly labeled AI-generated in the UI.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { buildCoverLetterMessages, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
+
+export const runtime = 'nodejs';
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_MODEL = 'claude-opus-4-8';
+
+export async function POST(req: NextRequest) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    // Honest: the feature isn't wired up in this environment.
+    return NextResponse.json({ configured: false }, { status: 200 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as {
+    opportunity?: CoverLetterOpportunity;
+    profileSummary?: string;
+  };
+  const opportunity = body.opportunity ?? {};
+  const profileSummary = typeof body.profileSummary === 'string' ? body.profileSummary : '';
+
+  const { system, user } = buildCoverLetterMessages({ profileSummary, opportunity });
+
+  try {
+    const res = await fetch(ANTHROPIC_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: process.env.COVER_LETTER_MODEL || DEFAULT_MODEL,
+        max_tokens: 1024,
+        system,
+        messages: [{ role: 'user', content: user }],
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'The drafting service is unavailable right now.' }, { status: 502 });
+    }
+
+    const data = (await res.json()) as {
+      stop_reason?: string;
+      content?: Array<{ type: string; text?: string }>;
+    };
+
+    if (data.stop_reason === 'refusal') {
+      return NextResponse.json(
+        { error: 'The model declined to draft this. Try adding a few more details to your profile.' },
+        { status: 200 },
+      );
+    }
+
+    const draft = (data.content ?? [])
+      .filter((b) => b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text as string)
+      .join('')
+      .trim();
+
+    if (!draft) {
+      return NextResponse.json({ error: 'No draft was produced. Please try again.' }, { status: 200 });
+    }
+
+    return NextResponse.json({ draft }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'Could not reach the drafting service. Please try again.' }, { status: 502 });
+  }
+}

--- a/apps/web/components/matcha/CoverLetterDrafter.tsx
+++ b/apps/web/components/matcha/CoverLetterDrafter.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+/**
+ * CoverLetterDrafter — generates an AI cover-letter DRAFT for an opportunity, grounded only in
+ * the clinician's stated preferences and the public opportunity details. The draft is editable
+ * and clearly labeled AI-generated. Honest states: not-configured, loading, error.
+ */
+
+import { useState } from 'react';
+import { Sparkles, Copy, Check } from 'lucide-react';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useMatchaPreferences } from './useMatchaPreferences';
+import { summarizeProfileForLetter, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+type State = 'idle' | 'loading' | 'ready' | 'unconfigured' | 'error';
+
+export function CoverLetterDrafter({ opportunity }: { opportunity: CoverLetterOpportunity }) {
+  const { data } = useClinicianMobile();
+  const person = data.workspace?.personProfile;
+  const npi = person?.npi ?? undefined;
+  const name = person?.firstName ?? undefined;
+  const { preferences } = useMatchaPreferences(npi);
+
+  const [state, setState] = useState<State>('idle');
+  const [draft, setDraft] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function generate() {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch('/api/matcha/cover-letter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          opportunity,
+          profileSummary: summarizeProfileForLetter(preferences, name),
+        }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as {
+        draft?: string;
+        configured?: boolean;
+        error?: string;
+      };
+      if (payload.configured === false) {
+        setState('unconfigured');
+        return;
+      }
+      if (payload.error) {
+        setMessage(payload.error);
+        setState('error');
+        return;
+      }
+      if (payload.draft) {
+        setDraft(payload.draft);
+        setState('ready');
+        return;
+      }
+      setMessage('No draft was produced. Please try again.');
+      setState('error');
+    } catch {
+      setMessage('Could not reach the drafting service. Please try again.');
+      setState('error');
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 16, borderTop: '1px solid var(--vt-border, #EEF2F0)', paddingTop: 14 }}>
+      {state === 'idle' || state === 'loading' ? (
+        <button
+          type="button"
+          onClick={generate}
+          disabled={state === 'loading'}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '9px 15px', borderRadius: 10, fontSize: 13, fontWeight: 600, cursor: state === 'loading' ? 'default' : 'pointer', border: `1px solid ${ACCENT}`, background: `color-mix(in srgb, ${ACCENT} 8%, transparent)`, color: ACCENT, opacity: state === 'loading' ? 0.7 : 1 }}
+        >
+          <Sparkles size={14} aria-hidden="true" />
+          {state === 'loading' ? 'Drafting…' : 'Draft a cover letter with MATCHA'}
+        </button>
+      ) : null}
+
+      {state === 'unconfigured' ? (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--vt-text-secondary)', lineHeight: 1.5 }}>
+          AI drafting isn&rsquo;t enabled in this environment yet.
+        </p>
+      ) : null}
+
+      {state === 'error' ? (
+        <div>
+          <p style={{ margin: '0 0 8px', fontSize: 13, color: 'var(--vt-risk-high, #8C2A2A)' }}>{message}</p>
+          <button type="button" onClick={generate} style={{ fontSize: 13, fontWeight: 600, color: ACCENT, background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}>
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {state === 'ready' ? (
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: ACCENT }}>
+              AI draft — review before sending
+            </span>
+            <button type="button" onClick={copy} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 12, fontWeight: 600, color: 'var(--vt-text-primary)', background: 'transparent', border: 0, cursor: 'pointer' }}>
+              {copied ? <Check size={13} aria-hidden="true" /> : <Copy size={13} aria-hidden="true" />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={10}
+            style={{ width: '100%', padding: '12px', fontSize: 14, lineHeight: 1.55, borderRadius: 10, border: '1px solid var(--vt-border, #D6DED9)', background: 'var(--vt-surface, #fff)', color: 'var(--vt-text-primary)', resize: 'vertical', fontFamily: 'inherit' }}
+          />
+          <p style={{ margin: '8px 0 0', fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>
+            Generated from your stated preferences and this role&rsquo;s public details. It makes no
+            claims about your credentials — edit before you send.
+          </p>
+          <button type="button" onClick={generate} style={{ marginTop: 8, fontSize: 12, fontWeight: 600, color: ACCENT, background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}>
+            Regenerate
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/matcha/OpportunityCard.tsx
+++ b/apps/web/components/matcha/OpportunityCard.tsx
@@ -13,6 +13,7 @@ import {
   type IntelligenceOpportunity,
 } from './OpportunityIntelligenceCard';
 import { Livability } from './Livability';
+import { CoverLetterDrafter } from './CoverLetterDrafter';
 import type { ExplanationReason } from './MatchaExplanation';
 import type { OpportunityBucket, OpportunityStatus } from '@/lib/matcha/opportunityActions';
 
@@ -86,6 +87,16 @@ export function OpportunityCard({ opportunity, explanation, preferenceReasons, b
 
         {/* Livability */}
         <Livability location={opportunity.location} state={opportunity.state} remote={opportunity.remote} />
+
+        {/* AI cover-letter draft */}
+        <CoverLetterDrafter
+          opportunity={{
+            title: opportunity.title,
+            organization: opportunity.organization,
+            specialty: opportunity.specialty,
+            location: opportunity.location,
+          }}
+        />
       </OpportunityIntelligenceCard>
     </div>
   );

--- a/apps/web/lib/matcha/coverLetter.ts
+++ b/apps/web/lib/matcha/coverLetter.ts
@@ -1,0 +1,99 @@
+/**
+ * MATCHA cover-letter drafting — prompt construction.
+ *
+ * Truth rule: the draft is grounded ONLY in what the clinician has stated about their own
+ * preferences and the public opportunity details. The system prompt forbids inventing
+ * credentials, licenses, board certifications, employers, dates, or metrics. The result is an
+ * editable DRAFT the clinician reviews — clearly labeled as AI-generated in the UI.
+ *
+ * Pure and testable — the API route (app/api/matcha/cover-letter) builds messages from here and
+ * calls the model. No network in this module.
+ */
+
+import type { MatchaPreferences } from './preferences';
+
+export interface CoverLetterOpportunity {
+  title?: string;
+  organization?: string;
+  specialty?: string;
+  location?: string;
+}
+
+const HIGH_INTEREST = new Set(['interested', 'passionate']);
+const HIGH_IMPORTANCE = new Set(['high']);
+
+/**
+ * Turn stated preferences into a factual bullet list for the prompt. Only answered fields are
+ * included, and only preference facts — never credential or verification claims.
+ */
+export function summarizeProfileForLetter(prefs: MatchaPreferences, name?: string): string {
+  const lines: string[] = [];
+  if (name?.trim()) lines.push(`Name: ${name.trim()}`);
+
+  if (prefs.currentSpecialties?.length) lines.push(`Practices: ${prefs.currentSpecialties.join(', ')}`);
+  if (prefs.desiredSpecialties?.length) lines.push(`Wants to move toward: ${prefs.desiredSpecialties.join(', ')}`);
+  if (prefs.careerDirection) lines.push(`Career direction: ${prefs.careerDirection}`);
+  if (prefs.careerGoals?.length) lines.push(`Goals: ${prefs.careerGoals.join(', ')}`);
+  if (prefs.preferredStates?.length) lines.push(`Prefers to work in: ${prefs.preferredStates.join(', ')}`);
+  if (prefs.employmentTypes?.length) lines.push(`Open to: ${prefs.employmentTypes.join(', ').replace(/_/g, ' ')}`);
+  if (prefs.favoriteProcedures?.length) lines.push(`Enjoys: ${prefs.favoriteProcedures.join(', ')}`);
+  if (prefs.populationPreferences?.length) lines.push(`Patient focus: ${prefs.populationPreferences.join(', ')}`);
+  if (prefs.languagesSpoken && prefs.languagesSpoken.length > 1) lines.push(`Languages: ${prefs.languagesSpoken.join(', ')}`);
+
+  const values: string[] = [];
+  if (HIGH_IMPORTANCE.has(prefs.workLifeBalanceImportance ?? '')) values.push('work–life balance');
+  if (HIGH_IMPORTANCE.has(prefs.missionDrivenImportance ?? '')) values.push('mission-driven work');
+  if (prefs.teachingInterest && HIGH_INTEREST.has(prefs.teachingInterest)) values.push('teaching & mentorship');
+  if (prefs.researchInterest && HIGH_INTEREST.has(prefs.researchInterest)) values.push('research');
+  if (prefs.leadershipAspiration && HIGH_INTEREST.has(prefs.leadershipAspiration)) values.push('leadership');
+  if (values.length) lines.push(`Values: ${values.join(', ')}`);
+
+  return lines.join('\n');
+}
+
+export interface CoverLetterMessages {
+  system: string;
+  user: string;
+}
+
+const SYSTEM_PROMPT = [
+  'You draft short, professional cover-letter DRAFTS for clinicians applying to healthcare roles.',
+  '',
+  'Hard rules:',
+  '- Use ONLY the facts provided below. Do NOT invent or imply any credential, license, board',
+  '  certification, NPI, degree, years of experience, past employer, publication, date, or metric',
+  '  that is not explicitly given.',
+  '- Do NOT claim anything is "verified" or make guarantees about the clinician.',
+  '- If a detail is not provided, leave it out — keep the letter general rather than fabricating.',
+  '- Warm, concise, first person, ~150–190 words. No greeting placeholders like "[Hiring Manager]"',
+  '  unless natural; prefer "Dear Hiring Team,".',
+  '- Output ONLY the letter text. No preamble, no notes, no markdown headers.',
+].join('\n');
+
+/** Build the system + user messages for the cover-letter request. */
+export function buildCoverLetterMessages(input: {
+  profileSummary: string;
+  opportunity: CoverLetterOpportunity;
+}): CoverLetterMessages {
+  const opp = input.opportunity;
+  const oppLines = [
+    opp.title ? `Role: ${opp.title}` : null,
+    opp.organization ? `Organization: ${opp.organization}` : null,
+    opp.specialty ? `Specialty: ${opp.specialty}` : null,
+    opp.location ? `Location: ${opp.location}` : null,
+  ].filter(Boolean).join('\n');
+
+  const profile = input.profileSummary.trim() || '(No preferences shared yet — keep the letter general.)';
+
+  const user = [
+    'Draft a cover letter for this opportunity.',
+    '',
+    'Opportunity:',
+    oppLines || '(No opportunity details provided.)',
+    '',
+    'What the clinician has shared about themselves (the only facts you may use):',
+    profile,
+  ].join('\n');
+
+  return { system: SYSTEM_PROMPT, user };
+}


### PR DESCRIPTION
## What this adds

A **"Draft a cover letter with MATCHA"** action on each opportunity card — a **real** Anthropic Messages API call (`claude-opus-4-8`, override via `COVER_LETTER_MODEL`) returning an editable, clearly-labeled AI draft.

## Truth contract
The draft is grounded **only** in the clinician's stated preferences (`summarizeProfileForLetter` — never credentials) plus the role's public details. The system prompt hard-forbids inventing any credential, license, board cert, NPI, degree, years of experience, past employer, publication, date, or metric, and bans "verified" claims. The UI labels it **"AI draft — review before sending"** and notes it makes no claims about the clinician's credentials.

## Honest fallbacks
- No `ANTHROPIC_API_KEY` → `{ configured: false }` and an "AI drafting isn't enabled here yet" state (no crash).
- Model refusal / service error → inline message with a retry.

No SDK dependency (raw `fetch`), so the web bundle and lockfile are untouched.

## Verification
- Typecheck clean; `next build` green (route registered).
- 6 tests covering profile grounding + the no-fabrication system prompt.

## Ops note
Set `ANTHROPIC_API_KEY` (and optionally `COVER_LETTER_MODEL`) on Railway to enable live drafting; until then the feature degrades honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)