### PR TITLE
ci(release-verify): neutral status when the monitor is unwired

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -14,6 +14,11 @@ name: Release verify
 # /auth/resolving interstitial, runs `pnpm check:deploy`, and records a DURABLE
 # GitHub commit status (context "vitalcv/release-verified") on the verified SHA.
 #
+# If CLERK_SECRET_KEY is unset the monitor is "not wired": it cannot mint a
+# session, so rather than post a red failure that reads as a broken deploy it
+# skips verification and records a NEUTRAL `pending` status ("skipped — monitor
+# not wired"). This self-heals — set the secret and the next run verifies for real.
+#
 # Required repo secrets: CLERK_SECRET_KEY, RAILWAY_API_TOKEN. Optional:
 # CLERK_FAPI_URL (default https://clerk.vitalcv.com), RELEASE_PROBE_BASE
 # (default https://vitalcv.com). GITHUB_TOKEN is automatic (statuses: write).
@@ -79,8 +84,27 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "Target SHA: ${SHA:-(main HEAD)}"
 
+      - name: Preflight — is the monitor wired?
+        id: preflight
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+        run: |
+          # The signed-in verification cannot run without a Clerk backend key to
+          # mint a synthetic session. When it is absent the monitor is "not wired":
+          # skip verification and post a NEUTRAL status (below) instead of a red
+          # failure that reads as a broken deploy. Self-heals — the moment
+          # CLERK_SECRET_KEY is set this passes and full verification runs.
+          if [ -n "${CLERK_SECRET_KEY}" ]; then
+            echo "wired=true" >> "$GITHUB_OUTPUT"
+            echo "Monitor wired — running full signed-in verification."
+          else
+            echo "wired=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLERK_SECRET_KEY unset — monitor not wired; skipping verification and posting a neutral status."
+          fi
+
       - name: Run release verification
         id: verify
+        if: steps.preflight.outputs.wired == 'true'
         continue-on-error: true
         # Bounded below the job budget so the status-recording step ALWAYS has
         # time to run — a hung verification must still yield a red commit status.
@@ -103,12 +127,24 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           TARGET_SHA: ${{ steps.target.outputs.sha }}
           VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          WIRED: ${{ steps.preflight.outputs.wired }}
         run: |
-          if [ "$VERIFY_OUTCOME" = "success" ]; then STATE=success; else STATE=failure; fi
+          # The commit Status API has no `neutral` state (that lives in the Checks
+          # API); `pending` is its non-pass/non-fail signal and renders as a grey
+          # dot — deliberately NOT the red X that reads as a broken deploy.
+          if [ "$WIRED" != "true" ]; then
+            STATE=pending
+            DESC="skipped — monitor not wired (set CLERK_SECRET_KEY)"
+          elif [ "$VERIFY_OUTCOME" = "success" ]; then
+            STATE=success
+            DESC="release verification"
+          else
+            STATE=failure
+            DESC="release verification"
+          fi
 
           SHA=""
-          DESC="release verification"
-          if [ -f report.json ]; then
+          if [ "$WIRED" = "true" ] && [ -f report.json ]; then
             # The status lands on the commit we INTENDED to verify (the deploy
             # commit), falling back to the served/main sha for scheduled runs.
             # Never containerSha-first: a failed rollout would repaint the OLD
@@ -149,7 +185,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail the job when verification failed
-        if: steps.verify.outcome != 'success'
+        # Only a wired run can fail red; an unwired run posts neutral and exits 0.
+        if: steps.preflight.outputs.wired == 'true' && steps.verify.outcome != 'success'
         run: |
           echo "::error::Release verification failed — see the vitalcv/release-verified commit status and the job summary." >&2
           exit 1

--- a/docs/deployment/release-monitoring.md
+++ b/docs/deployment/release-monitoring.md
@@ -50,7 +50,7 @@ POST /api/internal/release-monitor/webhook      ← thin bridge, runs in web con
    │    7. cleanup the synthetic user + org (always)
    ▼
 GitHub commit status on the verified SHA        ← DURABLE SIGNAL
-   context "vitalcv/release-verified" · success/failure · target_url = the run
+   context "vitalcv/release-verified" · success/failure/pending · target_url = the run
 ```
 
 ### Why the harness runs on GitHub Actions, not in the container
@@ -111,7 +111,8 @@ an unrelated commit. A genuinely-missed webhook is backstopped by the schedule.
 
 The primary durable record is a **GitHub commit status** on the verified SHA:
 
-- context `vitalcv/release-verified`, state `success`/`failure`,
+- context `vitalcv/release-verified`, state `success`/`failure` (or a neutral
+  `pending` when the monitor is not wired — see the fail-closed matrix below),
   `target_url` = the workflow run, description = e.g. `pass: holder 6/6`.
 - Survives deploys, is keyed by SHA, and is queryable:
   `gh api repos/ctol3r/vitalcv/commits/<sha>/status`.
@@ -215,9 +216,11 @@ gate. The receiver route itself is harmless when unwired — it fails closed
 
 **Fail-closed matrix:** no receiver secret → 500, never dispatches · missing
 `GITHUB_DISPATCH_TOKEN` → 500 + container log · missing `CLERK_SECRET_KEY` on
-the runner → crisp `synthetic_session` failure → red status · missing
-`RAILWAY_API_TOKEN` → `deploy_integrity` failure → red status. No missing
-secret can produce a false green.
+the runner → monitor is **not wired**: a preflight skips verification and posts
+a NEUTRAL `pending` status (never a red false-negative), self-healing the moment
+the secret is set · `CLERK_SECRET_KEY` set but `RAILWAY_API_TOKEN` missing →
+`deploy_integrity` failure → red status. No missing secret can produce a false
+green.
 
 ## Failure modes
 
@@ -242,6 +245,9 @@ secret can produce a false green.
 - **A red status** → open the linked run; the job summary lists the failing
   checks. `holder:*` red = the signed-in flow is broken for real clinicians
   (treat as a P0). `web_sha` red on a webhook run = the new code is not serving.
+- **A neutral `pending` status** ("skipped — monitor not wired") → *not* a broken
+  deploy; `CLERK_SECRET_KEY` is unset so verification never ran. Set the owner
+  secrets (above) and the next run verifies for real.
 - **Re-run manually:** Actions → *Release verify* → *Run workflow* (optionally
   pass a `target_sha`).
 - **Run locally against prod:**


### PR DESCRIPTION
## What & why

`.github/workflows/release-verify.yml` posts a red `vitalcv/release-verified`
**`fail: holder 0/6`** on every run against production — but it's a **false
negative**. The synthetic-session step can't mint a Clerk session without
`CLERK_SECRET_KEY`, so the runner logs `CLERK_FAPI_URL:` empty and all six
`/holder` probes print `skipped — no session`. `0/6` says nothing about whether
the signed-in flow works — it was **never exercised**. The signed-in path itself
is fine (verified `holder 6/6` via the curl harness on deploy `c7062badd`), but
the red reads as a broken deploy and has to be manually ignored.

Root cause is unset GitHub Actions secrets (owner-only / Tier-3 to set). This PR
doesn't set them — it makes the monitor **honest instead of ignorable** while
they're absent.

## Change

A `preflight` step detects the unwired state (`CLERK_SECRET_KEY` empty) and:
- **skips** the verification step (`if: steps.preflight.outputs.wired == 'true'`),
- records a **neutral `pending`** commit status — `skipped — monitor not wired
  (set CLERK_SECRET_KEY)` — instead of a red `failure`,
- lets the job **exit 0** (the fail-step is now gated on `wired == 'true'`).

**Self-healing:** the moment `CLERK_SECRET_KEY` is set, preflight passes and full
verification runs — no follow-up change needed.

> Note: the commit **Status** API has no `neutral` state (that's a **Checks** API
> concept). `pending` is its non-pass/non-fail signal and renders as a grey dot —
> deliberately *not* the red X that reads as a broken deploy. Nothing in the repo
> gates a merge on this context, so a `pending` state is safe.

### Behavior matrix

| Condition | Status posted | Job | Description |
|---|---|---|---|
| **Unwired** (secrets missing — today) | `pending` (grey) | **green, exit 0** | `skipped — monitor not wired (set CLERK_SECRET_KEY)` |
| Wired + healthy | `success` | green | `pass: holder 6/6` |
| Wired + broken | `failure` (red) | red, exit 1 | `fail: holder 0/6; failed synthetic_session` |

**Only the unwired row changes.** When wired, behavior is byte-for-byte what it is today.

## Testing

- YAML parses (8 steps; triggers intact); gates verified on the `verify` and
  fail steps.
- Executed the exact status-decision shell for all three paths — outputs match
  the matrix above (`pending`/green, `success`/green, `failure`/red).
- No unit-test impact: the change is workflow shell only; the release-monitor
  vitest suite covers the TS libs, untouched here.

## Docs

`docs/deployment/release-monitoring.md` — fail-closed matrix, durable-signal
section, ASCII diagram, and runbook updated (missing `CLERK_SECRET_KEY` now →
neutral, not red).

## Design Handoff References

No design handoff — CI workflow + ops docs only, no UI/design surface.

## Canon Checklist

- [x] Emits/preserves `Recognition` where required — N/A (CI + docs only)
- [x] Emits/preserves `Receipt` where required — N/A (CI + docs only)
- [x] CRS remains deterministic — N/A (no CRS surface touched)
- [x] Revocation/expiry fail-closed — N/A; and the monitor itself now fails
      *neutral* (never false-green) when unwired
- [x] UI/API reflects canonical truth — this is the point: a skipped check no
      longer masquerades as a failed one
