### PR TITLE
fix(backend): replace phantom Prisma includes with real-schema hydration (P0, unblocks /holder)

### DIFF
--- a/apps/api/backend/src/routes/velocity.ts
+++ b/apps/api/backend/src/routes/velocity.ts
@@ -46,11 +46,29 @@ async function assertOrganizationAccess(
     throw new HttpError(403, 'You do not have access to this organization.');
   }
 
+  // No relations exist between these models in the schema, so the membership
+  // check resolves each FK hop explicitly (a relation filter throws at
+  // runtime). Any missing hop fails closed to 403.
+  const [profile, orgProfile] = await Promise.all([
+    prisma.personProfile.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    }),
+    prisma.organizationProfile.findUnique({
+      where: { organizationId },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!profile || !orgProfile) {
+    throw new HttpError(403, 'You do not have access to this organization.');
+  }
+
   const membership = await prisma.workspaceMembership.findFirst({
     where: {
       active: true,
-      personProfile: { userId: user.id },
-      organizationProfile: { organizationId },
+      personProfileId: profile.id,
+      organizationProfileId: orgProfile.id,
     },
     select: { id: true },
   });

--- a/apps/api/backend/src/services/opportunities/applicationService.ts
+++ b/apps/api/backend/src/services/opportunities/applicationService.ts
@@ -13,8 +13,10 @@ import { processApplicationBilling } from '../billing/billingEngine';
 
 import {
   ApplicationStatus,
+  type PersonProfile,
   Prisma,
   PrismaClient,
+  type User,
 } from '@prisma/client';
 import { log } from '../../obs/logger';
 import { refreshActionRecommendations } from '../actions/actionEngineService';
@@ -68,14 +70,11 @@ const applicationWithOpportunity = Prisma.validator<Prisma.ApplicationDefaultArg
   },
 });
 
-const userWithProfile = Prisma.validator<Prisma.UserDefaultArgs>()({
-  include: {
-    personProfile: true,
-  },
-});
-
 type ApplicationRecord = Prisma.ApplicationGetPayload<typeof applicationWithOpportunity>;
-type ApplicantUserRecord = Prisma.UserGetPayload<typeof userWithProfile>;
+// No User→PersonProfile relation exists in the schema, so the applicant
+// composite is stitched from the two tables (see loadApplicantMap) instead of
+// a Prisma `include`, which throws at runtime.
+type ApplicantUserRecord = User & { personProfile: PersonProfile | null };
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -161,11 +160,15 @@ export async function applyToOpportunity(input: ApplyInput): Promise<Marketplace
     throw new HttpError(409, 'This opportunity is no longer accepting applications.');
   }
 
+  // No User→PersonProfile relation exists in the schema; `include` throws at
+  // runtime. Resolve the profile through its userId FK instead.
   const applicant = await prisma.user.findUnique({
     where: { clerkUserId },
-    include: { personProfile: true },
   });
-  const resolvedNpi = normalizeProvidedNpi(npi) ?? applicant?.personProfile?.npi ?? null;
+  const applicantProfile = applicant
+    ? await prisma.personProfile.findUnique({ where: { userId: applicant.id } })
+    : null;
+  const resolvedNpi = normalizeProvidedNpi(npi) ?? applicantProfile?.npi ?? null;
   if (!resolvedNpi) {
     throw new HttpError(409, 'Complete clinician onboarding before applying with VitalCV.');
   }
@@ -540,10 +543,18 @@ async function loadApplicantMap(
         in: clerkUserIds,
       },
     },
-    include: userWithProfile.include,
   });
+  const profiles = applicants.length > 0
+    ? await prisma.personProfile.findMany({
+        where: { userId: { in: applicants.map((applicant) => applicant.id) } },
+      })
+    : [];
+  const profileByUserId = new Map(profiles.map((profile) => [profile.userId, profile]));
 
-  return new Map(applicants.map((applicant) => [applicant.clerkUserId, applicant]));
+  return new Map(applicants.map((applicant) => [
+    applicant.clerkUserId,
+    { ...applicant, personProfile: profileByUserId.get(applicant.id) ?? null },
+  ]));
 }
 
 async function loadTrustStateMap(

--- a/apps/api/backend/src/services/pilot/pilotProofService.ts
+++ b/apps/api/backend/src/services/pilot/pilotProofService.ts
@@ -684,11 +684,15 @@ function uniqueById<T extends { id: string }>(items: readonly T[]): T[] {
 export async function getClinicianProofSummary(
   clerkUserId: string,
 ): Promise<ClinicianProofSummary> {
+  // No User→PersonProfile relation exists in the schema; `include` throws at
+  // runtime. Resolve the profile through its userId FK instead.
   const user = await prisma.user.findUnique({
     where: { clerkUserId },
-    include: { personProfile: true },
   });
-  const npi = user?.personProfile?.npi ?? null;
+  const profile = user
+    ? await prisma.personProfile.findUnique({ where: { userId: user.id } })
+    : null;
+  const npi = profile?.npi ?? null;
 
   const [applications, eventRows, trustHistory, findings, storylines] = await Promise.all([
     listClinicianApplications(clerkUserId),

--- a/apps/api/backend/src/services/search/requestContext.ts
+++ b/apps/api/backend/src/services/search/requestContext.ts
@@ -2,36 +2,28 @@
 import {
   ActivePersona,
   MembershipRole,
-  Prisma,
   SearchAclLevel,
 } from '@prisma/client';
 import type { Request } from 'express';
-import prisma from '../../graphql/prisma_client';
 import { getRequestOrganizationId } from '../../middleware/organizationContext';
 import { sha256Hex } from '../../utils/deterministic';
+import {
+  getHydratedWorkspaceUserByClerkUserId,
+  type HydratedWorkspaceMembership,
+  type WorkspaceUserRecord,
+} from '../workspace/workspaceService';
 
-const workspaceUserInclude = {
-  workspacePreference: true,
-  personProfile: {
-    include: {
-      memberships: {
-        where: { active: true },
-        include: {
-          organizationProfile: true,
-        },
-        orderBy: {
-          createdAt: 'asc',
-        },
-      },
-    },
-  },
-} satisfies Prisma.UserInclude;
+// The schema has no User→PersonProfile→membership relations, so this context
+// is hydrated through workspaceService's stitch helper instead of a Prisma
+// `include` (which fails at runtime). The old include filtered memberships to
+// `active: true` — activeMembershipsOf preserves that semantic.
+type WorkspaceUser = WorkspaceUserRecord;
 
-type WorkspaceUser = Prisma.UserGetPayload<{
-  include: typeof workspaceUserInclude;
-}>;
+type ActiveMembership = HydratedWorkspaceMembership;
 
-type ActiveMembership = NonNullable<WorkspaceUser['personProfile']>['memberships'][number];
+function activeMembershipsOf(user: WorkspaceUser | null): ActiveMembership[] {
+  return (user?.personProfile?.memberships ?? []).filter((membership) => membership.active);
+}
 
 export interface SearchRequestContext {
   aclLevel: SearchAclLevel;
@@ -132,7 +124,7 @@ function deriveOrganizationId(
   user: WorkspaceUser | null,
   requestedOrgId: string | undefined,
 ): string | undefined {
-  const memberships = user?.personProfile?.memberships ?? [];
+  const memberships = activeMembershipsOf(user);
   if (requestedOrgId) {
     const requestedMembership = pickRequestedMembership(memberships, requestedOrgId);
     if (requestedMembership) {
@@ -197,14 +189,11 @@ export async function resolveSearchRequestContext(
     };
   }
 
-  const user = await prisma.user.findUnique({
-    where: { clerkUserId },
-    include: workspaceUserInclude,
-  });
+  const user = await getHydratedWorkspaceUserByClerkUserId(clerkUserId);
 
   const requestedOrgId = getRequestOrganizationId(req);
   const resolvedOrganizationId = deriveOrganizationId(user, requestedOrgId);
-  const memberships = user?.personProfile?.memberships ?? [];
+  const memberships = activeMembershipsOf(user);
   const activeMembership = pickRequestedMembership(memberships, resolvedOrganizationId) ?? memberships[0];
   const activePersona = derivePersona(user, activeMembership);
   const aclLevel = deriveAclLevel({

--- a/apps/api/backend/src/services/workspace/__tests__/hydrateWorkspaceUser.test.ts
+++ b/apps/api/backend/src/services/workspace/__tests__/hydrateWorkspaceUser.test.ts
@@ -1,0 +1,124 @@
+// The Prisma schema declares no relations between User, PersonProfile,
+// WorkspaceMembership, OrganizationProfile, or WorkspacePreference, so the
+// workspace composite must be stitched from the real tables. These tests pin
+// that stitch: profile resolved via userId, memberships via personProfileId,
+// org profiles batched by id, and a membership whose org row is missing is
+// dropped (fail closed) rather than surfaced as a workspace.
+const prismaMock = {
+  user: { findUnique: jest.fn() },
+  personProfile: { findUnique: jest.fn() },
+  workspacePreference: { findUnique: jest.fn() },
+  workspaceMembership: { findMany: jest.fn() },
+  organizationProfile: { findMany: jest.fn() },
+};
+
+jest.mock('../../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: prismaMock,
+}));
+
+jest.mock('../../../obs/logger', () => ({
+  log: jest.fn(),
+}));
+
+import { hydrateWorkspaceUser, getHydratedWorkspaceUserByClerkUserId } from '../workspaceService';
+
+const baseUser = {
+  id: 'user-1',
+  clerkUserId: 'user_clerk1',
+  email: 'clin@example.com',
+  role: 'CLINICIAN',
+  roleVersion: 1,
+  status: 'ACTIVE',
+  organizationId: null,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('hydrateWorkspaceUser', () => {
+  it('returns a null profile composite when no PersonProfile row exists', async () => {
+    prismaMock.personProfile.findUnique.mockResolvedValue(null);
+    prismaMock.workspacePreference.findUnique.mockResolvedValue(null);
+
+    const result = await hydrateWorkspaceUser(baseUser);
+
+    expect(result.personProfile).toBeNull();
+    expect(result.workspacePreference).toBeNull();
+    expect(prismaMock.personProfile.findUnique).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+    });
+    expect(prismaMock.workspaceMembership.findMany).not.toHaveBeenCalled();
+  });
+
+  it('stitches profile, memberships, and org profiles through the FK hops', async () => {
+    prismaMock.personProfile.findUnique.mockResolvedValue({ id: 'profile-1', userId: 'user-1', npi: '1234567893' });
+    prismaMock.workspacePreference.findUnique.mockResolvedValue({ id: 'pref-1', userId: 'user-1', activePersona: 'CLINICIAN' });
+    prismaMock.workspaceMembership.findMany.mockResolvedValue([
+      { id: 'm-1', personProfileId: 'profile-1', organizationProfileId: 'org-a', role: 'VERIFIER', active: true },
+      { id: 'm-2', personProfileId: 'profile-1', organizationProfileId: 'org-b', role: 'ADMIN', active: false },
+    ]);
+    prismaMock.organizationProfile.findMany.mockResolvedValue([
+      { id: 'org-a', organizationId: 'org-uuid-a' },
+      { id: 'org-b', organizationId: 'org-uuid-b' },
+    ]);
+
+    const result = await hydrateWorkspaceUser(baseUser);
+
+    expect(prismaMock.workspaceMembership.findMany).toHaveBeenCalledWith({
+      where: { personProfileId: 'profile-1' },
+      orderBy: { createdAt: 'asc' },
+    });
+    expect(prismaMock.organizationProfile.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['org-a', 'org-b'] } },
+    });
+    expect(result.personProfile?.memberships).toHaveLength(2);
+    expect(result.personProfile?.memberships[0]).toMatchObject({
+      id: 'm-1',
+      organizationProfile: { id: 'org-a', organizationId: 'org-uuid-a' },
+    });
+    expect(result.workspacePreference).toMatchObject({ id: 'pref-1' });
+  });
+
+  it('drops a membership whose organization profile row is missing (fail closed)', async () => {
+    prismaMock.personProfile.findUnique.mockResolvedValue({ id: 'profile-1', userId: 'user-1' });
+    prismaMock.workspacePreference.findUnique.mockResolvedValue(null);
+    prismaMock.workspaceMembership.findMany.mockResolvedValue([
+      { id: 'm-1', personProfileId: 'profile-1', organizationProfileId: 'org-a', role: 'VERIFIER', active: true },
+      { id: 'm-orphan', personProfileId: 'profile-1', organizationProfileId: 'org-gone', role: 'ADMIN', active: true },
+    ]);
+    prismaMock.organizationProfile.findMany.mockResolvedValue([
+      { id: 'org-a', organizationId: 'org-uuid-a' },
+    ]);
+
+    const result = await hydrateWorkspaceUser(baseUser);
+
+    expect(result.personProfile?.memberships).toHaveLength(1);
+    expect(result.personProfile?.memberships[0].id).toBe('m-1');
+  });
+});
+
+describe('getHydratedWorkspaceUserByClerkUserId', () => {
+  it('returns null when no user row exists', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(getHydratedWorkspaceUserByClerkUserId('user_missing')).resolves.toBeNull();
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+      where: { clerkUserId: 'user_missing' },
+    });
+  });
+
+  it('hydrates the composite for an existing user', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(baseUser);
+    prismaMock.personProfile.findUnique.mockResolvedValue(null);
+    prismaMock.workspacePreference.findUnique.mockResolvedValue(null);
+
+    const result = await getHydratedWorkspaceUserByClerkUserId('user_clerk1');
+
+    expect(result?.id).toBe('user-1');
+    expect(result?.personProfile).toBeNull();
+  });
+});

--- a/apps/api/backend/src/services/workspace/workspaceService.ts
+++ b/apps/api/backend/src/services/workspace/workspaceService.ts
@@ -9,6 +9,7 @@ import {
   type User,
   UserRole,
   UserStatus,
+  type WorkspaceMembership,
   type WorkspacePreference,
 } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
@@ -20,23 +21,77 @@ import { HttpError } from '../../utils/httpError';
 
 const NPI_RE = /^\d{10}$/;
 
-type WorkspaceUserRecord = Prisma.UserGetPayload<{
-  include: {
-    personProfile: {
-      include: {
-        memberships: {
-          include: {
-            organizationProfile: true;
-          };
-          orderBy: {
-            createdAt: 'asc';
-          };
-        };
-      };
-    };
-    workspacePreference: true;
+// The Prisma schema declares NO relations between User, PersonProfile,
+// WorkspaceMembership, OrganizationProfile, or WorkspacePreference — the FK
+// columns exist as plain scalars, so `include` on any of them fails at
+// runtime ("Unknown field for include statement"). The composite below is
+// stitched from the real tables by hydrateWorkspaceUser(); do not reintroduce
+// `include` chains here without first adding the relations via an approved
+// migration.
+export type HydratedWorkspaceMembership = WorkspaceMembership & {
+  organizationProfile: OrganizationProfile;
+};
+
+export type HydratedPersonProfile = PersonProfile & {
+  memberships: HydratedWorkspaceMembership[];
+};
+
+export type WorkspaceUserRecord = User & {
+  personProfile: HydratedPersonProfile | null;
+  workspacePreference: WorkspacePreference | null;
+};
+
+export async function hydrateWorkspaceUser(user: User): Promise<WorkspaceUserRecord> {
+  const [personProfile, workspacePreference] = await Promise.all([
+    prisma.personProfile.findUnique({ where: { userId: user.id } }),
+    prisma.workspacePreference.findUnique({ where: { userId: user.id } }),
+  ]);
+
+  if (!personProfile) {
+    return { ...user, personProfile: null, workspacePreference };
+  }
+
+  const memberships = await prisma.workspaceMembership.findMany({
+    where: { personProfileId: personProfile.id },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  const hydratedMemberships: HydratedWorkspaceMembership[] = [];
+  if (memberships.length > 0) {
+    const orgProfileIds = [...new Set(memberships.map((m) => m.organizationProfileId))];
+    const orgProfiles = await prisma.organizationProfile.findMany({
+      where: { id: { in: orgProfileIds } },
+    });
+    const orgById = new Map(orgProfiles.map((o) => [o.id, o]));
+    for (const membership of memberships) {
+      const organizationProfile = orgById.get(membership.organizationProfileId);
+      if (!organizationProfile) {
+        // Fail closed: a membership whose organization profile row is missing
+        // cannot grant a workspace.
+        log('warn', 'Workspace membership dropped — organization profile missing', {
+          event: 'workspace_membership_org_missing',
+          membershipId: membership.id,
+          organizationProfileId: membership.organizationProfileId,
+        });
+        continue;
+      }
+      hydratedMemberships.push({ ...membership, organizationProfile });
+    }
+  }
+
+  return {
+    ...user,
+    personProfile: { ...personProfile, memberships: hydratedMemberships },
+    workspacePreference,
   };
-}>;
+}
+
+export async function getHydratedWorkspaceUserByClerkUserId(
+  clerkUserId: string,
+): Promise<WorkspaceUserRecord | null> {
+  const user = await prisma.user.findUnique({ where: { clerkUserId } });
+  return user ? hydrateWorkspaceUser(user) : null;
+}
 
 export interface WorkspaceList {
   userId: string;
@@ -435,10 +490,7 @@ export async function ensureWorkspacePreference(
 async function getWorkspaceUserByClerkUserId(
   clerkUserId: string,
 ): Promise<WorkspaceUserRecord> {
-  const user = await prisma.user.findUnique({
-    where: { clerkUserId },
-    include: workspaceUserInclude,
-  });
+  const user = await getHydratedWorkspaceUserByClerkUserId(clerkUserId);
 
   if (!user) {
     throw new HttpError(404, 'Authenticated user has no VitalCV user record.');
@@ -450,10 +502,8 @@ async function getWorkspaceUserByClerkUserId(
 async function getWorkspaceUserById(
   userId: string,
 ): Promise<WorkspaceUserRecord | null> {
-  return prisma.user.findUnique({
-    where: { id: userId },
-    include: workspaceUserInclude,
-  });
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  return user ? hydrateWorkspaceUser(user) : null;
 }
 
 function getAvailablePersonas(user: WorkspaceUserRecord): ActivePersona[] {
@@ -576,18 +626,3 @@ function clampCompleteness(value: number): number {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-const workspaceUserInclude = {
-  personProfile: {
-    include: {
-      memberships: {
-        include: {
-          organizationProfile: true,
-        },
-        orderBy: {
-          createdAt: 'asc',
-        },
-      },
-    },
-  },
-  workspacePreference: true,
-} satisfies Prisma.UserInclude;


### PR DESCRIPTION
## Summary

`/api/me/workspaces` 500s with `Unknown field \`personProfile\` for include statement on model \`User\`` — the schema has **no relations** between User, PersonProfile, WorkspaceMembership, OrganizationProfile, WorkspacePreference (plain FK columns only), and five services queried through relation `include`s/filters that can never work. All were written under `// @ts-nocheck`, and the tenant-guard 401 (fixed in #549) had masked every one of them since birth. This is the final blocker for the signed-in `/holder` P0.

- `workspaceService.ts`: new `hydrateWorkspaceUser()` + `getHydratedWorkspaceUserByClerkUserId()` stitch the composite from real tables; memberships ordered `createdAt asc` (as the fictional include declared); membership without its org row is **dropped fail-closed** with a warn log.
- `requestContext.ts` (search ACL): shared helper; old include's `where: { active: true }` semantic preserved via `activeMembershipsOf()`.
- `applicationService.ts`: applicant map (`loadApplicantMap`) + apply-path NPI resolution stitched.
- `pilotProofService.ts`: clinician proof summary profile lookup stitched.
- `velocity.ts`: org-access assertion resolves profile → org-profile → membership explicitly; any missing hop → 403.

## Not fixed here (disclosed, broken since birth, not on /holder path)

`workspaceAnalytics.ts` and `graph-engine/rebuildEngine.ts` still use phantom relation filters/selects — follow-up chipped, needs their consumers' context. The four files keep `// @ts-nocheck` (pre-existing); de-fictioning them is part of the same follow-up.

## Truth rules

No copy changes. No schema/migration changes (the alternative — adding real relations — is a founder-gated migration; this PR works with the schema as it exists). Fail-closed on missing org rows.

## Validation

- Backend `tsc --noEmit`: clean
- `jest`: 4 suites / 20 tests green (5 new cases pin stitch shape, FK-hop queries, fail-closed drop, null paths)
- Post-merge: Railway deploy watch + live `/holder` re-verification in Chrome (the P0 proof)

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)