### PR TITLE
feat(matcha): Calm Wave D56 — signed-in surfaces

### DIFF
--- a/apps/web/components/matcha/MatchaAssessment.tsx
+++ b/apps/web/components/matcha/MatchaAssessment.tsx
@@ -43,7 +43,7 @@ export function MatchaAssessment() {
   const totalQuestions = progress.reduce((n, p) => n + p.total, 0);
 
   return (
-    <div className="matcha-enter" style={{ maxWidth: 760, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+    <div className="mz mz-paper matcha-enter" style={{ maxWidth: 760, margin: '0 auto', padding: '28px 24px 96px', display: 'grid', gap: 20, minHeight: '100vh' }}>
       {/* Header */}
       <header>
         <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Match questions</h1>

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -69,7 +69,7 @@ export function MatchaHub() {
   const hasMatches = oppState === 'ready' && matches.length > 0;
 
   return (
-    <div className="matcha-enter" style={{ maxWidth: 960, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 24 }}>
+    <div className="mz mz-paper matcha-enter" style={{ maxWidth: 960, margin: '0 auto', padding: '28px 24px 96px', display: 'grid', gap: 24, minHeight: '100vh' }}>
       {/* Greeting + what to do next */}
       <Panel>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>

--- a/apps/web/components/matcha/MatchaOnboardingSurface.tsx
+++ b/apps/web/components/matcha/MatchaOnboardingSurface.tsx
@@ -15,7 +15,7 @@ export function MatchaOnboardingSurface() {
   const person = data.workspace?.personProfile;
 
   return (
-    <div style={{ padding: '28px 20px 96px' }}>
+    <div className="mz mz-paper" style={{ padding: '28px 24px 96px', minHeight: '100vh' }}>
       <MatchaOnboarding
         npi={person?.npi ?? undefined}
         clinicianName={person?.firstName ?? undefined}

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -29,7 +29,7 @@ export function MatchaOpportunitiesSurface() {
   const bucketCounts = counts(ids);
 
   return (
-    <div className="matcha-enter" style={{ maxWidth: 820, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 16 }}>
+    <div className="mz mz-paper matcha-enter" style={{ maxWidth: 820, margin: '0 auto', padding: '28px 24px 96px', display: 'grid', gap: 16, minHeight: '100vh' }}>
       <header style={{ marginBottom: 4 }}>
         <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
           Opportunities MATCHA found

--- a/apps/web/components/matcha/MatchaProfile.tsx
+++ b/apps/web/components/matcha/MatchaProfile.tsx
@@ -114,9 +114,9 @@ export function MatchaProfile({ derived, clinicianName }: MatchaProfileProps) {
       {/* Header card */}
       <div
         style={{
-          background: 'linear-gradient(135deg, color-mix(in srgb, var(--vt-accent, #0A7B7F) 8%, var(--vt-surface, #fff)), var(--vt-surface, #fff))',
+          background: 'var(--vt-surface-subtle, #EDF2F0)',
           border: '1px solid var(--vt-border, #E2E8E6)',
-          borderRadius: 20,
+          borderRadius: 4,
           padding: 24,
           display: 'flex',
           gap: 20,

--- a/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
+++ b/apps/web/components/matcha/employer/CandidatePoolSurface.tsx
@@ -36,7 +36,7 @@ export function CandidatePoolSurface() {
   }
 
   return (
-    <div className="matcha-enter" style={{ maxWidth: 860, margin: '0 auto', padding: '24px 20px 96px', display: 'grid', gap: 20 }}>
+    <div className="mz mz-paper matcha-enter" style={{ maxWidth: 860, margin: '0 auto', padding: '28px 24px 96px', display: 'grid', gap: 20, minHeight: '100vh' }}>
       <header>
         <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600, color: 'var(--vt-text-primary)', letterSpacing: '-0.01em' }}>
           Credential-ready clinicians

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -56,6 +56,29 @@
 /* Opt-in paper canvas for full standalone surfaces. */
 .mz-paper { background: var(--paper); }
 
+/**
+ * Compatibility bridge: inside `.mz`, alias the app's --vt-* tokens to the Calm Wave palette.
+ * This recolors existing inline `var(--vt-*)` styles (teal → indigo, surfaces → paper/card,
+ * text → ink) without rewriting every component. Scoped to .mz so the rest of the app is
+ * untouched. Pair with `.mz-paper` on the surface root so ink text always sits on paper.
+ */
+.mz {
+  --vt-accent: var(--accent);
+  --vt-surface: var(--card);
+  --vt-surface-subtle: var(--paper-2);
+  --vt-bg: var(--paper);
+  --vt-border: var(--rule);
+  --vt-border-subtle: var(--rule-soft);
+  --vt-text-primary: var(--ink-900);
+  --vt-text-secondary: var(--ink-600);
+  --vt-text-muted: var(--ink-400);
+  --vt-status-resolved: var(--ok);
+  --vt-state-verified: var(--ok);
+  --vt-risk-high: var(--p0);
+  --vt-risk-medium: var(--watch);
+  --vt-accent-strong: var(--ink-900);
+}
+
 /* ── Typography ───────────────────────────────────────────────────────────── */
 
 .mz-display {


### PR DESCRIPTION
## What this does

**Phase 2** of the Calm Wave redesign — the signed-in MATCHA surfaces adopt the paper/ink aesthetic.

- **`matcha-zen.css`** — a scoped compatibility bridge: inside `.mz`, the app's `--vt-*` tokens are aliased to the Calm Wave palette (teal→indigo, surfaces→paper/card, text→ink, status→ok/watch/p0). This recolors existing inline `var(--vt-*)` styles across the surfaces without rewriting each component.
- Each signed-in surface root (hub, assessment, opportunities, candidate pool, onboarding) is now a self-contained **`.mz mz-paper`** canvas, so ink text always sits on paper even inside the dark holder shell.
- **`MatchaProfile`** — removed a gradient header (doctrine §1.4 forbids gradients) → flat paper-subtle panel, near-sharp corners.

## Scope note
These surfaces are gated behind `MATCHA_V2`, so this is not visually verifiable without auth. The recolor is structurally safe (self-contained paper canvases → no invisible-text risk). A deeper per-component pass (serif headings, mono state chips on the cards) is a sensible follow-up once we can preview signed-in.

## Verification
Typecheck clean; `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)