### PR TITLE
chore(wave0): re-baseline blockers + NPPES v2.1 boot assertion + repo hygiene

### DIFF
--- a/apps/api/backend/adapters/NppesAdapter.ts
+++ b/apps/api/backend/adapters/NppesAdapter.ts
@@ -5,7 +5,7 @@
 import type { ProviderType } from "../types/psv";
 import type { PsvAdapter, NormalizedCredentialPayload } from "./types";
 
-const NPPES_ENDPOINT =
+export const NPPES_ENDPOINT =
   "https://npiregistry.cms.hhs.gov/api/?version=2.1&number=";
 
 // ── Taxonomy → ProviderType mapping ─────────────────────────

--- a/apps/api/backend/src/engine/adapters/nppesAdapter.ts
+++ b/apps/api/backend/src/engine/adapters/nppesAdapter.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types/psv';
 import type { PsvAdapter } from './types';
 
-const NPPES_API_URL = 'https://npiregistry.cms.hhs.gov/api/?version=2.1';
+export const NPPES_API_URL = 'https://npiregistry.cms.hhs.gov/api/?version=2.1';
 const AGENT_VERSION = '1.0.0';
 
 // ── NPPES API response shapes (minimal, only what we use) ────

--- a/apps/api/backend/src/index.ts
+++ b/apps/api/backend/src/index.ts
@@ -2,10 +2,18 @@ import app from './app';
 import { log } from './obs/logger';
 import { seedIssuerEntities } from './services/entity/seedIssuers';
 import { prewarmLeieCache } from './services/identity/leieCache';
+import { assertNppesApiVersion } from './services/identity/nppesApiVersion';
 
 export default app;
 
 export async function startServer() {
+  // NPPES V1 sunset 2026-03-03 — refuse to boot on a non-v2.1 endpoint constant.
+  const nppes = assertNppesApiVersion();
+  log('info', 'NPPES API version pinned', {
+    event: 'nppes_api_version',
+    version: nppes.version,
+    endpoints: nppes.endpoints,
+  });
   const port = process.env.PORT || 4000;
   app.listen(port, () => {
     log('info', 'Server ready', {

--- a/apps/api/backend/src/modules/identity/nppes.service.ts
+++ b/apps/api/backend/src/modules/identity/nppes.service.ts
@@ -4,7 +4,7 @@ import { sha256ForPayload } from '../../utils/deterministic';
 import { fetchWithRetry } from '../../utils/fetchWithRetry';
 import type { RawNppesResponse, NppesFetchResult } from './types';
 
-const CMS_NPPES_ENDPOINT =
+export const CMS_NPPES_ENDPOINT =
   'https://npiregistry.cms.hhs.gov/api/?version=2.1';
 
 /** In-memory NPPES response cache with TTL */

--- a/apps/api/backend/src/services/identity/nppesApiVersion.ts
+++ b/apps/api/backend/src/services/identity/nppesApiVersion.ts
@@ -1,0 +1,47 @@
+/**
+ * NPPES API version guard — Wave 0 (god-mode re-baseline, 2026-07-04).
+ *
+ * CMS sunset the NPPES V1 dissemination files and v1 API on 2026-03-03;
+ * the supported surface is API v2.1 + V2 bulk files. Every NPPES endpoint
+ * constant this backend fetches from must pin `version=2.1` explicitly.
+ * This module asserts that at startup so a drifted constant fails the boot
+ * loudly instead of silently degrading NPI enrichment.
+ *
+ * The check runs against the real constants imported from the adapter
+ * modules (not copies), so it cannot drift from what the fetchers use.
+ */
+import { CMS_NPPES_ENDPOINT } from '../../modules/identity/nppes.service';
+import { NPPES_API_URL } from '../../engine/adapters/nppesAdapter';
+import { NPPES_ENDPOINT } from '../../../adapters/NppesAdapter';
+
+export const REQUIRED_NPPES_API_VERSION = '2.1';
+
+const VERSION_PARAM = /[?&]version=2\.1(?:&|$)/;
+
+/** Every NPPES endpoint constant the backend fetches from, by owning module. */
+export const NPPES_ENDPOINTS: ReadonlyArray<{ owner: string; url: string }> = [
+  { owner: 'modules/identity/nppes.service', url: CMS_NPPES_ENDPOINT },
+  { owner: 'engine/adapters/nppesAdapter', url: NPPES_API_URL },
+  { owner: 'adapters/NppesAdapter', url: NPPES_ENDPOINT },
+];
+
+/**
+ * Throws when any NPPES endpoint constant is not pinned to API v2.1.
+ * Returns the endpoint report for the startup log line.
+ */
+export function assertNppesApiVersion(): {
+  version: string;
+  endpoints: string[];
+} {
+  const offenders = NPPES_ENDPOINTS.filter((e) => !VERSION_PARAM.test(e.url));
+  if (offenders.length > 0) {
+    throw new Error(
+      `NPPES API version assertion failed — endpoint(s) not pinned to v${REQUIRED_NPPES_API_VERSION} ` +
+        `(V1 sunset 2026-03-03): ${offenders.map((o) => `${o.owner} -> ${o.url}`).join('; ')}`,
+    );
+  }
+  return {
+    version: REQUIRED_NPPES_API_VERSION,
+    endpoints: NPPES_ENDPOINTS.map((e) => e.owner),
+  };
+}

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,7 @@
+# apps/docs — reserved, not built
+
+**Status (2026-07-04, Wave 0 re-baseline):** not a buildable app. No `package.json`, not a pnpm workspace member, nothing deploys from here.
+
+Contents: a single API note, `api-security-profiles.md` (DPoP + mTLS + EUDI flows, B119C-DOCS-028).
+
+Reserved for a future rendered docs app. Do not add build tooling or workspace registration without a wave brief; product/architecture documentation belongs in the repo-root `docs/` tree.

--- a/apps/lib/README.md
+++ b/apps/lib/README.md
@@ -1,0 +1,9 @@
+# apps/lib — load-bearing single module, do not delete
+
+**Status (2026-07-04, Wave 0 re-baseline):** not a workspace package (no `package.json`), but **not dead**.
+
+`credentials/blePresentation.ts` is imported cross-app by
+`apps/web/components/clinician/OfflineRadar.tsx` via the relative path
+`../../../lib/credentials/blePresentation` (which resolves here, outside the web app root). `OfflineRadar` is currently unmounted, but the import is part of the web compile graph.
+
+Deleting this directory without first removing that import breaks the web build. The right future disposition is relocating the module into `packages/` (or into `apps/web/lib/`) in a hygiene wave that also updates the importer.

--- a/apps/sample-api/README.md
+++ b/apps/sample-api/README.md
@@ -1,5 +1,7 @@
 # Sample API Applications
 
+> **Status (2026-07-04, Wave 0 re-baseline): reserved, not built.** This directory holds README placeholders only — no runnable code, no `package.json`, not a workspace member, nothing deploys. The apps described below (including `marketplace-integration/`) do not exist yet, and "Chai VC Platform" is legacy imported branding, not a VitalCV name. Treat everything below as an aspirational spec retained for reference.
+
 B235C-API-026: Sample Applications demonstrating how to use the public API
 
 This directory contains example applications demonstrating how to use the Chai VC Platform public API.

--- a/apps/status-api/README.md
+++ b/apps/status-api/README.md
@@ -1,0 +1,9 @@
+# apps/status-api — VC revocation status service (StatusList2021)
+
+**Status (2026-07-04, Wave 0 re-baseline):** real, minimal, **not deployed**. Workspace member `@vitalcv/status-api` (Express + `src/routes/statusList.ts`). The earlier "empty app" classification was wrong.
+
+Purpose: serves revocation status lists for verifiable credentials using the StatusList2021 mechanism.
+
+Forward path: **Wave E** of the god-mode plan (`docs/research/god-mode-research-report.md`) moves the revocation registry to the W3C VC 2.0 **Bitstring Status List** with revocation-first, fail-closed verifier checks. This service is the predecessor and reference implementation — keep it until Wave E lands, then fold or retire it inside that wave.
+
+Run locally: `pnpm --filter @vitalcv/status-api dev`

--- a/docs/LAUNCH_GATE.md
+++ b/docs/LAUNCH_GATE.md
@@ -2,6 +2,8 @@
 **Generated:** 2026-03-28
 **Purpose:** Defines exactly what "pilot-ready" means. Each item must be GREEN before silent pilot begins.
 
+> **⚠️ Historical snapshot (superseded 2026-07-04).** This gate reflects the 2026-03-28 tree (PR #87/#88 era). The canonical open-blocker list is now `docs/ops/launch-blockers.md`; the on-disk verification that retired most rows below is `docs/ops/REBASELINE-2026-07-04.md`. Kept unedited for audit lineage.
+
 ---
 
 ## WEDGE TRUTH

--- a/docs/architecture/package-status.md
+++ b/docs/architecture/package-status.md
@@ -1,0 +1,46 @@
+# Package status — verified inventory
+
+**Verified:** 2026-07-04 against `f7bdbe158` (Wave 0 re-baseline). Counts are TypeScript source files (`*.ts`/`*.tsx`, excluding `dist/`, `node_modules/`, `*.d.ts`).
+
+## Phantom packages — do not depend on these
+
+The god-mode research report flagged seven packages as "dist-only, verify before depending." Verification result: **they do not exist on `origin/main` at all** (likely observed in a stale worktree with build artifacts). No wave may list them as dependencies or build targets:
+
+`audit-receipts` · `claims` · `vitalindex` · `rate-limiter` · `runtime-mode` · `idempotency` · `conflict-resolution`
+
+If a future wave needs one of these capabilities, it is a **new package proposal**, not a revival.
+
+## Real packages (28)
+
+| Package | Source files | Notes |
+|---|---|---|
+| `domain-common` | 28 | Barrel for domain types; re-export with `type` keyword (`isolatedModules`) |
+| `source-adapters` | 23 | |
+| `domain-evidence` | 22 | |
+| `trust-contract` | 20 | |
+| `psv-adapters` | 16 | |
+| `shared` | 11 | |
+| `domain` | 10 | |
+| `trust-state` | 10 | Ships from `dist/`; must be turbo-prebuilt before `apps/web` builds |
+| `audit` | 8 | |
+| `ingest` | 7 | |
+| `psv` | 7 | |
+| `truth-enforcement` | 7 | |
+| `verifier-sdk` | 7 | |
+| `domain-core` | 6 | |
+| `poe-engine` | 6 | |
+| `sdk` | 6 | |
+| `domain-events` | 5 | |
+| `haip-config` | 5 | HAIP posture config — keep intact per doctrine |
+| `domain-provider` | 4 | |
+| `crs` | 3 | Composite readiness score — Wave G surfaces this |
+| `domain-authority` | 3 | |
+| `embed-sdk` | 3 | |
+| `issuer-sdk` | 3 | |
+| `wallet-sdk` | 3 | |
+| `domain-identity` | 2 | |
+| `graph-core` | 2 | |
+| `vc-formats-csdjwt` | 2 | SD-JWT formats — Wave E touches this |
+| `command-registry` | 1 | |
+
+Every package listed has real sources; none is a dist-only shell. Thin packages (1–3 files) are genuinely thin, not stubs pretending otherwise.

--- a/docs/ops/REBASELINE-2026-07-04.md
+++ b/docs/ops/REBASELINE-2026-07-04.md
@@ -1,0 +1,39 @@
+# Re-baseline — 2026-07-04 (Wave 0, god-mode plan)
+
+**Baseline commit:** `f7bdbe158` (origin/main tip at verification time)
+**Method:** every blocker claim in `docs/research/god-mode-research-report.md` §1 and the Wave 0 brief was verified against the tree on disk — not against older docs. Evidence paths below are the proof, not assertions.
+**Canonical open list:** `docs/ops/launch-blockers.md` (created by this wave). `docs/LAUNCH_GATE.md` (2026-03-28) is now a historical snapshot.
+
+## Confirmed resolved (do NOT re-work these)
+
+| Old blocker | Evidence on `f7bdbe158` |
+|---|---|
+| Marketing→web seam broken | `apps/marketing/app/clinician/page.tsx` redirects to the live `/passport` flow (NPI passthrough included) |
+| Hero/HomeSections banned-string copy | 0 live-copy hits for `hire instantly` / `zero-trust ledger` / `blockchain-anchored` / `HIPAA compliant` / `SOC 2 certified`; only ban-list definitions match (`apps/web/lib/source-health/unavailableLane.ts`, `apps/web/lib/trust/trust-container-view.ts`) |
+| `apps/mobile` empty | Built: `src/services/{LocalCredentialStore,OfflinePresentationEngine,OID4VPHandler,NotificationService,WalletSyncService,ReadinessService,HandoffService}.ts` + `__tests__` |
+| Passport fixture-backed | Backend-proxied: `apps/web/app/api/passport/[npi]/route.ts` → `resolvePassportRuntimePassport` |
+| Employer accept not audit-first | `apps/api/backend/src/routes/employerActions.ts` writes `AuditEvent` in-transaction before 2xx; duplicate-guarded; BLOCKED fails closed |
+| No CSP / security headers | `apps/web/security-headers.mjs` ships HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, Content-Security-Policy (+ `__tests__/security-headers.test.ts`); Clerk custom-domain CSP fixed in PR #536 |
+| No env validation | Web: `apps/web/lib/env.ts` (SEC-ENV-1 typed contract). Backend: `apps/api/backend/src/config/env.ts` + `envValidation.ts` (Zod) |
+| Nursys throws when flagged on | `apps/api/backend/src/services/nursysAdapter.ts` is an honest gated stub: returns NOT_AVAILABLE, never fabricates, no throw path in the default flow |
+| No ASVS scorecard | `docs/security/asvs-scorecard.md` exists (L1, evidence-cited). L2 mapping remains open |
+
+## Corrected premises (the plan docs were stale here)
+
+1. **The 7 "dist-only" packages do not exist.** `packages/{audit-receipts,claims,vitalindex,rate-limiter,runtime-mode,idempotency,conflict-resolution}` are absent from `origin/main`. All 28 real packages have sources. See `docs/architecture/package-status.md`. Nothing may depend on the phantom seven.
+2. **`apps/router` does not exist** on `origin/main` (git tracks no files there). No disposition needed.
+3. **`apps/status-api` is not empty.** It is a real minimal Express service for VC revocation status (StatusList2021), a workspace member (`@vitalcv/status-api`). It is the predecessor of Wave E (Bitstring Status List). See its README.
+4. **`apps/lib` is load-bearing.** `apps/web/components/clinician/OfflineRadar.tsx` imports `apps/lib/credentials/blePresentation.ts` via a cross-app relative path. Do not delete without removing that import. See its README.
+5. **Verifier RBAC flag lives in the web app**, not `apps/verifier-api`: `apps/web/lib/verifier/orgRolesFoundation.ts` pins `rbacEnforced: false` (literal, honest foundation — same pattern as the signup foundation).
+6. **Wave A is already in flight** on a parallel lane: gate PR 1/4 merged (#538, profession selector), 2/4 open (#539, attestation + audit + persistence). Wave 0 deliberately touched no signup surface.
+
+## NPPES V1→V2 cutover verdict (urgent check — PASSED)
+
+- Every runtime NPPES endpoint constant targets **API v2.1**: `apps/api/backend/src/modules/identity/nppes.service.ts`, `apps/api/backend/src/engine/adapters/nppesAdapter.ts`, `apps/api/backend/adapters/NppesAdapter.ts` (legacy path, still live — imported by `psvOrchestrator`, `PsvOrchestrator`, `verifyRoute`). Web-side probes/diagnostics also pin v2.1.
+- **Zero V1 references** anywhere in `apps/`, `packages/`, `scripts/` (negative scan for `version=1` / V1 dissemination names).
+- Bulk files: `sourceCatalog.ts` `NPPES_BULK` entry already points at the V2 file surface (`download.cms.gov/nppes/NPI_Files.html`). Note: there is **no bulk-file downloader implementation** — runtime NPI enrichment is API-only today. Bulk ingestion remains a phase-1 open item, not a pilot blocker.
+- **Runtime assertion added** (this wave): `apps/api/backend/src/services/identity/nppesApiVersion.ts` imports the three real endpoint constants and refuses boot if any is not pinned to v2.1; `startServer()` logs `nppes_api_version` on success.
+
+## Local-only artifacts noted
+
+`docs/research/vitalcv-research-pdf-index.md` (a Dropbox PDF catalog) remains deliberately uncommitted — it indexes personal filesystem paths. The god-mode report and the clinician signup brief are committed alongside this re-baseline for provenance.

--- a/docs/ops/launch-blockers.md
+++ b/docs/ops/launch-blockers.md
@@ -1,0 +1,28 @@
+# Launch blockers — canonical open list
+
+**Status date:** 2026-07-04 · **Baseline:** `f7bdbe158` (origin/main)
+**Provenance:** re-baselined on-disk by Wave 0; see `docs/ops/REBASELINE-2026-07-04.md` for what was verified-resolved and which older premises were corrected. `docs/LAUNCH_GATE.md` (2026-03-28) is historical.
+
+This file lists **only genuinely-open items**, each with its owning wave from the god-mode plan (`docs/research/god-mode-research-report.md`). When an item closes, move it to the resolved table in the re-baseline doc of the closing wave — do not leave ghosts here.
+
+## Open blockers
+
+| # | Item | Evidence it is open | Owning wave |
+|---|---|---|---|
+| 1 | Self-serve clinician signup gate completion — NPI confirm screen, identity-binding factor (work-email OTP), attestation flow, wallet provisioning | `apps/web/lib/commercial/selfServeSignupFoundation.ts` pins `accountCreationProductionReady: false`, `identityProofingComplete: false`; gate PRs 1/4 merged (#538), 2/4 open (#539), 3/4–4/4 unstarted | A (in flight) |
+| 2 | Verifier org-role RBAC enforcement | `apps/web/lib/verifier/orgRolesFoundation.ts` pins `rbacEnforced: false` (literal); no role checks on mutating verifier routes | B |
+| 3 | Prod auth / Google OAuth verification on Clerk | Unverified in Clerk prod config; sign-in CSP fixed (#536) but OAuth provider state unconfirmed; needs `.env.example` documentation | B |
+| 4 | E2E signup happy-path + fail-closed test | No e2e covering role→NPI→confirm→attest→wallet, nor a BLOCKED-passport-cannot-be-accepted case | B (gates A's acceptance) |
+| 5 | OWASP ASVS **L2** mapping | `docs/security/asvs-scorecard.md` covers L1 only | B |
+| 6 | STATE_BOARD / FSMB physician-licensure lane | Gated, no live adapter behind `STATE_BOARD_ENABLED`; license claims must stay `gated`, never `checked` | C |
+| 7 | SAM.gov exclusions adapter | Absent; OIG/LEIE is the only live exclusion source | C |
+| 8 | Nursys institutional access | Adapter is an honest gated stub (`nursysAdapter.ts`) — real E-Notify agreement + fetcher wiring outstanding; must stay `gated`/`accessRequired` | C |
+| 9 | Continuous monitoring not enabled | Wave 245 scheduler exists (`services/async/monitoringScheduler.ts`, `MONITORING_ENABLED` default false); NCQA-cadence re-checks not running | D |
+| 10 | NPPES bulk-file ingestion | Catalog declares V2 bulk surface; no downloader implementation — runtime enrichment is API-v2.1-only (asserted at boot) | C/D (phase 1, not a pilot blocker) |
+| 11 | Revocation registry on Bitstring Status List + VC 2.0 pinning | `apps/status-api` implements StatusList2021 (predecessor); VC 2.0 Bitstring alignment + verifier fail-closed tests outstanding | E |
+| 12 | Compliance proof-pack surfaces | JC survey-ready export, NIST 800-63-4 IAL mapping doc, passkey/DPoP AAL2 path — none present | F |
+| 13 | Certifications (SOC 2 Type II / HITRUST / NCQA accreditation) | Business-level procurement blocker; copy stays "aligned", never "certified" | GTM (not a code wave) |
+
+## Standing guardrails (apply to every closing PR)
+
+Audit-first mutations · Recognition→Acceptance→Start preserved · revoked/expired/missing fails closed · zero PHI on-chain · no `prisma migrate` without founder approval · banned-string discipline per `CLAUDE.md` (no bare `Verified` label; attested ≠ source-checked; never claim NPDB/DEA/ABMS/SAM until live).

--- a/docs/research/clinician-signup-verification-brief.md
+++ b/docs/research/clinician-signup-verification-brief.md
@@ -1,0 +1,140 @@
+# Clinician Self-Serve Signup & Verification — Competitive Research Brief
+
+> Purpose: Give Claude Code an implementation-ready reference for building a VitalCV
+> clinician signup/verification gate modeled on the two flows the founder captured —
+> **ChatGPT for Clinicians** (OpenAI) and **OpenEvidence** — adapted to VitalCV doctrine
+> (NPI-first, source-backed, checked/gated/pending honesty, audit-first).
+> Researched 2026-07-04. Verification-vendor names are **not** publicly confirmed; treat as `unknown`.
+
+---
+
+## 0. Why this matters for VitalCV
+
+Both products gate their entire product behind a **fast, self-serve "verified clinician" signup keyed on NPI**. That gate is the front door that produces their user base (OpenEvidence: ~757k verified clinicians, ~15M consultations/month).
+
+VitalCV already owns the harder half of this pipeline — `POST /api/ingest/npi/:npi → NPPES → OIG/LEIE → trustState → readinessEngine → passport`. What we are copying is the **thin, self-serve onboarding UX** that turns "enter your NPI" into "you're in, and here's your wallet."
+
+**The differentiation to preserve:** their signup outputs a *boolean* ("you are a clinician, here's the app"). VitalCV's signup should output *source-backed career evidence* (a readiness snapshot + wallet). Same front door, strictly more valuable artifact behind it.
+
+---
+
+## 1. ChatGPT for Clinicians (OpenAI) — launched 22 Apr 2026
+
+**Eligibility**
+- US-licensed **physicians (MD/DO), nurse practitioners, physician assistants, pharmacists**.
+- US-only at launch; more countries "over time."
+
+**Requirements to sign up**
+- A ChatGPT account.
+- A valid **NPI**.
+- A license that can be verified through a **third-party verification provider** (vendor not publicly named).
+
+**Flow (self-serve, minutes)**
+1. Go to `chatgpt.com/plans/clinicians`.
+2. Sign in with existing ChatGPT account, or create one.
+3. Complete **clinician verification via a third-party provider using your NPI**.
+4. **Attest** you are a licensed clinician + agree to the services agreement.
+5. "Get started with ChatGPT" → provisions a **ChatGPT for Clinicians workspace**.
+
+**Trust / compliance posture**
+- Free for verified US clinicians (individual tier).
+- HIPAA support, BAA, no-training-on-data, audit logs, RBAC, SAML/SCIM live at the **enterprise "ChatGPT for Healthcare"** tier — the individual free tier is the top of that funnel.
+- CME credit offered on eligible clinical questions.
+
+**Strategic read:** consumer → **free individual clinician (this gate)** → enterprise hospital contract. The free clinician signup exists to build familiarity and seed enterprise sales.
+
+---
+
+## 2. OpenEvidence
+
+**Eligibility**
+- Verified US HCPs: **MD, DO, NP, PA, pharmacist, dentist, RN with an NPI**; **medical students** via proof of student status.
+
+**Flow (self-serve, seconds)**
+1. Go to `openevidence.com` → **Sign Up**.
+2. **Select profession** (e.g., RN).
+3. **Enter NPI** — with an inline "look yours up at npiregistry.cms.hhs.gov" helper.
+4. System **verifies the NPI against the national NPI registry (NPPES)**.
+5. **Attest** professional credentials.
+6. On success → immediate access.
+
+**Fallback / corroboration**
+- **Hospital / institutional email confirmation** is used as an alternate or corroborating verification path alongside NPI.
+
+**Trust / compliance posture**
+- Free, **ad-funded** (pharma pays for loading-screen placement; very high CPMs).
+- **SOC 2 Type II**, HIPAA-compliant, **embedded in Epic** (Mount Sinai, Sutter).
+- NPI users identified as HIPAA-covered providers can earn **AMA PRA Category 1 CME**.
+
+---
+
+## 3. The common pattern (extract this and build it)
+
+Both flows reduce to the same 6 primitives:
+
+1. **Low-friction account creation** (OAuth / existing account / email).
+2. **Profession selection** (drives which license class + downstream rules apply).
+3. **NPI as the identity key** — single field, with an NPPES-lookup helper link.
+4. **Automated check against the public NPPES registry** (name/taxonomy/type match).
+5. **Attestation + services agreement** click-through (covers everything not source-verified).
+6. **Instant grant on success**, with a **fallback lane** (institutional email; third-party license/ID verification) for edge cases.
+
+Access is gated on "verified clinician" status; **monetization happens downstream** (ads, or enterprise funnel), never at the signup gate.
+
+### The gap both leave open (VitalCV's opening)
+An NPI is a **public identifier** — anyone can type another clinician's NPI. NPPES match alone proves "this NPI is real," not "**you** are that person." Competitors patch this with attestation + a third-party license/ID vendor (ChatGPT) or institutional-email possession (OpenEvidence). For VitalCV this is not a footnote — **binding NPI → person is the trust anchor of the wallet (NPI→DID)**, so the possession/knowledge factor must be a first-class design decision, not an afterthought.
+
+---
+
+## 4. Mapping to VitalCV (implementation-ready)
+
+### Reuse (already built)
+- `POST /api/ingest/npi/:npi` → `sourceVerifier (NPPES)` → `oigLeieChecker` → `trustStateEngine` → `readinessEngine` → `passportService.buildPassport`.
+- `packages/trust-state/sourceCoverage.ts` states: `checked | stale | pending | gated | unavailable | accessRequired | reviewRequired | notDecisionGrade | previewOnly`.
+- Wave 180 `PersonProfile` (dual-entity identity) as the account record the wallet hangs off.
+
+### Proposed signup gate (maps 1:1 to the common pattern)
+1. **Account** — Clerk (already the auth layer). OAuth or email.
+2. **Profession selector** — MD/DO, NP, PA, PharmD, RN, dentist, **student (no-NPI path)**. Drives license-class rules and which source lanes are relevant.
+3. **NPI entry** — single field + inline NPPES-lookup helper link (copy the OpenEvidence UX detail; it measurably lowers drop-off).
+4. **NPPES resolution** — call existing ingest pipeline; present the resolved **name + taxonomy + NPI type** back to the user to **confirm "this is me"** (Type 1 individual expected).
+5. **Identity-binding factor** (the gap above) — minimum: **institutional/work email OTP** as a possession signal → recorded as a **corroboration input to the Trust Gradient**. Upgrade path: third-party ID/license verification vendor, surfaced as a `gated`/`accessRequired` source until an agreement exists. Do **not** mark the clinician "source-checked on license" unless the `STATE_BOARD` lane is actually configured for their state.
+6. **OIG/LEIE** — run the exclusion check (already always-on); `CLEAR` required to issue a clean readiness snapshot.
+7. **Attestation + services agreement** — click-through covering every claim not yet source-backed. **Write an `AuditEvent` before returning success** (audit-first rule).
+8. **Grant + artifact** — provision the **Career Wallet** and render the **readiness snapshot / passport**, not a boolean. This is where VitalCV beats the boolean gate.
+
+### Student / no-NPI path
+Mirror OpenEvidence's student lane: proof-of-student-status instead of NPI → wallet created in **`previewOnly` / `pending`** state, upgraded to source-checked when an NPI is later issued.
+
+### Copy discipline (per CLAUDE.md banned strings)
+- Never the bare word **"Verified"** as a status label; use **"source-checked," "NPPES-confirmed," "attested,"** and the explicit coverage state.
+- "Credential **readiness** packet," not "credentialing complete."
+- Attestation ≠ verification — label attested fields as **attested**, keep them visually distinct from `checked` source data.
+
+---
+
+## 5. Concrete build tasks (hand to Claude Code / Codex)
+
+1. **`/onboarding` verified-clinician gate** — profession selector → NPI field (+ NPPES helper) → confirm-identity step → attestation + services agreement → wallet provision. Reuse the ingest pipeline; add the confirm-identity screen.
+2. **Identity-binding factor** — institutional-email OTP service feeding the Trust Gradient as a corroboration signal; stub a third-party ID/license verification adapter behind a feature flag as a `gated` source.
+3. **Attestation + AuditEvent** — services-agreement click-through that writes an `AuditEvent` row before 2xx; store attested claims as `attested`, never promoted to `checked`.
+4. **Coverage-honest result screen** — readiness snapshot showing NPPES `checked`, OIG/LEIE `checked`, license `gated`/`accessRequired` (per state lane), attestations flagged. This *is* the differentiator vs. the competitor boolean.
+5. **Student / no-NPI lane** — `previewOnly` wallet with an NPI-upgrade path.
+
+---
+
+## 6. Sources
+- ChatGPT for Clinicians — OpenAI Help Center: https://help.openai.com/en/articles/20001202-chatgpt-for-clinicians
+- ChatGPT for Clinicians plan page: https://chatgpt.com/plans/clinicians/
+- Making ChatGPT better for clinicians — OpenAI: https://openai.com/index/making-chatgpt-better-for-clinicians/
+- OpenAI launches ChatGPT for Clinicians — Fierce Healthcare: https://www.fiercehealthcare.com/ai-and-machine-learning/openai-launches-chatgpt-clinicians-free-ai-tool-physicians-nps-and
+- OpenEvidence for Nurses (signup/NPI walkthrough) — FindSkill: https://findskill.ai/blog/openevidence-for-nurses/
+- OpenEvidence outside the US (verification detail) — iatroX: https://www.iatrox.com/blog/openevidence-outside-us-access-verification-uk-alternatives
+- ChatGPT for Clinicians vs OpenEvidence (2026 comparison) — iatroX: https://www.iatrox.com/blog/chatgpt-for-clinicians-vs-openevidence-2026
+- OpenEvidence — About: https://www.openevidence.com/about
+
+### Founder-captured primary sources (in Dropbox)
+- `ChatGPT for Healthcare _ OpenAI Help Center 2026-04-23 06-38-57.pdf` (enterprise tier; links to the Clinicians signup article)
+- `How can I get a Business Associate Agreement (BAA) with OpenAI for the API Services_ ... 2026-04-23 06-40-39.pdf`
+- `OpenEvidence 2026-05-16 20-47-22.pdf` (credentialing-bottlenecks Q&A)
+- `Business Associate Agreement _ OpenEvidence 2026-05-16 19-22-37.pdf` (OpenEvidence Network BAA, HIPAA)

--- a/docs/research/god-mode-research-report.md
+++ b/docs/research/god-mode-research-report.md
@@ -1,0 +1,101 @@
+# VitalCV "God-Mode" Research Report — Ship-Now Transformation Base
+
+> Research foundation for a god-mode wave of Claude Code task bundles.
+> Compiled 2026-07-04 from three grounded streams: (1) live repo audit, (2) competitive gap/leapfrog analysis, (3) standards/regulatory/moat scan.
+> Lens: balanced (competitive + moat + GTM). Horizon: **ship-now (weeks)**, executable against the current tree.
+> **The actual task-wave bundles are the next step** — this report defines the targets they aim at.
+
+---
+
+## 0. Headline
+
+The market moved *toward* VitalCV in 2025–26. W3C VC 2.0, OID4VCI/VP/HAIP 1.0 Finals, NIST 800-63-4 accepting verifiable credentials as IAL2 evidence, and NCQA + Joint Commission now **mandating** continuous, traceable, source-backed verification — all describe exactly what VitalCV was built to be. Meanwhile the repo is in better shape than the doctrine docs claim: **the NPI→passport→employer-review wedge is wired end-to-end and audit-first**, live copy is clean of banned strings, and the mobile wallet is no longer empty. The transformation opportunity is therefore not a rebuild — it's **hardening the wedge, landing the front door, and packaging the moat as sellable proof points**.
+
+---
+
+## 1. Grounded repo reality (re-baseline before planning)
+
+**Already resolved on disk (contradicting older blocker docs — do NOT bundle these):**
+- Marketing→web seam: `apps/marketing/app/clinician/page.tsx` now redirects into the live `/passport` flow (old P0 fixed).
+- Hero/HomeSections banned-string copy: **zero hits** for `hire instantly`, `zero-trust ledger`, `blockchain-anchored`, `HIPAA compliant`, `SOC 2 certified` etc. across live `apps/web` + `apps/marketing`. Demo metrics labeled "illustrative."
+- `apps/mobile`: **built** (Expo: `LocalCredentialStore`, `OfflinePresentationEngine`, `OID4VPHandler`, `NotificationService` + tests).
+- Passport is **backend-proxied, not fixtures** (`apps/web/app/api/passport/[npi]/route.ts`).
+- Employer accept is **real + audit-first**: `POST /api/employer-review/:entityId/accept` writes `AuditEvent` in a transaction, guards duplicates, fails closed on BLOCKED.
+
+**Genuinely open, ship-now gaps (the real backlog):**
+- **Self-serve clinician signup gate: specified but unbuilt.** `apps/web/app/signup/page.tsx` renders an honest foundation stub (`accountCreationProductionReady: false`, `identityProofingComplete: false`). The brief at `docs/research/clinician-signup-verification-brief.md` describes the target.
+- **Security/pilot hardening:** prod auth/Google OAuth (unverified), no e2e signup test, no audited CSP/security headers, no Zod env validation, no OWASP ASVS scorecard, verifier RBAC not enforced (`rbacEnforced: false`).
+- **Source breadth:** only NPPES, OIG/LEIE, PECOS, Open Payments, academic sources live. STATE_BOARD/FSMB/Nursys/SAM.gov gated; `sourceRegistry.ts` throws "Real Nursys adapter not implemented" when flagged on.
+- **Empty apps:** `router`, `docs`, `sample-api`, `status-api`, `lib` (0–2 files). Several packages are dist-only (`audit-receipts`, `claims`, `vitalindex`, `rate-limiter`, `runtime-mode`, `idempotency`, `conflict-resolution`) — verify before depending on them.
+
+**Safe-to-build foundations:** the wedge API (`employerActions.ts`, `ingestStream.ts`, `passport.ts`), `sourceCatalog.ts` + adapter model, the signup foundation stub, issuer-api/verifier-api scaffolding.
+
+> ⚠️ **Two unknowns to verify first:** (a) whether the PR-merge-dependent blockers actually landed (can't tell from the working tree), and (b) prod auth/OAuth status. Re-baseline the blocker list against the current tree before executing any wave.
+
+---
+
+## 2. Competitive position (where to catch up vs. leapfrog)
+
+**VitalCV's uncontested territory (leapfrog — no competitor occupies it):**
+1. **Reusable, clinician-owned source-backed evidence** — everyone else re-verifies per customer; VitalCV's wallet+passport makes one verification portable. This *is* the category.
+2. **Claim-level receipts + provenance** (source→timestamp→checksum→parser version), selectively disclosable.
+3. **Trust gradients / coverage honesty** (checked/gated/stale/unknown, revoked fails closed) vs. competitors' binary verified/not.
+4. **Composite explainable trust score (CRS)** — nobody ships an explainable 0–100 readiness score.
+5. **Cross-employer portability + clinician ownership** — turns credentialing from per-hire cost into a network asset.
+
+**Must catch up (table stakes rivals already have):**
+1. **Source breadth** — Verifiable/Medallion/symplr verify NPDB, DEA, SAM, FSMB, Nursys. (Doctrine forbids *claiming* NPDB/DEA — land adapters honestly, gate the copy.)
+2. **Certifications** — SOC 2 Type II (OpenEvidence, Verifiable), HITRUST (symplr), NCQA accreditation (Medallion). VitalCV is "aligned," not certified → blocks procurement.
+3. **Epic / EHR embedding** — the shared distribution moat (OpenEvidence, Abridge, symplr).
+4. **Frictionless signup funnel** — OpenEvidence's NPI gate built 757k clinicians; VitalCV's pipeline exists but the front-door UX is thin.
+5. **Downstream integration** — integrate *into* payer-enrollment/privileging (Medallion/symplr depth) rather than appear to skip it.
+
+**Biggest strategic risk:** OpenEvidence/ChatGPT already hold the verified-clinician front door at scale (boolean gate). If either bolts credential *evidence* onto it, they leapfrog VitalCV's wedge. **Speed on the wallet-as-artifact front door is the priority.**
+
+---
+
+## 3. Standards & regulatory tailwinds (adopt now)
+
+- **NCQA (Jul 2025):** API-based PSV now production-legitimate (with human review); PSV window 180→120/90 days; **continuous monthly monitoring now required** (license expiry + OIG/SAM/board exclusions). VitalCV's readiness+freshness engine *is* rolling verification. → Package as an "NCQA-aligned continuous-verification substrate"; per-claim "monitored monthly" badge. **[M, ship-now]**
+- **Joint Commission (2025):** every verification must be traceable (date + source contacted), survey-ready. VitalCV's claim-level receipts answer this natively. → "JC survey-ready evidence export." **[S, ship-now]**
+- **CMS/NPPES:** V1 bulk files sunset **03/03/2026** → V2 only; API is v2.1. ⚠️ **That deadline has passed (today is 2026-07-04) — verify ingestion is on NPPES v2.1 + V2 bulk immediately, or NPI enrichment is silently degrading.** **[S, verify now]**
+- **W3C VC Data Model 2.0:** Recommendation since 15 May 2025 + Bitstring Status List for revocation → adopt for the revocation registry (revocation-first doctrine). **[M]**
+- **OID4VCI/VP 1.0 + HAIP 1.0 Final (Dec 2025):** pin wallet-sdk/verifier-api to the Final profiles; `packages/haip-config` already exists. **[M]**
+- **NIST SP 800-63-4 (final Jul 2025):** explicitly recognizes VCs/mDLs as IAL2 evidence; passkeys = AAL2 baseline. → map VitalCV L2↔IAL2, L3↔IAL3; add passkey + DPoP for AAL2. Becomes an enterprise/federal proof point. **[M]**
+
+---
+
+## 4. Prioritized opportunity themes (these seed the task waves)
+
+Ordered by leverage for "best platform, shippable in weeks." Each is a candidate god-mode wave.
+
+| # | Theme | Why now | Type | Size |
+|---|---|---|---|---|
+| **A** | **Land the self-serve clinician signup gate** (NPI→attestation→wallet, evidence not a boolean) | Owns the OpenEvidence-style front door; foundation stub + brief already exist | GTM + wedge | M |
+| **B** | **Pilot security hardening** (prod auth/OAuth, CSP + security headers, Zod env validation, verifier RBAC, e2e signup test, OWASP scorecard) | The real Tier-2 pilot blockers; gates any real buyer | Trust/infra | M |
+| **C** | **NPPES v2 cutover + source-breadth adapters** (verify v2.1/V2; land STATE_BOARD/FSMB honestly; SAM.gov) | Cutover deadline passed; breadth is table stakes | Catch-up | S–M |
+| **D** | **Continuous-monitoring + freshness packaging** (flip Wave 245 async engine on; per-claim freshness/decay badge; "monitored monthly") | NCQA now *requires* it; VitalCV nearly has it | Moat + compliance | M–L |
+| **E** | **Revocation registry via Bitstring Status List + VC 2.0 alignment** | Revocation-first doctrine; standards-final | Moat/standards | M |
+| **F** | **Compliance proof-pack surfaces** (JC survey-ready export; NIST IAL2 mapping doc + passkey/DPoP AAL2; audit-trail packet polish) | Turns architecture into sellable artifacts; unblocks procurement | GTM/compliance | S–M |
+| **G** | **Trust-gradient + CRS visibility polish** (make coverage honesty + explainable score the passport's visible signature) | The leapfrog differentiator, under-surfaced today | Moat/UX | M |
+| **H** | **Divergence detection + claim-level receipt surfacing** (7-rule cross-source divergence; provenance on every claim) | Uniquely VitalCV; the "truth layer" wedge | Moat | M |
+| **I** | **Repo hygiene** (empty apps: delete or scaffold `router`/`docs`/`status-api`; verify dist-only packages; re-baseline blocker docs) | Reduces drift; makes waves safe to execute | Infra | S |
+| **J** (longer-horizon) | **FHIR-triggered re-verification** (R5/R6 Subscriptions on Practitioner changes → auto re-verify) | Highest-moat EHR wedge; nobody's productized it | Moat/EHR | L |
+
+**Recommended ship-now sequence:** I (hygiene/re-baseline) → C (NPPES verify) as fast pre-work → then A (signup gate) + B (security) as the two flagship waves → D/E/F/G/H as moat/compliance waves → J queued for the next horizon.
+
+---
+
+## 5. Guardrails for every wave (from doctrine)
+
+- Preserve the canonical path (Recognition→Acceptance→Start); audit-first on every mutation; revoked fails closed.
+- Zero PHI on-chain; HAIP posture intact; no `prisma migrate` without approval (SQL plan to `docs/migrations/` only).
+- Never claim uncertified (SOC 2 / NCQA / HIPAA-certified) or unintegrated sources (NPDB/DEA/ABMS); banned-string discipline; no bare "Verified" status label.
+- Cowork builds the plan; **Claude Code executes**; Codex verifies before merge. Diff against `origin/main`.
+
+---
+
+## 6. Sources
+Competitive: Medallion, symplr/VerityStream CredentialStream, Verifiable, AMA VeriCre, OpenEvidence, ChatGPT for Clinicians, Abridge (see `competitive` stream links in this folder's companion notes).
+Standards: [W3C VC 2.0 Recommendation](https://www.w3.org/news/2025/the-verifiable-credentials-2-0-family-of-specifications-is-now-a-w3c-recommendation/) · [HAIP 1.0 Final](https://openid.net/openid4vc-high-assurance-interoperability-profile-haip-1-0-final-specification-approved/) · [NIST SP 800-63-4 final](https://csrc.nist.gov/pubs/sp/800/63/4/final) · [NCQA continuous monitoring](https://insights.wchsb.com/2026/01/27/credentialing-enters-the-continuous-monitoring-era/) · [Joint Commission PSV FAQ](https://www.jointcommission.org/en-us/knowledge-library/support-center/standards-interpretation/standards-faqs/000001440) · [NPPES files/API](https://download.cms.gov/nppes/NPI_Files.html) · [FHIR Subscriptions R6](https://build.fhir.org/subscription.html)
+Prior briefs: `docs/research/clinician-signup-verification-brief.md`, `docs/research/vitalcv-research-pdf-index.md`.


### PR DESCRIPTION
## Summary

Wave 0 of the god-mode execution pack (`docs/research/god-mode-research-report.md`, theme I + urgent C): make the plan trustworthy before flagship waves A/B run.

- **Re-baseline**: new canonical open-blocker list (`docs/ops/launch-blockers.md`, 13 genuinely-open items with evidence + owning wave) + one-page verification record (`docs/ops/REBASELINE-2026-07-04.md`). `docs/LAUNCH_GATE.md` (2026-03-28) banner-marked as historical, content untouched.
- **NPPES V1→V2 cutover (urgent)**: verified every runtime endpoint pins API v2.1, zero V1 references repo-wide; added `nppesApiVersion.ts` boot assertion that imports the three real adapter constants and refuses to boot on drift, plus a `nppes_api_version` startup log line. Runtime-smoked via tsx: `{"version":"2.1","endpoints":[3]}`.
- **Empty-app disposition (no half-states)**: READMEs declaring explicit status for `apps/docs` (reserved), `apps/sample-api` (reserved; legacy branding flagged), `apps/lib` (load-bearing — imported cross-app by `OfflineRadar.tsx`), `apps/status-api` (real StatusList2021 service, Wave E predecessor). `apps/router` doesn't exist on main — recorded, nothing to do.
- **Package audit**: `docs/architecture/package-status.md` — the 7 "dist-only" packages **do not exist on main** (phantom premise corrected); all 28 real packages inventoried with source counts.
- **Provenance**: committed `god-mode-research-report.md` + `clinician-signup-verification-brief.md` (Wave A spec already referenced by merged #538). The Dropbox PDF index stays local-only (personal paths).

## Truth rules

- No source-claim inflation: NPPES bulk ingestion explicitly documented as **not implemented** (API-only enrichment); Nursys/STATE_BOARD/SAM stay gated in the open list.
- No certification claims; banned-string scan over every file in this diff: clean (only ban-list descriptions in re-baseline docs).
- No Prisma/schema changes; no signup-surface changes (Wave A lane untouched).
- Code delta is boot-time-only: 3 `export` keywords + assertion module + startServer wiring. No behavior change to any fetch path.

## Validation

- Runtime smoke: `assertNppesApiVersion()` → `{"version":"2.1","endpoints":["modules/identity/nppes.service","engine/adapters/nppesAdapter","adapters/NppesAdapter"]}`
- `pnpm typecheck`: 42/42 · backend `tsc --noEmit`: clean · `pnpm lint`: clean
- `pnpm turbo run build --filter @vitalcv/web`: 14/14

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)