### PR TITLE
feat(onboarding): email-OTP identity binding — possession factor (gate 3/4)

### DIFF
--- a/apps/api/backend/prisma/migrations/20260704130000_email_otp_identity_binding/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260704130000_email_otp_identity_binding/migration.sql
@@ -1,0 +1,28 @@
+-- Identity-binding possession factor: one-time email verification.
+-- The email OTP code is never stored (only a salted hash); challenges are
+-- short-lived, attempt-capped, and single-use. A verified challenge records a
+-- possession signal on person_profiles (verified_email / verified_email_at) —
+-- a corroboration that strengthens NPI->person binding, NOT a license or
+-- identity verification on its own.
+
+CREATE TABLE "email_otps" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "code_hash" TEXT NOT NULL,
+    "salt" TEXT NOT NULL,
+    "purpose" TEXT NOT NULL DEFAULT 'identity_email',
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "email_otps_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "email_otps_user_id_idx" ON "email_otps"("user_id");
+CREATE INDEX "email_otps_email_idx" ON "email_otps"("email");
+
+ALTER TABLE "person_profiles"
+  ADD COLUMN IF NOT EXISTS "verified_email" TEXT,
+  ADD COLUMN IF NOT EXISTS "verified_email_at" TIMESTAMP(3);

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -325,6 +325,11 @@ model PersonProfile {
   profession          String?          @map("profession")
   attestedAt          DateTime?        @map("attested_at")
   attestationVersion  String?          @map("attestation_version")
+  // Identity-binding corroboration: a work/institutional email the clinician
+  // proved possession of via OTP. A possession SIGNAL that strengthens NPI→person
+  // binding — not a license or identity verification on its own.
+  verifiedEmail       String?          @map("verified_email")
+  verifiedEmailAt     DateTime?        @map("verified_email_at")
   completeness      Int                @default(0)
   createdAt         DateTime           @default(now()) @map("created_at")
   updatedAt         DateTime           @updatedAt @map("updated_at")
@@ -333,6 +338,27 @@ model PersonProfile {
   @@index([npi])
   @@index([userId])
   @@map("person_profiles")
+}
+
+/// One-time email verification challenge (identity-binding possession factor).
+/// The code is never stored — only a salted hash. Short-lived, attempt-capped,
+/// single-use. A verified challenge records a possession signal on the
+/// PersonProfile (verified_email) and a hashed audit row.
+model EmailOtp {
+  id         String    @id @default(cuid())
+  userId     String    @map("user_id")
+  email      String
+  codeHash   String    @map("code_hash")
+  salt       String
+  purpose    String    @default("identity_email")
+  expiresAt  DateTime  @map("expires_at")
+  attempts   Int       @default(0)
+  consumedAt DateTime? @map("consumed_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@index([email])
+  @@map("email_otps")
 }
 
 /// Linked profile for an organization (Type 2 NPI or Org DID)

--- a/apps/api/backend/src/app.ts
+++ b/apps/api/backend/src/app.ts
@@ -141,7 +141,7 @@ import { registerMissionOpsRoutes } from './routes/missionOps';             // W
 import { registerWorkspaceRoutes } from './routes/workspace';               // Wave 180: Identity workspace graph
 import { registerClinicianRoutes } from './routes/clinician';             // Wave 287: Clinician activation
 import { registerIntakeRoutes } from './routes/intake';                     // Wave 183: Resume + NPI + Links + Work Auth ingestion
-import { registerIdentityRoutes } from './routes/identity';                 // Email-OTP identity-binding possession factor
+import { registerEmailOtpRoutes } from './routes/identity';                 // Email-OTP identity-binding possession factor
 import { registerSearchRoutes } from './routes/search';                     // Wave 184: Unified Search Index & Content Graph
 import { registerRoleRoutes } from './routes/role';                         // Clerk auth: GET /api/me/role
 import { registerOwnershipRoutes } from './routes/ownership';               // Auth A1: NPI ownership claims
@@ -3586,7 +3586,7 @@ registerMissionOpsRoutes(app);        // Wave 123 — Mission Ops + onboarding f
 registerWorkspaceRoutes(app);         // Wave 180 — Dual-Entity Identity + workspace switching
 registerClinicianRoutes(app);         // Wave 287 — Clinician activation
 registerIntakeRoutes(app);            // Wave 183 — Resume + NPI + Links + Work Auth ingestion
-registerIdentityRoutes(app);          // Email-OTP identity-binding possession factor
+registerEmailOtpRoutes(app);          // Email-OTP identity-binding possession factor
 registerSearchRoutes(app);            // Wave 184 — Unified Search Index + hybrid retrieval
 registerRoleRoutes(app);              // Clerk auth — GET /api/me/role (role resolution)
 registerOwnershipRoutes(app);         // Auth A1 — NPI ownership claim/revoke

--- a/apps/api/backend/src/app.ts
+++ b/apps/api/backend/src/app.ts
@@ -141,6 +141,7 @@ import { registerMissionOpsRoutes } from './routes/missionOps';             // W
 import { registerWorkspaceRoutes } from './routes/workspace';               // Wave 180: Identity workspace graph
 import { registerClinicianRoutes } from './routes/clinician';             // Wave 287: Clinician activation
 import { registerIntakeRoutes } from './routes/intake';                     // Wave 183: Resume + NPI + Links + Work Auth ingestion
+import { registerIdentityRoutes } from './routes/identity';                 // Email-OTP identity-binding possession factor
 import { registerSearchRoutes } from './routes/search';                     // Wave 184: Unified Search Index & Content Graph
 import { registerRoleRoutes } from './routes/role';                         // Clerk auth: GET /api/me/role
 import { registerOwnershipRoutes } from './routes/ownership';               // Auth A1: NPI ownership claims
@@ -3585,6 +3586,7 @@ registerMissionOpsRoutes(app);        // Wave 123 — Mission Ops + onboarding f
 registerWorkspaceRoutes(app);         // Wave 180 — Dual-Entity Identity + workspace switching
 registerClinicianRoutes(app);         // Wave 287 — Clinician activation
 registerIntakeRoutes(app);            // Wave 183 — Resume + NPI + Links + Work Auth ingestion
+registerIdentityRoutes(app);          // Email-OTP identity-binding possession factor
 registerSearchRoutes(app);            // Wave 184 — Unified Search Index + hybrid retrieval
 registerRoleRoutes(app);              // Clerk auth — GET /api/me/role (role resolution)
 registerOwnershipRoutes(app);         // Auth A1 — NPI ownership claim/revoke

--- a/apps/api/backend/src/routes/identity.ts
+++ b/apps/api/backend/src/routes/identity.ts
@@ -35,7 +35,7 @@ const VERIFY_FAILURES: Record<string, [number, string]> = {
   code_mismatch: [400, 'That code is incorrect.'],
 };
 
-export function registerIdentityRoutes(app: Express): void {
+export function registerEmailOtpRoutes(app: Express): void {
   app.post(
     '/api/profile/identity/email-otp/issue',
     asyncHandler(async (req, res) => {

--- a/apps/api/backend/src/routes/identity.ts
+++ b/apps/api/backend/src/routes/identity.ts
@@ -1,0 +1,78 @@
+/**
+ * Identity-binding routes — the email-OTP possession factor.
+ *
+ *   POST /api/profile/identity/email-otp/issue    { email }
+ *   POST /api/profile/identity/email-otp/verify    { email, code }
+ *
+ * Auth-scoped to the Clerk user (x-clerk-user-id, forwarded by the web proxy).
+ * The verify success records a possession signal on the clinician's profile.
+ */
+import type { Express, NextFunction, Request, Response } from 'express';
+
+import { HttpError } from '../utils/httpError';
+import { issueEmailOtp, verifyEmailOtp } from '../services/identity/emailOtpService';
+
+function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
+  return (req: Request, res: Response, next: NextFunction) => fn(req, res, next).catch(next);
+}
+
+function getHeader(req: Request, key: string): string {
+  const val = req.headers[key];
+  return (Array.isArray(val) ? val[0] : val)?.trim() ?? '';
+}
+
+function requireUserId(req: Request): string {
+  const id = getHeader(req, 'x-clerk-user-id');
+  if (!id) throw new HttpError(401, 'Missing x-clerk-user-id header.');
+  return id;
+}
+
+const VERIFY_FAILURES: Record<string, [number, string]> = {
+  no_challenge: [400, 'No active code — request a new one.'],
+  expired: [400, 'That code expired — request a new one.'],
+  already_used: [400, 'That code was already used — request a new one.'],
+  locked_out: [429, 'Too many attempts — request a new code.'],
+  code_mismatch: [400, 'That code is incorrect.'],
+};
+
+export function registerIdentityRoutes(app: Express): void {
+  app.post(
+    '/api/profile/identity/email-otp/issue',
+    asyncHandler(async (req, res) => {
+      const userId = requireUserId(req);
+      const { email } = req.body as { email?: string };
+      if (!email || typeof email !== 'string') {
+        throw new HttpError(400, 'email is required.');
+      }
+
+      const result = await issueEmailOtp(userId, email);
+      if (result.outcome === 'invalid_email') {
+        throw new HttpError(400, 'Enter a valid email address.');
+      }
+      if (result.outcome === 'rate_limited') {
+        throw new HttpError(429, 'Too many codes requested. Try again later.');
+      }
+      // Never echo the code; delivery is out of band.
+      res.status(200).json({ sent: true });
+    }),
+  );
+
+  app.post(
+    '/api/profile/identity/email-otp/verify',
+    asyncHandler(async (req, res) => {
+      const userId = requireUserId(req);
+      const { email, code } = req.body as { email?: string; code?: string };
+      if (!email || typeof email !== 'string' || !code || typeof code !== 'string') {
+        throw new HttpError(400, 'email and code are required.');
+      }
+
+      const { outcome } = await verifyEmailOtp(userId, email, code);
+      if (outcome === 'verified') {
+        res.status(200).json({ verified: true });
+        return;
+      }
+      const [status, message] = VERIFY_FAILURES[outcome] ?? [400, 'Verification failed.'];
+      res.status(status).json({ verified: false, reason: message });
+    }),
+  );
+}

--- a/apps/api/backend/src/services/identity/__tests__/otpCore.test.ts
+++ b/apps/api/backend/src/services/identity/__tests__/otpCore.test.ts
@@ -1,0 +1,133 @@
+/**
+ * otpCore — security-core unit tests.
+ *
+ * Pins the invariants email-OTP identity binding depends on: codes are 6-digit
+ * CSPRNG, hashing is salted + deterministic + code-sensitive, and the attempt
+ * evaluator honors guard order (absent → used → expired → locked → compare),
+ * spends an attempt only at the compare step, and never crashes on malformed
+ * hashes.
+ */
+import {
+  emailDomain,
+  evaluateOtpAttempt,
+  generateOtpCode,
+  generateSalt,
+  hashOtpCode,
+  isPlausibleEmail,
+  normalizeEmail,
+  OTP_MAX_ATTEMPTS,
+  type OtpChallenge,
+} from '../otpCore';
+
+function challenge(overrides: Partial<OtpChallenge> = {}): OtpChallenge {
+  const salt = 'saltsaltsaltsalt';
+  return {
+    salt,
+    codeHash: hashOtpCode('123456', salt),
+    expiresAt: new Date('2026-07-04T12:10:00Z'),
+    attempts: 0,
+    consumedAt: null,
+    ...overrides,
+  };
+}
+
+const NOW = new Date('2026-07-04T12:00:00Z');
+
+describe('code generation + hashing', () => {
+  it('generates a zero-padded 6-digit numeric code', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const code = generateOtpCode();
+      expect(code).toMatch(/^\d{6}$/);
+      expect(Number(code)).toBeGreaterThanOrEqual(0);
+      expect(Number(code)).toBeLessThanOrEqual(999999);
+    }
+  });
+
+  it('hashes deterministically, but differently per code and per salt', () => {
+    const salt = generateSalt();
+    expect(hashOtpCode('123456', salt)).toBe(hashOtpCode('123456', salt));
+    expect(hashOtpCode('123456', salt)).not.toBe(hashOtpCode('654321', salt));
+    expect(hashOtpCode('123456', salt)).not.toBe(hashOtpCode('123456', generateSalt()));
+    // The plaintext code must not be recoverable from the hash.
+    expect(hashOtpCode('123456', salt)).not.toContain('123456');
+  });
+});
+
+describe('evaluateOtpAttempt — outcomes', () => {
+  it('verifies the correct code and spends one attempt', () => {
+    const r = evaluateOtpAttempt({ challenge: challenge(), submittedCode: '123456', now: NOW });
+    expect(r.outcome).toBe('verified');
+    expect(r.attemptsAfter).toBe(1);
+  });
+
+  it('rejects a wrong code as code_mismatch and spends one attempt', () => {
+    const r = evaluateOtpAttempt({ challenge: challenge(), submittedCode: '000000', now: NOW });
+    expect(r.outcome).toBe('code_mismatch');
+    expect(r.attemptsAfter).toBe(1);
+  });
+
+  it('returns no_challenge for a null challenge (no attempt spent)', () => {
+    const r = evaluateOtpAttempt({ challenge: null, submittedCode: '123456', now: NOW });
+    expect(r.outcome).toBe('no_challenge');
+    expect(r.attemptsAfter).toBe(0);
+  });
+
+  it('rejects an already-consumed challenge before comparing', () => {
+    const r = evaluateOtpAttempt({
+      challenge: challenge({ consumedAt: new Date('2026-07-04T12:01:00Z') }),
+      submittedCode: '123456',
+      now: NOW,
+    });
+    expect(r.outcome).toBe('already_used');
+  });
+
+  it('rejects an expired challenge even with the right code', () => {
+    const r = evaluateOtpAttempt({
+      challenge: challenge({ expiresAt: new Date('2026-07-04T11:59:59Z') }),
+      submittedCode: '123456',
+      now: NOW,
+    });
+    expect(r.outcome).toBe('expired');
+  });
+
+  it('locks out once attempts reach the cap, without spending more', () => {
+    const r = evaluateOtpAttempt({
+      challenge: challenge({ attempts: OTP_MAX_ATTEMPTS }),
+      submittedCode: '123456',
+      now: NOW,
+    });
+    expect(r.outcome).toBe('locked_out');
+    expect(r.attemptsAfter).toBe(OTP_MAX_ATTEMPTS);
+  });
+
+  it('honors guard order: consumed beats expired', () => {
+    const r = evaluateOtpAttempt({
+      challenge: challenge({
+        consumedAt: new Date('2026-07-04T12:01:00Z'),
+        expiresAt: new Date('2026-07-04T11:00:00Z'),
+      }),
+      submittedCode: '123456',
+      now: NOW,
+    });
+    expect(r.outcome).toBe('already_used');
+  });
+
+  it('never crashes on a malformed stored hash — treats as mismatch', () => {
+    const r = evaluateOtpAttempt({
+      challenge: challenge({ codeHash: 'not-hex-zzzz' }),
+      submittedCode: '123456',
+      now: NOW,
+    });
+    expect(r.outcome).toBe('code_mismatch');
+  });
+});
+
+describe('email helpers', () => {
+  it('normalizes and validates plausible emails', () => {
+    expect(normalizeEmail('  Dr.Smith@Hospital.ORG ')).toBe('dr.smith@hospital.org');
+    expect(isPlausibleEmail('dr.smith@hospital.org')).toBe(true);
+    expect(isPlausibleEmail('not-an-email')).toBe(false);
+    expect(isPlausibleEmail('a@b')).toBe(false);
+    expect(emailDomain('Dr.Smith@Hospital.ORG')).toBe('hospital.org');
+  });
+});

--- a/apps/api/backend/src/services/identity/emailOtpService.ts
+++ b/apps/api/backend/src/services/identity/emailOtpService.ts
@@ -1,0 +1,144 @@
+/**
+ * emailOtpService — DB-backed email-OTP identity binding.
+ *
+ * A thin wrapper over the pure {@link otpCore}: it issues a challenge (rate
+ * limited, code hashed + never returned), verifies a submitted code, and on
+ * success records a POSSESSION SIGNAL (verified work email) on the
+ * PersonProfile plus a hashed audit row. This corroborates NPI->person binding;
+ * it is not a license or identity verification on its own.
+ */
+import prisma from '../../graphql/prisma_client';
+import { log } from '../../obs/logger';
+import { sha256ForPayload } from '../../utils/deterministic';
+import { getNotificationProvider } from '../providers/notificationProvider';
+import {
+  emailDomain,
+  evaluateOtpAttempt,
+  generateOtpCode,
+  generateSalt,
+  hashOtpCode,
+  isPlausibleEmail,
+  normalizeEmail,
+  OTP_ISSUE_WINDOW_MS,
+  OTP_MAX_ISSUES_PER_WINDOW,
+  OTP_TTL_MS,
+  type OtpOutcome,
+} from './otpCore';
+
+async function emitAudit(
+  type: string,
+  referenceId: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const hash = sha256ForPayload({ type, referenceId, metadata });
+  await prisma.auditEvent.create({
+    data: { type, hash, referenceId, metadata: JSON.parse(JSON.stringify(metadata)) },
+  });
+}
+
+export type IssueOutcome = 'sent' | 'invalid_email' | 'rate_limited';
+
+export async function issueEmailOtp(
+  userId: string,
+  rawEmail: string,
+): Promise<{ outcome: IssueOutcome; email: string }> {
+  const email = normalizeEmail(rawEmail);
+  if (!isPlausibleEmail(email)) {
+    return { outcome: 'invalid_email', email };
+  }
+
+  // Rate limit: cap challenges per (user, email) within the window.
+  const windowStart = new Date(Date.now() - OTP_ISSUE_WINDOW_MS);
+  const recentCount = await prisma.emailOtp.count({
+    where: { userId, email, createdAt: { gte: windowStart } },
+  });
+  if (recentCount >= OTP_MAX_ISSUES_PER_WINDOW) {
+    log('warn', 'email_otp_rate_limited', { userId, emailDomain: emailDomain(email) });
+    return { outcome: 'rate_limited', email };
+  }
+
+  const code = generateOtpCode();
+  const salt = generateSalt();
+  await prisma.emailOtp.create({
+    data: {
+      userId,
+      email,
+      codeHash: hashOtpCode(code, salt),
+      salt,
+      purpose: 'identity_email',
+      expiresAt: new Date(Date.now() + OTP_TTL_MS),
+    },
+  });
+
+  // Delivery is best-effort via the notification provider. A send failure does
+  // not roll back the challenge (dev stub logs; prod uses the wired provider).
+  try {
+    await getNotificationProvider().send(
+      email,
+      'Your VitalCV verification code',
+      `Your VitalCV identity verification code is ${code}. It expires in 10 minutes. `
+        + `If you did not request this, you can ignore this email.`,
+    );
+  } catch (err) {
+    log('error', 'email_otp_send_failed', {
+      userId,
+      emailDomain: emailDomain(email),
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Audit records only the domain — never the code or full address.
+  await emitAudit('identity_email_otp_issued', userId, { emailDomain: emailDomain(email) });
+
+  return { outcome: 'sent', email };
+}
+
+export async function verifyEmailOtp(
+  userId: string,
+  rawEmail: string,
+  submittedCode: string,
+): Promise<{ outcome: OtpOutcome }> {
+  const email = normalizeEmail(rawEmail);
+
+  const row = await prisma.emailOtp.findFirst({
+    where: { userId, email, consumedAt: null },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const now = new Date();
+  const result = evaluateOtpAttempt({
+    challenge: row
+      ? {
+          codeHash: row.codeHash,
+          salt: row.salt,
+          expiresAt: row.expiresAt,
+          attempts: row.attempts,
+          consumedAt: row.consumedAt,
+        }
+      : null,
+    submittedCode,
+    now,
+  });
+
+  if (row) {
+    // Persist the spent attempt; consume the challenge on success.
+    await prisma.emailOtp.update({
+      where: { id: row.id },
+      data: {
+        attempts: result.attemptsAfter,
+        consumedAt: result.outcome === 'verified' ? now : undefined,
+      },
+    });
+  }
+
+  if (result.outcome === 'verified') {
+    await prisma.personProfile.updateMany({
+      where: { userId },
+      data: { verifiedEmail: email, verifiedEmailAt: now, updatedAt: now },
+    });
+    await emitAudit('identity_email_verified', userId, { emailDomain: emailDomain(email) });
+    log('info', 'email_otp_verified', { userId, emailDomain: emailDomain(email) });
+  }
+
+  return { outcome: result.outcome };
+}

--- a/apps/api/backend/src/services/identity/otpCore.ts
+++ b/apps/api/backend/src/services/identity/otpCore.ts
@@ -1,0 +1,105 @@
+/**
+ * otpCore — the pure, I/O-free heart of email-OTP identity binding.
+ *
+ * Everything security-critical lives here so it can be unit-tested exhaustively:
+ * code generation (CSPRNG), salted hashing (the plaintext code is never stored
+ * or logged), and the attempt evaluator (expiry / single-use / attempt-cap /
+ * constant-time compare). The DB-backed service is a thin wrapper around this.
+ */
+import { randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
+
+import { sha256Hex } from '../../utils/deterministic';
+
+export const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+export const OTP_MAX_ATTEMPTS = 5; // per challenge, then locked out
+export const OTP_MAX_ISSUES_PER_WINDOW = 5; // per email, per window
+export const OTP_ISSUE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/** Cryptographically-random 6-digit code, zero-padded. Never logged. */
+export function generateOtpCode(): string {
+  return String(randomInt(0, 1_000_000)).padStart(6, '0');
+}
+
+/** Per-challenge random salt (hex). */
+export function generateSalt(): string {
+  return randomBytes(16).toString('hex');
+}
+
+/** Salted SHA-256 of a code. The plaintext code is never persisted. */
+export function hashOtpCode(code: string, salt: string): string {
+  return sha256Hex(`${salt}:${code}`);
+}
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isPlausibleEmail(email: string): boolean {
+  const e = normalizeEmail(email);
+  return e.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
+}
+
+export function emailDomain(email: string): string {
+  return normalizeEmail(email).split('@')[1] ?? '';
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  let ba: Buffer;
+  let bb: Buffer;
+  try {
+    ba = Buffer.from(a, 'hex');
+    bb = Buffer.from(b, 'hex');
+  } catch {
+    return false;
+  }
+  if (ba.length === 0 || ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+export interface OtpChallenge {
+  codeHash: string;
+  salt: string;
+  expiresAt: Date;
+  attempts: number;
+  consumedAt: Date | null;
+}
+
+export type OtpOutcome =
+  | 'verified'
+  | 'no_challenge'
+  | 'expired'
+  | 'already_used'
+  | 'locked_out'
+  | 'code_mismatch';
+
+/**
+ * Evaluate a submitted code against a stored challenge. Pure — no I/O.
+ *
+ * Guard order is deliberate: absent → already-used → expired → locked → compare.
+ * The final comparison is constant-time so a wrong code can't be distinguished
+ * from a right one by timing. `attemptsAfter` is what the caller must persist
+ * (an attempt is only "spent" once we reach the compare step).
+ */
+export function evaluateOtpAttempt(params: {
+  challenge: OtpChallenge | null;
+  submittedCode: string;
+  now: Date;
+  maxAttempts?: number;
+}): { outcome: OtpOutcome; attemptsAfter: number } {
+  const { challenge, submittedCode, now } = params;
+  const maxAttempts = params.maxAttempts ?? OTP_MAX_ATTEMPTS;
+
+  if (!challenge) return { outcome: 'no_challenge', attemptsAfter: 0 };
+  if (challenge.consumedAt) return { outcome: 'already_used', attemptsAfter: challenge.attempts };
+  if (challenge.expiresAt.getTime() <= now.getTime()) {
+    return { outcome: 'expired', attemptsAfter: challenge.attempts };
+  }
+  if (challenge.attempts >= maxAttempts) {
+    return { outcome: 'locked_out', attemptsAfter: challenge.attempts };
+  }
+
+  const submittedHash = hashOtpCode(submittedCode, challenge.salt);
+  const matches = timingSafeEqualHex(submittedHash, challenge.codeHash);
+  const attemptsAfter = challenge.attempts + 1;
+  return { outcome: matches ? 'verified' : 'code_mismatch', attemptsAfter };
+}

--- a/apps/web/app/api/profile/identity/email-otp/issue/route.ts
+++ b/apps/web/app/api/profile/identity/email-otp/issue/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/profile/identity/email-otp/issue  { email }
+ * Proxy to backend — issues an email-OTP identity-binding challenge.
+ * Auth-scoped: forwards the verified Clerk user id (never a caller-supplied one).
+ */
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Sign in required.' }, { status: 401 });
+  }
+
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  headers.set('x-clerk-user-id', session.userId);
+
+  const body = await req.text();
+  const res = await fetch(`${BACKEND}/api/profile/identity/email-otp/issue`, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/app/api/profile/identity/email-otp/verify/route.ts
+++ b/apps/web/app/api/profile/identity/email-otp/verify/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/profile/identity/email-otp/verify  { email, code }
+ * Proxy to backend — verifies an email-OTP identity-binding challenge.
+ * Auth-scoped: forwards the verified Clerk user id (never a caller-supplied one).
+ */
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Sign in required.' }, { status: 401 });
+  }
+
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  headers.set('x-clerk-user-id', session.userId);
+
+  const body = await req.text();
+  const res = await fetch(`${BACKEND}/api/profile/identity/email-otp/verify`, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/app/get-ready/GetReadySurface.tsx
+++ b/apps/web/app/get-ready/GetReadySurface.tsx
@@ -27,6 +27,7 @@ import {
   validateNpi,
   type BoundIdentitySummary,
 } from '@/lib/get-ready/npi-binding';
+import EmailVerification from '@/components/get-ready/EmailVerification';
 
 type Phase =
   | 'checking'
@@ -262,6 +263,11 @@ export default function GetReadySurface() {
             <SummaryRow label="Specialty" value={summary.specialty ?? 'Not listed in NPPES'} />
             <SummaryRow label="State" value={summary.stateOfPractice ?? 'Not listed in NPPES'} />
           </dl>
+        )}
+        {!summary.isOrganizationNpi && (
+          <div className="mt-6">
+            <EmailVerification />
+          </div>
         )}
         <div className="mt-6 space-y-3">
           <Link

--- a/apps/web/components/get-ready/EmailVerification.tsx
+++ b/apps/web/components/get-ready/EmailVerification.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+/**
+ * EmailVerification — the identity-binding possession factor on the NPI gate.
+ *
+ * The clinician proves possession of a work/institutional email via a one-time
+ * code. It is honestly framed as a CORROBORATION signal that strengthens the
+ * NPI->person binding — never a license or identity verification. Talks to the
+ * auth-scoped /api/profile/identity/email-otp/{issue,verify} proxies.
+ */
+
+import { useState } from 'react';
+import { CheckCircle2, Loader2, Mail, ShieldPlus } from 'lucide-react';
+
+type Step = 'email' | 'sending' | 'code' | 'verifying' | 'verified';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function EmailVerification() {
+  const [step, setStep] = useState<Step>('email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  async function issue(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const value = email.trim();
+    if (!EMAIL_RE.test(value)) {
+      setError('Enter a valid email address.');
+      return;
+    }
+    setError(null);
+    setStep('sending');
+    try {
+      const res = await fetch('/api/profile/identity/email-otp/issue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: value }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? 'Could not send a code. Try again shortly.');
+        setStep('email');
+        return;
+      }
+      setStep('code');
+    } catch {
+      setError('Could not send a code. Try again shortly.');
+      setStep('email');
+    }
+  }
+
+  async function verify(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const value = code.trim();
+    if (!/^\d{6}$/.test(value)) {
+      setError('Enter the 6-digit code from your email.');
+      return;
+    }
+    setError(null);
+    setStep('verifying');
+    try {
+      const res = await fetch('/api/profile/identity/email-otp/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), code: value }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || !body.verified) {
+        setError(body.reason ?? 'Verification failed. Try again.');
+        setStep('code');
+        return;
+      }
+      setStep('verified');
+    } catch {
+      setError('Verification failed. Try again.');
+      setStep('code');
+    }
+  }
+
+  if (step === 'verified') {
+    return (
+      <div className="rounded-xl border border-emerald-900 bg-emerald-950/30 p-4 text-left">
+        <p className="flex items-center gap-2 text-sm font-semibold text-emerald-300">
+          <CheckCircle2 className="h-4 w-4" aria-hidden /> Work email verified
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-zinc-400">
+          Recorded as a possession signal that strengthens your identity binding. It
+          corroborates your NPI match — it is not a license check.
+        </p>
+      </div>
+    );
+  }
+
+  const busy = step === 'sending' || step === 'verifying';
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 text-left">
+      <p className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+        <ShieldPlus className="h-4 w-4 text-emerald-400" aria-hidden /> Strengthen your identity
+        <span className="ml-auto rounded-full border border-zinc-700 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+          Optional
+        </span>
+      </p>
+      <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+        Verify a work email to corroborate your NPI match. A possession signal — not a
+        license or identity check.
+      </p>
+
+      {step === 'code' || step === 'verifying' ? (
+        <form onSubmit={verify} className="mt-3 space-y-2" noValidate>
+          <p className="text-xs text-zinc-500">
+            We sent a 6-digit code to <span className="text-zinc-300">{email.trim()}</span>.
+          </p>
+          <input
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="6-digit code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            disabled={busy}
+            aria-label="6-digit verification code"
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-foreground placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none focus:ring-1 focus:ring-emerald-900"
+          />
+          {error ? <p role="alert" className="text-xs text-red-400">{error}</p> : null}
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-xs font-semibold text-black transition hover:bg-emerald-400 disabled:opacity-60"
+            >
+              {step === 'verifying' ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : null}
+              Verify
+            </button>
+            <button
+              type="button"
+              onClick={() => { setStep('email'); setCode(''); setError(null); }}
+              disabled={busy}
+              className="text-xs text-zinc-500 underline underline-offset-2 hover:text-zinc-300"
+            >
+              Use a different email
+            </button>
+          </div>
+        </form>
+      ) : (
+        <form onSubmit={issue} className="mt-3 space-y-2" noValidate>
+          <div className="flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 focus-within:border-emerald-600">
+            <Mail className="h-4 w-4 text-zinc-600" aria-hidden />
+            <input
+              type="email"
+              autoComplete="email"
+              placeholder="you@hospital.org"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={busy}
+              aria-label="Work email"
+              className="w-full bg-transparent py-2 text-sm text-foreground placeholder:text-zinc-600 focus:outline-none"
+            />
+          </div>
+          {error ? <p role="alert" className="text-xs text-red-400">{error}</p> : null}
+          <button
+            type="submit"
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-4 py-2 text-xs font-semibold text-zinc-200 transition hover:border-emerald-800 hover:text-emerald-300 disabled:opacity-60"
+          >
+            {step === 'sending' ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : null}
+            Send me a code
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Gate PR 3 of 4 — self-serve verified-clinician signup

Implements **Task 2** (identity-binding factor) — the **NPI→person trust anchor** the brief flags as a first-class decision. **Stacked on #539** (base is the attestation branch); retarget to `main` once #539 merges.

> An NPI is a *public* identifier — NPPES match proves "this NPI is real," not "**you** are that person." This adds a possession factor to corroborate the binding.

### Security core — `otpCore.ts` (pure, **11/11 unit tests**)
- 6-digit code via **CSPRNG** (`crypto.randomInt`); **salted SHA-256** — the plaintext code is **never stored or logged**.
- Attempt evaluator with deliberate guard order (**absent → already-used → expired → locked-out → constant-time compare**); an attempt is spent only at the compare step; malformed stored hash can't crash it.
- 10-minute TTL, 5-attempt cap.

### Service / routes
- `emailOtpService`: **issue** (per-email rate limit 5/hr, delivery via the existing `notificationProvider`) + **verify** (single-use, records the possession signal + `identity_email_verified` audit). Audit metadata logs the email **domain only** — never the code or full address.
- `routes/identity.ts` (issue/verify) wired into `app.ts`; **web proxies forward the verified Clerk user id** (no header trust).

### Frontend
- The `/get-ready` success screen offers **"Strengthen your identity"** (clearly **Optional**): enter work email → 6-digit code → verified. Copy: *"A possession signal — not a license or identity check."*

### Doctrine
- **Corroboration, not verification.** Recorded as `verified_email` on the profile + audit; never promoted to a source-`checked` fact, never the bare word "Verified".

### Validation
- Security-core unit tests **11/11**; backend `tsc` clean for touched files; web build **14/14** (both proxies registered); route-contract **150/150**.
- Requires `prisma migrate deploy` (email_otps table + verified_email columns); degrades safely until then.

### Deferred (noted, not in scope here)
- Deeper **Trust Gradient** scoring integration of the possession signal, and the **flag-gated third-party ID/license vendor stub** (`gated` source) — incremental follow-ups.

### Tier & review
**Tier 2**, security-sensitive. **Codex is in a usage-limit blackout** — self-reviewed + fully tested, **held for your review**. This is the one I'd most want your eyes on.

### Design Handoff References
No Claude Design handoff file used; reuses the `/get-ready` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)