### PR TITLE
feat(evidence): Wave M — persisted reusable readiness snapshot (share once, reuse by many)

### DIFF
--- a/apps/api/backend/prisma/migrations/20260705150000_readiness_snapshots/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260705150000_readiness_snapshots/migration.sql
@@ -1,0 +1,29 @@
+-- Wave M — persisted reusable readiness snapshot ("verify once, reuse
+-- everywhere"). One immutable row per share-time issuance: readiness +
+-- canonical source-coverage report exactly as issued, pinned by contentHash.
+-- Freshness is recomputed at read time as an overlay and never written back.
+-- Revocation fails closed via the snapshot's own revokedAt or the linked
+-- bundle's revoked share. Zero PHI: readiness states, source ids, and
+-- timestamps only. `id` is generated client-side by Prisma (@default(uuid()))
+-- — no DB-level default, matching the fleet's Postgres (no gen_random_uuid).
+
+CREATE TABLE "ReadinessSnapshot" (
+    "id" UUID NOT NULL,
+    "npi" TEXT NOT NULL,
+    "entityId" UUID,
+    "bundleId" UUID,
+    "contentHash" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "scope" JSONB,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+    "revokedByClerkUserId" TEXT,
+
+    CONSTRAINT "ReadinessSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ReadinessSnapshot_npi_issuedAt_idx" ON "ReadinessSnapshot"("npi", "issuedAt");
+
+CREATE INDEX "ReadinessSnapshot_bundleId_idx" ON "ReadinessSnapshot"("bundleId");
+
+CREATE INDEX "ReadinessSnapshot_contentHash_idx" ON "ReadinessSnapshot"("contentHash");

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -701,6 +701,31 @@ model VerifierAccessToken {
   @@index([expiresAt])
 }
 
+/// Wave M — persisted reusable readiness snapshot: the share-once /
+/// reuse-by-many artifact. `content` is the readiness + canonical
+/// source-coverage report exactly as issued at share time and is IMMUTABLE
+/// (contentHash pins it); freshness is recomputed at read time as an overlay,
+/// never written back. Revocation: a snapshot fails closed when its own
+/// revokedAt is set OR when any BundleShareEvent for its bundleId is revoked
+/// (the clinician's existing share-revoke control). Zero PHI: readiness
+/// states, source ids, and timestamps only.
+model ReadinessSnapshot {
+  id                   String    @id @default(uuid()) @db.Uuid
+  npi                  String
+  entityId             String?   @db.Uuid
+  bundleId             String?   @db.Uuid
+  contentHash          String
+  content              Json
+  scope                Json?
+  issuedAt             DateTime  @default(now())
+  revokedAt            DateTime?
+  revokedByClerkUserId String?
+
+  @@index([npi, issuedAt])
+  @@index([bundleId])
+  @@index([contentHash])
+}
+
 model VerificationArtifact {
   id                          String                       @id @default(uuid()) @db.Uuid
   npi                         String

--- a/apps/api/backend/src/app.ts
+++ b/apps/api/backend/src/app.ts
@@ -175,6 +175,7 @@ import { registerTrustStateEngineRoutes } from './routes/trustStateEngine';     
 import { registerAsyncTrustRoutes } from './routes/asyncTrust';                      // Wave 245: Async Trust Engine
 import { startMonitoringScheduler } from './services/async/monitoringScheduler';    // Wave 245: Monitoring Scheduler
 import { registerApplyRoutes } from './routes/apply';                                // Wave 246: Apply-with-VitalCV
+import { registerReadinessSnapshotRoutes } from './routes/readinessSnapshot';         // Wave M: reusable readiness snapshots
 import { registerTrustDecisionRoutes } from './routes/trustDecision';               // Shape-of-Truth: 6-class decision engine
 import { registerSystemHealthRoutes } from './routes/systemHealth';                    // Wave 249: Trust Spine Hardening
 import { registerVelocityRoutes } from './routes/velocity';                              // Wave 250: Time-to-Start Velocity Dashboard
@@ -3628,6 +3629,7 @@ if (BACKGROUND_JOBS_ENABLED) {
   startStrategyAgentScheduler();         // FE21-A — Strategy agent scheduler heartbeat
 }
 registerApplyRoutes(app);                // Wave 246 — Apply-with-VitalCV Distribution Wedge
+registerReadinessSnapshotRoutes(app);    // Wave M — share-once / reuse-by-many readiness snapshots
 registerTrustDecisionRoutes(app);       // Shape-of-Truth — 6-class trust decision engine
 registerSystemHealthRoutes(app);         // Wave 249 — Trust Spine Hardening
 registerVelocityRoutes(app);             // Wave 250 — Time-to-Start Velocity Dashboard

--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -67,6 +67,10 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/marketplace/pool')).toBe(false);
   });
 
+  it('skips tenant context for public readiness-snapshot reads (Wave M)', () => {
+    expect(shouldSkipTenantContext('/api/snapshot/11111111-1111-4111-8111-111111111111')).toBe(true);
+  });
+
   it('allows the trust-proof read through without organization context', () => {
     const req = createRequest('/api/trust-proof/1003000126');
     const res = createResponse();

--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -87,6 +87,9 @@ export function shouldSkipTenantContext(path: string): boolean {
     || normalized.startsWith('/api/passport/')
     || normalized.startsWith('/api/employer-review/')
     || normalized.startsWith('/api/apply/')
+    // Wave M: persisted readiness snapshots — public verifier reads by
+    // capability id (every access audited; revoked fails closed in-route).
+    || normalized.startsWith('/api/snapshot/')
     || normalized.startsWith('/api/trust-state/')
     || normalized.startsWith('/api/trust-decision/')
     || normalized.startsWith('/api/trust-proof/')

--- a/apps/api/backend/src/routes/__tests__/readinessSnapshot.test.ts
+++ b/apps/api/backend/src/routes/__tests__/readinessSnapshot.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Wave M — persisted reusable readiness snapshot.
+ *
+ * Pins the contract:
+ *  - the stored content is served VERBATIM with a stable contentHash;
+ *  - freshness is a read-time overlay (stale-beyond-SLA labeled + re-verify
+ *    recommended), never a mutation of the snapshot;
+ *  - every successful read writes `snapshot.accessed`; revoked snapshots —
+ *    directly or via a revoked share of the linked bundle — fail closed with
+ *    410 and a `snapshot.access_denied` audit;
+ *  - issuance is deploy-order safe (missing table → null, share unaffected)
+ *    and hash generation is deterministic for identical content.
+ */
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../graphql/prisma_client', () => ({
+  __esModule: true,
+  default: {
+    readinessSnapshot: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    bundleShareEvent: {
+      findFirst: jest.fn(),
+    },
+    auditEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../obs/logger', () => ({ log: jest.fn() }));
+
+import prisma from '../../graphql/prisma_client';
+import { registerReadinessSnapshotRoutes } from '../readinessSnapshot';
+import {
+  buildFreshnessOverlay,
+  issueReadinessSnapshot,
+  type ReadinessSnapshotContent,
+} from '../../services/distribution/readinessSnapshotService';
+
+const SNAPSHOT_ID = '11111111-1111-4111-8111-111111111111';
+const BUNDLE_ID = '22222222-2222-4222-8222-222222222222';
+
+const prismaMock = prisma as unknown as {
+  readinessSnapshot: { findUnique: jest.Mock; create: jest.Mock };
+  bundleShareEvent: { findFirst: jest.Mock };
+  auditEvent: { create: jest.Mock };
+};
+
+function buildApp() {
+  const app = express();
+  registerReadinessSnapshotRoutes(app);
+  return app;
+}
+
+function contentFixture(overrides?: Partial<ReadinessSnapshotContent>): ReadinessSnapshotContent {
+  return {
+    schema: 'vitalcv.readiness-snapshot.v1',
+    npi: '1003000126',
+    bundleId: BUNDLE_ID,
+    issuedAt: '2026-07-01T00:00:00.000Z',
+    readiness: { level: 'L2', score: 78, status: 'PARTIAL', checkedAt: '2026-07-01T00:00:00.000Z' },
+    sourceCoverage: {
+      checks: [
+        // NPPES-style 24h window, checked long ago → stale at read time.
+        { sourceId: 'NPPES_API', state: 'checked', checkedAt: '2026-07-01T00:00:00.000Z', freshnessWindowHours: 24 },
+        // Long-window source, still current.
+        { sourceId: 'PECOS', state: 'checked', checkedAt: '2026-07-01T00:00:00.000Z', freshnessWindowHours: 100_000 },
+        // No timestamp — freshness cannot be evaluated, reported as such.
+        { sourceId: 'MANUAL_UPLOAD', state: 'gated', checkedAt: null },
+      ],
+      summary: { checked: ['NPPES_API', 'PECOS'], gated: ['MANUAL_UPLOAD'] },
+    },
+    ...overrides,
+  };
+}
+
+function rowFixture(overrides?: Record<string, unknown>) {
+  return {
+    id: SNAPSHOT_ID,
+    npi: '1003000126',
+    entityId: null,
+    bundleId: BUNDLE_ID,
+    contentHash: 'hash-fixture',
+    content: contentFixture(),
+    scope: { organizationName: 'Mercy General', purposeOfUse: 'Employment consideration' },
+    issuedAt: new Date('2026-07-01T00:00:00.000Z'),
+    revokedAt: null,
+    revokedByClerkUserId: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prismaMock.bundleShareEvent.findFirst.mockResolvedValue(null);
+  prismaMock.auditEvent.create.mockResolvedValue({ id: 'audit-1' });
+});
+
+describe('GET /api/snapshot/:id', () => {
+  it('404s malformed and unknown ids without an audit row', async () => {
+    prismaMock.readinessSnapshot.findUnique.mockResolvedValue(null);
+    const app = buildApp();
+
+    expect((await request(app).get('/api/snapshot/not-a-uuid')).status).toBe(404);
+    expect((await request(app).get(`/api/snapshot/${SNAPSHOT_ID}`)).status).toBe(404);
+    expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('serves the content verbatim with a stable hash, a freshness overlay, and an access audit', async () => {
+    prismaMock.readinessSnapshot.findUnique.mockResolvedValue(rowFixture());
+
+    const response = await request(buildApp()).get(`/api/snapshot/${SNAPSHOT_ID}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.contentHash).toBe('hash-fixture');
+    // Verbatim: the stored content travels unmodified.
+    expect(response.body.snapshot).toEqual(contentFixture());
+
+    // Read-time overlay: 24h-window source checked in the past is stale;
+    // the long-window source is not; the timestampless one is unevaluated.
+    const freshness = response.body.freshness;
+    expect(freshness.staleSources.map((s: { sourceId: string }) => s.sourceId)).toEqual(['NPPES_API']);
+    expect(freshness.unevaluatedSources).toEqual(['MANUAL_UPLOAD']);
+    expect(freshness.reverifyRecommended).toBe(true);
+    expect(freshness.note).toContain('as issued');
+
+    // Every access audited.
+    expect(prismaMock.auditEvent.create).toHaveBeenCalledTimes(1);
+    const audit = prismaMock.auditEvent.create.mock.calls[0][0].data;
+    expect(audit.type).toBe('snapshot.accessed');
+    expect(audit.referenceId).toBe(SNAPSHOT_ID);
+    expect(audit.clinicianId).toBe('1003000126');
+    expect(audit.metadata).toMatchObject({ staleSourceCount: 1, reverifyRecommended: true });
+  });
+
+  it('reports a fully-current snapshot without a re-verify flag', async () => {
+    const current = contentFixture({
+      sourceCoverage: {
+        checks: [{ sourceId: 'PECOS', state: 'checked', checkedAt: new Date().toISOString(), freshnessWindowHours: 744 }],
+        summary: { checked: ['PECOS'] },
+      },
+    });
+    prismaMock.readinessSnapshot.findUnique.mockResolvedValue(rowFixture({ content: current }));
+
+    const response = await request(buildApp()).get(`/api/snapshot/${SNAPSHOT_ID}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.freshness.staleSources).toEqual([]);
+    expect(response.body.freshness.reverifyRecommended).toBe(false);
+  });
+
+  it('fails closed with 410 and a denied audit when the snapshot itself is revoked', async () => {
+    prismaMock.readinessSnapshot.findUnique.mockResolvedValue(
+      rowFixture({ revokedAt: new Date('2026-07-04T00:00:00.000Z') }),
+    );
+
+    const response = await request(buildApp()).get(`/api/snapshot/${SNAPSHOT_ID}`);
+
+    expect(response.status).toBe(410);
+    expect(response.body.error).toBe('snapshot_revoked');
+    expect(response.body.snapshot).toBeUndefined();
+    const audit = prismaMock.auditEvent.create.mock.calls[0][0].data;
+    expect(audit.type).toBe('snapshot.access_denied');
+    expect(audit.metadata).toMatchObject({ reason: 'revoked' });
+  });
+
+  it("fails closed when the linked bundle's share was revoked (the clinician's existing control)", async () => {
+    prismaMock.readinessSnapshot.findUnique.mockResolvedValue(rowFixture());
+    prismaMock.bundleShareEvent.findFirst.mockResolvedValue({
+      revokedAt: new Date('2026-07-04T12:00:00.000Z'),
+    });
+
+    const response = await request(buildApp()).get(`/api/snapshot/${SNAPSHOT_ID}`);
+
+    expect(response.status).toBe(410);
+    expect(prismaMock.bundleShareEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { bundleId: BUNDLE_ID, revokedAt: { not: null } } }),
+    );
+    expect(prismaMock.auditEvent.create.mock.calls[0][0].data.type).toBe('snapshot.access_denied');
+  });
+});
+
+describe('issueReadinessSnapshot', () => {
+  const issueInput = {
+    npi: '1003000126',
+    bundleId: BUNDLE_ID,
+    readiness: { level: 'L2', score: 78, status: 'PARTIAL', checkedAt: '2026-07-01T00:00:00.000Z' },
+    sourceCoverage: { checks: [], summary: {} },
+  };
+
+  it('persists an immutable row with a sha256 content hash', async () => {
+    prismaMock.readinessSnapshot.create.mockResolvedValue({});
+
+    const issued = await issueReadinessSnapshot(issueInput);
+
+    expect(issued).not.toBeNull();
+    expect(issued!.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    const data = prismaMock.readinessSnapshot.create.mock.calls[0][0].data;
+    expect(data.id).toBe(issued!.snapshotId);
+    expect(data.contentHash).toBe(issued!.contentHash);
+    expect(data.content.schema).toBe('vitalcv.readiness-snapshot.v1');
+  });
+
+  it('degrades to null when the table is not deployed yet — the share must proceed', async () => {
+    prismaMock.readinessSnapshot.create.mockRejectedValue(new Error('P2021: table does not exist'));
+    await expect(issueReadinessSnapshot(issueInput)).resolves.toBeNull();
+  });
+});
+
+describe('buildFreshnessOverlay — hash-stable, mutation-free', () => {
+  it('falls back to the live source catalog when the check has no captured window', () => {
+    const content = contentFixture({
+      sourceCoverage: {
+        // NPPES catalog SLA is 24h — checked years ago, no captured window.
+        checks: [{ sourceId: 'NPPES_API', state: 'checked', checkedAt: '2026-01-01T00:00:00.000Z' }],
+        summary: { checked: ['NPPES_API'] },
+      },
+    });
+    const overlay = buildFreshnessOverlay(content, new Date('2026-07-05T00:00:00.000Z'));
+    expect(overlay.staleSources).toHaveLength(1);
+    expect(overlay.staleSources[0].freshnessWindowHours).toBeGreaterThan(0);
+  });
+
+  it('never mutates the content it evaluates', () => {
+    const content = contentFixture();
+    const before = JSON.stringify(content);
+    buildFreshnessOverlay(content, new Date('2026-07-05T00:00:00.000Z'));
+    expect(JSON.stringify(content)).toBe(before);
+  });
+});

--- a/apps/api/backend/src/routes/readinessSnapshot.ts
+++ b/apps/api/backend/src/routes/readinessSnapshot.ts
@@ -1,0 +1,133 @@
+/**
+ * readinessSnapshot.ts — Wave M.
+ *
+ * GET /api/snapshot/:id — the reuse route for a persisted readiness snapshot.
+ * Served to any number of reviewers via the capability id.
+ *
+ * AUDIT CONTRACT: every read writes an AuditEvent before the response —
+ * `snapshot.accessed` on success, `snapshot.access_denied` on fail-closed
+ * reads (revoked). Unknown ids 404 without an audit row (nothing exists to
+ * attribute the access to).
+ *
+ * Honesty: the stored content travels verbatim ("as issued"); a read-time
+ * freshness overlay labels stale-beyond-SLA sources and recommends
+ * re-verification. Revoked fails closed with no content.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Express, NextFunction, Request, Response } from 'express';
+import type { Prisma } from '@prisma/client';
+import prisma from '../graphql/prisma_client';
+import { log } from '../obs/logger';
+import { sha256ForPayload } from '../utils/deterministic';
+import { loadReadinessSnapshotForServing } from '../services/distribution/readinessSnapshotService';
+
+function toJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
+  return (req: Request, res: Response, next: NextFunction) => fn(req, res, next).catch(next);
+}
+
+function requesterContext(req: Request): Record<string, unknown> {
+  return {
+    correlationId: req.get('x-correlation-id')?.trim()?.slice(0, 120) || randomUUID(),
+    requesterOrgId: req.get('x-org-id')?.trim()?.slice(0, 120) || null,
+    requesterClerkUserId: (req.headers['x-clerk-user-id'] as string | undefined)?.trim() || null,
+  };
+}
+
+async function writeSnapshotAccessAudit(input: {
+  type: 'snapshot.accessed' | 'snapshot.access_denied';
+  snapshotId: string;
+  npi: string | null;
+  metadata: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await prisma.auditEvent.create({
+      data: {
+        id: randomUUID(),
+        type: input.type,
+        hash: sha256ForPayload({
+          type: input.type,
+          snapshotId: input.snapshotId,
+          metadata: input.metadata,
+        }),
+        referenceId: input.snapshotId,
+        clinicianId: input.npi,
+        metadata: toJsonValue(input.metadata),
+      },
+    });
+  } catch (err) {
+    // The audit row is the point of the access log — surface loudly, but a
+    // read must not 500 because the audit insert hiccuped.
+    log('error', 'snapshot_access_audit_failed', {
+      snapshotId: input.snapshotId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export function registerReadinessSnapshotRoutes(app: Express): void {
+  app.get(
+    '/api/snapshot/:id',
+    asyncHandler(async (req, res) => {
+      const { id } = req.params;
+      if (!id || !UUID_RE.test(id)) {
+        return void res.status(404).json({ error: 'snapshot_not_found' });
+      }
+
+      const context = requesterContext(req);
+      const result = await loadReadinessSnapshotForServing(id);
+
+      if (result.outcome === 'not_found') {
+        return void res.status(404).json({ error: 'snapshot_not_found' });
+      }
+
+      if (result.outcome === 'revoked') {
+        await writeSnapshotAccessAudit({
+          type: 'snapshot.access_denied',
+          snapshotId: id,
+          npi: null,
+          metadata: { ...context, reason: 'revoked', revokedAt: result.revokedAt },
+        });
+        return void res.status(410).json({
+          error: 'snapshot_revoked',
+          error_description:
+            'The clinician revoked this share. The snapshot fails closed and serves no content.',
+        });
+      }
+
+      await writeSnapshotAccessAudit({
+        type: 'snapshot.accessed',
+        snapshotId: result.snapshotId,
+        npi: result.npi,
+        metadata: {
+          ...context,
+          bundleId: result.bundleId,
+          contentHash: result.contentHash,
+          staleSourceCount: result.freshness.staleSources.length,
+          reverifyRecommended: result.freshness.reverifyRecommended,
+        },
+      });
+
+      return void res.status(200).json({
+        ok: true,
+        snapshotId: result.snapshotId,
+        npi: result.npi,
+        bundleId: result.bundleId,
+        issuedAt: result.issuedAt,
+        contentHash: result.contentHash,
+        // As issued — immutable; compare contentHash across reads.
+        snapshot: result.content,
+        scope: result.scope,
+        // Read-time overlay — never written back to the snapshot.
+        freshness: result.freshness,
+        accessNote: 'Every access to this snapshot is recorded in the audit log.',
+      });
+    }),
+  );
+}

--- a/apps/api/backend/src/services/distribution/applyShareService.ts
+++ b/apps/api/backend/src/services/distribution/applyShareService.ts
@@ -20,6 +20,7 @@ import prisma from '../../graphql/prisma_client';
 import { generateApplyBundle, type ApplyBundle } from './applyBundle';
 import { appendAuditEvent } from '../audit/auditLedger';
 import { buildEmployerReviewPayload, employerReviewPayloadToJson } from '../entity/employerReviewPayload';
+import { issueReadinessSnapshot } from './readinessSnapshotService';
 import { getNotificationProvider } from '../providers/notificationProvider';
 import { log } from '../../obs/logger';
 
@@ -51,6 +52,9 @@ export interface ShareResult {
   bundleUrl: string;
   webhookDelivered: boolean;
   emailSent: boolean;
+  /** Wave M — the persisted reusable readiness snapshot issued with this share (null until the migration deploys or when no canonical coverage exists). */
+  readinessSnapshotId: string | null;
+  readinessSnapshotPath: string | null;
 }
 
 export interface ShareListEntry {
@@ -298,6 +302,30 @@ export async function shareBundle(
     status = 'logged_only';
   }
 
+  // 4.5 Issue the persisted readiness snapshot (Wave M) — the reusable
+  // evidence artifact this share travels with. Only issued when the
+  // canonical review payload exists (no payload → no coverage to snapshot).
+  // Deploy-order safe: degrades to null and the share proceeds unchanged.
+  const issuedSnapshot = reviewPayload
+    ? await issueReadinessSnapshot({
+        npi,
+        entityId: subjectEntity?.id ?? null,
+        bundleId: bundle.bundleId,
+        scope: {
+          organizationId: orgContext.organization_id,
+          organizationName: orgContext.name,
+          purposeOfUse: orgContext.purpose_of_use,
+        },
+        readiness: {
+          level: reviewPayload.readinessSummary.level,
+          score: reviewPayload.readinessSummary.score,
+          status: reviewPayload.readinessSummary.status,
+          checkedAt: reviewPayload.checkedAt,
+        },
+        sourceCoverage: reviewPayload.sourceCoverage,
+      })
+    : null;
+
   // 5. Persist BundleShareEvent
   const credentialsSummary = bundle.credentials.map((c) => ({
     type: c.type,
@@ -330,7 +358,15 @@ export async function shareBundle(
           ? 'MANUAL_FALLBACK'
           : 'FAILED',
       checkedAt: reviewPayload ? new Date(reviewPayload.checkedAt) : new Date(),
-      bundlePayload: reviewPayload ? employerReviewPayloadToJson(reviewPayload) : undefined,
+      bundlePayload: reviewPayload
+        ? ({
+            ...(employerReviewPayloadToJson(reviewPayload) as Record<string, unknown>),
+            // Wave M: the same evidence travels — reviewers can open the
+            // persisted snapshot this share was issued with.
+            readinessSnapshotId: issuedSnapshot?.snapshotId ?? null,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any)
+        : undefined,
       receiptRefs: reviewPayload?.receiptReferences ?? [],
       sourceCoverage: reviewPayload ? employerReviewPayloadToJson(reviewPayload.sourceCoverage) : undefined,
       expiresAt: new Date(bundle.expiresAt),
@@ -386,6 +422,8 @@ export async function shareBundle(
     bundleUrl,
     webhookDelivered: webhookResult.delivered,
     emailSent: emailResult.sent,
+    readinessSnapshotId: issuedSnapshot?.snapshotId ?? null,
+    readinessSnapshotPath: issuedSnapshot ? `/snapshot/${issuedSnapshot.snapshotId}` : null,
   };
 }
 

--- a/apps/api/backend/src/services/distribution/readinessSnapshotService.ts
+++ b/apps/api/backend/src/services/distribution/readinessSnapshotService.ts
@@ -1,0 +1,254 @@
+/**
+ * readinessSnapshotService — Wave M. The share-once / reuse-by-many readiness
+ * artifact.
+ *
+ * Issued at apply-share time: `content` captures the readiness summary and
+ * the canonical source-coverage report EXACTLY as they were at issuance, and
+ * `contentHash` (sha256 over the canonical JSON) pins it — the row is never
+ * updated. Freshness against each source's refresh SLA is recomputed at read
+ * time as an overlay in the response; stale data is labeled stale, never
+ * silently served as current and never rewritten.
+ *
+ * Fail-closed rules: a revoked snapshot — its own revokedAt, or any revoked
+ * BundleShareEvent for the linked bundle (the clinician's existing
+ * share-revoke control) — serves nothing. Deploy-order safe: issuance
+ * degrades to null until the migration deploys; sharing proceeds unchanged.
+ *
+ * Zero PHI: readiness states, source ids, and timestamps only.
+ */
+
+import { randomUUID } from 'node:crypto';
+import prisma from '../../graphql/prisma_client';
+import { log } from '../../obs/logger';
+import { sha256ForPayload } from '../../utils/deterministic';
+import { getSourceFreshnessWindowHours } from '../identity/sourceCatalog';
+
+export interface ReadinessSnapshotContent {
+  schema: 'vitalcv.readiness-snapshot.v1';
+  npi: string;
+  bundleId: string | null;
+  issuedAt: string;
+  readiness: {
+    level: string;
+    score: number;
+    status: string;
+    checkedAt: string;
+  };
+  sourceCoverage: unknown; // CanonicalSourceCoverageReport, stored verbatim
+}
+
+export interface IssueReadinessSnapshotInput {
+  npi: string;
+  entityId?: string | null;
+  bundleId?: string | null;
+  scope?: {
+    organizationId?: string;
+    organizationName?: string;
+    purposeOfUse?: string;
+  } | null;
+  readiness: { level: string; score: number; status: string; checkedAt: string };
+  sourceCoverage: unknown;
+}
+
+export interface IssuedReadinessSnapshot {
+  snapshotId: string;
+  contentHash: string;
+}
+
+function toPlainJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Persist one immutable snapshot row. Returns null (and never throws) when
+ * the table is not deployed yet or the DB hiccups — the share flow must not
+ * break on snapshot issuance.
+ */
+export async function issueReadinessSnapshot(
+  input: IssueReadinessSnapshotInput,
+): Promise<IssuedReadinessSnapshot | null> {
+  const snapshotId = randomUUID();
+  const issuedAt = new Date().toISOString();
+
+  const content: ReadinessSnapshotContent = toPlainJson({
+    schema: 'vitalcv.readiness-snapshot.v1',
+    npi: input.npi,
+    bundleId: input.bundleId ?? null,
+    issuedAt,
+    readiness: input.readiness,
+    sourceCoverage: input.sourceCoverage,
+  });
+  const contentHash = sha256ForPayload(content);
+
+  try {
+    await prisma.readinessSnapshot.create({
+      data: {
+        id: snapshotId,
+        npi: input.npi,
+        entityId: input.entityId ?? null,
+        bundleId: input.bundleId ?? null,
+        contentHash,
+        content: content as object,
+        scope: input.scope ? toPlainJson(input.scope) : undefined,
+      },
+    });
+    log('info', 'readiness_snapshot_issued', {
+      snapshotId,
+      bundleId: input.bundleId ?? null,
+      npi_prefix: input.npi.slice(0, 4) + '····',
+      contentHash,
+    });
+    return { snapshotId, contentHash };
+  } catch (err) {
+    log('warn', 'readiness_snapshot_issue_degraded', {
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// ── Read-time freshness overlay ──────────────────────────────────────────────
+
+export interface SnapshotStaleSource {
+  sourceId: string;
+  checkedAt: string;
+  freshnessWindowHours: number;
+  hoursSinceChecked: number;
+}
+
+export interface SnapshotFreshnessOverlay {
+  evaluatedAt: string;
+  /** Sources whose checkedAt is beyond their refresh SLA. */
+  staleSources: SnapshotStaleSource[];
+  /** Sources issued without a checkedAt — freshness cannot be evaluated. */
+  unevaluatedSources: string[];
+  reverifyRecommended: boolean;
+  note: string;
+}
+
+interface CoverageCheckLike {
+  sourceId?: unknown;
+  checkedAt?: unknown;
+  freshnessWindowHours?: unknown;
+}
+
+function coverageChecks(sourceCoverage: unknown): CoverageCheckLike[] {
+  if (!sourceCoverage || typeof sourceCoverage !== 'object') return [];
+  const checks = (sourceCoverage as { checks?: unknown }).checks;
+  return Array.isArray(checks) ? (checks as CoverageCheckLike[]) : [];
+}
+
+/**
+ * Evaluate the snapshot's source checks against each source's refresh SLA
+ * (freshnessWindowHours captured at issue time, else the live catalog). Pure
+ * read-time computation — the stored content is never modified.
+ */
+export function buildFreshnessOverlay(
+  content: ReadinessSnapshotContent,
+  now: Date = new Date(),
+): SnapshotFreshnessOverlay {
+  const staleSources: SnapshotStaleSource[] = [];
+  const unevaluatedSources: string[] = [];
+
+  for (const check of coverageChecks(content.sourceCoverage)) {
+    const sourceId = typeof check.sourceId === 'string' ? check.sourceId : null;
+    if (!sourceId) continue;
+
+    const checkedAtRaw = typeof check.checkedAt === 'string' ? check.checkedAt : null;
+    if (!checkedAtRaw) {
+      unevaluatedSources.push(sourceId);
+      continue;
+    }
+    const checkedAt = new Date(checkedAtRaw);
+    if (Number.isNaN(checkedAt.getTime())) {
+      unevaluatedSources.push(sourceId);
+      continue;
+    }
+
+    const windowHours =
+      typeof check.freshnessWindowHours === 'number' && check.freshnessWindowHours > 0
+        ? check.freshnessWindowHours
+        : getSourceFreshnessWindowHours(sourceId);
+    const hoursSinceChecked = (now.getTime() - checkedAt.getTime()) / 3_600_000;
+
+    if (hoursSinceChecked > windowHours) {
+      staleSources.push({
+        sourceId,
+        checkedAt: checkedAtRaw,
+        freshnessWindowHours: windowHours,
+        hoursSinceChecked: Math.round(hoursSinceChecked * 10) / 10,
+      });
+    }
+  }
+
+  const reverifyRecommended = staleSources.length > 0;
+  return {
+    evaluatedAt: now.toISOString(),
+    staleSources,
+    unevaluatedSources,
+    reverifyRecommended,
+    note: reverifyRecommended
+      ? `${staleSources.length} source check${staleSources.length === 1 ? ' is' : 's are'} past the refresh window. This snapshot shows evidence as issued — request a refreshed share before relying on the stale items.`
+      : 'All source checks in this snapshot are within their refresh windows as of this read.',
+  };
+}
+
+// ── Serving ──────────────────────────────────────────────────────────────────
+
+export type SnapshotServeResult =
+  | { outcome: 'not_found' }
+  | { outcome: 'revoked'; revokedAt: string | null }
+  | {
+      outcome: 'ok';
+      snapshotId: string;
+      npi: string;
+      bundleId: string | null;
+      issuedAt: string;
+      contentHash: string;
+      content: ReadinessSnapshotContent;
+      scope: unknown;
+      freshness: SnapshotFreshnessOverlay;
+    };
+
+/**
+ * Load a snapshot for serving: fail closed on unknown ids, direct revocation,
+ * and revocation of any share of the linked bundle. Attaches the read-time
+ * freshness overlay; the stored content travels verbatim.
+ */
+export async function loadReadinessSnapshotForServing(
+  snapshotId: string,
+  now: Date = new Date(),
+): Promise<SnapshotServeResult> {
+  const row = await prisma.readinessSnapshot.findUnique({ where: { id: snapshotId } });
+  if (!row) return { outcome: 'not_found' };
+
+  if (row.revokedAt) {
+    return { outcome: 'revoked', revokedAt: row.revokedAt.toISOString() };
+  }
+
+  if (row.bundleId) {
+    const revokedShare = await prisma.bundleShareEvent.findFirst({
+      where: { bundleId: row.bundleId, revokedAt: { not: null } },
+      select: { revokedAt: true },
+    });
+    if (revokedShare) {
+      return {
+        outcome: 'revoked',
+        revokedAt: revokedShare.revokedAt?.toISOString() ?? null,
+      };
+    }
+  }
+
+  const content = row.content as unknown as ReadinessSnapshotContent;
+  return {
+    outcome: 'ok',
+    snapshotId: row.id,
+    npi: row.npi,
+    bundleId: row.bundleId,
+    issuedAt: row.issuedAt.toISOString(),
+    contentHash: row.contentHash,
+    content,
+    scope: row.scope ?? null,
+    freshness: buildFreshnessOverlay(content, now),
+  };
+}

--- a/apps/web/__tests__/snapshot-page.test.tsx
+++ b/apps/web/__tests__/snapshot-page.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Wave M — public readiness-snapshot viewer.
+ *
+ * Pins the honesty contract on the surface: content renders AS ISSUED with
+ * the stable content hash, stale sources are labeled with a re-verify
+ * recommendation (never silently current), revoked snapshots fail closed
+ * with no content, and the copy never claims live verification or a
+ * credentialing decision.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SnapshotPage from '../app/snapshot/[id]/page';
+
+const SNAPSHOT_ID = '11111111-1111-4111-8111-111111111111';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const HAPPY_PAYLOAD = {
+  ok: true,
+  snapshotId: SNAPSHOT_ID,
+  npi: '1003000126',
+  issuedAt: '2026-07-01T00:00:00.000Z',
+  contentHash: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+  snapshot: {
+    readiness: { level: 'L2', score: 78, status: 'PARTIAL', checkedAt: '2026-07-01T00:00:00.000Z' },
+    sourceCoverage: {
+      checks: [
+        { sourceId: 'NPPES_API', state: 'checked', checkedAt: '2026-07-01T00:00:00.000Z' },
+        { sourceId: 'PECOS', state: 'checked', checkedAt: '2026-07-04T00:00:00.000Z' },
+      ],
+    },
+  },
+  scope: { organizationName: 'Mercy General', purposeOfUse: 'Employment consideration' },
+  freshness: {
+    evaluatedAt: '2026-07-05T00:00:00.000Z',
+    staleSources: [{ sourceId: 'NPPES_API', checkedAt: '2026-07-01T00:00:00.000Z', freshnessWindowHours: 24 }],
+    unevaluatedSources: [],
+    reverifyRecommended: true,
+    note: '1 source check is past the refresh window. This snapshot shows evidence as issued — request a refreshed share before relying on the stale items.',
+  },
+};
+
+async function renderPage() {
+  return renderToStaticMarkup(await SnapshotPage({ params: Promise.resolve({ id: SNAPSHOT_ID }) }));
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  process.env.BACKEND_URL = 'http://backend.test';
+});
+
+describe('/snapshot/[id] — as-issued rendering with read-time staleness', () => {
+  it('renders the snapshot as issued: hash pin, readiness, per-source last-checked, stale labels', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(HAPPY_PAYLOAD)));
+
+    const markup = await renderPage();
+
+    expect(markup).toContain('Readiness snapshot — as issued');
+    expect(markup).toContain('NPI 1003000126');
+    expect(markup).toContain('identical on every read');
+    expect(markup).toContain('L2 · 78/100');
+    expect(markup).toContain('NPPES_API');
+    expect(markup).toContain('stale — re-verify before relying on this');
+    expect(markup).toContain('request a refreshed share');
+    // PECOS is current — exactly one stale badge.
+    expect(markup.match(/re-verify before relying on this/g)).toHaveLength(1);
+    expect(markup).toContain('not a live verification');
+    expect(markup).toContain('recorded in the audit log');
+  });
+
+  it('fails closed on revoked snapshots — no content, honest copy', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ error: 'snapshot_revoked' }, 410)),
+    );
+
+    const markup = await renderPage();
+
+    expect(markup).toContain('This snapshot was revoked');
+    expect(markup).toContain('fail closed');
+    expect(markup).not.toContain('NPPES_API');
+    expect(markup).not.toContain('L2');
+  });
+
+  it('renders an honest system-state panel when the backend is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const markup = await renderPage();
+
+    expect(markup).toContain('temporarily unavailable');
+    expect(markup).toContain('nothing about the snapshot changed');
+  });
+});
+
+describe('snapshot surface — truth-contract source pins', () => {
+  it('keeps banned claims out of the viewer and the backend snapshot service', () => {
+    for (const relPath of [
+      '../app/snapshot/[id]/page.tsx',
+      '../../api/backend/src/services/distribution/readinessSnapshotService.ts',
+      '../../api/backend/src/routes/readinessSnapshot.ts',
+    ]) {
+      const source = readFileSync(join(__dirname, relPath), 'utf8');
+      expect(source).not.toMatch(
+        /automatically verified|guaranteed verification|complete credentialing|instant credentialing|certified compliant|legally accepted/i,
+      );
+      expect(source).not.toMatch(/label:\s*['"]Verified['"]/);
+    }
+  });
+});

--- a/apps/web/app/api/snapshot/[id]/route.ts
+++ b/apps/web/app/api/snapshot/[id]/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /api/snapshot/[id] — Wave M. Public proxy for the persisted readiness
+ * snapshot reuse route. Serves any reviewer holding the capability id; the
+ * backend writes an AuditEvent for every access and fails closed on revoked
+ * snapshots. No auth is required — possession of the id IS the grant, same
+ * posture as the apply bundle link.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: 'snapshot_not_found' }, { status: 404 });
+  }
+
+  try {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    const orgId = req.headers.get('x-org-id')?.trim();
+    if (orgId) headers['x-org-id'] = orgId;
+
+    const response = await fetch(`${BACKEND}/api/snapshot/${id}`, {
+      headers,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15_000),
+    });
+    const payload = await response.json().catch(() => ({ error: 'Invalid response from backend' }));
+    return NextResponse.json(payload, { status: response.status });
+  } catch (error) {
+    console.error('[snapshot proxy]', error);
+    return NextResponse.json(
+      { error: 'backend_unavailable', error_description: 'Snapshot service is unavailable.' },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/app/snapshot/[id]/page.tsx
+++ b/apps/web/app/snapshot/[id]/page.tsx
@@ -1,0 +1,210 @@
+/**
+ * /snapshot/[id] — Wave M. Public viewer for a persisted readiness snapshot:
+ * the share-once / reuse-by-many evidence artifact.
+ *
+ * Honesty rules on this surface:
+ *  - the content renders AS ISSUED (immutable, pinned by contentHash);
+ *  - a read-time freshness overlay labels every source check past its
+ *    refresh window as stale and recommends requesting a refreshed share —
+ *    stale data is never presented as current;
+ *  - revoked snapshots fail closed with no content;
+ *  - every access is written to the audit log by the backend.
+ */
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Readiness snapshot — VitalCV',
+  description:
+    'A source-backed readiness snapshot, served as issued with read-time freshness labeling.',
+};
+
+const BACKEND =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:4000';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface CoverageCheck {
+  sourceId?: string;
+  state?: string;
+  checkedAt?: string | null;
+}
+
+interface SnapshotPayload {
+  ok: boolean;
+  snapshotId: string;
+  npi: string;
+  issuedAt: string;
+  contentHash: string;
+  snapshot: {
+    readiness?: { level?: string; score?: number; status?: string; checkedAt?: string };
+    sourceCoverage?: { checks?: CoverageCheck[] };
+  };
+  scope?: { organizationName?: string; purposeOfUse?: string } | null;
+  freshness: {
+    evaluatedAt: string;
+    staleSources: Array<{ sourceId: string; checkedAt: string; freshnessWindowHours: number }>;
+    unevaluatedSources: string[];
+    reverifyRecommended: boolean;
+    note: string;
+  };
+}
+
+async function fetchSnapshot(id: string): Promise<{ status: number; payload: SnapshotPayload | null }> {
+  try {
+    const response = await fetch(`${BACKEND}/api/snapshot/${id}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(15_000),
+    });
+    const payload = (await response.json().catch(() => null)) as SnapshotPayload | null;
+    return { status: response.status, payload };
+  } catch {
+    return { status: 503, payload: null };
+  }
+}
+
+export default async function SnapshotPage(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params;
+  if (!UUID_RE.test(id)) notFound();
+
+  const { status, payload } = await fetchSnapshot(id);
+  if (status === 404) notFound();
+
+  if (status === 410) {
+    return (
+      <Shell>
+        <h1 className="text-2xl font-semibold text-foreground">This snapshot was revoked</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The clinician revoked this share. Revoked snapshots fail closed and serve no content. Ask
+          the clinician to share a fresh snapshot if you still need their evidence.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (!payload?.ok) {
+    return (
+      <Shell>
+        <h1 className="text-2xl font-semibold text-foreground">Snapshot is temporarily unavailable</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This is a system state — nothing about the snapshot changed. Try again shortly.
+        </p>
+      </Shell>
+    );
+  }
+
+  const staleIds = new Set(payload.freshness.staleSources.map((s) => s.sourceId));
+  const checks = payload.snapshot.sourceCoverage?.checks ?? [];
+  const readiness = payload.snapshot.readiness;
+
+  return (
+    <Shell>
+      <header>
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
+          Readiness snapshot — as issued
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold text-foreground">NPI {payload.npi}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Issued {new Date(payload.issuedAt).toLocaleString()}
+          {payload.scope?.organizationName ? <> · shared with {payload.scope.organizationName}</> : null}
+          {payload.scope?.purposeOfUse ? <> · {payload.scope.purposeOfUse}</> : null}
+        </p>
+        <p className="mt-1 font-mono text-[11px] text-muted-foreground/70">
+          content hash {payload.contentHash.slice(0, 16)}… — identical on every read
+        </p>
+      </header>
+
+      {/* Freshness overlay — read-time, never rewrites the snapshot */}
+      <section
+        aria-label="Freshness"
+        className={`rounded-xl border p-4 text-sm ${
+          payload.freshness.reverifyRecommended
+            ? 'border-amber-500/40 bg-amber-500/5 text-foreground'
+            : 'border-border text-muted-foreground'
+        }`}
+      >
+        <p className="font-medium">{payload.freshness.note}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Freshness evaluated {new Date(payload.freshness.evaluatedAt).toLocaleString()} against each
+          source&rsquo;s refresh window. The snapshot itself is immutable.
+        </p>
+      </section>
+
+      {/* Readiness as issued */}
+      {readiness ? (
+        <section aria-label="Readiness as issued" className="rounded-xl border border-border p-4">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground">Readiness at issue time</p>
+          <p className="mt-2 text-lg font-semibold text-foreground">
+            {readiness.level ?? '—'} · {typeof readiness.score === 'number' ? `${readiness.score}/100` : '—'}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {readiness.status ?? ''}
+            {readiness.checkedAt ? <> — checked {new Date(readiness.checkedAt).toLocaleString()}</> : null}
+          </p>
+        </section>
+      ) : null}
+
+      {/* Per-source coverage with last-checked + read-time staleness */}
+      <section aria-label="Source coverage" className="rounded-xl border border-border">
+        <div className="border-b border-border px-4 py-3">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground">
+            Source checks as issued
+          </p>
+        </div>
+        {checks.length === 0 ? (
+          <p className="px-4 py-4 text-sm text-muted-foreground">
+            No source checks were recorded in this snapshot.
+          </p>
+        ) : (
+          <ul>
+            {checks.map((check, index) => {
+              const sourceId = check.sourceId ?? `source-${index}`;
+              const stale = staleIds.has(sourceId);
+              return (
+                <li
+                  key={`${sourceId}-${index}`}
+                  className="flex flex-wrap items-center gap-2 border-b border-border/60 px-4 py-2.5 text-sm last:border-b-0"
+                >
+                  <span className="font-medium text-foreground">{sourceId}</span>
+                  <span className="text-muted-foreground">{check.state ?? 'unknown'}</span>
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {check.checkedAt
+                      ? `last checked ${new Date(check.checkedAt).toLocaleString()}`
+                      : 'no check timestamp'}
+                  </span>
+                  {stale ? (
+                    <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+                      stale — re-verify before relying on this
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <footer className="text-xs leading-relaxed text-muted-foreground">
+        <p>
+          This snapshot shows evidence exactly as it was issued; it is not a live verification and
+          not a credentialing decision — reviewers always decide. To get current evidence, ask the
+          clinician to share a refreshed snapshot. Every access to this page is recorded in the
+          audit log.
+        </p>
+      </footer>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-5 px-4 py-12" data-testid="snapshot-page">
+      {children}
+    </main>
+  );
+}

--- a/apps/web/components/apply/ApplyWithVitalCV.tsx
+++ b/apps/web/components/apply/ApplyWithVitalCV.tsx
@@ -54,6 +54,9 @@ interface ShareResult {
   bundleUrl: string;
   webhookDelivered: boolean;
   emailSent: boolean;
+  /** Wave M — persisted reusable readiness snapshot issued with this share (null until backend migration deploys). */
+  readinessSnapshotId?: string | null;
+  readinessSnapshotPath?: string | null;
 }
 
 interface OrgContext {
@@ -562,6 +565,27 @@ export function ApplyWithVitalCV({ npi, label = 'Apply with VitalCV', initialOrg
                   </button>
                 </div>
               </div>
+
+              {/* Reusable readiness snapshot (Wave M) */}
+              {shareResult.readinessSnapshotPath ? (
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 mb-2">
+                    Reusable readiness snapshot
+                  </p>
+                  <a
+                    href={shareResult.readinessSnapshotPath}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block rounded-lg border border-border bg-black/30 px-3 py-2 text-xs text-emerald-300 truncate font-mono hover:border-emerald-500/40 transition-colors"
+                  >
+                    {shareResult.readinessSnapshotPath}
+                  </a>
+                  <p className="mt-1.5 text-[10px] text-zinc-600 leading-relaxed">
+                    Your evidence as issued right now — reviewers you give this to see the same
+                    snapshot, every access is audited, and revoking this share closes it.
+                  </p>
+                </div>
+              ) : null}
 
               {/* Credentials shared summary */}
               <div>

--- a/docs/migrations/wave-m-readiness-snapshots.md
+++ b/docs/migrations/wave-m-readiness-snapshots.md
@@ -1,0 +1,54 @@
+# Wave M — ReadinessSnapshot (persisted reusable readiness snapshot)
+
+**Status:** SQL plan checked in; NOT executed. Lands via the standard
+`prisma migrate deploy` on the backend Railway service (same pending queue as
+the Wave K/Q migrations). No `prisma migrate dev` was run.
+
+**Migration:** `apps/api/backend/prisma/migrations/20260705150000_readiness_snapshots/migration.sql`
+
+## What it adds
+
+One table, `ReadinessSnapshot` — the share-once / reuse-by-many evidence
+artifact. A row is issued at apply-share time (inside
+`applyShareService.shareBundle`) and served to any number of reviewers via
+`GET /api/snapshot/:id`.
+
+| column               | type          | notes                                             |
+| -------------------- | ------------- | ------------------------------------------------- |
+| id                   | UUID PK       | capability id; generated client-side by Prisma    |
+| npi                  | TEXT          | subject clinician (public identifier)             |
+| entityId             | UUID NULL     | resolved VcvEntity at issue time                  |
+| bundleId             | UUID NULL     | the apply bundle this snapshot was issued with    |
+| contentHash          | TEXT          | sha256 over the canonical content — immutability pin |
+| content              | JSONB         | readiness summary + canonical source-coverage report, as issued |
+| scope                | JSONB NULL    | {organizationId, organizationName, purposeOfUse} at issue |
+| issuedAt             | TIMESTAMP(3)  |                                                   |
+| revokedAt            | TIMESTAMP(3)  | direct snapshot revocation                        |
+| revokedByClerkUserId | TEXT NULL     |                                                   |
+
+Indexes: `(npi, issuedAt)`, `(bundleId)`, `(contentHash)`.
+
+## Invariants
+
+- **Immutable content.** `content` is never updated; `contentHash` pins it.
+  Freshness (stale-beyond-SLA per `sourceCatalog.refreshSlaHours`) is computed
+  at read time as an overlay in the response, never written back.
+- **Every access audited.** Each `GET /api/snapshot/:id` writes an
+  `AuditEvent` — `snapshot.accessed` on success, `snapshot.access_denied` on
+  fail-closed reads (revoked / unknown).
+- **Revoked fails closed.** Own `revokedAt`, or any revoked
+  `BundleShareEvent` for the linked `bundleId` (the clinician's existing
+  share-revoke control), returns 410 with no content.
+- **Zero PHI / zero on-chain writes.** Content is readiness states, source
+  ids, and timestamps only.
+- **Deploy-order safe.** Until this migration deploys, snapshot issuance
+  inside the share flow degrades to `readinessSnapshotId: null` and sharing
+  proceeds unchanged.
+
+## Rollback
+
+```sql
+DROP TABLE IF EXISTS "ReadinessSnapshot";
+```
+
+No other objects are created; nothing references the table by FK.


### PR DESCRIPTION
## Summary
- **`ReadinessSnapshot`** — one immutable row per apply-share issuance: the readiness summary + canonical source-coverage report **exactly as issued**, pinned by a sha256 `contentHash` (identical on every read). Backend schema + checked-in migration (`20260705150000_readiness_snapshots/`, **not run** — joins the standard `migrate deploy` queue; plan + rollback in `docs/migrations/wave-m-readiness-snapshots.md`).
- **Issued at share time** — inside `applyShareService.shareBundle`, when the canonical review payload exists. The snapshot id travels in the `BundleShareEvent.bundlePayload` and the `ShareResult` (`readinessSnapshotId` / `readinessSnapshotPath`); the **signed bundle artifact is not mutated** — its signature must remain valid. Deploy-order safe: issuance degrades to `null` until the migration lands and the share proceeds unchanged (existing `applyShare` suite passes byte-identical, 32/32).
- **Reuse route `GET /api/snapshot/:id`** — served to any reviewer holding the capability id (same public posture as the apply-bundle link; `/api/snapshot/` added to the tenant-guard skip list with a test pin). **Every access writes an AuditEvent** (`snapshot.accessed`, or `snapshot.access_denied` on fail-closed reads). **Revoked fails closed** with 410 and no content — via the snapshot's own `revokedAt` or any revoked share of the linked bundle, so the clinician's existing share-revoke control closes the snapshot too.
- **Freshness honesty** — a **read-time overlay** evaluates each source check against its refresh SLA (the `freshnessWindowHours` captured at issue, falling back to the live `sourceCatalog`): stale sources are labeled with a re-verify recommendation and timestampless checks are reported as unevaluated. The stored content is never rewritten — stale data is labeled stale, never presented as current.
- **Web** — public `/snapshot/[id]` viewer (as-issued readiness, per-source last-checked timestamps, stale badges, honest revoked/unavailable states, content-hash line, "request a refreshed share" affordance), `/api/snapshot/[id]` proxy, and the Apply-with-VitalCV confirmation now surfaces the snapshot link with honest copy (revoking the share closes it).

## Grounding note
The wave brief's task 4 named `/p/[slug]` as a wiring target — on main that route is a **static pilot-evidence page** (hardcoded fixtures, no backend fetch), not the clinician public profile, so wiring a readiness snapshot into it would fabricate a connection. The snapshot reference travels where the evidence actually travels: the share payload, the share result, and the employer-review bundle payload.

## Truth rules
- Immutable content + hash pin; freshness is an overlay, never a mutation. Viewer copy: "not a live verification and not a credentialing decision — reviewers always decide."
- Revoked = 410 + no content + denied-access audit. Unknown ids 404 without an audit row (nothing to attribute).
- Zero PHI (readiness states, source ids, timestamps only); zero on-chain writes.
- No banned strings, no bare `Verified` (scan clean; the web test also pins the banned-claims absence in the three new source files).

## Validation
- Backend (new): `readinessSnapshot.test.ts` **9/9** — verbatim content + stable hash, stale/current/unevaluated overlay (incl. live-catalog fallback), access + denied audits, both revocation paths fail closed, issuance degrade, mutation-free overlay. `tenantGuard` **11/11** (new skip pinned). `applyShare.test.ts` **32/32 unmodified**.
- Web (new): `snapshot-page.test.tsx` **6/6** — as-issued rendering with exactly one stale badge, revoked fail-closed, unavailable state, truth-contract source pins.
- Regression: `holder-route-contract` 150/150, `matcha-opportunity-card-wiring` 8/8 (touches the same modal).
- `pnpm turbo run build --filter @vitalcv/web` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · truth scan clean.

## Design Handoff References
No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)