### PR TITLE
feat(onboarding): student / no-NPI lane — preview profile (gate 4/4)

### DIFF
--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -65,6 +65,8 @@ export function shouldSkipTenantContext(path: string): boolean {
     // Email-OTP identity binding: an onboarding-time possession factor scoped to
     // the Clerk user alone (no org context yet). Same rationale as /api/me/role.
     || normalized.startsWith('/api/profile/identity/')
+    // Student / no-NPI lane: first-time onboarding, resolved by Clerk user alone.
+    || normalized.startsWith('/api/profile/student/')
     || normalized.startsWith('/demo')
     || normalized.startsWith('/.well-known')
     || normalized.startsWith('/api/.well-known')

--- a/apps/api/backend/src/routes/intake.ts
+++ b/apps/api/backend/src/routes/intake.ts
@@ -11,6 +11,7 @@
 import type { Express, NextFunction, Request, Response } from 'express';
 import {
   bootstrapNpiIntake,
+  bootstrapStudentIntake,
   getProfileCompleteness,
   ingestLinks,
   ingestResumeUpload,
@@ -116,6 +117,24 @@ export function registerIntakeRoutes(app: Express): void {
         attested,
         attestationVersion,
       });
+      res.status(201).json(result);
+    }),
+  );
+
+  /**
+   * POST /api/profile/student/bootstrap
+   * Student / no-NPI lane — starts a preview-only profile.
+   * Body: { attested?: boolean, attestationVersion?: string }
+   */
+  app.post(
+    '/api/profile/student/bootstrap',
+    asyncHandler(async (req, res) => {
+      const userId = requireUserId(req);
+      const { attested, attestationVersion } = req.body as {
+        attested?: boolean;
+        attestationVersion?: string;
+      };
+      const result = await bootstrapStudentIntake(userId, { attested, attestationVersion });
       res.status(201).json(result);
     }),
   );

--- a/apps/api/backend/src/services/intake/intakeService.ts
+++ b/apps/api/backend/src/services/intake/intakeService.ts
@@ -348,6 +348,52 @@ export async function bootstrapNpiIntake(
 }
 
 /**
+ * Student / no-NPI lane. A clinician-in-training with no NPI yet starts a
+ * PREVIEW-ONLY profile (profession='student', no NPI). It upgrades to a
+ * source-checked record automatically when they later bind an NPI via
+ * bootstrapNpiIntake (same userId upsert overwrites profession + adds the NPI).
+ * Nothing here is source-verified; the student status is self-attested.
+ */
+export async function bootstrapStudentIntake(
+  userId: string,
+  attestation?: { attested?: boolean; attestationVersion?: string },
+): Promise<{ profession: string; previewOnly: boolean }> {
+  const existing = await prisma.personProfile.findUnique({ where: { userId } });
+  // Never downgrade an already NPI-backed profile to a student preview.
+  if (existing?.npi) {
+    return { profession: existing.profession ?? 'clinician', previewOnly: false };
+  }
+
+  const attested = attestation?.attested === true;
+  const attestedAt = attested ? new Date() : undefined;
+  const attestationVersion = attested ? (attestation?.attestationVersion ?? 'v1') : undefined;
+
+  await prisma.personProfile.upsert({
+    where: { userId },
+    create: {
+      userId,
+      profession: 'student',
+      attestedAt,
+      attestationVersion,
+      completeness: 10,
+    },
+    update: {
+      profession: 'student',
+      attestedAt: attestedAt ?? undefined,
+      attestationVersion: attestationVersion ?? undefined,
+      updatedAt: new Date(),
+    },
+  });
+
+  await emitAudit('student_bootstrapped', userId, {
+    previewOnly: true,
+    attestationVersion: attestationVersion ?? null,
+  });
+
+  return { profession: 'student', previewOnly: true };
+}
+
+/**
  * Get current profile completeness dimensions.
  */
 export async function getProfileCompleteness(userId: string): Promise<ProfileCompletenessResult> {

--- a/apps/web/app/api/profile/student/bootstrap/route.ts
+++ b/apps/web/app/api/profile/student/bootstrap/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/profile/student/bootstrap  { attested, attestationVersion }
+ * Proxy to backend — starts a preview-only student profile (no NPI yet).
+ * Auth-scoped: forwards the verified Clerk user id (never a caller-supplied one).
+ */
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Sign in required.' }, { status: 401 });
+  }
+
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  headers.set('x-clerk-user-id', session.userId);
+
+  const body = await req.text();
+  const res = await fetch(`${BACKEND}/api/profile/student/bootstrap`, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/app/get-ready/GetReadySurface.tsx
+++ b/apps/web/app/get-ready/GetReadySurface.tsx
@@ -36,6 +36,7 @@ type Phase =
   | 'form'
   | 'submitting'
   | 'success'
+  | 'student_success'
   | 'load_error';
 
 /**
@@ -63,6 +64,7 @@ export default function GetReadySurface() {
   const [existingNpi, setExistingNpi] = useState<string | null>(null);
   const [profession, setProfession] = useState<Profession | null>(null);
   const [attested, setAttested] = useState(false);
+  const [mode, setMode] = useState<'npi' | 'student'>('npi');
   const [npiInput, setNpiInput] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
   const [summary, setSummary] = useState<BoundIdentitySummary | null>(null);
@@ -158,6 +160,34 @@ export default function GetReadySurface() {
     } catch {
       if (!mountedRef.current) return;
       setFormError(describeBootstrapError(0, null));
+      setPhase('form');
+    }
+  }
+
+  async function submitStudent(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!attested) {
+      setFormError('Please attest and agree to the Services Agreement to continue.');
+      return;
+    }
+    setFormError(null);
+    setPhase('submitting');
+    try {
+      const res = await fetch('/api/profile/student/bootstrap', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ attested: true, attestationVersion: ATTESTATION_VERSION }),
+      });
+      if (!mountedRef.current) return;
+      if (!res.ok) {
+        setFormError('Could not start your student profile. Try again shortly.');
+        setPhase('form');
+        return;
+      }
+      setPhase('student_success');
+    } catch {
+      if (!mountedRef.current) return;
+      setFormError('Could not start your student profile. Try again shortly.');
       setPhase('form');
     }
   }
@@ -287,6 +317,36 @@ export default function GetReadySurface() {
     );
   }
 
+  /* ── Student success ── */
+  if (phase === 'student_success') {
+    return (
+      <Shell>
+        <div className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-sky-900 bg-sky-950/40">
+          <ShieldCheck className="h-7 w-7 text-sky-400" aria-hidden />
+        </div>
+        <Header
+          title="Your student profile is started"
+          lede="You're in preview. When you receive your NPI, connect it here to unlock your source-backed readiness — your profile upgrades automatically."
+        />
+        <div className="mt-6 space-y-3">
+          <Link
+            href="/holder"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-7 py-3.5 text-sm font-semibold text-black transition hover:bg-emerald-400"
+          >
+            Open your wallet <ChevronRight className="h-4 w-4" aria-hidden />
+          </Link>
+          <button
+            type="button"
+            onClick={() => { setMode('npi'); setPhase('form'); setAttested(false); setFormError(null); }}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-700 px-7 py-3.5 text-sm font-semibold text-zinc-300 transition hover:border-emerald-800 hover:text-emerald-300"
+          >
+            I have an NPI — connect it instead
+          </button>
+        </div>
+      </Shell>
+    );
+  }
+
   /* ── Form (+ submitting) ── */
   const submitting = phase === 'submitting';
   return (
@@ -298,6 +358,7 @@ export default function GetReadySurface() {
         title="Connect your NPI"
         lede="VitalCV reads your public NPPES registry record to start your clinician workspace. No document uploads required to get started."
       />
+      {mode === 'npi' ? (
       <form onSubmit={submit} className="mt-6 space-y-4 text-left" noValidate>
         <fieldset disabled={submitting} className="border-0 p-0 m-0">
           <legend className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
@@ -406,6 +467,50 @@ export default function GetReadySurface() {
           each with its own receipt.
         </p>
       </form>
+      ) : (
+        <form onSubmit={submitStudent} className="mt-6 space-y-4 text-left" noValidate>
+          <p className="text-sm leading-relaxed text-zinc-400">
+            No NPI yet? Start a preview profile as a health-professions student. When you
+            receive your NPI, connect it here and your profile upgrades to source-backed.
+          </p>
+          <label className="flex items-start gap-2.5 text-xs leading-relaxed text-zinc-400">
+            <input
+              type="checkbox"
+              checked={attested}
+              onChange={(e) => setAttested(e.target.checked)}
+              disabled={submitting}
+              className="mt-0.5 h-4 w-4 shrink-0 accent-emerald-500"
+            />
+            <span>
+              I attest that I am a health-professions student and agree to the{' '}
+              <a href="/terms" target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-zinc-200">
+                VitalCV Services Agreement
+              </a>
+              . VitalCV records this attestation; it does not verify it here.
+            </span>
+          </label>
+          {formError ? <p role="alert" className="text-sm text-red-400">{formError}</p> : null}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-7 py-3.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitting ? (
+              <><Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Starting…</>
+            ) : (
+              <>Start as a student <ChevronRight className="h-4 w-4" aria-hidden /></>
+            )}
+          </button>
+        </form>
+      )}
+      <button
+        type="button"
+        onClick={() => { setMode(mode === 'npi' ? 'student' : 'npi'); setAttested(false); setFormError(null); }}
+        disabled={submitting}
+        className="mt-4 text-xs text-zinc-500 underline underline-offset-2 transition hover:text-zinc-300"
+      >
+        {mode === 'npi' ? "Still in training and don't have an NPI yet?" : '← I have an NPI — connect it instead'}
+      </button>
     </Shell>
   );
 }


### PR DESCRIPTION
## Gate PR 4 of 4 — student / no-NPI lane (completes the self-serve signup gate)

Implements **Task 5**. Mirrors OpenEvidence's student path: a clinician-in-training with no NPI starts a **preview-only** profile that **upgrades to source-checked automatically** when they bind an NPI later (same-`userId` upsert overwrites `profession` + adds the NPI).

### Backend
- `bootstrapStudentIntake`: `profession='student'`, no NPI, `completeness: 10` + a `student_bootstrapped` audit. **Guards against downgrading** an existing NPI-backed profile to a student preview.
- `POST /api/profile/student/bootstrap` + **tenant-guard exemption** (`/api/profile/student/`, same org-less onboarding rationale as `/api/me/role`) + web proxy forwarding the verified Clerk user id.

### Frontend (`GetReadySurface`)
- A **"Still in training and don't have an NPI yet?"** toggle → student attestation form → a preview-success screen: *"You're in preview. When you receive your NPI, connect it here — your profile upgrades automatically."* Includes an "I have an NPI — connect it instead" path back.

### Doctrine
- `previewOnly` is inferred from `profession='student'` + null NPI (no new status column). Student status is **self-attested**, never source-verified.

### Validation
- Backend build green; web build **14/14** (student proxy registered); route-contract passing. No new migration (reuses `#539`'s `profession`).

**Tier 2**, review waived by owner. This closes the 4-PR gate: profession → NPI → attestation+audit → email-OTP binding → student lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)