### PR TITLE
feat(matcha): Calm Wave D56 redesign — public homepage

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -742,43 +742,36 @@ export default function HomePageClient() {
             </div>
           </section>
 
-          {/* Meet MATCHA — interactive intelligence layer (no signup) */}
-          <section aria-label="Meet MATCHA" data-home-matcha="" className="mt-16">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
-              Meet MATCHA
-            </p>
-            <h2 className="mt-3 text-[clamp(1.6rem,3.5vw,2.4rem)] font-semibold leading-tight tracking-[-0.03em] text-[var(--vt-text-primary)]">
-              Not a job board. A career operating system.
+          {/* Meet MATCHA — interactive intelligence layer (no signup) · Calm Wave D56 */}
+          <section aria-label="Meet MATCHA" data-home-matcha="" className="mz mt-16">
+            <p className="mz-eyebrow">Meet MATCHA</p>
+            <h2 className="mz-display" style={{ marginTop: 14, maxWidth: 640 }}>
+              Not a job board. <span className="mz-accent">A career operating system.</span>
             </h2>
-            <p className="mt-4 max-w-2xl text-[15px] leading-[1.65] text-[var(--vt-text-secondary)]">
+            <p className="mz-lede" style={{ marginTop: 16, maxWidth: 620 }}>
               MATCHA is the intelligence layer that learns what you want, then works in the background
               to surface roles worth your time — and it explains every recommendation instead of hiding
               it behind a score. Try it below. No signup, and everything it says traces to what you tell it.
             </p>
-            <div className="mt-6">
+            <div style={{ marginTop: 22 }}>
               <PublicMatchaExperience />
             </div>
           </section>
 
-          {/* Career Evidence Network — interactive graph */}
-          <section aria-label="The career evidence network" data-home-network="" className="mt-16">
-            <div
-              className="overflow-hidden rounded-[28px] border border-white/5 px-6 py-8 sm:px-10 sm:py-10"
-              style={{ background: 'radial-gradient(circle at 30% 20%, #1b2a2b 0%, #14181d 55%, #0f1216 100%)' }}
-            >
-              <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#4FD1C5]">
-                The career evidence network
-              </p>
-              <h2 className="max-w-2xl text-[clamp(1.6rem,3.5vw,2.4rem)] font-semibold leading-tight tracking-[-0.03em] text-white">
-                Your evidence isn&rsquo;t a document. It&rsquo;s a network.
+          {/* Career Evidence Network — static, calm diagram · Calm Wave D56 */}
+          <section aria-label="The career evidence network" data-home-network="" className="mz mt-16">
+            <div className="mz-card mz-dotgrid" style={{ padding: '32px 28px' }}>
+              <p className="mz-eyebrow">The career evidence network</p>
+              <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 620 }}>
+                Your evidence isn&rsquo;t a document. It&rsquo;s a <span className="mz-accent">network</span>.
               </h2>
-              <p className="mt-4 max-w-2xl text-[15px] leading-[1.65] text-white/65">
+              <p className="mz-body" style={{ marginTop: 14, maxWidth: 640 }}>
                 Every credential traces to its source, rolls up into your readiness, and connects to the
                 opportunities it unlocks and the employers who accept it. Verify once; reuse everywhere.
-                This is a model of how it fits together — hover to trace a thread.
+                This is one map of how it fits together.
               </p>
-              <div className="mt-6">
-                <CareerEvidenceGraph height={460} />
+              <div style={{ marginTop: 20 }}>
+                <CareerEvidenceGraph />
               </div>
             </div>
           </section>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -9,6 +9,7 @@
 @import '../styles/vitalTokens.css';
 @import '../styles/blueprint-overrides.css';
 @import '../styles/matcha.css';
+@import '../styles/matcha-zen.css';
 @import '../styles/graph.css';
 @import '../styles/intelligence.css';
 @import '../styles/clinician-doc.css';

--- a/apps/web/components/matcha/CareerEvidenceGraph.tsx
+++ b/apps/web/components/matcha/CareerEvidenceGraph.tsx
@@ -1,324 +1,120 @@
-'use client';
-
 /**
- * CareerEvidenceGraph — an interactive, animated map of VitalCV's core thesis: your career
- * evidence, the sources that back it, and the opportunities it unlocks, all interconnected.
+ * CareerEvidenceGraph — a calm, STATIC map of the career evidence network.
  *
- * Rendered with a small hand-rolled force simulation on a canvas (no external graph lib).
- * This is a *conceptual model*, labeled as such — the node labels are honest category names
- * (NPI, State License, NPPES, Readiness, Recognition…), not claims about a specific clinician.
+ * Redrawn to the Calm Wave D56 doctrine: paper + ink, thin ink strokes, mono labels, semantic
+ * dots only. No animation, no gradient, no glow, no force simulation (doctrine §1.4 / §3 forbid
+ * looping animations and decorative visuals). Deterministic layout — pure and server-renderable.
  *
- * Respects prefers-reduced-motion: settles to a static layout instead of animating.
+ * It's a conceptual model, labeled as such: your evidence, the sources that back it, your
+ * readiness, and the opportunities and recognition it unlocks — interconnected.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+type Kind = 'you' | 'credential' | 'source' | 'readiness' | 'recognition' | 'specialty' | 'opportunity';
 
-type NodeKind = 'you' | 'credential' | 'source' | 'readiness' | 'specialty' | 'opportunity' | 'recognition';
-
-interface GraphNode {
+interface Node {
   id: string;
-  label: string;
-  kind: NodeKind;
-  // simulation state
+  label?: string;
+  kind: Kind;
   x: number;
   y: number;
-  vx: number;
-  vy: number;
-  r: number;
   hub?: boolean;
 }
 
-interface GraphEdge {
-  a: string;
-  b: string;
-}
-
-const PALETTE: Record<NodeKind, string> = {
-  you: '#F6E05E',
-  credential: '#4FD1C5',
-  source: '#63B3ED',
-  readiness: '#38B2AC',
-  specialty: '#B794F4',
-  opportunity: '#68D391',
-  recognition: '#F6AD55',
+// Ink-first palette; two semantic accents (source-backed green, recognition indigo).
+const FILL: Record<Kind, string> = {
+  you: '#0f0e0c',
+  credential: '#1c5c38', // --ok (source-backed)
+  source: '#6b6860', // --ink-500
+  readiness: '#0f0e0c',
+  recognition: '#4f46e5', // --accent
+  specialty: '#474540', // --ink-600
+  opportunity: '#96938a', // --ink-400 (not yet acted)
 };
 
-const LEGEND: Array<{ kind: NodeKind; label: string }> = [
-  { kind: 'credential', label: 'Credentials' },
-  { kind: 'source', label: 'Sources' },
-  { kind: 'readiness', label: 'Readiness' },
-  { kind: 'recognition', label: 'Recognition' },
-  { kind: 'specialty', label: 'Specialty' },
-  { kind: 'opportunity', label: 'Opportunities' },
+const NODES: Node[] = [
+  { id: 'you', label: 'You', kind: 'you', x: 360, y: 205, hub: true },
+  // credentials (upper-left) → sources (far left)
+  { id: 'npi', label: 'NPI', kind: 'credential', x: 250, y: 120, hub: true },
+  { id: 'license', label: 'State License', kind: 'credential', x: 205, y: 205, hub: true },
+  { id: 'board', label: 'Board Cert', kind: 'credential', x: 250, y: 290, hub: true },
+  { id: 'nppes', label: 'NPPES', kind: 'source', x: 110, y: 120 },
+  { id: 'stateboard', label: 'State Board', kind: 'source', x: 92, y: 205 },
+  { id: 'abms', label: 'ABMS', kind: 'source', x: 110, y: 290 },
+  // readiness (right of center)
+  { id: 'readiness', label: 'Readiness', kind: 'readiness', x: 470, y: 150, hub: true },
+  // specialty (below center)
+  { id: 'specialty', label: 'Specialty', kind: 'specialty', x: 400, y: 320, hub: true },
+  // recognition (upper right)
+  { id: 'recognition', label: 'Recognition', kind: 'recognition', x: 545, y: 250, hub: true },
+  // opportunities (right)
+  { id: 'opp1', label: 'Opportunity', kind: 'opportunity', x: 615, y: 130 },
+  { id: 'opp2', kind: 'opportunity', x: 640, y: 195 },
+  { id: 'opp3', kind: 'opportunity', x: 625, y: 320 },
+  { id: 'emp1', label: 'Employer', kind: 'recognition', x: 590, y: 350 },
 ];
 
-// Honest, conceptual structure of the evidence network.
-function buildGraph(): { nodes: GraphNode[]; edges: GraphEdge[] } {
-  const raw: Array<Omit<GraphNode, 'x' | 'y' | 'vx' | 'vy'>> = [
-    { id: 'you', label: 'You', kind: 'you', r: 15, hub: true },
-    // credentials
-    { id: 'npi', label: 'NPI', kind: 'credential', r: 8, hub: true },
-    { id: 'license', label: 'State License', kind: 'credential', r: 8, hub: true },
-    { id: 'board', label: 'Board Cert', kind: 'credential', r: 8, hub: true },
-    { id: 'dea', label: 'DEA', kind: 'credential', r: 6 },
-    { id: 'bls', label: 'BLS / ACLS', kind: 'credential', r: 6 },
-    // sources
-    { id: 'nppes', label: 'NPPES', kind: 'source', r: 7 },
-    { id: 'stateboard', label: 'State Board', kind: 'source', r: 7 },
-    { id: 'abms', label: 'ABMS', kind: 'source', r: 6 },
-    { id: 'dea-reg', label: 'DEA Registry', kind: 'source', r: 5 },
-    // readiness + recognition
-    { id: 'readiness', label: 'Readiness', kind: 'readiness', r: 12, hub: true },
-    { id: 'recognition', label: 'Recognition', kind: 'recognition', r: 10, hub: true },
-    // specialty
-    { id: 'specialty', label: 'Specialty', kind: 'specialty', r: 9, hub: true },
-    // opportunities
-    { id: 'opp1', label: 'Opportunity', kind: 'opportunity', r: 7 },
-    { id: 'opp2', label: 'Opportunity', kind: 'opportunity', r: 6 },
-    { id: 'opp3', label: 'Opportunity', kind: 'opportunity', r: 6 },
-    { id: 'opp4', label: 'Opportunity', kind: 'opportunity', r: 5 },
-    // employers (recognition sources)
-    { id: 'emp1', label: 'Employer', kind: 'recognition', r: 5 },
-    { id: 'emp2', label: 'Employer', kind: 'recognition', r: 5 },
-  ];
+const EDGES: Array<[string, string]> = [
+  ['you', 'npi'], ['you', 'license'], ['you', 'board'], ['you', 'specialty'], ['you', 'readiness'],
+  ['npi', 'nppes'], ['license', 'stateboard'], ['board', 'abms'],
+  ['readiness', 'npi'], ['readiness', 'license'], ['readiness', 'board'],
+  ['readiness', 'opp1'], ['readiness', 'opp2'], ['specialty', 'opp1'], ['specialty', 'opp3'],
+  ['recognition', 'readiness'], ['recognition', 'opp1'], ['recognition', 'emp1'],
+];
 
-  const edges: GraphEdge[] = [
-    // you → your evidence
-    { a: 'you', b: 'npi' }, { a: 'you', b: 'license' }, { a: 'you', b: 'board' },
-    { a: 'you', b: 'specialty' }, { a: 'you', b: 'readiness' },
-    { a: 'license', b: 'dea' }, { a: 'board', b: 'bls' },
-    // credentials ← sources (provenance)
-    { a: 'npi', b: 'nppes' }, { a: 'license', b: 'stateboard' },
-    { a: 'board', b: 'abms' }, { a: 'dea', b: 'dea-reg' },
-    // readiness aggregates credentials
-    { a: 'readiness', b: 'npi' }, { a: 'readiness', b: 'license' }, { a: 'readiness', b: 'board' },
-    // opportunities ← readiness + specialty
-    { a: 'readiness', b: 'opp1' }, { a: 'readiness', b: 'opp2' }, { a: 'readiness', b: 'opp3' }, { a: 'readiness', b: 'opp4' },
-    { a: 'specialty', b: 'opp1' }, { a: 'specialty', b: 'opp2' }, { a: 'specialty', b: 'opp3' },
-    // recognition ← employers + readiness
-    { a: 'recognition', b: 'readiness' }, { a: 'recognition', b: 'emp1' }, { a: 'recognition', b: 'emp2' },
-    { a: 'recognition', b: 'opp1' },
-  ];
+const BY_ID = new Map(NODES.map((n) => [n.id, n] as const));
 
-  const nodes: GraphNode[] = raw.map((n, i) => {
-    const angle = (i / raw.length) * Math.PI * 2;
-    const radius = n.id === 'you' ? 0 : 120 + (i % 5) * 22;
-    return {
-      ...n,
-      x: Math.cos(angle) * radius,
-      y: Math.sin(angle) * radius,
-      vx: 0,
-      vy: 0,
-    };
-  });
+const LEGEND: Array<{ c: string; label: string }> = [
+  { c: FILL.credential, label: 'Source-backed evidence' },
+  { c: FILL.source, label: 'Sources' },
+  { c: FILL.recognition, label: 'Recognition' },
+  { c: FILL.opportunity, label: 'Opportunities' },
+];
 
-  return { nodes, edges };
-}
-
-export function CareerEvidenceGraph({ height = 460 }: { height?: number }) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
-  const [hoverLabel, setHoverLabel] = useState<string | null>(null);
-  const { nodes, edges } = useMemo(() => buildGraph(), []);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const wrap = wrapRef.current;
-    if (!canvas || !wrap) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    const adjacency = new Map<string, Set<string>>();
-    nodes.forEach((n) => adjacency.set(n.id, new Set()));
-    edges.forEach((e) => {
-      adjacency.get(e.a)?.add(e.b);
-      adjacency.get(e.b)?.add(e.a);
-    });
-    const byId = new Map(nodes.map((n) => [n.id, n] as const));
-
-    let width = wrap.clientWidth;
-    let dpr = Math.min(window.devicePixelRatio || 1, 2);
-    const setSize = () => {
-      width = wrap.clientWidth;
-      dpr = Math.min(window.devicePixelRatio || 1, 2);
-      canvas.width = width * dpr;
-      canvas.height = height * dpr;
-      canvas.style.width = `${width}px`;
-      canvas.style.height = `${height}px`;
-    };
-    setSize();
-
-    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
-    let hovered: string | null = null;
-    let mouse = { x: 0, y: 0, active: false };
-
-    const cx = () => width / 2;
-    const cy = () => height / 2;
-
-    function step(alpha: number) {
-      // repulsion
-      for (let i = 0; i < nodes.length; i++) {
-        const a = nodes[i];
-        for (let j = i + 1; j < nodes.length; j++) {
-          const b = nodes[j];
-          let dx = a.x - b.x;
-          let dy = a.y - b.y;
-          let d2 = dx * dx + dy * dy;
-          if (d2 < 0.01) { dx = Math.cos(i) * 0.5; dy = Math.sin(i) * 0.5; d2 = 0.25; }
-          const d = Math.sqrt(d2);
-          const force = (4200 / d2) * alpha;
-          const fx = (dx / d) * force;
-          const fy = (dy / d) * force;
-          a.vx += fx; a.vy += fy;
-          b.vx -= fx; b.vy -= fy;
-        }
-      }
-      // springs
-      for (const e of edges) {
-        const a = byId.get(e.a)!;
-        const b = byId.get(e.b)!;
-        const dx = b.x - a.x;
-        const dy = b.y - a.y;
-        const d = Math.sqrt(dx * dx + dy * dy) || 0.01;
-        const rest = 92;
-        const force = (d - rest) * 0.035 * alpha;
-        const fx = (dx / d) * force;
-        const fy = (dy / d) * force;
-        a.vx += fx; a.vy += fy;
-        b.vx -= fx; b.vy -= fy;
-      }
-      // centering + integrate
-      for (const n of nodes) {
-        n.vx += -n.x * 0.012 * alpha;
-        n.vy += -n.y * 0.012 * alpha;
-        n.vx *= 0.82;
-        n.vy *= 0.82;
-        if (n.id === 'you') { n.x = 0; n.y = 0; n.vx = 0; n.vy = 0; continue; }
-        n.x += n.vx;
-        n.y += n.vy;
-      }
-    }
-
-    function draw() {
-      if (!ctx) return;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      ctx.clearRect(0, 0, width, height);
-      ctx.translate(cx(), cy());
-
-      const near = hovered ? adjacency.get(hovered) : null;
-
-      // edges
-      for (const e of edges) {
-        const a = byId.get(e.a)!;
-        const b = byId.get(e.b)!;
-        const lit = hovered && (e.a === hovered || e.b === hovered);
-        ctx.strokeStyle = lit ? 'rgba(79,209,197,0.75)' : hovered ? 'rgba(79,209,197,0.06)' : 'rgba(79,209,197,0.16)';
-        ctx.lineWidth = lit ? 1.6 : 1;
-        ctx.beginPath();
-        ctx.moveTo(a.x, a.y);
-        ctx.lineTo(b.x, b.y);
-        ctx.stroke();
-      }
-
-      // nodes
-      for (const n of nodes) {
-        const dim = hovered && n.id !== hovered && !near?.has(n.id);
-        ctx.globalAlpha = dim ? 0.25 : 1;
-        ctx.beginPath();
-        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
-        ctx.fillStyle = PALETTE[n.kind];
-        ctx.shadowColor = PALETTE[n.kind];
-        ctx.shadowBlur = n.id === hovered ? 18 : n.hub ? 8 : 0;
-        ctx.fill();
-        ctx.shadowBlur = 0;
-
-        // labels: hubs always, plus hovered
-        if ((n.hub || n.id === hovered) && !dim) {
-          ctx.globalAlpha = 1;
-          ctx.fillStyle = 'rgba(237,242,240,0.92)';
-          ctx.font = `${n.id === 'you' ? 13 : 11}px ui-sans-serif, system-ui, sans-serif`;
-          ctx.textAlign = 'center';
-          ctx.fillText(n.label, n.x, n.y - n.r - 6);
-        }
-      }
-      ctx.globalAlpha = 1;
-    }
-
-    // reduced motion: settle then draw once
-    if (reduced) {
-      for (let i = 0; i < 320; i++) step(1);
-      draw();
-    }
-
-    let raf = 0;
-    let alpha = 1;
-    const loop = () => {
-      alpha = Math.max(0.05, alpha * 0.992);
-      step(alpha);
-      draw();
-      raf = requestAnimationFrame(loop);
-    };
-    if (!reduced) raf = requestAnimationFrame(loop);
-
-    // hover detection
-    const onMove = (ev: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect();
-      mouse = { x: ev.clientX - rect.left - cx(), y: ev.clientY - rect.top - cy(), active: true };
-      let found: string | null = null;
-      let best = 22 * 22;
-      for (const n of nodes) {
-        const dx = n.x - mouse.x;
-        const dy = n.y - mouse.y;
-        const d2 = dx * dx + dy * dy;
-        if (d2 < best && d2 < (n.r + 12) * (n.r + 12)) { best = d2; found = n.id; }
-      }
-      if (found !== hovered) {
-        hovered = found;
-        setHoverLabel(found ? byId.get(found)!.label : null);
-        if (reduced) draw();
-      }
-      canvas.style.cursor = found ? 'pointer' : 'default';
-    };
-    const onLeave = () => { hovered = null; setHoverLabel(null); if (reduced) draw(); };
-    canvas.addEventListener('mousemove', onMove);
-    canvas.addEventListener('mouseleave', onLeave);
-
-    const ro = new ResizeObserver(() => { setSize(); if (reduced) draw(); });
-    ro.observe(wrap);
-
-    return () => {
-      cancelAnimationFrame(raf);
-      canvas.removeEventListener('mousemove', onMove);
-      canvas.removeEventListener('mouseleave', onLeave);
-      ro.disconnect();
-    };
-  }, [nodes, edges, height]);
-
+export function CareerEvidenceGraph() {
   return (
-    <div ref={wrapRef} style={{ position: 'relative', width: '100%' }}>
-      <canvas ref={canvasRef} aria-label="Interactive diagram of the career evidence network" />
-      {/* Legend */}
-      <div
-        style={{
-          position: 'absolute',
-          left: 16,
-          bottom: 14,
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '6px 14px',
-          maxWidth: 'calc(100% - 32px)',
-        }}
-      >
+    <div>
+      <svg viewBox="0 0 720 400" width="100%" role="img" aria-label="A static map of the career evidence network" style={{ display: 'block' }}>
+        {/* edges — thin ink strokes */}
+        {EDGES.map(([a, b], i) => {
+          const na = BY_ID.get(a)!;
+          const nb = BY_ID.get(b)!;
+          return <line key={i} x1={na.x} y1={na.y} x2={nb.x} y2={nb.y} stroke="#c2bfb5" strokeWidth={1} />;
+        })}
+        {/* nodes */}
+        {NODES.map((n) => {
+          const r = n.id === 'you' ? 7 : n.hub ? 5 : 3.5;
+          return (
+            <g key={n.id}>
+              {n.kind === 'you' ? (
+                <rect x={n.x - r} y={n.y - r} width={r * 2} height={r * 2} fill={FILL.you} />
+              ) : (
+                <circle cx={n.x} cy={n.y} r={r} fill={FILL[n.kind]} />
+              )}
+              {n.label ? (
+                <text
+                  x={n.x}
+                  y={n.y - r - 6}
+                  textAnchor="middle"
+                  fontFamily="var(--font-geist-mono, ui-monospace, monospace)"
+                  fontSize={9.5}
+                  fill="#474540"
+                  style={{ letterSpacing: '0.02em' }}
+                >
+                  {n.label}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
+      </svg>
+      {/* legend — mono */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px 18px', marginTop: 8 }}>
         {LEGEND.map((l) => (
-          <span key={l.kind} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'rgba(237,242,240,0.6)' }}>
-            <span style={{ width: 8, height: 8, borderRadius: 999, background: PALETTE[l.kind] }} />
+          <span key={l.label} className="mz-mono" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 10, color: 'var(--ink-500, #6b6860)' }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: l.c }} />
             {l.label}
           </span>
         ))}
-      </div>
-      {/* Hover readout */}
-      <div style={{ position: 'absolute', right: 16, top: 14, fontSize: 12, color: 'rgba(237,242,240,0.7)', minHeight: 16 }}>
-        {hoverLabel ? `→ ${hoverLabel}` : 'Hover a node'}
       </div>
     </div>
   );

--- a/apps/web/components/matcha/PublicMatchaExperience.tsx
+++ b/apps/web/components/matcha/PublicMatchaExperience.tsx
@@ -15,15 +15,13 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Sparkles, ArrowRight, RotateCcw } from 'lucide-react';
+import { ArrowRight, RotateCcw } from 'lucide-react';
 
 import type { MatchaPreferences, PreferenceField } from '@/lib/matcha/preferences';
 import { deriveMatchaProfile } from '@/lib/matcha/profile';
 import { preferenceMatchReasons } from '@/lib/matcha/opportunityFit';
 import { MatchaExplanation } from './MatchaExplanation';
 import { useMatchaPreferences } from './useMatchaPreferences';
-
-const ACCENT = 'var(--vt-accent, #0A7B7F)';
 
 interface QuickQuestion {
   id: string;
@@ -127,32 +125,24 @@ export function PublicMatchaExperience() {
 
   return (
     <div
+      className="mz"
       style={{
         display: 'grid',
-        gap: 20,
+        gap: 16,
         gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
         alignItems: 'start',
       }}
     >
       {/* Left: the conversation */}
-      <div
-        style={{
-          background: 'var(--vt-surface, #fff)',
-          border: '1px solid var(--vt-border, #E2E8E6)',
-          borderRadius: 20,
-          padding: 24,
-          minHeight: 260,
-        }}
-      >
+      <div className="mz-card mz-card-pad" style={{ minHeight: 260 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 11, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: ACCENT }}>
-            <Sparkles size={14} /> Try MATCHA
-          </span>
+          <span className="mz-eyebrow">Try MATCHA</span>
           {answeredCount > 0 ? (
             <button
               type="button"
               onClick={() => { reset(); setIndex(0); }}
-              style={{ display: 'inline-flex', alignItems: 'center', gap: 5, border: 0, background: 'transparent', color: 'var(--vt-text-muted)', fontSize: 12, cursor: 'pointer' }}
+              className="mz-mono"
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 5, border: 0, background: 'transparent', color: 'var(--ink-500)', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', cursor: 'pointer' }}
             >
               <RotateCcw size={12} /> Reset
             </button>
@@ -163,16 +153,16 @@ export function PublicMatchaExperience() {
           {!done ? (
             <motion.div
               key={q.id}
-              initial={{ opacity: 0, y: 10 }}
+              initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.28, ease: [0.2, 0.8, 0.2, 1] }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.32, ease: [0.2, 0.7, 0.2, 1] }}
             >
-              <p style={{ margin: '18px 0 0', fontSize: 20, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{q.prompt}</p>
+              <p className="mz-h1" style={{ marginTop: 16, fontSize: 22 }}>{q.prompt}</p>
               {q.multi ? (
-                <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--vt-text-muted)' }}>Pick any that apply.</p>
+                <p className="mz-mono" style={{ margin: '6px 0 0', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--ink-400)' }}>Pick any that apply</p>
               ) : null}
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16 }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
                 {q.options.map((opt) => {
                   const v = preferences[q.field];
                   const active = Array.isArray(v) ? (v as string[]).includes(opt.value) : v === opt.value;
@@ -180,18 +170,9 @@ export function PublicMatchaExperience() {
                     <button
                       key={opt.value}
                       type="button"
+                      className="mz-opt"
+                      aria-pressed={active}
                       onClick={() => answer(q, opt.value)}
-                      style={{
-                        padding: '9px 15px',
-                        borderRadius: 11,
-                        fontSize: 14,
-                        fontWeight: 500,
-                        cursor: 'pointer',
-                        border: `1px solid ${active ? ACCENT : 'var(--vt-border, #D6DED9)'}`,
-                        background: active ? `color-mix(in srgb, ${ACCENT} 12%, transparent)` : 'var(--vt-surface, #fff)',
-                        color: active ? ACCENT : 'var(--vt-text-primary)',
-                        transition: 'all 160ms cubic-bezier(0.2,0.8,0.2,1)',
-                      }}
                     >
                       {opt.label}
                     </button>
@@ -201,26 +182,24 @@ export function PublicMatchaExperience() {
               {q.multi ? (
                 <button
                   type="button"
+                  className="mz-btn"
+                  style={{ marginTop: 18 }}
                   onClick={() => setIndex((i) => Math.min(i + 1, QUESTIONS.length))}
-                  style={{ marginTop: 18, padding: '9px 18px', borderRadius: 11, border: 0, background: ACCENT, color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
                 >
                   Continue
                 </button>
               ) : null}
             </motion.div>
           ) : (
-            <motion.div key="done" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
-              <p style={{ margin: '18px 0 0', fontSize: 20, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+            <motion.div key="done" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.32 }}>
+              <p className="mz-h1" style={{ marginTop: 16, fontSize: 22 }}>
                 That&rsquo;s the idea.
               </p>
-              <p style={{ margin: '8px 0 0', fontSize: 14, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>
+              <p className="mz-body" style={{ marginTop: 10 }}>
                 With your wallet, MATCHA keeps learning and works in the background — scoring real
                 roles on your source-backed readiness, not just what you typed here.
               </p>
-              <Link
-                href="/holder/matcha"
-                style={{ display: 'inline-flex', alignItems: 'center', gap: 8, marginTop: 18, padding: '11px 22px', borderRadius: 12, background: ACCENT, color: '#fff', fontSize: 15, fontWeight: 600, textDecoration: 'none' }}
-              >
+              <Link href="/holder/matcha" className="mz-btn" style={{ marginTop: 18 }}>
                 Let MATCHA work for you <ArrowRight size={16} />
               </Link>
             </motion.div>
@@ -229,37 +208,27 @@ export function PublicMatchaExperience() {
       </div>
 
       {/* Right: the live reflection */}
-      <div
-        style={{
-          background: `linear-gradient(135deg, color-mix(in srgb, ${ACCENT} 7%, var(--vt-surface, #fff)), var(--vt-surface, #fff))`,
-          border: `1px solid color-mix(in srgb, ${ACCENT} 22%, transparent)`,
-          borderRadius: 20,
-          padding: 24,
-          minHeight: 260,
-        }}
-      >
-        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: ACCENT }}>
-          MATCHA understands you
-        </span>
+      <div className="mz-card mz-card-pad mz-inset" style={{ minHeight: 260 }}>
+        <span className="mz-eyebrow">MATCHA understands you</span>
 
         {derived.insights.length === 0 ? (
-          <p style={{ margin: '16px 0 0', fontSize: 14, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>
+          <p className="mz-body" style={{ marginTop: 16 }}>
             Tap an answer and watch MATCHA reflect it back — always tied to exactly what you said,
             never guessed.
           </p>
         ) : (
           <>
-            <ul style={{ listStyle: 'none', margin: '14px 0 0', padding: 0, display: 'grid', gap: 10 }}>
+            <ul style={{ listStyle: 'none', margin: '14px 0 0', padding: 0, display: 'grid', gap: 12 }}>
               {derived.insights.slice(0, 4).map((insight, i) => (
                 <motion.li
                   key={`${insight.label}-${i}`}
-                  initial={{ opacity: 0, x: 8 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.25 }}
-                  style={{ display: 'grid', gap: 2 }}
+                  initial={{ opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.28, ease: [0.2, 0.7, 0.2, 1] }}
+                  style={{ display: 'grid', gap: 3 }}
                 >
-                  <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--vt-text-primary)' }}>{insight.label}</span>
-                  <span style={{ fontSize: 11, color: 'var(--vt-text-muted)' }}>
+                  <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--ink-900)' }}>{insight.label}</span>
+                  <span className="mz-mono" style={{ fontSize: 10, color: 'var(--ink-500)' }}>
                     because you told MATCHA: {insight.provenance.join(', ').replace(/([A-Z])/g, ' $1').toLowerCase()}
                   </span>
                 </motion.li>
@@ -267,8 +236,8 @@ export function PublicMatchaExperience() {
             </ul>
 
             {exampleReasons.length > 0 ? (
-              <div style={{ marginTop: 18, paddingTop: 16, borderTop: `1px solid color-mix(in srgb, ${ACCENT} 18%, transparent)` }}>
-                <p style={{ margin: '0 0 10px', fontSize: 11, color: 'var(--vt-text-muted)' }}>
+              <div style={{ marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--rule)' }}>
+                <p className="mz-mono" style={{ margin: '0 0 10px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', color: 'var(--ink-400)' }}>
                   Example role · illustration only
                 </p>
                 <MatchaExplanation reasons={exampleReasons} title="Why MATCHA would surface this" />

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -1,0 +1,225 @@
+/**
+ * matcha-zen.css — VitalCV "Calm Wave D56 / Zenlike" design layer for the MATCHA surfaces.
+ *
+ * Ported from the design handoff (docs/design/zenlike-ui-doctrine.md). Paper + ink, Geist prose,
+ * mono eyebrows/tokens, editorial serif display with italic indigo accents, near-sharp borders,
+ * semantic truth-state chips. Calm 320ms motion, single-shot only — NO gradients, NO looping
+ * animations, NO decorative visuals (doctrine §1.4 / §3).
+ *
+ * Everything is scoped under `.mz` so it never bleeds into the rest of the app. A surface adds
+ * className="mz" on its root; children use `.mz-*` classes.
+ */
+
+.mz {
+  /* Paper & ink */
+  --paper: #f4f2ec;
+  --paper-2: #efede7;
+  --card: #ffffff;
+  --ink-950: #050504;
+  --ink-900: #0f0e0c;
+  --ink-800: #1a1916;
+  --ink-700: #2d2c28;
+  --ink-600: #474540;
+  --ink-500: #6b6860;
+  --ink-400: #96938a;
+  --ink-300: #c2bfb5;
+  --ink-200: #dddbd3;
+  --ink-100: #efede7;
+  --ink-50: #f7f6f2;
+  --rule: #dddbd3;
+  --rule-soft: #eceae4;
+
+  /* Truth states */
+  --ok: #1c5c38;        --ok-bg: #f0faf5;      --ok-rule: #86c9a6;
+  --watch: #7d5a1e;     --watch-bg: #fdf4e7;   --watch-rule: #c9a84c;
+  --unknown: #3f3d38;   --unknown-bg: #f1efe9; --unknown-rule: #c8c4ba;
+  --p0: #7a1414;        --p0-bg: #fef2f2;      --p0-rule: #f5a5a5;
+
+  /* Editorial accent (italic display words) */
+  --accent: #4f46e5;
+
+  /* Fonts — reuse the app's exposed variables (Geist/serif/mono → system fallbacks) */
+  --mz-sans: var(--font-geist, var(--vt-font-body, ui-sans-serif, system-ui, sans-serif));
+  --mz-mono: var(--font-geist-mono, var(--font-mono, ui-monospace, 'JetBrains Mono', monospace));
+  --mz-serif: var(--vt-font-display, var(--font-fraunces, Georgia, 'Times New Roman', serif));
+
+  --mz-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --mz-dur: 320ms;
+
+  color: var(--ink-900);
+  font-family: var(--mz-sans);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Opt-in paper canvas for full standalone surfaces. */
+.mz-paper { background: var(--paper); }
+
+/* ── Typography ───────────────────────────────────────────────────────────── */
+
+.mz-display {
+  margin: 0;
+  font-family: var(--mz-serif);
+  font-weight: 500;
+  font-size: clamp(2.4rem, 5.5vw, 3.6rem);
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+  color: var(--ink-950);
+}
+.mz-accent { font-style: italic; color: var(--accent); }
+
+.mz-h1 { margin: 0; font-family: var(--mz-serif); font-weight: 500; font-size: clamp(1.6rem, 3vw, 2.1rem); line-height: 1.12; letter-spacing: -0.02em; color: var(--ink-950); }
+.mz-h2 { margin: 0; font-weight: 600; font-size: 1.05rem; line-height: 1.25; letter-spacing: -0.01em; color: var(--ink-900); }
+.mz-lede { margin: 0; font-size: 1.0625rem; line-height: 1.55; color: var(--ink-600); }
+.mz-body { margin: 0; font-size: 0.9375rem; line-height: 1.55; color: var(--ink-700); }
+.mz-small { font-size: 0.8125rem; color: var(--ink-500); }
+.mz-mono { font-family: var(--mz-mono); font-variant-numeric: tabular-nums; }
+
+.mz-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mz-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-400);
+}
+.mz-eyebrow::after { content: ''; width: 40px; height: 1px; background: var(--rule); }
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
+
+.mz-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border: 1px solid var(--ink-900);
+  background: var(--ink-900);
+  color: #fff;
+  border-radius: 3px;
+  font-family: var(--mz-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background var(--mz-dur) var(--mz-ease), transform 80ms var(--mz-ease);
+}
+.mz-btn:hover { background: var(--ink-700); }
+.mz-btn:active { transform: translateY(1px); }
+
+.mz-btn-ghost {
+  background: transparent;
+  color: var(--ink-900);
+  border-color: var(--rule);
+}
+.mz-btn-ghost:hover { background: var(--ink-50); border-color: var(--ink-300); }
+
+.mz-btn-sm { padding: 7px 13px; font-size: 12.5px; }
+
+/* ── Cards / surfaces ─────────────────────────────────────────────────────── */
+
+.mz-card {
+  border: 1px solid var(--rule);
+  background: var(--card);
+  border-radius: 3px;
+}
+.mz-card-pad { padding: 20px; }
+.mz-card-hd {
+  padding: 15px 20px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.mz-card-ttl { font-size: 13.5px; font-weight: 600; color: var(--ink-900); letter-spacing: -0.005em; }
+.mz-inset { background: var(--paper-2); border: 1px solid var(--rule-soft); border-radius: 3px; }
+
+/* Hairline-lift for interactive cards — border darkens, no shadow bloom, no lift bounce. */
+.mz-interactive { transition: border-color var(--mz-dur) var(--mz-ease), background var(--mz-dur) var(--mz-ease); }
+.mz-interactive:hover { border-color: var(--ink-400); }
+
+/* ── State chips ──────────────────────────────────────────────────────────── */
+
+.mz-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  border: 1px solid;
+  border-radius: 2px;
+  font-family: var(--mz-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.mz-gl { width: 8px; height: 8px; flex: 0 0 auto; border-radius: 1px; }
+.mz-chip-ok { color: var(--ok); background: var(--ok-bg); border-color: var(--ok-rule); }
+.mz-chip-ok .mz-gl { background: var(--ok); }
+.mz-chip-watch { color: var(--watch); background: var(--watch-bg); border-color: var(--watch-rule); }
+.mz-chip-watch .mz-gl { background: var(--watch); border-radius: 50%; }
+.mz-chip-unknown { color: var(--unknown); background: var(--unknown-bg); border-color: var(--unknown-rule); }
+.mz-chip-unknown .mz-gl { background: var(--unknown); opacity: 0.5; }
+.mz-chip-p0 { color: var(--p0); background: var(--p0-bg); border-color: var(--p0-rule); }
+.mz-chip-p0 .mz-gl { background: var(--p0); clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%); }
+
+/* ── Inputs / field ───────────────────────────────────────────────────────── */
+
+.mz-input {
+  width: 100%;
+  padding: 11px 13px;
+  border: 1px solid var(--ink-300);
+  background: var(--card);
+  color: var(--ink-900);
+  border-radius: 3px;
+  font: inherit;
+  font-size: 14px;
+  outline: none;
+  transition: border-color var(--mz-dur) var(--mz-ease);
+}
+.mz-input:focus { border-color: var(--ink-900); }
+.mz-input::placeholder { color: var(--ink-400); }
+
+.mz-field { display: flex; border: 1px solid var(--ink-900); background: var(--card); border-radius: 3px; overflow: hidden; }
+.mz-field .mz-prefix { padding: 0 14px; display: flex; align-items: center; font-family: var(--mz-mono); font-size: 10px; color: var(--ink-500); text-transform: uppercase; letter-spacing: 0.14em; border-right: 1px solid var(--rule); background: var(--ink-50); }
+.mz-field input { flex: 1; border: 0; padding: 13px 15px; font: inherit; font-size: 15px; color: var(--ink-900); background: transparent; outline: none; font-variant-numeric: tabular-nums; }
+
+/* ── Selectable chips (options) ───────────────────────────────────────────── */
+
+.mz-opt {
+  padding: 8px 13px;
+  border: 1px solid var(--ink-200);
+  background: var(--card);
+  border-radius: 3px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-700);
+  cursor: pointer;
+  transition: border-color var(--mz-dur) var(--mz-ease), background var(--mz-dur) var(--mz-ease);
+}
+.mz-opt:hover { border-color: var(--ink-400); }
+.mz-opt[aria-pressed='true'] { border-color: var(--ink-900); background: var(--ink-900); color: #fff; }
+
+/* ── Progress meter (ink, no gradient) ────────────────────────────────────── */
+
+.mz-meter { height: 5px; border-radius: 999px; background: var(--ink-100); overflow: hidden; }
+.mz-meter > span { display: block; height: 100%; background: var(--ink-800); border-radius: 999px; transition: width var(--mz-dur) var(--mz-ease); }
+
+/* ── Dotted grid backdrop (static, calm) ──────────────────────────────────── */
+
+.mz-dotgrid {
+  background-image: radial-gradient(var(--ink-200) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+/* ── Motion respect ───────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .mz *, .mz *::before, .mz *::after { transition: none !important; animation: none !important; }
+}


### PR DESCRIPTION
## What this does

Brings the **public MATCHA surfaces** in line with the **"Zenlike / Calm Wave D56"** design handoff — warm **paper + ink**, Geist prose, **mono eyebrows**, editorial **serif display with italic indigo accents**, near-sharp borders, semantic truth-state chips, calm 320ms motion.

- **`styles/matcha-zen.css`** — a scoped `.mz` design layer (paper/ink/truth tokens, serif display, mono eyebrow, cards, chips, `.mz-opt`, ink meter, dotted grid). Reduced-motion aware. **No gradients, no looping animation** (doctrine §1.4 / §3).
- **`CareerEvidenceGraph`** — replaced the animated, gradient, force-simulated canvas (which violated the no-looping / no-gradient / no-decorative-visual rules) with a **calm STATIC SVG** in ink strokes + mono labels. Now pure / server-renderable.
- **`PublicMatchaExperience`** — restyled to paper/ink cards, mono eyebrows, `.mz-opt` chips, ink prose; dropped the teal gradient panel; motion reduced to ≤6px.
- **`HomePageClient`** — the Meet MATCHA + Career Evidence Network sections rethemed; the dark radial-gradient panel removed.

## Scope
This is **Phase 1** — the live public homepage (highest visibility). The signed-in MATCHA surfaces (hub, assessment, opportunities, candidate pool) still use the prior tokens and will be rethemed to `.mz` in a follow-up.

## Verification
Typecheck clean; `next build` green; component render tests pass; verified in-browser (paper background, serif headings, static ink network graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)