### PR TITLE
feat(matcha): interactive Career Constellation — travel your career through time

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -27,7 +27,7 @@ import { Input } from '@/components/ui/input';
 import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
 import { cn } from '@/lib/utils';
 import { PublicMatchaExperience } from '@/components/matcha/PublicMatchaExperience';
-import { CareerEvidenceGraph } from '@/components/matcha/CareerEvidenceGraph';
+import { MatchaConstellation } from '@/components/matcha/MatchaConstellation';
 
 function formatNpi(value: string): string {
   const digits = value.replace(/\D/g, '').slice(0, 10);
@@ -759,19 +759,19 @@ export default function HomePageClient() {
           </section>
 
           {/* Career Evidence Network — static, calm diagram · Calm Wave D56 */}
-          <section aria-label="The career evidence network" data-home-network="" className="mz mt-16">
+          <section aria-label="Your career, in motion" data-home-network="" className="mz mt-16">
             <div className="mz-card mz-dotgrid" style={{ padding: '32px 28px' }}>
-              <p className="mz-eyebrow">The career evidence network</p>
-              <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 620 }}>
-                Your evidence isn&rsquo;t a document. It&rsquo;s a <span className="mz-accent">network</span>.
+              <p className="mz-eyebrow">Your career, in motion</p>
+              <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 640 }}>
+                Your career isn&rsquo;t a timeline. It&rsquo;s a <span className="mz-accent">constellation you can travel</span>.
               </h2>
               <p className="mz-body" style={{ marginTop: 14, maxWidth: 640 }}>
-                Every credential traces to its source, rolls up into your readiness, and connects to the
-                opportunities it unlocks and the employers who accept it. Verify once; reuse everywhere.
-                This is one map of how it fits together.
+                Where you began, where you are, and where you&rsquo;re headed — one living sky. Drag to
+                rotate it; pull the slider to move through your career and watch the opportunities on your
+                horizon light up. Past and future are illustrative; your real evidence lives in your wallet.
               </p>
               <div style={{ marginTop: 20 }}>
-                <CareerEvidenceGraph />
+                <MatchaConstellation height={480} />
               </div>
             </div>
           </section>

--- a/apps/web/components/matcha/MatchaConstellation.tsx
+++ b/apps/web/components/matcha/MatchaConstellation.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+/**
+ * MatchaConstellation — the signature interactive centerpiece.
+ *
+ * A clinician's career rendered as a living orbital constellation you can *scrub through time*:
+ * where you began (residency, first license), where you are now (source-backed evidence, readiness,
+ * recognition), and where you're headed (projected opportunities that light up as readiness grows).
+ * Drag to rotate the sky, hover a star to read it, and pull the time control to travel your career.
+ *
+ * This is a deliberate, alive moment — gentle orbital motion, depth, twinkle — inside the otherwise
+ * calm product. Honesty: "now" nodes are real career-evidence categories; past and future are
+ * clearly labeled as illustrative/projected, never asserted as verified facts.
+ *
+ * Respects prefers-reduced-motion (settles to a static sky, still fully interactive via the scrubber).
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type Era = 'origin' | 'now' | 'future';
+type Kind = 'you' | 'origin' | 'credential' | 'readiness' | 'recognition' | 'opportunity' | 'future';
+
+interface Star {
+  id: string;
+  label: string;
+  kind: Kind;
+  era: Era;
+  /** temporal position 0 (earliest) … 1 (furthest future) */
+  t: number;
+  ring: 1 | 2 | 3;
+  angle: number; // base angle (radians)
+  twinkle: number; // phase
+}
+
+const PALETTE: Record<Kind, string> = {
+  you: '#f4c76b',
+  origin: '#9aa0b5',
+  credential: '#5fd4bf',
+  readiness: '#8b8cf0',
+  recognition: '#f4a15f',
+  opportunity: '#7fe0a3',
+  future: '#8b8cf0',
+};
+
+// Deterministic layout (no Math.random at module scope; twinkle phase derived from index).
+function buildStars(): Star[] {
+  const defs: Array<Omit<Star, 'angle' | 'twinkle'>> = [
+    { id: 'you', label: 'You', kind: 'you', era: 'now', t: 0.5, ring: 1 },
+    // origin era
+    { id: 'residency', label: 'Residency', kind: 'origin', era: 'origin', t: 0.08, ring: 3 },
+    { id: 'first-license', label: 'First license', kind: 'origin', era: 'origin', t: 0.15, ring: 2 },
+    { id: 'boards', label: 'Board exam', kind: 'origin', era: 'origin', t: 0.2, ring: 3 },
+    { id: 'first-role', label: 'First role', kind: 'origin', era: 'origin', t: 0.27, ring: 2 },
+    // now era — real evidence categories
+    { id: 'npi', label: 'NPI', kind: 'credential', era: 'now', t: 0.46, ring: 1 },
+    { id: 'license', label: 'State license', kind: 'credential', era: 'now', t: 0.5, ring: 2 },
+    { id: 'board-cert', label: 'Board cert', kind: 'credential', era: 'now', t: 0.52, ring: 2 },
+    { id: 'dea', label: 'DEA', kind: 'credential', era: 'now', t: 0.48, ring: 3 },
+    { id: 'readiness', label: 'Readiness', kind: 'readiness', era: 'now', t: 0.5, ring: 1 },
+    { id: 'recognition', label: 'Recognition', kind: 'recognition', era: 'now', t: 0.55, ring: 2 },
+    { id: 'specialty', label: 'Specialty', kind: 'readiness', era: 'now', t: 0.54, ring: 3 },
+    // future era — projected
+    { id: 'opp1', label: 'Projected role', kind: 'future', era: 'future', t: 0.72, ring: 2 },
+    { id: 'opp2', label: 'Projected role', kind: 'future', era: 'future', t: 0.8, ring: 3 },
+    { id: 'next-license', label: 'Next license', kind: 'future', era: 'future', t: 0.76, ring: 2 },
+    { id: 'subspecialty', label: 'Subspecialty', kind: 'future', era: 'future', t: 0.88, ring: 3 },
+    { id: 'leadership', label: 'Leadership', kind: 'future', era: 'future', t: 0.93, ring: 2 },
+  ];
+  const perRing: Record<number, number> = { 1: 0, 2: 0, 3: 0 };
+  const ringCount: Record<number, number> = {
+    1: defs.filter((d) => d.ring === 1 && d.id !== 'you').length,
+    2: defs.filter((d) => d.ring === 2).length,
+    3: defs.filter((d) => d.ring === 3).length,
+  };
+  return defs.map((d, i) => {
+    if (d.id === 'you') return { ...d, angle: 0, twinkle: 0 };
+    const idx = perRing[d.ring]++;
+    const angle = (idx / Math.max(1, ringCount[d.ring])) * Math.PI * 2 + d.ring * 0.6;
+    return { ...d, angle, twinkle: (i * 1.7) % (Math.PI * 2) };
+  });
+}
+
+const ERA_LABEL: Record<Era, string> = {
+  origin: 'Where you began',
+  now: 'Where you are',
+  future: 'Where you’re headed',
+};
+
+function eraForTime(t: number): Era {
+  if (t < 0.35) return 'origin';
+  if (t > 0.62) return 'future';
+  return 'now';
+}
+
+export function MatchaConstellation({ height = 460 }: { height?: number }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const stars = useMemo(() => buildStars(), []);
+  const [time, setTime] = useState(0.5);
+  const [hoverLabel, setHoverLabel] = useState<string | null>(null);
+  const timeRef = useRef(0.5);
+  timeRef.current = time;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let width = wrap.clientWidth;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const setSize = () => {
+      width = wrap.clientWidth;
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    };
+    setSize();
+
+    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    const ringR = () => [0, Math.min(width, height * 1.6) * 0.16, Math.min(width, height * 1.6) * 0.26, Math.min(width, height * 1.6) * 0.36];
+
+    let rot = 0;
+    let dragRot = 0;
+    let dragging = false;
+    let lastX = 0;
+    let hovered: string | null = null;
+    let mouse = { x: 0, y: 0 };
+    let raf = 0;
+    let last = 0;
+
+    const positions = new Map<string, { x: number; y: number; scale: number; alpha: number }>();
+
+    function draw(now: number) {
+      if (!ctx) return;
+      const dt = last ? Math.min(0.05, (now - last) / 1000) : 0;
+      last = now;
+      if (!reduced) rot += dt * 0.18;
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height / 2;
+      const rings = ringR();
+      const t = timeRef.current;
+
+      // faint orbit rings (elliptical)
+      ctx.strokeStyle = 'rgba(139,140,240,0.10)';
+      ctx.lineWidth = 1;
+      for (let r = 1; r <= 3; r++) {
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, rings[r], rings[r] * 0.55, 0, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+
+      // compute positions
+      positions.clear();
+      for (const s of stars) {
+        if (s.id === 'you') {
+          positions.set(s.id, { x: cx, y: cy, scale: 1, alpha: 1 });
+          continue;
+        }
+        const ringSpeed = 1 / s.ring;
+        const a = s.angle + rot * ringSpeed + dragRot;
+        const r = rings[s.ring];
+        const x = cx + Math.cos(a) * r;
+        const depth = Math.sin(a); // -1 back … 1 front
+        const y = cy + Math.sin(a) * r * 0.55 - depth * 6;
+        const scale = 0.7 + (depth + 1) * 0.28;
+        // temporal brightness: bright near the scrubbed time, dim far away
+        const dist = Math.abs(t - s.t);
+        const timeAlpha = Math.max(0.05, 1 - dist * 2.6);
+        const tw = reduced ? 1 : 0.82 + 0.18 * Math.sin(now / 600 + s.twinkle);
+        positions.set(s.id, { x, y, scale, alpha: timeAlpha * tw });
+      }
+
+      // links from center to visible-ish stars
+      const you = positions.get('you')!;
+      for (const s of stars) {
+        if (s.id === 'you') continue;
+        const p = positions.get(s.id)!;
+        if (p.alpha < 0.12) continue;
+        ctx.strokeStyle = `rgba(139,140,240,${0.05 + p.alpha * 0.12})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(you.x, you.y);
+        ctx.lineTo(p.x, p.y);
+        ctx.stroke();
+      }
+
+      // stars — back to front
+      const order = [...stars].sort((a, b) => (positions.get(a.id)!.y) - (positions.get(b.id)!.y));
+      for (const s of order) {
+        const p = positions.get(s.id)!;
+        const isHover = hovered === s.id;
+        const baseR = (s.id === 'you' ? 9 : s.kind === 'future' ? 4.5 : 5.5) * p.scale;
+        const col = PALETTE[s.kind];
+        ctx.globalAlpha = Math.min(1, p.alpha + (isHover ? 0.4 : 0));
+        // glow
+        const glow = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, baseR * (isHover ? 5 : 3.4));
+        glow.addColorStop(0, col);
+        glow.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.globalAlpha = Math.min(0.5, p.alpha * (isHover ? 0.85 : 0.42));
+        ctx.fillStyle = glow;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, baseR * (isHover ? 5 : 3.4), 0, Math.PI * 2);
+        ctx.fill();
+        // core
+        ctx.globalAlpha = Math.min(1, p.alpha + (isHover ? 0.35 : 0));
+        ctx.fillStyle = col;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, baseR, 0, Math.PI * 2);
+        ctx.fill();
+        if (s.kind === 'future') {
+          ctx.globalAlpha = Math.min(1, p.alpha);
+          ctx.strokeStyle = col;
+          ctx.lineWidth = 1;
+          ctx.setLineDash([2, 3]);
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, baseR + 3.5, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.setLineDash([]);
+        }
+        // labels: You always, hovered, and the brightest of the current era
+        if ((s.id === 'you' || isHover || p.alpha > 0.72) && p.alpha > 0.2) {
+          ctx.globalAlpha = Math.min(1, p.alpha + 0.15);
+          ctx.fillStyle = 'rgba(233,232,240,0.92)';
+          ctx.font = `${s.id === 'you' ? 12 : 10.5}px ui-monospace, "Geist Mono", monospace`;
+          ctx.textAlign = 'center';
+          ctx.fillText(s.label, p.x, p.y - baseR - 7);
+        }
+      }
+      ctx.globalAlpha = 1;
+
+      // update hover from last mouse pos
+      if (mouse.x || mouse.y) {
+        let found: string | null = null;
+        let best = 20 * 20;
+        for (const s of stars) {
+          const p = positions.get(s.id)!;
+          if (p.alpha < 0.15) continue;
+          const dx = p.x - mouse.x;
+          const dy = p.y - mouse.y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < best) { best = d2; found = s.id; }
+        }
+        if (found !== hovered) {
+          hovered = found;
+          setHoverLabel(found ? stars.find((s) => s.id === found)!.label : null);
+          canvas!.style.cursor = found ? 'pointer' : dragging ? 'grabbing' : 'grab';
+        }
+      }
+
+      raf = requestAnimationFrame(draw);
+    }
+    raf = requestAnimationFrame(draw);
+
+    const onMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      if (dragging) {
+        dragRot += (e.clientX - lastX) * 0.005;
+        lastX = e.clientX;
+      }
+    };
+    const onDown = (e: MouseEvent) => { dragging = true; lastX = e.clientX; canvas.style.cursor = 'grabbing'; };
+    const onUp = () => { dragging = false; canvas.style.cursor = 'grab'; };
+    canvas.style.cursor = 'grab';
+    canvas.addEventListener('mousemove', onMove);
+    canvas.addEventListener('mousedown', onDown);
+    window.addEventListener('mouseup', onUp);
+    const ro = new ResizeObserver(setSize);
+    ro.observe(wrap);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      canvas.removeEventListener('mousemove', onMove);
+      canvas.removeEventListener('mousedown', onDown);
+      window.removeEventListener('mouseup', onUp);
+      ro.disconnect();
+    };
+  }, [stars, height]);
+
+  const currentEra = eraForTime(time);
+
+  return (
+    <div
+      ref={wrapRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+        borderRadius: 4,
+        overflow: 'hidden',
+        background: 'radial-gradient(120% 90% at 50% 30%, #12121c 0%, #0a0a12 55%, #070709 100%)',
+        border: '1px solid rgba(139,140,240,0.14)',
+      }}
+    >
+      <canvas ref={canvasRef} aria-label="Interactive constellation of a clinician career across time" style={{ display: 'block' }} />
+
+      {/* era readout — top left */}
+      <div style={{ position: 'absolute', left: 18, top: 16, pointerEvents: 'none' }}>
+        <div style={{ fontFamily: 'ui-monospace, "Geist Mono", monospace', fontSize: 9.5, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(139,140,240,0.85)' }}>
+          {String(currentEra === 'origin' ? '← past' : currentEra === 'future' ? 'future →' : 'present')}
+        </div>
+        <div style={{ marginTop: 4, fontFamily: 'var(--vt-font-display, Georgia, serif)', fontSize: 22, color: 'rgba(240,238,248,0.96)', letterSpacing: '-0.01em' }}>
+          {ERA_LABEL[currentEra]}
+        </div>
+      </div>
+
+      {/* hover readout — top right */}
+      <div style={{ position: 'absolute', right: 18, top: 16, fontFamily: 'ui-monospace, "Geist Mono", monospace', fontSize: 11, color: 'rgba(233,232,240,0.65)', pointerEvents: 'none', minHeight: 14 }}>
+        {hoverLabel ? `→ ${hoverLabel}` : 'drag to rotate'}
+      </div>
+
+      {/* time scrubber — bottom */}
+      <div style={{ position: 'absolute', left: 18, right: 18, bottom: 14 }}>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.001}
+          value={time}
+          onChange={(e) => setTime(parseFloat(e.target.value))}
+          aria-label="Travel your career timeline"
+          className="mzc-scrub"
+          style={{ width: '100%' }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4, fontFamily: 'ui-monospace, "Geist Mono", monospace', fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(233,232,240,0.4)' }}>
+          <span>Began</span>
+          <span>Now</span>
+          <span>Headed</span>
+        </div>
+      </div>
+
+      <style
+        dangerouslySetInnerHTML={{
+          __html:
+            '.mzc-scrub{-webkit-appearance:none;appearance:none;height:3px;border-radius:999px;background:linear-gradient(90deg,rgba(154,160,181,0.5),rgba(139,140,240,0.6),rgba(127,224,163,0.6));outline:none;cursor:pointer;}' +
+            '.mzc-scrub::-webkit-slider-thumb{-webkit-appearance:none;width:14px;height:14px;border-radius:50%;background:#f4c76b;border:2px solid #0a0a12;box-shadow:0 0 12px rgba(244,199,107,0.6);cursor:grab;}' +
+            '.mzc-scrub::-moz-range-thumb{width:14px;height:14px;border-radius:50%;background:#f4c76b;border:2px solid #0a0a12;cursor:grab;}',
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is

The **signature interactive centerpiece** — and a strategic pivot toward differentiation and daily-return engagement. Every other clinician platform is a *form you fill out*; VitalCV becomes a *place your career lives and moves*.

**The hook is non-linear time.** Your career is rendered as a living orbital **constellation** you can *scrub through time*: where you began (residency, first license) → where you are (source-backed evidence, readiness, recognition) → where you're headed (projected opportunities that light up on the horizon).

- **`MatchaConstellation`** — a canvas experience: You at center, career stars orbiting on tilted rings with gentle motion, depth, glow, and twinkle. **Drag** to rotate the sky, **hover** a star to read it, **pull the time scrubber** to travel your career. Respects `prefers-reduced-motion` (settles static, still fully scrubbable).
- **Homepage** — replaced the static evidence diagram with the constellation as a dramatic **dark cosmic panel inside the calm paper page** — a calm frame around one alive centerpiece (the premium pattern).

## Truth contract
"Now" stars are real career-evidence categories. Past and future are clearly labeled **illustrative / projected** ("your real evidence lives in your wallet") — never asserted as verified facts.

## Verification
Typecheck clean; `next build` green; the constellation + time scrubber verified in-browser (orbiting stars, era label morphing with the scrubber, drag-to-rotate).

## Where this goes next
This is the pattern for the daily-return strategy: signed-in, the constellation becomes *your* real evidence, and a daily "what moved" reveal brings clinicians back. Happy to build the daily-brief / streak loop next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)