### PR TITLE
feat(matcha): public preview of the signed-in experience

### DIFF
--- a/apps/web/app/matcha/experience/page.tsx
+++ b/apps/web/app/matcha/experience/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { MatchaExperienceShowcase } from '@/components/matcha/MatchaExperienceShowcase';
+
+export const metadata: Metadata = {
+  title: 'MATCHA — a preview of your signed-in experience — VitalCV',
+  description: 'See the MATCHA intelligence layer: your career constellation, a daily brief, and explained opportunity matches. Sample data.',
+};
+
+export default function MatchaExperiencePage() {
+  return <MatchaExperienceShowcase />;
+}

--- a/apps/web/components/matcha/MatchaDailyBrief.tsx
+++ b/apps/web/components/matcha/MatchaDailyBrief.tsx
@@ -7,6 +7,8 @@
  *
  * Every line is a real delta (see lib/matcha/daily.ts + useMatchaDaily). Nothing is fabricated.
  * Styled to the Calm Wave `.mz` aesthetic used by the hub.
+ *
+ * DailyBriefView is the presentational half — reused by the public experience preview with sample data.
  */
 
 import { useMemo } from 'react';
@@ -16,7 +18,7 @@ import { useMatchaPreferences } from './useMatchaPreferences';
 import { useMatchaOpportunities } from './useMatchaOpportunities';
 import { useOpportunityActions } from './useOpportunityActions';
 import { useMatchaDaily } from './useMatchaDaily';
-import { buildBriefItems, gapNudge, type BriefTone } from '@/lib/matcha/daily';
+import { buildBriefItems, gapNudge, type BriefItem, type BriefTone } from '@/lib/matcha/daily';
 import { CATEGORY_META, allCategoryProgress } from '@/lib/matcha/categories';
 
 const TONE_DOT: Record<BriefTone, string> = {
@@ -25,6 +27,75 @@ const TONE_DOT: Record<BriefTone, string> = {
   neutral: 'var(--ink-400, #96938a)',
 };
 
+export interface DailyBriefViewProps {
+  streak: number;
+  items: BriefItem[];
+  isNewDay: boolean;
+  onSeen?: () => void;
+}
+
+/** Presentational — given a streak and the "what moved" items, render the brief. */
+export function DailyBriefView({ streak, items, isNewDay, onSeen }: DailyBriefViewProps) {
+  const streakLine = streak <= 1 ? 'Welcome back' : `${streak}-day streak`;
+
+  if (!isNewDay) {
+    return (
+      <div className="mz-card mz-card-pad" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+        <span className="mz-mono" style={{ fontSize: 12, color: 'var(--ink-600)', letterSpacing: '0.04em' }}>
+          {streakLine} · you&rsquo;re up to date
+        </span>
+        <span className="mz-mono" style={{ fontSize: 20, fontWeight: 600, color: 'var(--ink-900)', fontVariantNumeric: 'tabular-nums' }}>
+          {streak > 1 ? `${streak}🔥` : ''}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="mz-card"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.32, ease: [0.2, 0.7, 0.2, 1] }}
+        style={{ overflow: 'hidden' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '16px 20px', borderBottom: '1px solid var(--rule)' }}>
+          <span className="mz-eyebrow">MATCHA today</span>
+          <span className="mz-mono" style={{ fontSize: 12, fontWeight: 600, color: 'var(--ink-700)', letterSpacing: '0.04em' }}>
+            {streak > 1 ? `${streak}-day streak 🔥` : 'Day 1'}
+          </span>
+        </div>
+
+        <ul style={{ listStyle: 'none', margin: 0, padding: '14px 20px', display: 'grid', gap: 12 }}>
+          {items.map((item, i) => (
+            <motion.li
+              key={item.id}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.28, delay: 0.06 * i, ease: [0.2, 0.7, 0.2, 1] }}
+              style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}
+            >
+              <span style={{ width: 7, height: 7, borderRadius: 2, background: TONE_DOT[item.tone], marginTop: 6, flex: '0 0 auto' }} />
+              <span style={{ fontSize: 14, lineHeight: 1.5, color: 'var(--ink-800)' }}>{item.text}</span>
+            </motion.li>
+          ))}
+        </ul>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 20px 18px' }}>
+          <a href="/holder/matcha/opportunities" className="mz-btn mz-btn-sm">Open your sky</a>
+          {onSeen ? (
+            <button type="button" className="mz-btn mz-btn-ghost mz-btn-sm" onClick={onSeen}>
+              Got it
+            </button>
+          ) : null}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+/** Container — wires the real deltas and renders DailyBriefView. */
 export function MatchaDailyBrief() {
   const { data } = useClinicianMobile();
   const npi = data.workspace?.personProfile?.npi ?? undefined;
@@ -63,64 +134,5 @@ export function MatchaDailyBrief() {
 
   if (!daily.loaded) return null;
 
-  const streakLine =
-    daily.streak <= 1 ? 'Welcome back' : `${daily.streak}-day streak`;
-
-  // Collapsed state: they've seen today's brief.
-  if (!daily.isNewDay) {
-    return (
-      <div className="mz-card mz-card-pad" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
-        <span className="mz-mono" style={{ fontSize: 12, color: 'var(--ink-600)', letterSpacing: '0.04em' }}>
-          {streakLine} · you&rsquo;re up to date
-        </span>
-        <span className="mz-mono" style={{ fontSize: 20, fontWeight: 600, color: 'var(--ink-900)', fontVariantNumeric: 'tabular-nums' }}>
-          {daily.streak > 1 ? `${daily.streak}🔥` : ''}
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <AnimatePresence>
-      <motion.div
-        className="mz-card"
-        initial={{ opacity: 0, y: 6 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.32, ease: [0.2, 0.7, 0.2, 1] }}
-        style={{ overflow: 'hidden' }}
-      >
-        {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '16px 20px', borderBottom: '1px solid var(--rule)' }}>
-          <span className="mz-eyebrow">MATCHA today</span>
-          <span className="mz-mono" style={{ fontSize: 12, fontWeight: 600, color: 'var(--ink-700)', letterSpacing: '0.04em' }}>
-            {daily.streak > 1 ? `${daily.streak}-day streak 🔥` : 'Day 1'}
-          </span>
-        </div>
-
-        {/* What moved */}
-        <ul style={{ listStyle: 'none', margin: 0, padding: '14px 20px', display: 'grid', gap: 12 }}>
-          {items.map((item, i) => (
-            <motion.li
-              key={item.id}
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.28, delay: 0.06 * i, ease: [0.2, 0.7, 0.2, 1] }}
-              style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}
-            >
-              <span style={{ width: 7, height: 7, borderRadius: 2, background: TONE_DOT[item.tone], marginTop: 6, flex: '0 0 auto' }} />
-              <span style={{ fontSize: 14, lineHeight: 1.5, color: 'var(--ink-800)' }}>{item.text}</span>
-            </motion.li>
-          ))}
-        </ul>
-
-        {/* Actions */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 20px 18px' }}>
-          <a href="/holder/matcha/opportunities" className="mz-btn mz-btn-sm">Open your sky</a>
-          <button type="button" className="mz-btn-ghost mz-btn-sm mz-btn" style={{ background: 'transparent' }} onClick={daily.markBriefSeen}>
-            Got it
-          </button>
-        </div>
-      </motion.div>
-    </AnimatePresence>
-  );
+  return <DailyBriefView streak={daily.streak} items={items} isNewDay={daily.isNewDay} onSeen={daily.markBriefSeen} />;
 }

--- a/apps/web/components/matcha/MatchaExperienceShowcase.tsx
+++ b/apps/web/components/matcha/MatchaExperienceShowcase.tsx
@@ -1,0 +1,98 @@
+/**
+ * MatchaExperienceShowcase — a public, honest preview of the signed-in MATCHA experience.
+ *
+ * Renders the REAL interactive components (constellation, daily brief, opportunity intelligence card)
+ * with clearly-labeled SAMPLE data for a fictional clinician, so the signed-in experience can be seen
+ * and QA'd without auth — and demoed to pilots/investors. Every sample is labeled as such; nothing
+ * here asserts a real person's verified facts.
+ */
+
+import { DailyBriefView } from './MatchaDailyBrief';
+import { MatchaConstellation } from './MatchaConstellation';
+import { OpportunityIntelligenceCard, type IntelligenceExplanation, type IntelligenceOpportunity } from './OpportunityIntelligenceCard';
+import { buildBriefItems, gapNudge } from '@/lib/matcha/daily';
+
+const SAMPLE_ITEMS = buildBriefItems({
+  newMatches: 4,
+  savedMatches: 2,
+  readinessScore: 78,
+  readinessDelta: 6,
+  completeness: 62,
+  memoryNotes: ['You added Washington to where you want to work.'],
+  gapNudge: gapNudge(62, 'Place'),
+});
+
+const SAMPLE_OPP: IntelligenceOpportunity = {
+  id: 'sample-1',
+  title: 'Cardiologist',
+  organization: 'Bay Area Cardiac',
+  location: 'Oakland, CA',
+  state: 'CA',
+  specialty: 'Cardiology',
+  payRange: '$385k–$430k',
+  hiringType: 'perm',
+  remote: false,
+};
+
+const SAMPLE_EXPLANATION: IntelligenceExplanation = {
+  matchBand: 'CLEAR',
+  matchScore: 88,
+  confidence: 0.9,
+  fitReasons: [
+    { label: 'California licensure on file', positive: true, dimension: 'eligibility' },
+    { label: 'Cardiology specialty match', positive: true, dimension: 'specialty' },
+    { label: 'Prefers California — this role is in Oakland', positive: true, dimension: 'location' },
+    { label: 'Board certification due for a refresh', positive: false, dimension: 'credential' },
+  ],
+  missingCredentials: [],
+  blockers: [],
+  instantOfferEligible: true,
+};
+
+export function MatchaExperienceShowcase() {
+  return (
+    <div className="mz mz-paper" style={{ maxWidth: 960, margin: '0 auto', padding: '32px 24px 96px', display: 'grid', gap: 24, minHeight: '100vh' }}>
+      {/* Preview banner */}
+      <div className="mz-inset" style={{ padding: '12px 16px', borderRadius: 4 }}>
+        <span className="mz-mono" style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.14em', color: 'var(--ink-500)' }}>
+          Preview · sample clinician · this is what MATCHA looks like when it&rsquo;s yours
+        </span>
+      </div>
+
+      {/* Greeting */}
+      <div>
+        <p className="mz-eyebrow">Your MATCHA</p>
+        <h1 className="mz-display" style={{ marginTop: 12, fontSize: 34 }}>
+          Welcome back, <span className="mz-accent">Dr. Rivera</span>.
+        </h1>
+        <p className="mz-lede" style={{ marginTop: 10 }}>MATCHA is 62% tuned to you. Here&rsquo;s what moved.</p>
+      </div>
+
+      {/* Daily brief — presentational, sample data, shown in its "new day" state */}
+      <DailyBriefView streak={5} items={SAMPLE_ITEMS} isNewDay />
+
+      {/* The personal constellation */}
+      <div>
+        <p className="mz-eyebrow" style={{ marginBottom: 10 }}>Your career, in motion</p>
+        <MatchaConstellation height={440} profile={{ specialty: 'Cardiology', readinessScore: 78, matchCount: 4 }} />
+        <p className="mz-mono" style={{ marginTop: 8, fontSize: 10, color: 'var(--ink-400)' }}>
+          Drag to rotate · pull the slider to travel your career. Past &amp; future are projected; your real evidence lives in your wallet.
+        </p>
+      </div>
+
+      {/* An opportunity intelligence card */}
+      <div>
+        <p className="mz-eyebrow" style={{ marginBottom: 10 }}>An opportunity MATCHA found</p>
+        <OpportunityIntelligenceCard opportunity={SAMPLE_OPP} explanation={SAMPLE_EXPLANATION} />
+      </div>
+
+      {/* Honest footer + CTA to the real thing */}
+      <div className="mz-card mz-card-pad" style={{ textAlign: 'center' }}>
+        <p className="mz-body" style={{ margin: 0 }}>
+          Signed in, this is built from <strong>your</strong> real evidence and live matches — not sample data.
+        </p>
+        <a href="/holder/matcha" className="mz-btn" style={{ marginTop: 14 }}>Let MATCHA work for you</a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this adds

An **auth-free, honest preview** of the signed-in MATCHA experience at **`/matcha/experience`** — so we can *see*, QA, and demo it without Clerk auth, and flip `MATCHA_V2` on with confidence (rather than real clinicians being the first to see it).

- **`MatchaExperienceShowcase` + `/matcha/experience`** (public) — renders the **real** components (daily brief, personal constellation, opportunity intelligence card) with clearly-labeled **sample** data for a fictional "Dr. Rivera." A banner and footer state it's a preview; nothing asserts a real person's verified facts.
- **`MatchaDailyBrief`** — split into `DailyBriefView` (presentational) + the wired container, so the preview and the real hub share one component.

## Why
The signed-in surfaces are Clerk-gated, so they'd never been visually verified. This makes the whole experience previewable — de-risking the go-live and doubling as a pilot/investor demo.

## Verification
Verified in-browser: greeting, a 5-day-streak "what moved" brief, the personal constellation (Cardiology / readiness 78 / time scrubber), and an opportunity card — all on the Calm Wave paper aesthetic. Typecheck clean; `next build` green; route registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)