### PR TITLE
feat(home): clinical-grade motion layer — living wallet monitor, EKG identity, scroll choreography

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -37,6 +37,122 @@ function formatNpi(value: string): string {
 }
 
 /**
+ * Scroll-choreography: adds `vh-in` when the element enters the viewport.
+ * SSR/no-JS renders are unaffected — the hidden initial state only applies
+ * under the `.vh-js` root class, which is set client-side.
+ */
+function useReveal<T extends HTMLElement>(): React.RefObject<T | null> {
+  const ref = React.useRef<T>(null);
+  React.useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('vh-in');
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+  return ref;
+}
+
+/**
+ * Pointer tilt for the wallet card — a few degrees of parallax that make the
+ * hero visual feel physical. Skipped entirely under prefers-reduced-motion.
+ */
+function useWalletTilt<T extends HTMLElement>(): React.RefObject<T | null> {
+  const ref = React.useRef<T>(null);
+  React.useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof window === 'undefined') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    let frame = 0;
+    const onMove = (event: PointerEvent) => {
+      const rect = node.getBoundingClientRect();
+      const px = (event.clientX - rect.left) / rect.width - 0.5;
+      const py = (event.clientY - rect.top) / rect.height - 0.5;
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        node.style.setProperty('--vh-ry', `${(px * 7).toFixed(2)}deg`);
+        node.style.setProperty('--vh-rx', `${(-py * 7).toFixed(2)}deg`);
+      });
+    };
+    const onLeave = () => {
+      cancelAnimationFrame(frame);
+      node.style.setProperty('--vh-rx', '0deg');
+      node.style.setProperty('--vh-ry', '0deg');
+    };
+    node.addEventListener('pointermove', onMove);
+    node.addEventListener('pointerleave', onLeave);
+    return () => {
+      cancelAnimationFrame(frame);
+      node.removeEventListener('pointermove', onMove);
+      node.removeEventListener('pointerleave', onLeave);
+    };
+  }, []);
+  return ref;
+}
+
+/**
+ * Count-up for the wallet readiness figure. Runs once when the wallet card
+ * mounts client-side; SSR shows the final value so nothing flashes wrong.
+ */
+function useCountUp(target: number, durationMs = 1400, startDelayMs = 500): number {
+  const [value, setValue] = React.useState(target);
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    let frame = 0;
+    let start: number | null = null;
+    setValue(0);
+    const timer = window.setTimeout(() => {
+      const tick = (ts: number) => {
+        if (start === null) start = ts;
+        const t = Math.min(1, (ts - start) / durationMs);
+        const eased = 1 - Math.pow(1 - t, 3);
+        setValue(Math.round(target * eased));
+        if (t < 1) frame = requestAnimationFrame(tick);
+      };
+      frame = requestAnimationFrame(tick);
+    }, startDelayMs);
+    return () => {
+      window.clearTimeout(timer);
+      cancelAnimationFrame(frame);
+    };
+  }, [target, durationMs, startDelayMs]);
+  return value;
+}
+
+/**
+ * The primary-source registries VitalCV reads today. Names only — the state
+ * vocabulary (checked / gated / stale) stays in the caption and product
+ * surfaces, so the marquee cannot overclaim an unintegrated source.
+ */
+const SOURCE_REGISTRY_STRIP = [
+  'NPPES NPI Registry',
+  'OIG LEIE Exclusions',
+  'CMS PECOS Enrollment',
+  'CMS Open Payments',
+  'State license boards',
+  'Academic & training records',
+] as const;
+
+/** One heartbeat cycle of the monitor trace, repeated twice for a seamless loop. */
+const EKG_BEAT =
+  'M0 22 H26 L34 22 L40 12 L46 30 L52 6 L58 34 L64 22 L72 22 H104 L112 22 L118 14 L124 28 L130 22 H160';
+
+/** Hero hairline heartbeat — one wide pass under the H1. */
+const EKG_HAIRLINE =
+  'M0 20 H150 L166 20 L176 8 L186 30 L194 2 L202 34 L210 20 L224 20 H400 L416 20 L426 12 L436 26 L444 20 H620';
+
+/**
  * Capability rail — the breadth of the product, stated once, above the fold.
  * A first-time visitor should see VitalCV is a wallet + readiness + recognition
  * + opportunity platform before scrolling, not just an NPI form. Each pill maps
@@ -292,11 +408,15 @@ const BUYER_AUDIENCES = [
  * Recognition badge, and a share affordance so the page reads as a product.
  */
 function WalletPreview() {
+  const tiltRef = useWalletTilt<HTMLDivElement>();
+  const readiness = useCountUp(72);
+
   return (
     <div
+      ref={tiltRef}
       aria-hidden="true"
       data-home-wallet-preview=""
-      className="vt-animate-rise relative w-full max-w-sm rounded-[1.75rem] border border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_97%,white)] p-5 shadow-[0_1px_0_rgba(255,255,255,0.75),0_30px_70px_rgba(15,23,42,0.10)]"
+      className="vh-wallet vt-animate-rise relative w-full max-w-sm rounded-[1.75rem] border border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_97%,white)] p-5 shadow-[0_1px_0_rgba(255,255,255,0.75),0_30px_70px_rgba(15,23,42,0.10)]"
     >
       {/* Wallet header */}
       <div className="flex items-center justify-between">
@@ -311,8 +431,17 @@ function WalletPreview() {
         </span>
       </div>
 
+      {/* Vitals monitor — the clinical heartbeat of the card */}
+      <div className="vh-monitor mt-4">
+        <svg viewBox="0 0 320 44" preserveAspectRatio="none">
+          <path d={EKG_BEAT} />
+          <path d={EKG_BEAT} transform="translate(160 0)" />
+        </svg>
+        <span className="vh-monitor-label">EVIDENCE · LIVE READ</span>
+      </div>
+
       {/* Readiness meter */}
-      <div className="mt-5 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[var(--vt-bg)] px-4 py-4">
+      <div className="mt-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[var(--vt-bg)] px-4 py-4">
         <div className="flex items-center justify-between">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vt-text-muted)]">
             Readiness snapshot
@@ -321,8 +450,13 @@ function WalletPreview() {
             <CheckCircle2 size={12} /> Source-backed
           </span>
         </div>
-        <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[var(--vt-surface-subtle)]">
-          <div className="vt-animate-grow-x h-full w-[72%] rounded-full bg-[var(--ink-800,#1a1916)]" />
+        <div className="mt-3 flex items-center gap-3">
+          <div className="vh-bar flex-1">
+            <div className="vh-bar-fill" />
+          </div>
+          <span className="w-9 text-right font-mono text-[13px] font-semibold tabular-nums text-[var(--vt-text-primary)]">
+            {readiness}%
+          </span>
         </div>
         <p className="mt-2 text-[11px] leading-relaxed text-[var(--vt-text-muted)]">
           Honest about what is checked, gated, or stale.
@@ -330,7 +464,7 @@ function WalletPreview() {
       </div>
 
       {/* Source rows */}
-      <div className="mt-3 space-y-1.5">
+      <div className="vh-scan mt-3 space-y-1.5">
         {WALLET_PREVIEW_ROWS.map((row) => (
           <div
             key={row.source}
@@ -361,7 +495,7 @@ function WalletPreview() {
       {/* Recognition + share footer */}
       <div className="mt-3 flex items-center justify-between rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-accent-emerald)_8%,var(--vt-surface))] px-4 py-3">
         <span className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vt-accent-emerald)_18%,transparent)] text-[var(--vt-accent-emerald)]">
+          <span className="vh-ring flex h-8 w-8 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vt-accent-emerald)_18%,transparent)] text-[var(--vt-accent-emerald)]">
             <Award size={16} />
           </span>
           <span className="flex flex-col">
@@ -387,6 +521,20 @@ export default function HomePageClient() {
   const [error, setError] = React.useState<string | null>(null);
   const [focused, setFocused] = React.useState(false);
 
+  // Flag JS availability on the root so entrance choreography only ever
+  // hides content when the runtime is actually there to reveal it again.
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    rootRef.current?.classList.add('vh-js');
+  }, []);
+
+  const loopRef = useReveal<HTMLDivElement>();
+  const aiRef = useReveal<HTMLUListElement>();
+  const valueRef = useReveal<HTMLDivElement>();
+  const audienceRef = useReveal<HTMLDivElement>();
+  const doorsRef = useReveal<HTMLDivElement>();
+  const proofRef = useReveal<HTMLDivElement>();
+
   const digits = raw.replace(/\D/g, '').slice(0, 10);
   const isFull = digits.length === 10;
 
@@ -407,7 +555,11 @@ export default function HomePageClient() {
   }, [digits, isFull, router]);
 
   return (
-    <div className="mz relative overflow-hidden bg-[var(--paper)] text-[var(--vt-text-primary)]">
+    <div
+      ref={rootRef}
+      className="mz vh-root relative overflow-hidden bg-[var(--paper)] text-[var(--vt-text-primary)]"
+    >
+      <div aria-hidden="true" className="vh-aurora" />
       <div
         aria-hidden="true"
         className="mz-dotgrid pointer-events-none absolute inset-x-0 top-0 h-[26rem] opacity-60"
@@ -444,13 +596,22 @@ export default function HomePageClient() {
               <div className="space-y-5">
                 <p
                   data-home-eyebrow=""
-                  className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--vt-text-muted)]"
+                  className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.24em] text-[var(--vt-text-muted)]"
                 >
+                  <span aria-hidden="true" className="vh-eyebrow-dot" />
                   The Provider Career Evidence Network
                 </p>
                 <h1 className="text-[clamp(2.4rem,5.6vw,3.75rem)] leading-[0.98] font-semibold tracking-[-0.04em] text-[var(--vt-text-primary)]">
                   Your clinical career evidence, in one wallet you own.
                 </h1>
+                <svg
+                  aria-hidden="true"
+                  className="vh-ekg-line"
+                  viewBox="0 0 620 40"
+                  preserveAspectRatio="none"
+                >
+                  <path d={EKG_HAIRLINE} />
+                </svg>
                 <p
                   data-home-hero-subhead=""
                   className="max-w-2xl text-[18px] leading-[1.6] text-[var(--vt-text-secondary)]"
@@ -470,7 +631,7 @@ export default function HomePageClient() {
                     return (
                       <li
                         key={pill.label}
-                        className="inline-flex items-center gap-1.5 rounded-full border border-[var(--vt-border)] bg-[var(--vt-surface)] px-3 py-1.5 text-[12px] font-medium text-[var(--vt-text-secondary)]"
+                        className="vh-lift inline-flex items-center gap-1.5 rounded-full border border-[var(--vt-border)] bg-[var(--vt-surface)] px-3 py-1.5 text-[12px] font-medium text-[var(--vt-text-secondary)]"
                       >
                         <Icon size={13} className="text-[var(--vt-accent-emerald)]" aria-hidden="true" />
                         {pill.label}
@@ -534,7 +695,7 @@ export default function HomePageClient() {
                         className={cn(
                           'inline-flex h-14 items-center justify-center gap-2 border-t border-[var(--vt-border)] px-5 text-[13px] font-semibold transition-colors sm:border-l sm:border-t-0 sm:px-6',
                           isFull
-                            ? 'bg-[var(--vt-text-primary)] text-[var(--vt-bg)] hover:bg-[color-mix(in_oklab,var(--vt-text-primary)_90%,black)]'
+                            ? 'vh-cta-ready bg-[var(--vt-text-primary)] text-[var(--vt-bg)] hover:bg-[color-mix(in_oklab,var(--vt-text-primary)_90%,black)]'
                             : 'cursor-not-allowed bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]',
                         )}
                       >
@@ -589,19 +750,63 @@ export default function HomePageClient() {
             </div>
           </section>
 
+          {/* Primary-source registry strip — breadth, in motion. Names only;
+              state vocabulary stays in the caption so nothing overclaims. */}
+          <section
+            aria-label="Primary sources VitalCV reads"
+            data-home-source-strip=""
+            className="mt-14 border-y border-[var(--vt-border-subtle)] py-5"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
+              <p className="shrink-0 text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+                Reads primary sources
+              </p>
+              <div className="vh-marquee min-w-0 flex-1">
+                <div className="vh-marquee-track">
+                  {[false, true].map((clone) => (
+                    <ul
+                      key={clone ? 'clone' : 'main'}
+                      aria-hidden={clone || undefined}
+                      className="flex shrink-0 items-center gap-3 pr-3"
+                    >
+                      {SOURCE_REGISTRY_STRIP.map((name) => (
+                        <li
+                          key={name}
+                          className="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--vt-border)] bg-[var(--vt-surface)] px-3.5 py-1.5 text-[12px] font-medium text-[var(--vt-text-secondary)]"
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="h-1.5 w-1.5 rounded-full bg-[var(--vt-accent-emerald)]"
+                          />
+                          {name}
+                        </li>
+                      ))}
+                    </ul>
+                  ))}
+                </div>
+              </div>
+              <p className="shrink-0 text-[11px] text-[var(--vt-text-muted)]">
+                Every field shows its state — checked, gated, or stale.
+              </p>
+            </div>
+          </section>
+
           {/* The loop — what VitalCV does, end to end */}
           <section aria-label="How VitalCV works" data-home-loop="" className="mt-16">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+            <p className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              <span aria-hidden="true" className="vh-eyebrow-dot" />
               How it works
             </p>
-            <ol className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            <div ref={loopRef} className="vh-loop-wrap relative">
+              <span aria-hidden="true" className="vh-loop-connector hidden lg:block" />
+              <ol className="vh-stagger mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
               {LOOP_STEPS.map((step) => (
                 <li
                   key={step.n}
                   data-home-loop-step={step.n}
-                  className="flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
+                  className="vh-lift relative flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
                 >
-                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--vt-text-primary)] text-[12px] font-semibold text-[var(--vt-bg)]">
+                  <span className="vh-step-n flex h-7 w-7 items-center justify-center rounded-full bg-[var(--vt-text-primary)] text-[12px] font-semibold text-[var(--vt-bg)]">
                     {step.n}
                   </span>
                   <p className="text-sm font-semibold leading-snug text-[var(--vt-text-primary)]">
@@ -612,7 +817,8 @@ export default function HomePageClient() {
                   </p>
                 </li>
               ))}
-            </ol>
+              </ol>
+            </div>
           </section>
 
           {/* AI layer — MATCHA as the honest intelligence layer */}
@@ -634,18 +840,18 @@ export default function HomePageClient() {
                   </p>
                 </div>
 
-                <ul className="grid gap-3 sm:grid-cols-2">
+                <ul ref={aiRef} className="vh-stagger grid gap-3 sm:grid-cols-2">
                   {AI_CAPABILITIES.map((cap) => {
                     const Icon = cap.icon;
                     return (
                       <li
                         key={cap.key}
                         data-home-ai-card={cap.key}
-                        className="flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] px-4 py-4 transition-transform duration-200 hover:-translate-y-0.5"
+                        className="vh-lift flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] px-4 py-4"
                       >
                         <span
                           aria-hidden="true"
-                          className="flex h-8 w-8 items-center justify-center rounded-lg bg-[color-mix(in_oklab,var(--vt-accent-emerald)_14%,transparent)] text-[var(--vt-accent-emerald)]"
+                          className="vh-icon-chip flex h-8 w-8 items-center justify-center rounded-lg bg-[color-mix(in_oklab,var(--vt-accent-emerald)_14%,transparent)] text-[var(--vt-accent-emerald)]"
                         >
                           <Icon size={16} />
                         </span>
@@ -669,21 +875,22 @@ export default function HomePageClient() {
             data-home-value=""
             className="mt-16"
           >
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+            <p className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              <span aria-hidden="true" className="vh-eyebrow-dot" />
               What you get
             </p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div ref={valueRef} className="vh-stagger mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {VALUE_CARDS.map((card) => {
                 const Icon = card.icon;
                 return (
                   <div
                     key={card.key}
                     data-home-value-card={card.key}
-                    className="flex flex-col gap-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-5 py-5"
+                    className="vh-lift flex flex-col gap-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-5 py-5"
                   >
                     <span
                       aria-hidden="true"
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
+                      className="vh-icon-chip flex h-9 w-9 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
                     >
                       <Icon size={17} />
                     </span>
@@ -710,21 +917,22 @@ export default function HomePageClient() {
 
           {/* Buyer audiences — the whole hire buys into one network */}
           <section aria-label="Who VitalCV is for" data-home-audiences="" className="mt-16">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+            <p className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              <span aria-hidden="true" className="vh-eyebrow-dot" />
               Who buys in
             </p>
-            <div className="mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+            <div ref={audienceRef} className="vh-stagger mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
               {BUYER_AUDIENCES.map((row) => {
                 const Icon = row.icon;
                 return (
                   <div
                     key={row.key}
                     data-home-audience={row.key}
-                    className="flex items-start gap-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
+                    className="vh-lift flex items-start gap-3 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
                   >
                     <span
                       aria-hidden="true"
-                      className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
+                      className="vh-icon-chip mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
                     >
                       <Icon size={16} />
                     </span>
@@ -782,16 +990,17 @@ export default function HomePageClient() {
             data-home-role-doors=""
             className="mt-16"
           >
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+            <p className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              <span aria-hidden="true" className="vh-eyebrow-dot" />
               By role
             </p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div ref={doorsRef} className="vh-stagger mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               {ROLE_DOORS.map((door) => (
                 <Link
                   key={door.role}
                   href={door.href}
                   data-home-role-door={door.role.toLowerCase()}
-                  className="group flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.6)] transition-colors hover:border-[var(--vt-text-primary)]"
+                  className="vh-lift group flex flex-col gap-2 rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4 shadow-[0_1px_0_rgba(255,255,255,0.6)] transition-colors hover:border-[var(--vt-text-primary)]"
                 >
                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
                     {door.role}
@@ -813,15 +1022,16 @@ export default function HomePageClient() {
             data-home-proof-strip=""
             className="mt-16"
           >
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+            <p className="vh-eyebrow text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--vt-text-muted)]">
+              <span aria-hidden="true" className="vh-eyebrow-dot" />
               Every row carries
             </p>
-            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div ref={proofRef} className="vh-stagger mt-4 grid gap-3 sm:grid-cols-3">
               {PROOF_STRIP.map((col) => (
                 <div
                   key={col.label}
                   data-home-proof-col={col.label.toLowerCase().replace(/\s+/g, '-')}
-                  className="rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
+                  className="vh-lift rounded-[1.25rem] border border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)] px-4 py-4"
                 >
                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
                     {col.label}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -13,6 +13,7 @@
 @import '../styles/graph.css';
 @import '../styles/intelligence.css';
 @import '../styles/clinician-doc.css';
+@import '../styles/home-vitals.css';
 /* glue.css superseded by antigravity.css (imported in layout.tsx) */
 
 @custom-variant dark (&:is(.dark *));

--- a/apps/web/styles/home-vitals.css
+++ b/apps/web/styles/home-vitals.css
@@ -1,0 +1,509 @@
+/* ============================================================
+   home-vitals.css — motion + clinical visual layer for the
+   public homepage (HomePageClient). Scoped: every class is
+   prefixed .vh- and most effects require .vh-js on the page
+   root (set client-side), so SSR / no-JS / test renders are
+   fully visible and unchanged.
+
+   Truth notes: this layer is purely visual. It introduces no
+   product claims. The wallet visual remains a schematic
+   (aria-hidden) and its states come from the TSX data.
+   ============================================================ */
+
+.vh-root {
+  --vh-pulse: var(--vt-accent-emerald, #047857);
+  --vh-pulse-soft: color-mix(in oklab, var(--vh-pulse) 22%, transparent);
+  --vh-teal: color-mix(in oklab, var(--vh-pulse) 62%, #0ea5a3);
+  --vh-amber: color-mix(in oklab, #b45309 70%, var(--paper, #f4f1ea));
+  --vh-ink: var(--vt-text-primary, #1a1916);
+}
+
+/* ------------------------------------------------------------
+   Aurora backdrop — two slow clinical-green drifts behind hero.
+   ------------------------------------------------------------ */
+.vh-aurora {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.vh-aurora::before,
+.vh-aurora::after {
+  content: '';
+  position: absolute;
+  width: 52rem;
+  height: 52rem;
+  border-radius: 9999px;
+  filter: blur(70px);
+  opacity: 0.5;
+  will-change: transform;
+}
+.vh-aurora::before {
+  top: -30rem;
+  right: -14rem;
+  background: radial-gradient(
+    circle at center,
+    color-mix(in oklab, var(--vh-pulse) 16%, transparent) 0%,
+    color-mix(in oklab, var(--vh-teal) 10%, transparent) 42%,
+    transparent 70%
+  );
+}
+.vh-aurora::after {
+  top: 6rem;
+  left: -22rem;
+  background: radial-gradient(
+    circle at center,
+    color-mix(in oklab, var(--vh-amber) 14%, transparent) 0%,
+    transparent 62%
+  );
+  opacity: 0.38;
+}
+.vh-js .vh-aurora::before {
+  animation: vh-drift-a 26s ease-in-out infinite alternate;
+}
+.vh-js .vh-aurora::after {
+  animation: vh-drift-b 34s ease-in-out infinite alternate;
+}
+@keyframes vh-drift-a {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to   { transform: translate3d(-6rem, 4rem, 0) scale(1.12); }
+}
+@keyframes vh-drift-b {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to   { transform: translate3d(5rem, -2.5rem, 0) scale(1.08); }
+}
+
+/* ------------------------------------------------------------
+   Scroll reveal system. Initial hidden state ONLY under .vh-js,
+   so SSR markup and tests see everything.
+   ------------------------------------------------------------ */
+.vh-js .vh-reveal {
+  opacity: 0;
+  transform: translateY(22px);
+  transition:
+    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: var(--vh-delay, 0ms);
+  will-change: opacity, transform;
+}
+.vh-js .vh-reveal.vh-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+/* Stagger helper: children of a revealed group cascade. The group is marked
+   vh-in directly, or sits inside a revealed wrapper (descendant form). */
+.vh-js .vh-stagger > * {
+  opacity: 0;
+  transform: translateY(16px);
+  transition:
+    opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.vh-js .vh-stagger.vh-in > *,
+.vh-js .vh-in .vh-stagger > * {
+  opacity: 1;
+  transform: translateY(0);
+}
+.vh-js .vh-stagger.vh-in > *:nth-child(1), .vh-js .vh-in .vh-stagger > *:nth-child(1) { transition-delay: 0ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(2), .vh-js .vh-in .vh-stagger > *:nth-child(2) { transition-delay: 70ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(3), .vh-js .vh-in .vh-stagger > *:nth-child(3) { transition-delay: 140ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(4), .vh-js .vh-in .vh-stagger > *:nth-child(4) { transition-delay: 210ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(5), .vh-js .vh-in .vh-stagger > *:nth-child(5) { transition-delay: 280ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(6), .vh-js .vh-in .vh-stagger > *:nth-child(6) { transition-delay: 350ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(7), .vh-js .vh-in .vh-stagger > *:nth-child(7) { transition-delay: 420ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(8), .vh-js .vh-in .vh-stagger > *:nth-child(8) { transition-delay: 490ms; }
+
+/* ------------------------------------------------------------
+   Eyebrow: pulsing status dot + growing hairline.
+   ------------------------------------------------------------ */
+.vh-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.vh-eyebrow-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: var(--vh-pulse);
+  box-shadow: 0 0 0 0 var(--vh-pulse-soft);
+  flex: none;
+}
+.vh-js .vh-eyebrow-dot {
+  animation: vh-ping 2.6s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+@keyframes vh-ping {
+  0%   { box-shadow: 0 0 0 0 var(--vh-pulse-soft); }
+  55%  { box-shadow: 0 0 0 9px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+/* ------------------------------------------------------------
+   Hero EKG hairline — a heartbeat trace that draws itself once
+   under the H1, then idles with a soft glow sweep.
+   ------------------------------------------------------------ */
+.vh-ekg-line {
+  display: block;
+  width: min(34rem, 100%);
+  height: 28px;
+  overflow: visible;
+}
+.vh-ekg-line path {
+  fill: none;
+  stroke: color-mix(in oklab, var(--vh-pulse) 55%, var(--vt-border, #d8d3c8));
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.vh-js .vh-ekg-line path {
+  stroke-dasharray: 640;
+  stroke-dashoffset: 640;
+  animation: vh-ekg-draw 2.2s cubic-bezier(0.65, 0, 0.35, 1) 0.35s forwards;
+}
+@keyframes vh-ekg-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+/* ------------------------------------------------------------
+   Wallet card — living vitals monitor.
+   ------------------------------------------------------------ */
+.vh-wallet {
+  transform-style: preserve-3d;
+  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease;
+}
+.vh-js .vh-wallet {
+  transform:
+    perspective(1100px)
+    rotateX(var(--vh-rx, 0deg))
+    rotateY(var(--vh-ry, 0deg));
+}
+.vh-wallet:hover {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.75),
+    0 42px 90px rgba(15, 23, 42, 0.16);
+}
+/* Sheen sweep across the card on reveal + on hover. */
+.vh-wallet::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    transparent 38%,
+    rgba(255, 255, 255, 0.5) 48%,
+    transparent 58%
+  );
+  background-size: 260% 100%;
+  background-position: 130% 0;
+  mix-blend-mode: soft-light;
+}
+.vh-js .vh-wallet:hover::after {
+  animation: vh-sheen 1.1s ease forwards;
+}
+@keyframes vh-sheen {
+  from { background-position: 130% 0; }
+  to   { background-position: -60% 0; }
+}
+
+/* Monitor strip: continuously running EKG trace. */
+.vh-monitor {
+  position: relative;
+  height: 44px;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  background:
+    linear-gradient(
+      color-mix(in oklab, var(--vh-pulse) 5%, var(--vt-bg, #faf8f3)),
+      color-mix(in oklab, var(--vh-pulse) 5%, var(--vt-bg, #faf8f3))
+    );
+  border: 1px solid color-mix(in oklab, var(--vh-pulse) 18%, var(--vt-border-subtle, #e4dfd4));
+}
+/* faint clinical grid */
+.vh-monitor::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--vh-pulse) 9%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--vh-pulse) 9%, transparent) 1px, transparent 1px);
+  background-size: 11px 11px;
+  opacity: 0.5;
+}
+.vh-monitor svg {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  height: 100%;
+}
+.vh-monitor path {
+  fill: none;
+  stroke: var(--vh-pulse);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--vh-pulse) 60%, transparent));
+}
+.vh-js .vh-monitor svg {
+  animation: vh-trace 7s linear infinite;
+}
+@keyframes vh-trace {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+/* Static fallback (no JS / reduced motion): show one heartbeat, no loop. */
+
+.vh-monitor-label {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: color-mix(in oklab, var(--vh-pulse) 80%, var(--vh-ink));
+}
+.vh-monitor-label::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background: var(--vh-pulse);
+}
+.vh-js .vh-monitor-label::before {
+  animation: vh-blink 1.6s ease-in-out infinite;
+}
+@keyframes vh-blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.25; }
+}
+
+/* Readiness bar — clinical gradient + shimmer, replaces the ink-black bar. */
+.vh-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 9999px;
+  overflow: hidden;
+  background: var(--vt-surface-subtle, #eee9de);
+}
+.vh-bar-fill {
+  position: relative;
+  height: 100%;
+  width: var(--vh-bar, 72%);
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--vh-pulse) 88%, #064e3b),
+    var(--vh-pulse) 55%,
+    var(--vh-teal)
+  );
+  box-shadow: 0 0 10px color-mix(in oklab, var(--vh-pulse) 35%, transparent);
+}
+.vh-js .vh-bar-fill {
+  width: 0;
+  animation: vh-bar-fill 1.5s cubic-bezier(0.22, 1, 0.36, 1) 0.5s forwards;
+}
+@keyframes vh-bar-fill {
+  to { width: var(--vh-bar, 72%); }
+}
+.vh-bar-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.55) 50%,
+    transparent 70%
+  );
+  background-size: 220% 100%;
+  background-position: 130% 0;
+}
+.vh-js .vh-bar-fill::after {
+  animation: vh-shimmer 2.6s ease-in-out 2.1s infinite;
+}
+@keyframes vh-shimmer {
+  0%   { background-position: 130% 0; }
+  60%, 100% { background-position: -90% 0; }
+}
+
+/* Wallet source rows: scan highlight sweeps the stack. */
+.vh-scan {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+}
+.vh-js .vh-scan::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    color-mix(in oklab, var(--vh-pulse) 7%, transparent) 50%,
+    transparent 100%
+  );
+  transform: translateY(-110%);
+  animation: vh-scan 6.5s ease-in-out 3s infinite;
+}
+@keyframes vh-scan {
+  0%, 55%  { transform: translateY(-110%); }
+  80%, 100% { transform: translateY(110%); }
+}
+
+/* Recognition pulse ring. */
+.vh-ring {
+  position: relative;
+}
+.vh-js .vh-ring::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  border: 1.5px solid color-mix(in oklab, var(--vh-pulse) 55%, transparent);
+  opacity: 0;
+  animation: vh-ring 3.4s cubic-bezier(0.4, 0, 0.6, 1) 1.4s infinite;
+}
+@keyframes vh-ring {
+  0%   { opacity: 0.9; transform: scale(0.86); }
+  45%  { opacity: 0; transform: scale(1.45); }
+  100% { opacity: 0; transform: scale(1.45); }
+}
+
+/* ------------------------------------------------------------
+   Source registry marquee — institutional breadth, in motion.
+   Pure names; state vocabulary stays in the caption.
+   ------------------------------------------------------------ */
+.vh-marquee {
+  position: relative;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+  mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+}
+.vh-marquee-track {
+  display: flex;
+  gap: 0.75rem;
+  width: max-content;
+}
+.vh-js .vh-marquee-track {
+  animation: vh-marquee 30s linear infinite;
+}
+.vh-marquee:hover .vh-marquee-track {
+  animation-play-state: paused;
+}
+@keyframes vh-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+/* ------------------------------------------------------------
+   Card micro-interactions (loop steps, value, ai, doors).
+   ------------------------------------------------------------ */
+.vh-lift {
+  transition:
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+.vh-lift:hover {
+  transform: translateY(-4px);
+  border-color: color-mix(in oklab, var(--vh-pulse) 38%, var(--vt-border, #d8d3c8)) !important;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6),
+    0 18px 40px rgba(15, 23, 42, 0.09);
+}
+.vh-lift:hover .vh-icon-chip {
+  background: color-mix(in oklab, var(--vh-pulse) 15%, transparent);
+  color: var(--vh-pulse);
+  border-color: color-mix(in oklab, var(--vh-pulse) 35%, transparent);
+  transform: scale(1.06);
+}
+.vh-icon-chip {
+  transition:
+    background 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease,
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Loop connector — hairline that draws across the steps row. */
+.vh-loop-wrap {
+  position: relative;
+}
+.vh-loop-connector {
+  position: absolute;
+  top: 2.35rem;
+  left: 1rem;
+  right: 1rem;
+  height: 2px;
+  transform-origin: left center;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--vh-pulse) 45%, transparent),
+    color-mix(in oklab, var(--vh-teal) 40%, transparent)
+  );
+  opacity: 0;
+}
+.vh-js .vh-in .vh-loop-connector {
+  animation: vh-grow-x 1.4s cubic-bezier(0.22, 1, 0.36, 1) 0.2s forwards;
+}
+@keyframes vh-grow-x {
+  from { opacity: 1; transform: scaleX(0); }
+  to   { opacity: 1; transform: scaleX(1); }
+}
+
+/* Step number badge fills in as its card reveals. */
+.vh-step-n {
+  transition: background 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
+}
+.vh-lift:hover .vh-step-n {
+  box-shadow: 0 0 0 5px var(--vh-pulse-soft);
+  background: var(--vh-pulse);
+}
+
+/* ------------------------------------------------------------
+   Primary CTA — ready-state glow when the NPI is complete.
+   ------------------------------------------------------------ */
+.vh-js .vh-cta-ready {
+  animation: vh-cta 2.2s ease-in-out infinite;
+}
+@keyframes vh-cta {
+  0%, 100% { box-shadow: 0 0 0 0 var(--vh-pulse-soft); }
+  50%      { box-shadow: 0 0 0 7px transparent; }
+}
+
+/* ------------------------------------------------------------
+   Reduced motion: kill continuous + entrance animation.
+   ------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .vh-js .vh-reveal,
+  .vh-js .vh-stagger > * {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+  .vh-js .vh-aurora::before,
+  .vh-js .vh-aurora::after,
+  .vh-js .vh-eyebrow-dot,
+  .vh-js .vh-ekg-line path,
+  .vh-js .vh-monitor svg,
+  .vh-js .vh-monitor-label::before,
+  .vh-js .vh-bar-fill,
+  .vh-js .vh-bar-fill::after,
+  .vh-js .vh-scan::after,
+  .vh-js .vh-ring::after,
+  .vh-js .vh-marquee-track,
+  .vh-js .vh-in .vh-loop-connector,
+  .vh-js .vh-cta-ready {
+    animation: none !important;
+  }
+  .vh-js .vh-bar-fill { width: var(--vh-bar, 72%); }
+  .vh-js .vh-ekg-line path { stroke-dasharray: none; stroke-dashoffset: 0; }
+  .vh-js .vh-in .vh-loop-connector { opacity: 1; transform: scaleX(1); }
+  .vh-js .vh-wallet { transform: none; }
+  .vh-lift:hover { transform: none; }
+}


### PR DESCRIPTION
## Summary

Chris's brief: the homepage doesn't visually show the progress — needs dynamic animation, interaction, healthcare-coded visuals, and the wallet's black progress bar looks wrong. This PR is a pure visual/motion elevation of `HomePageClient` — zero copy or claim changes:

- **Wallet → living vitals monitor**: continuously-tracing EKG strip ("EVIDENCE · LIVE READ"), clinical emerald→teal gradient readiness bar replacing the near-black `--ink-800` bar, count-up % figure, staggered source-row entrance, periodic scan sweep, Recognition pulse ring, pointer tilt + hover sheen. Card stays `aria-hidden` schematic.
- **Hero**: pulsing dot on the Network eyebrow, self-drawing EKG hairline under the H1, slow aurora gradient drift.
- **Primary-source marquee**: NPPES / OIG LEIE / CMS PECOS / CMS Open Payments / state boards / academic — names only, with the honest state caption; no new source claims.
- **Scroll choreography**: reveal-on-enter with staggered cascades across all sections; loop steps connected by a self-drawing hairline.
- **Micro-interactions**: card lift + icon tint, CTA ready-state pulse.

## Truth rules

- No copy changes; every pinned string + `data-home-*` attribute preserved (`home-npi-role-doors` 16/16).
- Marquee lists source **names only** — no per-source state claims, no unintegrated-source claims (NPDB/DEA/ABMS absent).
- Truth scan clean on the diff; wallet remains a labeled schematic.

## Validation

- `pnpm turbo run build --filter @vitalcv/web` green (typecheck + eslint enforced)
- `vitest home-npi-role-doors` 16/16
- Local `next start` verified in real Chrome: EKG trace + hairline animating, bar count-up 0→72%, marquee scrolling (frame-diff confirmed), loop stagger + connector, zero app console errors
- All motion SSR-safe (`.vh-js` gate) and `prefers-reduced-motion`-disabled

## Design Handoff References

No Claude Design handoff file used for this PR (direct founder visual brief, 2026-07-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)