### PR TITLE
feat(matcha): Career Scoreboard — your career at a glance (Wave 6)

### DIFF
--- a/apps/web/__tests__/matcha-scoreboard.test.ts
+++ b/apps/web/__tests__/matcha-scoreboard.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Career Scoreboard (Wave 6) — truth-model unit tests.
+ *
+ * Pins the honest-by-construction behavior: real signals become real tiles,
+ * absent signals become explicit empty states (never fabricated numbers), the
+ * MATCHA-tuning tile is omitted when the pilot is off, and the board never
+ * emits a banned truth-contract phrase or a bare "Verified" label.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCareerScoreboard,
+  type ScoreboardInput,
+} from '@/lib/matcha/scoreboard';
+
+function baseInput(overrides: Partial<ScoreboardInput> = {}): ScoreboardInput {
+  return {
+    readiness: { score: 78, level: 'L3', status: 'Clinical' },
+    recognition: { state: 'none_recorded' },
+    opportunities: { total: 4, clearedToApply: 2 },
+    applicationsInMotion: 1,
+    profile: { score: 60, answered: 3, total: 5 },
+    matchaTuning: { percent: 40 },
+    blockers: 1,
+    ...overrides,
+  };
+}
+
+const BANNED = [
+  /\bverified\b/i,
+  /automatically verified/i,
+  /guaranteed verification/i,
+  /instant credentialing/i,
+  /complete credentialing/i,
+  /legally accepted/i,
+  /risk transferred/i,
+  /HIPAA compliant/i,
+  /SOC2 certified/i,
+  /certified compliant/i,
+];
+
+function allText(board: ReturnType<typeof buildCareerScoreboard>): string {
+  return [
+    board.headline,
+    board.subhead,
+    board.note,
+    ...board.tiles.flatMap((t) => [t.label, t.value, t.detail, t.source, t.ctaLabel]),
+  ].join(' | ');
+}
+
+describe('buildCareerScoreboard — real signals', () => {
+  it('renders a source-backed readiness tile from a real snapshot', () => {
+    const board = buildCareerScoreboard(baseInput());
+    const readiness = board.tiles.find((t) => t.key === 'readiness')!;
+    expect(readiness.value).toBe('78/100');
+    expect(readiness.tone).toBe('strong');
+    expect(readiness.href).toBe('/holder/readiness');
+    expect(readiness.source).toBe('Source-backed readiness');
+  });
+
+  it('counts cleared-to-apply roles honestly against the total', () => {
+    const board = buildCareerScoreboard(baseInput());
+    const roles = board.tiles.find((t) => t.key === 'opportunities')!;
+    expect(roles.value).toBe('2 ready');
+    expect(roles.detail).toContain('2 cleared to apply');
+    expect(roles.detail).toContain('4 matched');
+  });
+
+  it('shows recorded recognition when an acceptance exists', () => {
+    const board = buildCareerScoreboard(baseInput({ recognition: { state: 'recognized', count: 3 } }));
+    const rec = board.tiles.find((t) => t.key === 'recognition')!;
+    expect(rec.value).toBe('3 recorded');
+    expect(rec.tone).toBe('strong');
+  });
+});
+
+describe('buildCareerScoreboard — honest empty / unavailable states (never invented)', () => {
+  it('shows an empty readiness tile with no fabricated score when there is no snapshot', () => {
+    const board = buildCareerScoreboard(baseInput({ readiness: null }));
+    const readiness = board.tiles.find((t) => t.key === 'readiness')!;
+    expect(readiness.value).toBe('—');
+    expect(readiness.tone).toBe('empty');
+    expect(readiness.detail).toMatch(/Add your NPI/i);
+  });
+
+  it('distinguishes "none recorded" from "unavailable" for recognition', () => {
+    const none = buildCareerScoreboard(baseInput({ recognition: { state: 'none_recorded' } }));
+    const unavailable = buildCareerScoreboard(baseInput({ recognition: { state: 'unavailable' } }));
+    expect(none.tiles.find((t) => t.key === 'recognition')!.value).toBe('None yet');
+    expect(none.tiles.find((t) => t.key === 'recognition')!.tone).toBe('empty');
+    expect(unavailable.tiles.find((t) => t.key === 'recognition')!.tone).toBe('unavailable');
+    expect(unavailable.tiles.find((t) => t.key === 'recognition')!.detail).toMatch(/system state/i);
+  });
+
+  it('shows an empty roles tile (not a zero claim) when nothing is live', () => {
+    const board = buildCareerScoreboard(baseInput({ opportunities: { total: 0, clearedToApply: 0 } }));
+    const roles = board.tiles.find((t) => t.key === 'opportunities')!;
+    expect(roles.value).toBe('None live');
+    expect(roles.tone).toBe('empty');
+  });
+
+  it('marks "what\'s left" clear when there are no blockers', () => {
+    const board = buildCareerScoreboard(baseInput({ blockers: 0 }));
+    const left = board.tiles.find((t) => t.key === 'whats-left')!;
+    expect(left.value).toBe('Clear');
+    expect(left.tone).toBe('strong');
+  });
+});
+
+describe('buildCareerScoreboard — MATCHA tuning gating', () => {
+  it('includes the tuning tile when preferences are available', () => {
+    const board = buildCareerScoreboard(baseInput({ matchaTuning: { percent: 40 } }));
+    expect(board.tiles.some((t) => t.key === 'matcha-tuning')).toBe(true);
+  });
+
+  it('omits the tuning tile entirely when the MATCHA pilot is off (null)', () => {
+    const board = buildCareerScoreboard(baseInput({ matchaTuning: null }));
+    expect(board.tiles.some((t) => t.key === 'matcha-tuning')).toBe(false);
+  });
+
+  it('always links every tile to a reachable route', () => {
+    const board = buildCareerScoreboard(baseInput({ matchaTuning: null }));
+    for (const tile of board.tiles) {
+      expect(tile.href.startsWith('/')).toBe(true);
+    }
+  });
+});
+
+describe('buildCareerScoreboard — truth contract', () => {
+  it('never emits a banned phrase or a bare "Verified" label across any state', () => {
+    const permutations: ScoreboardInput[] = [
+      baseInput(),
+      baseInput({ readiness: null, recognition: { state: 'unavailable' }, opportunities: { total: 0, clearedToApply: 0 }, applicationsInMotion: 0, profile: null, matchaTuning: null, blockers: 0 }),
+      baseInput({ recognition: { state: 'recognized', count: 5 }, blockers: 3, matchaTuning: { percent: 0 } }),
+    ];
+    for (const input of permutations) {
+      const text = allText(buildCareerScoreboard(input));
+      for (const pattern of BANNED) {
+        expect(pattern.test(text), `banned pattern ${pattern} matched in: ${text}`).toBe(false);
+      }
+    }
+  });
+
+  it('keeps the honest omission note naming what is not shown', () => {
+    const board = buildCareerScoreboard(baseInput());
+    expect(board.note).toMatch(/omitted rather than invented/i);
+  });
+});

--- a/apps/web/app/holder/scoreboard/CareerScoreboardSurface.tsx
+++ b/apps/web/app/holder/scoreboard/CareerScoreboardSurface.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+/**
+ * Career Scoreboard (Wave 6) — "your career at a glance" for the signed-in
+ * clinician. A thin renderer over the pure truth model in
+ * lib/matcha/scoreboard.ts: it maps the clinician's REAL account signals
+ * (source-backed readiness, recorded employer acceptances, live MATCHA matches,
+ * tracked applications, profile completeness, and — when the MATCHA pilot is on
+ * — their own stated preferences) into honest tiles. No demo data: absent
+ * signals render explicit empty states, never fabricated numbers.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowUpRight } from 'lucide-react';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { fetchAcceptanceRecognition } from '@/lib/recognition/acceptance-recognition';
+import { completenessPercent } from '@/lib/matcha/preferences';
+import { loadStoredPreferences } from '@/lib/matcha/storage';
+import { FEATURES } from '@/lib/features';
+import {
+  buildCareerScoreboard,
+  type RecognitionSummaryInput,
+  type ScoreboardTile,
+  type ScoreboardTone,
+} from '@/lib/matcha/scoreboard';
+
+const CLEARED_BANDS = new Set(['CLEAR', 'NEAR_CLEAR']);
+
+const TONE_ACCENT: Record<ScoreboardTone, string> = {
+  strong: 'var(--state-ok, #0f766e)',
+  progress: 'var(--state-info, #2563eb)',
+  attention: 'var(--state-pending, #b45309)',
+  empty: 'var(--hairline, #cbd2cc)',
+  unavailable: 'var(--hairline, #cbd2cc)',
+};
+
+export default function CareerScoreboardSurface() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? null;
+  const name =
+    [data.workspace?.personProfile?.firstName, data.workspace?.personProfile?.lastName]
+      .filter(Boolean)
+      .join(' ') || 'Your career';
+
+  const [recognition, setRecognition] = useState<RecognitionSummaryInput>({ state: 'unavailable' });
+  const [matchaPercent, setMatchaPercent] = useState<number | null>(null);
+
+  // Recognition — public acceptance-history read, keyed to the clinician NPI.
+  useEffect(() => {
+    let cancelled = false;
+    if (!npi) {
+      setRecognition({ state: 'none_recorded' });
+      return;
+    }
+    void (async () => {
+      const result = await fetchAcceptanceRecognition(npi);
+      if (cancelled) return;
+      if (result.state === 'recognized') {
+        setRecognition({ state: 'recognized', count: result.recognition.history.length });
+      } else {
+        setRecognition({ state: result.state });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  // MATCHA tuning — only when the pilot surface is reachable, so the tile never
+  // links to a gated route. Read from the clinician's own stored answers.
+  useEffect(() => {
+    if (!FEATURES.MATCHA_V2) {
+      setMatchaPercent(null);
+      return;
+    }
+    setMatchaPercent(completenessPercent(loadStoredPreferences()));
+  }, []);
+
+  const board = useMemo(() => {
+    const readiness = data.trustState
+      ? {
+          score: data.trustState.readinessScore,
+          level: data.trustState.readinessLevel,
+          status: data.trustState.readinessStatus,
+        }
+      : null;
+
+    const profile = data.profileCompleteness
+      ? {
+          score: data.profileCompleteness.score,
+          answered: Object.values(data.profileCompleteness.dimensions).filter(Boolean).length,
+          total: Object.keys(data.profileCompleteness.dimensions).length,
+        }
+      : null;
+
+    const clearedToApply = data.availableOpportunities.filter(
+      (opp) => opp.match && CLEARED_BANDS.has(opp.match.band),
+    ).length;
+
+    return buildCareerScoreboard({
+      readiness,
+      recognition,
+      opportunities: { total: data.availableOpportunities.length, clearedToApply },
+      applicationsInMotion: data.activeApplications.length,
+      profile,
+      matchaTuning: matchaPercent === null ? null : { percent: matchaPercent },
+      blockers: data.blockers.length,
+    });
+  }, [data, recognition, matchaPercent]);
+
+  return (
+    <div className="vcv-doc min-h-screen">
+      {/* Top bar — signed-artifact register (D57 op-bar), matches readiness/recognition */}
+      <div className="vcv-register text-xs px-6 py-2 flex items-center justify-between">
+        <Link href="/holder/home" className="vcv-mono transition-opacity hover:opacity-80">
+          ← Dashboard
+        </Link>
+        <span className="vcv-eyebrow">Scoreboard</span>
+        <span className="vcv-mono text-[10px] opacity-70">{npi ? `NPI ${npi}` : '…'}</span>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+        <header>
+          <p className="vcv-mono text-xs vcv-muted">{name}</p>
+          <h1 className="vcv-title text-3xl mt-1">{board.headline}</h1>
+          <p className="text-sm vcv-muted mt-2 max-w-2xl">{board.subhead}</p>
+        </header>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {board.tiles.map((tile) => (
+            <TileCard key={tile.key} tile={tile} />
+          ))}
+        </div>
+
+        <p className="text-xs vcv-subtle max-w-2xl leading-relaxed border-t pt-4" style={{ borderColor: 'var(--hairline, #e3e7e3)' }}>
+          {board.note}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function TileCard({ tile }: { tile: ScoreboardTile }) {
+  const accent = TONE_ACCENT[tile.tone];
+  const muted = tile.tone === 'empty' || tile.tone === 'unavailable';
+  return (
+    <Link
+      href={tile.href}
+      className="vcv-panel group flex flex-col gap-2 p-4 transition-colors hover:border-[color:var(--ink)]"
+      style={{ borderLeft: `3px solid ${accent}` }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="vcv-eyebrow">{tile.label}</span>
+        <ArrowUpRight className="h-3.5 w-3.5 opacity-40 transition-opacity group-hover:opacity-80" aria-hidden />
+      </div>
+      <p
+        className="vcv-title text-2xl leading-none"
+        style={muted ? { color: 'var(--muted-ink, #6b7280)' } : undefined}
+      >
+        {tile.value}
+      </p>
+      <p className="text-xs leading-relaxed" style={{ color: 'var(--ink)' }}>
+        {tile.detail}
+      </p>
+      <div className="mt-auto flex items-center justify-between gap-2 pt-1">
+        <span className="vcv-mono text-[10px] vcv-subtle uppercase tracking-wide">{tile.source}</span>
+        <span className="text-[11px] font-medium" style={{ color: 'var(--accent, #0f766e)' }}>
+          {tile.ctaLabel} →
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/app/holder/scoreboard/page.tsx
+++ b/apps/web/app/holder/scoreboard/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import CareerScoreboardSurface from './CareerScoreboardSurface';
+
+export const metadata: Metadata = {
+  title: 'Career Scoreboard · VitalCV',
+  description:
+    'Your career at a glance — source-backed readiness, employer Recognition, live role matches, applications, and what to do next. Every tile traces to your own evidence.',
+};
+
+export default function HolderScoreboardPage() {
+  return <CareerScoreboardSurface />;
+}

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -6,6 +6,7 @@ import {
   BellRing,
   BriefcaseBusiness,
   Compass,
+  Gauge,
   History,
   RefreshCw,
   Settings,
@@ -182,6 +183,14 @@ export default function ClinicianHomeSurface() {
   }, [npi, previousVisitAt, resumePath, unreadNotifications.length]);
 
   const quickActions: MobileQuickAction[] = [
+    {
+      id: 'open-scoreboard',
+      label: 'Career scoreboard',
+      description: 'Your career at a glance — readiness, recognition, live roles, and the next clear step.',
+      href: '/holder/scoreboard',
+      icon: Gauge,
+      tone: 'emerald',
+    },
     {
       id: 'finish-onboarding',
       label: readiness ? 'View readiness' : 'Start onboarding',

--- a/apps/web/lib/matcha/scoreboard.ts
+++ b/apps/web/lib/matcha/scoreboard.ts
@@ -1,0 +1,279 @@
+// apps/web/lib/matcha/scoreboard.ts
+//
+// Career Scoreboard (Wave 6) — one honest "career at a glance" for the signed-in
+// clinician. Pure + isomorphic so the truth logic is unit-tested and the surface
+// stays a thin renderer.
+//
+// Truth rule (mirrors the MATCHA engine + preferences modules): every tile is
+// derived ONLY from signals the clinician's own account already holds —
+// source-backed readiness, recorded employer acceptances, live engine matches,
+// tracked applications, profile completeness, and the clinician's stated MATCHA
+// answers. Nothing is estimated or invented. Metrics VitalCV cannot ground from
+// real data — interview odds, time-to-promotion, projected "income unlocked",
+// network strength — are deliberately OMITTED rather than faked (see
+// OMITTED_METRICS). If an input is absent, the tile shows an honest empty state
+// instead of a fabricated number.
+
+export type ScoreboardTone = 'strong' | 'progress' | 'attention' | 'empty' | 'unavailable';
+
+export interface ScoreboardTile {
+  key: string;
+  label: string;
+  /** Short display value, e.g. "78/100", "3 recorded", "—". */
+  value: string;
+  tone: ScoreboardTone;
+  /** One honest sentence describing the value or its absence. */
+  detail: string;
+  /** Provenance — the real signal this tile reads from. */
+  source: string;
+  href: string;
+  ctaLabel: string;
+}
+
+export interface RecognitionSummaryInput {
+  state: 'recognized' | 'none_recorded' | 'unavailable';
+  /** Present only when state === 'recognized'. */
+  count?: number;
+}
+
+export interface ScoreboardInput {
+  /** Source-backed readiness, or null when no NPI/snapshot exists yet. */
+  readiness: { score: number; level: string; status: string } | null;
+  recognition: RecognitionSummaryInput;
+  /** Live engine matches: total surfaced, and how many are cleared to apply. */
+  opportunities: { total: number; clearedToApply: number };
+  applicationsInMotion: number;
+  /** Profile completeness, or null when unavailable. */
+  profile: { score: number; answered: number; total: number } | null;
+  /**
+   * MATCHA preference tuning. `null` omits the tile entirely — used when the
+   * MATCHA pilot surface is not enabled, so the scoreboard never links to a
+   * route the clinician cannot reach.
+   */
+  matchaTuning: { percent: number } | null;
+  /** Count of open readiness/credential blockers ("what's left"). */
+  blockers: number;
+}
+
+export interface CareerScoreboard {
+  headline: string;
+  subhead: string;
+  tiles: ScoreboardTile[];
+  /** Honest footnote naming what is deliberately not shown. */
+  note: string;
+}
+
+/** Metrics we will not show because we cannot ground them in real data. */
+export const OMITTED_METRICS = [
+  'interview readiness / interview odds',
+  'time to next promotion',
+  'projected income unlocked',
+  'network strength',
+] as const;
+
+function readinessTone(score: number): ScoreboardTone {
+  if (score >= 75) return 'strong';
+  if (score >= 50) return 'progress';
+  return 'attention';
+}
+
+function readinessTile(readiness: ScoreboardInput['readiness']): ScoreboardTile {
+  if (!readiness) {
+    return {
+      key: 'readiness',
+      label: 'Readiness',
+      value: '—',
+      tone: 'empty',
+      detail: 'Add your NPI to build a source-backed readiness snapshot.',
+      source: 'Source-backed readiness',
+      href: '/holder/readiness',
+      ctaLabel: 'Start readiness',
+    };
+  }
+  return {
+    key: 'readiness',
+    label: 'Readiness',
+    value: `${readiness.score}/100`,
+    tone: readinessTone(readiness.score),
+    detail: `${readiness.level} · ${readiness.status}`,
+    source: 'Source-backed readiness',
+    href: '/holder/readiness',
+    ctaLabel: 'Open readiness',
+  };
+}
+
+function recognitionTile(recognition: RecognitionSummaryInput): ScoreboardTile {
+  const base = {
+    key: 'recognition',
+    label: 'Recognition',
+    source: 'Employer acceptances',
+    href: '/holder/recognition',
+  };
+  if (recognition.state === 'recognized') {
+    const count = recognition.count ?? 0;
+    return {
+      ...base,
+      value: count > 0 ? `${count} recorded` : 'Recorded',
+      tone: 'strong',
+      detail: 'An employer accepted your evidence as a head start — it stays on your record.',
+      ctaLabel: 'View recognition',
+    };
+  }
+  if (recognition.state === 'unavailable') {
+    return {
+      ...base,
+      value: '—',
+      tone: 'unavailable',
+      detail: 'Temporarily unavailable — a system state, not a finding about your record.',
+      ctaLabel: 'View recognition',
+    };
+  }
+  return {
+    ...base,
+    value: 'None yet',
+    tone: 'empty',
+    detail: 'Recorded when an employer accepts your evidence as a head start — not a final credentialing decision.',
+    ctaLabel: 'View recognition',
+  };
+}
+
+function opportunitiesTile(opportunities: ScoreboardInput['opportunities']): ScoreboardTile {
+  const base = {
+    key: 'opportunities',
+    label: 'Roles ready',
+    source: 'Live MATCHA matches',
+    href: '/holder/opportunities',
+    ctaLabel: 'See roles',
+  };
+  if (opportunities.total <= 0) {
+    return {
+      ...base,
+      value: 'None live',
+      tone: 'empty',
+      detail: 'No live roles match right now — MATCHA keeps watching in the background.',
+    };
+  }
+  return {
+    ...base,
+    value: `${opportunities.clearedToApply} ready`,
+    tone: opportunities.clearedToApply > 0 ? 'strong' : 'progress',
+    detail: `${opportunities.clearedToApply} cleared to apply · ${opportunities.total} matched to your evidence.`,
+  };
+}
+
+function applicationsTile(count: number): ScoreboardTile {
+  const base = {
+    key: 'applications',
+    label: 'Applications in motion',
+    source: 'Your applications',
+    href: '/holder/applications',
+    ctaLabel: 'Track updates',
+  };
+  if (count <= 0) {
+    return {
+      ...base,
+      value: 'None active',
+      tone: 'empty',
+      detail: 'Applications you start with your VitalCV appear here with live status.',
+    };
+  }
+  return {
+    ...base,
+    value: `${count}`,
+    tone: 'progress',
+    detail: count === 1 ? 'One application in review with an employer.' : `${count} applications in review with employers.`,
+  };
+}
+
+function profileTile(profile: ScoreboardInput['profile']): ScoreboardTile {
+  const base = {
+    key: 'profile',
+    label: 'Profile completeness',
+    source: 'Your profile record',
+    href: '/clinician/profile',
+    ctaLabel: 'Edit profile',
+  };
+  if (!profile) {
+    return {
+      ...base,
+      value: '—',
+      tone: 'empty',
+      detail: 'Complete your profile to strengthen every match.',
+    };
+  }
+  const tone: ScoreboardTone = profile.score >= 80 ? 'strong' : profile.score >= 40 ? 'progress' : 'attention';
+  return {
+    ...base,
+    value: `${profile.score}%`,
+    tone,
+    detail: `${profile.answered} of ${profile.total} sections complete.`,
+  };
+}
+
+function matchaTuningTile(tuning: { percent: number }): ScoreboardTile {
+  const tone: ScoreboardTone = tuning.percent >= 60 ? 'strong' : tuning.percent >= 20 ? 'progress' : 'empty';
+  return {
+    key: 'matcha-tuning',
+    label: 'MATCHA tuning',
+    value: `${tuning.percent}%`,
+    tone,
+    detail: 'How well MATCHA understands what you want — from your own answers.',
+    source: 'Your MATCHA answers',
+    href: '/holder/matcha/assessment',
+    ctaLabel: tuning.percent > 0 ? 'Tune further' : 'Start tuning',
+  };
+}
+
+function blockersTile(blockers: number): ScoreboardTile {
+  const base = {
+    key: 'whats-left',
+    label: "What's left",
+    source: 'Readiness gaps',
+    href: '/holder/home',
+  };
+  if (blockers <= 0) {
+    return {
+      ...base,
+      value: 'Clear',
+      tone: 'strong',
+      detail: 'Nothing is blocking your next step right now.',
+      ctaLabel: 'Open dashboard',
+    };
+  }
+  return {
+    ...base,
+    value: `${blockers} to resolve`,
+    tone: 'attention',
+    detail: 'Resolve these to raise readiness and unlock more matches.',
+    ctaLabel: 'Resolve now',
+  };
+}
+
+/**
+ * Build the honest career scoreboard from the clinician's real account signals.
+ * Tile order leads with identity (readiness, recognition), then momentum
+ * (roles, applications), then the levers the clinician controls (profile,
+ * MATCHA tuning), and closes on the next action ("what's left").
+ */
+export function buildCareerScoreboard(input: ScoreboardInput): CareerScoreboard {
+  const tiles: ScoreboardTile[] = [
+    readinessTile(input.readiness),
+    recognitionTile(input.recognition),
+    opportunitiesTile(input.opportunities),
+    applicationsTile(input.applicationsInMotion),
+    profileTile(input.profile),
+  ];
+
+  if (input.matchaTuning) {
+    tiles.push(matchaTuningTile(input.matchaTuning));
+  }
+
+  tiles.push(blockersTile(input.blockers));
+
+  return {
+    headline: 'Your career at a glance',
+    subhead: 'One honest board — readiness, recognition, roles, and the next clear step.',
+    tiles,
+    note: 'Every tile traces to your own evidence and answers. VitalCV does not estimate interview odds, promotions, or income — those are omitted rather than invented.',
+  };
+}


### PR DESCRIPTION
## Summary

The first slice of the **MATCHA Career Intelligence** vision — Wave 6, the personal dashboard. A single **honest "career at a glance"** for the signed-in clinician at **`/holder/scoreboard`**, aggregating what was previously scattered across home / readiness / recognition / blockers into one board:

- **Readiness** — source-backed score from the clinician's trust state
- **Recognition** — recorded employer acceptances (public acceptance-history read)
- **Roles ready** — live MATCHA matches, honestly split into *cleared to apply* vs *matched*
- **Applications in motion** — tracked applications
- **Profile completeness** — sections complete
- **MATCHA tuning** — how well MATCHA understands the clinician (only when the `MATCHA_V2` pilot is enabled, so the tile never links to a gated route)
- **What's left** — open readiness/credential blockers → the next clear step

Discoverable via a new **Career scoreboard** quick action on the holder dashboard. Reads the data the holder context already loads — **no new fetches on the critical path, no migration, no auth change.**

## Truth rules (what this does NOT do)

- **No invented data.** Every tile derives only from the clinician's own account signals. Absent signals render explicit **empty / unavailable** states (`—`, "None yet", "None live"), never a fabricated number. Pure model in `lib/matcha/scoreboard.ts`.
- **Honest omissions.** Metrics VitalCV cannot ground — interview odds/readiness, time-to-promotion, projected "income unlocked", network strength — are **deliberately omitted rather than faked**, and a footnote says so. Mirrors the engine's existing "MATCHA does not estimate interview outcomes" stance.
- No bare `Verified` label; no banned truth-contract phrases (asserted by a test across all tile states).
- Recognition framed as "a head start, not a final credentialing decision."

## Validation

- New truth-model tests **12/12** (`__tests__/matcha-scoreboard.test.ts`) — real signals → real tiles, absent signals → honest empty states, tuning-tile gating, banned-phrase scan across permutations.
- Holder route-contract **150/150** (auto-discovered `/holder/scoreboard`, page present, link reachable).
- `pnpm turbo run build --filter @vitalcv/web`: **14/14** (TS + ESLint enforced); route emitted `ƒ /holder/scoreboard`.
- Truth scan clean (only matches are the test's own BANNED array).

## Tier

**Tier 1** — clinician-facing surface, reads existing real data, no migration, no auth/session change, ungated (like readiness/recognition). Additive; links only to reachable routes.

## Design Handoff References

No Claude Design handoff file used for this PR. The surface reuses the in-repo **D57 `.vcv-doc`** light-document design system established by #505 (readiness/recognition lineage) for visual consistency with its sibling surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)