### PR TITLE
fix(auth): unblock /holder profile load — workspace bootstrap 401s behind tenant guard (P0)

### DIFF
--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -40,6 +40,16 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/clinician/activate')).toBe(false);
   });
 
+  it('skips tenant context for clerk-scoped workspace bootstrap routes', () => {
+    expect(shouldSkipTenantContext('/api/me/workspaces')).toBe(true);
+    expect(shouldSkipTenantContext('/api/workspaces/switch')).toBe(true);
+  });
+
+  it('keeps other workspace-prefixed routes protected', () => {
+    expect(shouldSkipTenantContext('/api/workspaces/other')).toBe(false);
+    expect(shouldSkipTenantContext('/api/me/workspaces/extra')).toBe(false);
+  });
+
   it('skips tenant context for public verifier reads (trust proof)', () => {
     expect(shouldSkipTenantContext('/api/trust-proof/1003000126')).toBe(true);
   });

--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -65,6 +65,12 @@ export function shouldSkipTenantContext(path: string): boolean {
     // Email-OTP identity binding: an onboarding-time possession factor scoped to
     // the Clerk user alone (no org context yet). Same rationale as /api/me/role.
     || normalized.startsWith('/api/profile/identity/')
+    // Workspace bootstrap: resolves by Clerk user id alone (x-clerk-user-id
+    // header) and *produces* the persona/org context the rest of the app runs
+    // on. Requiring org context before the workspace lookup is a chicken-and-
+    // egg 401 that dead-ends /holder ("Couldn't load your profile").
+    || normalized === '/api/me/workspaces'
+    || normalized === '/api/workspaces/switch'
     || normalized.startsWith('/demo')
     || normalized.startsWith('/.well-known')
     || normalized.startsWith('/api/.well-known')


### PR DESCRIPTION
## Summary

Signed-in production QA found every `/holder` surface firing `GET /api/me/workspaces` → **401**, dead-ending the clinician home on "Couldn't load your profile" (recognition shows its honest system-state banner; readiness silently degrades to the "Connect your NPI" empty state).

**Root cause (proven by probe, not inferred):** `curl` on the backend route with no headers returns `{"error":"organization_context_required"}` — the `tenantGuard` middleware intercepts before the workspace handler (whose own 401 says `Missing x-clerk-user-id header`). Clinician wallets have no org context; the workspace lookup is what *produces* persona/org context. Chicken-and-egg — byte-for-byte the `/api/me/role` bug class fixed in #503 and the `/api/profile/identity/*` skip added in #542.

**Fix:** add `/api/me/workspaces` and `/api/workspaces/switch` to `shouldSkipTenantContext` with the documented rationale. Exact-match entries only — `/api/workspaces/other` and `/api/me/workspaces/extra` remain guarded (negative tests added). Both routes still authenticate via `x-clerk-user-id` (the same transport-auth posture as `/api/me/role`; the header-trust hardening follow-up remains tracked from Wave 2C).

## Truth rules

No copy changes. No new claims. No schema changes. Auth posture unchanged apart from org-context exemption for two clerk-scoped bootstrap reads/switches.

## Validation

- `jest src/middleware/__tests__/tenantGuard.test.ts`: **9/9** (2 new positive, 1 new negative pair)
- Backend `tsc --noEmit`: clean
- Post-merge: Railway deploy watch + **live signed-in browser re-verification** that `/holder` loads the profile (the failing surface that found this)

## Design Handoff References

No Claude Design handoff file used for this PR (backend middleware fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)