### PR TITLE
fix(backend): explicit ids on workspace creates — DB has no gen_random_uuid default (P2011)

### DIFF
--- a/apps/api/backend/src/services/opportunities/opportunityService.ts
+++ b/apps/api/backend/src/services/opportunities/opportunityService.ts
@@ -10,6 +10,7 @@
  *   clerkUserId → User → PersonProfile → WorkspaceMembership → OrganizationProfile → Organization
  */
 
+import { randomUUID } from 'node:crypto';
 import { Prisma } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 import { HttpError } from '../../utils/httpError';
@@ -230,6 +231,10 @@ export async function upsertOrgProfile(
 
   await prisma.workspaceMembership.create({
     data: {
+      // workspace_memberships.id has no DB default despite the schema's
+      // dbgenerated(gen_random_uuid()) (verified in prod 2026-07-05) —
+      // supply the id client-side or the insert throws P2011.
+      id: randomUUID(),
       personProfileId: personProfile.id,
       organizationProfileId: orgProfile.id,
       role: 'ADMIN',

--- a/apps/api/backend/src/services/workspace/__tests__/hydrateWorkspaceUser.test.ts
+++ b/apps/api/backend/src/services/workspace/__tests__/hydrateWorkspaceUser.test.ts
@@ -7,7 +7,7 @@
 const prismaMock = {
   user: { findUnique: jest.fn() },
   personProfile: { findUnique: jest.fn() },
-  workspacePreference: { findUnique: jest.fn() },
+  workspacePreference: { findUnique: jest.fn(), create: jest.fn() },
   workspaceMembership: { findMany: jest.fn() },
   organizationProfile: { findMany: jest.fn() },
 };
@@ -21,7 +21,11 @@ jest.mock('../../../obs/logger', () => ({
   log: jest.fn(),
 }));
 
-import { hydrateWorkspaceUser, getHydratedWorkspaceUserByClerkUserId } from '../workspaceService';
+import {
+  ensureWorkspacePreference,
+  getHydratedWorkspaceUserByClerkUserId,
+  hydrateWorkspaceUser,
+} from '../workspaceService';
 
 const baseUser = {
   id: 'user-1',
@@ -98,6 +102,24 @@ describe('hydrateWorkspaceUser', () => {
 
     expect(result.personProfile?.memberships).toHaveLength(1);
     expect(result.personProfile?.memberships[0].id).toBe('m-1');
+  });
+});
+
+describe('ensureWorkspacePreference', () => {
+  it('supplies an explicit id on create — workspace_preferences has no DB default (P2011 guard)', async () => {
+    prismaMock.workspacePreference.findUnique.mockResolvedValue(null);
+    prismaMock.user.findUnique.mockResolvedValue(baseUser);
+    prismaMock.personProfile.findUnique.mockResolvedValue(null);
+    prismaMock.workspacePreference.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+      Promise.resolve(data),
+    );
+
+    await ensureWorkspacePreference('user-1');
+
+    expect(prismaMock.workspacePreference.create).toHaveBeenCalledTimes(1);
+    const createData = prismaMock.workspacePreference.create.mock.calls[0][0].data;
+    expect(createData.userId).toBe('user-1');
+    expect(createData.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 });
 

--- a/apps/api/backend/src/services/workspace/workspaceService.ts
+++ b/apps/api/backend/src/services/workspace/workspaceService.ts
@@ -12,6 +12,7 @@ import {
   type WorkspaceMembership,
   type WorkspacePreference,
 } from '@prisma/client';
+import { randomUUID } from 'node:crypto';
 import prisma from '../../graphql/prisma_client';
 import { fetchNpiFromCMS, normalizeProvider } from '../../modules/identity';
 import { AVAILABILITY_PLACEHOLDER_PREFIX } from '../matcha/availabilityRegistry';
@@ -480,6 +481,11 @@ export async function ensureWorkspacePreference(
 
   return prisma.workspacePreference.create({
     data: {
+      // The schema declares id as dbgenerated(gen_random_uuid()) but the
+      // actual workspace_preferences table has NO column default (verified in
+      // prod information_schema 2026-07-05) — inserting without an id throws
+      // P2011. Supply it client-side.
+      id: randomUUID(),
       userId,
       activePersona: resolveDefaultPersona(user),
       activeOrgId: activeMemberships[0]?.organizationProfile.organizationId ?? null,


### PR DESCRIPTION
## Summary

Layer 3 of the /holder 500. After #549 (guard 401) and #555 (phantom includes), `/api/me/workspaces` now fails with `P2011 Null constraint violation on (id)`: `workspace_preferences.id` and `workspace_memberships.id` are `dbgenerated("gen_random_uuid()")` in schema.prisma, but the **actual prod columns have no default** (`information_schema.columns.column_default IS NULL`, checked 2026-07-05 via read-only query). First workspace fetch for a user creates their preference row → insert without id → P2011.

- `workspaceService.ensureWorkspacePreference`: `id: randomUUID()` on create.
- `opportunityService` membership create: same guard.
- New jest case pins the explicit-id create (UUID-shape asserted).

The schema-truth alternative (`ALTER TABLE ... SET DEFAULT gen_random_uuid()`) is a founder-gated migration; this code-side fix works with the DB as it exists. The dbgenerated-vs-DB audit for the other 8 models using that pattern is folded into chip task_b2096849.

## Truth rules

No copy, no schema/migration changes, no behavior change beyond making the insert succeed.

## Validation

- Backend `tsc --noEmit` clean; workspace jest suites 10/10.
- Post-merge: deploy watch + live /holder check in Chris's real Chrome session (the gate #549/#555 were verified against).

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)