### PR TITLE
feat(revenue): Wave Q — durable lead capture, concierge readiness-packet offer, internal leads view

### DIFF
--- a/apps/api/backend/prisma/migrations/20260705120000_pilot_leads/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260705120000_pilot_leads/migration.sql
@@ -1,0 +1,29 @@
+-- Wave Q — durable commercial lead capture. One row per submitted pilot
+-- request / pilot intake, in addition to the existing Slack + stdout
+-- delivery (which stays). Operational CRM-lite, never evidence. Every insert
+-- is paired with an AuditEvent ('pilot.lead_captured') in the same
+-- transaction. `id` is generated client-side by Prisma (@default(uuid())) —
+-- no DB-level default, matching the fleet's Postgres (no gen_random_uuid).
+
+CREATE TABLE "PilotLead" (
+    "id" UUID NOT NULL,
+    "source" TEXT NOT NULL,
+    "persona" TEXT,
+    "organization" TEXT NOT NULL,
+    "contactName" TEXT,
+    "email" TEXT NOT NULL,
+    "message" TEXT,
+    "workflowTarget" TEXT,
+    "sourceContext" TEXT,
+    "payload" JSONB NOT NULL,
+    "slackDelivered" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PilotLead_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "PilotLead_createdAt_idx" ON "PilotLead"("createdAt");
+
+CREATE INDEX "PilotLead_source_createdAt_idx" ON "PilotLead"("source", "createdAt");
+
+CREATE INDEX "PilotLead_email_idx" ON "PilotLead"("email");

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -39,6 +39,31 @@ model MatchaPreference {
   @@index([clerkUserId])
 }
 
+/// Wave Q — durable commercial lead capture. One row per submitted pilot
+/// request / pilot intake (in addition to the existing Slack + stdout
+/// delivery, which stays). Operational CRM-lite, never evidence: rows carry
+/// buyer contact context only and are paired with an AuditEvent
+/// (`pilot.lead_captured`) at insert. Mirrored in apps/web/prisma/schema.prisma
+/// — the web app writes this table directly (deploy-order safe).
+model PilotLead {
+  id             String   @id @default(uuid()) @db.Uuid
+  source         String // pilot_request | pilot_intake
+  persona        String?
+  organization   String
+  contactName    String?
+  email          String
+  message        String?
+  workflowTarget String?
+  sourceContext  String?
+  payload        Json
+  slackDelivered Boolean  @default(false)
+  createdAt      DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([source, createdAt])
+  @@index([email])
+}
+
 /// Wave K — server-persisted clinician Save / Connect / Decline decisions on
 /// MATCHA opportunities. Append-only: every decision (including clearing one
 /// back to "new") is a NEW row; current state = latest row per

--- a/apps/web/__tests__/pilot-intake-route.test.ts
+++ b/apps/web/__tests__/pilot-intake-route.test.ts
@@ -57,7 +57,7 @@ describe('POST /api/pilot-intake', () => {
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toEqual({ ok: true, slackDelivered: true, slackReason: null });
+    expect(json).toEqual({ ok: true, persisted: false, slackDelivered: true, slackReason: null });
     expect(slackMock).toHaveBeenCalledTimes(1);
   });
 
@@ -66,7 +66,7 @@ describe('POST /api/pilot-intake', () => {
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toEqual({ ok: true, slackDelivered: false, slackReason: 'http_error' });
+    expect(json).toEqual({ ok: true, persisted: false, slackDelivered: false, slackReason: 'http_error' });
   });
 
   it('still returns 200 even when SLACK env is unconfigured (intake is logged-only)', async () => {
@@ -76,6 +76,7 @@ describe('POST /api/pilot-intake', () => {
     const json = await res.json();
     expect(json).toEqual({
       ok: true,
+      persisted: false,
       slackDelivered: false,
       slackReason: 'unconfigured',
     });

--- a/apps/web/__tests__/pilot-lead-persistence.test.tsx
+++ b/apps/web/__tests__/pilot-lead-persistence.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Wave Q — durable commercial lead capture.
+ *
+ * - persistPilotLead writes the lead row + its AuditEvent in ONE transaction
+ *   (audit-first) and degrades to persisted:false, never a throw.
+ * - /api/pilot-intake persists FIRST, then delivers to Slack (a crash can no
+ *   longer lose the lead), and keeps its existing validation contract.
+ * - /api/pilot-request persists the structured record (the previously
+ *   deferred wiring) without changing the buyer-facing confirmation.
+ * - The concierge offer stays honest: readiness packet wording, no payment
+ *   collected, employer still decides.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const { pilotLeadCreate, pilotLeadUpdate, auditEventCreate, transactionMock, slackMock } = vi.hoisted(() => ({
+  pilotLeadCreate: vi.fn(),
+  pilotLeadUpdate: vi.fn(),
+  auditEventCreate: vi.fn(),
+  transactionMock: vi.fn(),
+  slackMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    pilotLead: { create: pilotLeadCreate, update: pilotLeadUpdate },
+    auditEvent: { create: auditEventCreate },
+    $transaction: transactionMock,
+  },
+}));
+
+vi.mock('@/lib/pilot-intake/slack', () => ({
+  deliverPilotIntakeToSlack: slackMock,
+}));
+
+import { persistPilotLead } from '../lib/leads/pilotLeadPersistence';
+import { validatePilotIntake } from '../lib/pilot-intake/validate';
+import ConciergePage from '../app/concierge/page';
+
+const VALID_INTAKE = {
+  fullName: 'Dana Buyer',
+  email: 'dana@mercy.example',
+  organization: 'Mercy General',
+  persona: 'health_system',
+  description: 'We want to pilot readiness packets for our locum intake.',
+};
+
+beforeEach(() => {
+  pilotLeadCreate.mockReset().mockImplementation((args) => ({ __op: 'lead', args }));
+  pilotLeadUpdate.mockReset().mockResolvedValue({});
+  auditEventCreate.mockReset().mockImplementation((args) => ({ __op: 'audit', args }));
+  transactionMock.mockReset().mockResolvedValue([{}, {}]);
+  slackMock.mockReset().mockResolvedValue({ delivered: false, reason: 'unconfigured' });
+});
+
+describe('persistPilotLead', () => {
+  it('writes the lead and its audit event in one transaction', async () => {
+    const result = await persistPilotLead({
+      source: 'pilot_intake',
+      persona: 'concierge',
+      organization: 'Mercy General',
+      contactName: 'Dana Buyer',
+      email: 'dana@mercy.example',
+      message: 'Requesting the readiness packet.',
+      sourceContext: '/contact',
+      payload: { anything: true },
+    });
+
+    expect(result.persisted).toBe(true);
+    expect(result.leadId).toMatch(/^[0-9a-f-]{36}$/);
+
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock.mock.calls[0][0]).toHaveLength(2);
+
+    const lead = pilotLeadCreate.mock.calls[0][0].data;
+    expect(lead).toMatchObject({
+      id: result.leadId,
+      source: 'pilot_intake',
+      persona: 'concierge',
+      organization: 'Mercy General',
+      email: 'dana@mercy.example',
+      slackDelivered: false,
+    });
+
+    const audit = auditEventCreate.mock.calls[0][0].data;
+    expect(audit.type).toBe('pilot.lead_captured');
+    expect(audit.referenceId).toBe(result.leadId);
+    expect(audit.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(audit.metadata).toMatchObject({ source: 'pilot_intake', organization: 'Mercy General' });
+  });
+
+  it('degrades to persisted:false when the table is not deployed yet', async () => {
+    transactionMock.mockRejectedValue(new Error('P2021: table does not exist'));
+    const result = await persistPilotLead({
+      source: 'pilot_request',
+      organization: 'Mercy General',
+      email: 'dana@mercy.example',
+      payload: {},
+    });
+    expect(result).toEqual({ persisted: false, leadId: null });
+  });
+});
+
+describe('POST /api/pilot-intake', () => {
+  async function post(body: unknown) {
+    const { POST } = await import(new URL('../app/api/pilot-intake/route.ts', import.meta.url).href);
+    return POST(new Request('http://localhost/api/pilot-intake', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+
+  it('persists the lead before Slack and reports both statuses', async () => {
+    slackMock.mockResolvedValue({ delivered: true });
+
+    const res = await post(VALID_INTAKE);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      persisted: true,
+      slackDelivered: true,
+    });
+    expect(pilotLeadCreate.mock.calls[0][0].data).toMatchObject({
+      source: 'pilot_intake',
+      organization: 'Mercy General',
+      contactName: 'Dana Buyer',
+      persona: 'health_system',
+    });
+    // Delivery succeeded → operational flag corrected after the durable write.
+    expect(pilotLeadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { slackDelivered: true } }),
+    );
+    // Persist happened even though it ran before Slack.
+    expect(transactionMock.mock.invocationCallOrder[0]).toBeLessThan(
+      slackMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps the lead durable when Slack fails', async () => {
+    slackMock.mockResolvedValue({ delivered: false, reason: 'http_error' });
+
+    const res = await post(VALID_INTAKE);
+
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      persisted: true,
+      slackDelivered: false,
+    });
+    expect(pilotLeadUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid submissions without touching the DB', async () => {
+    const res = await post({ ...VALID_INTAKE, email: 'not-an-email' });
+    expect(res.status).toBe(400);
+    expect(transactionMock).not.toHaveBeenCalled();
+    expect(slackMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/pilot-request', () => {
+  it('persists the structured record as a pilot_request lead', async () => {
+    const { POST } = await import(new URL('../app/api/pilot-request/route.ts', import.meta.url).href);
+    const res = await POST(new Request('http://localhost/api/pilot-request', {
+      method: 'POST',
+      body: JSON.stringify({
+        organization: 'Mercy General',
+        name: 'Dana Buyer',
+        email: 'dana@mercy.example',
+        usecase: 'Credentialing review',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.ok).toBe(true);
+    expect(payload.persisted).toBe(true);
+    expect(payload.record.orgName).toBe('Mercy General');
+
+    const lead = pilotLeadCreate.mock.calls[0][0].data;
+    expect(lead).toMatchObject({
+      source: 'pilot_request',
+      organization: 'Mercy General',
+      email: 'dana@mercy.example',
+      workflowTarget: 'Credentialing review',
+    });
+    expect(lead.payload.pilotId).toBeTruthy();
+  });
+});
+
+describe('concierge persona + offer page honesty', () => {
+  it("accepts 'concierge' as an intake persona", () => {
+    const result = validatePilotIntake({ ...VALID_INTAKE, persona: 'concierge' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('renders the honest concierge offer: readiness packet, no payment, routed to contact', () => {
+    const markup = renderToStaticMarkup(<ConciergePage />);
+    expect(markup).toContain('credential readiness packet');
+    expect(markup).toContain('/contact?persona=concierge');
+    expect(markup).toContain('no payment is collected on');
+    expect(markup).toContain('always make their own acceptance decisions');
+  });
+
+  it('keeps banned claims out of the concierge copy', () => {
+    const source = readFileSync(join(__dirname, '../app/concierge/page.tsx'), 'utf8');
+    expect(source).not.toMatch(
+      /automatically verified|guaranteed verification|complete credentialing|instant credentialing|certified compliant/i,
+    );
+    expect(source).not.toMatch(/label:\s*['"]Verified['"]/);
+  });
+});

--- a/apps/web/__tests__/pilot-request-route.test.ts
+++ b/apps/web/__tests__/pilot-request-route.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// The route now imports the lead-persistence lib (server-only + prisma).
+// Without a DB in the test env the write degrades to persisted:false, which
+// is exactly the deploy-order-safe contract.
+vi.mock('server-only', () => ({}));
 import { POST } from '@/app/api/pilot-request/route';
 
 function jsonRequest(body: unknown): Request {

--- a/apps/web/app/admin/leads/page.tsx
+++ b/apps/web/app/admin/leads/page.tsx
@@ -1,0 +1,123 @@
+/**
+ * /admin/leads — Wave Q. Minimal internal list of captured commercial leads
+ * (PilotLead rows). ADMIN-gated with the same pattern as /admin/platform.
+ * Read-only; the durable trail is the paired AuditEvent per lead.
+ * Deploy-order safe: renders an honest empty state until the PilotLead
+ * migration deploys.
+ */
+import type { Metadata } from 'next';
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Leads · VitalCV',
+  description: 'Captured pilot leads — internal.',
+};
+
+interface LeadRow {
+  id: string;
+  source: string;
+  persona: string | null;
+  organization: string;
+  contactName: string | null;
+  email: string;
+  workflowTarget: string | null;
+  sourceContext: string | null;
+  slackDelivered: boolean;
+  createdAt: Date;
+}
+
+export default async function AdminLeadsPage() {
+  const session = await auth();
+  if (!session.userId) {
+    redirect('/sign-in?redirect_url=/admin/leads');
+  }
+  const role = (session.sessionClaims as { vitalcv?: { role?: string } } | null)?.vitalcv?.role;
+  if (role !== 'ADMIN') {
+    redirect('/');
+  }
+
+  let leads: LeadRow[] = [];
+  let tablePending = false;
+  try {
+    leads = await prisma.pilotLead.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+      select: {
+        id: true,
+        source: true,
+        persona: true,
+        organization: true,
+        contactName: true,
+        email: true,
+        workflowTarget: true,
+        sourceContext: true,
+        slackDelivered: true,
+        createdAt: true,
+      },
+    });
+  } catch {
+    tablePending = true;
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <header className="mb-6">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">Internal</p>
+        <h1 className="mt-1 text-2xl font-semibold text-foreground">Captured leads</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Durable pilot-request and pilot-intake submissions, newest first. Each row has a paired
+          audit event; Slack delivery status is operational only.
+        </p>
+      </header>
+
+      {tablePending ? (
+        <p className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+          The PilotLead table is not deployed yet (migration pending). Leads keep flowing to Slack
+          and the server log in the meantime.
+        </p>
+      ) : leads.length === 0 ? (
+        <p className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+          No captured leads yet.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-border text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2">When</th>
+                <th className="px-3 py-2">Source</th>
+                <th className="px-3 py-2">Persona</th>
+                <th className="px-3 py-2">Organization</th>
+                <th className="px-3 py-2">Contact</th>
+                <th className="px-3 py-2">Target</th>
+                <th className="px-3 py-2">Slack</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leads.map((lead) => (
+                <tr key={lead.id} className="border-b border-border/60 align-top">
+                  <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                    {lead.createdAt.toISOString().slice(0, 16).replace('T', ' ')}
+                  </td>
+                  <td className="px-3 py-2">{lead.source}</td>
+                  <td className="px-3 py-2">{lead.persona ?? '—'}</td>
+                  <td className="px-3 py-2 font-medium text-foreground">{lead.organization}</td>
+                  <td className="px-3 py-2">
+                    {lead.contactName ? `${lead.contactName} · ` : ''}
+                    {lead.email}
+                  </td>
+                  <td className="px-3 py-2">{lead.workflowTarget ?? lead.sourceContext ?? '—'}</td>
+                  <td className="px-3 py-2">{lead.slackDelivered ? 'delivered' : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/api/pilot-intake/route.ts
+++ b/apps/web/app/api/pilot-intake/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 
 import { validatePilotIntake } from '@/lib/pilot-intake/validate';
 import { deliverPilotIntakeToSlack } from '@/lib/pilot-intake/slack';
+import { markPilotLeadSlackDelivered, persistPilotLead } from '@/lib/leads/pilotLeadPersistence';
 
 /**
  * POST /api/pilot-intake — pilot inquiry submission endpoint.
@@ -55,11 +56,30 @@ export async function POST(request: Request): Promise<NextResponse> {
     }),
   );
 
+  // Durable lead row FIRST (a crash mid-request can no longer lose the
+  // lead; slackDelivered is corrected after delivery). Degrades to
+  // persisted:false until the PilotLead migration deploys — Slack and the
+  // stdout paper trail keep working either way.
+  const lead = await persistPilotLead({
+    source: 'pilot_intake',
+    persona: intake.persona,
+    organization: intake.organization,
+    contactName: intake.fullName,
+    email: intake.email,
+    message: intake.description,
+    sourceContext: '/contact',
+    payload: intake,
+  });
+
   const slack = await deliverPilotIntakeToSlack(intake);
+  if (slack.delivered && lead.persisted && lead.leadId) {
+    await markPilotLeadSlackDelivered(lead.leadId);
+  }
 
   return NextResponse.json(
     {
       ok: true,
+      persisted: lead.persisted,
       slackDelivered: slack.delivered,
       slackReason: slack.delivered ? null : slack.reason,
     },

--- a/apps/web/app/api/pilot-request/route.ts
+++ b/apps/web/app/api/pilot-request/route.ts
@@ -14,9 +14,10 @@
  * Response on validation failure (400):
  *   { ok: false, errors: PilotIntakeInputError[] }
  *
- * Side effects are deliberately minimal — this wave produces the
- * structured record and returns it. Persistence + email notification
- * wiring is deferred to a separate wave ("do not build a full CRM").
+ * Side effects stay deliberately small ("do not build a full CRM"):
+ * the structured record is returned to the caller and one durable
+ * PilotLead row + AuditEvent is written (Wave Q). Email notification
+ * wiring remains deferred.
  */
 
 import { NextResponse } from 'next/server';
@@ -26,6 +27,7 @@ import {
   type PilotIntakeInput,
 } from '@/lib/pilot/pilot-intake';
 import { buildPilotConfirmationRenderModel } from '@/lib/pilot/pilot-confirmation-copy';
+import { persistPilotLead } from '@/lib/leads/pilotLeadPersistence';
 
 async function readRequestBody(request: Request): Promise<Record<string, unknown>> {
   const contentType = request.headers.get('content-type') ?? '';
@@ -89,9 +91,23 @@ export async function POST(request: Request): Promise<NextResponse> {
   const record = createPilotRequestRecord(input);
   const confirmation = buildPilotConfirmationRenderModel(record);
 
+  // Wave Q: the previously-deferred persistence. Durable PilotLead row +
+  // AuditEvent in one transaction; degrades to persisted:false until the
+  // migration deploys and never blocks the buyer's confirmation.
+  const lead = await persistPilotLead({
+    source: 'pilot_request',
+    organization: record.orgName,
+    contactName: record.contactName,
+    email: record.contactEmail,
+    workflowTarget: record.roleOrWorkflowTarget,
+    sourceContext: record.sourceContext,
+    payload: record,
+  });
+
   return NextResponse.json(
     {
       ok: true,
+      persisted: lead.persisted,
       record,
       confirmation,
       message: confirmation.acknowledgement,

--- a/apps/web/app/concierge/page.tsx
+++ b/apps/web/app/concierge/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Concierge — Credential Readiness Packet — VitalCV',
+  description:
+    'A source-backed credential readiness packet, assembled with you and ready to hand to employers and recruiters.',
+};
+
+/**
+ * /concierge — Wave Q. The first sellable concierge offer, honestly worded:
+ * a done-with-you credential readiness packet. This page collects no payment
+ * (pricingFoundation keeps collectsPayment: false until real billing exists)
+ * and promises no verification outcome — it routes to /contact with the
+ * concierge persona preselected.
+ */
+export default function ConciergePage() {
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-12" data-testid="concierge-page">
+      <header className="mb-8">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+          Concierge service
+        </p>
+        <h1 className="mt-1 text-3xl font-semibold text-foreground">
+          A recruiter-ready credential readiness packet — assembled with you.
+        </h1>
+        <p className="mt-3 text-base text-muted-foreground">
+          We sit with you, run your NPI through the source checks VitalCV already performs, and
+          assemble your evidence into one shareable, source-backed packet — so the next
+          opportunity starts from a head start instead of a blank form.
+        </p>
+      </header>
+
+      <section aria-labelledby="what-you-get" className="mb-8">
+        <h2 id="what-you-get" className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          What the packet contains
+        </h2>
+        <ul className="mt-3 space-y-3 text-sm text-foreground">
+          <li className="rounded-lg border border-border p-3">
+            <strong>Readiness snapshot.</strong> Your current credential readiness from live source
+            checks, with every item labeled checked, gated, stale, or unknown — never guessed.
+          </li>
+          <li className="rounded-lg border border-border p-3">
+            <strong>Source-coverage summary.</strong> Exactly which primary sources were checked and
+            when, so a reviewer can see the provenance of every claim.
+          </li>
+          <li className="rounded-lg border border-border p-3">
+            <strong>Shareable proof link.</strong> A revocable link employers can open to review the
+            same evidence — acceptance stays their decision, on their timeline.
+          </li>
+          <li className="rounded-lg border border-border p-3">
+            <strong>Gap list with next steps.</strong> What is still blocking or stale, and the
+            concrete step that resolves each item.
+          </li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="honest-scope" className="mb-8">
+        <h2 id="honest-scope" className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          What this is — and is not
+        </h2>
+        <p className="mt-3 text-sm text-muted-foreground">
+          This is a readiness packet, not a credentialing decision. Employers and credentialing
+          teams always make their own acceptance decisions; the packet gives them source-backed
+          evidence to start from. Items we cannot check against a source are labeled that way
+          rather than claimed.
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This is a concierge engagement scoped with you over email — no payment is collected on
+          this site today.
+        </p>
+      </section>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Link
+          href="/contact?persona=concierge"
+          className="inline-flex items-center rounded-lg bg-foreground px-5 py-2.5 text-sm font-semibold text-background transition hover:opacity-90"
+        >
+          Request the concierge packet
+        </Link>
+        <Link href="/pricing" className="text-sm font-medium text-muted-foreground underline">
+          See how VitalCV prices pilots
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/contact/PilotIntakeForm.tsx
+++ b/apps/web/app/contact/PilotIntakeForm.tsx
@@ -12,6 +12,7 @@ const PERSONA_OPTIONS: ReadonlyArray<{ value: PilotIntakePersona; label: string 
   { value: 'staffing_exchange', label: 'Staffing Exchange / Locum Network' },
   { value: 'health_system', label: 'Hospital / Health System' },
   { value: 'individual_clinician', label: 'Individual Clinician' },
+  { value: 'concierge', label: 'Concierge — credential readiness packet' },
   { value: 'other', label: 'Other' },
 ];
 

--- a/apps/web/lib/leads/pilotLeadPersistence.ts
+++ b/apps/web/lib/leads/pilotLeadPersistence.ts
@@ -1,0 +1,111 @@
+import 'server-only';
+
+/**
+ * pilotLeadPersistence — Wave Q. Durable capture of commercial leads.
+ *
+ * Writes one PilotLead row plus its AuditEvent ('pilot.lead_captured') in a
+ * single transaction (audit-first rule). Deploy-order safe: if the table is
+ * not deployed yet or the DB hiccups, returns { persisted: false } and never
+ * throws — lead capture must keep working on Slack/stdout alone.
+ *
+ * Leads are operational CRM data, never evidence: no clinician credentials,
+ * no verification state, no trust-state inputs.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { prisma } from '@/lib/db';
+
+export interface PilotLeadInput {
+  source: 'pilot_request' | 'pilot_intake';
+  persona?: string | null;
+  organization: string;
+  contactName?: string | null;
+  email: string;
+  message?: string | null;
+  workflowTarget?: string | null;
+  sourceContext?: string | null;
+  /** Full sanitized submission / structured record for follow-up context. */
+  payload: unknown;
+  slackDelivered?: boolean;
+}
+
+export interface PilotLeadResult {
+  persisted: boolean;
+  leadId: string | null;
+}
+
+const clamp = (value: string | null | undefined, max: number): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, max) : null;
+};
+
+export async function persistPilotLead(input: PilotLeadInput): Promise<PilotLeadResult> {
+  const leadId = randomUUID();
+  const capturedAt = new Date().toISOString();
+  const organization = clamp(input.organization, 200) ?? 'Unknown organization';
+  const email = clamp(input.email, 320) ?? '';
+
+  const hash = createHash('sha256')
+    .update(
+      JSON.stringify({
+        capturedAt,
+        email,
+        leadId,
+        organization,
+        source: input.source,
+      }),
+    )
+    .digest('hex');
+
+  try {
+    await prisma.$transaction([
+      prisma.pilotLead.create({
+        data: {
+          id: leadId,
+          source: input.source,
+          persona: clamp(input.persona, 80),
+          organization,
+          contactName: clamp(input.contactName, 200),
+          email,
+          message: clamp(input.message, 4000),
+          workflowTarget: clamp(input.workflowTarget, 200),
+          sourceContext: clamp(input.sourceContext, 200),
+          payload: JSON.parse(JSON.stringify(input.payload ?? {})),
+          slackDelivered: input.slackDelivered ?? false,
+        },
+      }),
+      prisma.auditEvent.create({
+        data: {
+          id: randomUUID(),
+          type: 'pilot.lead_captured',
+          hash,
+          referenceId: leadId,
+          metadata: {
+            capturedAt,
+            leadId,
+            organization,
+            persona: clamp(input.persona, 80),
+            source: input.source,
+            sourceContext: clamp(input.sourceContext, 200),
+          },
+        },
+      }),
+    ]);
+    return { persisted: true, leadId };
+  } catch (err) {
+    console.error('[pilotLeadPersistence]', err);
+    // Slack/stdout remain the paper trail until the migration deploys.
+    return { persisted: false, leadId: null };
+  }
+}
+
+/** Best-effort operational-status update; the AuditEvent stays immutable. */
+export async function markPilotLeadSlackDelivered(leadId: string): Promise<void> {
+  try {
+    await prisma.pilotLead.update({
+      where: { id: leadId },
+      data: { slackDelivered: true },
+    });
+  } catch {
+    /* operational flag only — never surface an error for this */
+  }
+}

--- a/apps/web/lib/pilot-intake/validate.ts
+++ b/apps/web/lib/pilot-intake/validate.ts
@@ -22,6 +22,7 @@ export type PilotIntakePersona =
   | 'staffing_exchange'
   | 'health_system'
   | 'individual_clinician'
+  | 'concierge'
   | 'other';
 
 export interface PilotIntakeInput {
@@ -48,6 +49,7 @@ const ALLOWED_PERSONAS: ReadonlySet<PilotIntakePersona> = new Set([
   'staffing_exchange',
   'health_system',
   'individual_clinician',
+  'concierge',
   'other',
 ]);
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -96,6 +96,29 @@ model MatchaPreference {
   @@index([clerkUserId])
 }
 
+// Wave Q — durable commercial lead capture (mirror of the backend model;
+// migration lives in apps/api/backend/prisma/migrations/20260705120000_pilot_leads).
+// One row per submitted pilot request / pilot intake, paired with an
+// AuditEvent at insert. Operational CRM-lite, never evidence.
+model PilotLead {
+  id             String   @id @default(uuid()) @db.Uuid
+  source         String // pilot_request | pilot_intake
+  persona        String?
+  organization   String
+  contactName    String?
+  email          String
+  message        String?
+  workflowTarget String?
+  sourceContext  String?
+  payload        Json
+  slackDelivered Boolean  @default(false)
+  createdAt      DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([source, createdAt])
+  @@index([email])
+}
+
 // Wave K — clinician Save / Connect / Decline decisions on MATCHA
 // opportunities (mirror of the backend model; migration lives in
 // apps/api/backend/prisma/migrations/20260705000000_opportunity_actions).

--- a/docs/migrations/wave-q-pilot-leads.md
+++ b/docs/migrations/wave-q-pilot-leads.md
@@ -1,0 +1,51 @@
+# Wave Q — PilotLead (durable commercial lead capture)
+
+**Status:** SQL plan checked in; NOT executed. Lands via the standard
+`prisma migrate deploy` on the backend Railway service (same pending queue as
+the signup-gate and Wave K migrations). No `prisma migrate dev` was run.
+
+**Migration:** `apps/api/backend/prisma/migrations/20260705120000_pilot_leads/migration.sql`
+
+## What it adds
+
+One table, `PilotLead` — a durable row per submitted pilot request
+(`/pilot` → `POST /api/pilot-request`) or pilot intake
+(`/contact` → `POST /api/pilot-intake`), in addition to the existing Slack +
+stdout delivery, which stays.
+
+| column         | type          | notes                                        |
+| -------------- | ------------- | -------------------------------------------- |
+| id             | UUID PK       | generated client-side by Prisma (no DB default) |
+| source         | TEXT          | `pilot_request` \| `pilot_intake`            |
+| persona        | TEXT NULL     | intake persona (cvo, payer, …, concierge)    |
+| organization   | TEXT          | buyer organization name                      |
+| contactName    | TEXT NULL     |                                              |
+| email          | TEXT          | contact email                                |
+| message        | TEXT NULL     | free-text description                        |
+| workflowTarget | TEXT NULL     | e.g. "Credentialing review"                  |
+| sourceContext  | TEXT NULL     | originating surface (/pilot, /contact, …)    |
+| payload        | JSONB         | full sanitized submission / structured record |
+| slackDelivered | BOOLEAN       | operational delivery status (default false)  |
+| createdAt      | TIMESTAMP(3)  | insert time                                  |
+
+Indexes: `(createdAt)`, `(source, createdAt)`, `(email)`.
+
+## Invariants
+
+- **Audit-first.** Every insert is paired with an `AuditEvent`
+  (`type = 'pilot.lead_captured'`) in the same transaction.
+- **Never evidence.** Rows are buyer contact context only — no clinician
+  credentials, no verification state, no trust-state inputs.
+- **Deploy-order safe.** Until this migration deploys, both routes keep their
+  existing behavior (stdout + Slack) and report `persisted: false` — a missing
+  table never breaks lead capture.
+- `slackDelivered` is operational status and may be updated after insert; the
+  immutable trail is the AuditEvent.
+
+## Rollback
+
+```sql
+DROP TABLE IF EXISTS "PilotLead";
+```
+
+No other objects are created; nothing references the table by FK.


### PR DESCRIPTION
## Summary
- **Leads become durable** — new `PilotLead` table (backend schema source of truth + web mirror; migration checked in at `prisma/migrations/20260705120000_pilot_leads/`, **not run** — it joins the standard `migrate deploy` queue; plan + rollback in `docs/migrations/wave-q-pilot-leads.md`). Every insert pairs with an `AuditEvent` (`pilot.lead_captured`) in one transaction via the new `lib/leads/pilotLeadPersistence.ts`.
- **Both funnels wired** — `/api/pilot-intake` (contact form) persists **before** Slack delivery, so a crash mid-request can no longer lose the lead (`slackDelivered` is corrected after delivery; the AuditEvent stays immutable). `/api/pilot-request` (pilot page) writes the structured record it previously only returned — the wiring its own header comment deferred "to a separate wave". Both keep Slack + stdout behavior unchanged and degrade to `persisted:false` until the migration deploys — never a 500 in the funnel.
- **Concierge offer** — new public `/concierge` page: a truthfully-worded **credential readiness packet** offer (readiness snapshot with checked/gated/stale/unknown labeling, source-coverage summary, revocable share link, gap list). Explicitly states no payment is collected on the site today (`pricingFoundation` stays `collectsPayment:false`) and that employers always make their own acceptance decisions. CTA routes to `/contact?persona=concierge`; the intake enum + form gain the `concierge` persona (the form already preselects `?persona=` from the URL).
- **Internal leads view** — `/admin/leads`, ADMIN-gated with the exact `/admin/platform` pattern (Clerk `auth()` + `vitalcv.role === 'ADMIN'`, redirects otherwise), read-only newest-200 table with a deploy-order-safe pending state.

## Truth rules
- Leads are operational CRM data, never evidence — no clinician credentials, no verification state, no trust-state inputs.
- No payment or billing claims anywhere ("no payment is collected on this site today"); "credential readiness packet", never "credentialing complete"; no banned strings, no bare `Verified` (scan clean; the new test pins the honest copy in source).
- Capture paths never block the buyer: persistence failures degrade silently to the existing Slack/stdout trail with `persisted:false` reported honestly.

## Validation
- New suite `pilot-lead-persistence.test.tsx` **9/9**: lead+audit in one transaction (64-hex hash, `referenceId=leadId`), deploy-order degrade, persist-before-Slack ordering, Slack-failure durability, intake validation untouched, pilot-request record persistence, `concierge` persona accepted, concierge page honesty render + banned-claims source scan.
- Updated legacy suites for the intended response addition (`persisted` field): `pilot-intake-route` 6/6, `pilot-request-route` 7/7.
- Regression: `holder-route-contract` 150/150, `pilot-intake-validate`, `pilot-intake` all green (222 total in the run).
- `pnpm turbo run build --filter @vitalcv/web` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · truth scan clean.

## Design Handoff References
No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)