### PR TITLE
feat(matcha): source-refresh events in the daily brief

### DIFF
--- a/apps/web/__tests__/matcha-daily.test.ts
+++ b/apps/web/__tests__/matcha-daily.test.ts
@@ -6,7 +6,9 @@ import {
   daysBetween,
   gapNudge,
   toISODate,
+  trustEventNotes,
   type DailyDelta,
+  type TrustHistoryEventLike,
 } from '../lib/matcha/daily';
 
 const EMPTY: DailyDelta = {
@@ -78,6 +80,59 @@ describe('daily — brief items are grounded in real deltas', () => {
   it('marks a readiness drop as neutral, not celebratory', () => {
     const item = buildBriefItems({ ...EMPTY, readinessScore: 64, readinessDelta: -4 }).find((i) => i.id === 'readiness')!;
     expect(item.tone).toBe('neutral');
+  });
+});
+
+describe('daily — source-refresh events from trust history', () => {
+  const entry = (over: Partial<TrustHistoryEventLike>): TrustHistoryEventLike => ({
+    computedAt: '2026-07-04T09:00:00.000Z',
+    deltaScore: null,
+    newGaps: [],
+    resolvedGaps: [],
+    reason: null,
+    ...over,
+  });
+
+  it('emits nothing on a first-ever visit (no baseline) — old history is not "news"', () => {
+    expect(trustEventNotes([entry({})], null)).toHaveLength(0);
+  });
+
+  it('includes only events strictly after the previous visit day', () => {
+    const events = [
+      entry({ computedAt: '2026-07-01T10:00:00.000Z', reason: 'old check' }),
+      entry({ computedAt: '2026-07-04T10:00:00.000Z', reason: 'License re-checked with the state board' }),
+    ];
+    const notes = trustEventNotes(events, '2026-07-02');
+    expect(notes).toHaveLength(1);
+    expect(notes[0].text).toContain('state board');
+  });
+
+  it('phrases resolved gaps as wins and new gaps as nudges', () => {
+    const resolved = trustEventNotes([entry({ resolvedGaps: ['DEA registration confirmed'] })], '2026-07-02')[0];
+    expect(resolved.tone).toBe('up');
+    expect(resolved.text).toContain('DEA registration confirmed');
+    const flagged = trustEventNotes([entry({ newGaps: ['License expiring soon'] })], '2026-07-02')[0];
+    expect(flagged.tone).toBe('nudge');
+  });
+
+  it('falls back to a plain re-check line and caps at 2', () => {
+    const notes = trustEventNotes([entry({}), entry({}), entry({})], '2026-07-02');
+    expect(notes).toHaveLength(2);
+    expect(notes[0].text).toBe('Your sources were re-checked');
+  });
+
+  it('source events appear in the brief between readiness and memory notes', () => {
+    const items = buildBriefItems({
+      ...EMPTY,
+      completeness: 50,
+      readinessScore: 70,
+      readinessDelta: 3,
+      sourceEvents: [{ text: 'Resolved since your last visit: DEA registration confirmed', tone: 'up' }],
+      memoryNotes: ['You updated your target compensation.'],
+    });
+    const ids = items.map((i) => i.id);
+    expect(ids.indexOf('readiness')).toBeLessThan(ids.findIndex((id) => id.startsWith('src-')));
+    expect(ids.findIndex((id) => id.startsWith('src-'))).toBeLessThan(ids.findIndex((id) => id.startsWith('mem-')));
   });
 });
 

--- a/apps/web/components/matcha/MatchaDailyBrief.tsx
+++ b/apps/web/components/matcha/MatchaDailyBrief.tsx
@@ -18,7 +18,7 @@ import { useMatchaPreferences } from './useMatchaPreferences';
 import { useMatchaOpportunities } from './useMatchaOpportunities';
 import { useOpportunityActions } from './useOpportunityActions';
 import { useMatchaDaily } from './useMatchaDaily';
-import { buildBriefItems, gapNudge, type BriefItem, type BriefTone } from '@/lib/matcha/daily';
+import { buildBriefItems, gapNudge, trustEventNotes, type BriefItem, type BriefTone } from '@/lib/matcha/daily';
 import { CATEGORY_META, allCategoryProgress } from '@/lib/matcha/categories';
 
 const TONE_DOT: Record<BriefTone, string> = {
@@ -118,6 +118,11 @@ export function MatchaDailyBrief() {
     return progress ? CATEGORY_META[progress.category].label : null;
   }, [preferences]);
 
+  const sourceEvents = useMemo(
+    () => trustEventNotes(data.trustHistory ?? [], daily.prevVisit),
+    [data.trustHistory, daily.prevVisit],
+  );
+
   const items = useMemo(
     () =>
       buildBriefItems({
@@ -127,9 +132,10 @@ export function MatchaDailyBrief() {
         readinessDelta: daily.readinessDelta,
         completeness,
         memoryNotes: daily.memoryNotes,
+        sourceEvents,
         gapNudge: gapNudge(completeness, thinnest),
       }),
-    [bucketCounts.new, bucketCounts.saved, readinessScore, daily.readinessDelta, completeness, daily.memoryNotes, thinnest],
+    [bucketCounts.new, bucketCounts.saved, readinessScore, daily.readinessDelta, completeness, daily.memoryNotes, sourceEvents, thinnest],
   );
 
   if (!daily.loaded) return null;

--- a/apps/web/components/matcha/MatchaExperienceShowcase.tsx
+++ b/apps/web/components/matcha/MatchaExperienceShowcase.tsx
@@ -19,6 +19,7 @@ const SAMPLE_ITEMS = buildBriefItems({
   readinessDelta: 6,
   completeness: 62,
   memoryNotes: ['You added Washington to where you want to work.'],
+  sourceEvents: [{ text: 'Resolved since your last visit: state license re-check cleared', tone: 'up' }],
   gapNudge: gapNudge(62, 'Place'),
 });
 

--- a/apps/web/components/matcha/useMatchaDaily.ts
+++ b/apps/web/components/matcha/useMatchaDaily.ts
@@ -29,6 +29,8 @@ interface DailyResult {
   streak: number;
   /** True until the clinician has seen today's brief. */
   isNewDay: boolean;
+  /** The visit date (YYYY-MM-DD) before this one — the "since" for source-event filtering. */
+  prevVisit: string | null;
   readinessDelta: number | null;
   memoryNotes: string[];
   markBriefSeen: () => void;
@@ -69,6 +71,7 @@ export function useMatchaDaily(input: {
     loaded: false,
     streak: 0,
     isNewDay: false,
+    prevVisit: null,
     readinessDelta: null,
     memoryNotes: [],
     markBriefSeen: () => {},
@@ -111,6 +114,7 @@ export function useMatchaDaily(input: {
       loaded: true,
       streak: nextStreak.streak,
       isNewDay,
+      prevVisit: prev.lastVisit,
       readinessDelta,
       memoryNotes,
     }));

--- a/apps/web/lib/matcha/daily.ts
+++ b/apps/web/lib/matcha/daily.ts
@@ -68,8 +68,53 @@ export interface DailyDelta {
   completeness: number;
   /** Plain-language notes for preference edits since last visit (from diffPreferences). */
   memoryNotes: string[];
+  /** Real source-refresh events since last visit (from trust-state history). */
+  sourceEvents?: Array<{ text: string; tone: BriefTone }>;
   /** Optional "you're closer to X" nudge, already phrased. */
   gapNudge?: string | null;
+}
+
+// ── Source-refresh events (trust-state history → brief lines) ───────────────
+
+/** The subset of a trust-history entry the brief needs. */
+export interface TrustHistoryEventLike {
+  computedAt: string | null;
+  deltaScore: number | null;
+  newGaps: string[];
+  resolvedGaps: string[];
+  reason: string | null;
+}
+
+/**
+ * Turn trust-state history entries into honest brief lines — only events recorded strictly
+ * after the clinician's previous visit. On a first-ever visit (no baseline) nothing is
+ * emitted, so we never dump old history as "news".
+ */
+export function trustEventNotes(
+  entries: readonly TrustHistoryEventLike[],
+  sinceISODate: string | null,
+): Array<{ text: string; tone: BriefTone }> {
+  if (!sinceISODate) return [];
+  const since = Date.parse(`${sinceISODate}T23:59:59`);
+  if (!Number.isFinite(since)) return [];
+
+  const out: Array<{ text: string; tone: BriefTone }> = [];
+  for (const e of entries) {
+    if (!e.computedAt) continue;
+    const t = Date.parse(e.computedAt);
+    if (!Number.isFinite(t) || t <= since) continue;
+
+    if (e.resolvedGaps.length > 0) {
+      out.push({ text: `Resolved since your last visit: ${e.resolvedGaps[0]}`, tone: 'up' });
+    } else if (e.newGaps.length > 0) {
+      out.push({ text: `A source flagged something new: ${e.newGaps[0]}`, tone: 'nudge' });
+    } else if (e.reason) {
+      out.push({ text: e.reason, tone: 'neutral' });
+    } else {
+      out.push({ text: 'Your sources were re-checked', tone: 'neutral' });
+    }
+  }
+  return out.slice(0, 2);
 }
 
 /**
@@ -95,6 +140,10 @@ export function buildBriefItems(d: DailyDelta): BriefItem[] {
         : `Readiness changed ${d.readinessDelta} to ${d.readinessScore}/100`,
       tone: d.readinessDelta > 0 ? 'up' : 'neutral',
     });
+  }
+
+  for (const ev of (d.sourceEvents ?? []).slice(0, 2)) {
+    items.push({ id: `src-${items.length}`, text: ev.text, tone: ev.tone });
   }
 
   for (const note of d.memoryNotes.slice(0, 2)) {


### PR DESCRIPTION
## What this adds

The daily brief now surfaces **real source activity** — *"Resolved since your last visit: DEA registration confirmed"*, *"your sources were re-checked"* — deepening the daily-return loop with events the platform actually recorded.

- **`trustEventNotes()`** (pure, tested) — turns trust-state **history entries** (already loaded by the holder provider) into honest brief lines: resolved gaps read as wins (tone `up`), newly-flagged gaps as nudges (`nudge`), otherwise the entry's reason or a plain re-check line. **Only events strictly after the previous visit qualify; a first-ever visit emits nothing** (old history is not "news"). Capped at 2.
- **`useMatchaDaily`** exposes `prevVisit`; **`MatchaDailyBrief`** wires `data.trustHistory` through.
- The public preview at `/matcha/experience` demonstrates a labeled sample source event.

## Truth contract
Events come only from recorded trust-state history; phrasing never celebrates a flag or grades the clinician.

## Verification
16 daily tests pass (5 new: since-filtering, first-visit suppression, win/nudge phrasing, cap, brief ordering); typecheck clean; `next build` green; the line renders in the preview surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)