### PR TITLE
feat(backend): SAM.gov exclusions honest gated adapter (launch-blocker #7)

### DIFF
--- a/apps/api/backend/src/config/env.ts
+++ b/apps/api/backend/src/config/env.ts
@@ -148,6 +148,10 @@ const envSchema = z.object({
   }, z.boolean()),
   SYSTEM_FROZEN: z.preprocess((raw) => parseBooleanEnvVar(raw, 'SYSTEM_FROZEN', false), z.boolean()),
   REAL_NURSYS_ENABLED: z.preprocess((raw) => parseBooleanEnvVar(raw, 'REAL_NURSYS_ENABLED', false), z.boolean()),
+  // Live SAM.gov exclusion checks (services/samGovAdapter.ts). Default false:
+  // the lane stays an honest gated stub until SAM_GOV_API_KEY is configured
+  // and a live fetcher is wired.
+  SAM_GOV_ENABLED: z.preprocess((raw) => parseBooleanEnvVar(raw, 'SAM_GOV_ENABLED', false), z.boolean()),
   // RBAC rollout for employer-review mutations. false = shadow mode (log
   // would-deny, never block); true = enforce (403 + denied-mutation audit).
   // Deliberately NOT in the SYSTEM_FROZEN blocklist: freezing features must
@@ -241,6 +245,7 @@ export function loadEnv(): Env {
     const blockedFlags = {
       ENTERPRISE_MODE: result.data.ENTERPRISE_MODE,
       REAL_NURSYS_ENABLED: result.data.REAL_NURSYS_ENABLED,
+      SAM_GOV_ENABLED: result.data.SAM_GOV_ENABLED,
       LOW_FRICTION_MODE: result.data.LOW_FRICTION_MODE,
     } as const;
 
@@ -262,6 +267,7 @@ export function loadEnv(): Env {
       ...result.data,
       ENTERPRISE_MODE: false,
       REAL_NURSYS_ENABLED: false,
+      SAM_GOV_ENABLED: false,
       LOW_FRICTION_MODE: false,
     };
   }

--- a/apps/api/backend/src/services/__tests__/samGovAdapter.test.ts
+++ b/apps/api/backend/src/services/__tests__/samGovAdapter.test.ts
@@ -1,0 +1,261 @@
+import {
+  buildSamGovConnectorSnapshot,
+  computeSamGovArtifactChecksum,
+  isSamGovApiKeyConfigured,
+  isSamGovEnabled,
+  normalizeSamGovResult,
+  querySamGovExclusions,
+  SAM_GOV_EXCLUSIONS_API_BASE,
+  type SamGovExclusionQuery,
+  type SamGovExclusionRecord,
+  type SamGovExclusionResult,
+} from '../samGovAdapter';
+import { sha256ForPayload } from '../../utils/deterministic';
+
+const QUERY = { npi: '1234567890', firstName: 'Jane', lastName: 'Doe' } as const;
+
+const SAMPLE_RECORD: SamGovExclusionRecord = {
+  classificationType: 'Individual',
+  exclusionType: 'Ineligible (Proceedings Completed)',
+  exclusionProgram: 'Reciprocal',
+  excludingAgencyCode: 'HHS',
+  activeDate: '2024-01-15',
+  terminationDate: null,
+};
+
+function liveResult(overrides: Partial<SamGovExclusionResult> = {}): SamGovExclusionResult {
+  return {
+    checkStatus: 'NO_EXCLUSION_RECORDS_FOUND',
+    matchType: 'NO_MATCH',
+    totalRecords: 0,
+    records: [],
+    searchedNpi: QUERY.npi,
+    searchedName: 'Jane Doe',
+    sourceScope: 'SAM_GOV_EXCLUSIONS_API',
+    sourceUrl: SAM_GOV_EXCLUSIONS_API_BASE,
+    sourceQueriedAt: '2026-07-04T00:00:00.000Z',
+    connectorState: 'configured',
+    coverageState: 'checked',
+    reviewRequired: false,
+    ...overrides,
+  };
+}
+
+describe('samGovAdapter', () => {
+  const savedEnabled = process.env.SAM_GOV_ENABLED;
+  const savedApiKey = process.env.SAM_GOV_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.SAM_GOV_ENABLED;
+    delete process.env.SAM_GOV_API_KEY;
+  });
+
+  afterAll(() => {
+    if (savedEnabled === undefined) delete process.env.SAM_GOV_ENABLED;
+    else process.env.SAM_GOV_ENABLED = savedEnabled;
+    if (savedApiKey === undefined) delete process.env.SAM_GOV_API_KEY;
+    else process.env.SAM_GOV_API_KEY = savedApiKey;
+  });
+
+  describe('gating helpers', () => {
+    it('is disabled by default and only enabled by the literal "true"', () => {
+      expect(isSamGovEnabled()).toBe(false);
+      process.env.SAM_GOV_ENABLED = 'false';
+      expect(isSamGovEnabled()).toBe(false);
+      process.env.SAM_GOV_ENABLED = '1';
+      expect(isSamGovEnabled()).toBe(false);
+      process.env.SAM_GOV_ENABLED = 'true';
+      expect(isSamGovEnabled()).toBe(true);
+    });
+
+    it('treats an unset, empty, or whitespace API key as not configured', () => {
+      expect(isSamGovApiKeyConfigured()).toBe(false);
+      process.env.SAM_GOV_API_KEY = '';
+      expect(isSamGovApiKeyConfigured()).toBe(false);
+      process.env.SAM_GOV_API_KEY = '   ';
+      expect(isSamGovApiKeyConfigured()).toBe(false);
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      expect(isSamGovApiKeyConfigured()).toBe(true);
+    });
+  });
+
+  describe('buildSamGovConnectorSnapshot', () => {
+    it('reports gated when the flag is off', () => {
+      expect(buildSamGovConnectorSnapshot()).toEqual({
+        source: 'SAM_GOV',
+        enabled: false,
+        apiKeyConfigured: false,
+        state: 'unavailable',
+        coverageState: 'gated',
+      });
+    });
+
+    it('stays gated when only the API key is present (flag off dominates)', () => {
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      const snapshot = buildSamGovConnectorSnapshot();
+      expect(snapshot.coverageState).toBe('gated');
+      expect(snapshot.state).toBe('unavailable');
+    });
+
+    it('reports accessRequired when enabled without an API key', () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      const snapshot = buildSamGovConnectorSnapshot();
+      expect(snapshot.coverageState).toBe('accessRequired');
+      expect(snapshot.state).toBe('unavailable');
+    });
+
+    it('reports configured + pending when enabled with an API key', () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      const snapshot = buildSamGovConnectorSnapshot();
+      expect(snapshot.state).toBe('configured');
+      expect(snapshot.coverageState).toBe('pending');
+    });
+  });
+
+  describe('querySamGovExclusions — honest stub', () => {
+    it('returns EXCLUSION_CHECK_NOT_AVAILABLE by default and never fabricates an outcome', async () => {
+      const result = await querySamGovExclusions(QUERY);
+      expect(result.checkStatus).toBe('EXCLUSION_CHECK_NOT_AVAILABLE');
+      expect(result.matchType).toBe('NOT_ATTEMPTED');
+      expect(result.totalRecords).toBe(0);
+      expect(result.records).toEqual([]);
+      expect(result.coverageState).toBe('gated');
+      expect(result.reviewRequired).toBe(false);
+      expect(result.searchedNpi).toBe(QUERY.npi);
+      expect(result.searchedName).toBe('Jane Doe');
+      expect(result.unavailableReason).toContain('SAM_GOV_ENABLED');
+    });
+
+    it('does not call a fetcher while the flag is off', async () => {
+      const fetcher = jest.fn<Promise<SamGovExclusionResult>, [SamGovExclusionQuery]>();
+      const result = await querySamGovExclusions(QUERY, fetcher);
+      expect(fetcher).not.toHaveBeenCalled();
+      expect(result.checkStatus).toBe('EXCLUSION_CHECK_NOT_AVAILABLE');
+      expect(result.coverageState).toBe('gated');
+    });
+
+    it('does not call a fetcher when enabled without an API key', async () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      const fetcher = jest.fn<Promise<SamGovExclusionResult>, [SamGovExclusionQuery]>();
+      const result = await querySamGovExclusions(QUERY, fetcher);
+      expect(fetcher).not.toHaveBeenCalled();
+      expect(result.coverageState).toBe('accessRequired');
+      expect(result.unavailableReason).toContain('SAM_GOV_API_KEY');
+    });
+
+    it('stays pending when enabled with a key but no fetcher is wired', async () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      const result = await querySamGovExclusions(QUERY);
+      expect(result.checkStatus).toBe('EXCLUSION_CHECK_NOT_AVAILABLE');
+      expect(result.coverageState).toBe('pending');
+      expect(result.unavailableReason).toContain('fetcher not wired');
+    });
+
+    it('never reports a completed check from any gated combination', async () => {
+      const combos: Array<[string | undefined, string | undefined]> = [
+        [undefined, undefined],
+        ['true', undefined],
+        [undefined, 'real-key'],
+      ];
+      for (const [enabled, key] of combos) {
+        delete process.env.SAM_GOV_ENABLED;
+        delete process.env.SAM_GOV_API_KEY;
+        if (enabled !== undefined) process.env.SAM_GOV_ENABLED = enabled;
+        if (key !== undefined) process.env.SAM_GOV_API_KEY = key;
+        const result = await querySamGovExclusions(QUERY);
+        expect(result.checkStatus).toBe('EXCLUSION_CHECK_NOT_AVAILABLE');
+        expect(result.coverageState).not.toBe('checked');
+        expect(result.coverageState).not.toBe('reviewRequired');
+      }
+    });
+
+    it('delegates to the fetcher when enabled with a key', async () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      const fetcher = jest.fn().mockResolvedValue(liveResult());
+      const result = await querySamGovExclusions(QUERY, fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(fetcher).toHaveBeenCalledWith(QUERY);
+      expect(result.checkStatus).toBe('NO_EXCLUSION_RECORDS_FOUND');
+      expect(result.coverageState).toBe('checked');
+      expect(result.matchType).toBe('NO_MATCH');
+    });
+  });
+
+  describe('normalizeSamGovResult — fail closed', () => {
+    it('forces review on found records even when the fetcher under-reports them', () => {
+      const dishonest = liveResult({
+        checkStatus: 'NO_EXCLUSION_RECORDS_FOUND',
+        matchType: 'NO_MATCH',
+        totalRecords: 0,
+        records: [SAMPLE_RECORD],
+        coverageState: 'checked',
+        reviewRequired: false,
+      });
+      const normalized = normalizeSamGovResult(dishonest);
+      expect(normalized.checkStatus).toBe('EXCLUSION_RECORDS_FOUND');
+      expect(normalized.matchType).toBe('NAME_MATCH');
+      expect(normalized.totalRecords).toBe(1);
+      expect(normalized.coverageState).toBe('reviewRequired');
+      expect(normalized.reviewRequired).toBe(true);
+    });
+
+    it('treats a positive totalRecords as records found even with an empty records array', () => {
+      const normalized = normalizeSamGovResult(liveResult({ totalRecords: 3 }));
+      expect(normalized.checkStatus).toBe('EXCLUSION_RECORDS_FOUND');
+      expect(normalized.reviewRequired).toBe(true);
+      expect(normalized.coverageState).toBe('reviewRequired');
+      expect(normalized.totalRecords).toBe(3);
+    });
+
+    it('downgrades an incomplete check that claims checked coverage to unavailable', () => {
+      const normalized = normalizeSamGovResult(liveResult({
+        checkStatus: 'EXCLUSION_CHECK_NOT_AVAILABLE',
+        coverageState: 'checked',
+      }));
+      expect(normalized.coverageState).toBe('unavailable');
+      expect(normalized.matchType).toBe('NOT_ATTEMPTED');
+    });
+
+    it('passes an honest clear result through unchanged apart from the match type pin', () => {
+      const clear = liveResult({ matchType: 'NAME_MATCH' });
+      const normalized = normalizeSamGovResult(clear);
+      expect(normalized.checkStatus).toBe('NO_EXCLUSION_RECORDS_FOUND');
+      expect(normalized.coverageState).toBe('checked');
+      expect(normalized.matchType).toBe('NO_MATCH');
+      expect(normalized.reviewRequired).toBe(false);
+    });
+
+    it('applies fail-closed normalization to live fetcher results end to end', async () => {
+      process.env.SAM_GOV_ENABLED = 'true';
+      process.env.SAM_GOV_API_KEY = 'real-key';
+      const fetcher = jest.fn().mockResolvedValue(liveResult({
+        records: [SAMPLE_RECORD],
+        reviewRequired: false,
+        coverageState: 'checked',
+      }));
+      const result = await querySamGovExclusions(QUERY, fetcher);
+      expect(result.checkStatus).toBe('EXCLUSION_RECORDS_FOUND');
+      expect(result.reviewRequired).toBe(true);
+      expect(result.coverageState).toBe('reviewRequired');
+    });
+  });
+
+  describe('computeSamGovArtifactChecksum', () => {
+    it('is deterministic across key ordering and matches sha256ForPayload', () => {
+      const a = computeSamGovArtifactChecksum({ npi: QUERY.npi, totalRecords: 0 });
+      const b = computeSamGovArtifactChecksum({ totalRecords: 0, npi: QUERY.npi });
+      expect(a).toBe(b);
+      expect(a).toBe(sha256ForPayload({ npi: QUERY.npi, totalRecords: 0 }));
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces different checksums for different payloads', () => {
+      const a = computeSamGovArtifactChecksum({ npi: QUERY.npi, totalRecords: 0 });
+      const b = computeSamGovArtifactChecksum({ npi: QUERY.npi, totalRecords: 1 });
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/apps/api/backend/src/services/identity/sourceCatalog.ts
+++ b/apps/api/backend/src/services/identity/sourceCatalog.ts
@@ -171,7 +171,7 @@ export const SOURCE_CATALOG: Record<string, SourceDefinition> = {
     claimTypes: ['FEDERAL_EXCLUSION', 'EXCLUSION_STATUS'],
     parserVersion: 'v1.0.0', envFlag: 'SAM_GOV_ENABLED', liveAvailable: false,
     decisionGrade: true,
-    notes: 'Requires SAM.gov API key. Covers debarment, suspension, proposed debarment beyond healthcare.',
+    notes: 'Honest gated adapter (services/samGovAdapter.ts): coverage stays gated until SAM_GOV_ENABLED=true, then accessRequired until SAM_GOV_API_KEY is configured; checks resolve EXCLUSION_CHECK_NOT_AVAILABLE until a live fetcher is wired. SAM.gov has no NPI field — name-based hits require identity review and must never auto-block. liveAvailable flips true only when live access is real. Covers debarment, suspension, proposed debarment beyond healthcare.',
   },
 
   STATE_BOARD: {

--- a/apps/api/backend/src/services/samGovAdapter.ts
+++ b/apps/api/backend/src/services/samGovAdapter.ts
@@ -1,0 +1,242 @@
+import type { CanonicalSourceCoverageState } from '@vitalcv/trust-state';
+import { sha256ForPayload } from '../utils/deterministic';
+
+/**
+ * samGovAdapter.ts — SAM.gov Exclusions integration layer
+ *
+ * SAM.gov is the GSA-operated, government-wide exclusion and debarment
+ * registry. It is broader than OIG LEIE: it covers debarment, suspension,
+ * and proposed debarment across ALL federal programs, not just HHS.
+ *
+ * Authorization model:
+ *   - Public Exclusions API (api.sam.gov) — requires a free api.data.gov
+ *     key supplied via SAM_GOV_API_KEY; the free tier is quota-limited
+ *     (~10 requests/day), so production volume needs a higher tier
+ *   - SAM_GOV_ENABLED=true only when a key is configured and the quota
+ *     tier fits the expected check volume
+ *
+ * Matching model:
+ *   SAM.gov has NO NPI field — search is name-based only. Every positive
+ *   hit is therefore a NAME_MATCH that requires identity review before any
+ *   action is taken. A name-only hit must never auto-block a clinician.
+ */
+
+// ── Endpoint constants ───────────────────────────────────────────────────────
+
+/**
+ * Exclusions API base for the live fetcher (Exclusions API v4 per source
+ * governance). NOTE: the phase-2 ingestion lane (identity/phase2Sources.ts)
+ * currently calls the v3 endpoint; both remain served by api.sam.gov.
+ */
+export const SAM_GOV_EXCLUSIONS_API_BASE =
+  'https://api.sam.gov/entity-information/v4/exclusions';
+
+/** Human-facing source URL used for provenance on stub results. */
+export const SAM_GOV_SOURCE_URL = 'https://sam.gov/';
+
+// ── Gating (env-driven, read at call time like buildNursysContractSnapshot) ──
+
+export function isSamGovEnabled(): boolean {
+  return process.env.SAM_GOV_ENABLED === 'true';
+}
+
+export function isSamGovApiKeyConfigured(): boolean {
+  return Boolean(process.env.SAM_GOV_API_KEY?.trim());
+}
+
+// ── Result types ─────────────────────────────────────────────────────────────
+
+export type SamGovExclusionCheckStatus =
+  | 'EXCLUSION_RECORDS_FOUND'
+  | 'NO_EXCLUSION_RECORDS_FOUND'
+  | 'EXCLUSION_CHECK_NOT_AVAILABLE'; // lane gated, key missing, or API unreachable
+
+/** SAM.gov cannot match on NPI — a positive result is always a name match. */
+export type SamGovMatchType = 'NAME_MATCH' | 'NO_MATCH' | 'NOT_ATTEMPTED';
+
+export type SamGovConnectorState = 'configured' | 'unavailable';
+
+/**
+ * Coverage states this lane may legally emit, pinned to the canonical
+ * trust-state taxonomy so a rename there breaks this build.
+ *   gated          — SAM_GOV_ENABLED is false (lane switched off)
+ *   accessRequired — enabled but SAM_GOV_API_KEY is not configured
+ *   pending        — enabled + key present, live fetcher not wired/run yet
+ *   unavailable    — a live check was attempted but did not complete
+ *   checked        — a live check completed (only a real fetcher may produce this)
+ *   reviewRequired — live check found records; name match needs identity review
+ */
+export type SamGovCoverageState = Extract<
+  CanonicalSourceCoverageState,
+  'gated' | 'accessRequired' | 'pending' | 'unavailable' | 'checked' | 'reviewRequired'
+>;
+
+export interface SamGovExclusionRecord {
+  readonly classificationType:  string | null; // e.g. 'Individual', 'Firm'
+  readonly exclusionType:       string | null; // e.g. 'Ineligible (Proceedings Completed)'
+  readonly exclusionProgram:    string | null; // e.g. 'Reciprocal', 'Nonprocurement'
+  readonly excludingAgencyCode: string | null; // e.g. 'HHS', 'TREAS-OFAC'
+  readonly activeDate:          string | null;
+  readonly terminationDate:     string | null; // null = indefinite
+}
+
+export interface SamGovExclusionQuery {
+  /** Carried for subject linkage/provenance only — SAM.gov cannot search by NPI. */
+  readonly npi:        string;
+  readonly firstName?: string;
+  readonly lastName?:  string;
+}
+
+export interface SamGovExclusionResult {
+  readonly checkStatus:       SamGovExclusionCheckStatus;
+  readonly matchType:         SamGovMatchType;
+  readonly totalRecords:      number;
+  readonly records:           readonly SamGovExclusionRecord[];
+  readonly searchedNpi:       string;
+  readonly searchedName:      string | null;
+  readonly sourceScope:       'SAM_GOV_EXCLUSIONS_API';
+  readonly sourceUrl:         string;
+  readonly sourceQueriedAt:   string;
+  readonly connectorState:    SamGovConnectorState;
+  readonly coverageState:     SamGovCoverageState;
+  readonly reviewRequired:    boolean;
+  /** If checkStatus === 'EXCLUSION_CHECK_NOT_AVAILABLE', explains why */
+  readonly unavailableReason?: string;
+}
+
+export type SamGovFetcher = (query: SamGovExclusionQuery) => Promise<SamGovExclusionResult>;
+
+// ── Connector snapshot ───────────────────────────────────────────────────────
+
+export interface SamGovConnectorSnapshot {
+  readonly source:           'SAM_GOV';
+  readonly enabled:          boolean;
+  readonly apiKeyConfigured: boolean;
+  readonly state:            SamGovConnectorState;
+  /** Stub-side coverage — a live fetcher result supersedes this. */
+  readonly coverageState:    Extract<SamGovCoverageState, 'gated' | 'accessRequired' | 'pending'>;
+}
+
+export function buildSamGovConnectorSnapshot(): SamGovConnectorSnapshot {
+  const enabled = isSamGovEnabled();
+  const apiKeyConfigured = isSamGovApiKeyConfigured();
+
+  return {
+    source: 'SAM_GOV',
+    enabled,
+    apiKeyConfigured,
+    state: enabled && apiKeyConfigured ? 'configured' : 'unavailable',
+    coverageState: !enabled ? 'gated' : !apiKeyConfigured ? 'accessRequired' : 'pending',
+  };
+}
+
+// ── Stub (returns unavailable — do not fabricate an exclusion outcome) ──────
+
+function searchedNameOf(query: SamGovExclusionQuery): string | null {
+  const name = [query.firstName, query.lastName]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(' ');
+  return name.length > 0 ? name : null;
+}
+
+/**
+ * Stub implementation: returns EXCLUSION_CHECK_NOT_AVAILABLE — never
+ * fabricates a clear or excluded outcome.
+ *
+ * IMPORTANT: Do not replace this with fake-but-realistic data. A fabricated
+ * "no exclusion records" result would be materially misleading — an exclusion
+ * check that did not run must never read as clear.
+ */
+function unavailableStub(query: SamGovExclusionQuery): SamGovExclusionResult {
+  const snapshot = buildSamGovConnectorSnapshot();
+
+  const unavailableReason = !snapshot.enabled
+    ? 'SAM.gov exclusions lane is disabled. Set SAM_GOV_ENABLED=true with a configured SAM_GOV_API_KEY to allow live checks.'
+    : !snapshot.apiKeyConfigured
+      ? 'SAM.gov API key not configured. Set SAM_GOV_API_KEY (free api.data.gov key; free tier is quota-limited).'
+      : 'SAM.gov live fetcher not wired. The exclusion check was not performed.';
+
+  return {
+    checkStatus:      'EXCLUSION_CHECK_NOT_AVAILABLE',
+    matchType:        'NOT_ATTEMPTED',
+    totalRecords:     0,
+    records:          [],
+    searchedNpi:      query.npi,
+    searchedName:     searchedNameOf(query),
+    sourceScope:      'SAM_GOV_EXCLUSIONS_API',
+    sourceUrl:        SAM_GOV_SOURCE_URL,
+    sourceQueriedAt:  new Date().toISOString(),
+    connectorState:   snapshot.state,
+    coverageState:    snapshot.coverageState,
+    reviewRequired:   false,
+    unavailableReason,
+  };
+}
+
+// ── Fail-closed normalization ────────────────────────────────────────────────
+
+/**
+ * Enforce fail-closed invariants on a live fetcher result:
+ *   1. Any exclusion records found → reviewRequired=true and
+ *      coverageState='reviewRequired' (name matches must never auto-clear
+ *      nor silently pass).
+ *   2. A check that did not complete may never present as 'checked' or
+ *      'reviewRequired' — it is downgraded to 'unavailable'.
+ *   3. A no-records result must not carry a NAME_MATCH.
+ */
+export function normalizeSamGovResult(result: SamGovExclusionResult): SamGovExclusionResult {
+  const recordsFound =
+    result.checkStatus === 'EXCLUSION_RECORDS_FOUND'
+    || result.totalRecords > 0
+    || result.records.length > 0;
+
+  if (recordsFound) {
+    return {
+      ...result,
+      checkStatus:    'EXCLUSION_RECORDS_FOUND',
+      matchType:      'NAME_MATCH',
+      totalRecords:   Math.max(result.totalRecords, result.records.length),
+      coverageState:  'reviewRequired',
+      reviewRequired: true,
+    };
+  }
+
+  if (result.checkStatus === 'EXCLUSION_CHECK_NOT_AVAILABLE') {
+    const coverageState =
+      result.coverageState === 'checked' || result.coverageState === 'reviewRequired'
+        ? 'unavailable'
+        : result.coverageState;
+    return { ...result, matchType: 'NOT_ATTEMPTED', coverageState };
+  }
+
+  return { ...result, matchType: 'NO_MATCH' };
+}
+
+/**
+ * Query SAM.gov exclusions for a clinician.
+ *
+ * When SAM_GOV_ENABLED=false (default): returns the unavailable stub.
+ * When enabled + SAM_GOV_API_KEY configured + fetcher provided: uses the
+ * fetcher (real Exclusions API client) and enforces fail-closed invariants.
+ * A fetcher without the flag and key never runs — the lane stays honest
+ * about its gated/accessRequired coverage until access is real.
+ */
+export async function querySamGovExclusions(
+  query: SamGovExclusionQuery,
+  fetcher?: SamGovFetcher,
+): Promise<SamGovExclusionResult> {
+  if (isSamGovEnabled() && isSamGovApiKeyConfigured() && fetcher) {
+    return normalizeSamGovResult(await fetcher(query));
+  }
+  // No live access — return honest unavailable state
+  return unavailableStub(query);
+}
+
+/**
+ * Compute a SHA-256 checksum for a serialized payload.
+ * Uses deterministic JSON key ordering for reproducibility.
+ */
+export function computeSamGovArtifactChecksum(payload: unknown): string {
+  return sha256ForPayload(payload);
+}

--- a/docs/ops/launch-blockers.md
+++ b/docs/ops/launch-blockers.md
@@ -15,7 +15,7 @@ This file lists **only genuinely-open items**, each with its owning wave from th
 | 4 | E2E signup happy-path + fail-closed test | No e2e covering role→NPI→confirm→attest→wallet, nor a BLOCKED-passport-cannot-be-accepted case | B (gates A's acceptance) |
 | 5 | OWASP ASVS **L2** mapping | `docs/security/asvs-scorecard.md` covers L1 only | B |
 | 6 | STATE_BOARD / FSMB physician-licensure lane | Gated, no live adapter behind `STATE_BOARD_ENABLED`; license claims must stay `gated`, never `checked` | C |
-| 7 | SAM.gov exclusions adapter | Absent; OIG/LEIE is the only live exclusion source | C |
+| 7 | SAM.gov exclusions adapter | Honest gated adapter landed (`services/samGovAdapter.ts`, `SAM_GOV_ENABLED` default false); live API key + fetcher wiring outstanding — coverage stays `gated`/`accessRequired`, OIG/LEIE remains the only live exclusion source | C |
 | 8 | Nursys institutional access | Adapter is an honest gated stub (`nursysAdapter.ts`) — real E-Notify agreement + fetcher wiring outstanding; must stay `gated`/`accessRequired` | C |
 | 9 | Continuous monitoring not enabled | Wave 245 scheduler exists (`services/async/monitoringScheduler.ts`, `MONITORING_ENABLED` default false); NCQA-cadence re-checks not running | D |
 | 10 | NPPES bulk-file ingestion | Catalog declares V2 bulk surface; no downloader implementation — runtime enrichment is API-v2.1-only (asserted at boot) | C/D (phase 1, not a pilot blocker) |


### PR DESCRIPTION
## Summary

God-mode **Wave C task 2** — closes the "adapter absent" half of launch-blockers row 7 (SAM.gov exclusions). Adds a governed SAM.gov Exclusions integration layer modeled exactly on the honest-stub pattern in `apps/api/backend/src/services/nursysAdapter.ts`.

- **`apps/api/backend/src/services/samGovAdapter.ts`** (new): `querySamGovExclusions()` returns `EXCLUSION_CHECK_NOT_AVAILABLE` unless `SAM_GOV_ENABLED=true`, `SAM_GOV_API_KEY` is configured, **and** a live fetcher is provided — it never fabricates a clear or an excluded outcome. A fetcher passed while the lane is gated is never called.
- **Fail-closed normalization** (`normalizeSamGovResult`): SAM.gov has no NPI field, so any found records are forced to `NAME_MATCH` + `reviewRequired: true` + coverage `reviewRequired` (a name hit must never auto-clear, auto-block, or silently pass); an incomplete check claiming `checked` coverage is downgraded to `unavailable`.
- **Provenance**: `computeSamGovArtifactChecksum()` via `sha256ForPayload` (deterministic key ordering), same as the Nursys layer.
- **`config/env.ts`**: `SAM_GOV_ENABLED` added with the existing `z.preprocess` boolean idiom (default **false**), and added to the `SYSTEM_FROZEN` blocklist alongside `REAL_NURSYS_ENABLED` — freezing the system force-disables live SAM calls (the `process.env` write also flows through `isSourceFlagEnabled`).
- **`sourceCatalog.ts`**: `SAM_GOV` entry notes now state the honest coverage ladder — `gated` until `SAM_GOV_ENABLED=true`, then `accessRequired` until the key is configured, `pending` until a live fetcher is wired; `liveAvailable` stays `false`.
- **`docs/ops/launch-blockers.md`** row 7 evidence updated **in place** (item stays open — live key + fetcher wiring outstanding, mirroring the Nursys row 8 idiom).

## Coverage-state honesty (acceptance bar)

Coverage states are pinned to the canonical `@vitalcv/trust-state` taxonomy via `Extract<CanonicalSourceCoverageState, …>`, so a rename there breaks this build. The stub can only ever emit `gated` / `accessRequired` / `pending`; `checked` and `reviewRequired` are reachable exclusively through a real fetcher result. Nothing user-facing claims SAM is checked or integrated — no UI copy changed.

## Verification

- `pnpm --filter chai-vc-platform-backend exec jest src/services/__tests__/samGovAdapter.test.ts` — **19/19 pass** (pure, no DB)
- `cd apps/api/backend && pnpm exec tsc --noEmit` — clean
- `pnpm typecheck` — clean · `pnpm lint` — clean
- `pnpm turbo run build --filter @vitalcv/web` — clean (worktree ritual)
- Banned-strings sweep over all changed files — clean

## Design Handoff References

> No Claude Design handoff file used for this PR.

## Standing guardrails

No mutations (audit-first N/A) · exclusion findings fail closed (`reviewRequired`, never silent pass) · no PHI · no prisma migrations · attested ≠ source-checked preserved (an unrun check never reads as clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)