### PR TITLE
feat(profile): editable self-attested clinician profile in the D57 document system

### DIFF
--- a/apps/api/backend/__tests__/intakeService.sanitizeSelfAttested.test.ts
+++ b/apps/api/backend/__tests__/intakeService.sanitizeSelfAttested.test.ts
@@ -1,0 +1,68 @@
+/**
+ * sanitizeSelfAttested — whitelist-sanitizes the untrusted self-attested
+ * profile payload before it is stored in the PersonProfile.selfAttested JSON
+ * column. Pure function (no DB), so it runs without a database.
+ *
+ * Guards: unknown keys dropped, strings trimmed + length-capped, years bounded,
+ * array rows without their required field removed, empty sections omitted.
+ */
+
+import { sanitizeSelfAttested } from '../src/services/intake/intakeService';
+
+describe('sanitizeSelfAttested', () => {
+  it('keeps only known, non-empty fields and trims strings', () => {
+    const out = sanitizeSelfAttested({
+      contact: { practiceEmail: '  dr@example.com  ', practicePhone: '', hacker: 'x' },
+      medicalSchool: { institutionName: 'State U', degree: 'MD', graduationYear: '2010' },
+      subspecialty: 'Cardiology',
+      careerGoals: '  Lead a rural clinic  ',
+      researchSummary: '',
+      unknownTopLevel: 'nope',
+    });
+
+    expect(out).toEqual({
+      contact: { practiceEmail: 'dr@example.com' },
+      medicalSchool: { institutionName: 'State U', degree: 'MD', graduationYear: 2010 },
+      subspecialty: 'Cardiology',
+      careerGoals: 'Lead a rural clinic',
+    });
+    expect('unknownTopLevel' in out).toBe(false);
+    expect('researchSummary' in out).toBe(false);
+    expect((out.contact as Record<string, unknown>).hacker).toBeUndefined();
+  });
+
+  it('drops work-history/affiliation rows missing their required field and caps rows', () => {
+    const out = sanitizeSelfAttested({
+      workHistory: [
+        { employer: 'Cedar Health', role: 'PA-C', startYear: 2018, endYear: 2022 },
+        { role: 'no employer' },
+        { employer: '   ' },
+      ],
+      affiliations: [
+        { organization: 'County Hospital', role: 'Attending' },
+        { role: 'no org' },
+      ],
+    });
+
+    expect(out.workHistory).toEqual([
+      { employer: 'Cedar Health', role: 'PA-C', startYear: 2018, endYear: 2022 },
+    ]);
+    expect(out.affiliations).toEqual([{ organization: 'County Hospital', role: 'Attending' }]);
+  });
+
+  it('bounds out-of-range or non-numeric years', () => {
+    const out = sanitizeSelfAttested({
+      medicalSchool: { institutionName: 'X', graduationYear: 3005 },
+      workHistory: [{ employer: 'Y', startYear: 'abc', endYear: 1850 }],
+    });
+    expect(out.medicalSchool).toEqual({ institutionName: 'X' });
+    expect(out.workHistory).toEqual([{ employer: 'Y' }]);
+  });
+
+  it('returns an empty object for junk input', () => {
+    expect(sanitizeSelfAttested(null)).toEqual({});
+    expect(sanitizeSelfAttested('string')).toEqual({});
+    expect(sanitizeSelfAttested(42)).toEqual({});
+    expect(sanitizeSelfAttested({})).toEqual({});
+  });
+});

--- a/apps/api/backend/prisma/migrations/20260705120000_self_attested_profile/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260705120000_self_attested_profile/migration.sql
@@ -1,0 +1,9 @@
+-- Self-attested structured profile sections for the signed-in clinician.
+-- One JSON document holding the USER_ENTERED layer: contact details, medical
+-- school, subspecialty, work history, affiliations, career goals, research.
+-- These are clinician-stated and NEVER source-verified — source-checked facts
+-- (NPPES / licensure / board) live in their own tables with their own receipts.
+-- Additive, nullable column: safe to apply on a live table with no backfill.
+
+ALTER TABLE "person_profiles"
+  ADD COLUMN IF NOT EXISTS "self_attested" JSONB;

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -330,6 +330,12 @@ model PersonProfile {
   // binding — not a license or identity verification on its own.
   verifiedEmail       String?          @map("verified_email")
   verifiedEmailAt     DateTime?        @map("verified_email_at")
+  // Self-attested structured profile sections (contact, education, work
+  // history, affiliations, career goals, research). The clinician typed these;
+  // they are USER_ENTERED and NEVER source-verified. Stored as a single JSON
+  // document so the whole self-attested layer moves as one edit. Source-checked
+  // facts (NPPES / licensure / board) live elsewhere with their own receipts.
+  selfAttested        Json?            @map("self_attested")
   completeness      Int                @default(0)
   createdAt         DateTime           @default(now()) @map("created_at")
   updatedAt         DateTime           @updatedAt @map("updated_at")

--- a/apps/api/backend/src/routes/intake.ts
+++ b/apps/api/backend/src/routes/intake.ts
@@ -11,10 +11,13 @@
 import type { Express, NextFunction, Request, Response } from 'express';
 import {
   bootstrapNpiIntake,
+  clearResume,
   getProfileCompleteness,
   ingestLinks,
   ingestResumeUpload,
   ingestWorkAuth,
+  updateSelfAttested,
+  type ClearableLinkField,
 } from '../services/intake/intakeService';
 import { HttpError } from '../utils/httpError';
 
@@ -39,13 +42,24 @@ export function registerIntakeRoutes(app: Express): void {
 
   /**
    * POST /api/profile/resume/upload
-   * Body: { fileName: string; fileUrl: string }
+   * Body: { fileName: string; fileUrl: string } to attach, or { clear: true }
+   * to remove the current resume link.
    */
   app.post(
     '/api/profile/resume/upload',
     asyncHandler(async (req, res) => {
       const userId = requireUserId(req);
-      const { fileName, fileUrl } = req.body as { fileName?: string; fileUrl?: string };
+      const { fileName, fileUrl, clear } = req.body as {
+        fileName?: string;
+        fileUrl?: string;
+        clear?: boolean;
+      };
+
+      if (clear === true) {
+        const cleared = await clearResume(userId);
+        res.json(cleared);
+        return;
+      }
 
       if (!fileName || !fileUrl) {
         throw new HttpError(400, 'fileName and fileUrl are required.');
@@ -58,29 +72,49 @@ export function registerIntakeRoutes(app: Express): void {
 
   /**
    * POST /api/profile/links
-   * Body: { linkedinUrl?: string; portfolioUrl?: string; otherUrls?: string[] }
+   * Body: { linkedinUrl?: string; portfolioUrl?: string; otherUrls?: string[];
+   *         clear?: ('linkedinUrl'|'portfolioUrl')[] }
+   * A field named in `clear` is taken back to empty (unless the same payload
+   * also provides a new value for it).
    */
   app.post(
     '/api/profile/links',
     asyncHandler(async (req, res) => {
       const userId = requireUserId(req);
-      const { linkedinUrl, portfolioUrl, otherUrls } =
-        req.body as { linkedinUrl?: string; portfolioUrl?: string; otherUrls?: string[] };
+      const { linkedinUrl, portfolioUrl, otherUrls, clear } =
+        req.body as {
+          linkedinUrl?: string;
+          portfolioUrl?: string;
+          otherUrls?: string[];
+          clear?: string[];
+        };
 
-      const result = await ingestLinks(userId, linkedinUrl, portfolioUrl, otherUrls ?? []);
+      const CLEARABLE: ClearableLinkField[] = ['linkedinUrl', 'portfolioUrl'];
+      const clearFields = Array.isArray(clear)
+        ? CLEARABLE.filter((f) => clear.includes(f))
+        : [];
+
+      const result = await ingestLinks(userId, linkedinUrl, portfolioUrl, otherUrls ?? [], clearFields);
       res.json(result);
     }),
   );
 
   /**
    * POST /api/profile/work-auth
-   * Body: { workAuthStatus: 'authorized' | 'visa_required' | 'other' }
+   * Body: { workAuthStatus: 'authorized' | 'visa_required' | 'other' } to set,
+   * or { clear: true } to take work authorization back to unstated.
    */
   app.post(
     '/api/profile/work-auth',
     asyncHandler(async (req, res) => {
       const userId = requireUserId(req);
-      const { workAuthStatus } = req.body as { workAuthStatus?: string };
+      const { workAuthStatus, clear } = req.body as { workAuthStatus?: string; clear?: boolean };
+
+      if (clear === true) {
+        const cleared = await ingestWorkAuth(userId, null);
+        res.json(cleared);
+        return;
+      }
 
       const ALLOWED = ['authorized', 'visa_required', 'other'];
       if (!workAuthStatus || !ALLOWED.includes(workAuthStatus)) {
@@ -89,6 +123,26 @@ export function registerIntakeRoutes(app: Express): void {
 
       const result = await ingestWorkAuth(userId, workAuthStatus);
       res.json(result);
+    }),
+  );
+
+  /**
+   * POST /api/profile/self-attested
+   * Body: { selfAttested: SelfAttestedProfile } — full-document replace of the
+   * clinician's USER_ENTERED profile layer (contact, medical school,
+   * subspecialty, work history, affiliations, career goals, research). Values
+   * here are never source-verified.
+   */
+  app.post(
+    '/api/profile/self-attested',
+    asyncHandler(async (req, res) => {
+      const userId = requireUserId(req);
+      const body = req.body as { selfAttested?: unknown } | undefined;
+      const input = body && typeof body === 'object' && 'selfAttested' in body
+        ? body.selfAttested
+        : body;
+      const result = await updateSelfAttested(userId, input);
+      res.json({ selfAttested: result });
     }),
   );
 

--- a/apps/api/backend/src/services/intake/intakeService.ts
+++ b/apps/api/backend/src/services/intake/intakeService.ts
@@ -16,6 +16,7 @@
 import prisma from '../../graphql/prisma_client';
 import { log } from '../../obs/logger';
 import { sha256ForPayload } from '../../utils/deterministic';
+import { HttpError } from '../../utils/httpError';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -167,14 +168,9 @@ export async function ingestResumeUpload(
 
   const inferredSkills: string[] = [];
 
-  // Update profile completeness
-  const dims = await getProfileDimensions(userId);
-  dims.resumeUploaded = true;
-  const completeness = computeCompleteness(dims);
-  await prisma.personProfile.updateMany({
-    where: { userId },
-    data:  { completeness },
-  });
+  // Recompute completeness from the persisted profile so the dimension always
+  // matches what is actually on file.
+  const completeness = await recomputeCompleteness(userId);
 
   await emitAudit('resume_uploaded', userId, { fileName, fileUrl });
 
@@ -189,17 +185,48 @@ export async function ingestResumeUpload(
 }
 
 /**
+ * Clear the clinician's resume link. Self-service removal of a self-attested
+ * value — the intake surface can now take a field back to empty, not only add.
+ */
+export async function clearResume(userId: string): Promise<ResumeUploadResult> {
+  await prisma.personProfile.updateMany({
+    where: { userId },
+    data:  { resumeUrl: null, updatedAt: new Date() },
+  });
+  const completeness = await recomputeCompleteness(userId);
+  await emitAudit('resume_cleared', userId, {});
+  return {
+    resumeId:      '',
+    fileName:      '',
+    inferredName:  undefined,
+    inferredTitle: undefined,
+    inferredSkills: [],
+    completeness,
+  };
+}
+
+/**
  * Ingest professional links (LinkedIn, portfolio, other).
  */
+export type ClearableLinkField = 'linkedinUrl' | 'portfolioUrl';
+
 export async function ingestLinks(
   userId:       string,
   linkedinUrl?: string,
   portfolioUrl?: string,
   otherUrls:    string[] = [],
+  clear:        ClearableLinkField[] = [],
 ): Promise<LinksIngestionResult> {
-  const update: Record<string, string | undefined> = {};
+  const update: Record<string, string | null> = {};
   if (linkedinUrl)  update.linkedinUrl  = linkedinUrl;
   if (portfolioUrl) update.portfolioUrl = portfolioUrl;
+  // Explicit clears take a saved value back to empty. A value present in the
+  // same payload wins over a clear for that field (edit beats remove).
+  for (const field of clear) {
+    if ((field === 'linkedinUrl' || field === 'portfolioUrl') && !(field in update)) {
+      update[field] = null;
+    }
+  }
 
   if (Object.keys(update).length > 0) {
     await prisma.personProfile.updateMany({
@@ -208,47 +235,38 @@ export async function ingestLinks(
     });
   }
 
-  const dims = await getProfileDimensions(userId);
-  dims.linksAdded = Boolean(linkedinUrl || portfolioUrl || otherUrls.length);
-  const completeness = computeCompleteness(dims);
-  await prisma.personProfile.updateMany({
-    where: { userId },
-    data:  { completeness },
-  });
+  // Recompute from what is actually persisted so clearing both links flips the
+  // linksAdded dimension back off.
+  const completeness = await recomputeCompleteness(userId);
 
-  await emitAudit('links_ingested', userId, { linkedinUrl, portfolioUrl, otherUrls });
+  await emitAudit('links_ingested', userId, { linkedinUrl, portfolioUrl, otherUrls, clear });
 
+  const profile = await prisma.personProfile.findUnique({ where: { userId } });
   return {
-    linkedinUrl,
-    portfolioUrl,
+    linkedinUrl:  profile?.linkedinUrl ?? undefined,
+    portfolioUrl: profile?.portfolioUrl ?? undefined,
     otherUrls,
     updatedAt: new Date().toISOString(),
   };
 }
 
 /**
- * Ingest work authorization status.
+ * Ingest (or clear) work authorization status. Passing `null` clears it.
  */
 export async function ingestWorkAuth(
   userId:         string,
-  workAuthStatus: string,
+  workAuthStatus: string | null,
 ): Promise<WorkAuthResult> {
   await prisma.personProfile.updateMany({
     where: { userId },
     data:  { workAuthStatus, updatedAt: new Date() },
   });
 
-  const dims = await getProfileDimensions(userId);
-  dims.workAuthProvided = true;
-  const completeness = computeCompleteness(dims);
-  await prisma.personProfile.updateMany({
-    where: { userId },
-    data:  { completeness },
-  });
+  const completeness = await recomputeCompleteness(userId);
 
   await emitAudit('work_auth_ingested', userId, { workAuthStatus });
 
-  return { userId, workAuthStatus, updatedAt: new Date().toISOString() };
+  return { userId, workAuthStatus: workAuthStatus ?? '', updatedAt: new Date().toISOString() };
 }
 
 /**
@@ -357,6 +375,180 @@ export async function getProfileCompleteness(userId: string): Promise<ProfileCom
     score: computeCompleteness(dims),
     dimensions: dims,
   };
+}
+
+/**
+ * Recompute completeness from the persisted profile and store it. Called after
+ * every write (add OR clear) so the score always reflects what is on file.
+ */
+async function recomputeCompleteness(userId: string): Promise<number> {
+  const dims = await getProfileDimensions(userId);
+  const completeness = computeCompleteness(dims);
+  await prisma.personProfile.updateMany({
+    where: { userId },
+    data:  { completeness },
+  });
+  return completeness;
+}
+
+// ── Self-attested structured profile sections ───────────────────────────────
+
+export interface SelfAttestedContact {
+  practiceEmail?:   string;
+  practicePhone?:   string;
+  practiceWebsite?: string;
+}
+
+export interface SelfAttestedEducation {
+  institutionName?: string;
+  degree?:          string;
+  graduationYear?:  number;
+}
+
+export interface SelfAttestedWorkEntry {
+  employer:   string;
+  role?:      string;
+  startYear?: number;
+  endYear?:   number;
+}
+
+export interface SelfAttestedAffiliation {
+  organization: string;
+  role?:        string;
+}
+
+/**
+ * The clinician's self-attested profile layer. Every field here is
+ * USER_ENTERED — typed by the clinician and never source-verified. Source-
+ * checked facts (identity, licensure, board) are held separately.
+ */
+export interface SelfAttestedProfile {
+  contact?:        SelfAttestedContact;
+  medicalSchool?:  SelfAttestedEducation;
+  subspecialty?:   string;
+  workHistory?:    SelfAttestedWorkEntry[];
+  affiliations?:   SelfAttestedAffiliation[];
+  careerGoals?:    string;
+  researchSummary?: string;
+}
+
+const MAX_ROWS = 40;
+const MAX_STR = 500;
+const MIN_YEAR = 1900;
+const MAX_YEAR = 2100;
+
+function cleanStr(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().slice(0, MAX_STR);
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function cleanYear(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(n)) return undefined;
+  const year = Math.trunc(n);
+  return year >= MIN_YEAR && year <= MAX_YEAR ? year : undefined;
+}
+
+/** Drop keys whose values are all undefined so the JSON stays compact. */
+function compact<T extends Record<string, unknown>>(obj: T): T | undefined {
+  const entries = Object.entries(obj).filter(([, v]) => v !== undefined);
+  return entries.length > 0 ? (Object.fromEntries(entries) as T) : undefined;
+}
+
+/**
+ * Whitelist-sanitize an untrusted self-attested payload before it is stored in
+ * the JSON column: known keys only, strings trimmed and length-capped, years
+ * bounded, arrays capped and stripped of empty rows. Unknown keys are dropped.
+ */
+export function sanitizeSelfAttested(input: unknown): SelfAttestedProfile {
+  const src = (input && typeof input === 'object' ? input : {}) as Record<string, unknown>;
+  const out: SelfAttestedProfile = {};
+
+  const contactSrc = (src.contact && typeof src.contact === 'object' ? src.contact : {}) as Record<string, unknown>;
+  const contact = compact({
+    practiceEmail:   cleanStr(contactSrc.practiceEmail),
+    practicePhone:   cleanStr(contactSrc.practicePhone),
+    practiceWebsite: cleanStr(contactSrc.practiceWebsite),
+  });
+  if (contact) out.contact = contact;
+
+  const schoolSrc = (src.medicalSchool && typeof src.medicalSchool === 'object' ? src.medicalSchool : {}) as Record<string, unknown>;
+  const medicalSchool = compact({
+    institutionName: cleanStr(schoolSrc.institutionName),
+    degree:          cleanStr(schoolSrc.degree),
+    graduationYear:  cleanYear(schoolSrc.graduationYear),
+  });
+  if (medicalSchool) out.medicalSchool = medicalSchool;
+
+  const subspecialty = cleanStr(src.subspecialty);
+  if (subspecialty) out.subspecialty = subspecialty;
+
+  if (Array.isArray(src.workHistory)) {
+    const rows = src.workHistory
+      .slice(0, MAX_ROWS)
+      .map((raw) => {
+        const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+        const employer = cleanStr(r.employer);
+        if (!employer) return null;
+        const entry: SelfAttestedWorkEntry = { employer };
+        const role = cleanStr(r.role);
+        if (role) entry.role = role;
+        const startYear = cleanYear(r.startYear);
+        if (startYear !== undefined) entry.startYear = startYear;
+        const endYear = cleanYear(r.endYear);
+        if (endYear !== undefined) entry.endYear = endYear;
+        return entry;
+      })
+      .filter((r): r is SelfAttestedWorkEntry => r !== null);
+    if (rows.length > 0) out.workHistory = rows;
+  }
+
+  if (Array.isArray(src.affiliations)) {
+    const rows = src.affiliations
+      .slice(0, MAX_ROWS)
+      .map((raw) => {
+        const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+        const organization = cleanStr(r.organization);
+        if (!organization) return null;
+        const entry: SelfAttestedAffiliation = { organization };
+        const role = cleanStr(r.role);
+        if (role) entry.role = role;
+        return entry;
+      })
+      .filter((r): r is SelfAttestedAffiliation => r !== null);
+    if (rows.length > 0) out.affiliations = rows;
+  }
+
+  const careerGoals = cleanStr(src.careerGoals);
+  if (careerGoals) out.careerGoals = careerGoals;
+
+  const researchSummary = cleanStr(src.researchSummary);
+  if (researchSummary) out.researchSummary = researchSummary;
+
+  return out;
+}
+
+/**
+ * Replace the clinician's self-attested profile layer. Full-document replace:
+ * the caller sends the complete self-attested state, so omitted sections are
+ * cleared. Requires an existing PersonProfile (the clinician has connected an
+ * NPI); returns 404-style signal via a thrown error when none is found.
+ */
+export async function updateSelfAttested(
+  userId: string,
+  input:  unknown,
+): Promise<SelfAttestedProfile> {
+  const clean = sanitizeSelfAttested(input);
+  const result = await prisma.personProfile.updateMany({
+    where: { userId },
+    data:  { selfAttested: clean as object, updatedAt: new Date() },
+  });
+  if (result.count === 0) {
+    throw new HttpError(404, 'No profile to update. Connect your NPI first.');
+  }
+  await emitAudit('self_attested_updated', userId, { sections: Object.keys(clean) });
+  return clean;
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/apps/web/__tests__/clinician-profile-surface.test.tsx
+++ b/apps/web/__tests__/clinician-profile-surface.test.tsx
@@ -228,25 +228,31 @@ describe('ProfileSurface (Wave 2B editing depth)', () => {
     expect((container.querySelector('button[type="submit"]') as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('blocks a save that clears a previously saved field, with honest copy', async () => {
-    const { savePosts } = installFetchMock();
+  it('clears a previously saved field by sending an explicit clear, not a block', async () => {
+    const { savePosts, mock } = installFetchMock();
     await renderSurface();
 
     const linkedin = container.querySelector('#profile-linkedin') as HTMLInputElement;
     await act(async () => {
       setInputValue(linkedin, '');
     });
+    // Clearing is supported: honest confirm copy names the field, no block.
+    expect(container.textContent).toContain('Saving will remove LinkedIn');
     const button = container.querySelector('button[type="submit"]') as HTMLButtonElement;
     expect(button.disabled).toBe(false);
+
     await act(async () => {
       submitForm(container);
     });
+    await flushEffects();
 
-    const alert = container.querySelector('[role="alert"]');
-    expect(alert?.textContent).toContain('Removing a saved value is not supported on this surface yet');
-    expect(alert?.textContent).toContain('LinkedIn');
-    expect(savePosts).toEqual([]);
-    expect(container.querySelector('button[type="submit"]')?.textContent).toContain('Retry save');
+    // A links POST carried an explicit clear for linkedinUrl (and no set value).
+    expect(savePosts.some((url) => url.includes('/api/profile/links'))).toBe(true);
+    const linksCall = mock.mock.calls.find(([url]) => String(url).includes('/api/profile/links'));
+    const body = JSON.parse((linksCall?.[1] as RequestInit).body as string);
+    expect(body.clear).toEqual(['linkedinUrl']);
+    expect(body.linkedinUrl).toBeUndefined();
+    expect(container.textContent).toContain('Saved as self-attested.');
   });
 
   it('saves only the changed field and reports a failed save with a retry affordance', async () => {

--- a/apps/web/app/api/profile/self-attested/route.ts
+++ b/apps/web/app/api/profile/self-attested/route.ts
@@ -1,0 +1,22 @@
+import { auth } from '@clerk/nextjs/server';
+import { getApiBase } from '@/lib/api';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const BACKEND = getApiBase();
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = `${BACKEND}/api/profile/self-attested`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-clerk-user-id': session.userId,
+  };
+  const body = await req.text();
+  const res = await fetch(url, { method: 'POST', headers, body });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/app/clinician/profile/ProfileSurface.tsx
+++ b/apps/web/app/clinician/profile/ProfileSurface.tsx
@@ -1,43 +1,34 @@
 'use client';
 
 /**
- * ProfileSurface — the live professional profile for the signed-in clinician.
+ * ProfileSurface — the live professional profile for the signed-in clinician,
+ * rendered in the D57 `.vcv-doc` paper/ink document system.
  *
  * Reads the real workspace PersonProfile (bound at /get-ready via the NPPES
  * bootstrap) and the clinician's live passport, renders the provenance-honest
- * profile sections (ClinicianProfileSections), and lets the clinician save
- * SELF-ATTESTED fields (career links, resume link, work authorization)
- * through the existing intake endpoints. User-entered information is never
- * presented as verified.
+ * profile, and lets the clinician:
+ *   - edit SELF-ATTESTED career links / resume link / work authorization
+ *     (and now CLEAR any of them — clearing a saved value is supported)
+ *   - edit the SELF-ATTESTED structured sections (contact, education, work
+ *     history, affiliations, career goals, research) via SelfAttestedEditor
+ * User-entered information is never presented as verified.
  *
  *   checking → signed_out | no_npi | load_error | ready
- *
- * Wave 2B (profile editing depth):
- *   - per-field provenance chips on the identity header (registry-hydrated
- *     fields are source-confirmed; a bare NPI stays user-entered)
- *   - dirty tracking: save is disabled with no changes, "Saved" clears the
- *     moment the form is edited again, and a failed save offers a retry
- *   - clearing a saved field is blocked with an honest explanation (the
- *     intake API cannot clear values yet)
- *   - completeness guidance: the backend dimension breakdown renders as a
- *     what's-done / what's-missing checklist. Filled-ness only — completing
- *     the checklist is never presented as verification.
- *   - recorded employer acceptances (recognition) surface with a link to the
- *     full recognition record
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
-  AlertCircle,
   Award,
   CheckCircle2,
   ChevronRight,
   CircleDashed,
   Loader2,
+  Share2,
   UserRound,
 } from 'lucide-react';
 import { ClinicianProfileSections } from '@/components/profile/ClinicianProfileSections';
+import SelfAttestedEditor from '@/components/profile/SelfAttestedEditor';
 import { isPassportData, type PassportData } from '@/lib/trust/passport-contract';
 import { PROVENANCE_META, type ProfileProvenance } from '@/lib/profile/provenance';
 import {
@@ -49,7 +40,7 @@ import {
   WORK_AUTH_OPTIONS,
   completenessStatement,
   computeProfileFormDiff,
-  describeClearedFieldsBlock,
+  describeClearedFields,
   describeIdentityFields,
   describeProfileSaveError,
   displayName,
@@ -62,6 +53,11 @@ import {
   type ProfileFormValues,
   type WorkspacePersonProfile,
 } from '@/lib/clinician-profile/liveProfile';
+import {
+  countSelfAttestedSections,
+  selfAttestedToExtended,
+  type SelfAttestedProfile,
+} from '@/lib/clinician-profile/selfAttested';
 
 type Phase = 'checking' | 'signed_out' | 'no_npi' | 'load_error' | 'ready';
 
@@ -80,6 +76,9 @@ const EMPTY_FORM: ProfileFormValues = {
   resumeUrl: '',
   workAuthStatus: '',
 };
+
+const INPUT_CLASS = 'mt-2 w-full rounded-[6px] border px-3 py-2.5 text-sm outline-none transition focus:border-[var(--accent)]';
+const INPUT_STYLE = { borderColor: 'var(--paper-edge)', background: '#fff', color: 'var(--ink)' } as const;
 
 export default function ProfileSurface() {
   const [phase, setPhase] = useState<Phase>('checking');
@@ -219,16 +218,15 @@ export default function ProfileSurface() {
     setSaveError(null);
   }
 
+  /** Merge a saved self-attested layer back into the profile in place. */
+  const handleSelfAttestedSaved = useCallback((next: SelfAttestedProfile) => {
+    setProfile((p) => (p ? { ...p, selfAttested: next } : p));
+  }, []);
+
   async function saveSelfAttested(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!profile || !diff) return;
     setSaveError(null);
-
-    if (diff.clearedFields.length > 0) {
-      setSaveState('error');
-      setSaveError(describeClearedFieldsBlock(diff.clearedFields));
-      return;
-    }
     if (!diff.dirty) return;
 
     const linkedin = validateProfileUrl(form.linkedinUrl);
@@ -237,7 +235,7 @@ export default function ProfileSurface() {
     for (const [label, v] of [
       ['LinkedIn', linkedin],
       ['Portfolio', portfolio],
-      ['Resume', resume],
+      ['Resume link', resume],
     ] as const) {
       if (!v.ok) {
         setSaveState('error');
@@ -255,9 +253,14 @@ export default function ProfileSurface() {
     try {
       const requests: Array<Promise<Response>> = [];
 
-      if (diff.linksChanged) {
-        const linkedinChanged = linkedin.url && linkedin.url !== (profile.linkedinUrl ?? '');
-        const portfolioChanged = portfolio.url && portfolio.url !== (profile.portfolioUrl ?? '');
+      // Links: set changed values and/or clear emptied ones in one call.
+      const linkedinChanged = Boolean(linkedin.url) && linkedin.url !== (profile.linkedinUrl ?? '');
+      const portfolioChanged = Boolean(portfolio.url) && portfolio.url !== (profile.portfolioUrl ?? '');
+      const clearLinks: string[] = [
+        ...(diff.clearLinkedin ? ['linkedinUrl'] : []),
+        ...(diff.clearPortfolio ? ['portfolioUrl'] : []),
+      ];
+      if (linkedinChanged || portfolioChanged || clearLinks.length > 0) {
         requests.push(
           fetch('/api/profile/links', {
             method: 'POST',
@@ -265,11 +268,13 @@ export default function ProfileSurface() {
             body: JSON.stringify({
               ...(linkedinChanged ? { linkedinUrl: linkedin.url } : {}),
               ...(portfolioChanged ? { portfolioUrl: portfolio.url } : {}),
+              ...(clearLinks.length > 0 ? { clear: clearLinks } : {}),
             }),
           }),
         );
       }
 
+      // Resume: attach a new link, or clear the saved one.
       if (diff.resumeChanged && resume.url) {
         requests.push(
           fetch('/api/profile/resume/upload', {
@@ -281,14 +286,31 @@ export default function ProfileSurface() {
             }),
           }),
         );
+      } else if (diff.clearResume) {
+        requests.push(
+          fetch('/api/profile/resume/upload', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ clear: true }),
+          }),
+        );
       }
 
+      // Work authorization: set, or clear back to unstated.
       if (diff.workAuthChanged && form.workAuthStatus) {
         requests.push(
           fetch('/api/profile/work-auth', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ workAuthStatus: form.workAuthStatus }),
+          }),
+        );
+      } else if (diff.clearWorkAuth) {
+        requests.push(
+          fetch('/api/profile/work-auth', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ clear: true }),
           }),
         );
       }
@@ -320,9 +342,9 @@ export default function ProfileSurface() {
   if (phase === 'checking') {
     return (
       <Shell>
-        <div className="flex flex-col items-center gap-3 py-16" role="status" aria-live="polite">
-          <Loader2 className="h-7 w-7 animate-spin text-zinc-500" aria-hidden />
-          <p className="text-sm text-zinc-500">Loading your profile…</p>
+        <div className="vcv-panel flex flex-col items-center gap-3 py-16" role="status" aria-live="polite">
+          <Loader2 className="h-7 w-7 animate-spin" style={{ color: 'var(--ink-subtle)' }} aria-hidden />
+          <p className="text-sm vcv-muted">Loading your profile…</p>
         </div>
       </Shell>
     );
@@ -360,10 +382,9 @@ export default function ProfileSurface() {
   if (phase === 'load_error' || !profile) {
     return (
       <Shell>
-        <div className="space-y-4 py-10 text-center">
-          <AlertCircle className="mx-auto h-8 w-8 text-red-400" aria-hidden />
-          <p className="font-medium text-foreground">Couldn&apos;t load your profile</p>
-          <p className="text-sm text-zinc-400">
+        <div className="vcv-panel space-y-4 p-8 text-center">
+          <p className="font-medium" style={{ color: 'var(--ink-strong)' }}>Couldn&apos;t load your profile</p>
+          <p className="text-sm vcv-muted">
             This is a system state — not a finding about your profile. Try again shortly.
           </p>
           <button
@@ -372,7 +393,8 @@ export default function ProfileSurface() {
               setPhase('checking');
               void loadWorkspace();
             }}
-            className="rounded-lg border border-zinc-700 px-5 py-2 text-sm text-zinc-300 transition hover:text-foreground"
+            className="rounded-[6px] border px-5 py-2 text-sm transition hover:opacity-80"
+            style={{ borderColor: 'var(--paper-edge)', color: 'var(--ink)' }}
           >
             Try again
           </button>
@@ -386,50 +408,67 @@ export default function ProfileSurface() {
   const identityFields = describeIdentityFields(profile);
   const saving = saveState === 'saving';
   const saveDisabled = saving || !diff?.dirty;
+  const savedSections = countSelfAttestedSections(profile.selfAttested);
 
   return (
-    <Shell wide>
+    <Shell wide npi={profile.npi ?? undefined}>
       {/* Identity header — from the NPPES-bootstrapped PersonProfile */}
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-start gap-4">
-          <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900">
-            <UserRound className="h-6 w-6 text-emerald-400" aria-hidden />
+          <div
+            className="inline-flex h-12 w-12 items-center justify-center rounded-[10px] border"
+            style={{ borderColor: 'var(--paper-edge)', background: '#fff' }}
+          >
+            <UserRound className="h-6 w-6" style={{ color: 'var(--accent)' }} aria-hidden />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-foreground">{name ?? 'Your professional profile'}</h1>
-            <p className="mt-0.5 font-mono text-sm tracking-wide text-zinc-500">NPI {profile.npi}</p>
-            <p className="mt-1 text-xs text-zinc-600">
+            <h1 className="vcv-title text-3xl">{name ?? 'Your professional profile'}</h1>
+            <p className="vcv-mono mt-1 text-sm vcv-muted">NPI {profile.npi}</p>
+            <p className="mt-1 text-xs vcv-subtle">
               Identity fields come from your NPPES registry record at connect time.
             </p>
           </div>
         </div>
-        <Link
-          href="/holder/readiness"
-          className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-300 transition hover:border-emerald-800 hover:text-emerald-300"
-        >
-          Your readiness <ChevronRight className="h-4 w-4" aria-hidden />
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/verify/${profile.npi}`}
+            className="vcv-cta inline-flex items-center gap-1.5 px-4 py-2 text-sm"
+          >
+            <Share2 className="h-4 w-4" aria-hidden /> Share proof
+          </Link>
+          <Link
+            href="/holder/readiness"
+            className="inline-flex items-center gap-1.5 rounded-[6px] border px-4 py-2 text-sm font-semibold transition hover:opacity-80"
+            style={{ borderColor: 'var(--paper-edge)', color: 'var(--ink)' }}
+          >
+            Your readiness <ChevronRight className="h-4 w-4" aria-hidden />
+          </Link>
+        </div>
       </header>
 
       {/* Where each identity field came from */}
       <section
         aria-labelledby="identity-provenance-heading"
-        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+        className="vcv-panel p-5"
         data-testid="identity-provenance"
       >
-        <h2 id="identity-provenance-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+        <h2 id="identity-provenance-heading" className="vcv-eyebrow">
           Where your identity data comes from
         </h2>
         <dl className="mt-3 grid gap-3 sm:grid-cols-2">
           {identityFields.map((field) => (
-            <div key={field.key} className="rounded-xl border border-zinc-800/80 bg-zinc-950/40 p-3">
+            <div
+              key={field.key}
+              className="rounded-[8px] border p-3"
+              style={{ borderColor: 'var(--paper-edge)', background: 'var(--paper-warm)' }}
+            >
               <div className="flex items-center justify-between gap-2">
-                <dt className="text-xs uppercase tracking-[0.12em] text-zinc-500">{field.label}</dt>
+                <dt className="text-xs uppercase tracking-[0.12em] vcv-subtle">{field.label}</dt>
                 <ProvenanceChip provenance={field.provenance} />
               </div>
               <dd className="mt-1.5">
-                <p className="text-sm text-foreground/90">{field.value ?? 'Not on file'}</p>
-                <p className="mt-1 text-xs leading-relaxed text-zinc-600">{field.note}</p>
+                <p className="text-sm" style={{ color: 'var(--ink)' }}>{field.value ?? 'Not on file'}</p>
+                <p className="mt-1 text-xs leading-relaxed vcv-subtle">{field.note}</p>
               </dd>
             </div>
           ))}
@@ -437,11 +476,8 @@ export default function ProfileSurface() {
       </section>
 
       {/* Completeness — filled-ness only, with what's-missing guidance */}
-      <section
-        aria-labelledby="completeness-heading"
-        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
-      >
-        <h2 id="completeness-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+      <section aria-labelledby="completeness-heading" className="vcv-panel p-5">
+        <h2 id="completeness-heading" className="vcv-eyebrow">
           Profile completeness
         </h2>
         {(() => {
@@ -450,24 +486,28 @@ export default function ProfileSurface() {
           if (score === null) return null;
           return (
             <>
-              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800" role="presentation">
+              <div
+                className="mt-3 h-2 w-full overflow-hidden rounded-full"
+                role="presentation"
+                style={{ background: 'var(--paper-inset)' }}
+              >
                 <div
-                  className="h-full rounded-full bg-emerald-500 transition-all"
-                  style={{ width: `${Math.max(0, Math.min(100, score))}%` }}
+                  className="h-full rounded-full transition-all"
+                  style={{ width: `${Math.max(0, Math.min(100, score))}%`, background: 'var(--state-verified)' }}
                 />
               </div>
-              <p className="mt-2 text-sm text-zinc-400">{completenessStatement(score)}</p>
+              <p className="mt-2 text-sm vcv-muted">{completenessStatement(score)}</p>
             </>
           );
         })()}
 
         {completeness.status === 'loading' && (
-          <p className="mt-3 animate-pulse font-mono text-xs text-zinc-600" role="status" aria-live="polite">
+          <p className="vcv-mono mt-3 animate-pulse text-xs vcv-subtle" role="status" aria-live="polite">
             Loading what&apos;s complete and what&apos;s missing…
           </p>
         )}
         {completeness.status === 'unavailable' && (
-          <p className="mt-3 text-xs text-zinc-500">
+          <p className="mt-3 text-xs vcv-muted">
             The completeness breakdown is temporarily unavailable. This is a system state — not a
             finding about your profile.
           </p>
@@ -484,21 +524,21 @@ export default function ProfileSurface() {
                   data-complete={done}
                 >
                   {done ? (
-                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" aria-hidden />
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" style={{ color: 'var(--state-verified)' }} aria-hidden />
                   ) : (
-                    <CircleDashed className="mt-0.5 h-4 w-4 shrink-0 text-zinc-600" aria-hidden />
+                    <CircleDashed className="mt-0.5 h-4 w-4 shrink-0" style={{ color: 'var(--ink-ghost)' }} aria-hidden />
                   )}
                   <div className="min-w-0">
-                    <p className="text-sm text-foreground/90">
+                    <p className="text-sm" style={{ color: 'var(--ink)' }}>
                       {dim.label}
-                      <span className="ml-2 text-xs text-zinc-600">
+                      <span className="ml-2 text-xs vcv-subtle">
                         {done ? 'Done' : 'Missing'} · {dim.weight} of 100 points
                       </span>
                     </p>
                     {!done && (
-                      <p className="mt-0.5 text-xs leading-relaxed text-zinc-500">
+                      <p className="mt-0.5 text-xs leading-relaxed vcv-muted">
                         {dim.whyItMatters}{' '}
-                        <a href={dim.fixHref} className="font-semibold text-emerald-400 hover:text-emerald-300">
+                        <a href={dim.fixHref} className="font-semibold" style={{ color: 'var(--accent)' }}>
                           {dim.fixLabel}
                         </a>
                       </p>
@@ -512,36 +552,32 @@ export default function ProfileSurface() {
       </section>
 
       {/* Recorded employer acceptances */}
-      <section
-        aria-labelledby="recognition-heading"
-        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
-        data-testid="profile-recognition"
-      >
+      <section aria-labelledby="recognition-heading" className="vcv-panel p-5" data-testid="profile-recognition">
         <div className="flex items-center gap-2">
-          <Award className="h-4 w-4 text-emerald-400" aria-hidden />
-          <h2 id="recognition-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+          <Award className="h-4 w-4" style={{ color: 'var(--accent)' }} aria-hidden />
+          <h2 id="recognition-heading" className="vcv-eyebrow">
             Employer recognition
           </h2>
         </div>
         {recognition.state === 'loading' && (
-          <p className="mt-2 animate-pulse font-mono text-xs text-zinc-600" role="status" aria-live="polite">
+          <p className="vcv-mono mt-2 animate-pulse text-xs vcv-subtle" role="status" aria-live="polite">
             Checking your recognition record…
           </p>
         )}
         {recognition.state === 'recognized' && (
-          <p className="mt-2 text-sm text-zinc-300">
+          <p className="mt-2 text-sm" style={{ color: 'var(--ink)' }}>
             {recognition.recognition.summary.headline} Each acceptance is an employer decision
             recorded with an audit event.
           </p>
         )}
         {recognition.state === 'none_recorded' && (
-          <p className="mt-2 text-sm text-zinc-400">
+          <p className="mt-2 text-sm vcv-muted">
             No employer acceptances recorded yet. When an employer accepts your evidence as a head
             start, it shows up here.
           </p>
         )}
         {recognition.state === 'unavailable' && (
-          <p className="mt-2 text-xs text-zinc-500">
+          <p className="mt-2 text-xs vcv-muted">
             Your recognition record is temporarily unavailable. This is a system state — not a
             finding about your record.
           </p>
@@ -549,35 +585,32 @@ export default function ProfileSurface() {
         {recognition.state !== 'loading' && (
           <Link
             href="/holder/recognition"
-            className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-400 transition hover:text-emerald-300"
+            className="vcv-link mt-3 inline-flex items-center gap-1.5 text-sm font-semibold"
           >
             View your recognition record <ChevronRight className="h-4 w-4" aria-hidden />
           </Link>
         )}
       </section>
 
-      {/* Self-attested fields — editable */}
+      {/* Self-attested links / resume / work authorization — editable */}
       <section
         id="self-attested"
         aria-labelledby="self-attested-heading"
-        className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+        className="vcv-panel p-5"
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 id="self-attested-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+          <h2 id="self-attested-heading" className="vcv-eyebrow">
             Career links &amp; work authorization
           </h2>
           <span className="flex items-center gap-2">
-            <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-emerald-500">
-              Editable
-            </span>
-            <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-amber-500">
-              Self-attested
-            </span>
+            <span className="vcv-chip" data-state="verified">Editable</span>
+            <span className="vcv-chip" data-state="pending">Self-attested</span>
           </span>
         </div>
-        <p className="mt-2 text-xs leading-relaxed text-zinc-500">
+        <p className="mt-2 text-xs leading-relaxed vcv-muted">
           These fields are entered by you and shared with employers as self-attested information.
-          User-entered information is not verified until source-backed evidence is attached.
+          User-entered information is not verified until source-backed evidence is attached. You can
+          clear any saved value by emptying it and saving.
         </p>
         <form onSubmit={saveSelfAttested} className="mt-4 grid gap-4 sm:grid-cols-2" noValidate>
           <FormField
@@ -606,10 +639,15 @@ export default function ProfileSurface() {
             savedValue={profile.resumeUrl}
             disabled={saving}
             onChange={(v) => updateForm({ resumeUrl: v })}
+            hint={
+              form.resumeUrl.trim()
+                ? `Attached: ${resumeFileNameFromUrl(validateProfileUrl(form.resumeUrl).url ?? form.resumeUrl)}`
+                : 'Paste a link to your hosted resume. Files are stored by link — no upload storage yet.'
+            }
           />
           <div>
             <span className="flex items-center justify-between gap-2">
-              <label htmlFor="profile-work-auth" className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+              <label htmlFor="profile-work-auth" className="text-xs font-semibold uppercase tracking-widest vcv-muted">
                 Work authorization
               </label>
               <FieldStateChip savedValue={profile.workAuthStatus} />
@@ -619,7 +657,8 @@ export default function ProfileSurface() {
               value={form.workAuthStatus}
               disabled={saving}
               onChange={(e) => updateForm({ workAuthStatus: e.target.value })}
-              className="mt-2 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm text-foreground focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-900"
+              className={INPUT_CLASS}
+              style={INPUT_STYLE}
             >
               <option value="">Not stated</option>
               {WORK_AUTH_OPTIONS.map((option) => (
@@ -633,7 +672,7 @@ export default function ProfileSurface() {
             <button
               type="submit"
               disabled={saveDisabled}
-              className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              className="vcv-cta inline-flex items-center justify-center gap-2 px-6 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
               {saving ? (
                 <>
@@ -647,41 +686,50 @@ export default function ProfileSurface() {
             </button>
             <p aria-live="polite" className="text-sm">
               {saveError ? (
-                <span role="alert" className="text-red-400">{saveError}</span>
+                <span role="alert" style={{ color: 'var(--state-blocked)' }}>{saveError}</span>
               ) : saving ? (
-                <span className="text-zinc-400">Saving your self-attested fields…</span>
+                <span className="vcv-muted">Saving your self-attested fields…</span>
               ) : saveState === 'saved' && !diff?.dirty ? (
-                <span className="text-emerald-400">Saved as self-attested.</span>
+                <span style={{ color: 'var(--state-verified)' }}>Saved as self-attested.</span>
+              ) : diff && diff.clearedFields.length > 0 ? (
+                <span style={{ color: 'var(--state-pending)' }}>{describeClearedFields(diff.clearedFields)}</span>
               ) : diff?.dirty ? (
-                <span className="text-amber-400">Unsaved changes.</span>
+                <span style={{ color: 'var(--state-pending)' }}>Unsaved changes.</span>
               ) : (
-                <span className="text-zinc-600">No unsaved changes.</span>
+                <span className="vcv-subtle">No unsaved changes.</span>
               )}
             </p>
           </div>
         </form>
       </section>
 
-      {/* Passport-backed profile sections */}
+      {/* Self-attested structured sections — editable */}
+      <SelfAttestedEditor initial={profile.selfAttested} onSaved={handleSelfAttestedSaved} />
+
+      {/* Passport-backed + self-attested profile sections (read projection) */}
       {passport ? (
         <>
-          <p className="text-xs leading-relaxed text-zinc-600">
-            The sections below are read projections from your passport and registry sources —
-            uploads and source checks keep them current. Direct editing of these sections ships in
-            later waves.
+          <p className="text-xs leading-relaxed vcv-subtle">
+            The sections below read from your passport and registry sources plus the self-attested
+            details you saved above. Source checks keep the verified rows current.
           </p>
-          <ClinicianProfileSections passport={passport} />
+          <ClinicianProfileSections
+            passport={passport}
+            extended={selfAttestedToExtended(profile.selfAttested)}
+          />
         </>
       ) : passportUnavailable ? (
-        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
-          <p className="text-sm text-zinc-300">Your source-backed profile sections are temporarily unavailable.</p>
-          <p className="mt-1 text-xs text-zinc-500">
-            This is a system state — not a finding about your credentials. Your self-attested fields above still save normally.
+        <section className="vcv-panel p-5">
+          <p className="text-sm" style={{ color: 'var(--ink)' }}>Your source-backed profile sections are temporarily unavailable.</p>
+          <p className="mt-1 text-xs vcv-muted">
+            This is a system state — not a finding about your credentials. Your self-attested fields
+            {savedSections > 0 ? ' (including the sections you saved) ' : ' '}
+            still save normally.
           </p>
         </section>
       ) : (
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-8 text-center" role="status" aria-live="polite">
-          <p className="animate-pulse font-mono text-sm text-zinc-500">Loading source-backed sections…</p>
+        <div className="vcv-panel p-8 text-center" role="status" aria-live="polite">
+          <p className="vcv-mono animate-pulse text-sm vcv-subtle">Loading source-backed sections…</p>
         </div>
       )}
     </Shell>
@@ -707,7 +755,8 @@ function FieldStateChip({ savedValue }: { savedValue: string | null }) {
     <ProvenanceChip provenance="USER_ENTERED" />
   ) : (
     <span
-      className="inline-flex items-center rounded-full border border-zinc-700 bg-zinc-800/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-zinc-500"
+      className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] vcv-subtle"
+      style={{ borderColor: 'var(--paper-edge)', background: 'var(--paper-inset)' }}
       data-provenance="NOT_PROVIDED"
       title="Nothing saved for this field yet. Anything you enter is stored as self-attested."
     >
@@ -716,10 +765,17 @@ function FieldStateChip({ savedValue }: { savedValue: string | null }) {
   );
 }
 
-function Shell({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
+function Shell({ children, wide, npi }: { children: React.ReactNode; wide?: boolean; npi?: string }) {
   return (
-    <div className="min-h-screen bg-zinc-950 px-4 py-8 sm:px-6">
-      <div className={`mx-auto flex w-full flex-col gap-5 ${wide ? 'max-w-4xl' : 'max-w-md'}`}>{children}</div>
+    <div className="vcv-doc min-h-screen">
+      <div className="vcv-register mx-4 mt-4 flex items-center justify-between px-6 py-2 text-xs sm:mx-6">
+        <Link href="/holder/home" className="vcv-mono transition-opacity hover:opacity-80">← Dashboard</Link>
+        <span className="vcv-eyebrow">Profile</span>
+        <span className="vcv-mono text-[10px] opacity-70">{npi ? `NPI ${npi}` : '…'}</span>
+      </div>
+      <div className="px-4 py-8 sm:px-6">
+        <div className={`mx-auto flex w-full flex-col gap-5 ${wide ? 'max-w-4xl' : 'max-w-md'}`}>{children}</div>
+      </div>
     </div>
   );
 }
@@ -736,17 +792,20 @@ function EmptyCard({
   ctaLabel: string;
 }) {
   return (
-    <div className="space-y-5 py-10 text-center">
-      <div className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900">
-        <UserRound className="h-7 w-7 text-emerald-400" aria-hidden />
+    <div className="vcv-panel space-y-5 p-10 text-center">
+      <div
+        className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-[10px] border"
+        style={{ borderColor: 'var(--paper-edge)', background: 'var(--paper-warm)' }}
+      >
+        <UserRound className="h-7 w-7" style={{ color: 'var(--accent)' }} aria-hidden />
       </div>
       <div>
-        <h1 className="mb-2 text-2xl font-bold text-foreground">{title}</h1>
-        <p className="text-sm leading-relaxed text-zinc-400">{body}</p>
+        <h1 className="vcv-title mb-2 text-2xl">{title}</h1>
+        <p className="text-sm leading-relaxed vcv-muted">{body}</p>
       </div>
       <Link
         href={ctaHref}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-7 py-3.5 text-sm font-semibold text-black transition hover:bg-emerald-400"
+        className="vcv-cta inline-flex w-full items-center justify-center gap-2 px-7 py-3.5 text-sm"
       >
         {ctaLabel} <ChevronRight className="h-4 w-4" aria-hidden />
       </Link>
@@ -762,6 +821,7 @@ function FormField({
   savedValue,
   disabled,
   onChange,
+  hint,
 }: {
   id: string;
   label: string;
@@ -770,11 +830,12 @@ function FormField({
   savedValue: string | null;
   disabled: boolean;
   onChange: (value: string) => void;
+  hint?: string;
 }) {
   return (
     <div>
       <span className="flex items-center justify-between gap-2">
-        <label htmlFor={id} className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+        <label htmlFor={id} className="text-xs font-semibold uppercase tracking-widest vcv-muted">
           {label}
         </label>
         <FieldStateChip savedValue={savedValue} />
@@ -787,8 +848,10 @@ function FormField({
         value={value}
         disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
-        className="mt-2 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm text-foreground placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-900"
+        className={INPUT_CLASS}
+        style={INPUT_STYLE}
       />
+      {hint ? <p className="mt-1.5 text-xs vcv-subtle">{hint}</p> : null}
     </div>
   );
 }

--- a/apps/web/app/clinician/profile/page.tsx
+++ b/apps/web/app/clinician/profile/page.tsx
@@ -25,14 +25,14 @@ const LEGEND_ORDER: ReadonlyArray<ProfileProvenance> = [
  */
 export default function ClinicianProfilePage() {
   return (
-    <div className="bg-zinc-950">
+    <div className="vcv-doc">
       <ProfileSurface />
       <aside
         aria-labelledby="provenance-legend-heading"
         className="mx-auto w-full max-w-4xl px-4 pb-12 sm:px-6"
       >
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
-          <h2 id="provenance-legend-heading" className="text-xs font-bold uppercase tracking-widest text-zinc-500">
+        <div className="vcv-panel p-5">
+          <h2 id="provenance-legend-heading" className="vcv-eyebrow">
             How to read provenance badges
           </h2>
           <dl className="mt-3 space-y-2">
@@ -47,7 +47,7 @@ export default function ClinicianProfilePage() {
                       {meta.label}
                     </span>
                   </dt>
-                  <dd className="text-xs leading-relaxed text-zinc-500">{meta.description}</dd>
+                  <dd className="text-xs leading-relaxed vcv-muted">{meta.description}</dd>
                 </div>
               );
             })}

--- a/apps/web/components/profile/ClinicianProfileSections.tsx
+++ b/apps/web/components/profile/ClinicianProfileSections.tsx
@@ -93,10 +93,10 @@ function Field({
   const { display, provenance: resolved } = normalizeFieldProvenance(value, provenance);
   return (
     <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between gap-y-1">
-      <span className="text-xs uppercase tracking-[0.12em] text-muted-foreground/70">
+      <span className="text-xs uppercase tracking-[0.12em] vcv-subtle">
         {label}
       </span>
-      <span className="flex items-center gap-2 text-sm text-foreground/90">
+      <span className="flex items-center gap-2 text-sm" style={{ color: 'var(--ink)' }}>
         <span className="break-words">{display}</span>
         <ProvenanceBadge provenance={resolved} />
       </span>
@@ -119,12 +119,12 @@ function Section({
     <section
       id={`profile-${id}`}
       data-testid={`profile-section-${id}`}
-      className="rounded-xl border border-border bg-card p-5 sm:p-6"
+      className="vcv-panel p-5 sm:p-6"
     >
       <header className="mb-4 space-y-1">
-        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        <h3 className="text-base font-semibold" style={{ color: 'var(--ink-strong)' }}>{title}</h3>
         {description ? (
-          <p className="text-xs text-muted-foreground/80">{description}</p>
+          <p className="text-xs vcv-muted">{description}</p>
         ) : null}
       </header>
       <div className="space-y-3">{children}</div>
@@ -135,7 +135,7 @@ function Section({
 function EmptyList({ label }: { label: string }) {
   return (
     <div className="flex items-center justify-between text-sm">
-      <span className="text-muted-foreground/70">{label}</span>
+      <span className="vcv-subtle">{label}</span>
       <ProvenanceBadge provenance="UNKNOWN" />
     </div>
   );

--- a/apps/web/components/profile/SelfAttestedEditor.tsx
+++ b/apps/web/components/profile/SelfAttestedEditor.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+/**
+ * SelfAttestedEditor — edits the clinician's USER_ENTERED profile layer:
+ * contact, medical school, subspecialty, work history, affiliations, career
+ * goals, and a research summary. Everything here is self-attested — typed by
+ * the clinician and never source-verified. Saves the whole layer in one
+ * document to POST /api/profile/self-attested (full replace).
+ *
+ * Styled for the D57 `.vcv-doc` paper/ink system: assumes a `.vcv-doc` ancestor
+ * supplies the design tokens.
+ */
+
+import { useMemo, useState } from 'react';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import type {
+  SelfAttestedAffiliation,
+  SelfAttestedProfile,
+  SelfAttestedWorkEntry,
+} from '@/lib/clinician-profile/selfAttested';
+import { parseSelfAttested } from '@/lib/clinician-profile/selfAttested';
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+/** Editable form mirror of SelfAttestedProfile — strings everywhere for inputs. */
+interface EditorState {
+  practiceEmail: string;
+  practicePhone: string;
+  practiceWebsite: string;
+  schoolInstitution: string;
+  schoolDegree: string;
+  schoolGradYear: string;
+  subspecialty: string;
+  workHistory: Array<{ employer: string; role: string; startYear: string; endYear: string }>;
+  affiliations: Array<{ organization: string; role: string }>;
+  careerGoals: string;
+  researchSummary: string;
+}
+
+function toEditorState(sa: SelfAttestedProfile): EditorState {
+  return {
+    practiceEmail: sa.contact?.practiceEmail ?? '',
+    practicePhone: sa.contact?.practicePhone ?? '',
+    practiceWebsite: sa.contact?.practiceWebsite ?? '',
+    schoolInstitution: sa.medicalSchool?.institutionName ?? '',
+    schoolDegree: sa.medicalSchool?.degree ?? '',
+    schoolGradYear: sa.medicalSchool?.graduationYear ? String(sa.medicalSchool.graduationYear) : '',
+    subspecialty: sa.subspecialty ?? '',
+    workHistory: (sa.workHistory ?? []).map((w) => ({
+      employer: w.employer,
+      role: w.role ?? '',
+      startYear: w.startYear ? String(w.startYear) : '',
+      endYear: w.endYear ? String(w.endYear) : '',
+    })),
+    affiliations: (sa.affiliations ?? []).map((a) => ({ organization: a.organization, role: a.role ?? '' })),
+    careerGoals: sa.careerGoals ?? '',
+    researchSummary: sa.researchSummary ?? '',
+  };
+}
+
+function yearOrUndef(raw: string): number | undefined {
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n)) return undefined;
+  const y = Math.trunc(n);
+  return y >= 1900 && y <= 2100 ? y : undefined;
+}
+
+/** Build the SelfAttestedProfile payload from editor state (drops empties). */
+function toPayload(s: EditorState): SelfAttestedProfile {
+  const out: SelfAttestedProfile = {};
+
+  const contact = {
+    ...(s.practiceEmail.trim() ? { practiceEmail: s.practiceEmail.trim() } : {}),
+    ...(s.practicePhone.trim() ? { practicePhone: s.practicePhone.trim() } : {}),
+    ...(s.practiceWebsite.trim() ? { practiceWebsite: s.practiceWebsite.trim() } : {}),
+  };
+  if (Object.keys(contact).length) out.contact = contact;
+
+  const school = {
+    ...(s.schoolInstitution.trim() ? { institutionName: s.schoolInstitution.trim() } : {}),
+    ...(s.schoolDegree.trim() ? { degree: s.schoolDegree.trim() } : {}),
+    ...(yearOrUndef(s.schoolGradYear) !== undefined ? { graduationYear: yearOrUndef(s.schoolGradYear) } : {}),
+  };
+  if (Object.keys(school).length) out.medicalSchool = school;
+
+  if (s.subspecialty.trim()) out.subspecialty = s.subspecialty.trim();
+
+  const work = s.workHistory
+    .map((w): SelfAttestedWorkEntry | null => {
+      const employer = w.employer.trim();
+      if (!employer) return null;
+      const entry: SelfAttestedWorkEntry = { employer };
+      if (w.role.trim()) entry.role = w.role.trim();
+      const sy = yearOrUndef(w.startYear);
+      if (sy !== undefined) entry.startYear = sy;
+      const ey = yearOrUndef(w.endYear);
+      if (ey !== undefined) entry.endYear = ey;
+      return entry;
+    })
+    .filter((w): w is SelfAttestedWorkEntry => w !== null);
+  if (work.length) out.workHistory = work;
+
+  const affs = s.affiliations
+    .map((a): SelfAttestedAffiliation | null => {
+      const organization = a.organization.trim();
+      if (!organization) return null;
+      const entry: SelfAttestedAffiliation = { organization };
+      if (a.role.trim()) entry.role = a.role.trim();
+      return entry;
+    })
+    .filter((a): a is SelfAttestedAffiliation => a !== null);
+  if (affs.length) out.affiliations = affs;
+
+  if (s.careerGoals.trim()) out.careerGoals = s.careerGoals.trim();
+  if (s.researchSummary.trim()) out.researchSummary = s.researchSummary.trim();
+
+  return out;
+}
+
+const INPUT_CLASS = 'w-full rounded-[6px] border px-3 py-2 text-sm outline-none transition focus:border-[var(--accent)]';
+const INPUT_STYLE = { borderColor: 'var(--paper-edge)', background: '#fff', color: 'var(--ink)' } as const;
+
+export default function SelfAttestedEditor({
+  initial,
+  onSaved,
+}: {
+  initial: SelfAttestedProfile;
+  onSaved: (next: SelfAttestedProfile) => void;
+}) {
+  const [state, setState] = useState<EditorState>(() => toEditorState(initial));
+  const [baseline, setBaseline] = useState<SelfAttestedProfile>(initial);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const payload = useMemo(() => toPayload(state), [state]);
+  const dirty = useMemo(
+    () => JSON.stringify(payload) !== JSON.stringify(baseline),
+    [payload, baseline],
+  );
+
+  function patch(p: Partial<EditorState>) {
+    setState((s) => ({ ...s, ...p }));
+    setSaveState((s) => (s === 'saving' ? s : 'idle'));
+    setError(null);
+  }
+
+  function addWork() {
+    patch({ workHistory: [...state.workHistory, { employer: '', role: '', startYear: '', endYear: '' }] });
+  }
+  function removeWork(index: number) {
+    patch({ workHistory: state.workHistory.filter((_, i) => i !== index) });
+  }
+  function updateWork(index: number, field: keyof EditorState['workHistory'][number], value: string) {
+    patch({ workHistory: state.workHistory.map((w, i) => (i === index ? { ...w, [field]: value } : w)) });
+  }
+
+  function addAffiliation() {
+    patch({ affiliations: [...state.affiliations, { organization: '', role: '' }] });
+  }
+  function removeAffiliation(index: number) {
+    patch({ affiliations: state.affiliations.filter((_, i) => i !== index) });
+  }
+  function updateAffiliation(index: number, field: 'organization' | 'role', value: string) {
+    patch({ affiliations: state.affiliations.map((a, i) => (i === index ? { ...a, [field]: value } : a)) });
+  }
+
+  async function save(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!dirty || saveState === 'saving') return;
+    setSaveState('saving');
+    setError(null);
+    try {
+      const res = await fetch('/api/profile/self-attested', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ selfAttested: payload }),
+      });
+      if (!res.ok) {
+        setSaveState('error');
+        setError(
+          res.status === 401
+            ? 'Your session expired. Sign in again to save.'
+            : 'Saving is temporarily unavailable. Your entries were not lost; try again shortly.',
+        );
+        return;
+      }
+      const body: unknown = await res.json().catch(() => null);
+      const saved =
+        body && typeof body === 'object' && 'selfAttested' in body
+          ? parseSelfAttested((body as { selfAttested: unknown }).selfAttested)
+          : payload;
+      setBaseline(saved);
+      setState(toEditorState(saved));
+      setSaveState('saved');
+      onSaved(saved);
+    } catch {
+      setSaveState('error');
+      setError('Saving is temporarily unavailable. Your entries were not lost; try again shortly.');
+    }
+  }
+
+  const saving = saveState === 'saving';
+
+  return (
+    <section
+      className="vcv-panel p-5 sm:p-6"
+      aria-labelledby="self-attested-editor-heading"
+      data-testid="self-attested-editor"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="vcv-eyebrow mb-1">Your self-attested profile</p>
+          <h2 id="self-attested-editor-heading" className="vcv-title text-xl">
+            Add the details you want employers to see
+          </h2>
+        </div>
+        <span className="vcv-chip" data-state="pending">Self-attested</span>
+      </div>
+      <p className="mt-2 text-sm vcv-muted">
+        You type these, and they are shared with employers as self-attested information. Nothing here
+        is source-verified — a reviewer still confirms it against evidence.
+      </p>
+
+      <form onSubmit={save} className="mt-5 space-y-6" noValidate>
+        {/* Contact */}
+        <FieldGroup label="Contact">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Labeled label="Practice email">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.practiceEmail}
+                disabled={saving} onChange={(e) => patch({ practiceEmail: e.target.value })} placeholder="you@practice.org" />
+            </Labeled>
+            <Labeled label="Practice phone">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.practicePhone}
+                disabled={saving} onChange={(e) => patch({ practicePhone: e.target.value })} placeholder="(555) 555-5555" />
+            </Labeled>
+            <Labeled label="Practice website">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.practiceWebsite}
+                disabled={saving} onChange={(e) => patch({ practiceWebsite: e.target.value })} placeholder="practice.org" />
+            </Labeled>
+          </div>
+        </FieldGroup>
+
+        {/* Medical school + subspecialty */}
+        <FieldGroup label="Education">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Labeled label="Medical school">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.schoolInstitution}
+                disabled={saving} onChange={(e) => patch({ schoolInstitution: e.target.value })} placeholder="Institution" />
+            </Labeled>
+            <Labeled label="Degree">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.schoolDegree}
+                disabled={saving} onChange={(e) => patch({ schoolDegree: e.target.value })} placeholder="MD, DO, PA-C…" />
+            </Labeled>
+            <Labeled label="Graduation year">
+              <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.schoolGradYear} inputMode="numeric"
+                disabled={saving} onChange={(e) => patch({ schoolGradYear: e.target.value })} placeholder="2015" />
+            </Labeled>
+          </div>
+          <Labeled label="Subspecialty">
+            <input className={INPUT_CLASS} style={INPUT_STYLE} value={state.subspecialty}
+              disabled={saving} onChange={(e) => patch({ subspecialty: e.target.value })} placeholder="e.g. Interventional cardiology" />
+          </Labeled>
+        </FieldGroup>
+
+        {/* Work history */}
+        <FieldGroup label="Work history" onAdd={saving ? undefined : addWork} addLabel="Add role">
+          {state.workHistory.length === 0 ? (
+            <EmptyRow label="No employment added yet." />
+          ) : (
+            <div className="space-y-3">
+              {state.workHistory.map((w, i) => (
+                <RepeatableRow key={i} onRemove={saving ? undefined : () => removeWork(i)}>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <Labeled label="Employer">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={w.employer}
+                        disabled={saving} onChange={(e) => updateWork(i, 'employer', e.target.value)} placeholder="Employer" />
+                    </Labeled>
+                    <Labeled label="Role">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={w.role}
+                        disabled={saving} onChange={(e) => updateWork(i, 'role', e.target.value)} placeholder="Title" />
+                    </Labeled>
+                    <Labeled label="Start year">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={w.startYear} inputMode="numeric"
+                        disabled={saving} onChange={(e) => updateWork(i, 'startYear', e.target.value)} placeholder="2018" />
+                    </Labeled>
+                    <Labeled label="End year">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={w.endYear} inputMode="numeric"
+                        disabled={saving} onChange={(e) => updateWork(i, 'endYear', e.target.value)} placeholder="2022 or blank" />
+                    </Labeled>
+                  </div>
+                </RepeatableRow>
+              ))}
+            </div>
+          )}
+        </FieldGroup>
+
+        {/* Affiliations */}
+        <FieldGroup label="Affiliations" onAdd={saving ? undefined : addAffiliation} addLabel="Add affiliation">
+          {state.affiliations.length === 0 ? (
+            <EmptyRow label="No affiliations added yet." />
+          ) : (
+            <div className="space-y-3">
+              {state.affiliations.map((a, i) => (
+                <RepeatableRow key={i} onRemove={saving ? undefined : () => removeAffiliation(i)}>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <Labeled label="Organization">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={a.organization}
+                        disabled={saving} onChange={(e) => updateAffiliation(i, 'organization', e.target.value)} placeholder="Hospital or group" />
+                    </Labeled>
+                    <Labeled label="Role">
+                      <input className={INPUT_CLASS} style={INPUT_STYLE} value={a.role}
+                        disabled={saving} onChange={(e) => updateAffiliation(i, 'role', e.target.value)} placeholder="Attending, member…" />
+                    </Labeled>
+                  </div>
+                </RepeatableRow>
+              ))}
+            </div>
+          )}
+        </FieldGroup>
+
+        {/* Career goals + research */}
+        <FieldGroup label="Narrative">
+          <Labeled label="Career goals">
+            <textarea className={INPUT_CLASS} style={INPUT_STYLE} rows={2} value={state.careerGoals}
+              disabled={saving} onChange={(e) => patch({ careerGoals: e.target.value })}
+              placeholder="What you're looking for next. Used for matching, never for verification." />
+          </Labeled>
+          <Labeled label="Research summary">
+            <textarea className={INPUT_CLASS} style={INPUT_STYLE} rows={2} value={state.researchSummary}
+              disabled={saving} onChange={(e) => patch({ researchSummary: e.target.value })}
+              placeholder="A short summary of your research interests or output." />
+          </Labeled>
+        </FieldGroup>
+
+        <div className="flex flex-wrap items-center gap-3 border-t pt-4" style={{ borderColor: 'var(--paper-edge)' }}>
+          <button
+            type="submit"
+            disabled={!dirty || saving}
+            className="vcv-cta inline-flex items-center justify-center gap-2 px-5 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? (<><Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Saving…</>) : 'Save self-attested details'}
+          </button>
+          <p aria-live="polite" className="text-sm" data-testid="self-attested-editor-status">
+            {error ? (
+              <span role="alert" style={{ color: 'var(--state-blocked)' }}>{error}</span>
+            ) : saving ? (
+              <span className="vcv-muted">Saving your self-attested details…</span>
+            ) : saveState === 'saved' && !dirty ? (
+              <span style={{ color: 'var(--state-verified)' }}>Saved as self-attested.</span>
+            ) : dirty ? (
+              <span style={{ color: 'var(--state-pending)' }}>Unsaved changes.</span>
+            ) : (
+              <span className="vcv-subtle">No unsaved changes.</span>
+            )}
+          </p>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function FieldGroup({
+  label,
+  onAdd,
+  addLabel,
+  children,
+}: {
+  label: string;
+  onAdd?: () => void;
+  addLabel?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="vcv-eyebrow">{label}</h3>
+        {onAdd && (
+          <button
+            type="button"
+            onClick={onAdd}
+            className="inline-flex items-center gap-1 text-xs font-semibold"
+            style={{ color: 'var(--accent)' }}
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden /> {addLabel}
+          </button>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Labeled({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs vcv-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function RepeatableRow({ onRemove, children }: { onRemove?: () => void; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[8px] border p-3" style={{ borderColor: 'var(--paper-edge)', background: 'var(--paper-warm)' }}>
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">{children}</div>
+        {onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label="Remove"
+            className="mt-6 shrink-0 rounded p-1 transition hover:opacity-70"
+            style={{ color: 'var(--ink-subtle)' }}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyRow({ label }: { label: string }) {
+  return <p className="text-sm vcv-subtle">{label}</p>;
+}

--- a/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
+++ b/apps/web/lib/clinician-profile/__tests__/liveProfile.test.ts
@@ -4,7 +4,7 @@ import {
   WORK_AUTH_OPTIONS,
   completenessStatement,
   computeProfileFormDiff,
-  describeClearedFieldsBlock,
+  describeClearedFields,
   describeIdentityFields,
   describeProfileSaveError,
   displayName,
@@ -29,6 +29,7 @@ function baseProfile(overrides: Partial<WorkspacePersonProfile> = {}): Workspace
     linkedinUrl: 'https://linkedin.com/in/test',
     portfolioUrl: null,
     completeness: 55,
+    selfAttested: {},
     ...overrides,
   };
 }
@@ -156,7 +157,7 @@ describe('computeProfileFormDiff', () => {
     expect(workAuth).toMatchObject({ dirty: true, workAuthChanged: true });
   });
 
-  it('reports cleared saved fields instead of treating them as changes to send', () => {
+  it('reports cleared saved fields as per-field clears, not as set-changes to send', () => {
     const profile = baseProfile();
     const diff = computeProfileFormDiff(profile, {
       ...formFromProfile(profile),
@@ -165,21 +166,28 @@ describe('computeProfileFormDiff', () => {
     });
     expect(diff.dirty).toBe(true);
     expect(diff.clearedFields).toEqual(['LinkedIn', 'Work authorization']);
+    // Clears are distinct from set-writes: nothing is "changed", it is removed.
     expect(diff.linksChanged).toBe(false);
     expect(diff.workAuthChanged).toBe(false);
+    expect(diff.clearLinkedin).toBe(true);
+    expect(diff.clearWorkAuth).toBe(true);
+    expect(diff.clearPortfolio).toBe(false);
+    expect(diff.clearResume).toBe(false);
   });
 
   it('never reports a never-saved empty field as cleared', () => {
     const profile = baseProfile({ portfolioUrl: null });
     const diff = computeProfileFormDiff(profile, formFromProfile(profile));
     expect(diff.clearedFields).toEqual([]);
+    expect(diff.clearPortfolio).toBe(false);
   });
 
-  it('cleared-fields copy names the fields and is honest about the limitation', () => {
-    const copy = describeClearedFieldsBlock(['LinkedIn', 'Resume link']);
+  it('cleared-fields copy names the fields and frames clearing honestly', () => {
+    const copy = describeClearedFields(['LinkedIn', 'Resume link']);
     expect(copy).toContain('LinkedIn');
     expect(copy).toContain('Resume link');
-    expect(copy).toContain('not supported on this surface yet');
+    expect(copy).toContain('remove');
+    expect(copy).toContain('self-attested');
   });
 });
 

--- a/apps/web/lib/clinician-profile/__tests__/selfAttested.test.ts
+++ b/apps/web/lib/clinician-profile/__tests__/selfAttested.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countSelfAttestedSections,
+  hasSelfAttestedContent,
+  parseSelfAttested,
+  selfAttestedToExtended,
+} from '@/lib/clinician-profile/selfAttested';
+
+describe('parseSelfAttested', () => {
+  it('keeps known non-empty fields, trims strings, bounds years, drops junk', () => {
+    const sa = parseSelfAttested({
+      contact: { practiceEmail: '  dr@x.org ', practicePhone: '', evil: 'x' },
+      medicalSchool: { institutionName: 'State U', graduationYear: '2010', degree: 'MD' },
+      subspecialty: 'Cards',
+      workHistory: [
+        { employer: 'Cedar', role: 'PA', startYear: 2018, endYear: 2022 },
+        { role: 'no employer' },
+      ],
+      affiliations: [{ organization: 'County' }, { role: 'no org' }],
+      careerGoals: '  Rural medicine  ',
+      researchSummary: '',
+      unknown: 'nope',
+    });
+
+    expect(sa).toEqual({
+      contact: { practiceEmail: 'dr@x.org' },
+      medicalSchool: { institutionName: 'State U', degree: 'MD', graduationYear: 2010 },
+      subspecialty: 'Cards',
+      workHistory: [{ employer: 'Cedar', role: 'PA', startYear: 2018, endYear: 2022 }],
+      affiliations: [{ organization: 'County' }],
+      careerGoals: 'Rural medicine',
+    });
+  });
+
+  it('returns an empty object for null/garbage', () => {
+    expect(parseSelfAttested(null)).toEqual({});
+    expect(parseSelfAttested('nope')).toEqual({});
+    expect(parseSelfAttested(undefined)).toEqual({});
+  });
+});
+
+describe('selfAttestedToExtended', () => {
+  it('projects saved values onto the sections ExtendedProfileData shape', () => {
+    const ext = selfAttestedToExtended({
+      contact: { practiceEmail: 'dr@x.org' },
+      medicalSchool: { institutionName: 'State U', graduationYear: 2010 },
+      workHistory: [{ employer: 'Cedar', role: 'PA' }],
+      affiliations: [{ organization: 'County' }],
+      careerGoals: 'Rural medicine',
+    });
+
+    expect(ext.contact?.practiceEmail).toBe('dr@x.org');
+    expect(ext.contact?.practicePhone).toBeNull();
+    expect(ext.medicalSchool?.institutionName).toBe('State U');
+    expect(ext.medicalSchool?.degree).toBeNull();
+    expect(ext.workHistory).toEqual([{ employer: 'Cedar', role: 'PA', startYear: null, endYear: null }]);
+    expect(ext.affiliations).toEqual([{ organization: 'County', role: null }]);
+    expect(ext.careerGoals).toBe('Rural medicine');
+  });
+
+  it('yields empty collections and nulls when nothing is saved', () => {
+    const ext = selfAttestedToExtended({});
+    expect(ext.workHistory).toEqual([]);
+    expect(ext.affiliations).toEqual([]);
+    expect(ext.careerGoals).toBeNull();
+    expect(ext.researchSummary).toBeNull();
+  });
+});
+
+describe('content helpers', () => {
+  it('detects and counts filled sections', () => {
+    expect(hasSelfAttestedContent({})).toBe(false);
+    expect(countSelfAttestedSections({})).toBe(0);
+    const sa = {
+      contact: { practiceEmail: 'a@b.c' },
+      subspecialty: 'Cards',
+      workHistory: [{ employer: 'X' }],
+      careerGoals: 'g',
+    };
+    expect(hasSelfAttestedContent(sa)).toBe(true);
+    expect(countSelfAttestedSections(sa)).toBe(4);
+  });
+});

--- a/apps/web/lib/clinician-profile/liveProfile.ts
+++ b/apps/web/lib/clinician-profile/liveProfile.ts
@@ -17,6 +17,7 @@
  */
 
 import type { ProfileProvenance } from '@/lib/profile/provenance';
+import { parseSelfAttested, type SelfAttestedProfile } from '@/lib/clinician-profile/selfAttested';
 
 export const WORK_AUTH_OPTIONS = [
   { value: 'authorized', label: 'Authorized to work in the U.S.' },
@@ -42,6 +43,8 @@ export interface WorkspacePersonProfile {
   linkedinUrl: string | null;
   portfolioUrl: string | null;
   completeness: number | null;
+  /** The clinician's USER_ENTERED structured sections. Never source-verified. */
+  selfAttested: SelfAttestedProfile;
 }
 
 export function extractPersonProfile(payload: unknown): WorkspacePersonProfile | null {
@@ -64,6 +67,7 @@ export function extractPersonProfile(payload: unknown): WorkspacePersonProfile |
     linkedinUrl: str('linkedinUrl'),
     portfolioUrl: str('portfolioUrl'),
     completeness: typeof p.completeness === 'number' ? (p.completeness as number) : null,
+    selfAttested: parseSelfAttested(p.selfAttested),
   };
 }
 
@@ -127,11 +131,14 @@ export interface ProfileFormDiff {
   linksChanged: boolean;
   resumeChanged: boolean;
   workAuthChanged: boolean;
+  /** Per-field clears: a previously saved value the form now leaves empty. */
+  clearLinkedin: boolean;
+  clearPortfolio: boolean;
+  clearResume: boolean;
+  clearWorkAuth: boolean;
   /**
-   * Labels of previously saved fields the form now leaves empty. The intake
-   * API only writes non-empty values (it cannot clear a saved field), so a
-   * save with cleared fields must be blocked with an honest explanation
-   * instead of silently leaving the old value in place.
+   * Human labels of previously saved fields the form now clears. Used to
+   * confirm the removal in the UI — clearing is supported, not blocked.
    */
   clearedFields: string[];
 }
@@ -160,11 +167,16 @@ export function computeProfileFormDiff(
   const nextResume = normalizedUrlOrRaw(form.resumeUrl);
   const nextWorkAuth = form.workAuthStatus;
 
+  const clearLinkedin = Boolean(savedLinkedin) && nextLinkedin === '';
+  const clearPortfolio = Boolean(savedPortfolio) && nextPortfolio === '';
+  const clearResume = Boolean(savedResume) && nextResume === '';
+  const clearWorkAuth = Boolean(savedWorkAuth) && nextWorkAuth === '';
+
   const clearedFields: string[] = [];
-  if (savedLinkedin && nextLinkedin === '') clearedFields.push('LinkedIn');
-  if (savedPortfolio && nextPortfolio === '') clearedFields.push('Portfolio');
-  if (savedResume && nextResume === '') clearedFields.push('Resume link');
-  if (savedWorkAuth && nextWorkAuth === '') clearedFields.push('Work authorization');
+  if (clearLinkedin) clearedFields.push('LinkedIn');
+  if (clearPortfolio) clearedFields.push('Portfolio');
+  if (clearResume) clearedFields.push('Resume link');
+  if (clearWorkAuth) clearedFields.push('Work authorization');
 
   const linksChanged =
     (nextLinkedin !== savedLinkedin && nextLinkedin !== '') ||
@@ -177,15 +189,18 @@ export function computeProfileFormDiff(
     linksChanged,
     resumeChanged,
     workAuthChanged,
+    clearLinkedin,
+    clearPortfolio,
+    clearResume,
+    clearWorkAuth,
     clearedFields,
   };
 }
 
-/** Copy for a blocked save when the form clears previously saved fields. */
-export function describeClearedFieldsBlock(clearedFields: string[]): string {
-  return `Removing a saved value is not supported on this surface yet (${clearedFields.join(
-    ', ',
-  )}). Restore the previous value or enter a replacement.`;
+/** Confirm copy when a save will remove previously saved self-attested fields. */
+export function describeClearedFields(clearedFields: string[]): string {
+  const list = clearedFields.join(', ');
+  return `Saving will remove ${list} from your profile. ${clearedFields.length > 1 ? 'These are' : 'This is'} self-attested — clearing only removes what you entered.`;
 }
 
 export function describeProfileSaveError(status: number, body: unknown): string {

--- a/apps/web/lib/clinician-profile/selfAttested.ts
+++ b/apps/web/lib/clinician-profile/selfAttested.ts
@@ -1,0 +1,183 @@
+/**
+ * selfAttested — the clinician's USER_ENTERED profile layer.
+ *
+ * These structured sections (contact, medical school, subspecialty, work
+ * history, affiliations, career goals, research) are typed by the clinician and
+ * stored as one JSON document on PersonProfile.selfAttested. They are NEVER
+ * source-verified: everything here renders with USER_ENTERED provenance and is
+ * shared with employers as self-attested information.
+ *
+ * Read path:  GET  /api/me/workspaces → personProfile.selfAttested
+ * Write path: POST /api/profile/self-attested { selfAttested }  (full replace)
+ */
+
+import type { ExtendedProfileData } from '@/components/profile/ClinicianProfileSections';
+
+export interface SelfAttestedContact {
+  practiceEmail?: string;
+  practicePhone?: string;
+  practiceWebsite?: string;
+}
+
+export interface SelfAttestedEducation {
+  institutionName?: string;
+  degree?: string;
+  graduationYear?: number;
+}
+
+export interface SelfAttestedWorkEntry {
+  employer: string;
+  role?: string;
+  startYear?: number;
+  endYear?: number;
+}
+
+export interface SelfAttestedAffiliation {
+  organization: string;
+  role?: string;
+}
+
+export interface SelfAttestedProfile {
+  contact?: SelfAttestedContact;
+  medicalSchool?: SelfAttestedEducation;
+  subspecialty?: string;
+  workHistory?: SelfAttestedWorkEntry[];
+  affiliations?: SelfAttestedAffiliation[];
+  careerGoals?: string;
+  researchSummary?: string;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+function year(v: unknown): number | undefined {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN;
+  if (!Number.isFinite(n)) return undefined;
+  const y = Math.trunc(n);
+  return y >= 1900 && y <= 2100 ? y : undefined;
+}
+
+function compact<T extends Record<string, unknown>>(obj: T): T | undefined {
+  const entries = Object.entries(obj).filter(([, v]) => v !== undefined);
+  return entries.length > 0 ? (Object.fromEntries(entries) as T) : undefined;
+}
+
+/**
+ * Defensive parse of the self-attested payload read from the workspace. Mirrors
+ * the backend sanitizer so the surface never renders a malformed row.
+ */
+export function parseSelfAttested(payload: unknown): SelfAttestedProfile {
+  if (!payload || typeof payload !== 'object') return {};
+  const p = payload as Record<string, unknown>;
+  const out: SelfAttestedProfile = {};
+
+  const c = (p.contact && typeof p.contact === 'object' ? p.contact : {}) as Record<string, unknown>;
+  const contact = compact({
+    practiceEmail: str(c.practiceEmail),
+    practicePhone: str(c.practicePhone),
+    practiceWebsite: str(c.practiceWebsite),
+  });
+  if (contact) out.contact = contact;
+
+  const s = (p.medicalSchool && typeof p.medicalSchool === 'object' ? p.medicalSchool : {}) as Record<string, unknown>;
+  const medicalSchool = compact({
+    institutionName: str(s.institutionName),
+    degree: str(s.degree),
+    graduationYear: year(s.graduationYear),
+  });
+  if (medicalSchool) out.medicalSchool = medicalSchool;
+
+  const subspecialty = str(p.subspecialty);
+  if (subspecialty) out.subspecialty = subspecialty;
+
+  if (Array.isArray(p.workHistory)) {
+    const rows = p.workHistory
+      .map((raw) => {
+        const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+        const employer = str(r.employer);
+        if (!employer) return null;
+        const entry: SelfAttestedWorkEntry = { employer };
+        const role = str(r.role);
+        if (role) entry.role = role;
+        const startYear = year(r.startYear);
+        if (startYear !== undefined) entry.startYear = startYear;
+        const endYear = year(r.endYear);
+        if (endYear !== undefined) entry.endYear = endYear;
+        return entry;
+      })
+      .filter((r): r is SelfAttestedWorkEntry => r !== null);
+    if (rows.length > 0) out.workHistory = rows;
+  }
+
+  if (Array.isArray(p.affiliations)) {
+    const rows = p.affiliations
+      .map((raw) => {
+        const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+        const organization = str(r.organization);
+        if (!organization) return null;
+        const entry: SelfAttestedAffiliation = { organization };
+        const role = str(r.role);
+        if (role) entry.role = role;
+        return entry;
+      })
+      .filter((r): r is SelfAttestedAffiliation => r !== null);
+    if (rows.length > 0) out.affiliations = rows;
+  }
+
+  const careerGoals = str(p.careerGoals);
+  if (careerGoals) out.careerGoals = careerGoals;
+
+  const researchSummary = str(p.researchSummary);
+  if (researchSummary) out.researchSummary = researchSummary;
+
+  return out;
+}
+
+/**
+ * Project the self-attested layer onto the ExtendedProfileData shape the
+ * read-only ClinicianProfileSections grid consumes, so saved values render with
+ * their USER_ENTERED badges. Fields the self-attested layer doesn't own
+ * (publications, documents) stay null.
+ */
+export function selfAttestedToExtended(sa: SelfAttestedProfile): Partial<ExtendedProfileData> {
+  return {
+    contact: {
+      practiceEmail: sa.contact?.practiceEmail ?? null,
+      practicePhone: sa.contact?.practicePhone ?? null,
+      practiceWebsite: sa.contact?.practiceWebsite ?? null,
+    },
+    medicalSchool: {
+      institutionName: sa.medicalSchool?.institutionName ?? null,
+      degree: sa.medicalSchool?.degree ?? null,
+      graduationYear: sa.medicalSchool?.graduationYear ?? null,
+    },
+    researchSummary: sa.researchSummary ?? null,
+    careerGoals: sa.careerGoals ?? null,
+    affiliations: (sa.affiliations ?? []).map((a) => ({ organization: a.organization, role: a.role ?? null })),
+    workHistory: (sa.workHistory ?? []).map((w) => ({
+      employer: w.employer,
+      role: w.role ?? null,
+      startYear: w.startYear ?? null,
+      endYear: w.endYear ?? null,
+    })),
+  };
+}
+
+/** True when the clinician has saved anything in the self-attested layer. */
+export function hasSelfAttestedContent(sa: SelfAttestedProfile): boolean {
+  return Object.keys(sa).length > 0;
+}
+
+/** Count of filled self-attested sections, for the "N sections added" summary. */
+export function countSelfAttestedSections(sa: SelfAttestedProfile): number {
+  let n = 0;
+  if (sa.contact) n += 1;
+  if (sa.medicalSchool) n += 1;
+  if (sa.subspecialty) n += 1;
+  if (sa.workHistory?.length) n += 1;
+  if (sa.affiliations?.length) n += 1;
+  if (sa.careerGoals) n += 1;
+  if (sa.researchSummary) n += 1;
+  return n;
+}


### PR DESCRIPTION
## Summary

Turns `/clinician/profile` into a real, impressive, editable surface.

**Heads-up on the task premise:** the issue described the surface as a "read-only foundation shell (11 empty placeholder sections)." That was **stale** — two prior PRs (`73ea7baf4` + #496) already made it data-backed and editable, and a test even asserts *"the legacy foundation shell is gone."* So this PR closes the **genuine** remaining gaps rather than rebuilding what already shipped.

## What's in scope (all 4 confirmed with the owner)

- **D57 light-theme migration** — `ProfileSurface`, `page.tsx`, and `ClinicianProfileSections` ported from the dark zinc theme to the `.vcv-doc` paper/ink document system (matching the Clinician Profile handoff and `ReadinessSurface`). The `fetch` data flow, every `data-testid`, and all truth-contract copy are preserved.
- **Field clearing** — the intake service now accepts explicit clears (`clear[]` for links, `{clear:true}` for resume/work-auth) and recomputes completeness from what's persisted. **No migration** (columns were already nullable). The web surface unblocks clearing and sends the right payload.
- **Editable self-attested sections** — one additive `PersonProfile.selfAttested Json?` column + migration, a whitelist-sanitizing `POST /api/profile/self-attested` endpoint + web proxy, and a new `SelfAttestedEditor` (contact, education, work history, affiliations, career goals, research — all `USER_ENTERED`). Saved data flows into the existing read grid via its `extended` prop.
- **Resume** — honest link-attach with filename display. The backend has **no blob storage**, so real binary upload was intentionally out of scope; nothing fakes storage.

## Truth contract

Nothing user-entered is presented as verified. The existing provenance vocabulary (`Source-confirmed` / `User-entered` / `Inferred` / `Unknown` / `Conflict`) is kept; no bare "Verified"; completeness stays "filled-ness only."

## Testing

- **269 relevant tests green**: profile surface (9), sections (11), liveProfile (27), new selfAttested (5), holder-route-contract (150), foundation-sweep banned-word guards + a backend `sanitizeSelfAttested` jest test.
- Backend + changed frontend files typecheck clean.
- **Verified via a throwaway dev-preview route** (stubbed sample data, deleted before commit): confirmed the D57 light theme renders, the editor save round-trips (`Unsaved changes.` → POST → `Saved as self-attested.`), and all 16 read sections populate from self-attested data. No React warnings.

## ⚠️ Deploy note

The `selfAttested` column adds a Prisma migration — it needs `migrate deploy` on Railway before the editable-sections feature works in production. Everything else is runtime-safe.

## Design Handoff References

- `design-handoff/claude-design-2026-06-26/vitalcv/project/Clinician Profile.html`
- `apps/web/styles/clinician-doc.css` (the D57 `.vcv-doc` system) + `docs/design/design-lineage-policy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)