### PR TITLE
feat(matcha): persist career preferences to DB — Career DNA follows the provider

### DIFF
--- a/apps/api/backend/prisma/migrations/20260704000000_matcha_preferences/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260704000000_matcha_preferences/migration.sql
@@ -1,0 +1,19 @@
+-- MATCHA career preferences / Career DNA persistence.
+-- One row per authenticated Clerk user; `data` is the sanitized
+-- MatchaPreferences bag (self-stated, editable preferences — never credentials
+-- or evidence). Keyed by clerkUserId so preferences follow the provider across
+-- devices instead of living only in the browser's localStorage.
+
+CREATE TABLE "MatchaPreference" (
+    "id" TEXT NOT NULL,
+    "clerkUserId" TEXT NOT NULL,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MatchaPreference_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MatchaPreference_clerkUserId_key" ON "MatchaPreference"("clerkUserId");
+
+CREATE INDEX "MatchaPreference_clerkUserId_idx" ON "MatchaPreference"("clerkUserId");

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -24,6 +24,21 @@ model User {
   @@index([status])
 }
 
+/// MATCHA career preferences / Career DNA for a clinician.
+/// Keyed by the authenticated Clerk user id so preferences follow the provider
+/// across devices, not the browser. `data` holds the full MatchaPreferences bag
+/// (self-stated, editable preferences — never credentials or evidence),
+/// sanitized to known fields before write. One row per user.
+model MatchaPreference {
+  id          String   @id @default(cuid())
+  clerkUserId String   @unique
+  data        Json
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([clerkUserId])
+}
+
 model Recognition {
   id              String       @id @default(uuid()) @db.Uuid
   recognitionId   String       @unique

--- a/apps/web/__tests__/matcha-preferences-sanitize.test.ts
+++ b/apps/web/__tests__/matcha-preferences-sanitize.test.ts
@@ -1,0 +1,81 @@
+/**
+ * sanitizeStoredPreferences — the write-boundary guard for the durable MATCHA
+ * preference store. Pins that only known preference fields survive, types are
+ * enforced, sizes are bounded, and arbitrary/unknown input is dropped — so the
+ * server store can never hold junk (or anything shaped like a credential claim).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeStoredPreferences } from '@/lib/matcha/preferences';
+
+describe('sanitizeStoredPreferences', () => {
+  it('keeps known fields with valid typed values', () => {
+    const out = sanitizeStoredPreferences({
+      careerGoals: ['ICU', 'Leadership'],
+      preferredStates: ['CA', 'WA'],
+      minimumSalary: 180000,
+      remoteInterest: 'prefer',
+      researchInterest: 3,
+      newGraduate: true,
+    });
+    expect(out.careerGoals).toEqual(['ICU', 'Leadership']);
+    expect(out.preferredStates).toEqual(['CA', 'WA']);
+    expect(out.minimumSalary).toBe(180000);
+    expect(out.remoteInterest).toBe('prefer');
+    expect(out.researchInterest).toBe(3);
+    expect(out.newGraduate).toBe(true);
+  });
+
+  it('drops unknown keys entirely', () => {
+    const out = sanitizeStoredPreferences({
+      careerGoals: ['X'],
+      __proto__pollution: 'nope',
+      credentials_hack: ['MD'],
+      evilBlob: { a: 1 },
+      npi: '1234567890',
+    }) as Record<string, unknown>;
+    expect(out.careerGoals).toEqual(['X']);
+    expect(out.credentials_hack).toBeUndefined();
+    expect(out.evilBlob).toBeUndefined();
+    expect(out.npi).toBeUndefined();
+  });
+
+  it('drops empty arrays, empty strings, and non-finite numbers', () => {
+    const out = sanitizeStoredPreferences({
+      careerGoals: [],
+      remoteInterest: '   ',
+      minimumSalary: Number.NaN,
+      preferredStates: ['CA'],
+    }) as Record<string, unknown>;
+    expect(out.careerGoals).toBeUndefined();
+    expect(out.remoteInterest).toBeUndefined();
+    expect(out.minimumSalary).toBeUndefined();
+    expect(out.preferredStates).toEqual(['CA']);
+  });
+
+  it('filters non-string items out of arrays', () => {
+    const out = sanitizeStoredPreferences({ careerGoals: ['ICU', 42, null, { x: 1 }, 'OR'] });
+    expect(out.careerGoals).toEqual(['ICU', 'OR']);
+  });
+
+  it('caps array length and string length', () => {
+    const bigArray = Array.from({ length: 200 }, (_, i) => `item-${i}`);
+    const longString = 'x'.repeat(1000);
+    const out = sanitizeStoredPreferences({ certifications: bigArray, remoteInterest: longString });
+    expect(out.certifications!.length).toBe(60);
+    expect((out.remoteInterest as string).length).toBe(240);
+  });
+
+  it('returns an empty object for non-object input', () => {
+    expect(sanitizeStoredPreferences(null)).toEqual({});
+    expect(sanitizeStoredPreferences(undefined)).toEqual({});
+    expect(sanitizeStoredPreferences('nope')).toEqual({});
+    expect(sanitizeStoredPreferences(42)).toEqual({});
+    expect(sanitizeStoredPreferences(['a', 'b'])).toEqual({});
+  });
+
+  it('is idempotent (sanitizing a sanitized bag is a fixed point)', () => {
+    const once = sanitizeStoredPreferences({ careerGoals: ['ICU'], minimumSalary: 200000, garbage: 'x' });
+    expect(sanitizeStoredPreferences(once)).toEqual(once);
+  });
+});

--- a/apps/web/app/api/matcha/preferences/route.ts
+++ b/apps/web/app/api/matcha/preferences/route.ts
@@ -1,0 +1,80 @@
+/**
+ * /api/matcha/preferences — durable MATCHA career preferences (Career DNA).
+ *
+ * Auth-scoped to the authenticated Clerk user (identity from auth(), NOT a
+ * caller-supplied header), so a clinician's preferences follow the provider
+ * across devices instead of living only in the browser's localStorage. Reads
+ * and writes the shared `MatchaPreference` table via the web Prisma client.
+ *
+ * These are self-stated, editable preferences ONLY — never credentials or
+ * evidence. Writes are sanitized to the known preference fields before persist.
+ *
+ * Deploy-order safe: if the table does not exist yet (migration not deployed)
+ * or the DB hiccups, both verbs degrade to an empty/no-op response so the
+ * client silently falls back to its local cache — never a 500 in the signed-in
+ * experience.
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@/lib/generated/prisma';
+import { prisma } from '@/lib/db';
+import { sanitizeStoredPreferences } from '@/lib/matcha/preferences';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  try {
+    const row = await prisma.matchaPreference.findUnique({ where: { clerkUserId: userId } });
+    return NextResponse.json({
+      preferences: row ? sanitizeStoredPreferences(row.data) : {},
+      updatedAt: row?.updatedAt.toISOString() ?? null,
+    });
+  } catch (err) {
+    console.error('[matcha/preferences GET]', err);
+    // Degrade to empty — the client keeps its local cache as the fallback.
+    return NextResponse.json({ preferences: {}, updatedAt: null });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  // Accept either { preferences: {...} } or a bare preferences object.
+  const raw =
+    body && typeof body === 'object' && !Array.isArray(body) && 'preferences' in (body as object)
+      ? (body as { preferences: unknown }).preferences
+      : body;
+  const data = sanitizeStoredPreferences(raw);
+
+  try {
+    const row = await prisma.matchaPreference.upsert({
+      where: { clerkUserId: userId },
+      create: { clerkUserId: userId, data: data as Prisma.InputJsonValue },
+      update: { data: data as Prisma.InputJsonValue },
+    });
+    return NextResponse.json({
+      ok: true,
+      updatedAt: row.updatedAt.toISOString(),
+      fields: Object.keys(data).length,
+    });
+  } catch (err) {
+    console.error('[matcha/preferences PUT]', err);
+    // Best-effort: never break the client; localStorage remains the fallback.
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+}

--- a/apps/web/components/matcha/useMatchaPreferences.ts
+++ b/apps/web/components/matcha/useMatchaPreferences.ts
@@ -16,6 +16,8 @@ import {
   type PreferenceField,
   ENGINE_BACKED_FIELDS,
   completenessPercent,
+  countAnsweredFields,
+  sanitizeStoredPreferences,
   toCandidateIntent,
 } from '@/lib/matcha/preferences';
 import { deriveMatchaProfile, type MatchaDerivedProfile } from '@/lib/matcha/profile';
@@ -49,12 +51,67 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
   const [loaded, setLoaded] = useState(false);
   const [memory, setMemory] = useState<MemoryNote[]>([]);
   const pushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prefsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Hydrate from storage on mount.
+  // Hydrate from local storage on mount (instant, offline-safe).
   useEffect(() => {
     setPreferences(loadStoredPreferences());
     setLoaded(true);
   }, []);
+
+  /**
+   * Persist the full preference bag to the durable, auth-scoped server store
+   * so it follows the provider across devices. Best-effort: a failed write
+   * never loses the answer (local storage remains the fallback). Unauthenticated
+   * callers get 401 and simply stay local-only.
+   */
+  const persistToServer = useCallback((prefs: MatchaPreferences) => {
+    void fetch('/api/matcha/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ preferences: prefs }),
+      keepalive: true,
+    }).catch(() => {
+      /* best-effort — local storage remains the source of truth */
+    });
+  }, []);
+
+  // Hydrate from the durable server store once on mount. When signed in and the
+  // server holds preferences, the server is the cross-device source of truth;
+  // when the server is empty, migrate any existing local preferences up once.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/matcha/preferences', { cache: 'no-store' });
+        if (cancelled || !res.ok) return; // 401 / degraded → stay local-only
+        const body = (await res.json()) as { preferences?: unknown };
+        const server = sanitizeStoredPreferences(body?.preferences ?? {});
+        if (cancelled) return;
+        if (countAnsweredFields(server) > 0) {
+          setPreferences(server);
+          savePreferences(server, nowIso());
+        } else {
+          const local = loadStoredPreferences();
+          if (countAnsweredFields(local) > 0) persistToServer(local);
+        }
+      } catch {
+        /* stay local-only */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [persistToServer]);
+
+  // Debounced durable persistence so rapid answers collapse into one write.
+  const pushPrefs = useCallback(
+    (next: MatchaPreferences) => {
+      if (prefsTimer.current) clearTimeout(prefsTimer.current);
+      prefsTimer.current = setTimeout(() => persistToServer(next), 800);
+    },
+    [persistToServer],
+  );
 
   const pushIntent = useCallback(
     (next: MatchaPreferences) => {
@@ -90,10 +147,11 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
         }
         savePreferences(next, nowIso());
         pushIntent(next);
+        pushPrefs(next);
         return next;
       });
     },
-    [pushIntent],
+    [pushIntent, pushPrefs],
   );
 
   const reset = useCallback(() => {
@@ -105,6 +163,7 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
   useEffect(
     () => () => {
       if (pushTimer.current) clearTimeout(pushTimer.current);
+      if (prefsTimer.current) clearTimeout(prefsTimer.current);
     },
     [],
   );

--- a/apps/web/components/matcha/useMatchaPreferences.ts
+++ b/apps/web/components/matcha/useMatchaPreferences.ts
@@ -52,6 +52,9 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
   const [memory, setMemory] = useState<MemoryNote[]>([]);
   const pushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Flips true on the first local edit so an in-flight server hydration can
+  // never clobber a live edit the clinician just made.
+  const userEditedRef = useRef(false);
 
   // Hydrate from local storage on mount (instant, offline-safe).
   useEffect(() => {
@@ -88,6 +91,9 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
         const body = (await res.json()) as { preferences?: unknown };
         const server = sanitizeStoredPreferences(body?.preferences ?? {});
         if (cancelled) return;
+        // The clinician started editing while this GET was in flight — their
+        // live edit (already persisted via its own PUT) wins; never overwrite it.
+        if (userEditedRef.current) return;
         if (countAnsweredFields(server) > 0) {
           setPreferences(server);
           savePreferences(server, nowIso());
@@ -139,6 +145,7 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
 
   const setField = useCallback(
     (field: PreferenceField, value: MatchaPreferences[PreferenceField]) => {
+      userEditedRef.current = true;
       setPreferences((prev) => {
         const next: MatchaPreferences = { ...prev, [field]: value };
         const notes = diffPreferences(prev, next, [field]);
@@ -155,6 +162,7 @@ export function useMatchaPreferences(npi?: string): UseMatchaPreferences {
   );
 
   const reset = useCallback(() => {
+    userEditedRef.current = true;
     clearStoredPreferences();
     setPreferences({});
     setMemory([]);

--- a/apps/web/lib/matcha/preferences.ts
+++ b/apps/web/lib/matcha/preferences.ts
@@ -179,6 +179,41 @@ export function completenessPercent(prefs: MatchaPreferences): number {
   return Math.round((countAnsweredFields(prefs) / total) * 100);
 }
 
+/**
+ * Sanitize an untrusted preferences payload (e.g. a request body or a stored
+ * blob) down to the known MatchaPreferences shape: ONLY whitelisted fields,
+ * type-checked values, and bounded sizes. Unknown keys are dropped and nothing
+ * is coerced. Used before persisting server-side so the store can never hold
+ * arbitrary data — and, per the truth contract, these are self-stated
+ * preferences only, never a credential or evidence claim.
+ */
+export function sanitizeStoredPreferences(input: unknown): MatchaPreferences {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  const src = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  const MAX_ARRAY_ITEMS = 60;
+  const MAX_STRING = 240;
+
+  for (const field of ALL_PREFERENCE_FIELDS) {
+    const value = src[field as string];
+    if (Array.isArray(value)) {
+      const arr = value
+        .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+        .slice(0, MAX_ARRAY_ITEMS)
+        .map((x) => x.slice(0, MAX_STRING));
+      if (arr.length > 0) out[field] = arr;
+    } else if (typeof value === 'number' && Number.isFinite(value)) {
+      out[field] = value;
+    } else if (typeof value === 'boolean') {
+      out[field] = value;
+    } else if (typeof value === 'string' && value.trim().length > 0) {
+      out[field] = value.slice(0, MAX_STRING);
+    }
+  }
+
+  return out as MatchaPreferences;
+}
+
 // ── Engine mapping ──────────────────────────────────────────────────────────
 
 /**

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -80,3 +80,18 @@ model ReceiptCandidate {
   @@index([reviewState])
   @@index([createdAt])
 }
+
+// MATCHA career preferences / Career DNA — mirror of the backend model (one
+// shared DB; migration + source of truth live in apps/api/backend/prisma).
+// The web app reads/writes this table directly via an auth-scoped route, keyed
+// by the authenticated Clerk user id. `data` is the sanitized MatchaPreferences
+// bag (self-stated, editable preferences — never credentials or evidence).
+model MatchaPreference {
+  id          String   @id @default(cuid())
+  clerkUserId String   @unique
+  data        Json
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([clerkUserId])
+}


### PR DESCRIPTION
## Summary

**The persistence keystone.** Until now, a clinician's MATCHA preferences / Career DNA lived only in the **browser** (`localStorage`) plus a best-effort **in-memory** server intent (lost on restart). They didn't survive a device switch or a redeploy — which directly contradicts the doctrine that VitalCV is *"reusable evidence that follows providers."* This makes preferences **durable and auth-scoped**, so Career DNA follows the *provider*, not the browser. It unblocks Memory, the Scoreboard's tuning tile, Daily, and a future MATCHA Conversation to read durable signals.

## What's included

- **Prisma model `MatchaPreference`** (keyed by `clerkUserId`, JSON `data` bag) + backend migration `20260704000000_matcha_preferences`, mirrored in the web schema (one shared DB; migration source of truth is `apps/api/backend/prisma`).
- **Auth-scoped web route** `GET`/`PUT /api/matcha/preferences`:
  - identity comes from Clerk `auth()` — **not** a caller-supplied header (no spoof vector),
  - writes are **sanitized** to the known preference fields only (`sanitizeStoredPreferences`: whitelist + bounded array/string sizes) — the store can never hold arbitrary data,
  - **deploy-order safe**: if the table isn't migrated yet or the DB hiccups, both verbs degrade to empty/no-op (never a 500 in the signed-in experience).
- **`useMatchaPreferences`** now hydrates from the server on mount (server is the cross-device source of truth when signed in; existing local prefs migrate up once) and debounced-persists every edit. `localStorage` remains the offline fallback; unauthenticated callers stay local-only.

## Truth rules

- **Self-stated preferences only** — never credentials or evidence. The sanitizer drops anything that isn't a known preference field (a doc comment and the model comments say so).
- No banned strings; no bare `Verified`.

## Validation

- Sanitizer tests **7/7** (whitelist, type enforcement, size caps, junk/`__proto__` dropped, idempotent).
- `pnpm turbo run build --filter @vitalcv/web`: **14/14** — Prisma Client regenerated with the model; route + hook typecheck clean (TS + ESLint enforced).
- Truth scan clean. Diff scoped to the 7 keystone files.

## Tier, deploy & merge

**Tier 2** — DB migration + auth-scoped route. Requires `prisma migrate deploy` on the **backend** deploy to create the table (the route degrades gracefully until then, so merge order is safe). Running `codex exec` (3 audits) before any merge; **holding for Chris's approval.**

## Design Handoff References

No Claude Design handoff file used for this PR (backend/data + client wiring; no new UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)