### PR TITLE
fix(backend): finish phantom-relation cleanup (P2009), watchlist create ids (P2011), drop @ts-nocheck on stitched files

### DIFF
--- a/apps/api/backend/src/routes/entity.ts
+++ b/apps/api/backend/src/routes/entity.ts
@@ -173,19 +173,27 @@ export function registerEntityRoutes(app: Express): void {
         ...(typeList ? { relationshipType: { in: typeList } } : {}),
       };
 
+      // VcvEntityRelationship has NO subject/object Prisma relations (plain
+      // FK columns) — an include here throws P2009 at runtime; fetch the
+      // entity summaries by FK and stitch in JS.
       const rels = await prisma.vcvEntityRelationship.findMany({
         where: {
           ...(direction === 'outbound' ? whereSubject
             : direction === 'inbound'  ? whereObject
             : { OR: [whereSubject, whereObject] }),
         },
-        include: {
-          subject: { select: { id: true, displayName: true, entityType: true } },
-          object:  { select: { id: true, displayName: true, entityType: true } },
-        },
         orderBy: { createdAt: 'desc' },
         take: 100,
       });
+
+      const relatedEntityIds = [...new Set(rels.flatMap(r => [r.subjectId, r.objectId]))];
+      const relatedEntities = relatedEntityIds.length > 0
+        ? await prisma.vcvEntity.findMany({
+            where: { id: { in: relatedEntityIds } },
+            select: { id: true, displayName: true, entityType: true },
+          })
+        : [];
+      const entityById = new Map(relatedEntities.map(e => [e.id, e]));
 
       res.json({
         entityId: id,
@@ -193,8 +201,8 @@ export function registerEntityRoutes(app: Express): void {
           id:               r.id,
           relationshipType: r.relationshipType,
           direction:        r.subjectId === id ? 'outbound' : 'inbound',
-          subject:          r.subject,
-          object:           r.object,
+          subject:          entityById.get(r.subjectId) ?? null,
+          object:           entityById.get(r.objectId) ?? null,
           confidence:       r.confidence,
           tier:             r.tier,
           startDate:        r.startDate,

--- a/apps/api/backend/src/services/graph-engine/rebuildEngine.ts
+++ b/apps/api/backend/src/services/graph-engine/rebuildEngine.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Prisma, type GraphBuildRun as PrismaGraphBuildRun, type PrismaClient } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 import { log } from '../../obs/logger';
@@ -605,6 +604,100 @@ async function resolveTargetedScopes(
   };
 }
 
+// WorkspaceMembership has NO Prisma relations to PersonProfile or
+// OrganizationProfile (plain FK columns), so relation-style filters/selects
+// throw P2009 at runtime. Resolve the npi/organization scopes to FK ids
+// first, filter on the FK columns, then stitch npi + organizationId back in
+// JS (same pattern as hydrateWorkspaceUser in workspaceService.ts).
+async function loadWorkspaceMembershipRows(
+  prismaClient: PrismaClient,
+  npiScope: string[],
+  organizationScope: string[],
+): Promise<Array<{
+  role: string;
+  active: boolean;
+  createdAt: Date;
+  personProfile: { npi: string | null };
+  organizationProfile: { organizationId: string | null };
+}>> {
+  let scopedPersonProfiles: Array<{ id: string; npi: string | null }> | null = null;
+  let scopedOrgProfiles: Array<{ id: string; organizationId: string }> | null = null;
+
+  if (npiScope.length > 0) {
+    scopedPersonProfiles = await prismaClient.personProfile.findMany({
+      where: { npi: { in: npiScope } },
+      select: { id: true, npi: true },
+    });
+  } else if (organizationScope.length > 0) {
+    scopedOrgProfiles = await prismaClient.organizationProfile.findMany({
+      where: { organizationId: { in: organizationScope } },
+      select: { id: true, organizationId: true },
+    });
+  }
+
+  const memberships = await prismaClient.workspaceMembership.findMany({
+    where: scopedPersonProfiles
+      ? { personProfileId: { in: scopedPersonProfiles.map((profile) => profile.id) } }
+      : scopedOrgProfiles
+        ? { organizationProfileId: { in: scopedOrgProfiles.map((profile) => profile.id) } }
+        : undefined,
+    select: {
+      role: true,
+      active: true,
+      createdAt: true,
+      personProfileId: true,
+      organizationProfileId: true,
+    },
+  });
+
+  if (memberships.length === 0) {
+    return [];
+  }
+
+  const npiByProfileId = new Map<string, string | null>(
+    (scopedPersonProfiles ?? []).map((profile) => [profile.id, profile.npi]),
+  );
+  const orgIdByProfileId = new Map<string, string>(
+    (scopedOrgProfiles ?? []).map((profile) => [profile.id, profile.organizationId]),
+  );
+
+  const missingPersonProfileIds = [
+    ...new Set(memberships.map((membership) => membership.personProfileId)),
+  ].filter((id) => !npiByProfileId.has(id));
+  const missingOrgProfileIds = [
+    ...new Set(memberships.map((membership) => membership.organizationProfileId)),
+  ].filter((id) => !orgIdByProfileId.has(id));
+
+  const [personProfiles, orgProfiles] = await Promise.all([
+    missingPersonProfileIds.length > 0
+      ? prismaClient.personProfile.findMany({
+          where: { id: { in: missingPersonProfileIds } },
+          select: { id: true, npi: true },
+        })
+      : Promise.resolve([]),
+    missingOrgProfileIds.length > 0
+      ? prismaClient.organizationProfile.findMany({
+          where: { id: { in: missingOrgProfileIds } },
+          select: { id: true, organizationId: true },
+        })
+      : Promise.resolve([]),
+  ]);
+  personProfiles.forEach((profile) => npiByProfileId.set(profile.id, profile.npi));
+  orgProfiles.forEach((profile) => orgIdByProfileId.set(profile.id, profile.organizationId));
+
+  // A dangling FK resolves to null npi/organizationId; the projection loop
+  // skips memberships it cannot link to both nodes.
+  return memberships.map((membership) => ({
+    role: membership.role,
+    active: membership.active,
+    createdAt: membership.createdAt,
+    personProfile: { npi: npiByProfileId.get(membership.personProfileId) ?? null },
+    organizationProfile: {
+      organizationId: orgIdByProfileId.get(membership.organizationProfileId) ?? null,
+    },
+  }));
+}
+
 async function buildProjection(
   prismaClient: PrismaClient,
   input: GraphRebuildInput,
@@ -667,26 +760,7 @@ async function buildProjection(
         },
       },
     }),
-    prismaClient.workspaceMembership.findMany({
-      where: npiScope.length > 0
-        ? { personProfile: { npi: { in: npiScope } } }
-        : organizationScope.length > 0
-          ? { organizationProfile: { organizationId: { in: organizationScope } } }
-          : undefined,
-      select: {
-        role: true,
-        active: true,
-        createdAt: true,
-        personProfile: {
-          select: { npi: true },
-        },
-        organizationProfile: {
-          select: {
-            organizationId: true,
-          },
-        },
-      },
-    }),
+    loadWorkspaceMembershipRows(prismaClient, npiScope, organizationScope),
     safeOptionalFindMany('Opportunity', () =>
       prismaClient.opportunity.findMany({
         where: organizationScope.length > 0 ? { organizationId: { in: organizationScope } } : undefined,
@@ -897,7 +971,9 @@ async function buildProjection(
     const clinicianNode = membership.personProfile.npi
       ? clinicianNodeByNpi.get(membership.personProfile.npi)
       : undefined;
-    const orgNode = organizationNodeById.get(membership.organizationProfile.organizationId);
+    const orgNode = membership.organizationProfile.organizationId
+      ? organizationNodeById.get(membership.organizationProfile.organizationId)
+      : undefined;
     if (!clinicianNode || !orgNode) continue;
 
     addEdge(context, buildEdge({

--- a/apps/api/backend/src/services/identity/watchtowerStore.ts
+++ b/apps/api/backend/src/services/identity/watchtowerStore.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import prisma, { Prisma } from '../../graphql/prisma_client';
 
 function toJsonValue(value: unknown): Prisma.InputJsonValue {
@@ -223,6 +223,10 @@ export function buildWatchlistDedupeKey(input: Omit<CreateWatchlistInput, 'metad
 export async function createWatchlist(input: CreateWatchlistInput): Promise<WatchlistRecord> {
   return watchtowerPrisma.watchlist.create({
     data: {
+      // watchlists.id has no DB default despite the schema's
+      // dbgenerated(gen_random_uuid()) (verified in prod 2026-07-05) —
+      // supply the id client-side or the insert throws P2011.
+      id: randomUUID(),
       dedupeKey: buildWatchlistDedupeKey(input),
       name: input.name.trim(),
       ownerOrganizationId: input.ownerOrganizationId ?? null,
@@ -362,6 +366,10 @@ export async function persistWatchlistHit(
   try {
     return await watchtowerPrisma.watchlistHit.create({
       data: {
+        // watchlist_hits.id has no DB default despite the schema's
+        // dbgenerated(gen_random_uuid()) (verified in prod 2026-07-05) —
+        // supply the id client-side or the insert throws P2011.
+        id: randomUUID(),
         watchlistId: input.watchlistId,
         trustAlertRecordId: input.trustAlertRecordId ?? null,
         entityChangeEventId: input.entityChangeEventId ?? null,

--- a/apps/api/backend/src/services/intelligenceLayer/intelligenceLayerService.ts
+++ b/apps/api/backend/src/services/intelligenceLayer/intelligenceLayerService.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { Prisma, type PrismaClient } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 import { listInvestigatorFindings } from '../investigators/investigatorEngineService';
@@ -2231,6 +2231,10 @@ export async function createIntelligenceWatch(
       }),
     },
     create: {
+      // watchlists.id has no DB default despite the schema's
+      // dbgenerated(gen_random_uuid()) (verified in prod 2026-07-05) —
+      // supply the id client-side or the insert throws P2011.
+      id: randomUUID(),
       dedupeKey,
       name,
       ownerOrganizationId: input.ownerOrganizationId ?? null,

--- a/apps/api/backend/src/services/opportunities/__tests__/opportunityService.test.ts
+++ b/apps/api/backend/src/services/opportunities/__tests__/opportunityService.test.ts
@@ -133,11 +133,11 @@ describe('opportunityService org profile pilot policy', () => {
     prismaMock.personProfile.findUnique.mockResolvedValue({ id: 'person-1' });
     prismaMock.workspaceMembership.findFirst.mockResolvedValue({
       organizationProfileId: 'org-profile-1',
-      organizationProfile: {
-        organizationId: 'org-1',
-        requirements: [{ label: 'Legacy requirement', level: 'L1' }],
-        organization: { name: 'General Hospital' },
-      },
+    });
+    prismaMock.organizationProfile.findUnique.mockResolvedValue({
+      id: 'org-profile-1',
+      organizationId: 'org-1',
+      requirements: [{ label: 'Legacy requirement', level: 'L1' }],
     });
     prismaMock.organization.findUnique.mockResolvedValue(null);
     prismaMock.organization.update.mockResolvedValue({});
@@ -233,11 +233,11 @@ describe('opportunityService org profile pilot policy', () => {
     prismaMock.personProfile.findUnique.mockResolvedValue({ id: 'person-1' });
     prismaMock.workspaceMembership.findFirst.mockResolvedValue({
       organizationProfileId: 'org-profile-1',
-      organizationProfile: {
-        organizationId: 'org-1',
-        requirements: [],
-        organization: { name: 'General Hospital' },
-      },
+    });
+    prismaMock.organizationProfile.findUnique.mockResolvedValue({
+      id: 'org-profile-1',
+      organizationId: 'org-1',
+      requirements: [],
     });
     prismaMock.organization.findUnique.mockResolvedValue(null);
     prismaMock.organization.update.mockResolvedValue({});

--- a/apps/api/backend/src/services/opportunities/applicationService.ts
+++ b/apps/api/backend/src/services/opportunities/applicationService.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { processApplicationBilling } from '../billing/billingEngine';
 /**
  * applicationService.ts — Wave 229
@@ -168,6 +167,9 @@ export async function applyToOpportunity(input: ApplyInput): Promise<Marketplace
   const applicantProfile = applicant
     ? await prisma.personProfile.findUnique({ where: { userId: applicant.id } })
     : null;
+  const applicantRecord: ApplicantUserRecord | null = applicant
+    ? { ...applicant, personProfile: applicantProfile }
+    : null;
   const resolvedNpi = normalizeProvidedNpi(npi) ?? applicantProfile?.npi ?? null;
   if (!resolvedNpi) {
     throw new HttpError(409, 'Complete clinician onboarding before applying with VitalCV.');
@@ -188,10 +190,10 @@ export async function applyToOpportunity(input: ApplyInput): Promise<Marketplace
         },
         ...applicationWithOpportunity,
       }) as ApplicationRecord;
-      return hydrateApplication(reactivated, applicant ?? null);
+      return hydrateApplication(reactivated, applicantRecord);
     }
 
-    return hydrateApplication(existing, applicant ?? null);
+    return hydrateApplication(existing, applicantRecord);
   }
 
   const created = await prisma.application.create({
@@ -205,7 +207,7 @@ export async function applyToOpportunity(input: ApplyInput): Promise<Marketplace
     ...applicationWithOpportunity,
   });
 
-  return hydrateApplication(created, applicant ?? null);
+  return hydrateApplication(created, applicantRecord);
 }
 
 // ── Clinician: list own applications ─────────────────────────────────────────
@@ -520,6 +522,8 @@ async function loadEmployerAcceptanceMap(
 
   const acceptanceMap = new Map<string, string>();
   for (const acceptance of acceptances) {
+    // The `in` filters above cannot match NULL; guards only narrow the types.
+    if (!acceptance.employerId || !acceptance.clinicianNpi) continue;
     const key = employerAcceptanceKey(acceptance.employerId, acceptance.clinicianNpi);
     if (!acceptanceMap.has(key)) {
       acceptanceMap.set(key, acceptance.acceptedAt.toISOString());

--- a/apps/api/backend/src/services/opportunities/opportunityService.ts
+++ b/apps/api/backend/src/services/opportunities/opportunityService.ts
@@ -123,23 +123,32 @@ export async function upsertOrgProfile(
     data: { userId: user.id, completeness: 0 },
   });
 
-  // Check for existing membership
+  // Check for existing membership. WorkspaceMembership has NO Prisma
+  // relation to OrganizationProfile (plain FK column) — an include here
+  // throws P2009 at runtime; fetch the profile by FK and stitch instead.
   const existingMembership = await prisma.workspaceMembership.findFirst({
     where: { personProfileId: personProfile.id, active: true },
-    include: { organizationProfile: { include: { organization: true } } },
   });
+  const membershipOrgProfile = existingMembership
+    ? await prisma.organizationProfile.findUnique({
+        where: { id: existingMembership.organizationProfileId },
+      })
+    : null;
 
   if (existingMembership) {
+    if (!membershipOrgProfile) {
+      throw new HttpError(500, 'Workspace membership references a missing organization profile.');
+    }
     const conflictingOrg = await prisma.organization.findUnique({
       where: { slug: canonicalIdentity.slug },
       select: { id: true },
     });
-    if (conflictingOrg && conflictingOrg.id !== existingMembership.organizationProfile.organizationId) {
+    if (conflictingOrg && conflictingOrg.id !== membershipOrgProfile.organizationId) {
       throw new HttpError(409, 'An organization with this canonical identity already exists.');
     }
 
     const existingEnvelope = parseOrganizationRequirementsEnvelope(
-      existingMembership.organizationProfile.requirements,
+      membershipOrgProfile.requirements,
       [],
     );
     const nextEnvelope = buildOrganizationRequirementsEnvelope({
@@ -155,7 +164,7 @@ export async function upsertOrgProfile(
 
     // Update existing org profile
     await prisma.organization.update({
-      where: { id: existingMembership.organizationProfile.organizationId },
+      where: { id: membershipOrgProfile.organizationId },
       data: {
         name: canonicalIdentity.displayName,
         slug: canonicalIdentity.slug,
@@ -175,7 +184,7 @@ export async function upsertOrgProfile(
         requirements: nextEnvelope as unknown as Prisma.InputJsonValue,
       },
     });
-    return { organizationId: existingMembership.organizationProfile.organizationId };
+    return { organizationId: membershipOrgProfile.organizationId };
   }
 
   // Create new org + profile + membership

--- a/apps/api/backend/src/services/pilot/pilotProofService.ts
+++ b/apps/api/backend/src/services/pilot/pilotProofService.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { ApplicationStatus, Prisma } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 import { computePilotKpis, type PilotKpiSnapshot } from './pilotKpiService';

--- a/apps/api/backend/src/services/search/__tests__/requestContext.test.ts
+++ b/apps/api/backend/src/services/search/__tests__/requestContext.test.ts
@@ -6,6 +6,18 @@ jest.mock('../../../graphql/prisma_client', () => ({
     user: {
       findUnique: jest.fn(),
     },
+    personProfile: {
+      findUnique: jest.fn(),
+    },
+    workspacePreference: {
+      findUnique: jest.fn(),
+    },
+    workspaceMembership: {
+      findMany: jest.fn(),
+    },
+    organizationProfile: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
@@ -15,6 +27,18 @@ import { resolveSearchRequestContext } from '../requestContext';
 const prismaMock = prisma as unknown as {
   user: {
     findUnique: jest.Mock;
+  };
+  personProfile: {
+    findUnique: jest.Mock;
+  };
+  workspacePreference: {
+    findUnique: jest.Mock;
+  };
+  workspaceMembership: {
+    findMany: jest.Mock;
+  };
+  organizationProfile: {
+    findMany: jest.Mock;
   };
 };
 
@@ -32,6 +56,10 @@ function buildRequest(headers: Record<string, string> = {}, query: Record<string
 describe('resolveSearchRequestContext', () => {
   beforeEach(() => {
     prismaMock.user.findUnique.mockReset();
+    prismaMock.personProfile.findUnique.mockReset();
+    prismaMock.workspacePreference.findUnique.mockReset();
+    prismaMock.workspaceMembership.findMany.mockReset();
+    prismaMock.organizationProfile.findMany.mockReset();
   });
 
   it('returns a public context for anonymous requests', async () => {
@@ -46,23 +74,32 @@ describe('resolveSearchRequestContext', () => {
   });
 
   it('derives verifier workspace context from active org preference', async () => {
-    prismaMock.user.findUnique.mockResolvedValue({
-      id: 'user-1',
-      workspacePreference: {
-        activePersona: 'VERIFIER',
-        activeOrgId: 'org-1',
-      },
-      personProfile: {
-        memberships: [
-          {
-            role: 'VERIFIER',
-            organizationProfile: {
-              organizationId: 'org-1',
-            },
-          },
-        ],
-      },
+    // No relations exist between these models — the workspace user is
+    // stitched from the four tables by hydrateWorkspaceUser().
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1' });
+    prismaMock.personProfile.findUnique.mockResolvedValue({
+      id: 'person-1',
+      userId: 'user-1',
     });
+    prismaMock.workspacePreference.findUnique.mockResolvedValue({
+      activePersona: 'VERIFIER',
+      activeOrgId: 'org-1',
+    });
+    prismaMock.workspaceMembership.findMany.mockResolvedValue([
+      {
+        id: 'membership-1',
+        personProfileId: 'person-1',
+        organizationProfileId: 'org-profile-1',
+        role: 'VERIFIER',
+        active: true,
+      },
+    ]);
+    prismaMock.organizationProfile.findMany.mockResolvedValue([
+      {
+        id: 'org-profile-1',
+        organizationId: 'org-1',
+      },
+    ]);
 
     const context = await resolveSearchRequestContext(
       buildRequest({ 'x-clerk-user-id': 'clerk_123' }),

--- a/apps/api/backend/src/services/search/__tests__/searchIndex.test.ts
+++ b/apps/api/backend/src/services/search/__tests__/searchIndex.test.ts
@@ -7,6 +7,9 @@ jest.mock('../../../graphql/prisma_client', () => ({
       groupBy: jest.fn(),
       findFirst: jest.fn(),
     },
+    searchObjectACL: {
+      findMany: jest.fn(),
+    },
     searchIndexRun: {
       count: jest.fn(),
     },
@@ -43,11 +46,15 @@ const prismaMock = prisma as unknown as {
   searchObject: {
     findMany: jest.Mock;
   };
+  searchObjectACL: {
+    findMany: jest.Mock;
+  };
 };
 
 describe('querySearch', () => {
   beforeEach(() => {
     prismaMock.searchObject.findMany.mockReset();
+    prismaMock.searchObjectACL.findMany.mockReset();
   });
 
   it('enforces aclLevel, orgId, and roleRequired without leaking holder-only content to verifier queries', async () => {
@@ -64,7 +71,6 @@ describe('querySearch', () => {
         freshAt: new Date('2026-03-01T00:00:00Z'),
         indexedAt: new Date('2026-03-01T00:00:00Z'),
         active: true,
-        acl: [],
       },
       {
         id: 'verifier-1',
@@ -78,7 +84,6 @@ describe('querySearch', () => {
         freshAt: new Date('2026-03-02T00:00:00Z'),
         indexedAt: new Date('2026-03-02T00:00:00Z'),
         active: true,
-        acl: [{ orgId: 'org-1', roleRequired: 'VERIFIER' }],
       },
       {
         id: 'holder-1',
@@ -92,7 +97,6 @@ describe('querySearch', () => {
         freshAt: new Date('2026-03-03T00:00:00Z'),
         indexedAt: new Date('2026-03-03T00:00:00Z'),
         active: true,
-        acl: [],
       },
       {
         id: 'other-org-1',
@@ -106,8 +110,13 @@ describe('querySearch', () => {
         freshAt: new Date('2026-03-03T00:00:00Z'),
         indexedAt: new Date('2026-03-03T00:00:00Z'),
         active: true,
-        acl: [{ orgId: 'org-2', roleRequired: 'VERIFIER' }],
       },
+    ]);
+    // SearchObject has no `acl` relation — the service stitches these rows
+    // from the standalone SearchObjectACL table by searchObjectId.
+    prismaMock.searchObjectACL.findMany.mockResolvedValue([
+      { searchObjectId: 'verifier-1', orgId: 'org-1', roleRequired: 'VERIFIER' },
+      { searchObjectId: 'other-org-1', orgId: 'org-2', roleRequired: 'VERIFIER' },
     ]);
 
     const response = await querySearch({

--- a/apps/api/backend/src/services/search/requestContext.ts
+++ b/apps/api/backend/src/services/search/requestContext.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   ActivePersona,
   MembershipRole,

--- a/apps/api/backend/src/services/search/searchIndex.ts
+++ b/apps/api/backend/src/services/search/searchIndex.ts
@@ -70,11 +70,39 @@ export interface IndexStatusResponse {
   activeRuns: number;
 }
 
-type IndexedSearchObject = Prisma.SearchObjectGetPayload<{
-  include: {
-    acl: true;
-  };
-}>;
+// SearchObject has NO `acl` Prisma relation — SearchObjectACL is a
+// standalone table keyed by a plain searchObjectId FK column, so
+// `include: { acl: true }` throws P2009 at runtime. The ACL rows are
+// stitched in JS by attachSearchObjectAcls() instead.
+type SearchObjectAclEntry = Prisma.SearchObjectACLGetPayload<object>;
+
+type IndexedSearchObject = Prisma.SearchObjectGetPayload<object> & {
+  acl: SearchObjectAclEntry[];
+};
+
+async function attachSearchObjectAcls(
+  objects: Prisma.SearchObjectGetPayload<object>[],
+): Promise<IndexedSearchObject[]> {
+  if (objects.length === 0) {
+    return [];
+  }
+  const aclRows = await prisma.searchObjectACL.findMany({
+    where: { searchObjectId: { in: objects.map((object) => object.id) } },
+  });
+  const aclByObjectId = new Map<string, SearchObjectAclEntry[]>();
+  for (const row of aclRows) {
+    const list = aclByObjectId.get(row.searchObjectId);
+    if (list) {
+      list.push(row);
+    } else {
+      aclByObjectId.set(row.searchObjectId, [row]);
+    }
+  }
+  return objects.map((object) => ({
+    ...object,
+    acl: aclByObjectId.get(object.id) ?? [],
+  }));
+}
 
 const ACL_COMPATIBILITY: Record<SearchAclLevel, SearchAclLevel[]> = {
   PUBLIC: ['PUBLIC'],
@@ -273,7 +301,7 @@ function dedupeResults(results: SearchResult[]): SearchResult[] {
 }
 
 async function fetchIndexedResults(query: SearchQuery): Promise<SearchResult[]> {
-  const rawResults = await prisma.searchObject.findMany({
+  const rawResults = await attachSearchObjectAcls(await prisma.searchObject.findMany({
     where: {
       active: true,
       aclLevel: { in: resolveAclLevels(query.aclLevel ?? 'PUBLIC') },
@@ -285,8 +313,7 @@ async function fetchIndexedResults(query: SearchQuery): Promise<SearchResult[]> 
     },
     orderBy: { indexedAt: 'desc' },
     take: Math.max((query.limit ?? 10) + (query.offset ?? 0), 20),
-    include: { acl: true },
-  });
+  }));
 
   return rawResults
     .filter((object) => canAccessIndexedObject(object, query))
@@ -578,15 +605,14 @@ export async function suggestSearch(
     return { suggestions: [] };
   }
 
-  const indexedHits = await prisma.searchObject.findMany({
+  const indexedHits = await attachSearchObjectAcls(await prisma.searchObject.findMany({
     where: {
       active: true,
       aclLevel: { in: resolveAclLevels(options.aclLevel ?? 'PUBLIC') },
       title: { contains: normalizedQuery, mode: 'insensitive' },
     },
-    include: { acl: true },
     take: Math.max(limit * 2, 10),
-  });
+  }));
 
   const indexedSuggestions = indexedHits
     .filter((object) => canAccessIndexedObject(object, { q: normalizedQuery, ...options }))

--- a/apps/api/backend/src/services/workspace/workspaceAnalytics.ts
+++ b/apps/api/backend/src/services/workspace/workspaceAnalytics.ts
@@ -1,38 +1,38 @@
-// @ts-nocheck
 import prisma from '../../graphql/prisma_client';
 
+// The Prisma schema declares NO relations between User, PersonProfile and
+// WorkspaceMembership (plain FK columns), so relation-style filters/selects
+// (`personProfile: { isNot: null }`, nested `memberships`) throw P2009 at
+// runtime. Fetch the real tables and compose in JS instead (see
+// hydrateWorkspaceUser in workspaceService.ts).
 export async function getDualRoleUserRate(): Promise<{
   total: number;
   dualRole: number;
   rate: number;
 }> {
-  const users = await prisma.user.findMany({
-    where: {
-      personProfile: {
-        isNot: null,
-      },
-    },
-    select: {
-      id: true,
-      personProfile: {
-        select: {
-          memberships: {
-            where: {
-              active: true,
-            },
-            select: {
-              id: true,
-            },
-          },
-        },
-      },
-    },
+  // PersonProfile.userId is unique + required, so profiles stand in 1:1 for
+  // users that have one.
+  const personProfiles = await prisma.personProfile.findMany({
+    select: { id: true },
   });
 
-  const total = users.length;
-  const dualRole = users.filter(
-    (user) => (user.personProfile?.memberships.length ?? 0) > 0,
-  ).length;
+  const total = personProfiles.length;
+  if (total === 0) {
+    return { total: 0, dualRole: 0, rate: 0 };
+  }
+
+  const activeMemberships = await prisma.workspaceMembership.findMany({
+    where: { active: true },
+    select: { personProfileId: true },
+  });
+
+  const profileIds = new Set(personProfiles.map((profile) => profile.id));
+  const dualRoleProfileIds = new Set(
+    activeMemberships
+      .map((membership) => membership.personProfileId)
+      .filter((personProfileId) => profileIds.has(personProfileId)),
+  );
+  const dualRole = dualRoleProfileIds.size;
 
   return {
     total,

--- a/apps/api/backend/src/services/workspace/workspaceService.ts
+++ b/apps/api/backend/src/services/workspace/workspaceService.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   ActivePersona,
   type MembershipRole,


### PR DESCRIPTION
## Summary

Backend follow-up to #555/#556. Three work items: rewrite the remaining phantom Prisma relation queries (throw `P2009` when reached — the schema declares **no relations** between User/PersonProfile/WorkspaceMembership/OrganizationProfile/WorkspacePreference), audit the `dbgenerated("gen_random_uuid()")` id defaults against the real production DB (`P2011` risk), and attempt `@ts-nocheck` removal on the files stitched in #555.

## 1 — Phantom relation queries → FK + JS stitch

All rewritten with the `hydrateWorkspaceUser()` pattern from #555 (fetch by FK columns, compose in JS, fail closed on dangling FKs):

| Site | Phantom pattern |
|---|---|
| `workspaceAnalytics.getDualRoleUserRate` | `user.findMany` where `personProfile: { isNot: null }` + nested `personProfile→memberships` select |
| `rebuildEngine.buildProjection` | `workspaceMembership.findMany` with `personProfile:{npi:{in}}` / `organizationProfile:{organizationId:{in}}` filters + nested selects → new `loadWorkspaceMembershipRows()` |
| `opportunityService.upsertOrgProfile` | `workspaceMembership.findFirst` + `include: { organizationProfile: { include: { organization } } }` (employer org-registration path) |
| `routes/entity.ts` GET `/api/entity/:id/relationships` | `include: { subject, object }` — **`VcvEntityRelationship` has no relations**, plain FK columns |
| `searchIndex.fetchIndexedResults` + `suggestSearch` | `include: { acl: true }` — **`SearchObject` has no `acl` relation**; `SearchObjectACL` is a standalone table (also: nothing ever writes it, so stitched rows are empty today, same as intended) |

The last three are stragglers found by the repo-wide sweep (every `include:`/nested-select/relation-filter in all 47 `@ts-nocheck` files was checked against the schema; everything else rides real relations, e.g. `application→opportunity→organization→organizationProfile`).

## 2 — dbgenerated id audit (prod `information_schema`, read-only)

| table | prod default | action |
|---|---|---|
| workspace_memberships / workspace_preferences | NULL | already fixed in #556 (sanity-confirmed) |
| **watchlists** | **NULL** | `id: randomUUID()` added: `watchtowerStore.createWatchlist`, `intelligenceLayerService.createIntelligenceWatch` (upsert create-branch) |
| **watchlist_hits** | **NULL** | `id: randomUUID()` added: `watchtowerStore.persistWatchlistHit` |
| verification_receipt_records | NULL | no `.create` call sites anywhere — dormant; comment-only risk, no code change |
| vcv_organization_contexts / _subjects / _status_events / vcv_user_entity_claims | `gen_random_uuid()` ✓ | none needed — orgContextService/passportEntity creates are safe as-is |
| EventLog | **table missing** | prisma model is dead code (zero call sites) — no change |

No migrations written (founder-gated).

## 3 — @ts-nocheck removal

Removed and typecheck-clean: `workspaceService.ts`, `search/requestContext.ts`, `opportunities/applicationService.ts`, `pilot/pilotProofService.ts` — plus `workspaceAnalytics.ts` and `graph-engine/rebuildEngine.ts` (the ~1000-line rebuild engine now fully typechecks, which also vouches its queries are schema-valid).

Surfaced fixes, including one real bug: `applyToOpportunity` fetched the applicant's PersonProfile but passed a **bare User** into `hydrateApplication`, so the immediate apply response silently lost provider profile data (npi/name/specialty). Now stitched into `ApplicantUserRecord`. Also null-narrowing guards in `loadEmployerAcceptanceMap` (the `in` filters can't match NULL).

## Tests

- `pnpm exec tsc --noEmit` — clean
- Jest (placeholder DATABASE_URL): **15/15 suites, 44/44 tests** across workspace, opportunities, search, pilot, graph-engine (unit), identity/watchtowerCore, routes/intelligenceLayer
- `requestContext.test.ts` was **failing on main since #555** (mock still assumed the relation include) — fixed to the stitched mocks; `opportunityService.test.ts` + `searchIndex.test.ts` mocks updated likewise
- `graphRuntime.integration.test.ts` needs a real DB (fails identically on pristine origin/main; environmental, untouched)

## Design Handoff References

No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)