### PR TITLE
feat(security): server-side RBAC gate on employer-review mutations (Wave B, shadow-first)

### DIFF
--- a/apps/api/backend/src/config/env.ts
+++ b/apps/api/backend/src/config/env.ts
@@ -148,6 +148,11 @@ const envSchema = z.object({
   }, z.boolean()),
   SYSTEM_FROZEN: z.preprocess((raw) => parseBooleanEnvVar(raw, 'SYSTEM_FROZEN', false), z.boolean()),
   REAL_NURSYS_ENABLED: z.preprocess((raw) => parseBooleanEnvVar(raw, 'REAL_NURSYS_ENABLED', false), z.boolean()),
+  // RBAC rollout for employer-review mutations. false = shadow mode (log
+  // would-deny, never block); true = enforce (403 + denied-mutation audit).
+  // Deliberately NOT in the SYSTEM_FROZEN blocklist: freezing features must
+  // not switch a security control off.
+  VERIFIER_RBAC_ENFORCED: z.preprocess((raw) => parseBooleanEnvVar(raw, 'VERIFIER_RBAC_ENFORCED', false), z.boolean()),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/backend/src/routes/employerActions.ts
+++ b/apps/api/backend/src/routes/employerActions.ts
@@ -26,6 +26,8 @@ import prisma from '../graphql/prisma_client';
 import { log } from '../obs/logger';
 import { HttpError } from '../utils/httpError';
 import { sha256ForPayload } from '../utils/deterministic';
+import { env } from '../config/env';
+import { decideEmployerActionRbac } from '../services/authz/employerActionRbac';
 import {
   captureEmployerDecision,
   captureStartOutcome,
@@ -181,6 +183,53 @@ async function writeDeniedEmployerReviewMutation(input: {
   });
 }
 
+// ── RBAC (Wave B) — server-side role gate on employer-review mutations ──────
+// Roles come from the User table (clerkUserId → role/status), never from
+// caller-supplied headers like x-verifier-team-role. VERIFIER_RBAC_ENFORCED
+// false = shadow mode: would-deny decisions are logged but never block, so
+// the golden path cannot break before production role coverage is verified.
+// Enforced mode writes the standard denied-mutation AuditEvent before 403.
+async function enforceEmployerMutationRbac(input: {
+  req: Request;
+  employerId: string;
+  entityId: string;
+  clinicianNpi: string;
+  action: 'accept' | 'request-refresh' | 'route-to-review' | 'share-packet' | 'confirm-start';
+}): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { clerkUserId: input.employerId },
+    select: { role: true, status: true },
+  });
+  const decision = decideEmployerActionRbac(user);
+  if (decision.allowed) return;
+
+  if (!env().VERIFIER_RBAC_ENFORCED) {
+    log('warn', 'employer_rbac_shadow_would_deny', {
+      action: input.action,
+      entityId: input.entityId,
+      actorId: input.employerId,
+      denialReason: decision.denialReason,
+      resolvedRole: decision.resolvedRole,
+      enforcement: 'shadow',
+    });
+    return;
+  }
+
+  await writeDeniedEmployerReviewMutation({
+    req: input.req,
+    actorId: input.employerId,
+    entityId: input.entityId,
+    clinicianNpi: input.clinicianNpi,
+    denialReason: decision.denialReason ?? 'rbac_denied',
+    payload: {
+      action: input.action,
+      resolvedRole: decision.resolvedRole,
+      enforcement: 'rbac',
+    },
+  });
+  throw new HttpError(403, 'Employer-review mutations require an active verifier-role account.');
+}
+
 const SHARE_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 const SHARE_TOKEN_PATTERN = /^chk_[A-Za-z0-9_-]{43}$/;
 
@@ -266,6 +315,10 @@ export function registerEmployerActionRoutes(app: Express): void {
 
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found or has no NPI.`);
+
+      await enforceEmployerMutationRbac({
+        req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action: 'accept',
+      });
 
       // Guard: no duplicate open acceptances
       const existing = await prisma.employerAcceptance.findFirst({
@@ -437,6 +490,10 @@ export function registerEmployerActionRoutes(app: Express): void {
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found.`);
 
+      await enforceEmployerMutationRbac({
+        req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action: 'request-refresh',
+      });
+
       const { staleSources, missingDomains, message } = (req.body ?? {}) as {
         staleSources?:    string[];
         missingDomains?:  string[];
@@ -540,6 +597,10 @@ export function registerEmployerActionRoutes(app: Express): void {
 
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found.`);
+
+      await enforceEmployerMutationRbac({
+        req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action: 'route-to-review',
+      });
 
       const { reason, priority } = (req.body ?? {}) as {
         reason?: string;
@@ -826,6 +887,10 @@ export function registerEmployerActionRoutes(app: Express): void {
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found or has no NPI.`);
 
+      await enforceEmployerMutationRbac({
+        req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action: 'share-packet',
+      });
+
       const { npi: bodyNpi, organizationContextId, bundleId } = (req.body ?? {}) as {
         npi?: string;
         organizationContextId?: string | null;
@@ -1005,6 +1070,10 @@ export function registerEmployerActionRoutes(app: Express): void {
 
       const subject = await resolveEmployerReviewSubject(entityId);
       if (!subject) throw new HttpError(404, `Entity ${entityId} not found or has no NPI.`);
+
+      await enforceEmployerMutationRbac({
+        req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action: 'confirm-start',
+      });
 
       const { startedAt, role, facility, acceptanceId: bodyAcceptanceId } = (req.body ?? {}) as {
         startedAt?: string;

--- a/apps/api/backend/src/services/authz/__tests__/employerActionRbac.test.ts
+++ b/apps/api/backend/src/services/authz/__tests__/employerActionRbac.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure decision-matrix tests for employer-review mutation RBAC.
+ * No DB, no network — the module is a pure transform.
+ */
+import {
+  decideEmployerActionRbac,
+  EMPLOYER_MUTATION_ALLOWED_ROLES,
+} from '../employerActionRbac';
+
+describe('decideEmployerActionRbac', () => {
+  it('denies when no User row exists (header alone is not an identity)', () => {
+    const decision = decideEmployerActionRbac(null);
+    expect(decision.allowed).toBe(false);
+    expect(decision.denialReason).toBe('rbac_unknown_user');
+    expect(decision.resolvedRole).toBeNull();
+  });
+
+  it('denies CLINICIAN — a clinician must never self-accept as an employer', () => {
+    const decision = decideEmployerActionRbac({ role: 'CLINICIAN', status: 'ACTIVE' });
+    expect(decision.allowed).toBe(false);
+    expect(decision.denialReason).toBe('rbac_role_not_permitted');
+    expect(decision.resolvedRole).toBe('CLINICIAN');
+  });
+
+  it('denies ISSUER', () => {
+    const decision = decideEmployerActionRbac({ role: 'ISSUER', status: 'ACTIVE' });
+    expect(decision.allowed).toBe(false);
+    expect(decision.denialReason).toBe('rbac_role_not_permitted');
+  });
+
+  it('allows ACTIVE VERIFIER', () => {
+    const decision = decideEmployerActionRbac({ role: 'VERIFIER', status: 'ACTIVE' });
+    expect(decision).toEqual({
+      allowed: true,
+      denialReason: null,
+      resolvedRole: 'VERIFIER',
+    });
+  });
+
+  it('allows ADMIN, including while still INVITED (schema default, lazy activation)', () => {
+    expect(decideEmployerActionRbac({ role: 'ADMIN', status: 'ACTIVE' }).allowed).toBe(true);
+    expect(decideEmployerActionRbac({ role: 'ADMIN', status: 'INVITED' }).allowed).toBe(true);
+    expect(decideEmployerActionRbac({ role: 'VERIFIER', status: 'INVITED' }).allowed).toBe(true);
+  });
+
+  it('denies SUSPENDED and DEACTIVATED regardless of role', () => {
+    for (const status of ['SUSPENDED', 'DEACTIVATED'] as const) {
+      const decision = decideEmployerActionRbac({ role: 'ADMIN', status });
+      expect(decision.allowed).toBe(false);
+      expect(decision.denialReason).toBe('rbac_user_inactive');
+      expect(decision.resolvedRole).toBe('ADMIN');
+    }
+  });
+
+  it('pins the allowed-role set to VERIFIER + ADMIN only', () => {
+    expect([...EMPLOYER_MUTATION_ALLOWED_ROLES].sort()).toEqual(['ADMIN', 'VERIFIER']);
+  });
+});

--- a/apps/api/backend/src/services/authz/employerActionRbac.ts
+++ b/apps/api/backend/src/services/authz/employerActionRbac.ts
@@ -1,0 +1,70 @@
+/**
+ * Employer-review mutation RBAC — pure decision core (Wave B).
+ *
+ * Decides whether a caller may perform a mutating employer-review action
+ * (accept / request-refresh / route-to-review / share-packet / confirm-start).
+ * Roles come from the server-side User table (clerkUserId → role/status),
+ * never from caller-supplied headers like x-verifier-team-role.
+ *
+ * Pure transform: no fetches, no DB reads, no audit writes. The route layer
+ * resolves the User row and handles shadow-vs-enforced rollout
+ * (VERIFIER_RBAC_ENFORCED) plus the denied-mutation AuditEvent.
+ */
+import type { UserRole, UserStatus } from '@prisma/client';
+
+export interface EmployerActionRbacSubject {
+  role: UserRole;
+  status: UserStatus;
+}
+
+export interface EmployerActionRbacDecision {
+  allowed: boolean;
+  /** Set only on deny; stable machine-readable reason for audit rows + logs. */
+  denialReason:
+    | 'rbac_unknown_user'
+    | 'rbac_user_inactive'
+    | 'rbac_role_not_permitted'
+    | null;
+  /** Role the caller resolved to, or null when no User row exists. */
+  resolvedRole: UserRole | null;
+}
+
+/** Roles permitted to perform employer-review mutations. */
+export const EMPLOYER_MUTATION_ALLOWED_ROLES: readonly UserRole[] = [
+  'VERIFIER',
+  'ADMIN',
+];
+
+/**
+ * Decision rules:
+ * - No User row → deny (`rbac_unknown_user`). A header alone is not an identity.
+ * - SUSPENDED / DEACTIVATED → deny (`rbac_user_inactive`). INVITED is not
+ *   hard-denied: it is the schema default and pilots activate lazily; the
+ *   shadow-mode rollout measures whether INVITED callers exist before any
+ *   tightening.
+ * - CLINICIAN / ISSUER → deny (`rbac_role_not_permitted`). A clinician must
+ *   never be able to accept their own passport as an employer.
+ * - VERIFIER / ADMIN → allow.
+ */
+export function decideEmployerActionRbac(
+  user: EmployerActionRbacSubject | null,
+): EmployerActionRbacDecision {
+  if (!user) {
+    return { allowed: false, denialReason: 'rbac_unknown_user', resolvedRole: null };
+  }
+  if (user.status === 'SUSPENDED' || user.status === 'DEACTIVATED') {
+    return {
+      allowed: false,
+      denialReason: 'rbac_user_inactive',
+      resolvedRole: user.role,
+    };
+  }
+  if (!EMPLOYER_MUTATION_ALLOWED_ROLES.includes(user.role)) {
+    return {
+      allowed: false,
+      denialReason: 'rbac_role_not_permitted',
+      resolvedRole: user.role,
+    };
+  }
+  return { allowed: true, denialReason: null, resolvedRole: user.role };
+}


### PR DESCRIPTION
## Summary

Wave B (pilot security hardening) task 4, staged rollout part 1 of 2. Today any caller who can set `x-clerk-user-id` can perform every employer-review mutation — including a clinician accepting **their own** passport. This PR adds a server-side role gate on all five mutating routes (`accept`, `request-refresh`, `route-to-review`, `share-packet`, `confirm-start`):

- **Role source of truth**: `User` table (`clerkUserId → role/status`) — never caller-supplied headers (the existing `x-verifier-team-role` header remains display/telemetry only).
- **Decision core**: pure module `services/authz/employerActionRbac.ts` — no User row → deny (`rbac_unknown_user`); `SUSPENDED`/`DEACTIVATED` → deny (`rbac_user_inactive`); `CLINICIAN`/`ISSUER` → deny (`rbac_role_not_permitted`); `VERIFIER`/`ADMIN` → allow. `INVITED` is not hard-denied (schema default; shadow metrics decide any tightening).
- **Shadow-first rollout**: `VERIFIER_RBAC_ENFORCED` (Zod env flag, default **false**) — shadow mode logs `employer_rbac_shadow_would_deny` and never blocks, so the golden path (Recognition→Acceptance→Start) cannot break before production role coverage is verified. Enforced mode writes the existing `EMPLOYER_REVIEW_MUTATION_DENIED` AuditEvent (audit-first) then rejects 403.
- Deliberately **not** in the `SYSTEM_FROZEN` blocklist — freezing features must not switch a security control off.

**Part 2 (separate PR, after prod shadow verification + flag flip)**: default-on enforcement + flip `rbacEnforced` in `apps/web/lib/verifier/orgRolesFoundation.ts` + update the `foundation-sweep-7` truth pin. The web foundation flag stays honestly `false` until enforcement is real in production.

## Truth rules

- No claim RBAC is enforced anywhere until the flag is verified on in prod — web foundation + its truth-pin test untouched by design.
- Audit-first preserved: enforced denials write the AuditEvent before the 403.
- No Prisma schema changes, no migrations, no web-app changes.

## Validation

- Pure decision-matrix tests: 7/7 (`services/authz/__tests__/employerActionRbac.test.ts`)
- Backend `tsc --noEmit`: clean · `pnpm lint`: clean · truth scan on diff: clean
- Shadow-mode neutrality: deny path only logs; the sole addition to existing allowed flows is one `prisma.user.findUnique` read per mutation
- Follow-up (named): enforced-mode DB test in `routes/__tests__/employerActions.test.ts` toggling `VERIFIER_RBAC_ENFORCED=true` (403 + audit row)

## Tier / merge gate

**Tier 2 (security-sensitive) — do not self-merge.** Codex is usage-limited until Aug 3; per the agreed blackout policy this PR waits for founder review (or Codex when quota returns).

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)