### PR TITLE
fix(wave0): run NPPES version assertion on the production entrypoint

### DIFF
--- a/apps/api/backend/src/server.ts
+++ b/apps/api/backend/src/server.ts
@@ -193,6 +193,20 @@ async function bootstrapApp() {
   const cronMod = await import('node-cron');
 
   const config = loadEnv();
+
+  // NPPES V1 sunset 2026-03-03 — this is the production entrypoint
+  // (railway.toml startCommand runs server.js, not index.js), so the
+  // version guard must fire here. A drifted endpoint constant throws,
+  // which surfaces through the bootstrap failure path instead of
+  // silently degrading NPI enrichment.
+  const { assertNppesApiVersion } = await import('./services/identity/nppesApiVersion');
+  const nppes = assertNppesApiVersion();
+  log('info', 'NPPES API version pinned', {
+    event: 'nppes_api_version',
+    version: nppes.version,
+    endpoints: nppes.endpoints,
+  });
+
   await ensureInvestigationSeedDataBootstrapped({ logger: log });
   if (config.NODE_ENV === 'production') {
     await ensureLaunchOpportunitiesBootstrapped({ logger: log });

--- a/docs/ops/REBASELINE-2026-07-04.md
+++ b/docs/ops/REBASELINE-2026-07-04.md
@@ -32,7 +32,7 @@
 - Every runtime NPPES endpoint constant targets **API v2.1**: `apps/api/backend/src/modules/identity/nppes.service.ts`, `apps/api/backend/src/engine/adapters/nppesAdapter.ts`, `apps/api/backend/adapters/NppesAdapter.ts` (legacy path, still live — imported by `psvOrchestrator`, `PsvOrchestrator`, `verifyRoute`). Web-side probes/diagnostics also pin v2.1.
 - **Zero V1 references** anywhere in `apps/`, `packages/`, `scripts/` (negative scan for `version=1` / V1 dissemination names).
 - Bulk files: `sourceCatalog.ts` `NPPES_BULK` entry already points at the V2 file surface (`download.cms.gov/nppes/NPI_Files.html`). Note: there is **no bulk-file downloader implementation** — runtime NPI enrichment is API-only today. Bulk ingestion remains a phase-1 open item, not a pilot blocker.
-- **Runtime assertion added** (this wave): `apps/api/backend/src/services/identity/nppesApiVersion.ts` imports the three real endpoint constants and refuses boot if any is not pinned to v2.1; `startServer()` logs `nppes_api_version` on success.
+- **Runtime assertion added** (this wave): `apps/api/backend/src/services/identity/nppesApiVersion.ts` imports the three real endpoint constants and refuses boot if any is not pinned to v2.1; logs `nppes_api_version` on success. Wired into **both** entrypoints: `index.ts` `startServer()` (dev/local) and `server.ts` `bootstrapApp()` — the production entry per `railway.toml` `startCommand`, added in a follow-up fix after the first deploy proved container health but not assertion execution.
 
 ## Local-only artifacts noted
 


### PR DESCRIPTION
## Summary

Follow-up to #541. The Wave 0 NPPES v2.1 boot assertion was wired into `index.ts` `startServer()`, but production runs `server.js` (`railway.toml` `startCommand`) — so the first deploy proved container health, not assertion execution. This wires `assertNppesApiVersion()` into `server.ts` `bootstrapApp()` immediately after `loadEnv()`: a drifted endpoint constant now throws through the bootstrap failure path, and the `nppes_api_version` log line becomes visible in production logs (deploy verification will grep for it).

- `apps/api/backend/src/server.ts`: dynamic-import + assert + log, matching the file's bootstrap idiom.
- `docs/ops/REBASELINE-2026-07-04.md`: assertion bullet corrected to name both entrypoints and the reason.

## Truth rules

No copy changes; no behavior change beyond the guard; no schema changes.

## Validation

- Backend `tsc --noEmit`: clean
- Assertion logic itself unchanged (runtime-smoked in #541: `{"version":"2.1","endpoints":[3]}`)
- Post-merge: Railway deploy watched to SUCCESS + production log grep for `nppes_api_version`

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)