### PR TITLE
feat(matcha): employer discoverability + Wave 9 polish

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -8,6 +8,7 @@
 @import '../styles/tokens.css';
 @import '../styles/vitalTokens.css';
 @import '../styles/blueprint-overrides.css';
+@import '../styles/matcha.css';
 @import '../styles/graph.css';
 @import '../styles/intelligence.css';
 @import '../styles/clinician-doc.css';

--- a/apps/web/components/employer/EmployerDashboard.tsx
+++ b/apps/web/components/employer/EmployerDashboard.tsx
@@ -25,6 +25,7 @@ import {
   Users,
 } from 'lucide-react';
 import Link from 'next/link';
+import { FEATURES } from '@/lib/features';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import {
   buildEmployerApplicationProofMoments,
@@ -549,6 +550,11 @@ export function EmployerDashboard() {
               <Link href="/verifier/opportunities" className="glue-btn border border-border bg-muted text-foreground hover:bg-muted">
                 Post opportunity
               </Link>
+              {FEATURES.MATCHA_V2 ? (
+                <Link href="/employer/candidates" className="glue-btn border border-emerald-400/30 bg-emerald-400/10 text-emerald-100 hover:bg-emerald-400/15">
+                  Browse credential-ready clinicians
+                </Link>
+              ) : null}
             </div>
           </div>
         </header>

--- a/apps/web/components/matcha/MatchaAssessment.tsx
+++ b/apps/web/components/matcha/MatchaAssessment.tsx
@@ -43,7 +43,7 @@ export function MatchaAssessment() {
   const totalQuestions = progress.reduce((n, p) => n + p.total, 0);
 
   return (
-    <div style={{ maxWidth: 760, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+    <div className="matcha-enter" style={{ maxWidth: 760, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
       {/* Header */}
       <header>
         <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Match questions</h1>

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -69,7 +69,7 @@ export function MatchaHub() {
   const hasMatches = oppState === 'ready' && matches.length > 0;
 
   return (
-    <div style={{ maxWidth: 960, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 24 }}>
+    <div className="matcha-enter" style={{ maxWidth: 960, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 24 }}>
       {/* Greeting + what to do next */}
       <Panel>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -29,7 +29,7 @@ export function MatchaOpportunitiesSurface() {
   const bucketCounts = counts(ids);
 
   return (
-    <div style={{ maxWidth: 820, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 16 }}>
+    <div className="matcha-enter" style={{ maxWidth: 820, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 16 }}>
       <header style={{ marginBottom: 4 }}>
         <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
           Opportunities MATCHA found

--- a/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
+++ b/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
@@ -101,6 +101,7 @@ export function OpportunityIntelligenceCard({
   return (
     <Wrapper
       {...(href ? { href } : {})}
+      className="matcha-lift"
       style={{
         display: 'block',
         textDecoration: 'none',

--- a/apps/web/components/matcha/employer/CandidateCard.tsx
+++ b/apps/web/components/matcha/employer/CandidateCard.tsx
@@ -54,7 +54,7 @@ export function CandidateCard({ candidate, now }: { candidate: PoolCandidate; no
   }
 
   return (
-    <div style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
+    <div className="matcha-lift" style={{ background: 'var(--vt-surface, #fff)', border: '1px solid var(--vt-border, #E2E8E6)', borderRadius: 16, padding: 20 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
         <div style={{ minWidth: 0 }}>
           <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--vt-text-primary)' }}>

--- a/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
+++ b/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
@@ -36,7 +36,7 @@ export function CandidatePoolSurface() {
   }
 
   return (
-    <div style={{ maxWidth: 860, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+    <div className="matcha-enter" style={{ maxWidth: 860, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
       <header>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>
           Credential-ready clinicians

--- a/apps/web/styles/matcha.css
+++ b/apps/web/styles/matcha.css
@@ -1,0 +1,67 @@
+/**
+ * MATCHA polish utilities (Wave 9).
+ *
+ * Small, opt-in classes for the MATCHA intelligence surfaces: a calm entrance, hover elevation
+ * on interactive cards, and a skeleton shimmer. Reduced-motion users get static equivalents.
+ * Uses the house motion curve (cubic-bezier(0.2,0.8,0.2,1)).
+ */
+
+@keyframes matcha-enter-kf {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes matcha-shimmer-kf {
+  0% {
+    background-position: -420px 0;
+  }
+  100% {
+    background-position: 420px 0;
+  }
+}
+
+/* Calm fade-in-up for surface roots. */
+.matcha-enter {
+  animation: matcha-enter-kf 420ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+/* Hover elevation for interactive cards. */
+.matcha-lift {
+  transition:
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.matcha-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.1);
+  border-color: color-mix(in srgb, var(--vt-accent, #0a7b7f) 40%, transparent);
+}
+
+/* Skeleton shimmer block. */
+.matcha-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--vt-surface-subtle, #edf2f0) 25%,
+    color-mix(in srgb, var(--vt-surface-subtle, #edf2f0) 60%, white) 37%,
+    var(--vt-surface-subtle, #edf2f0) 63%
+  );
+  background-size: 840px 100%;
+  animation: matcha-shimmer-kf 1.5s ease-in-out infinite;
+  border-radius: 10px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .matcha-enter,
+  .matcha-lift,
+  .matcha-skeleton {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What this adds

- **Employer discoverability** — a `MATCHA_V2`-gated **"Browse credential-ready clinicians"** CTA on the employer dashboard header, linking to `/employer/candidates` (the pool from #522 was previously reachable only by direct URL).
- **Wave 9 polish** — `styles/matcha.css` with opt-in utilities: a calm fade-in-up entrance (`.matcha-enter`), hover elevation on interactive cards (`.matcha-lift`), and a skeleton shimmer (`.matcha-skeleton`). House motion curve (`cubic-bezier(0.2,0.8,0.2,1)`); **reduced-motion users get static equivalents**. Applied to the four MATCHA surface roots and the opportunity + candidate cards.

## Verification
- Typecheck clean; `next build` green.
- `globals.css` change is a single `@import` line (verified against main to avoid dragging in unrelated branch drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)