### PR TITLE
feat(matcha): Career Compass — the signed-in centerpiece (Wave 4 Part 1)

### DIFF
--- a/apps/web/__tests__/matcha-career-compass.test.ts
+++ b/apps/web/__tests__/matcha-career-compass.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Career Compass (Wave 4, Part 1) — truth-model unit tests.
+ *
+ * Pins the honesty invariants: the next action is chosen deterministically by
+ * priority, impact is stated as real counts (never fabricated deltas),
+ * confidence tracks data coverage (High only with a readiness snapshot), absent
+ * signals become explicit empty states, and no banned/estimative copy appears.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildCareerCompass, type CompassInput } from '@/lib/matcha/careerCompass';
+
+function base(overrides: Partial<CompassInput> = {}): CompassInput {
+  return {
+    readiness: { score: 78, level: 'L3 · Clinical' },
+    recognition: { state: 'none_recorded' },
+    opportunities: { total: 5, clearedToApply: 2 },
+    profileScore: 60,
+    blockers: [],
+    recommendedAction: null,
+    ...overrides,
+  };
+}
+
+describe('buildCareerCompass — metrics from real signals', () => {
+  it('renders readiness / recognition / roles / profile from the inputs', () => {
+    const m = buildCareerCompass(base()).metrics;
+    expect(m.find((x) => x.key === 'readiness')!.value).toBe('78%');
+    expect(m.find((x) => x.key === 'roles')!.value).toBe('2');
+    expect(m.find((x) => x.key === 'roles')!.sub).toBe('of 5 matched');
+    expect(m.find((x) => x.key === 'profile')!.value).toBe('60%');
+  });
+
+  it('shows honest empty states when signals are absent (no fabricated numbers)', () => {
+    const m = buildCareerCompass(
+      base({ readiness: null, recognition: { state: 'unavailable' }, opportunities: { total: 0, clearedToApply: 0 }, profileScore: null }),
+    ).metrics;
+    expect(m.find((x) => x.key === 'readiness')!.value).toBe('—');
+    expect(m.find((x) => x.key === 'readiness')!.tone).toBe('empty');
+    expect(m.find((x) => x.key === 'recognition')!.tone).toBe('unavailable');
+    expect(m.find((x) => x.key === 'profile')!.value).toBe('—');
+  });
+});
+
+describe('buildCareerCompass — deterministic next action by priority', () => {
+  it('prioritizes an open readiness item, with real-count impact', () => {
+    const compass = buildCareerCompass(
+      base({
+        blockers: [
+          { title: 'License renewal', detail: 'Your license expires soon.', href: '/holder/blockers/lic', nextActionLabel: 'Renew now' },
+          { title: 'Upload DEA', detail: 'DEA on file is pending.', href: '/holder/blockers/dea', nextActionLabel: 'Upload' },
+        ],
+        opportunities: { total: 5, clearedToApply: 2 },
+      }),
+    );
+    expect(compass.action.title).toBe('Resolve: License renewal');
+    expect(compass.action.href).toBe('/holder/blockers/lic');
+    expect(compass.action.ctaLabel).toBe('Renew now');
+    // Impact is real counts, not invented deltas.
+    expect(compass.action.impact[0]).toBe('Clears 1 of your 2 open readiness items');
+    expect(compass.action.impact.join(' ')).toContain('3 of your 5 matched roles');
+  });
+
+  it('falls back to the recommended action when there are no blockers', () => {
+    const compass = buildCareerCompass(
+      base({ blockers: [], recommendedAction: { title: 'Open your passport', description: 'Share it.', href: '/holder', ctaLabel: 'Open' } }),
+    );
+    expect(compass.action.title).toBe('Open your passport');
+    expect(compass.action.href).toBe('/holder');
+  });
+
+  it('suggests finishing the profile when incomplete and nothing else pending', () => {
+    const compass = buildCareerCompass(base({ blockers: [], recommendedAction: null, profileScore: 60 }));
+    expect(compass.action.title).toBe('Complete your profile');
+    expect(compass.action.impact.join(' ')).toContain('60% complete');
+  });
+
+  it('points to cleared roles when profile is complete and nothing is blocking', () => {
+    const compass = buildCareerCompass(
+      base({ blockers: [], recommendedAction: null, profileScore: 100, opportunities: { total: 4, clearedToApply: 3 } }),
+    );
+    expect(compass.action.title).toContain('Apply to 3 roles');
+  });
+
+  it('degrades to keep-current when everything is done', () => {
+    const compass = buildCareerCompass(
+      base({ blockers: [], recommendedAction: null, profileScore: 100, opportunities: { total: 0, clearedToApply: 0 } }),
+    );
+    expect(compass.action.title).toBe('Keep your readiness current');
+  });
+});
+
+describe('buildCareerCompass — confidence tracks data coverage, not invention', () => {
+  it('is High only when a readiness snapshot exists', () => {
+    expect(buildCareerCompass(base({ readiness: { score: 70, level: 'L2' } })).action.confidence).toBe('High');
+    expect(buildCareerCompass(base({ readiness: null })).action.confidence).toBe('Building');
+  });
+
+  it('never emits estimative or banned copy across states', () => {
+    const banned = [
+      /interview probability/i,
+      /estimated salary/i,
+      /\bverified\b/i,
+      /guaranteed verification/i,
+      /instant credentialing/i,
+      /HIPAA compliant/i,
+    ];
+    const permutations: CompassInput[] = [
+      base(),
+      base({ readiness: null, recognition: { state: 'unavailable' }, opportunities: { total: 0, clearedToApply: 0 }, profileScore: null }),
+      base({ blockers: [{ title: 'X', detail: 'Y', href: '/holder', nextActionLabel: 'Go' }] }),
+      base({ recognition: { state: 'recognized', count: 3 } }),
+    ];
+    for (const input of permutations) {
+      const c = buildCareerCompass(input);
+      const text = [c.note, c.action.title, c.action.why, c.action.confidenceReason, ...c.action.impact, ...c.metrics.flatMap((m) => [m.label, m.value, m.sub])].join(' | ');
+      for (const re of banned) {
+        expect(re.test(text), `banned ${re} in: ${text}`).toBe(false);
+      }
+    }
+  });
+});

--- a/apps/web/components/matcha/CareerCompass.tsx
+++ b/apps/web/components/matcha/CareerCompass.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+/**
+ * Career Compass (Wave 4, Part 1) — the signed-in centerpiece.
+ *
+ * "Where you are, and the one thing to do next." A thin renderer over the pure
+ * truth model in lib/matcha/careerCompass.ts: it maps the clinician's REAL
+ * account signals (source-backed readiness, recorded employer acceptances, live
+ * MATCHA matches, profile completeness, open readiness items) into four honest
+ * metrics and a single deterministic next-best action with real-count impact,
+ * a why tied to evidence, and a confidence that reflects data coverage. No demo
+ * data: absent signals render explicit empty states, never fabricated numbers.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, Check, Compass, Sparkles } from 'lucide-react';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { fetchAcceptanceRecognition } from '@/lib/recognition/acceptance-recognition';
+import {
+  buildCareerCompass,
+  type CompassInput,
+  type CompassMetric,
+  type CompassTone,
+} from '@/lib/matcha/careerCompass';
+
+const CLEARED_BANDS = new Set(['CLEAR', 'NEAR_CLEAR']);
+
+const METRIC_COLOR: Record<CompassTone, string> = {
+  strong: 'text-emerald-300',
+  progress: 'text-sky-300',
+  attention: 'text-amber-300',
+  empty: 'text-white/40',
+  unavailable: 'text-white/40',
+};
+
+function greetingFor(hour: number): string {
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+export default function CareerCompass() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? null;
+  const firstName = data.workspace?.personProfile?.firstName || 'there';
+
+  const [recognition, setRecognition] = useState<CompassInput['recognition']>({ state: 'unavailable' });
+  const [greeting, setGreeting] = useState('Hello');
+
+  // Time-of-day greeting is computed client-side (Date is a display concern,
+  // kept out of the pure model).
+  useEffect(() => {
+    setGreeting(greetingFor(new Date().getHours()));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!npi) {
+      setRecognition({ state: 'none_recorded' });
+      return;
+    }
+    void (async () => {
+      const result = await fetchAcceptanceRecognition(npi);
+      if (cancelled) return;
+      if (result.state === 'recognized') {
+        setRecognition({ state: 'recognized', count: result.recognition.history.length });
+      } else {
+        setRecognition({ state: result.state });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [npi]);
+
+  const compass = useMemo(() => {
+    const readiness = data.trustState
+      ? { score: data.trustState.readinessScore, level: data.trustState.readinessLevel }
+      : null;
+    const clearedToApply = data.availableOpportunities.filter(
+      (opp) => opp.match && CLEARED_BANDS.has(opp.match.band),
+    ).length;
+    const recommendedAction = data.recommendedAction
+      ? {
+          title: data.recommendedAction.title,
+          description: data.recommendedAction.description,
+          href: data.recommendedAction.href,
+          ctaLabel: data.recommendedAction.ctaLabel,
+        }
+      : null;
+
+    return buildCareerCompass({
+      readiness,
+      recognition,
+      opportunities: { total: data.availableOpportunities.length, clearedToApply },
+      profileScore: data.profileCompleteness?.score ?? null,
+      blockers: data.blockers.map((b) => ({
+        title: b.title,
+        detail: b.detail,
+        href: b.href,
+        nextActionLabel: b.nextActionLabel,
+      })),
+      recommendedAction,
+    });
+  }, [data, recognition]);
+
+  const { action } = compass;
+
+  return (
+    <section className="rounded-[28px] border border-white/10 bg-gradient-to-b from-teal-400/[0.06] to-white/[0.02] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.28)] sm:p-6">
+      <div className="flex items-center gap-2 text-teal-200/80">
+        <Compass className="h-4 w-4" aria-hidden />
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em]">MATCHA Career Compass</p>
+      </div>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+        {greeting}, {firstName}.
+      </h1>
+
+      {/* Four honest metrics */}
+      <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {compass.metrics.map((m) => (
+          <MetricCell key={m.key} metric={m} />
+        ))}
+      </div>
+
+      {/* The one next action */}
+      <div className="mt-5 rounded-[22px] border border-white/10 bg-black/30 p-4 sm:p-5">
+        <div className="flex items-center justify-between gap-3">
+          <p className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/50">
+            <Sparkles className="h-3.5 w-3.5 text-teal-300" aria-hidden />
+            What should I do next?
+          </p>
+          <ConfidenceChip confidence={action.confidence} />
+        </div>
+
+        <h2 className="mt-3 text-xl font-semibold text-white">{action.title}</h2>
+        <p className="mt-2 text-sm leading-6 text-white/65">{action.why}</p>
+
+        <ul className="mt-4 space-y-1.5">
+          {action.impact.map((line) => (
+            <li key={line} className="flex items-start gap-2 text-sm text-white/75">
+              <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-teal-300" aria-hidden />
+              {line}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href={action.href}
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-teal-300 px-5 text-sm font-semibold text-teal-950 transition hover:bg-teal-200"
+          >
+            {action.ctaLabel}
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
+          <p className="text-xs text-white/40">{action.confidenceReason}</p>
+        </div>
+      </div>
+
+      <p className="mt-4 text-[11px] leading-relaxed text-white/40">{compass.note}</p>
+    </section>
+  );
+}
+
+function MetricCell({ metric }: { metric: CompassMetric }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/40">{metric.label}</p>
+      <p className={`mt-1.5 text-xl font-semibold leading-none ${METRIC_COLOR[metric.tone]}`}>{metric.value}</p>
+      <p className="mt-1 text-[11px] text-white/45">{metric.sub}</p>
+    </div>
+  );
+}
+
+function ConfidenceChip({ confidence }: { confidence: 'High' | 'Building' }) {
+  const strong = confidence === 'High';
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${
+        strong
+          ? 'border-teal-300/30 bg-teal-300/10 text-teal-200'
+          : 'border-white/15 bg-white/5 text-white/55'
+      }`}
+    >
+      Confidence: {confidence}
+    </span>
+  );
+}

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -28,6 +28,7 @@ import { ClinicianStatusBanner } from '@/components/mobile/ClinicianStatusBanner
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import { RecognitionCard } from '@/components/recognition/RecognitionCard';
+import CareerCompass from '@/components/matcha/CareerCompass';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
 import { MatchaHomeActivity } from '@/components/matcha/MatchaHomeActivity';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
@@ -294,6 +295,8 @@ export default function ClinicianHomeSurface() {
           </button>
         </div>
       </header>
+
+      <CareerCompass />
 
       {refreshError ? (
         <ClinicianStatusBanner

--- a/apps/web/lib/matcha/careerCompass.ts
+++ b/apps/web/lib/matcha/careerCompass.ts
@@ -1,0 +1,224 @@
+// apps/web/lib/matcha/careerCompass.ts
+//
+// Career Compass (Wave 4, Part 1) — the signed-in centerpiece: "where you are,
+// and the one thing to do next." Pure + isomorphic so the truth logic is
+// unit-tested and the surface stays a thin renderer.
+//
+// Truth rule (mirrors the MATCHA engine + scoreboard modules): every number and
+// every recommendation is derived ONLY from the clinician's real account
+// signals — source-backed readiness, recorded employer acceptances, live engine
+// matches, profile completeness, and their open readiness items. The "one next
+// action" is chosen deterministically by priority; its impact is stated as
+// honest real COUNTS ("clears 1 of your 3 open items"), never fabricated deltas
+// like "+6 Recognition". Confidence reflects DATA COVERAGE, not a made-up
+// percentage: it is "High" only when a source-backed readiness snapshot exists.
+// If MATCHA cannot ground it, MATCHA does not claim it.
+
+export type CompassTone = 'strong' | 'progress' | 'attention' | 'empty' | 'unavailable';
+export type CompassConfidence = 'High' | 'Building';
+
+export interface CompassMetric {
+  key: string;
+  label: string;
+  value: string;
+  sub: string;
+  tone: CompassTone;
+}
+
+export interface CompassAction {
+  /** e.g. "Resolve: License renewal". */
+  title: string;
+  /** Why this is the next step — tied to a real item. */
+  why: string;
+  href: string;
+  ctaLabel: string;
+  /** Honest, real-count impact statements (never fabricated deltas). */
+  impact: string[];
+  confidence: CompassConfidence;
+  confidenceReason: string;
+}
+
+export interface CareerCompassModel {
+  metrics: CompassMetric[];
+  action: CompassAction;
+  /** Honest footnote about what is and isn't measured. */
+  note: string;
+}
+
+export interface CompassBlocker {
+  title: string;
+  detail: string;
+  href: string;
+  nextActionLabel: string;
+}
+
+export interface CompassInput {
+  readiness: { score: number; level: string } | null;
+  recognition: { state: 'recognized' | 'none_recorded' | 'unavailable'; count?: number };
+  opportunities: { total: number; clearedToApply: number };
+  profileScore: number | null;
+  blockers: CompassBlocker[];
+  recommendedAction: { title: string; description: string; href: string; ctaLabel: string } | null;
+}
+
+function readinessMetric(readiness: CompassInput['readiness']): CompassMetric {
+  if (!readiness) {
+    return {
+      key: 'readiness',
+      label: 'Readiness',
+      value: '—',
+      sub: 'Add your NPI to measure it',
+      tone: 'empty',
+    };
+  }
+  const tone: CompassTone = readiness.score >= 75 ? 'strong' : readiness.score >= 50 ? 'progress' : 'attention';
+  return {
+    key: 'readiness',
+    label: 'Readiness',
+    value: `${readiness.score}%`,
+    sub: readiness.level,
+    tone,
+  };
+}
+
+function recognitionMetric(recognition: CompassInput['recognition']): CompassMetric {
+  if (recognition.state === 'recognized') {
+    const count = recognition.count ?? 0;
+    return {
+      key: 'recognition',
+      label: 'Recognition',
+      value: count > 0 ? `${count}` : 'Recorded',
+      sub: count === 1 ? 'employer acceptance' : 'employer acceptances',
+      tone: 'strong',
+    };
+  }
+  if (recognition.state === 'unavailable') {
+    return { key: 'recognition', label: 'Recognition', value: '—', sub: 'temporarily unavailable', tone: 'unavailable' };
+  }
+  return { key: 'recognition', label: 'Recognition', value: 'None yet', sub: 'earned when an employer accepts', tone: 'empty' };
+}
+
+function rolesMetric(opportunities: CompassInput['opportunities']): CompassMetric {
+  if (opportunities.total <= 0) {
+    return { key: 'roles', label: 'Roles ready', value: '0', sub: 'no live matches yet', tone: 'empty' };
+  }
+  return {
+    key: 'roles',
+    label: 'Roles ready',
+    value: `${opportunities.clearedToApply}`,
+    sub: `of ${opportunities.total} matched`,
+    tone: opportunities.clearedToApply > 0 ? 'strong' : 'progress',
+  };
+}
+
+function profileMetric(profileScore: number | null): CompassMetric {
+  if (profileScore === null) {
+    return { key: 'profile', label: 'Profile', value: '—', sub: 'not started', tone: 'empty' };
+  }
+  const tone: CompassTone = profileScore >= 80 ? 'strong' : profileScore >= 40 ? 'progress' : 'attention';
+  return { key: 'profile', label: 'Profile', value: `${profileScore}%`, sub: 'complete', tone };
+}
+
+function confidenceFrom(readiness: CompassInput['readiness']): { confidence: CompassConfidence; confidenceReason: string } {
+  if (readiness) {
+    return { confidence: 'High', confidenceReason: 'Based on your source-backed readiness snapshot.' };
+  }
+  return { confidence: 'Building', confidenceReason: 'Add your NPI so MATCHA can measure your readiness first.' };
+}
+
+/**
+ * Choose the single next-best action deterministically by priority:
+ *   1. An open readiness item (blocker) — the most concrete, highest-leverage move.
+ *   2. The workspace's recommended action, if one is set.
+ *   3. Finish the profile, if incomplete.
+ *   4. Apply to roles already cleared.
+ *   5. Otherwise, keep readiness current.
+ */
+function chooseAction(input: CompassInput): CompassAction {
+  const { confidence, confidenceReason } = confidenceFrom(input.readiness);
+  const gated = Math.max(0, input.opportunities.total - input.opportunities.clearedToApply);
+  const blockerCount = input.blockers.length;
+
+  if (blockerCount > 0) {
+    const b = input.blockers[0];
+    const impact: string[] = [
+      `Clears 1 of your ${blockerCount} open readiness item${blockerCount === 1 ? '' : 's'}`,
+    ];
+    if (gated > 0) {
+      impact.push(`${gated} of your ${input.opportunities.total} matched roles still have gating items`);
+    }
+    impact.push('Keeps your evidence employer-ready');
+    return {
+      title: `Resolve: ${b.title}`,
+      why: b.detail,
+      href: b.href,
+      ctaLabel: b.nextActionLabel || 'Resolve',
+      impact,
+      confidence,
+      confidenceReason,
+    };
+  }
+
+  if (input.recommendedAction) {
+    const r = input.recommendedAction;
+    return {
+      title: r.title,
+      why: r.description,
+      href: r.href,
+      ctaLabel: r.ctaLabel || 'Continue',
+      impact: ['Your next recorded step toward a stronger match'],
+      confidence,
+      confidenceReason,
+    };
+  }
+
+  if (input.profileScore !== null && input.profileScore < 100) {
+    return {
+      title: 'Complete your profile',
+      why: 'A fuller profile strengthens every match and gives reviewers more to work from.',
+      href: '/clinician/profile',
+      ctaLabel: 'Edit profile',
+      impact: [`Profile is ${input.profileScore}% complete`, 'Stronger profile → stronger matches'],
+      confidence,
+      confidenceReason,
+    };
+  }
+
+  if (input.opportunities.clearedToApply > 0) {
+    return {
+      title: `Apply to ${input.opportunities.clearedToApply} role${input.opportunities.clearedToApply === 1 ? '' : 's'} you're ready for`,
+      why: 'These live roles have no gating items outstanding against your evidence.',
+      href: '/holder/opportunities',
+      ctaLabel: 'View roles',
+      impact: [`${input.opportunities.clearedToApply} cleared to apply now`],
+      confidence,
+      confidenceReason,
+    };
+  }
+
+  return {
+    title: 'Keep your readiness current',
+    why: 'Nothing is blocking your next step right now — keep your evidence fresh so matches stay strong.',
+    href: '/holder/readiness',
+    ctaLabel: 'Open readiness',
+    impact: ['Nothing is blocking you right now'],
+    confidence,
+    confidenceReason,
+  };
+}
+
+/**
+ * Build the Career Compass from the clinician's real account signals.
+ */
+export function buildCareerCompass(input: CompassInput): CareerCompassModel {
+  return {
+    metrics: [
+      readinessMetric(input.readiness),
+      recognitionMetric(input.recognition),
+      rolesMetric(input.opportunities),
+      profileMetric(input.profileScore),
+    ],
+    action: chooseAction(input),
+    note: 'Every number here is your own — VitalCV shows what it can measure from your evidence and no more. It does not estimate interview odds, salaries, or outcomes.',
+  };
+}


### PR DESCRIPTION
## Summary

**Wave 4, Part 1 — the Career Compass.** The signed-in centerpiece that answers, the moment a clinician opens VitalCV: *where am I, and what's the one thing to do next?* It sits at the top of the holder dashboard (`/holder/home`) and shows:

- **Four honest metrics** — Readiness (source-backed score), Recognition (recorded employer acceptances), Roles ready (cleared-to-apply of matched), Profile completeness.
- **One deterministic next-best action** — chosen by priority (open readiness item → recommended action → finish profile → apply to cleared roles → keep current), with:
  - **real-count impact** ("Clears 1 of your 3 open readiness items"; "3 of your 5 matched roles still have gating items") — never a fabricated `+6 Recognition` delta,
  - a **why** tied to the actual item,
  - a **confidence** that reflects *data coverage* — "High" only when a source-backed readiness snapshot exists, "Building" otherwise. Not a made-up percentage.

## Truth rules (what it deliberately does NOT do)

Per your own mission ("no fake AI") and the truth contract, and honoring where the spec collides with it:
- **No fabricated interview probability** — the engine explicitly does not estimate outcomes; the Compass doesn't either.
- **No invented salary/recognition/readiness deltas** — impact is stated as real counts of your own items, or omitted.
- Absent signals render explicit empty states (`—`, "None yet"), never fabricated numbers.
- A footnote states it plainly: *"VitalCV shows what it can measure from your evidence and no more. It does not estimate interview odds, salaries, or outcomes."*
- No banned strings; no bare `Verified` (asserted by a test across all states).

## Validation

- Pure truth-model tests **9/9** (`matcha-career-compass.test.ts`): priority selection, real-count impact, confidence-from-coverage, honest empty states, banned/estimative-copy scan.
- Holder route-contract **150/150** (every Compass link resolves).
- `pnpm turbo run build --filter @vitalcv/web`: **14/14** (TS + ESLint enforced).
- Truth scan clean.

## Tier & merge

**Tier 1** — clinician-facing surface, reads existing holder-context data, no migration, no auth change; additive (mounted above the existing sections, nothing removed). Per your standing note on this wave, **holding for your approval — I will not self-merge.**

## Design Handoff References

No Claude Design handoff file used for this PR. Follows the existing dark holder-home aesthetic with the Calm Wave palette (MATCHA teal accent) called out in your Wave 4 design notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)