### PR TITLE
feat(matcha): deterministic Opportunity Simulator — "what if" credential impact

### DIFF
--- a/apps/api/backend/src/routes/matcha.ts
+++ b/apps/api/backend/src/routes/matcha.ts
@@ -655,13 +655,12 @@ export function registerMatchaRoutes(app: Express): void {
       const result = await simulateForNpi(npi);
       res.json(result);
     } catch (error) {
+      // Detail is logged server-side only — never leaked in the response body
+      // (the web proxy mirrors this JSON to the browser).
       log('error', 'matcha: simulate_failed', {
         error: error instanceof Error ? error.message : String(error),
       });
-      res.status(500).json({
-        error: 'Failed to simulate MATCHA impact',
-        detail: error instanceof Error ? error.message : String(error),
-      });
+      res.status(500).json({ error: 'Failed to simulate MATCHA impact' });
     }
   });
 

--- a/apps/api/backend/src/routes/matcha.ts
+++ b/apps/api/backend/src/routes/matcha.ts
@@ -46,6 +46,7 @@ import {
 import {
   getLiveMatchesForNpi,
   scoreOpportunityForNpi,
+  simulateForNpi,
 } from '../services/matcha/liveMatchaService';
 import type {
   CanonicalFactSummary,
@@ -631,6 +632,34 @@ export function registerMatchaRoutes(app: Express): void {
       });
       res.status(500).json({
         error: 'Failed to load MATCHA opportunities',
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  /**
+   * GET /api/matcha/simulate/:npi
+   * Deterministic "what if" impact: for each credential that currently blocks
+   * the clinician's real live roles, re-scores the whole set with it earned and
+   * reports how many roles would become cleared to apply. No estimates — every
+   * number is the engine's own recomputed output.
+   */
+  app.get('/api/matcha/simulate/:npi', async (req: Request, res: Response) => {
+    try {
+      const { npi } = req.params;
+      if (!npi || !NPI_RE.test(npi)) {
+        res.status(400).json({ error: 'Invalid NPI — expected 10 digits' });
+        return;
+      }
+
+      const result = await simulateForNpi(npi);
+      res.json(result);
+    } catch (error) {
+      log('error', 'matcha: simulate_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(500).json({
+        error: 'Failed to simulate MATCHA impact',
         detail: error instanceof Error ? error.message : String(error),
       });
     }

--- a/apps/api/backend/src/services/matcha/__tests__/matchaSimulator.test.ts
+++ b/apps/api/backend/src/services/matcha/__tests__/matchaSimulator.test.ts
@@ -1,0 +1,172 @@
+/**
+ * MATCHA Opportunity Simulator — deterministic-truth unit tests.
+ *
+ * These pin the honesty invariants rather than brittle exact scores:
+ *   • adding a credential never REDUCES the cleared-to-apply set (monotonic),
+ *   • unblocking a hard-required credential yields a positive-impact scenario,
+ *   • non-earnable identity facts (npi, sanctions_clear) are never suggested,
+ *   • the clinician's real credentials are never mutated,
+ *   • no opportunities → no scenarios, and a fully-credentialed clinician has
+ *     nothing to "unlock".
+ */
+import {
+  simulateCredentialImpact,
+} from '../matchaSimulator';
+import type {
+  ClinicianProfile,
+  CredentialKey,
+  HeldCredential,
+  Opportunity,
+  RequirementSpec,
+} from '../matchaModels';
+
+const NOW = '2026-07-04T00:00:00.000Z';
+
+function cred(key: CredentialKey, over: Partial<HeldCredential> = {}): HeldCredential {
+  return { key, status: 'active', claimLevel: 'L3', issuer: 'test', ...over };
+}
+
+function req(key: CredentialKey, over: Partial<RequirementSpec> = {}): RequirementSpec {
+  return { key, label: key, level: 'L3', priority: 'required', ...over };
+}
+
+function makeOpp(id: string, requirements: RequirementSpec[], over: Partial<Opportunity> = {}): Opportunity {
+  return {
+    id,
+    title: `Role ${id}`,
+    employerSlug: 'acme',
+    facility: 'Acme Medical',
+    location: 'Oakland, CA',
+    state: 'CA',
+    specialty: 'Emergency',
+    hiringType: 'perm',
+    employerType: 'hospital',
+    startUrgency: 'flexible',
+    remote: false,
+    requirements,
+    urgency: 'within_30_days',
+    minimumTrustBand: 'L2',
+    credentialRequirements: [],
+    postedAt: NOW,
+    active: true,
+    ...over,
+  };
+}
+
+function makeClinician(credentials: HeldCredential[], over: Partial<ClinicianProfile> = {}): ClinicianProfile {
+  return {
+    npi: '1234567890',
+    name: 'Test Clinician',
+    specialty: 'Emergency',
+    states: ['CA'],
+    credentials,
+    ...over,
+  };
+}
+
+describe('simulateCredentialImpact', () => {
+  it('surfaces a positive-impact scenario for a hard-required credential the clinician lacks', () => {
+    const clinician = makeClinician([
+      cred('npi'),
+      cred('state_license', { claimLevel: 'L2', state: 'CA' }),
+    ]);
+    const opp = makeOpp('a', [
+      req('state_license', { level: 'L2', state: 'CA' }),
+      req('acls', { level: 'L3' }),
+    ]);
+
+    const result = simulateCredentialImpact(clinician, [opp], NOW);
+    const acls = result.scenarios.find((s) => s.credentialKey === 'acls');
+
+    expect(acls).toBeDefined();
+    expect(acls!.id).toBe('earn:acls');
+    expect(acls!.label).toBe('Earn ACLS');
+    // Unblocking a hard requirement can only raise the engine's score.
+    expect(acls!.avgScoreDelta).toBeGreaterThan(0);
+    expect(acls!.basis).toContain('Re-scored 1 live role');
+  });
+
+  it('never REDUCES the cleared set — clearedAfter is monotonic vs baseline', () => {
+    const clinician = makeClinician([cred('npi'), cred('state_license', { claimLevel: 'L2', state: 'CA' })]);
+    const opps = [
+      makeOpp('a', [req('acls', { level: 'L3' })]),
+      makeOpp('b', [req('atls', { level: 'L3' })]),
+    ];
+    const result = simulateCredentialImpact(clinician, opps, NOW);
+    for (const s of result.scenarios) {
+      expect(s.clearedAfter).toBeGreaterThanOrEqual(result.baselineCleared);
+      expect(s.jobsUnlocked).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('never suggests non-earnable identity facts (npi, sanctions_clear)', () => {
+    // Clinician lacks both sanctions_clear (non-earnable) and acls (earnable).
+    const clinician = makeClinician([
+      cred('npi'),
+      cred('state_license', { claimLevel: 'L2', state: 'CA' }),
+    ]);
+    const opps = [
+      // Blocked only by a NON-earnable identity fact → must never be suggested.
+      makeOpp('a', [req('state_license', { level: 'L2', state: 'CA' }), req('sanctions_clear', { level: 'L2' })]),
+      // Blocked only by an EARNABLE certification → should surface.
+      makeOpp('b', [req('state_license', { level: 'L2', state: 'CA' }), req('acls', { level: 'L3' })]),
+    ];
+    const result = simulateCredentialImpact(clinician, opps, NOW);
+
+    const keys = result.scenarios.map((s) => s.credentialKey);
+    expect(keys).not.toContain('sanctions_clear');
+    expect(keys).not.toContain('npi');
+    // ACLS (earnable) still surfaces.
+    expect(keys).toContain('acls');
+  });
+
+  it('does not mutate the clinician real credentials (pure)', () => {
+    const clinician = makeClinician([cred('npi'), cred('state_license', { claimLevel: 'L2', state: 'CA' })]);
+    const before = clinician.credentials.length;
+    const beforeKeys = clinician.credentials.map((c) => c.key).join(',');
+
+    simulateCredentialImpact(clinician, [makeOpp('a', [req('acls', { level: 'L3' })])], NOW);
+
+    expect(clinician.credentials.length).toBe(before);
+    expect(clinician.credentials.map((c) => c.key).join(',')).toBe(beforeKeys);
+  });
+
+  it('returns no scenarios when there are no opportunities', () => {
+    const result = simulateCredentialImpact(makeClinician([cred('npi')]), [], NOW);
+    expect(result.scenarios).toEqual([]);
+    expect(result.totalOpportunities).toBe(0);
+    expect(result.baselineCleared).toBe(0);
+  });
+
+  it('offers nothing to unlock when the clinician already holds every required credential', () => {
+    const clinician = makeClinician([
+      cred('npi'),
+      cred('state_license', { claimLevel: 'L2', state: 'CA' }),
+      cred('acls'),
+    ]);
+    const opp = makeOpp('a', [
+      req('state_license', { level: 'L2', state: 'CA' }),
+      req('acls', { level: 'L3' }),
+    ]);
+    const result = simulateCredentialImpact(clinician, [opp], NOW);
+    expect(result.scenarios).toEqual([]);
+  });
+
+  it('sorts scenarios by impact (jobsUnlocked desc, then avgScoreDelta desc)', () => {
+    const clinician = makeClinician([cred('npi'), cred('state_license', { claimLevel: 'L2', state: 'CA' })]);
+    // Two roles each blocked only by a different missing credential.
+    const opps = [
+      makeOpp('a', [req('acls', { level: 'L3' })]),
+      makeOpp('b', [req('acls', { level: 'L3' })]),
+      makeOpp('c', [req('atls', { level: 'L3' })]),
+    ];
+    const result = simulateCredentialImpact(clinician, opps, NOW);
+    for (let i = 1; i < result.scenarios.length; i += 1) {
+      const prev = result.scenarios[i - 1];
+      const curr = result.scenarios[i];
+      const prevRank = prev.jobsUnlocked * 1000 + prev.avgScoreDelta;
+      const currRank = curr.jobsUnlocked * 1000 + curr.avgScoreDelta;
+      expect(prevRank).toBeGreaterThanOrEqual(currRank);
+    }
+  });
+});

--- a/apps/api/backend/src/services/matcha/liveMatchaService.ts
+++ b/apps/api/backend/src/services/matcha/liveMatchaService.ts
@@ -14,6 +14,7 @@
 import { PrismaClient } from '@prisma/client';
 
 import { matchOpportunities, scoreOpportunity } from './matchaEngine';
+import { simulateCredentialImpact } from './matchaSimulator';
 import type {
   ClinicianProfile,
   HeldCredential,
@@ -307,6 +308,33 @@ export async function getLiveMatchesForNpi(
         .filter(c => c.status === 'pending' || c.claimLevel === 'L1')
         .map(c => c.key),
     },
+  };
+}
+
+/**
+ * Deterministic "what if" simulation for a clinician's real live roles.
+ * Loads the same real ClinicianProfile + active Opportunity set as the live
+ * match, then re-scores with each blocking credential hypothetically earned.
+ * Never mutates evidence; every number is the engine's own recomputed output.
+ */
+export async function simulateForNpi(npi: string) {
+  const [profile, dbOpportunities] = await Promise.all([
+    buildClinicianProfile(npi),
+    prisma.opportunity.findMany({
+      where: { status: 'ACTIVE' },
+      include: { organization: { select: { id: true, name: true } } },
+      take: 50,
+    }),
+  ]);
+
+  const matchaOpps = dbOpportunities.map(dbOppToMatcha);
+  const result = simulateCredentialImpact(profile, matchaOpps, new Date().toISOString());
+
+  return {
+    npi,
+    clinicianName: profile.name,
+    specialty: profile.specialty,
+    ...result,
   };
 }
 

--- a/apps/api/backend/src/services/matcha/matchaSimulator.ts
+++ b/apps/api/backend/src/services/matcha/matchaSimulator.ts
@@ -1,0 +1,178 @@
+// apps/api/backend/src/services/matcha/matchaSimulator.ts
+//
+// MATCHA Opportunity Simulator — deterministic "what if" impact analysis.
+//
+// Answers "if you earned credential X, how many more live roles would become
+// cleared to apply?" by RE-RUNNING the pure matching engine
+// (`matchOpportunities`) with X added to a LOCAL COPY of the clinician's
+// evidence, then diffing against the real baseline. It never estimates and
+// never invents: every number is the engine's own recomputed output over the
+// clinician's real opportunity set. The credentials it offers are derived from
+// what actually blocks the clinician's real roles (`missingCredentials`), so it
+// only ever suggests moves that genuinely matter.
+//
+// Honesty properties:
+//   • Never mutates the clinician's real credentials/evidence (local spread only).
+//   • Only surfaces positive-impact moves (no zero/negative theatre).
+//   • CONSERVATIVE by construction: a hypothetical credential carries no state
+//     or specialty scope, so a state-/specialty-scoped requirement (e.g. a
+//     specific state license, a specialty board cert) is only counted as
+//     satisfied when the engine does not require a matching scope. This can
+//     UNDER-count impact but can never OVER-count it — the truth-contract-safe
+//     direction. The high-signal, unambiguous moves (ACLS, BLS, ATLS, DEA, CDS,
+//     malpractice, privileges, work auth) simulate exactly.
+
+import { matchOpportunities } from './matchaEngine';
+import type {
+  ClinicianProfile,
+  CredentialKey,
+  HeldCredential,
+  MatchBand,
+  Opportunity,
+  OpportunityMatch,
+} from './matchaModels';
+
+const CLEARED_BANDS: ReadonlySet<MatchBand> = new Set<MatchBand>(['CLEAR', 'NEAR_CLEAR']);
+
+/** Human labels for credential keys. */
+const CREDENTIAL_LABELS: Record<CredentialKey, string> = {
+  state_license: 'State License',
+  board_cert: 'Board Certification',
+  dea: 'DEA Registration',
+  npi: 'NPI',
+  malpractice: 'Malpractice Coverage',
+  sanctions_clear: 'Sanctions Clearance',
+  work_auth: 'Work Authorization',
+  cds: 'CDS Registration',
+  hospital_privileges: 'Hospital Privileges',
+  bls: 'BLS',
+  acls: 'ACLS',
+  atls: 'ATLS',
+};
+
+/**
+ * Identity/registry facts that are not clinician-"earnable" certifications —
+ * we never suggest "earn" these even if an opportunity lists them.
+ */
+const NON_EARNABLE: ReadonlySet<CredentialKey> = new Set<CredentialKey>([
+  'npi',
+  'sanctions_clear',
+]);
+
+export interface CredentialScenario {
+  /** Stable id, e.g. 'earn:acls'. */
+  id: string;
+  credentialKey: CredentialKey;
+  /** e.g. 'Earn ACLS'. */
+  label: string;
+  /** Net new roles that become cleared to apply if this credential is earned. */
+  jobsUnlocked: number;
+  /** Cleared-to-apply count after the change. */
+  clearedAfter: number;
+  /** Average engine score change across all roles (whole number). */
+  avgScoreDelta: number;
+  /** Provenance line — what was actually recomputed. */
+  basis: string;
+}
+
+export interface SimulationResult {
+  totalOpportunities: number;
+  baselineCleared: number;
+  /** Positive-impact moves only, sorted by impact. */
+  scenarios: CredentialScenario[];
+  generatedAt: string;
+}
+
+function clearedIds(matches: OpportunityMatch[]): Set<string> {
+  const ids = new Set<string>();
+  for (const m of matches) {
+    if (CLEARED_BANDS.has(m.explanation.matchBand)) ids.add(m.opportunity.id);
+  }
+  return ids;
+}
+
+function avgScore(matches: OpportunityMatch[]): number {
+  if (matches.length === 0) return 0;
+  return matches.reduce((sum, m) => sum + m.explanation.matchScore, 0) / matches.length;
+}
+
+function heldActiveKeys(profile: ClinicianProfile): Set<CredentialKey> {
+  const keys = new Set<CredentialKey>();
+  for (const c of profile.credentials) {
+    if (c.status === 'active' || c.status === 'expiring') keys.add(c.key);
+  }
+  return keys;
+}
+
+/**
+ * Deterministically simulate the impact of earning each credential that
+ * currently blocks one or more of the clinician's real live opportunities.
+ * Pure: no I/O, no mutation of `profile`.
+ */
+export function simulateCredentialImpact(
+  profile: ClinicianProfile,
+  opportunities: Opportunity[],
+  generatedAt: string,
+): SimulationResult {
+  const active = opportunities.filter((o) => o.active);
+  const baseline = matchOpportunities(profile, null, active);
+  const baseCleared = clearedIds(baseline);
+  const baseAvg = avgScore(baseline);
+  const held = heldActiveKeys(profile);
+
+  // Candidate credentials = what actually blocks real roles, that the clinician
+  // does not already hold, minus non-earnable identity facts.
+  const candidates = new Set<CredentialKey>();
+  for (const m of baseline) {
+    for (const key of m.explanation.missingCredentials) {
+      if (!held.has(key) && !NON_EARNABLE.has(key)) candidates.add(key);
+    }
+  }
+
+  const scenarios: CredentialScenario[] = [];
+  for (const key of candidates) {
+    const hypothetical: HeldCredential = {
+      key,
+      status: 'active',
+      claimLevel: 'L3',
+      issuer: 'simulated',
+    };
+    const simProfile: ClinicianProfile = {
+      ...profile,
+      credentials: [...profile.credentials, hypothetical],
+    };
+    const simMatches = matchOpportunities(simProfile, null, active);
+    const simCleared = clearedIds(simMatches);
+
+    let jobsUnlocked = 0;
+    for (const id of simCleared) {
+      if (!baseCleared.has(id)) jobsUnlocked += 1;
+    }
+    const avgScoreDelta = Math.round(avgScore(simMatches) - baseAvg);
+
+    // Only surface moves that genuinely help.
+    if (jobsUnlocked <= 0 && avgScoreDelta <= 0) continue;
+
+    const label = CREDENTIAL_LABELS[key];
+    scenarios.push({
+      id: `earn:${key}`,
+      credentialKey: key,
+      label: `Earn ${label}`,
+      jobsUnlocked,
+      clearedAfter: simCleared.size,
+      avgScoreDelta,
+      basis: `Re-scored ${active.length} live role${active.length === 1 ? '' : 's'} with ${label} added to your evidence`,
+    });
+  }
+
+  scenarios.sort(
+    (a, b) => b.jobsUnlocked - a.jobsUnlocked || b.avgScoreDelta - a.avgScoreDelta,
+  );
+
+  return {
+    totalOpportunities: active.length,
+    baselineCleared: baseCleared.size,
+    scenarios,
+    generatedAt,
+  };
+}

--- a/apps/web/app/api/matcha/simulate/[npi]/route.ts
+++ b/apps/web/app/api/matcha/simulate/[npi]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * MATCHA Opportunity Simulator — web proxy.
+ * GET /api/matcha/simulate/[npi]
+ * Proxies to backend GET /api/matcha/simulate/:npi (deterministic "what if"
+ * credential-impact analysis, re-scored from the clinician's real roles).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+const NPI_RE = /^\d{10}$/;
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ npi: string }> },
+) {
+  try {
+    const { npi } = await context.params;
+    if (!NPI_RE.test(npi)) {
+      return NextResponse.json({ error: 'Invalid NPI — expected 10 digits' }, { status: 400 });
+    }
+
+    const res = await fetch(`${BACKEND}/api/matcha/simulate/${npi}`, {
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('[matcha/simulate proxy] error:', error);
+    return NextResponse.json(
+      { error: 'Failed to simulate impact', scenarios: [] },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/app/holder/scoreboard/CareerScoreboardSurface.tsx
+++ b/apps/web/app/holder/scoreboard/CareerScoreboardSurface.tsx
@@ -18,6 +18,7 @@ import { fetchAcceptanceRecognition } from '@/lib/recognition/acceptance-recogni
 import { completenessPercent } from '@/lib/matcha/preferences';
 import { loadStoredPreferences } from '@/lib/matcha/storage';
 import { FEATURES } from '@/lib/features';
+import { OpportunitySimulator } from '@/components/matcha/OpportunitySimulator';
 import {
   buildCareerScoreboard,
   type RecognitionSummaryInput,
@@ -132,6 +133,8 @@ export default function CareerScoreboardSurface() {
             <TileCard key={tile.key} tile={tile} />
           ))}
         </div>
+
+        <OpportunitySimulator npi={npi} />
 
         <p className="text-xs vcv-subtle max-w-2xl leading-relaxed border-t pt-4" style={{ borderColor: 'var(--hairline, #e3e7e3)' }}>
           {board.note}

--- a/apps/web/components/matcha/OpportunitySimulator.tsx
+++ b/apps/web/components/matcha/OpportunitySimulator.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+/**
+ * MATCHA Opportunity Simulator — deterministic "what if" impact.
+ *
+ * Fetches /api/matcha/simulate/[npi] and shows the credential moves that would
+ * unlock the most of the clinician's REAL live roles. Every number is the
+ * matching engine's own recomputed output over real opportunities — no
+ * estimates, no invented AI. Honest states: no NPI / nothing to unlock / a
+ * system-unavailable state are all distinct and never presented as findings.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowUpRight, Loader2, Sparkles } from 'lucide-react';
+
+interface CredentialScenario {
+  id: string;
+  credentialKey: string;
+  label: string;
+  jobsUnlocked: number;
+  clearedAfter: number;
+  avgScoreDelta: number;
+  basis: string;
+}
+
+interface SimResult {
+  totalOpportunities: number;
+  baselineCleared: number;
+  scenarios: CredentialScenario[];
+}
+
+type Phase =
+  | { s: 'loading' }
+  | { s: 'ready'; data: SimResult }
+  | { s: 'empty' }
+  | { s: 'unavailable' };
+
+export function OpportunitySimulator({ npi }: { npi: string | null }) {
+  const [phase, setPhase] = useState<Phase>({ s: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!npi) {
+      setPhase({ s: 'empty' });
+      return;
+    }
+    setPhase({ s: 'loading' });
+    void (async () => {
+      try {
+        const res = await fetch(`/api/matcha/simulate/${encodeURIComponent(npi)}`, {
+          cache: 'no-store',
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setPhase({ s: 'unavailable' });
+          return;
+        }
+        const data = (await res.json()) as SimResult;
+        if (!data || !Array.isArray(data.scenarios) || data.scenarios.length === 0) {
+          setPhase({ s: 'empty' });
+          return;
+        }
+        setPhase({ s: 'ready', data });
+      } catch {
+        if (!cancelled) setPhase({ s: 'unavailable' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  return (
+    <section className="vcv-panel p-5 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4" style={{ color: 'var(--accent, #0f766e)' }} aria-hidden />
+          <div>
+            <p className="vcv-eyebrow">What if — improve your MATCH</p>
+            <h2 className="vcv-title text-xl mt-0.5">The fastest ways to unlock more roles</h2>
+          </div>
+        </div>
+      </div>
+
+      {phase.s === 'loading' && (
+        <div className="flex items-center gap-2 text-sm vcv-muted">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Re-scoring your live roles…
+        </div>
+      )}
+
+      {phase.s === 'empty' && (
+        <p className="text-sm vcv-muted">
+          {npi
+            ? 'No credential is currently gating your matched roles — nothing to unlock right now.'
+            : 'Add your NPI to simulate how new credentials would change your matches.'}
+        </p>
+      )}
+
+      {phase.s === 'unavailable' && (
+        <p className="text-sm" style={{ color: 'var(--state-blocked, #b91c1c)' }}>
+          The simulator is temporarily unavailable — a system state, not a finding about your record.
+        </p>
+      )}
+
+      {phase.s === 'ready' && (
+        <>
+          <p className="text-xs vcv-subtle">
+            Baseline: {phase.data.baselineCleared} of {phase.data.totalOpportunities} live roles cleared to
+            apply. Each move below re-scores all {phase.data.totalOpportunities}.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {phase.data.scenarios.slice(0, 6).map((s) => (
+              <ScenarioCard key={s.id} scenario={s} />
+            ))}
+          </div>
+          <p className="text-xs vcv-subtle border-t pt-3" style={{ borderColor: 'var(--hairline, #e3e7e3)' }}>
+            Every projection re-scores your own real live roles with the credential added — deterministic, not
+            an estimate. Earning a credential is verified separately; this only shows how matching would change.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+
+function ScenarioCard({ scenario }: { scenario: CredentialScenario }) {
+  const headline =
+    scenario.jobsUnlocked > 0
+      ? `+${scenario.jobsUnlocked} role${scenario.jobsUnlocked === 1 ? '' : 's'} ready`
+      : `+${scenario.avgScoreDelta} match strength`;
+  const sub =
+    scenario.jobsUnlocked > 0 && scenario.avgScoreDelta > 0
+      ? `· +${scenario.avgScoreDelta} avg match`
+      : null;
+
+  return (
+    <Link
+      href="/holder/readiness"
+      className="group flex flex-col gap-1.5 rounded-lg p-3 transition-colors"
+      style={{ border: '1px solid var(--hairline, #e3e7e3)' }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold" style={{ color: 'var(--ink)' }}>
+          {scenario.label}
+        </span>
+        <ArrowUpRight className="h-3.5 w-3.5 opacity-40 transition-opacity group-hover:opacity-80" aria-hidden />
+      </div>
+      <p className="vcv-title text-lg leading-none" style={{ color: 'var(--accent, #0f766e)' }}>
+        {headline} <span className="text-xs font-normal vcv-subtle">{sub}</span>
+      </p>
+      <p className="text-[11px] vcv-subtle leading-relaxed">{scenario.basis}</p>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

The **Opportunity Simulator** — the deterministic core of the MATCHA intelligence layer (the "Simulations" / "what if" section across the Intelligence Profile + Wave 4 specs). It answers **"if you earned credential X, how many more live roles would become cleared to apply?"** with a real number, not an estimate.

**How it stays honest:** the matching engine (`scoreOpportunity` / `matchOpportunities`) is a **pure function**. The simulator re-runs it with a hypothetical credential added to a *local copy* of the clinician's evidence, then diffs the cleared-to-apply set against the real baseline. Every number is the engine's own recomputed output over the clinician's **real** opportunity set.

- **Candidates are earned honestly:** only credentials that actually block the clinician's real roles (`missingCredentials`) are simulated — never a generic wishlist.
- **Conservative by construction:** a hypothetical credential carries no state/specialty scope, so scoped requirements are only counted as satisfied when the engine doesn't require a matching scope. This can *under*-count impact but never *over*-count it.
- **Never mutates evidence.** The hypothetical profile is a local spread used for scoring only.
- **Only positive-impact moves surface** — no zero/negative theatre.

## What's included

- Backend: `services/matcha/matchaSimulator.ts` (pure) + `GET /api/matcha/simulate/:npi` (reuses the real profile + opportunity load).
- Web: `/api/matcha/simulate/[npi]` proxy + `OpportunitySimulator` card mounted on the Career Scoreboard ("What if — improve your MATCH"), with honest loading / nothing-to-unlock / unavailable states.

## Validation

- **7/7** deterministic unit tests (`matchaSimulator.test.ts`): unblock → positive scenario, **monotonic** cleared set, **non-earnable** identity facts (npi/sanctions_clear) never suggested, **purity** (evidence never mutated), empty/all-credentialed cases, impact sort.
- Web build green **14/14** (turbo `@vitalcv/web`, TS + ESLint enforced) with the proxy + surface.
- Backend: pure logic typechecks against existing engine types; matcha files clean.

## Truth rules

- No estimates, no invented AI: the only numbers shown are the engine's recomputed match deltas.
- "Earning a credential is verified separately; this only shows how matching would change" — stated on the surface.
- No banned truth-contract phrases; no bare `Verified`.

## Tier & merge

**Tier 2** — adds a backend endpoint + service touching the matching engine. Per your standing note on this wave: **do not merge without Chris approval.** I'll run `codex exec` (implementation / diff / copy) before any merge and post the verdict here. Deploys touch both web and API (backend endpoint).

## Design Handoff References

No Claude Design handoff file used for this PR. The surface reuses the in-repo D57 `.vcv-doc` system for consistency with the Career Scoreboard it extends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)