### PR TITLE
feat(review): Wave L — employer review queue, batch actions, first-class head-start signal

### DIFF
--- a/apps/api/backend/src/routes/__tests__/employerReviewBatchQueue.test.ts
+++ b/apps/api/backend/src/routes/__tests__/employerReviewBatchQueue.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Wave L — batch review actions + org-scoped review queue.
+ *
+ * Pins the contract that matters:
+ *  - batch runs the FULL single-entity semantics per candidate (RBAC shadow,
+ *    duplicate guard, BLOCKED fail-closed) and one candidate failing never
+ *    aborts the rest;
+ *  - every candidate gets its own AuditEvent — denied candidates get the
+ *    standard denied-mutation audit, successful ones the action audit;
+ *  - the queue is bound server-side to the caller's own registered
+ *    organization (uuid + slug), shows only live (unrevoked, unexpired)
+ *    shares, dedupes to the latest share per NPI, and labels readiness as
+ *    the cached snapshot.
+ */
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    user: { findUnique: jest.fn() },
+    vcvEntity: { findUnique: jest.fn(), findFirst: jest.fn() },
+    employerAcceptance: { findFirst: jest.fn(), create: jest.fn() },
+    auditEvent: { create: jest.fn(), findMany: jest.fn() },
+    outboxEvent: { upsert: jest.fn() },
+    bundleShareEvent: { findMany: jest.fn() },
+    organization: { findUnique: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/entity/passportService', () => ({
+  buildPassport: jest.fn(),
+  buildPassportByNpi: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../services/trust/trustScoreV1', () => ({
+  computeTrustScoreV1: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../services/entity/employerReviewAttribution', () => ({
+  resolveEmployerReviewAttribution: jest.fn().mockResolvedValue({
+    organizationContextId: null,
+    bundleShareEventId: null,
+    bundleId: null,
+    organizationId: null,
+    organizationName: null,
+    purposeOfUse: null,
+    attributionSource: 'none',
+  }),
+  normalizeEmployerReviewAttribution: jest.fn((value: unknown) => value ?? null),
+  matchesEmployerReviewAttribution: jest.fn(() => true),
+}));
+
+jest.mock('../../services/seal/sealEventCapture', () => ({
+  captureAdvisoryEvent: jest.fn(),
+  captureEmployerDecision: jest.fn(),
+  captureStartOutcome: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../services/feedback/prismaEventStore', () => ({ emitLearningEvent: jest.fn() }));
+jest.mock('../../services/feedback/decisionSignalService', () => ({ captureDecisionSignal: jest.fn() }));
+jest.mock('../../services/feedback/matchBoostService', () => ({
+  recomputeMatchBoosts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../services/entity/employerPacket', () => ({ buildEmployerEvidencePacket: jest.fn() }));
+jest.mock('../../services/entity/employerPacketExport', () => ({
+  createEmployerEvidencePacketZipStream: jest.fn(),
+}));
+jest.mock('../../services/trust/container/trustContainerIssuance', () => ({
+  issueTrustContainerManifestEntry: jest.fn(),
+}));
+jest.mock('../../services/trust/trustStateEngine', () => ({ getCachedTrustState: jest.fn() }));
+jest.mock('../../services/opportunities/opportunityService', () => ({ getOrgProfile: jest.fn() }));
+jest.mock('../../obs/logger', () => ({ log: jest.fn() }));
+
+import prisma from '../../graphql/prisma_client';
+import { buildPassport } from '../../services/entity/passportService';
+import { getCachedTrustState } from '../../services/trust/trustStateEngine';
+import { getOrgProfile } from '../../services/opportunities/opportunityService';
+import { registerEmployerActionRoutes } from '../employerActions';
+
+const ENTITY_A = '11111111-1111-4111-8111-111111111111';
+const ENTITY_B = '22222222-2222-4222-8222-222222222222';
+const NPI_A = '1111111111';
+const NPI_B = '2222222222';
+
+const prismaMock = prisma as unknown as {
+  user: { findUnique: jest.Mock };
+  vcvEntity: { findUnique: jest.Mock; findFirst: jest.Mock };
+  employerAcceptance: { findFirst: jest.Mock; create: jest.Mock };
+  auditEvent: { create: jest.Mock; findMany: jest.Mock };
+  outboxEvent: { upsert: jest.Mock };
+  bundleShareEvent: { findMany: jest.Mock };
+  organization: { findUnique: jest.Mock };
+  $transaction: jest.Mock;
+};
+
+const buildPassportMock = buildPassport as jest.Mock;
+const getCachedTrustStateMock = getCachedTrustState as jest.Mock;
+const getOrgProfileMock = getOrgProfile as jest.Mock;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  registerEmployerActionRoutes(app);
+  app.use((err: { status?: number; message?: string }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.status ?? 500).json({ error: err.message ?? 'error' });
+  });
+  return app;
+}
+
+function wireHappyPersistence() {
+  let auditCounter = 0;
+  prismaMock.auditEvent.create.mockImplementation(async (args: { data: Record<string, unknown> }) => ({
+    id: `audit-${++auditCounter}`,
+    createdAt: new Date('2026-07-05T12:00:00.000Z'),
+    ...args.data,
+  }));
+  prismaMock.outboxEvent.upsert.mockResolvedValue({ id: 'outbox-1' });
+  prismaMock.employerAcceptance.create.mockImplementation(async (args: { data: { id: string } }) => ({
+    id: args.data.id ?? 'acceptance-1',
+  }));
+  const tx = {
+    employerAcceptance: { create: prismaMock.employerAcceptance.create },
+    auditEvent: { create: prismaMock.auditEvent.create },
+    outboxEvent: { upsert: prismaMock.outboxEvent.upsert },
+    hITLReviewItem: { create: jest.fn().mockResolvedValue({ id: 'hitl-1' }) },
+  };
+  prismaMock.$transaction.mockImplementation(async (callback: (value: typeof tx) => unknown) => callback(tx));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prismaMock.user.findUnique.mockResolvedValue(null); // RBAC shadow mode: logged, never blocks
+  prismaMock.employerAcceptance.findFirst.mockResolvedValue(null);
+  prismaMock.auditEvent.findMany.mockResolvedValue([]);
+  prismaMock.vcvEntity.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+    if (args.where.id === ENTITY_A) return { id: ENTITY_A, npi: NPI_A };
+    if (args.where.id === ENTITY_B) return { id: ENTITY_B, npi: NPI_B };
+    return null;
+  });
+  prismaMock.vcvEntity.findFirst.mockResolvedValue(null);
+  wireHappyPersistence();
+});
+
+describe('POST /api/employer-review/batch', () => {
+  it('requires the acting employer identity', async () => {
+    const response = await request(buildApp())
+      .post('/api/employer-review/batch')
+      .send({ action: 'accept', entityIds: [ENTITY_A] });
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects unknown actions and oversized batches up front', async () => {
+    const app = buildApp();
+
+    const badAction = await request(app)
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({ action: 'approve-all', entityIds: [ENTITY_A] });
+    expect(badAction.status).toBe(400);
+
+    const oversized = await request(app)
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({
+        action: 'accept',
+        entityIds: Array.from({ length: 26 }, (_, i) => `${i}0000000-0000-4000-8000-000000000000`),
+      });
+    expect(oversized.status).toBe(400);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('fails a BLOCKED candidate closed with its own denied audit while the rest of the batch proceeds', async () => {
+    buildPassportMock.mockImplementation(async (entityId: string) => {
+      if (entityId === ENTITY_A) {
+        return {
+          decisionPosture: {
+            status: 'BLOCKED',
+            blockers: ['OIG exclusion check unavailable'],
+            missing: [{ sourceId: 'OIG_LEIE' }],
+          },
+        };
+      }
+      return { decisionPosture: { status: 'READY', blockers: [], missing: [] } };
+    });
+
+    const response = await request(buildApp())
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({ action: 'accept', entityIds: [ENTITY_A, ENTITY_B], notes: 'pilot cohort triage' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({ requested: 2, succeeded: 1, failed: 1 });
+
+    const [blocked, accepted] = response.body.results as Array<Record<string, unknown>>;
+    expect(blocked).toMatchObject({
+      entityId: ENTITY_A,
+      ok: false,
+      status: 422,
+      error: 'acceptance_blocked',
+    });
+    expect(accepted).toMatchObject({ entityId: ENTITY_B, ok: true, status: 201 });
+    expect(accepted.auditEventId).toBeTruthy();
+
+    // One AuditEvent per candidate: a denied-mutation audit for the blocked
+    // candidate, the acceptance audit for the successful one.
+    const auditTypes = prismaMock.auditEvent.create.mock.calls.map(
+      (call) => (call[0] as { data: { type: string } }).data.type,
+    );
+    expect(auditTypes).toContain('EMPLOYER_REVIEW_MUTATION_DENIED');
+    expect(auditTypes).toContain('EMPLOYER_REVIEW_ACCEPTED');
+    expect(prismaMock.employerAcceptance.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails an already-accepted candidate closed without new persistence side effects', async () => {
+    buildPassportMock.mockResolvedValue({ decisionPosture: { status: 'READY', blockers: [], missing: [] } });
+    prismaMock.employerAcceptance.findFirst.mockImplementation(async (args: { where: { clinicianNpi: string } }) =>
+      args.where.clinicianNpi === NPI_A ? { id: 'existing-acceptance' } : null,
+    );
+
+    const response = await request(buildApp())
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({ action: 'accept', entityIds: [ENTITY_A, ENTITY_B] });
+
+    expect(response.status).toBe(200);
+    const [duplicate, accepted] = response.body.results as Array<Record<string, unknown>>;
+    expect(duplicate).toMatchObject({
+      entityId: ENTITY_A,
+      ok: false,
+      status: 409,
+      error: 'already_accepted',
+      acceptanceId: 'existing-acceptance',
+    });
+    expect(accepted).toMatchObject({ entityId: ENTITY_B, ok: true });
+    expect(prismaMock.employerAcceptance.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes one refresh audit per candidate and never consults the passport gate', async () => {
+    const response = await request(buildApp())
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({
+        action: 'request-refresh',
+        entityIds: [ENTITY_A, ENTITY_B],
+        staleSources: ['DEA_REGISTRY'],
+        message: 'Please refresh your DEA record.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toEqual({ requested: 2, succeeded: 2, failed: 0 });
+    expect(buildPassportMock).not.toHaveBeenCalled();
+
+    const refreshAudits = prismaMock.auditEvent.create.mock.calls.filter(
+      (call) => (call[0] as { data: { type: string } }).data.type === 'EMPLOYER_REVIEW_REFRESH_REQUESTED',
+    );
+    expect(refreshAudits).toHaveLength(2);
+  });
+
+  it('dedupes repeated entity ids and reports unresolvable candidates individually', async () => {
+    buildPassportMock.mockResolvedValue({ decisionPosture: { status: 'READY', blockers: [], missing: [] } });
+
+    const response = await request(buildApp())
+      .post('/api/employer-review/batch')
+      .set('x-clerk-user-id', 'employer-1')
+      .send({
+        action: 'accept',
+        entityIds: [ENTITY_B, ENTITY_B, '99999999-9999-4999-8999-999999999999', 'not-a-uuid'],
+      });
+
+    expect(response.status).toBe(200);
+    const results = response.body.results as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(3);
+    expect(results.filter((r) => r.entityId === ENTITY_B)).toHaveLength(1);
+    expect(results.find((r) => r.entityId === '99999999-9999-4999-8999-999999999999')).toMatchObject({
+      ok: false,
+      status: 404,
+      error: 'entity_not_found',
+    });
+    expect(results.find((r) => r.entityId === 'not-a-uuid')).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'invalid_entity_id',
+    });
+  });
+});
+
+describe('GET /api/employer-review/queue', () => {
+  it('requires the acting employer identity', async () => {
+    const response = await request(buildApp()).get('/api/employer-review/queue');
+    expect(response.status).toBe(401);
+  });
+
+  it('refuses callers with no registered employer organization', async () => {
+    getOrgProfileMock.mockResolvedValue(null);
+    const response = await request(buildApp())
+      .get('/api/employer-review/queue')
+      .set('x-clerk-user-id', 'employer-1');
+    expect(response.status).toBe(403);
+    expect(prismaMock.bundleShareEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('serves only the caller organization inbox: live shares, deduped per NPI, snapshot-labeled readiness', async () => {
+    getOrgProfileMock.mockResolvedValue({ organizationId: 'org-uuid-1', name: 'Mercy General' });
+    prismaMock.organization.findUnique.mockResolvedValue({
+      id: 'org-uuid-1',
+      slug: 'mercy-general',
+      name: 'Mercy General',
+    });
+    prismaMock.bundleShareEvent.findMany.mockResolvedValue([
+      {
+        npi: NPI_A,
+        subjectEntityId: ENTITY_A,
+        sharedAt: new Date('2026-07-05T10:00:00.000Z'),
+        purposeOfUse: 'Employment consideration',
+        organizationContextId: null,
+        bundleId: 'bundle-2',
+      },
+      {
+        npi: NPI_A,
+        subjectEntityId: ENTITY_A,
+        sharedAt: new Date('2026-07-04T10:00:00.000Z'),
+        purposeOfUse: 'Employment consideration',
+        organizationContextId: null,
+        bundleId: 'bundle-1',
+      },
+      {
+        npi: '3333333333',
+        subjectEntityId: null,
+        sharedAt: new Date('2026-07-03T10:00:00.000Z'),
+        purposeOfUse: 'Credentialing review',
+        organizationContextId: null,
+        bundleId: 'bundle-0',
+      },
+    ]);
+    getCachedTrustStateMock.mockImplementation(async (npi: string) =>
+      npi === NPI_A
+        ? {
+            readiness_level: 'L2',
+            readiness_score: 72,
+            readiness_status: 'PARTIAL',
+            blockers: ['DEA registration expiring'],
+            gaps: [],
+            facts: [],
+          }
+        : null,
+    );
+
+    const response = await request(buildApp())
+      .get('/api/employer-review/queue')
+      .set('x-clerk-user-id', 'employer-1');
+
+    expect(response.status).toBe(200);
+    expect(response.body.scope).toEqual({
+      type: 'organization',
+      organizationId: 'org-uuid-1',
+      organizationName: 'Mercy General',
+    });
+
+    // Scope binding: the query matched the org's uuid AND slug, and only
+    // live (unrevoked, unexpired) shares.
+    const where = prismaMock.bundleShareEvent.findMany.mock.calls[0][0].where;
+    expect(where.organizationId).toEqual({ in: ['org-uuid-1', 'mercy-general'] });
+    expect(where.revokedAt).toBeNull();
+    expect(where.expiresAt).toHaveProperty('gt');
+
+    const candidates = response.body.candidates as Array<Record<string, unknown>>;
+    expect(candidates).toHaveLength(2); // NPI_A deduped to latest share
+
+    const resolved = candidates.find((c) => c.npi === NPI_A)!;
+    expect(resolved).toMatchObject({
+      entityId: ENTITY_A,
+      reviewable: true,
+      bundleId: 'bundle-2', // latest share wins
+      reviewPath: `/review/${ENTITY_A}`,
+    });
+    expect(resolved.readiness).toMatchObject({
+      level: 'L2',
+      score: 72,
+      source: 'cached_trust_snapshot',
+      topBlockers: ['DEA registration expiring'],
+    });
+    expect(resolved.headStart).toMatchObject({ hasPriorAcceptances: false });
+
+    const unresolved = candidates.find((c) => c.npi === '3333333333')!;
+    expect(unresolved).toMatchObject({ entityId: null, reviewable: false, reviewPath: null, readiness: null });
+
+    expect(typeof response.body.readinessNote).toBe('string');
+  });
+});

--- a/apps/api/backend/src/routes/employerActions.ts
+++ b/apps/api/backend/src/routes/employerActions.ts
@@ -48,7 +48,10 @@ import {
   recordEmployerReviewRouting,
   resolveEmployerReviewSubject,
   resolveEmployerReviewSubjectByNpi,
+  type EmployerReviewActionState,
 } from '../services/entity/employerReviewActions';
+import { getCachedTrustState } from '../services/trust/trustStateEngine';
+import { getOrgProfile } from '../services/opportunities/opportunityService';
 import {
   buildRuntimeMutationMetadata,
   type RuntimeReadonlyIndicator,
@@ -686,6 +689,516 @@ export function registerEmployerActionRoutes(app: Express): void {
       void recomputeMatchBoosts().catch(() => {});
 
       return void res.status(201).json({ ok: true, state });
+    }),
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // POST /api/employer-review/batch
+  // Wave L — one decision applied across a selected set of candidates.
+  //
+  // Per-candidate semantics are IDENTICAL to the single-entity routes above:
+  // same RBAC gate, same duplicate-acceptance guard, same BLOCKED fail-closed
+  // check at the moment of action, and one AuditEvent per candidate written
+  // by the same record* service calls — there is no batch shortcut that
+  // skips per-entity audit. One candidate failing (blocked, not found,
+  // already accepted) never aborts the rest; the response reports every
+  // outcome individually.
+  //
+  // bundleId is deliberately NOT accepted here: a bundle belongs to one
+  // clinician's share, so a shared bundle id across a batch would
+  // mis-attribute evidence. Per-candidate bundle attribution stays on the
+  // single-entity routes.
+  //
+  // Body: { action: 'accept'|'request-refresh'|'route-to-review',
+  //         entityIds: string[] (1..25),
+  //         ...same optional fields as the matching single route (minus bundleId) }
+  // Returns: 200 { ok, action, results[], summary { requested, succeeded, failed } }
+  // ─────────────────────────────────────────────────────────────────────────
+  app.post(
+    '/api/employer-review/batch',
+    asyncHandler(async (req, res) => {
+      const employerId = requireClerkUserId(req);
+
+      const BATCH_ACTIONS = ['accept', 'request-refresh', 'route-to-review'] as const;
+      type BatchAction = (typeof BATCH_ACTIONS)[number];
+      const BATCH_LIMIT = 25;
+
+      const body = (req.body ?? {}) as {
+        action?: unknown;
+        entityIds?: unknown;
+        role?: string;
+        facility?: string;
+        notes?: string;
+        acceptanceScope?: string;
+        acceptanceReason?: string;
+        staleSources?: string[];
+        missingDomains?: string[];
+        message?: string;
+        reason?: string;
+        priority?: string;
+        organizationContextId?: string;
+      };
+
+      const action = body.action as BatchAction;
+      if (!BATCH_ACTIONS.includes(action)) {
+        throw new HttpError(400, `action must be one of ${BATCH_ACTIONS.join(' | ')}.`);
+      }
+      if (!Array.isArray(body.entityIds) || body.entityIds.length === 0) {
+        throw new HttpError(400, 'entityIds must be a non-empty array.');
+      }
+      const entityIds = [...new Set(
+        body.entityIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0),
+      )];
+      if (entityIds.length === 0) {
+        throw new HttpError(400, 'entityIds must contain at least one entity id.');
+      }
+      if (entityIds.length > BATCH_LIMIT) {
+        throw new HttpError(400, `entityIds is limited to ${BATCH_LIMIT} candidates per batch.`);
+      }
+
+      type BatchResult = {
+        entityId: string;
+        ok: boolean;
+        status: number;
+        error?: string;
+        error_description?: string;
+        acceptanceId?: string;
+        auditEventId?: string;
+        blockers?: unknown;
+      };
+
+      const fail = (
+        entityId: string,
+        status: number,
+        error: string,
+        description: string,
+        extra?: Partial<BatchResult>,
+      ): BatchResult => ({ entityId, ok: false, status, error, error_description: description, ...extra });
+
+      const snapshotBase = (snap: EmployerReviewActionState['trustSnapshot']) => ({
+        readinessStatus: snap?.readinessStatus,
+        readinessScore: snap?.readinessScore,
+        trustBand: snap?.trustBand,
+        trustScore: snap?.trustScore,
+        blockerCount: snap?.blockerCount,
+        exclusionStatus: snap?.exclusionStatus,
+        snapshotHash: snap?.snapshotHash,
+      });
+
+      const learningSnapshot = (snap: EmployerReviewActionState['trustSnapshot']) => (snap ? {
+        readinessStatus: snap.readinessStatus,
+        readinessScore: snap.readinessScore,
+        trustBand: snap.trustBand,
+        trustScore: snap.trustScore,
+        blockerCount: snap.blockerCount,
+        topBlockers: snap.topBlockers,
+        exclusionStatus: snap.exclusionStatus,
+        verifiedCredentialCount: snap.verifiedCredentialCount,
+        staleCredentialCount: snap.staleCredentialCount,
+        snapshotHash: snap.snapshotHash,
+      } : null);
+
+      const results: BatchResult[] = [];
+
+      // Sequential on purpose: deterministic audit ordering, and no fan-out of
+      // passport builds against live sources.
+      for (const entityId of entityIds) {
+        const outcome = await (async (): Promise<BatchResult> => {
+          try {
+            if (!UUID_RE.test(entityId)) {
+              return fail(entityId, 400, 'invalid_entity_id', 'entityId must be a UUID.');
+            }
+
+            const subject = await resolveEmployerReviewSubject(entityId);
+            if (!subject) {
+              return fail(entityId, 404, 'entity_not_found', 'Entity not found or has no NPI.');
+            }
+
+            // Same actor-role gate as the single routes — in enforced mode a
+            // denial writes the standard denied-mutation AuditEvent for THIS
+            // candidate before failing it closed.
+            await enforceEmployerMutationRbac({
+              req, employerId, entityId, clinicianNpi: subject.clinicianNpi, action,
+            });
+
+            if (action === 'accept') {
+              const existing = await prisma.employerAcceptance.findFirst({
+                where: { employerId, clinicianNpi: subject.clinicianNpi, status: 'ACCEPTED' },
+                select: { id: true },
+              });
+              if (existing) {
+                await writeDeniedEmployerReviewMutation({
+                  req,
+                  actorId: employerId,
+                  entityId,
+                  clinicianNpi: subject.clinicianNpi,
+                  denialReason: 'already_accepted',
+                  payload: { batch: true, action, existingAcceptanceId: existing.id },
+                });
+                return fail(entityId, 409, 'already_accepted',
+                  'An active acceptance already exists for this employer/NPI pair.',
+                  { acceptanceId: existing.id });
+              }
+
+              // Source coverage gate — fail THIS candidate closed, never the batch.
+              const passport = await buildPassport(entityId);
+              if (!passport) {
+                await writeDeniedEmployerReviewMutation({
+                  req,
+                  actorId: employerId,
+                  entityId,
+                  clinicianNpi: subject.clinicianNpi,
+                  denialReason: 'passport_unavailable',
+                  payload: { batch: true, action },
+                });
+                return fail(entityId, 422, 'passport_unavailable',
+                  'Cannot accept: passport data is not available for this entity.');
+              }
+              if (passport.decisionPosture.status === 'BLOCKED') {
+                await writeDeniedEmployerReviewMutation({
+                  req,
+                  actorId: employerId,
+                  entityId,
+                  clinicianNpi: subject.clinicianNpi,
+                  denialReason: 'acceptance_blocked',
+                  payload: {
+                    batch: true,
+                    action,
+                    blockers: passport.decisionPosture.blockers,
+                    missingSources: passport.decisionPosture.missing.map((s) => s.sourceId),
+                  },
+                });
+                return fail(entityId, 422, 'acceptance_blocked',
+                  'Cannot accept: one or more critical source checks are blocking readiness.',
+                  { blockers: passport.decisionPosture.blockers });
+              }
+
+              const state = await recordEmployerReviewAcceptance({
+                entityId,
+                employerId,
+                clinicianNpi: subject.clinicianNpi,
+                correlationId: resolveCorrelationId(req),
+                organizationContextId: body.organizationContextId,
+                role: body.role,
+                facility: body.facility,
+                notes: body.notes,
+                acceptanceScope: body.acceptanceScope,
+                acceptanceReason: body.acceptanceReason,
+              });
+
+              const snap = state.trustSnapshot;
+              void captureEmployerDecision({
+                entityId,
+                organizationContextId: state.attribution.organizationContextId,
+                decision: 'PROCEED',
+                reviewerRole: 'EMPLOYER',
+                auditEventId: state.auditEventId,
+                trustSnapshotAtDecision: {
+                  acceptanceId: state.persistence.acceptanceId,
+                  ...snapshotBase(snap),
+                  verifiedCredentials: snap?.verifiedCredentialCount,
+                  staleCredentials: snap?.staleCredentialCount,
+                },
+                readinessScoreAtDecision: snap?.readinessScore ?? null,
+                blockersAtDecision: snap?.topBlockers ?? [],
+                metadata: buildEmployerDecisionMetadata({
+                  attribution: state.attribution,
+                  scopeSource: req.body ?? null,
+                  extra: {
+                    batch: true,
+                    acceptedByOrgId: state.acceptance?.acceptedByOrgId ?? null,
+                    acceptanceScope: state.acceptance?.acceptanceScope ?? null,
+                    acceptanceReason: state.acceptance?.acceptanceReason ?? null,
+                    role: body.role ?? null,
+                    facility: body.facility ?? null,
+                  },
+                }),
+              });
+              void captureDecisionSignal({
+                entityId,
+                employerId,
+                decision: 'accept',
+                trustSnapshot: learningSnapshot(snap),
+                bundleId: state.attribution.bundleId,
+              });
+
+              return {
+                entityId,
+                ok: true,
+                status: 201,
+                acceptanceId: state.persistence.acceptanceId ?? undefined,
+                auditEventId: state.auditEventId,
+              };
+            }
+
+            if (action === 'request-refresh') {
+              const state = await recordEmployerReviewRefreshRequest({
+                entityId,
+                employerId,
+                clinicianNpi: subject.clinicianNpi,
+                correlationId: resolveCorrelationId(req),
+                organizationContextId: body.organizationContextId,
+                staleSources: body.staleSources,
+                missingDomains: body.missingDomains,
+                message: body.message,
+              });
+
+              const snap = state.trustSnapshot;
+              void captureEmployerDecision({
+                entityId,
+                organizationContextId: state.attribution.organizationContextId,
+                decision: 'REQUEST_REFRESH',
+                reviewerRole: 'EMPLOYER',
+                auditEventId: state.auditEventId,
+                trustSnapshotAtDecision: {
+                  staleSources: state.details.staleSources,
+                  missingDomains: state.details.missingDomains,
+                  ...snapshotBase(snap),
+                  topBlockers: snap?.topBlockers,
+                },
+                readinessScoreAtDecision: snap?.readinessScore ?? null,
+                blockersAtDecision: [...new Set([
+                  ...(snap?.topBlockers ?? []),
+                  ...state.details.missingDomains,
+                ])],
+                metadata: buildEmployerDecisionMetadata({
+                  attribution: state.attribution,
+                  scopeSource: req.body ?? null,
+                  extra: {
+                    batch: true,
+                    staleSources: state.details.staleSources,
+                    missingDomains: state.details.missingDomains,
+                    reason: state.details.reason,
+                  },
+                }),
+              });
+              void captureDecisionSignal({
+                entityId,
+                employerId,
+                decision: 'request_info',
+                trustSnapshot: learningSnapshot(snap),
+                bundleId: state.attribution.bundleId,
+              });
+
+              return { entityId, ok: true, status: 201, auditEventId: state.auditEventId };
+            }
+
+            // route-to-review
+            const state = await recordEmployerReviewRouting({
+              entityId,
+              employerId,
+              clinicianNpi: subject.clinicianNpi,
+              correlationId: resolveCorrelationId(req),
+              organizationContextId: body.organizationContextId,
+              reason: body.reason,
+              priority: body.priority,
+            });
+
+            const snap = state.trustSnapshot;
+            void captureEmployerDecision({
+              entityId,
+              organizationContextId: state.attribution.organizationContextId,
+              decision: 'ROUTE_TO_REVIEW',
+              reviewerRole: 'EMPLOYER',
+              auditEventId: state.auditEventId,
+              trustSnapshotAtDecision: {
+                priority: state.details.priority,
+                reviewItemCreated: state.persistence.reviewItemCreated,
+                reviewItemId: state.persistence.reviewItemId,
+                ...snapshotBase(snap),
+                topBlockers: snap?.topBlockers,
+              },
+              readinessScoreAtDecision: snap?.readinessScore ?? null,
+              blockersAtDecision: snap?.topBlockers ?? [],
+              metadata: buildEmployerDecisionMetadata({
+                attribution: state.attribution,
+                scopeSource: req.body ?? null,
+                extra: {
+                  batch: true,
+                  reason: state.details.reason,
+                  reviewItemCreated: state.persistence.reviewItemCreated,
+                },
+              }),
+            });
+            void captureDecisionSignal({
+              entityId,
+              employerId,
+              decision: 'reject',
+              trustSnapshot: learningSnapshot(snap),
+              bundleId: state.attribution.bundleId,
+            });
+
+            return { entityId, ok: true, status: 201, auditEventId: state.auditEventId };
+          } catch (err) {
+            if (err instanceof HttpError) {
+              return fail(entityId, err.status,
+                err.status === 403 ? 'rbac_denied' : 'action_failed', err.message);
+            }
+            log('error', 'employer_review_batch_candidate_failed', {
+              entityId,
+              action,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return fail(entityId, 500, 'action_failed', 'Internal error applying this action.');
+          }
+        })();
+
+        results.push(outcome);
+      }
+
+      const succeeded = results.filter((r) => r.ok).length;
+      if (succeeded > 0 && (action === 'accept' || action === 'route-to-review')) {
+        void recomputeMatchBoosts().catch(() => {});
+      }
+
+      log('info', 'employer_review_batch_completed', {
+        action,
+        employerId,
+        requested: entityIds.length,
+        succeeded,
+        failed: results.length - succeeded,
+      });
+
+      return void res.status(200).json({
+        ok: true,
+        action,
+        results,
+        summary: {
+          requested: entityIds.length,
+          succeeded,
+          failed: results.length - succeeded,
+        },
+      });
+    }),
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // GET /api/employer-review/queue
+  // Wave L — the organization's review inbox: clinicians who shared an apply
+  // bundle WITH this organization, newest share first, one row per NPI.
+  //
+  // Scope integrity: the queue is ALWAYS bound to the calling employer's own
+  // registered organization (resolved server-side from their Clerk user id).
+  // A caller-supplied organizationId is never honored — org context from
+  // query/header is unauthenticated (ASVS gap G1) and a candidate pipeline
+  // must not be readable cross-tenant. No unscoped aggregation exists.
+  //
+  // Consent honesty: revoked shares and expired bundles fail closed out of
+  // the queue. Readiness shown per row comes from the cached trust snapshot
+  // (clearly labeled); accepting re-checks live posture and fails closed.
+  // ─────────────────────────────────────────────────────────────────────────
+  app.get(
+    '/api/employer-review/queue',
+    asyncHandler(async (req, res) => {
+      const employerId = requireClerkUserId(req);
+
+      const orgProfile = await getOrgProfile(employerId);
+      if (!orgProfile) {
+        throw new HttpError(403, 'No employer organization is registered for this account. Complete employer setup first.');
+      }
+
+      // Clinicians address shares by system id or slug — match both, exactly.
+      const organization = await prisma.organization.findUnique({
+        where: { id: orgProfile.organizationId },
+        select: { id: true, slug: true, name: true },
+      });
+      const organizationIds = [orgProfile.organizationId, organization?.slug].filter(
+        (v): v is string => typeof v === 'string' && v.length > 0,
+      );
+
+      const limitRaw = Number.parseInt(String(req.query.limit ?? ''), 10);
+      const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 50) : 25;
+
+      const shares = await prisma.bundleShareEvent.findMany({
+        where: {
+          organizationId: { in: organizationIds },
+          revokedAt: null,
+          expiresAt: { gt: new Date() },
+        },
+        orderBy: { sharedAt: 'desc' },
+        take: 200,
+        select: {
+          npi: true,
+          subjectEntityId: true,
+          sharedAt: true,
+          purposeOfUse: true,
+          organizationContextId: true,
+          bundleId: true,
+        },
+      });
+
+      // Latest live share per clinician.
+      const latestByNpi = new Map<string, (typeof shares)[number]>();
+      for (const share of shares) {
+        if (!latestByNpi.has(share.npi)) latestByNpi.set(share.npi, share);
+      }
+      const picked = [...latestByNpi.values()].slice(0, limit);
+
+      const candidates = [];
+      for (const share of picked) {
+        const subject = share.subjectEntityId && UUID_RE.test(share.subjectEntityId)
+          ? await resolveEmployerReviewSubject(share.subjectEntityId)
+          : await resolveEmployerReviewSubjectByNpi(share.npi);
+
+        const npi = subject?.clinicianNpi ?? share.npi;
+        const trust = await getCachedTrustState(npi).catch(() => null);
+        const history = subject
+          ? await loadEmployerAcceptanceHistory({
+              entityId: subject.entityId,
+              clinicianNpi: subject.clinicianNpi,
+            }).catch(() => null)
+          : null;
+        const alreadyAccepted = subject
+          ? await prisma.employerAcceptance.findFirst({
+              where: { employerId, clinicianNpi: subject.clinicianNpi, status: 'ACCEPTED' },
+              select: { id: true, acceptedAt: true },
+            })
+          : null;
+
+        candidates.push({
+          entityId: subject?.entityId ?? null,
+          npi: share.npi,
+          // A share whose subject cannot be resolved to an entity is shown but
+          // not actionable — reviewing requires a resolved identity.
+          reviewable: Boolean(subject),
+          sharedAt: share.sharedAt.toISOString(),
+          purposeOfUse: share.purposeOfUse,
+          organizationContextId: share.organizationContextId,
+          bundleId: share.bundleId,
+          readiness: trust
+            ? {
+                level: trust.readiness_level,
+                score: trust.readiness_score,
+                status: trust.readiness_status,
+                topBlockers: (trust.blockers ?? trust.gaps ?? []).slice(0, 3),
+                source: 'cached_trust_snapshot',
+              }
+            : null,
+          // Honest wording (headline/trustCopy) comes from the acceptance
+          // history service — visibility and a soft signal only; this
+          // employer still decides.
+          headStart: history?.summary ?? null,
+          alreadyAccepted: alreadyAccepted
+            ? { acceptanceId: alreadyAccepted.id, acceptedAt: alreadyAccepted.acceptedAt.toISOString() }
+            : null,
+          reviewPath: subject ? `/review/${subject.entityId}` : null,
+        });
+      }
+
+      return void res.status(200).json({
+        ok: true,
+        scope: {
+          type: 'organization',
+          organizationId: orgProfile.organizationId,
+          organizationName: organization?.name ?? orgProfile.name,
+        },
+        total: candidates.length,
+        liveShares: shares.length,
+        candidates,
+        readinessNote:
+          'Readiness per row is the cached trust snapshot. Accepting re-checks live decision posture and fails closed if BLOCKED.',
+        generatedAt: new Date().toISOString(),
+      });
     }),
   );
 

--- a/apps/web/__tests__/employer-review-queue.test.tsx
+++ b/apps/web/__tests__/employer-review-queue.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Wave L — employer review queue web layer.
+ *
+ * - Queue proxy: identity from Clerk auth() only; no caller-supplied org is
+ *   forwarded (the backend binds scope server-side).
+ * - Batch proxy: body sanitized to known fields; bundleId never forwarded
+ *   (per-clinician attribution); oversized batches rejected, never truncated.
+ * - Surface: honest loading/signed-out/no-org states and honest head-start
+ *   wording ("your organization still decides").
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMock = vi.fn();
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: authMock,
+}));
+
+import { ReviewQueueSurface } from '../components/review/ReviewQueueSurface';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function loadQueueRoute() {
+  return import(new URL('../app/api/employer-review/queue/route.ts', import.meta.url).href);
+}
+
+async function loadBatchRoute() {
+  return import(new URL('../app/api/employer-review/batch/route.ts', import.meta.url).href);
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  authMock.mockReset();
+  process.env.BACKEND_URL = 'http://backend.test';
+});
+
+describe('GET /api/employer-review/queue proxy', () => {
+  it('rejects signed-out callers before touching the backend', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { GET } = await loadQueueRoute();
+    const { NextRequest } = await import('next/server');
+    const res = await GET(new NextRequest('http://localhost/api/employer-review/queue'));
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards only the Clerk identity and a bounded limit — never a caller-chosen org', async () => {
+    authMock.mockResolvedValue({ userId: 'clerk-employer-1' });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true, candidates: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { GET } = await loadQueueRoute();
+    const { NextRequest } = await import('next/server');
+    const res = await GET(
+      new NextRequest('http://localhost/api/employer-review/queue?limit=10&organizationId=someone-elses-org'),
+    );
+
+    expect(res.status).toBe(200);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://backend.test/api/employer-review/queue?limit=10');
+    expect(url).not.toContain('organizationId');
+    expect((init as { headers: Record<string, string> }).headers['x-clerk-user-id']).toBe('clerk-employer-1');
+  });
+
+  it('degrades to 503 when the backend is unreachable', async () => {
+    authMock.mockResolvedValue({ userId: 'clerk-employer-1' });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')));
+
+    const { GET } = await loadQueueRoute();
+    const { NextRequest } = await import('next/server');
+    const res = await GET(new NextRequest('http://localhost/api/employer-review/queue'));
+
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('POST /api/employer-review/batch proxy', () => {
+  function batchRequest(body: unknown) {
+    return import('next/server').then(({ NextRequest }) =>
+      new NextRequest('http://localhost/api/employer-review/batch', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  }
+
+  it('rejects signed-out callers', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadBatchRoute();
+    const res = await POST(await batchRequest({ action: 'accept', entityIds: ['a'] }));
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed and oversized batches instead of truncating them', async () => {
+    authMock.mockResolvedValue({ userId: 'clerk-employer-1' });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadBatchRoute();
+
+    const badAction = await POST(await batchRequest({ action: 'approve-all', entityIds: ['a'] }));
+    expect(badAction.status).toBe(400);
+
+    const oversized = await POST(
+      await batchRequest({ action: 'accept', entityIds: Array.from({ length: 26 }, (_, i) => `id-${i}`) }),
+    );
+    expect(oversized.status).toBe(400);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards a sanitized body: known fields only, bundleId and unknown keys dropped', async () => {
+    authMock.mockResolvedValue({ userId: 'clerk-employer-1' });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true, results: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await loadBatchRoute();
+    const res = await POST(
+      await batchRequest({
+        action: 'request-refresh',
+        entityIds: [' entity-1 ', 'entity-2'],
+        staleSources: ['DEA_REGISTRY', 42, '  '],
+        message: '  Please refresh your DEA record.  ',
+        bundleId: 'bundle-should-not-forward',
+        decisionGrade: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0];
+    const forwarded = JSON.parse((init as { body: string }).body);
+    expect(forwarded).toEqual({
+      action: 'request-refresh',
+      entityIds: ['entity-1', 'entity-2'],
+      staleSources: ['DEA_REGISTRY'],
+      message: 'Please refresh your DEA record.',
+    });
+    expect((init as { headers: Record<string, string> }).headers['x-clerk-user-id']).toBe('clerk-employer-1');
+  });
+});
+
+describe('ReviewQueueSurface — honest states and wording', () => {
+  it('renders the header and an honest loading state on first paint', () => {
+    const markup = renderToStaticMarkup(<ReviewQueueSurface />);
+    expect(markup).toContain('Review queue');
+    expect(markup).toContain('Loading your queue');
+  });
+
+  it('keeps the head-start signal honest in source: soft signal, employer still decides', () => {
+    const source = readFileSync(
+      join(__dirname, '../components/review/ReviewQueueSurface.tsx'),
+      'utf8',
+    );
+    expect(source).toContain('your organization still');
+    expect(source).toContain('fail closed individually');
+    expect(source).toContain('overrides a blocked readiness state');
+    // Banned-strings + bare-Verified discipline on this new surface.
+    expect(source).not.toMatch(/automatically verified|guaranteed verification|instant credentialing/i);
+    expect(source).not.toMatch(/label:\s*['"]Verified['"]/);
+  });
+});

--- a/apps/web/app/api/employer-review/batch/route.ts
+++ b/apps/web/app/api/employer-review/batch/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/employer-review/batch — Wave L.
+ *
+ * Applies one review decision (accept-as-head-start / request-refresh /
+ * route-to-review) across a selected set of candidates. The backend runs the
+ * full single-entity semantics per candidate — RBAC, duplicate guard, BLOCKED
+ * fail-closed check, one AuditEvent per candidate — and reports per-candidate
+ * outcomes. The body is sanitized to the known batch fields before forwarding;
+ * bundleId is intentionally not forwardable (per-clinician attribution).
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+const BATCH_ACTIONS = new Set(['accept', 'request-refresh', 'route-to-review']);
+const MAX_BATCH = 25;
+
+const STRING_FIELDS = [
+  'role',
+  'facility',
+  'notes',
+  'acceptanceScope',
+  'acceptanceReason',
+  'message',
+  'reason',
+  'priority',
+  'organizationContextId',
+] as const;
+
+const STRING_LIST_FIELDS = ['staleSources', 'missingDomains'] as const;
+
+function sanitizeBatchBody(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const body = raw as Record<string, unknown>;
+
+  if (typeof body.action !== 'string' || !BATCH_ACTIONS.has(body.action)) return null;
+  if (!Array.isArray(body.entityIds) || body.entityIds.length === 0) return null;
+
+  const entityIds = body.entityIds
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    .map((id) => id.trim());
+  if (entityIds.length === 0) return null;
+  // Reject oversized batches outright — silently truncating a selection would
+  // drop decisions the employer believes they made.
+  if (entityIds.length > MAX_BATCH) return null;
+
+  const sanitized: Record<string, unknown> = { action: body.action, entityIds };
+
+  for (const field of STRING_FIELDS) {
+    const value = body[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      sanitized[field] = value.trim().slice(0, 2000);
+    }
+  }
+  for (const field of STRING_LIST_FIELDS) {
+    const value = body[field];
+    if (Array.isArray(value)) {
+      const list = value
+        .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+        .map((v) => v.trim().slice(0, 200))
+        .slice(0, 25);
+      if (list.length > 0) sanitized[field] = list;
+    }
+  }
+
+  return sanitized;
+}
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_request', error_description: 'Body must be valid JSON.' }, { status: 400 });
+  }
+
+  const sanitized = sanitizeBatchBody(raw);
+  if (!sanitized) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: 'Malformed batch request body.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await fetch(`${BACKEND}/api/employer-review/batch`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'x-clerk-user-id': userId,
+      },
+      body: JSON.stringify(sanitized),
+      cache: 'no-store',
+      // Batches run the full per-candidate gate sequence — allow more time
+      // than the single-entity proxy.
+      signal: AbortSignal.timeout(60_000),
+    });
+    const payload = await response.json().catch(() => ({ error: 'Invalid response from backend' }));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    console.error('[employer-review/batch proxy]', error);
+    return NextResponse.json(
+      { error: 'backend_unavailable', error_description: 'Employer review backend is unavailable.' },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/app/api/employer-review/queue/route.ts
+++ b/apps/web/app/api/employer-review/queue/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /api/employer-review/queue — Wave L.
+ *
+ * The signed-in employer's review inbox: clinicians who shared an apply
+ * bundle with the employer's own registered organization. The backend binds
+ * the scope server-side to the caller's org profile — no caller-supplied
+ * organizationId is honored, so this proxy forwards identity (Clerk user id)
+ * and the row limit only.
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+export async function GET(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  const limitParam = req.nextUrl.searchParams.get('limit');
+  const limit = limitParam && /^\d{1,2}$/.test(limitParam) ? `?limit=${limitParam}` : '';
+
+  try {
+    const response = await fetch(`${BACKEND}/api/employer-review/queue${limit}`, {
+      headers: {
+        Accept: 'application/json',
+        'x-clerk-user-id': userId,
+      },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15_000),
+    });
+    const payload = await response.json().catch(() => ({ error: 'Invalid response from backend' }));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    console.error('[employer-review/queue proxy]', error);
+    return NextResponse.json(
+      { error: 'backend_unavailable', error_description: 'Employer review backend is unavailable.' },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/app/employer/review-queue/page.tsx
+++ b/apps/web/app/employer/review-queue/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { ReviewQueueSurface } from '@/components/review/ReviewQueueSurface';
+
+export const metadata: Metadata = {
+  title: 'Review queue — VitalCV',
+  description:
+    'Clinicians who shared source-backed evidence with your organization — triage with per-candidate audit events.',
+};
+
+// Data access is enforced at the API layer: the queue proxy requires a Clerk
+// session and the backend binds scope to the caller's own registered
+// organization. The surface renders honest signed-out / no-org states.
+export default function EmployerReviewQueuePage() {
+  return <ReviewQueueSurface />;
+}

--- a/apps/web/components/review/ReviewQueueSurface.tsx
+++ b/apps/web/components/review/ReviewQueueSurface.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+/**
+ * ReviewQueueSurface — Wave L. The employer's review inbox: clinicians who
+ * shared an apply bundle with the employer's own registered organization,
+ * with a readiness summary (cached trust snapshot, labeled as such), the
+ * honest prior-acceptance head-start signal, and batch actions.
+ *
+ * Batch semantics mirror the single-entity review exactly: every candidate
+ * writes its own audit event, and a blocked candidate fails closed
+ * individually — the response reports each outcome and this surface renders
+ * them per row. The head start is visibility and a soft signal only; this
+ * organization still decides.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type QueueReadiness = {
+  level: string;
+  score: number;
+  status: string;
+  topBlockers: string[];
+  source: string;
+};
+
+type QueueHeadStart = {
+  acceptedOrganizationCount: number;
+  hasPriorAcceptances: boolean;
+  headline: string;
+  trustCopy: string | null;
+};
+
+export interface QueueCandidate {
+  entityId: string | null;
+  npi: string;
+  reviewable: boolean;
+  sharedAt: string;
+  purposeOfUse: string;
+  readiness: QueueReadiness | null;
+  headStart: QueueHeadStart | null;
+  alreadyAccepted: { acceptanceId: string; acceptedAt: string } | null;
+  reviewPath: string | null;
+}
+
+interface QueuePayload {
+  ok: boolean;
+  scope: { type: string; organizationId: string; organizationName: string };
+  total: number;
+  candidates: QueueCandidate[];
+  readinessNote: string;
+  generatedAt: string;
+}
+
+type BatchAction = 'accept' | 'request-refresh' | 'route-to-review';
+
+interface BatchResult {
+  entityId: string;
+  ok: boolean;
+  status: number;
+  error?: string;
+  error_description?: string;
+}
+
+type LoadState = 'loading' | 'ready' | 'signed-out' | 'no-org' | 'error';
+
+const ACTION_LABEL: Record<BatchAction, string> = {
+  accept: 'Accept as head start',
+  'request-refresh': 'Request refresh',
+  'route-to-review': 'Route to review',
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+  L0: 'var(--vt-risk-high, #8C2A2A)',
+  L1: 'var(--vt-risk-medium, #A05C00)',
+  L2: 'var(--vt-accent, #0A7B7F)',
+  L3: 'var(--vt-status-resolved, #2E7D45)',
+};
+
+export function ReviewQueueSurface() {
+  const [state, setState] = useState<LoadState>('loading');
+  const [payload, setPayload] = useState<QueuePayload | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState<BatchAction | null>(null);
+  const [outcomes, setOutcomes] = useState<Record<string, BatchResult>>({});
+  const [batchNote, setBatchNote] = useState<string | null>(null);
+
+  const loadQueue = useCallback(() => {
+    setState('loading');
+    fetch('/api/employer-review/queue', { cache: 'no-store', signal: AbortSignal.timeout(20_000) })
+      .then(async (r) => {
+        if (r.status === 401) return setState('signed-out');
+        if (r.status === 403) return setState('no-org');
+        if (!r.ok) return setState('error');
+        const data = (await r.json()) as QueuePayload;
+        setPayload(data);
+        setState('ready');
+      })
+      .catch(() => setState('error'));
+  }, []);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  const selectable = useMemo(
+    () => (payload?.candidates ?? []).filter((c) => c.reviewable && c.entityId),
+    [payload],
+  );
+
+  const toggle = (entityId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(entityId)) next.delete(entityId);
+      else next.add(entityId);
+      return next;
+    });
+  };
+
+  const runBatch = async (action: BatchAction) => {
+    if (selected.size === 0 || submitting) return;
+    setSubmitting(action);
+    setBatchNote(null);
+    try {
+      const res = await fetch('/api/employer-review/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, entityIds: [...selected] }),
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { results?: BatchResult[]; summary?: { succeeded: number; failed: number } }
+        | null;
+      if (!res.ok || !data?.results) {
+        setBatchNote('The batch could not be processed. No decisions were recorded silently — try again.');
+        return;
+      }
+      const byEntity: Record<string, BatchResult> = {};
+      for (const result of data.results) byEntity[result.entityId] = result;
+      setOutcomes((prev) => ({ ...prev, ...byEntity }));
+      setSelected(new Set());
+      setBatchNote(
+        `${ACTION_LABEL[action]}: ${data.summary?.succeeded ?? 0} recorded, ${data.summary?.failed ?? 0} failed closed. Each candidate has its own audit event.`,
+      );
+      loadQueue();
+    } catch {
+      setBatchNote('The batch could not be processed. No decisions were recorded silently — try again.');
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: '28px 24px 96px', display: 'grid', gap: 16 }}>
+      <header>
+        <h1 style={{ margin: 0, fontSize: 24, fontWeight: 600, color: 'var(--vt-text-primary)' }}>Review queue</h1>
+        <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)' }}>
+          {payload?.scope
+            ? `Clinicians who shared their evidence with ${payload.scope.organizationName}.`
+            : 'Clinicians who shared their evidence with your organization.'}
+        </p>
+      </header>
+
+      {state === 'loading' && <Note title="Loading your queue…" body="Fetching live shares for your organization." />}
+      {state === 'signed-out' && (
+        <Note title="Sign in to see your review queue" body="The queue is scoped to your organization's account." />
+      )}
+      {state === 'no-org' && (
+        <Note
+          title="No employer organization on this account"
+          body="Complete employer setup first — the queue is always bound to your own registered organization."
+        />
+      )}
+      {state === 'error' && (
+        <Note title="Queue is temporarily unavailable" body="This is a system state — nothing about your candidates changed. Try again shortly." />
+      )}
+      {state === 'ready' && (payload?.candidates.length ?? 0) === 0 && (
+        <Note title="No live shares yet" body="When a clinician shares an apply bundle with your organization, they appear here." />
+      )}
+
+      {state === 'ready' && (payload?.candidates.length ?? 0) > 0 && (
+        <>
+          {/* Batch action bar */}
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              gap: 10,
+              padding: '12px 14px',
+              border: '1px solid var(--vt-border, #E2E8E6)',
+              borderRadius: 12,
+              background: 'var(--vt-surface, #fff)',
+            }}
+          >
+            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-text-primary)' }}>
+              {selected.size} of {selectable.length} selected
+            </span>
+            {(Object.keys(ACTION_LABEL) as BatchAction[]).map((action) => (
+              <button
+                key={action}
+                type="button"
+                disabled={selected.size === 0 || submitting !== null}
+                onClick={() => runBatch(action)}
+                style={{
+                  padding: '8px 14px',
+                  borderRadius: 10,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: selected.size === 0 || submitting ? 'not-allowed' : 'pointer',
+                  opacity: selected.size === 0 || submitting ? 0.5 : 1,
+                  border: '1px solid var(--vt-border, #D6DED9)',
+                  background: action === 'accept' ? 'var(--vt-accent, #0A7B7F)' : 'var(--vt-surface, #fff)',
+                  color: action === 'accept' ? '#fff' : 'var(--vt-text-primary)',
+                }}
+              >
+                {submitting === action ? 'Recording…' : ACTION_LABEL[action]}
+              </button>
+            ))}
+            <p style={{ margin: 0, flexBasis: '100%', fontSize: 11, color: 'var(--vt-text-muted)' }}>
+              Every candidate gets its own audit event. Blocked candidates fail closed individually — the batch never
+              overrides a blocked readiness state.
+            </p>
+          </div>
+
+          {batchNote && (
+            <div
+              role="status"
+              style={{
+                padding: '10px 14px',
+                borderRadius: 10,
+                fontSize: 13,
+                border: '1px solid var(--vt-border, #D6DED9)',
+                background: 'var(--vt-surface, #fff)',
+                color: 'var(--vt-text-primary)',
+              }}
+            >
+              {batchNote}
+            </div>
+          )}
+
+          {/* Candidate rows */}
+          <div style={{ display: 'grid', gap: 12 }}>
+            {payload!.candidates.map((candidate) => {
+              const outcome = candidate.entityId ? outcomes[candidate.entityId] : undefined;
+              const levelColor = candidate.readiness ? (LEVEL_COLORS[candidate.readiness.level] ?? 'var(--vt-text-muted)') : 'var(--vt-text-muted)';
+              const checked = candidate.entityId ? selected.has(candidate.entityId) : false;
+              return (
+                <div
+                  key={`${candidate.npi}-${candidate.sharedAt}`}
+                  style={{
+                    display: 'grid',
+                    gap: 10,
+                    padding: 16,
+                    borderRadius: 14,
+                    border: '1px solid var(--vt-border, #E2E8E6)',
+                    background: 'var(--vt-surface, #fff)',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 10 }}>
+                    <input
+                      type="checkbox"
+                      aria-label={`Select NPI ${candidate.npi}`}
+                      checked={checked}
+                      disabled={!candidate.reviewable || !candidate.entityId}
+                      onChange={() => candidate.entityId && toggle(candidate.entityId)}
+                      style={{ width: 18, height: 18 }}
+                    />
+                    <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--vt-text-primary)', fontVariantNumeric: 'tabular-nums' }}>
+                      NPI {candidate.npi}
+                    </span>
+                    {candidate.readiness ? (
+                      <span
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 600,
+                          padding: '4px 10px',
+                          borderRadius: 999,
+                          color: levelColor,
+                          border: `1px solid color-mix(in srgb, ${levelColor} 30%, transparent)`,
+                          background: `color-mix(in srgb, ${levelColor} 10%, transparent)`,
+                        }}
+                      >
+                        {candidate.readiness.level} · {candidate.readiness.score}/100
+                      </span>
+                    ) : (
+                      <span style={{ fontSize: 12, color: 'var(--vt-text-muted)' }}>Readiness snapshot unavailable</span>
+                    )}
+                    {candidate.alreadyAccepted ? (
+                      <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--vt-status-resolved, #2E7D45)' }}>
+                        Accepted {new Date(candidate.alreadyAccepted.acceptedAt).toLocaleDateString()}
+                      </span>
+                    ) : null}
+                    <span style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--vt-text-muted)' }}>
+                      Shared {new Date(candidate.sharedAt).toLocaleString()} · {candidate.purposeOfUse}
+                    </span>
+                  </div>
+
+                  {/* Head start — honest wording comes from the acceptance-history service */}
+                  {candidate.headStart?.hasPriorAcceptances ? (
+                    <div
+                      style={{
+                        padding: '8px 12px',
+                        borderRadius: 10,
+                        fontSize: 12,
+                        border: '1px solid color-mix(in srgb, var(--vt-accent, #0A7B7F) 25%, transparent)',
+                        background: 'color-mix(in srgb, var(--vt-accent, #0A7B7F) 7%, transparent)',
+                        color: 'var(--vt-text-primary)',
+                      }}
+                    >
+                      <strong>Head start:</strong> {candidate.headStart.headline}. A soft signal — your organization still
+                      decides.
+                      {candidate.headStart.trustCopy ? (
+                        <span style={{ display: 'block', marginTop: 4, color: 'var(--vt-text-secondary)' }}>
+                          {candidate.headStart.trustCopy}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {candidate.readiness && candidate.readiness.topBlockers.length > 0 ? (
+                    <div style={{ fontSize: 12, color: 'var(--vt-risk-medium, #A05C00)' }}>
+                      Open items: {candidate.readiness.topBlockers.join(' · ')}
+                    </div>
+                  ) : null}
+
+                  {outcome ? (
+                    <div
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 600,
+                        color: outcome.ok ? 'var(--vt-status-resolved, #2E7D45)' : 'var(--vt-risk-high, #8C2A2A)',
+                      }}
+                    >
+                      {outcome.ok
+                        ? 'Recorded — audit event written.'
+                        : `Failed closed: ${outcome.error_description ?? outcome.error ?? 'not recorded'}`}
+                    </div>
+                  ) : null}
+
+                  <div>
+                    {candidate.reviewPath ? (
+                      <a
+                        href={candidate.reviewPath}
+                        style={{ fontSize: 13, fontWeight: 600, color: 'var(--vt-accent, #0A7B7F)', textDecoration: 'none' }}
+                      >
+                        Open full review →
+                      </a>
+                    ) : (
+                      <span style={{ fontSize: 12, color: 'var(--vt-text-muted)' }}>
+                        Identity not yet resolved — this share can&rsquo;t be reviewed yet.
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <p style={{ margin: 0, fontSize: 11, color: 'var(--vt-text-muted)', lineHeight: 1.5 }}>{payload!.readinessNote}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Note({ title, body }: { title: string; body: string }) {
+  return (
+    <div
+      style={{
+        background: 'var(--vt-surface, #fff)',
+        border: '1px solid var(--vt-border, #E2E8E6)',
+        borderRadius: 16,
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--vt-text-primary)' }}>{title}</p>
+      <p style={{ margin: '6px 0 0', fontSize: 14, color: 'var(--vt-text-secondary)' }}>{body}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Org-scoped review queue** — `GET /api/employer-review/queue` is the employer's inbox: clinicians whose apply-bundle shares are addressed to the caller's **own registered organization**. Scope is resolved server-side from the Clerk user (org profile → uuid + slug match); a caller-supplied `organizationId` is **never** honored (org context via query/header is the tracked unauthenticated G1 gap, and a candidate pipeline must not be readable cross-tenant). No unscoped aggregation path exists.
- **Consent honesty** — revoked shares and expired bundles fail closed out of the queue; rows dedupe to the latest live share per NPI; unresolvable identities are shown but explicitly not reviewable (no silent drops).
- **Readiness summary, honestly labeled** — per-row readiness comes from the 2-tier cached trust snapshot (`source: 'cached_trust_snapshot'` + a response-level note); the authoritative BLOCKED check still happens at action time.
- **Batch actions** — `POST /api/employer-review/batch` applies accept-as-head-start / request-refresh / route-to-review across ≤25 candidates with per-candidate semantics **identical** to the single-entity routes: same shadow-RBAC gate, same duplicate-acceptance guard, same `decisionPosture.status === 'BLOCKED'` fail-closed check, and **one AuditEvent per candidate** written by the same `recordEmployerReview*` services (denied candidates get the standard denied-mutation audit). A failed candidate never aborts the rest; SEAL/learning signals fire per candidate as on the single routes. `bundleId` is deliberately not accepted — a bundle belongs to one clinician's share, so a shared bundle id would mis-attribute evidence.
- **Head-start signal, first-class** — each queue row carries the acceptance-history summary (`headline`/`trustCopy` built by the existing service, wording unchanged) rendered as a badge: *a soft signal — your organization still decides*. The single-entity surface already had this; the queue makes it visible at triage time.
- **Queue UI** — `/employer/review-queue` (new page + `ReviewQueueSurface`): selection, batch action bar, per-candidate outcome chips (recorded vs failed-closed with reason), open-full-review links to the existing `/review/[entityId]` surface, honest signed-out / no-org / empty / error states. Cursor polish can layer on top.

## Truth rules
- Head start is visibility + a soft signal; copy states the employer still decides. No auto-bypass of any gate.
- Blocked candidates fail closed individually — the batch response reports them; nothing is recorded silently (oversized batches are rejected, never truncated).
- Readiness rows are labeled as cached snapshots, never presented as live verification; the live posture check guards the actual accept.
- No banned strings; no bare `Verified` (scan clean over the diff scope; the new web test pins the honest wording in source).
- Data protection is at the API layer (Clerk `auth()` on proxies + server-side org binding); `/employer/*` pages remain un-gated in the route map, consistent with every existing `/employer` page while backend RBAC is in shadow mode.

## Validation
- Backend (new, green): `employerReviewBatchQueue.test.ts` **9/9** — per-candidate BLOCKED fail-closed with its own denied audit while the batch proceeds, duplicate-accept 409 without side effects, one refresh audit per candidate (passport gate never consulted), dedupe + unresolvable-candidate reporting, queue scope binding (uuid+slug, revoked/expired excluded), 401/403 gates. Note: the legacy `employerActions.test.ts` is 14-failed/15-passed **on main already** (pre-existing, backend jest is not a CI gate) — this PR adds no new failures.
- Web (new): `employer-review-queue.test.tsx` **8/8** — queue proxy forwards identity only (caller org param dropped), batch proxy sanitization (bundleId/unknown keys dropped, oversized rejected), 401 gates, SSR render + honest-wording source pins.
- Regression: `holder-route-contract` 150/150, `employer-review-proxy` 15/15.
- `pnpm turbo run build --filter @vitalcv/web` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · truth scan clean.

## Design Handoff References
No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)