### PR TITLE
feat(matcha): Wave K — opportunity engine completion: mount API, card→detail, gated apply, persisted actions

### DIFF
--- a/apps/api/backend/prisma/migrations/20260705000000_opportunity_actions/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260705000000_opportunity_actions/migration.sql
@@ -1,0 +1,24 @@
+-- Wave K — server-persisted clinician opportunity actions (Save / Connect /
+-- Decline on MATCHA opportunities). Append-only decision log: every action,
+-- including clearing one back to "new", inserts a NEW row; the latest row per
+-- (clerkUserId, opportunityId) is the current state. Rows are never updated
+-- or deleted. `id` is generated client-side by Prisma (@default(uuid())) —
+-- no DB-level default, matching the fleet's Postgres (no gen_random_uuid).
+
+CREATE TABLE "OpportunityAction" (
+    "id" UUID NOT NULL,
+    "clerkUserId" TEXT NOT NULL,
+    "npi" TEXT,
+    "opportunityId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'web',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OpportunityAction_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "OpportunityAction_clerkUserId_opportunityId_createdAt_idx" ON "OpportunityAction"("clerkUserId", "opportunityId", "createdAt");
+
+CREATE INDEX "OpportunityAction_opportunityId_idx" ON "OpportunityAction"("opportunityId");
+
+CREATE INDEX "OpportunityAction_createdAt_idx" ON "OpportunityAction"("createdAt");

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -39,6 +39,26 @@ model MatchaPreference {
   @@index([clerkUserId])
 }
 
+/// Wave K — server-persisted clinician Save / Connect / Decline decisions on
+/// MATCHA opportunities. Append-only: every decision (including clearing one
+/// back to "new") is a NEW row; current state = latest row per
+/// (clerkUserId, opportunityId). Rows are never updated or deleted. Mirrored
+/// in apps/web/prisma/schema.prisma — the web app writes this table directly
+/// via an auth-scoped route (identity from Clerk auth(), never a header).
+model OpportunityAction {
+  id            String   @id @default(uuid()) @db.Uuid
+  clerkUserId   String
+  npi           String?
+  opportunityId String
+  action        String // saved | connected | declined | cleared
+  source        String   @default("web")
+  createdAt     DateTime @default(now())
+
+  @@index([clerkUserId, opportunityId, createdAt])
+  @@index([opportunityId])
+  @@index([createdAt])
+}
+
 model Recognition {
   id              String       @id @default(uuid()) @db.Uuid
   recognitionId   String       @unique

--- a/apps/api/backend/src/app.ts
+++ b/apps/api/backend/src/app.ts
@@ -150,6 +150,7 @@ import { registerPassportEntityRoutes } from './routes/passportEntity';      // 
 import { registerIngestStreamRoutes }   from './routes/ingestStream';        // Real-time ingest SSE
 import { leieCacheStats }               from './services/identity/leieCache'; // OIG LEIE cache
 import { registerOpportunityRoutes } from './routes/opportunities';          // Wave 227: Opportunities + Candidates
+import { registerMatchaRoutes } from './routes/matcha';                      // Wave K: MATCHA demand-side engine
 import { registerApplicationRoutes } from './routes/applications';            // Wave 229: Application Flow
 import { registerAskRoutes } from './routes/ask';                           // Wave 185: Ask VitalCV answer engine
 import { registerCopilotRoutes } from './routes/copilot';                   // Waves C25-C28: Copilot query engine
@@ -3597,6 +3598,7 @@ registerIngestStreamRoutes(app);      // Real-time ingest — POST /api/ingest/:
 // GET /api/leie/status — OIG LEIE cache health
 app.get('/api/leie/status', (_req, res) => { res.json(leieCacheStats()); });
 registerOpportunityRoutes(app);       // Wave 227 — Opportunities + Candidates
+registerMatchaRoutes(app);            // Wave K — MATCHA demand-side engine (was built + tested but never mounted)
 registerApplicationRoutes(app);       // Wave 229 — Clinician Application Flow
 registerAskRoutes(app);               // Wave 185 — Ask VitalCV natural language answer engine
 registerCopilotRoutes(app);           // Waves C25-C28 — Copilot query engine

--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -59,6 +59,14 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/employer-review/1003000126/acceptance-history')).toBe(true);
   });
 
+  it('skips tenant context for MATCHA demand-side routes but keeps marketplace guarded (Wave K)', () => {
+    expect(shouldSkipTenantContext('/api/matcha/opportunities/1003000126')).toBe(true);
+    expect(shouldSkipTenantContext('/api/matcha/explain')).toBe(true);
+    expect(shouldSkipTenantContext('/api/matcha/simulate/1003000126')).toBe(true);
+    expect(shouldSkipTenantContext('/api/marketplace/match')).toBe(false);
+    expect(shouldSkipTenantContext('/api/marketplace/pool')).toBe(false);
+  });
+
   it('allows the trust-proof read through without organization context', () => {
     const req = createRequest('/api/trust-proof/1003000126');
     const res = createResponse();

--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -101,6 +101,12 @@ export function shouldSkipTenantContext(path: string): boolean {
     || normalized.startsWith('/api/watch')
     || normalized.startsWith('/api/search')
     || normalized.startsWith('/api/employers')
+    // MATCHA clinician demand-side surfaces: NPI-keyed scoring reads plus
+    // Clerk-header-scoped intent/opportunity writes, called via the web
+    // proxies before any org context exists (same posture as
+    // /api/opportunities above). Marketplace routes (/api/marketplace/*)
+    // intentionally stay behind the tenant guard.
+    || normalized.startsWith('/api/matcha')
     || normalized.startsWith('/bundle')
     || normalized.startsWith('/api/issuer/')
     || normalized.startsWith('/api/poe/')

--- a/apps/api/backend/src/services/matcha/liveMatchaService.ts
+++ b/apps/api/backend/src/services/matcha/liveMatchaService.ts
@@ -301,6 +301,10 @@ export async function getLiveMatchesForNpi(
       score: m.explanation.matchScore,
       blockers: m.explanation.blockers.map(b => ({ label: b.label, action: b.actionLabel })),
       fitReasons: m.explanation.fitReasons.map(f => f.label),
+      // Full objects for the clinician surfaces (cards + detail view). The slim
+      // fields above are kept for existing consumers — additive only.
+      opportunity: m.opportunity,
+      explanation: m.explanation,
     })),
     profileCompleteness: {
       level: profile.credentials.some(c => c.claimLevel === 'L1') ? 'partial' : 'full',

--- a/apps/web/__tests__/matcha-opportunity-action-route.test.ts
+++ b/apps/web/__tests__/matcha-opportunity-action-route.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Wave K — server-persisted opportunity actions: route contract.
+ *
+ * POST /api/matcha/opportunity/[id]/action
+ *   - identity comes from Clerk auth(), never a caller-supplied header
+ *   - append-only OpportunityAction row + AuditEvent in ONE transaction
+ *   - deploy-order safe: DB failure degrades to persisted:false, never a 500
+ *
+ * GET /api/matcha/opportunity-actions
+ *   - latest row per opportunityId wins (append-only log collapse)
+ *   - degrades to an empty map on DB failure
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMock = vi.fn();
+const opportunityActionCreate = vi.fn();
+const auditEventCreate = vi.fn();
+const opportunityActionFindMany = vi.fn();
+const transactionMock = vi.fn();
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: authMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    opportunityAction: {
+      create: opportunityActionCreate,
+      findMany: opportunityActionFindMany,
+    },
+    auditEvent: {
+      create: auditEventCreate,
+    },
+    $transaction: transactionMock,
+  },
+}));
+
+async function loadActionRoute() {
+  return import(new URL('../app/api/matcha/opportunity/[id]/action/route.ts', import.meta.url).href);
+}
+
+async function loadActionsRoute() {
+  return import(new URL('../app/api/matcha/opportunity-actions/route.ts', import.meta.url).href);
+}
+
+function postRequest(body: unknown) {
+  return import('next/server').then(({ NextRequest }) =>
+    new NextRequest('http://localhost/api/matcha/opportunity/opp-1/action', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  authMock.mockReset();
+  opportunityActionCreate.mockReset();
+  auditEventCreate.mockReset();
+  opportunityActionFindMany.mockReset();
+  transactionMock.mockReset();
+  opportunityActionCreate.mockImplementation((args) => ({ __op: 'action', args }));
+  auditEventCreate.mockImplementation((args) => ({ __op: 'audit', args }));
+  transactionMock.mockResolvedValue([{}, {}]);
+});
+
+describe('POST /api/matcha/opportunity/[id]/action', () => {
+  it('rejects unauthenticated callers without touching the DB', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(await postRequest({ action: 'saved' }), params('opp-1'));
+
+    expect(res.status).toBe(401);
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown action values', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(await postRequest({ action: 'applied' }), params('opp-1'));
+
+    expect(res.status).toBe(400);
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed opportunity ids', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(await postRequest({ action: 'saved' }), params('has space'));
+
+    expect(res.status).toBe(400);
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it('appends the action row and its AuditEvent in one transaction (audit-first)', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(
+      await postRequest({ action: 'saved', npi: '1003000126' }),
+      params('opp-1'),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, persisted: true, action: 'saved' });
+
+    expect(opportunityActionCreate).toHaveBeenCalledTimes(1);
+    const actionData = opportunityActionCreate.mock.calls[0][0].data;
+    expect(actionData).toMatchObject({
+      clerkUserId: 'user_1',
+      npi: '1003000126',
+      opportunityId: 'opp-1',
+      action: 'saved',
+      source: 'web',
+    });
+    expect(actionData.id).toMatch(/^[0-9a-f-]{36}$/);
+
+    expect(auditEventCreate).toHaveBeenCalledTimes(1);
+    const auditData = auditEventCreate.mock.calls[0][0].data;
+    expect(auditData.type).toBe('matcha.opportunity_action');
+    expect(auditData.referenceId).toBe('opp-1');
+    expect(auditData.clinicianId).toBe('1003000126');
+    expect(auditData.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(auditData.metadata).toMatchObject({
+      action: 'saved',
+      actionId: actionData.id,
+      clerkUserId: 'user_1',
+      opportunityId: 'opp-1',
+      source: 'web',
+    });
+
+    // Both writes travel through ONE transaction — no unaudited mutation path.
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it("records 'cleared' as an append (toggle back to new), never a delete", async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(await postRequest({ action: 'cleared' }), params('opp-1'));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ persisted: true, action: 'cleared' });
+    expect(opportunityActionCreate.mock.calls[0][0].data.action).toBe('cleared');
+  });
+
+  it('drops a malformed NPI instead of persisting it', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    const { POST } = await loadActionRoute();
+
+    await POST(await postRequest({ action: 'saved', npi: 'not-an-npi' }), params('opp-1'));
+
+    expect(opportunityActionCreate.mock.calls[0][0].data.npi).toBeNull();
+  });
+
+  it('degrades to persisted:false when the table is not deployed yet (never a 500)', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    transactionMock.mockRejectedValue(new Error('P2021: table does not exist'));
+    const { POST } = await loadActionRoute();
+
+    const res = await POST(await postRequest({ action: 'saved' }), params('opp-1'));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: false, persisted: false, action: 'saved' });
+  });
+});
+
+describe('GET /api/matcha/opportunity-actions', () => {
+  it('rejects unauthenticated callers', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const { GET } = await loadActionsRoute();
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    expect(opportunityActionFindMany).not.toHaveBeenCalled();
+  });
+
+  it('collapses the append-only log to the latest decision per opportunity', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    // Newest-first, as the route orders by createdAt desc.
+    opportunityActionFindMany.mockResolvedValue([
+      { opportunityId: 'a', action: 'cleared' },
+      { opportunityId: 'a', action: 'saved' },
+      { opportunityId: 'b', action: 'connected' },
+      { opportunityId: 'b', action: 'declined' },
+    ]);
+    const { GET } = await loadActionsRoute();
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      actions: { a: 'cleared', b: 'connected' },
+    });
+    expect(opportunityActionFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clerkUserId: 'user_1' },
+        orderBy: { createdAt: 'desc' },
+      }),
+    );
+  });
+
+  it('degrades to an empty map when the table is not deployed yet (never a 500)', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1' });
+    opportunityActionFindMany.mockRejectedValue(new Error('P2021: table does not exist'));
+    const { GET } = await loadActionsRoute();
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ actions: {} });
+  });
+});

--- a/apps/web/__tests__/matcha-opportunity-actions.test.ts
+++ b/apps/web/__tests__/matcha-opportunity-actions.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  actionValueForTap,
   bucketFor,
+  isOpportunityActionValue,
+  mergeServerActions,
   statusCounts,
   type OpportunityActionMap,
 } from '../lib/matcha/opportunityActions';
@@ -27,6 +30,44 @@ describe('opportunity actions — buckets & counts', () => {
 
   it('is all-new for an empty action map', () => {
     expect(statusCounts({}, ['a', 'b', 'c'])).toEqual({ new: 3, saved: 0, connected: 0, declined: 0 });
+  });
+});
+
+describe('opportunity actions — server persistence semantics (Wave K)', () => {
+  it('maps a tap on a new status to that status', () => {
+    expect(actionValueForTap({}, 'opp1', 'saved')).toBe('saved');
+    expect(actionValueForTap({ opp1: 'saved' }, 'opp1', 'connected')).toBe('connected');
+  });
+
+  it("maps a tap on the already-active status to 'cleared' (append-only toggle-off)", () => {
+    expect(actionValueForTap({ opp1: 'saved' }, 'opp1', 'saved')).toBe('cleared');
+    expect(actionValueForTap({ opp1: 'declined' }, 'opp1', 'declined')).toBe('cleared');
+  });
+
+  it('accepts exactly the four server action values', () => {
+    expect(isOpportunityActionValue('saved')).toBe(true);
+    expect(isOpportunityActionValue('connected')).toBe(true);
+    expect(isOpportunityActionValue('declined')).toBe(true);
+    expect(isOpportunityActionValue('cleared')).toBe(true);
+    expect(isOpportunityActionValue('applied')).toBe(false);
+    expect(isOpportunityActionValue('')).toBe(false);
+    expect(isOpportunityActionValue(42)).toBe(false);
+    expect(isOpportunityActionValue(null)).toBe(false);
+  });
+
+  it('merges server decisions over the local cache — server wins, cleared removes, local-only kept', () => {
+    const local: OpportunityActionMap = { a: 'saved', b: 'connected', c: 'declined' };
+    const merged = mergeServerActions(local, { a: 'declined', b: 'cleared', d: 'saved' });
+    expect(merged).toEqual({ a: 'declined', c: 'declined', d: 'saved' });
+  });
+
+  it('is identity for an empty server map and does not mutate the input', () => {
+    const local: OpportunityActionMap = { a: 'saved' };
+    const merged = mergeServerActions(local, {});
+    expect(merged).toEqual({ a: 'saved' });
+    expect(merged).not.toBe(local);
+    mergeServerActions(local, { a: 'cleared' });
+    expect(local).toEqual({ a: 'saved' });
   });
 });
 

--- a/apps/web/__tests__/matcha-opportunity-card-wiring.test.tsx
+++ b/apps/web/__tests__/matcha-opportunity-card-wiring.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Wave K — MATCHA opportunity card wiring: click-through to the role detail
+ * route and the readiness-gated Apply-with-VitalCV CTA.
+ *
+ * The gate is the engine's own output: hard blockers (or an INELIGIBLE band)
+ * render an honest "resolve blockers" affordance pointing at the full
+ * breakdown — never a broken apply button. Clear roles render the real
+ * Apply-with-VitalCV entry point (the audited POST /api/apply/share flow).
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// The drafter needs the clinician workspace provider; it is not under test here.
+vi.mock('../components/matcha/CoverLetterDrafter', () => ({
+  CoverLetterDrafter: () => null,
+}));
+
+import { OpportunityCard } from '../components/matcha/OpportunityCard';
+import { hardGateCount } from '../components/matcha/OpportunityApplyCta';
+import type { IntelligenceExplanation } from '../components/matcha/OpportunityIntelligenceCard';
+
+const OPPORTUNITY = {
+  id: 'opp-1',
+  title: 'Cardiology — Interventional',
+  organization: 'Bay Area Cardiac Group',
+  organizationId: 'org-9',
+  location: 'Oakland, CA',
+  state: 'CA',
+  specialty: 'Cardiology',
+  payRange: '$310k–$360k',
+  remote: false,
+};
+
+const CLEAR: IntelligenceExplanation = {
+  matchBand: 'CLEAR',
+  matchScore: 92,
+  confidence: 0.9,
+  fitReasons: [{ label: 'CA license on file', positive: true }],
+  missingCredentials: [],
+  blockers: [],
+};
+
+const HARD_GATED: IntelligenceExplanation = {
+  matchBand: 'PARTIAL',
+  matchScore: 48,
+  confidence: 0.8,
+  fitReasons: [],
+  missingCredentials: ['dea'],
+  blockers: [
+    { label: 'DEA registration required', severity: 'hard', actionLabel: 'Add your DEA number' },
+    { label: 'Board cert preferred', severity: 'soft' },
+  ],
+};
+
+function renderCard(props: Partial<Parameters<typeof OpportunityCard>[0]> = {}) {
+  return renderToStaticMarkup(
+    <OpportunityCard
+      opportunity={OPPORTUNITY}
+      explanation={CLEAR}
+      bucket="new"
+      onSetStatus={() => {}}
+      npi="1003000126"
+      detailHref="/holder/opportunities/opp-1"
+      {...props}
+    />,
+  );
+}
+
+describe('opportunity card — detail click-through (Wave K)', () => {
+  it('links the title and the Full breakdown affordance to the role detail route', () => {
+    const markup = renderCard();
+    expect(markup).toContain('href="/holder/opportunities/opp-1"');
+    expect(markup).toContain('Full breakdown');
+  });
+
+  it('renders no dead link when detailHref is absent', () => {
+    const markup = renderCard({ detailHref: undefined });
+    expect(markup).not.toContain('/holder/opportunities/opp-1');
+    expect(markup).not.toContain('Full breakdown');
+  });
+});
+
+describe('opportunity card — gated Apply with VitalCV (Wave K)', () => {
+  it('shows the real Apply with VitalCV entry point when no hard gates remain', () => {
+    const markup = renderCard();
+    expect(markup).toContain('Apply with VitalCV');
+    expect(markup).not.toContain('gating requirement');
+  });
+
+  it('shows remediation, not a broken apply, when the engine hard-gates the role', () => {
+    const markup = renderCard({ explanation: HARD_GATED });
+    expect(markup).not.toContain('Apply with VitalCV');
+    expect(markup).toContain('1 gating requirement to resolve before you can apply');
+    // The affordance routes to the full breakdown where blockers + actions live.
+    expect(markup).toContain('See what');
+    expect(markup).toContain('href="/holder/opportunities/opp-1"');
+  });
+
+  it('renders no apply CTA at all without an NPI', () => {
+    const markup = renderCard({ npi: null });
+    expect(markup).not.toContain('Apply with VitalCV');
+    expect(markup).not.toContain('gating requirement');
+  });
+});
+
+describe('hardGateCount — the gate is the engine output, never a guess', () => {
+  it('is zero without an explanation (no fabricated gate)', () => {
+    expect(hardGateCount(undefined)).toBe(0);
+  });
+
+  it('counts hard blockers only', () => {
+    expect(hardGateCount(HARD_GATED)).toBe(1);
+    expect(hardGateCount(CLEAR)).toBe(0);
+  });
+
+  it('treats an INELIGIBLE band as gated even when blocker details are absent', () => {
+    expect(
+      hardGateCount({
+        matchBand: 'INELIGIBLE',
+        matchScore: 10,
+        confidence: 0.7,
+        missingCredentials: ['dea', 'state_license'],
+        blockers: [],
+      }),
+    ).toBe(2);
+    expect(
+      hardGateCount({
+        matchBand: 'INELIGIBLE',
+        matchScore: 10,
+        confidence: 0.7,
+        blockers: [],
+      }),
+    ).toBe(1);
+  });
+});

--- a/apps/web/app/api/matcha/opportunity-actions/route.ts
+++ b/apps/web/app/api/matcha/opportunity-actions/route.ts
@@ -1,0 +1,49 @@
+/**
+ * GET /api/matcha/opportunity-actions — Wave K.
+ *
+ * The authenticated clinician's current opportunity decisions, derived from
+ * the append-only OpportunityAction log: latest row per opportunityId wins
+ * (a 'cleared' row means the opportunity is back to "new"). Used to hydrate
+ * the Save / Connect / Decline state across devices; localStorage remains the
+ * client's optimistic cache.
+ *
+ * Deploy-order safe: if the table does not exist yet (migration not deployed)
+ * or the DB hiccups, degrades to an empty map so the client silently falls
+ * back to its local cache — never a 500 in the signed-in experience.
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import type { OpportunityActionValue } from '@/lib/matcha/opportunityActions';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  try {
+    // Newest-first, then first-seen per opportunityId = the latest decision.
+    const rows = await prisma.opportunityAction.findMany({
+      where: { clerkUserId: userId },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+      select: { opportunityId: true, action: true },
+    });
+
+    const actions: Record<string, OpportunityActionValue> = {};
+    for (const row of rows) {
+      if (!(row.opportunityId in actions)) {
+        actions[row.opportunityId] = row.action as OpportunityActionValue;
+      }
+    }
+
+    return NextResponse.json({ actions });
+  } catch (err) {
+    console.error('[matcha/opportunity-actions GET]', err);
+    // Degrade to empty — the client keeps its local cache as the fallback.
+    return NextResponse.json({ actions: {} });
+  }
+}

--- a/apps/web/app/api/matcha/opportunity/[id]/action/route.ts
+++ b/apps/web/app/api/matcha/opportunity/[id]/action/route.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /api/matcha/opportunity/[id]/action — Wave K.
+ *
+ * Server-persists a clinician's Save / Connect / Decline decision on a MATCHA
+ * opportunity. Append-only: every action — including clearing one back to
+ * "new" (`action: 'cleared'`) — inserts a NEW OpportunityAction row, paired
+ * with an AuditEvent in the same transaction (audit-first rule). Rows are the
+ * clinician's own workflow decisions — never credentials, never verification
+ * state, never inputs to trust-state/CRS.
+ *
+ * Auth-scoped to the authenticated Clerk user (identity from auth(), NOT a
+ * caller-supplied header). Deploy-order safe: until the OpportunityAction
+ * migration deploys (or if the DB hiccups) the route degrades to
+ * `persisted: false` so the client silently keeps its localStorage cache —
+ * never a 500 in the signed-in experience (same pattern as MatchaPreference).
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { isOpportunityActionValue } from '@/lib/matcha/opportunityActions';
+
+export const runtime = 'nodejs';
+
+const NPI_RE = /^\d{10}$/;
+// Opportunity ids are opaque string keys (DB uuids or registry slugs) —
+// bound the length and reject whitespace/control characters.
+const OPPORTUNITY_ID_RE = /^[\x21-\x7e]{1,128}$/;
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const { id: opportunityId } = await context.params;
+  if (!OPPORTUNITY_ID_RE.test(opportunityId)) {
+    return NextResponse.json({ error: 'invalid opportunity id' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  const action = (body as { action?: unknown })?.action;
+  if (!isOpportunityActionValue(action)) {
+    return NextResponse.json(
+      { error: 'action must be one of saved | connected | declined | cleared' },
+      { status: 400 },
+    );
+  }
+
+  const rawNpi = (body as { npi?: unknown })?.npi;
+  const npi = typeof rawNpi === 'string' && NPI_RE.test(rawNpi) ? rawNpi : null;
+
+  const recordedAt = new Date().toISOString();
+  const actionId = randomUUID();
+  const hash = createHash('sha256')
+    .update(
+      JSON.stringify({
+        action,
+        actionId,
+        clerkUserId: userId,
+        npi,
+        opportunityId,
+        recordedAt,
+      }),
+    )
+    .digest('hex');
+
+  try {
+    await prisma.$transaction([
+      prisma.opportunityAction.create({
+        data: {
+          id: actionId,
+          clerkUserId: userId,
+          npi,
+          opportunityId,
+          action,
+          source: 'web',
+        },
+      }),
+      prisma.auditEvent.create({
+        data: {
+          id: randomUUID(),
+          type: 'matcha.opportunity_action',
+          hash,
+          referenceId: opportunityId,
+          clinicianId: npi,
+          metadata: {
+            action,
+            actionId,
+            // Actor attribution — the authenticated Clerk user, from auth().
+            clerkUserId: userId,
+            opportunityId,
+            recordedAt,
+            source: 'web',
+          },
+        },
+      }),
+    ]);
+    return NextResponse.json({ ok: true, persisted: true, action });
+  } catch (err) {
+    console.error('[matcha/opportunity action POST]', err);
+    // Best-effort: never break the client; localStorage remains the fallback.
+    return NextResponse.json({ ok: false, persisted: false, action }, { status: 200 });
+  }
+}

--- a/apps/web/components/apply/ApplyWithVitalCV.tsx
+++ b/apps/web/components/apply/ApplyWithVitalCV.tsx
@@ -68,6 +68,8 @@ type Step = 'credentials' | 'org_context' | 'confirmed';
 interface Props {
   npi: string;
   label?: string;
+  /** Prefill the share destination (e.g. from a MATCHA opportunity's employer). Always editable. */
+  initialOrgContext?: Partial<OrgContext>;
   onShareComplete?: (result: ShareResult) => void;
 }
 
@@ -128,7 +130,13 @@ function clerkId(): string {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', onShareComplete }: Props) {
+export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', initialOrgContext, onShareComplete }: Props) {
+  const baseOrgCtx = useCallback((): OrgContext => ({
+    organization_id: initialOrgContext?.organization_id ?? '',
+    name: initialOrgContext?.name ?? '',
+    callback_url: initialOrgContext?.callback_url ?? '',
+    purpose_of_use: initialOrgContext?.purpose_of_use ?? PURPOSE_OPTIONS[0],
+  }), [initialOrgContext]);
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<Step>('credentials');
   const [isLoading, setIsLoading] = useState(false);
@@ -138,9 +146,7 @@ export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', onShareCom
   const [trustState, setTrustState] = useState<TrustStateData | null>(null);
   const [credentials, setCredentials] = useState<BundleCredential[]>([]);
   const [selectedTypes, setSelectedTypes] = useState<Set<string>>(new Set());
-  const [orgCtx, setOrgCtx] = useState<OrgContext>({
-    organization_id: '', name: '', callback_url: '', purpose_of_use: PURPOSE_OPTIONS[0],
-  });
+  const [orgCtx, setOrgCtx] = useState<OrgContext>(baseOrgCtx);
   const [orgCtxErrors, setOrgCtxErrors] = useState<Partial<Record<keyof OrgContext, string>>>({});
   const [shareResult, setShareResult] = useState<ShareResult | null>(null);
   const [countdown, setCountdown] = useState('');
@@ -153,10 +159,10 @@ export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', onShareCom
     setStep('credentials');
     setError(null);
     setShareResult(null);
-    setOrgCtx({ organization_id: '', name: '', callback_url: '', purpose_of_use: PURPOSE_OPTIONS[0] });
+    setOrgCtx(baseOrgCtx());
     setOrgCtxErrors({});
     setIsOpen(true);
-  }, []);
+  }, [baseOrgCtx]);
 
   const closeModal = useCallback(() => { setIsOpen(false); }, []);
 
@@ -637,7 +643,7 @@ export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', onShareCom
                   onClick={() => {
                     setStep('credentials');
                     setShareResult(null);
-                    setOrgCtx({ organization_id: '', name: '', callback_url: '', purpose_of_use: PURPOSE_OPTIONS[0] });
+                    setOrgCtx(baseOrgCtx());
                   }}
                   className="flex-1 py-3 rounded-xl border border-border text-xs font-medium text-zinc-400 hover:text-foreground transition-colors"
                 >

--- a/apps/web/components/matcha/MatchaHub.tsx
+++ b/apps/web/components/matcha/MatchaHub.tsx
@@ -42,7 +42,7 @@ export function MatchaHub() {
   const categoryProgress = allCategoryProgress(preferences);
 
   const { matches, state: oppState } = useMatchaOpportunities(npi ?? null);
-  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions();
+  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions(npi);
 
   const oppIds = useMemo(
     () => matches.map((m) => m.opportunity?.id).filter((id): id is string => Boolean(id)),
@@ -179,6 +179,8 @@ export function MatchaHub() {
                   preferenceReasons={preferenceMatchReasons(preferences, opp)}
                   bucket={bucketOf(opp.id)}
                   onSetStatus={(status) => setStatus(opp.id, status)}
+                  npi={npi}
+                  detailHref={`/holder/opportunities/${encodeURIComponent(opp.id)}`}
                 />
               );
             })}

--- a/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
+++ b/apps/web/components/matcha/MatchaOpportunitiesSurface.tsx
@@ -19,7 +19,7 @@ export function MatchaOpportunitiesSurface() {
   const { data } = useClinicianMobile();
   const npi = data.workspace?.personProfile?.npi ?? null;
   const { preferences } = useMatchaPreferences(npi ?? undefined);
-  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions();
+  const { loaded: actionsLoaded, bucketOf, setStatus, counts } = useOpportunityActions(npi);
   const { matches, state } = useMatchaOpportunities(npi);
 
   const ids = useMemo(
@@ -75,6 +75,8 @@ export function MatchaOpportunitiesSurface() {
               preferenceReasons={reasons}
               bucket={bucketOf(opp.id)}
               onSetStatus={(status) => setStatus(opp.id, status)}
+              npi={npi}
+              detailHref={`/holder/opportunities/${encodeURIComponent(opp.id)}`}
             />
           );
         })}

--- a/apps/web/components/matcha/OpportunityApplyCta.tsx
+++ b/apps/web/components/matcha/OpportunityApplyCta.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * OpportunityApplyCta — Wave K. Gates the real Apply-with-VitalCV share flow on
+ * the engine's own hard gates:
+ *   - hard blockers (or an INELIGIBLE band) → an honest "review what's blocking"
+ *     affordance pointing at the full breakdown, never a broken apply button;
+ *   - otherwise → the real ApplyWithVitalCV modal (POST /api/apply/share,
+ *     audit-first, revocable), prefilled with this opportunity's employer.
+ *
+ * The gate reflects credential eligibility from the clinician's trust state —
+ * it is the engine's output, not a promise about hiring outcomes.
+ */
+
+import { ApplyWithVitalCV } from '@/components/apply/ApplyWithVitalCV';
+import type {
+  IntelligenceExplanation,
+  IntelligenceOpportunity,
+} from './OpportunityIntelligenceCard';
+
+export interface ApplyCtaOpportunity extends IntelligenceOpportunity {
+  organizationId?: string;
+  employerSlug?: string;
+}
+
+export function hardGateCount(explanation?: IntelligenceExplanation): number {
+  if (!explanation) return 0;
+  const hard = (explanation.blockers ?? []).filter((b) => b.severity === 'hard').length;
+  if (hard > 0) return hard;
+  return explanation.matchBand === 'INELIGIBLE'
+    ? Math.max(explanation.missingCredentials?.length ?? 0, 1)
+    : 0;
+}
+
+export interface OpportunityApplyCtaProps {
+  npi: string | null | undefined;
+  opportunity: ApplyCtaOpportunity;
+  explanation?: IntelligenceExplanation;
+  /** Where the blocked state's "review" affordance points (the detail breakdown). */
+  detailHref?: string;
+  onShareComplete?: () => void;
+}
+
+export function OpportunityApplyCta({
+  npi,
+  opportunity,
+  explanation,
+  detailHref,
+  onShareComplete,
+}: OpportunityApplyCtaProps) {
+  if (!npi) return null;
+
+  const gates = hardGateCount(explanation);
+  if (gates > 0) {
+    const label = `${gates} gating requirement${gates === 1 ? '' : 's'} to resolve before you can apply`;
+    return (
+      <div
+        data-testid="apply-blocked"
+        style={{
+          marginTop: 16,
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 10,
+          padding: '12px 14px',
+          borderRadius: 12,
+          border: '1px solid color-mix(in srgb, var(--vt-risk-medium, #A05C00) 30%, transparent)',
+          background: 'color-mix(in srgb, var(--vt-risk-medium, #A05C00) 8%, transparent)',
+        }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-risk-medium, #A05C00)' }}>
+          {label}
+        </span>
+        {detailHref ? (
+          <a
+            href={detailHref}
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--vt-accent, #0A7B7F)',
+              textDecoration: 'none',
+            }}
+          >
+            See what&rsquo;s needed →
+          </a>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: 16 }}>
+      <ApplyWithVitalCV
+        npi={npi}
+        initialOrgContext={{
+          name: opportunity.organization ?? '',
+          organization_id: opportunity.organizationId ?? opportunity.employerSlug ?? '',
+          purpose_of_use: 'Employment consideration',
+        }}
+        onShareComplete={onShareComplete ? () => onShareComplete() : undefined}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/matcha/OpportunityCard.tsx
+++ b/apps/web/components/matcha/OpportunityCard.tsx
@@ -2,7 +2,8 @@
 
 /**
  * OpportunityCard — interactive wrapper around OpportunityIntelligenceCard.
- * Adds the clinician's Save / Connect / Decline actions and the honest Livability section.
+ * Adds the clinician's Save / Connect / Decline actions, the gated Apply-with-VitalCV
+ * CTA, the click-through to the full breakdown, and the honest Livability section.
  * Status is owned by the surface (one shared action map) and passed in.
  */
 
@@ -12,6 +13,7 @@ import {
   type IntelligenceExplanation,
   type IntelligenceOpportunity,
 } from './OpportunityIntelligenceCard';
+import { OpportunityApplyCta, type ApplyCtaOpportunity } from './OpportunityApplyCta';
 import { Livability } from './Livability';
 import { CoverLetterDrafter } from './CoverLetterDrafter';
 import type { ExplanationReason } from './MatchaExplanation';
@@ -36,14 +38,18 @@ const ACTIONS: ActionDef[] = [
 ];
 
 export interface OpportunityCardProps {
-  opportunity: IntelligenceOpportunity;
+  opportunity: ApplyCtaOpportunity;
   explanation?: IntelligenceExplanation;
   preferenceReasons?: ExplanationReason[];
   bucket: OpportunityBucket;
   onSetStatus: (status: OpportunityStatus) => void;
+  /** Clinician NPI — enables the Apply-with-VitalCV CTA. */
+  npi?: string | null;
+  /** The opportunity detail route (full breakdown). Links the title + footer affordance. */
+  detailHref?: string;
 }
 
-export function OpportunityCard({ opportunity, explanation, preferenceReasons, bucket, onSetStatus }: OpportunityCardProps) {
+export function OpportunityCard({ opportunity, explanation, preferenceReasons, bucket, onSetStatus, npi, detailHref }: OpportunityCardProps) {
   const declined = bucket === 'declined';
   return (
     <div style={{ opacity: declined ? 0.6 : 1, transition: 'opacity 200ms' }}>
@@ -51,6 +57,7 @@ export function OpportunityCard({ opportunity, explanation, preferenceReasons, b
         opportunity={opportunity}
         explanation={explanation}
         preferenceReasons={preferenceReasons}
+        titleHref={detailHref}
       >
         {/* Action bar */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
@@ -83,7 +90,39 @@ export function OpportunityCard({ opportunity, explanation, preferenceReasons, b
               </button>
             );
           })}
+          {detailHref ? (
+            <a
+              href={detailHref}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '8px 14px',
+                borderRadius: 10,
+                fontSize: 13,
+                fontWeight: 600,
+                border: `1px solid ${MUTED_BORDER}`,
+                background: 'var(--vt-surface, #fff)',
+                color: 'var(--vt-accent, #0A7B7F)',
+                textDecoration: 'none',
+                marginLeft: 'auto',
+              }}
+            >
+              Full breakdown →
+            </a>
+          ) : null}
         </div>
+
+        {/* Apply with VitalCV — the real share flow, gated on the engine's hard gates */}
+        <OpportunityApplyCta
+          npi={npi}
+          opportunity={opportunity}
+          explanation={explanation}
+          detailHref={detailHref}
+          onShareComplete={() => {
+            if (bucket !== 'connected') onSetStatus('connected');
+          }}
+        />
 
         {/* Livability */}
         <Livability location={opportunity.location} state={opportunity.state} remote={opportunity.remote} />

--- a/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
+++ b/apps/web/components/matcha/OpportunityIntelligenceCard.tsx
@@ -35,7 +35,7 @@ export interface IntelligenceExplanation {
   confidence: number;
   fitReasons?: Array<{ label: string; positive: boolean; dimension?: string }>;
   missingCredentials?: string[];
-  blockers?: Array<{ label: string; severity: 'hard' | 'soft' }>;
+  blockers?: Array<{ label: string; severity: 'hard' | 'soft'; actionLabel?: string }>;
   instantOfferEligible?: boolean;
 }
 
@@ -46,6 +46,12 @@ export interface OpportunityIntelligenceCardProps {
   /** Preference-grounded reasons from opportunityFit.preferenceMatchReasons. */
   preferenceReasons?: ExplanationReason[];
   href?: string;
+  /**
+   * Links the title to the opportunity detail route. Use this (not `href`)
+   * when the card body contains interactive children — a whole-card anchor
+   * would nest buttons inside an <a>.
+   */
+  titleHref?: string;
   /** Interactive content injected before the honesty footer (action bar, livability). */
   children?: React.ReactNode;
 }
@@ -76,6 +82,7 @@ export function OpportunityIntelligenceCard({
   explanation,
   preferenceReasons = [],
   href,
+  titleHref,
   children,
 }: OpportunityIntelligenceCardProps) {
   const band = explanation ? matchBandDisplay(explanation.matchBand) : null;
@@ -116,7 +123,13 @@ export function OpportunityIntelligenceCard({
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start' }}>
         <div style={{ minWidth: 0 }}>
           <h3 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
-            {opportunity.title}
+            {titleHref ? (
+              <a href={titleHref} style={{ color: 'inherit', textDecoration: 'none' }}>
+                {opportunity.title}
+              </a>
+            ) : (
+              opportunity.title
+            )}
           </h3>
           <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--vt-text-secondary)' }}>
             {[opportunity.organization, opportunity.location].filter(Boolean).join(' · ')}

--- a/apps/web/components/matcha/useOpportunityActions.ts
+++ b/apps/web/components/matcha/useOpportunityActions.ts
@@ -1,42 +1,99 @@
 'use client';
 
 /**
- * useOpportunityActions — React state over the clinician's Save/Connect/Decline decisions,
- * backed by localStorage. Toggling a status off returns the opportunity to "new".
+ * useOpportunityActions — React state over the clinician's Save/Connect/Decline decisions.
+ * Server-persisted (append-only OpportunityAction rows keyed by the authenticated Clerk
+ * user) with localStorage as the optimistic cache: every tap updates local state
+ * immediately and fires a best-effort POST; on mount the server's decisions are merged
+ * over the local cache so they follow the clinician across devices. Toggling a status
+ * off returns the opportunity to "new" (recorded server-side as 'cleared').
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type OpportunityActionMap,
+  type OpportunityActionValue,
   type OpportunityBucket,
   type OpportunityStatus,
+  actionValueForTap,
   bucketFor,
   loadOpportunityActions,
+  mergeServerActions,
   persistOpportunityActions,
   statusCounts,
 } from '@/lib/matcha/opportunityActions';
 
-export function useOpportunityActions() {
+function postActionBestEffort(id: string, action: OpportunityActionValue, npi?: string | null): void {
+  try {
+    void fetch(`/api/matcha/opportunity/${encodeURIComponent(id)}/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, ...(npi ? { npi } : {}) }),
+      keepalive: true,
+    }).catch(() => {
+      /* localStorage remains the fallback */
+    });
+  } catch {
+    /* no-op — never let persistence break the interaction */
+  }
+}
+
+export function useOpportunityActions(npi?: string | null) {
   const [map, setMap] = useState<OpportunityActionMap>({});
   const [loaded, setLoaded] = useState(false);
+  const mapRef = useRef<OpportunityActionMap>({});
+  // Ids acted on this session — a late server hydrate must not clobber them.
+  const pendingRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    mapRef.current = map;
+  }, [map]);
 
   useEffect(() => {
     setMap(loadOpportunityActions());
     setLoaded(true);
+
+    let cancelled = false;
+    fetch('/api/matcha/opportunity-actions', { signal: AbortSignal.timeout(10_000) })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((payload: { actions?: Record<string, OpportunityActionValue> } | null) => {
+        if (cancelled || !payload?.actions) return;
+        const server = Object.fromEntries(
+          Object.entries(payload.actions).filter(([id]) => !pendingRef.current.has(id)),
+        );
+        setMap((prev) => {
+          const next = mergeServerActions(prev, server);
+          persistOpportunityActions(next);
+          return next;
+        });
+      })
+      .catch(() => {
+        /* signed-out / offline / table not deployed — local cache stands */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const setStatus = useCallback((id: string, status: OpportunityStatus) => {
-    setMap((prev) => {
-      const next = { ...prev };
-      if (next[id] === status) {
-        delete next[id]; // toggle back to "new"
-      } else {
-        next[id] = status;
-      }
-      persistOpportunityActions(next);
-      return next;
-    });
-  }, []);
+  const setStatus = useCallback(
+    (id: string, status: OpportunityStatus) => {
+      const requestValue = actionValueForTap(mapRef.current, id, status);
+      pendingRef.current.add(id);
+      setMap((prev) => {
+        const next = { ...prev };
+        if (next[id] === status) {
+          delete next[id]; // toggle back to "new"
+        } else {
+          next[id] = status;
+        }
+        persistOpportunityActions(next);
+        return next;
+      });
+      postActionBestEffort(id, requestValue, npi);
+    },
+    [npi],
+  );
 
   const bucketOf = useCallback((id: string): OpportunityBucket => bucketFor(map, id), [map]);
   const counts = useCallback((ids: readonly string[]) => statusCounts(map, ids), [map]);

--- a/apps/web/lib/matcha/opportunityActions.ts
+++ b/apps/web/lib/matcha/opportunityActions.ts
@@ -1,13 +1,17 @@
 /**
  * Opportunity actions — the clinician's own Save / Connect / Decline decisions.
  *
- * These are real user actions, persisted locally (the clinician owns them). "New" is simply an
+ * These are real user actions, persisted server-side (append-only rows keyed by the
+ * authenticated Clerk user) with localStorage as the optimistic cache. "New" is simply an
  * opportunity that hasn't been acted on yet. Pure + SSR-safe; the React hook lives in
  * components/matcha/useOpportunityActions.ts.
  */
 
 export type OpportunityStatus = 'saved' | 'connected' | 'declined';
 export type OpportunityBucket = 'new' | OpportunityStatus;
+
+/** What gets written to the server log: a status, or 'cleared' (toggled back to "new"). */
+export type OpportunityActionValue = OpportunityStatus | 'cleared';
 
 export type OpportunityActionMap = Record<string, OpportunityStatus>;
 
@@ -57,6 +61,51 @@ export function persistOpportunityActions(map: OpportunityActionMap): void {
 /** The bucket an opportunity falls in — acted-on status, or 'new' if untouched. */
 export function bucketFor(map: OpportunityActionMap, id: string): OpportunityBucket {
   return map[id] ?? 'new';
+}
+
+export const OPPORTUNITY_ACTION_VALUES: readonly OpportunityActionValue[] = [
+  'saved',
+  'connected',
+  'declined',
+  'cleared',
+];
+
+export function isOpportunityActionValue(value: unknown): value is OpportunityActionValue {
+  return typeof value === 'string' && (OPPORTUNITY_ACTION_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * The action value the server log should record for a tap on `status`:
+ * tapping the already-active status toggles the opportunity back to "new",
+ * which the append-only log represents as 'cleared'.
+ */
+export function actionValueForTap(
+  map: OpportunityActionMap,
+  id: string,
+  status: OpportunityStatus,
+): OpportunityActionValue {
+  return map[id] === status ? 'cleared' : status;
+}
+
+/**
+ * Server actions layered over the local optimistic cache. The server is the
+ * source of truth for every opportunity it has a decision for ('cleared'
+ * removes the local entry); local-only entries are kept so a signed-out or
+ * not-yet-migrated session loses nothing.
+ */
+export function mergeServerActions(
+  local: OpportunityActionMap,
+  server: Record<string, OpportunityActionValue>,
+): OpportunityActionMap {
+  const merged: OpportunityActionMap = { ...local };
+  for (const [id, action] of Object.entries(server)) {
+    if (action === 'cleared') {
+      delete merged[id];
+    } else {
+      merged[id] = action;
+    }
+  }
+  return merged;
 }
 
 /**

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -95,3 +95,48 @@ model MatchaPreference {
 
   @@index([clerkUserId])
 }
+
+// Wave K — clinician Save / Connect / Decline decisions on MATCHA
+// opportunities (mirror of the backend model; migration lives in
+// apps/api/backend/prisma/migrations/20260705000000_opportunity_actions).
+// Append-only: every decision (including clearing one back to "new") is a
+// NEW row; current state = latest row per (clerkUserId, opportunityId).
+// These are the clinician's own workflow decisions — never credentials,
+// never verification state.
+model OpportunityAction {
+  id            String   @id @default(uuid()) @db.Uuid
+  clerkUserId   String
+  npi           String?
+  opportunityId String
+  action        String // saved | connected | declined | cleared
+  source        String   @default("web")
+  createdAt     DateTime @default(now())
+
+  @@index([clerkUserId, opportunityId, createdAt])
+  @@index([opportunityId])
+  @@index([createdAt])
+}
+
+// Mirror of the backend AuditEvent model (one shared DB; migrations owned by
+// apps/api/backend/prisma). The web app APPENDS audit rows for the mutations
+// it owns (audit-first rule) — it never updates or deletes them, and never
+// anchors (anchored/merkleRoot are written by backend anchoring jobs only).
+model AuditEvent {
+  id             String   @id @default(uuid()) @db.Uuid
+  type           String
+  hash           String
+  referenceId    String?
+  clinicianId    String?
+  metadata       Json?
+  createdAt      DateTime @default(now())
+  organizationId String?
+  anchored       Boolean  @default(false)
+  merkleRoot     String?
+
+  @@index([type, createdAt])
+  @@index([clinicianId])
+  @@index([referenceId])
+  @@index([organizationId])
+  @@index([anchored])
+  @@index([merkleRoot])
+}

--- a/docs/migrations/wave-k-opportunity-actions.md
+++ b/docs/migrations/wave-k-opportunity-actions.md
@@ -1,0 +1,48 @@
+# Wave K — OpportunityAction (server-persisted clinician opportunity actions)
+
+**Status:** SQL plan checked in; NOT executed. Lands via the standard
+`prisma migrate deploy` on the backend Railway service (same pending queue as
+the 2026-07-04 signup-gate migrations). No `prisma migrate dev` was run.
+
+**Migration:** `apps/api/backend/prisma/migrations/20260705000000_opportunity_actions/migration.sql`
+
+## What it adds
+
+One append-only table, `OpportunityAction` — the clinician's Save / Connect /
+Decline decisions on MATCHA opportunities, keyed by the authenticated Clerk
+user id (identity from Clerk `auth()` in the web route, never a caller-supplied
+header).
+
+| column        | type         | notes                                          |
+| ------------- | ------------ | ---------------------------------------------- |
+| id            | UUID PK      | generated client-side by Prisma (no DB default — fleet Postgres has no `gen_random_uuid`) |
+| clerkUserId   | TEXT         | acting clinician (Clerk user id)               |
+| npi           | TEXT NULL    | NPI in context at action time, when known      |
+| opportunityId | TEXT         | MATCHA opportunity id (string key, not an FK)  |
+| action        | TEXT         | `saved` \| `connected` \| `declined` \| `cleared` |
+| source        | TEXT         | producing surface, default `web`               |
+| createdAt     | TIMESTAMP(3) | insert time                                    |
+
+Indexes: `(clerkUserId, opportunityId, createdAt)`, `(opportunityId)`,
+`(createdAt)`.
+
+## Invariants
+
+- **Append-only.** Every decision — including clearing one back to "new" via
+  `action = 'cleared'` — inserts a NEW row. Rows are never updated or deleted.
+  Current state = latest row per `(clerkUserId, opportunityId)`.
+- **Audit-first.** Every insert is paired with an `AuditEvent` row
+  (`type = 'MATCHA_OPPORTUNITY_ACTION'`) in the same transaction.
+- **Not evidence.** Rows are the clinician's own workflow decisions — never
+  credentials, never verification state, never inputs to trust-state/CRS.
+- **Deploy-order safe.** Until this migration deploys, the web route degrades
+  to `persisted: false` and the client keeps its localStorage cache — no 500s
+  in the signed-in experience (same pattern as `MatchaPreference`, PR #534).
+
+## Rollback
+
+```sql
+DROP TABLE IF EXISTS "OpportunityAction";
+```
+
+No other objects are created; nothing references the table by FK.


### PR DESCRIPTION
## Summary
- **Mounts the MATCHA backend** — `registerMatchaRoutes(app)` was built + tested but never registered on the Express app, so `/api/matcha/*` 404'd in production and every demand-side surface (opportunities list, hub, daily brief, and the workspace feed's match payload) could only reach its error state. Adds the `/api/matcha` tenant-guard skip entry (NPI-keyed demand-side reads, same posture as `/api/opportunities`); `/api/marketplace/*` intentionally stays behind the tenant guard.
- **Fixes the payload shape mismatch** — `getLiveMatchesForNpi` now additively includes the full `opportunity` + `explanation` objects per match (the shape `useMatchaOpportunities` consumers already read); the slim fields the mobile workspace feed parses are preserved unchanged.
- **Card → detail wiring** — `OpportunityCard` titles and a "Full breakdown →" affordance now link to the **existing** `/holder/opportunities/[id]` role detail (which already renders match explanation + blockers with remediation and supports deep links). No duplicate detail page was built.
- **Gated "Apply with VitalCV"** — new `OpportunityApplyCta`: hard-gated roles (engine hard blockers or INELIGIBLE band) render an honest "N gating requirement(s) to resolve" affordance pointing at the breakdown — never a broken apply; clear roles launch the real, audited `POST /api/apply/share` modal (`components/apply/ApplyWithVitalCV`), prefilled with the opportunity's employer (always editable). Completing a share marks the opportunity Connected.
- **Server-persisted card actions** — Save / Connect / Decline now persist as **append-only** `OpportunityAction` rows + an `AuditEvent` (`matcha.opportunity_action`) in one transaction; identity from Clerk `auth()`, never a caller-supplied header. Latest row per opportunity wins; toggling off appends `cleared`. localStorage remains the optimistic cache; a mount-time GET hydrates decisions across devices.

## Schema / migration
- `OpportunityAction` added to `apps/api/backend/prisma/schema.prisma` (source of truth) + mirrored in `apps/web/prisma/schema.prisma` (with an `AuditEvent` mirror for the web writer).
- Migration checked in at `prisma/migrations/20260705000000_opportunity_actions/` — **no `prisma migrate` was run**; it lands with the standard `migrate deploy` (same pending queue as the 2026-07-04 signup-gate migrations). Plan + rollback: `docs/migrations/wave-k-opportunity-actions.md`.
- Deploy-order safe: until the table exists, POST degrades to `persisted:false` and GET to `{}` — never a 500 (MatchaPreference pattern, #534).

## Truth rules
- No fabricated readiness: the apply gate is the engine's own output (`hardGateCount` returns 0 without an explanation — absence of scoring never fabricates a gate, and also never fabricates eligibility claims; the modal itself only shares real trust-state facts).
- Opportunity actions are the clinician's own workflow decisions — never credentials, never verification state, never inputs to trust-state/CRS.
- No bare `Verified` label, no banned strings (scan clean over the diff scope).
- Mounting exposes only endpoints the web product already proxies to; `POST /api/matcha/opportunity` keeps its existing Clerk-header gate (same posture as the already-live `POST /api/opportunities`; header-trust authn remains tracked in the ASVS gap register), and `/api/matcha/analytics` returns aggregates only (no NPIs).

## Validation
- Targeted vitest: `matcha-opportunity-actions` 13/13, `matcha-opportunity-action-route` 10/10 (audit-first transaction, degrade paths, auth), `matcha-opportunity-card-wiring` 8/8 (gating + click-through) — 31/31 new/extended.
- Regression: `holder-route-contract` 150/150 (link scan covers the new hrefs), `matcha-components`, `matcha-daily`, `matcha-pool` all green.
- Backend `tenantGuard` jest 10/10 (new skip pinned; marketplace stays guarded).
- `pnpm turbo run build --filter @vitalcv/web` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅.

## Design Handoff References
No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)