### PR TITLE
fix(theme): make dark mode actually work on Calm Wave surfaces

### DIFF
--- a/apps/web/components/ui/ThemeToggle.tsx
+++ b/apps/web/components/ui/ThemeToggle.tsx
@@ -19,11 +19,9 @@ function resolveTheme(
     return theme;
   }
 
-  if (resolvedTheme === 'light') {
-    return 'light';
-  }
-
-  return 'dark';
+  // For 'system' (or unset), trust next-themes' resolved value and default to
+  // light — matching the provider default and the Calm Wave paper aesthetic.
+  return resolvedTheme === 'dark' ? 'dark' : 'light';
 }
 
 /**
@@ -33,12 +31,11 @@ export function ThemeToggle({ className = '' }: { className?: string }) {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
-  // Avoid hydration mismatch — only render icon client-side
+  // Avoid hydration mismatch — only render icon client-side. Do NOT force a
+  // theme here: let the provider default (light) + any stored choice govern, so
+  // the icon never disagrees with what's rendered.
   useEffect(() => {
     setMounted(true);
-    if (!theme) {
-      setTheme('dark');
-    }
   }, [theme, setTheme]);
 
   if (!mounted) {

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -80,6 +80,46 @@
   --vt-accent-strong: var(--ink-900);
 }
 
+/**
+ * ── Dark mode ─────────────────────────────────────────────────────────────────
+ * A dark Calm Wave: warm charcoal "paper", warm off-white "ink", indigo accent
+ * brightened for contrast. Only the BASE tokens are redefined here — the --vt-*
+ * bridge above resolves through them, so every `.mz` surface (homepage included)
+ * flips together with no per-component changes. Activated by next-themes adding
+ * `.dark` on <html>.
+ */
+.dark .mz {
+  /* Warm charcoal paper */
+  --paper: #15140f;
+  --paper-2: #1d1b15;
+  --card: #1b1915;
+
+  /* Ink ramp inverted: 950/900 = brightest (primary text on dark),
+     low numbers sit nearest the paper (subtle borders / raised fills). */
+  --ink-950: #faf9f4;
+  --ink-900: #f1efe8;
+  --ink-800: #e2dfd6;
+  --ink-700: #c9c5bb;
+  --ink-600: #a6a297;
+  --ink-500: #89857b;
+  --ink-400: #6e6a61;
+  --ink-300: #514e46;
+  --ink-200: #3a3830;
+  --ink-100: #2a2822;
+  --ink-50: #201e19;
+  --rule: #322f29;
+  --rule-soft: #262420;
+
+  /* Truth states — same hues, lifted foregrounds on deep backgrounds. */
+  --ok: #6cc79a;        --ok-bg: #10241a;      --ok-rule: #245c3d;
+  --watch: #dab662;     --watch-bg: #241d0f;   --watch-rule: #6b5620;
+  --unknown: #c7c3b9;   --unknown-bg: #201e1a; --unknown-rule: #423f38;
+  --p0: #f0a2a2;        --p0-bg: #2a1414;      --p0-rule: #6b2222;
+
+  /* Brighten the italic-display accent so it reads on charcoal. */
+  --accent: #8f88f6;
+}
+
 /* ── Typography ───────────────────────────────────────────────────────────── */
 
 .mz-display {


### PR DESCRIPTION
## Summary

You reported the day/night button "doesn't seem to work." Root cause: the toggle **is** wired correctly (it flips `.dark` on `<html>` via next-themes), but the homepage and every `.mz` "Calm Wave" surface **hardcode a light paper palette** (`--paper`/`--ink-*`/`--vt-*`) with no dark override — so the class flips and nothing on screen changes. You asked for dark mode to actually work.

## Fix

- **Dark palette:** add a `.dark .mz` block — warm charcoal paper, an inverted warm off-white ink ramp, deep truth-state backgrounds, and a brightened indigo accent. Only the **base** tokens are redefined; the existing `--vt-*` bridge resolves through them, so every `.mz` surface (homepage included) flips together with **no per-component changes**.
- **Toggle bug:** `ThemeToggle` was forcing `'dark'` on mount (contradicting the provider's `light` default), so its icon could disagree with what was rendered. It now defaults to light and trusts the resolved theme.

## Validation

- `pnpm turbo run build --filter @vitalcv/web`: **14/14**.
- The homepage is entirely token-driven (0 `bg-background`/`text-foreground`, 122 `var(--vt-*)`/`var(--paper)`/`var(--ink)` per the trace), so redefining those tokens flips the whole surface. Visual confirmation on deploy (no browser-preview in this session).
- Avoids the `--vt-state-verified` CSS-token banned-word trap — only base tokens are touched.

## Tier

**Tier 1** — CSS + a client toggle default; no data, no API, no truth-contract copy. Holding for your review.

## Design Handoff References

No Claude Design handoff file used for this PR. The dark palette follows the existing Calm Wave `.mz` token structure (`docs/design/zenlike-ui-doctrine.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)