### PR TITLE
fix(copy): applications surface — replace 'verified profile' with 'source-backed profile'

### DIFF
--- a/apps/web/components/mobile/ClinicianApplicationsSurface.tsx
+++ b/apps/web/components/mobile/ClinicianApplicationsSurface.tsx
@@ -94,7 +94,7 @@ export default function ClinicianApplicationsSurface() {
           <div>
             <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">What completed because of VitalCV</p>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-              Application progress is recorded against your verified profile, readiness, and follow-up state.
+              Application progress is recorded against your source-backed profile, readiness, and follow-up state.
             </p>
           </div>
           <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-right">


### PR DESCRIPTION
## Summary

Signed-in QA (2026-07-05) found live `/holder/applications` copy claiming progress is recorded against "your **verified profile**" — a banned truth-contract phrase. One-string fix to the doctrine term "source-backed profile" in `ClinicianApplicationsSurface.tsx`.

## Truth rules

Removes an overclaim; adds none. No other copy touched.

## Validation

- `vitest run __tests__/foundation-sweep-5.test.ts __tests__/application-detail-surface.test.tsx`: 30/30
- Post-merge: live copy re-check on /holder/applications in the signed-in browser session

## Design Handoff References

No Claude Design handoff file used for this PR (truth-contract copy fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)