### PR TITLE
feat(home): clinical-luminous homepage — living vitals monitor, signal palette, motion system

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -588,11 +588,34 @@ export default function HomePageClient() {
       <main className="relative mx-auto w-full max-w-6xl px-6 py-16 sm:py-20">
         <div className="w-full">
 
+          {/* Hero — presented as a clinical monitor. The device stage is a
+              dark panel; its content flips light-on-dark via .vh-dark so the
+              NPI card, pills and wallet adapt with no per-component edits. */}
+          <div className="vh-stage vh-dark">
+            <div aria-hidden="true" className="vh-stage-grid" />
+            <div aria-hidden="true" className="vh-stage-bezel">
+              <span className="vh-stage-tag">
+                <span className="vh-stage-led" />
+                VITALCV · PROVIDER EVIDENCE MONITOR
+              </span>
+              <span className="vh-stage-dots">
+                <i />
+                <i />
+                <i />
+              </span>
+            </div>
+            <div aria-hidden="true" className="vh-stage-ekg">
+              <svg viewBox="0 0 320 44" preserveAspectRatio="none">
+                <path d={EKG_BEAT} />
+                <path d={EKG_BEAT} transform="translate(160 0)" />
+              </svg>
+            </div>
+
           {/* Hero — clinician wallet product, NPI-first entry */}
           <section
             aria-label="NPI lookup"
             data-home-hero=""
-            className="grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
+            className="vh-stage-content grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
           >
             {/* Left: messaging + NPI entry */}
             <div className="max-w-2xl">
@@ -760,6 +783,7 @@ export default function HomePageClient() {
               <WalletPreview />
             </div>
           </section>
+          </div>
 
           {/* Primary-source registry strip — breadth, in motion. Names only;
               state vocabulary stays in the caption so nothing overclaims. */}

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -416,8 +416,9 @@ function WalletPreview() {
       ref={tiltRef}
       aria-hidden="true"
       data-home-wallet-preview=""
-      className="vh-wallet vt-animate-rise relative w-full max-w-sm rounded-[1.75rem] border border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_97%,white)] p-5 shadow-[0_1px_0_rgba(255,255,255,0.75),0_30px_70px_rgba(15,23,42,0.10)]"
+      className="vh-wallet vt-animate-rise relative w-full max-w-sm rounded-[1.75rem] border border-[var(--vt-border)] bg-[color-mix(in_oklab,var(--vt-surface)_97%,white)] p-5"
     >
+      <span aria-hidden="true" className="vh-wallet-halo" />
       {/* Wallet header */}
       <div className="flex items-center justify-between">
         <span className="inline-flex items-center gap-2 text-[13px] font-semibold text-[var(--vt-text-primary)]">
@@ -437,6 +438,7 @@ function WalletPreview() {
           <path d={EKG_BEAT} />
           <path d={EKG_BEAT} transform="translate(160 0)" />
         </svg>
+        <span aria-hidden="true" className="vh-monitor-beam" />
         <span className="vh-monitor-label">EVIDENCE · LIVE READ</span>
       </div>
 
@@ -560,9 +562,10 @@ export default function HomePageClient() {
       className="mz vh-root relative overflow-hidden bg-[var(--paper)] text-[var(--vt-text-primary)]"
     >
       <div aria-hidden="true" className="vh-aurora" />
+      <div aria-hidden="true" className="vh-signalgrid" />
       <div
         aria-hidden="true"
-        className="mz-dotgrid pointer-events-none absolute inset-x-0 top-0 h-[26rem] opacity-60"
+        className="mz-dotgrid pointer-events-none absolute inset-x-0 top-0 h-[26rem] opacity-40"
       />
 
       {CLERK_PROVIDER_ENABLED && (
@@ -610,7 +613,15 @@ export default function HomePageClient() {
                   viewBox="0 0 620 40"
                   preserveAspectRatio="none"
                 >
-                  <path d={EKG_HAIRLINE} />
+                  <defs>
+                    <linearGradient id="vh-ekg-grad" x1="0" y1="0" x2="1" y2="0">
+                      <stop offset="0%" stopColor="var(--vh-emerald)" />
+                      <stop offset="55%" stopColor="var(--vh-teal)" />
+                      <stop offset="100%" stopColor="var(--vh-cyan)" />
+                    </linearGradient>
+                  </defs>
+                  <path className="vh-ekg-draw" d={EKG_HAIRLINE} />
+                  <path className="vh-ekg-spark" d={EKG_HAIRLINE} />
                 </svg>
                 <p
                   data-home-hero-subhead=""

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -598,10 +598,26 @@ export default function HomePageClient() {
                 <span className="vh-stage-led" />
                 VITALCV · PROVIDER EVIDENCE MONITOR
               </span>
-              <span className="vh-stage-dots">
-                <i />
-                <i />
-                <i />
+              <span className="vh-stage-readout">
+                <span className="vh-stage-bars">
+                  <i />
+                  <i />
+                  <i />
+                  <i />
+                </span>
+                <span className="vh-stage-ticker">
+                  <span className="vh-stage-ticker-track">
+                    <span>READING · NPPES</span>
+                    <span>READING · OIG LEIE</span>
+                    <span>READING · CMS PECOS</span>
+                    <span>READING · STATE BOARDS</span>
+                    <span>READING · NPPES</span>
+                  </span>
+                </span>
+                <span className="vh-stage-live">
+                  <span className="vh-stage-led" />
+                  LIVE
+                </span>
               </span>
             </div>
             <div aria-hidden="true" className="vh-stage-ekg">

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -14,7 +14,7 @@ import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // Public-only nav items. Never add ops/internal routes here.
 const NAV_ITEMS = [
@@ -24,7 +24,25 @@ const NAV_ITEMS = [
 export default function Navbar() {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const { track } = useUxTelemetry();
+
+  // Homepage renders a dark clinical-monitor hero at the top. While the nav is
+  // over that hero it goes transparent-dark (light text) so it reads as one
+  // continuous device surface; once scrolled into the light body it returns to
+  // the normal solid bar. Only the homepage has the dark hero.
+  const isHome = pathname === '/';
+  useEffect(() => {
+    if (!isHome) {
+      setScrolled(false);
+      return;
+    }
+    const onScroll = () => setScrolled(window.scrollY > 60);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [isHome]);
+  const overHero = isHome && !scrolled && !menuOpen;
 
   if (!isPublicSurfacePath(pathname)) {
     return null;
@@ -41,7 +59,14 @@ export default function Navbar() {
   };
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/90 backdrop-blur-xl">
+    <header
+      data-nav-over={overHero ? '' : undefined}
+      className={`sticky top-0 z-50 border-b backdrop-blur-xl transition-colors duration-300 ${
+        overHero
+          ? 'vh-nav-over border-transparent bg-transparent'
+          : 'border-border bg-background/90'
+      }`}
+    >
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-6 px-6">
 
         {/* Logo */}

--- a/apps/web/styles/home-vitals.css
+++ b/apps/web/styles/home-vitals.css
@@ -1,62 +1,96 @@
 /* ============================================================
-   home-vitals.css — motion + clinical visual layer for the
-   public homepage (HomePageClient). Scoped: every class is
-   prefixed .vh- and most effects require .vh-js on the page
-   root (set client-side), so SSR / no-JS / test renders are
-   fully visible and unchanged.
+   home-vitals.css — clinical-luminous motion + visual layer for
+   the public homepage (HomePageClient). Scoped: every class is
+   prefixed .vh- and continuous / entrance effects require .vh-js
+   on the page root (set client-side), so SSR / no-JS / test
+   renders stay fully visible and unchanged.
 
-   Truth notes: this layer is purely visual. It introduces no
-   product claims. The wallet visual remains a schematic
-   (aria-hidden) and its states come from the TSX data.
+   Design intent (Wave: Immaculate): this is medicine. A living
+   vitals monitor, a heartbeat that draws itself, a readiness
+   meter that reads like a clinical device — a luminous emerald /
+   teal / monitor-cyan signal on calm paper. Premium depth and
+   motion, never noise.
+
+   Truth notes: purely visual. Introduces no product claims. The
+   wallet visual stays a schematic (aria-hidden); its states come
+   from the TSX data. No banned copy, no status label reads as a
+   bare "verified".
    ============================================================ */
 
 .vh-root {
-  --vh-pulse: var(--vt-accent-emerald, #047857);
-  --vh-pulse-soft: color-mix(in oklab, var(--vh-pulse) 22%, transparent);
-  --vh-teal: color-mix(in oklab, var(--vh-pulse) 62%, #0ea5a3);
-  --vh-amber: color-mix(in oklab, #b45309 70%, var(--paper, #f4f1ea));
-  --vh-ink: var(--vt-text-primary, #1a1916);
+  /* Clinical signal palette — saturated, healthcare-native. */
+  --vh-emerald: #059669;
+  --vh-teal: #0d9aa2;
+  --vh-cyan: #22aecb;
+  --vh-mint: #34d399;
+  --vh-amber: #d97706;
+
+  --vh-pulse: var(--vh-emerald);
+  --vh-pulse-soft: color-mix(in oklab, var(--vh-mint) 42%, transparent);
+  --vh-ink: var(--vt-text-primary, #141414);
+
+  /* The signature gradient — one identity across meter, chips,
+     EKG, CTA and section accents so the page reads as one system. */
+  --vh-signal: linear-gradient(100deg, var(--vh-emerald), var(--vh-teal) 52%, var(--vh-cyan));
+  --vh-signal-soft: linear-gradient(
+    100deg,
+    color-mix(in oklab, var(--vh-emerald) 22%, transparent),
+    color-mix(in oklab, var(--vh-cyan) 20%, transparent)
+  );
+  --vh-glow: 0 0 22px color-mix(in oklab, var(--vh-teal) 40%, transparent);
+}
+.dark .vh-root {
+  --vh-emerald: #34d399;
+  --vh-teal: #2dd4bf;
+  --vh-cyan: #38bdf8;
+  --vh-mint: #6ee7b7;
+  --vh-amber: #fbbf24;
 }
 
 /* ------------------------------------------------------------
-   Aurora backdrop — two slow clinical-green drifts behind hero.
+   Luminous clinical atmosphere — three slow drifts + a soft
+   signal wash behind the hero. Present, not a whisper.
    ------------------------------------------------------------ */
 .vh-aurora {
   position: absolute;
   inset: 0;
   overflow: hidden;
   pointer-events: none;
+  z-index: 0;
 }
 .vh-aurora::before,
 .vh-aurora::after {
   content: '';
   position: absolute;
-  width: 52rem;
-  height: 52rem;
+  width: 54rem;
+  height: 54rem;
   border-radius: 9999px;
-  filter: blur(70px);
-  opacity: 0.5;
+  filter: blur(64px);
+  opacity: 0.85;
   will-change: transform;
 }
 .vh-aurora::before {
-  top: -30rem;
-  right: -14rem;
+  top: -28rem;
+  right: -12rem;
   background: radial-gradient(
     circle at center,
-    color-mix(in oklab, var(--vh-pulse) 16%, transparent) 0%,
-    color-mix(in oklab, var(--vh-teal) 10%, transparent) 42%,
+    color-mix(in oklab, var(--vh-teal) 32%, transparent) 0%,
+    color-mix(in oklab, var(--vh-emerald) 20%, transparent) 40%,
     transparent 70%
   );
 }
 .vh-aurora::after {
-  top: 6rem;
-  left: -22rem;
+  top: 2rem;
+  left: -24rem;
+  width: 46rem;
+  height: 46rem;
   background: radial-gradient(
     circle at center,
-    color-mix(in oklab, var(--vh-amber) 14%, transparent) 0%,
-    transparent 62%
+    color-mix(in oklab, var(--vh-cyan) 26%, transparent) 0%,
+    color-mix(in oklab, var(--vh-mint) 14%, transparent) 45%,
+    transparent 66%
   );
-  opacity: 0.38;
+  opacity: 0.7;
 }
 .vh-js .vh-aurora::before {
   animation: vh-drift-a 26s ease-in-out infinite alternate;
@@ -66,11 +100,29 @@
 }
 @keyframes vh-drift-a {
   from { transform: translate3d(0, 0, 0) scale(1); }
-  to   { transform: translate3d(-6rem, 4rem, 0) scale(1.12); }
+  to   { transform: translate3d(-6rem, 4rem, 0) scale(1.14); }
 }
 @keyframes vh-drift-b {
   from { transform: translate3d(0, 0, 0) scale(1); }
-  to   { transform: translate3d(5rem, -2.5rem, 0) scale(1.08); }
+  to   { transform: translate3d(5rem, -3rem, 0) scale(1.1); }
+}
+
+/* Clinical signal grid — a faint monitor lattice over the hero,
+   fading out downward. Reads "device", not "spreadsheet". */
+.vh-signalgrid {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 40rem;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--vh-teal) 8%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--vh-teal) 8%, transparent) 1px, transparent 1px);
+  background-size: 46px 46px;
+  -webkit-mask-image: radial-gradient(120% 90% at 70% 0%, #000 0%, transparent 72%);
+  mask-image: radial-gradient(120% 90% at 70% 0%, #000 0%, transparent 72%);
+  opacity: 0.6;
 }
 
 /* ------------------------------------------------------------
@@ -79,10 +131,10 @@
    ------------------------------------------------------------ */
 .vh-js .vh-reveal {
   opacity: 0;
-  transform: translateY(22px);
+  transform: translateY(24px);
   transition:
-    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
-    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+    opacity 0.8s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
   transition-delay: var(--vh-delay, 0ms);
   will-change: opacity, transform;
 }
@@ -90,14 +142,12 @@
   opacity: 1;
   transform: translateY(0);
 }
-/* Stagger helper: children of a revealed group cascade. The group is marked
-   vh-in directly, or sits inside a revealed wrapper (descendant form). */
 .vh-js .vh-stagger > * {
   opacity: 0;
-  transform: translateY(16px);
+  transform: translateY(18px);
   transition:
-    opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1),
-    transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+    opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
 }
 .vh-js .vh-stagger.vh-in > *,
 .vh-js .vh-in .vh-stagger > * {
@@ -105,16 +155,16 @@
   transform: translateY(0);
 }
 .vh-js .vh-stagger.vh-in > *:nth-child(1), .vh-js .vh-in .vh-stagger > *:nth-child(1) { transition-delay: 0ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(2), .vh-js .vh-in .vh-stagger > *:nth-child(2) { transition-delay: 70ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(3), .vh-js .vh-in .vh-stagger > *:nth-child(3) { transition-delay: 140ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(4), .vh-js .vh-in .vh-stagger > *:nth-child(4) { transition-delay: 210ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(5), .vh-js .vh-in .vh-stagger > *:nth-child(5) { transition-delay: 280ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(6), .vh-js .vh-in .vh-stagger > *:nth-child(6) { transition-delay: 350ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(7), .vh-js .vh-in .vh-stagger > *:nth-child(7) { transition-delay: 420ms; }
-.vh-js .vh-stagger.vh-in > *:nth-child(8), .vh-js .vh-in .vh-stagger > *:nth-child(8) { transition-delay: 490ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(2), .vh-js .vh-in .vh-stagger > *:nth-child(2) { transition-delay: 75ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(3), .vh-js .vh-in .vh-stagger > *:nth-child(3) { transition-delay: 150ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(4), .vh-js .vh-in .vh-stagger > *:nth-child(4) { transition-delay: 225ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(5), .vh-js .vh-in .vh-stagger > *:nth-child(5) { transition-delay: 300ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(6), .vh-js .vh-in .vh-stagger > *:nth-child(6) { transition-delay: 375ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(7), .vh-js .vh-in .vh-stagger > *:nth-child(7) { transition-delay: 450ms; }
+.vh-js .vh-stagger.vh-in > *:nth-child(8), .vh-js .vh-in .vh-stagger > *:nth-child(8) { transition-delay: 525ms; }
 
 /* ------------------------------------------------------------
-   Eyebrow: pulsing status dot + growing hairline.
+   Eyebrow: pulsing signal dot with a luminous halo.
    ------------------------------------------------------------ */
 .vh-eyebrow {
   display: inline-flex;
@@ -122,40 +172,42 @@
   gap: 0.6rem;
 }
 .vh-eyebrow-dot {
-  width: 7px;
-  height: 7px;
+  position: relative;
+  width: 8px;
+  height: 8px;
   border-radius: 9999px;
-  background: var(--vh-pulse);
-  box-shadow: 0 0 0 0 var(--vh-pulse-soft);
+  background: var(--vh-mint);
+  box-shadow: 0 0 8px 1px color-mix(in oklab, var(--vh-mint) 70%, transparent);
   flex: none;
 }
 .vh-js .vh-eyebrow-dot {
   animation: vh-ping 2.6s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 @keyframes vh-ping {
-  0%   { box-shadow: 0 0 0 0 var(--vh-pulse-soft); }
-  55%  { box-shadow: 0 0 0 9px transparent; }
-  100% { box-shadow: 0 0 0 0 transparent; }
+  0%   { box-shadow: 0 0 8px 1px color-mix(in oklab, var(--vh-mint) 70%, transparent), 0 0 0 0 var(--vh-pulse-soft); }
+  55%  { box-shadow: 0 0 8px 1px color-mix(in oklab, var(--vh-mint) 70%, transparent), 0 0 0 10px transparent; }
+  100% { box-shadow: 0 0 8px 1px color-mix(in oklab, var(--vh-mint) 70%, transparent), 0 0 0 0 transparent; }
 }
 
 /* ------------------------------------------------------------
-   Hero EKG hairline — a heartbeat trace that draws itself once
-   under the H1, then idles with a soft glow sweep.
+   Hero EKG hairline — a bright heartbeat that draws itself once
+   under the H1, then a light pulse travels the trace.
    ------------------------------------------------------------ */
 .vh-ekg-line {
   display: block;
   width: min(34rem, 100%);
-  height: 28px;
+  height: 30px;
   overflow: visible;
 }
 .vh-ekg-line path {
   fill: none;
-  stroke: color-mix(in oklab, var(--vh-pulse) 55%, var(--vt-border, #d8d3c8));
-  stroke-width: 1.6;
+  stroke: url(#vh-ekg-grad);
+  stroke-width: 2.1;
   stroke-linecap: round;
   stroke-linejoin: round;
+  filter: drop-shadow(0 0 5px color-mix(in oklab, var(--vh-teal) 45%, transparent));
 }
-.vh-js .vh-ekg-line path {
+.vh-js .vh-ekg-line path.vh-ekg-draw {
   stroke-dasharray: 640;
   stroke-dashoffset: 640;
   animation: vh-ekg-draw 2.2s cubic-bezier(0.65, 0, 0.35, 1) 0.35s forwards;
@@ -163,13 +215,36 @@
 @keyframes vh-ekg-draw {
   to { stroke-dashoffset: 0; }
 }
+/* A short bright pulse that rides the line after it draws. */
+.vh-ekg-line path.vh-ekg-spark {
+  stroke: var(--vh-mint);
+  stroke-width: 3;
+  filter: drop-shadow(0 0 6px var(--vh-mint));
+  stroke-dasharray: 26 614;
+  stroke-dashoffset: 640;
+  opacity: 0;
+}
+.vh-js .vh-ekg-line path.vh-ekg-spark {
+  animation: vh-ekg-spark 3.4s linear 2.6s infinite;
+}
+@keyframes vh-ekg-spark {
+  0%   { stroke-dashoffset: 640; opacity: 0; }
+  6%   { opacity: 1; }
+  60%  { opacity: 1; }
+  70%  { stroke-dashoffset: -40; opacity: 0; }
+  100% { stroke-dashoffset: -40; opacity: 0; }
+}
 
 /* ------------------------------------------------------------
-   Wallet card — living vitals monitor.
+   Wallet card — living clinical monitor with real depth.
    ------------------------------------------------------------ */
 .vh-wallet {
+  position: relative;
   transform-style: preserve-3d;
   transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.35s ease;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 34px 80px -18px color-mix(in oklab, var(--vh-teal) 30%, rgba(15, 23, 42, 0.28));
 }
 .vh-js .vh-wallet {
   transform:
@@ -179,10 +254,22 @@
 }
 .vh-wallet:hover {
   box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.75),
-    0 42px 90px rgba(15, 23, 42, 0.16);
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 46px 100px -20px color-mix(in oklab, var(--vh-teal) 40%, rgba(15, 23, 42, 0.32));
 }
-/* Sheen sweep across the card on reveal + on hover. */
+/* Luminous signal edge along the top of the card. */
+.vh-wallet::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  border-radius: 999px;
+  margin: 0 1.5rem;
+  background: var(--vh-signal);
+  opacity: 0.9;
+  box-shadow: 0 0 16px color-mix(in oklab, var(--vh-teal) 55%, transparent);
+}
+/* Sheen sweep across the card on hover. */
 .vh-wallet::after {
   content: '';
   position: absolute;
@@ -192,7 +279,7 @@
   background: linear-gradient(
     105deg,
     transparent 38%,
-    rgba(255, 255, 255, 0.5) 48%,
+    rgba(255, 255, 255, 0.55) 48%,
     transparent 58%
   );
   background-size: 260% 100%;
@@ -206,30 +293,49 @@
   from { background-position: 130% 0; }
   to   { background-position: -60% 0; }
 }
+/* Soft aura floating behind the wallet — the device glows. */
+.vh-wallet-halo {
+  position: absolute;
+  inset: -14% -10% -18% -10%;
+  z-index: -1;
+  border-radius: 50%;
+  background: radial-gradient(
+    60% 55% at 60% 40%,
+    color-mix(in oklab, var(--vh-teal) 30%, transparent),
+    transparent 70%
+  );
+  filter: blur(30px);
+  pointer-events: none;
+}
+.vh-js .vh-wallet-halo {
+  animation: vh-halo 6s ease-in-out infinite;
+}
+@keyframes vh-halo {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50%      { opacity: 1; transform: scale(1.06); }
+}
 
-/* Monitor strip: continuously running EKG trace. */
+/* Monitor strip: continuously running EKG trace + scan beam. */
 .vh-monitor {
   position: relative;
-  height: 44px;
+  height: 48px;
   border-radius: 0.9rem;
   overflow: hidden;
   background:
-    linear-gradient(
-      color-mix(in oklab, var(--vh-pulse) 5%, var(--vt-bg, #faf8f3)),
-      color-mix(in oklab, var(--vh-pulse) 5%, var(--vt-bg, #faf8f3))
-    );
-  border: 1px solid color-mix(in oklab, var(--vh-pulse) 18%, var(--vt-border-subtle, #e4dfd4));
+    radial-gradient(120% 180% at 0% 0%, color-mix(in oklab, var(--vh-teal) 14%, #06231f) 0%, #071c1a 60%);
+  border: 1px solid color-mix(in oklab, var(--vh-teal) 40%, transparent);
+  box-shadow: inset 0 0 24px color-mix(in oklab, var(--vh-teal) 22%, transparent);
 }
-/* faint clinical grid */
+/* clinical grid inside the monitor */
 .vh-monitor::before {
   content: '';
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(to right, color-mix(in oklab, var(--vh-pulse) 9%, transparent) 1px, transparent 1px),
-    linear-gradient(to bottom, color-mix(in oklab, var(--vh-pulse) 9%, transparent) 1px, transparent 1px);
-  background-size: 11px 11px;
-  opacity: 0.5;
+    linear-gradient(to right, color-mix(in oklab, var(--vh-mint) 16%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--vh-mint) 16%, transparent) 1px, transparent 1px);
+  background-size: 12px 12px;
+  opacity: 0.4;
 }
 .vh-monitor svg {
   position: absolute;
@@ -239,68 +345,94 @@
 }
 .vh-monitor path {
   fill: none;
-  stroke: var(--vh-pulse);
-  stroke-width: 1.8;
+  stroke: var(--vh-mint);
+  stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
-  filter: drop-shadow(0 0 3px color-mix(in oklab, var(--vh-pulse) 60%, transparent));
+  filter: drop-shadow(0 0 4px var(--vh-mint));
 }
 .vh-js .vh-monitor svg {
-  animation: vh-trace 7s linear infinite;
+  animation: vh-trace 6s linear infinite;
 }
 @keyframes vh-trace {
   from { transform: translateX(0); }
   to   { transform: translateX(-50%); }
 }
-/* Static fallback (no JS / reduced motion): show one heartbeat, no loop. */
-
+/* Bright scan beam sweeping left→right like a cardiac monitor cursor. */
+.vh-monitor-beam {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 60px;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklab, var(--vh-mint) 45%, transparent) 70%,
+    color-mix(in oklab, var(--vh-mint) 85%, white) 100%
+  );
+  mix-blend-mode: screen;
+  transform: translateX(-70px);
+}
+.vh-js .vh-monitor-beam {
+  animation: vh-beam 6s linear infinite;
+}
+@keyframes vh-beam {
+  from { transform: translateX(-70px); }
+  to   { transform: translateX(360px); }
+}
 .vh-monitor-label {
   position: absolute;
   top: 6px;
-  right: 8px;
+  right: 9px;
   display: inline-flex;
   align-items: center;
   gap: 5px;
   font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  color: color-mix(in oklab, var(--vh-pulse) 80%, var(--vh-ink));
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  color: color-mix(in oklab, var(--vh-mint) 75%, white);
+  text-shadow: 0 0 8px color-mix(in oklab, var(--vh-mint) 60%, transparent);
 }
 .vh-monitor-label::before {
   content: '';
   width: 5px;
   height: 5px;
   border-radius: 9999px;
-  background: var(--vh-pulse);
+  background: var(--vh-mint);
+  box-shadow: 0 0 6px var(--vh-mint);
 }
 .vh-js .vh-monitor-label::before {
   animation: vh-blink 1.6s ease-in-out infinite;
 }
 @keyframes vh-blink {
   0%, 100% { opacity: 1; }
-  50%      { opacity: 0.25; }
+  50%      { opacity: 0.2; }
 }
 
-/* Readiness bar — clinical gradient + shimmer, replaces the ink-black bar. */
+/* Readiness meter — segmented clinical readout with a leading
+   pulse. This is the deliberate replacement for the old ink bar:
+   a luminous signal, never a heavy block. */
 .vh-bar {
   position: relative;
-  height: 10px;
+  height: 12px;
   border-radius: 9999px;
   overflow: hidden;
-  background: var(--vt-surface-subtle, #eee9de);
+  background: color-mix(in oklab, var(--vh-teal) 10%, var(--vt-surface-subtle, #eee9de));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--vh-teal) 16%, transparent);
 }
 .vh-bar-fill {
   position: relative;
   height: 100%;
   width: var(--vh-bar, 72%);
   border-radius: inherit;
-  background: linear-gradient(
-    90deg,
-    color-mix(in oklab, var(--vh-pulse) 88%, #064e3b),
-    var(--vh-pulse) 55%,
-    var(--vh-teal)
-  );
-  box-shadow: 0 0 10px color-mix(in oklab, var(--vh-pulse) 35%, transparent);
+  background: var(--vh-signal);
+  box-shadow:
+    0 0 12px color-mix(in oklab, var(--vh-teal) 55%, transparent),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+  /* segment ticks via mask — reads like a clinical device meter */
+  -webkit-mask-image: repeating-linear-gradient(90deg, #000 0 12px, transparent 12px 15px);
+  mask-image: repeating-linear-gradient(90deg, #000 0 12px, transparent 12px 15px);
 }
 .vh-js .vh-bar-fill {
   width: 0;
@@ -309,28 +441,36 @@
 @keyframes vh-bar-fill {
   to { width: var(--vh-bar, 72%); }
 }
-.vh-bar-fill::after {
+/* Leading pulse dot at the meter head. */
+.vh-bar::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    100deg,
-    transparent 30%,
-    rgba(255, 255, 255, 0.55) 50%,
-    transparent 70%
-  );
-  background-size: 220% 100%;
-  background-position: 130% 0;
+  top: 50%;
+  left: var(--vh-bar, 72%);
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  border-radius: 9999px;
+  background: #fff;
+  box-shadow: 0 0 10px 2px var(--vh-mint);
+  transform: translateY(-50%) scale(0);
 }
-.vh-js .vh-bar-fill::after {
-  animation: vh-shimmer 2.6s ease-in-out 2.1s infinite;
+.vh-js .vh-bar::after {
+  animation:
+    vh-bar-head 1.5s cubic-bezier(0.22, 1, 0.36, 1) 0.5s forwards,
+    vh-head-pulse 2s ease-in-out 2.1s infinite;
 }
-@keyframes vh-shimmer {
-  0%   { background-position: 130% 0; }
-  60%, 100% { background-position: -90% 0; }
+@keyframes vh-bar-head {
+  from { left: 0; transform: translateY(-50%) scale(0); }
+  to   { left: var(--vh-bar, 72%); transform: translateY(-50%) scale(1); }
+}
+@keyframes vh-head-pulse {
+  0%, 100% { box-shadow: 0 0 10px 2px var(--vh-mint); }
+  50%      { box-shadow: 0 0 16px 4px var(--vh-mint); }
 }
 
-/* Wallet source rows: scan highlight sweeps the stack. */
+/* Wallet source rows: scan highlight sweeps the stack + each row
+   glows as it "checks in" on reveal. */
 .vh-scan {
   position: relative;
   overflow: hidden;
@@ -344,11 +484,11 @@
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    color-mix(in oklab, var(--vh-pulse) 7%, transparent) 50%,
+    color-mix(in oklab, var(--vh-mint) 16%, transparent) 50%,
     transparent 100%
   );
   transform: translateY(-110%);
-  animation: vh-scan 6.5s ease-in-out 3s infinite;
+  animation: vh-scan 5.5s ease-in-out 2.5s infinite;
 }
 @keyframes vh-scan {
   0%, 55%  { transform: translateY(-110%); }
@@ -358,25 +498,27 @@
 /* Recognition pulse ring. */
 .vh-ring {
   position: relative;
+  background: var(--vh-signal) !important;
+  color: #fff !important;
+  box-shadow: 0 0 16px color-mix(in oklab, var(--vh-teal) 45%, transparent);
 }
 .vh-js .vh-ring::after {
   content: '';
   position: absolute;
   inset: -2px;
   border-radius: inherit;
-  border: 1.5px solid color-mix(in oklab, var(--vh-pulse) 55%, transparent);
+  border: 1.5px solid color-mix(in oklab, var(--vh-mint) 70%, transparent);
   opacity: 0;
   animation: vh-ring 3.4s cubic-bezier(0.4, 0, 0.6, 1) 1.4s infinite;
 }
 @keyframes vh-ring {
   0%   { opacity: 0.9; transform: scale(0.86); }
-  45%  { opacity: 0; transform: scale(1.45); }
-  100% { opacity: 0; transform: scale(1.45); }
+  45%  { opacity: 0; transform: scale(1.5); }
+  100% { opacity: 0; transform: scale(1.5); }
 }
 
 /* ------------------------------------------------------------
    Source registry marquee — institutional breadth, in motion.
-   Pure names; state vocabulary stays in the caption.
    ------------------------------------------------------------ */
 .vh-marquee {
   position: relative;
@@ -404,33 +546,36 @@
    Card micro-interactions (loop steps, value, ai, doors).
    ------------------------------------------------------------ */
 .vh-lift {
+  position: relative;
   transition:
     transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
     box-shadow 0.3s ease,
     border-color 0.3s ease;
 }
 .vh-lift:hover {
-  transform: translateY(-4px);
-  border-color: color-mix(in oklab, var(--vh-pulse) 38%, var(--vt-border, #d8d3c8)) !important;
+  transform: translateY(-5px);
+  border-color: color-mix(in oklab, var(--vh-teal) 48%, var(--vt-border, #d8d3c8)) !important;
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.6),
-    0 18px 40px rgba(15, 23, 42, 0.09);
+    0 22px 46px -12px color-mix(in oklab, var(--vh-teal) 30%, rgba(15, 23, 42, 0.14));
 }
 .vh-lift:hover .vh-icon-chip {
-  background: color-mix(in oklab, var(--vh-pulse) 15%, transparent);
-  color: var(--vh-pulse);
-  border-color: color-mix(in oklab, var(--vh-pulse) 35%, transparent);
+  background: var(--vh-signal);
+  color: #fff;
+  border-color: transparent;
   transform: scale(1.06);
+  box-shadow: 0 0 16px color-mix(in oklab, var(--vh-teal) 45%, transparent);
 }
 .vh-icon-chip {
   transition:
     background 0.3s ease,
     color 0.3s ease,
     border-color 0.3s ease,
-    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.3s ease;
 }
 
-/* Loop connector — hairline that draws across the steps row. */
+/* Loop connector — signal line that draws across the steps row. */
 .vh-loop-wrap {
   position: relative;
 }
@@ -441,11 +586,8 @@
   right: 1rem;
   height: 2px;
   transform-origin: left center;
-  background: linear-gradient(
-    90deg,
-    color-mix(in oklab, var(--vh-pulse) 45%, transparent),
-    color-mix(in oklab, var(--vh-teal) 40%, transparent)
-  );
+  background: var(--vh-signal);
+  box-shadow: 0 0 10px color-mix(in oklab, var(--vh-teal) 45%, transparent);
   opacity: 0;
 }
 .vh-js .vh-in .vh-loop-connector {
@@ -455,29 +597,47 @@
   from { opacity: 1; transform: scaleX(0); }
   to   { opacity: 1; transform: scaleX(1); }
 }
-
-/* Step number badge fills in as its card reveals. */
 .vh-step-n {
   transition: background 0.4s ease, color 0.4s ease, box-shadow 0.4s ease;
 }
 .vh-lift:hover .vh-step-n {
   box-shadow: 0 0 0 5px var(--vh-pulse-soft);
-  background: var(--vh-pulse);
+  background: var(--vh-signal);
 }
 
 /* ------------------------------------------------------------
-   Primary CTA — ready-state glow when the NPI is complete.
+   Primary CTA — luminous signal fill + ready-state glow when the
+   NPI is complete.
    ------------------------------------------------------------ */
+.vh-cta-ready {
+  background: var(--vh-signal) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
 .vh-js .vh-cta-ready {
-  animation: vh-cta 2.2s ease-in-out infinite;
+  animation: vh-cta 2s ease-in-out infinite;
 }
 @keyframes vh-cta {
   0%, 100% { box-shadow: 0 0 0 0 var(--vh-pulse-soft); }
-  50%      { box-shadow: 0 0 0 7px transparent; }
+  50%      { box-shadow: 0 0 0 8px transparent; }
+}
+
+/* Section accent — a small gradient tick before eyebrow labels
+   deeper on the page (added via .vh-accent-line where wanted). */
+.vh-accent-line::before {
+  content: '';
+  display: inline-block;
+  width: 22px;
+  height: 2px;
+  margin-right: 0.6rem;
+  vertical-align: middle;
+  border-radius: 999px;
+  background: var(--vh-signal);
 }
 
 /* ------------------------------------------------------------
-   Reduced motion: kill continuous + entrance animation.
+   Reduced motion: kill continuous + entrance animation, keep the
+   finished state fully visible.
    ------------------------------------------------------------ */
 @media (prefers-reduced-motion: reduce) {
   .vh-js .vh-reveal,
@@ -488,12 +648,15 @@
   }
   .vh-js .vh-aurora::before,
   .vh-js .vh-aurora::after,
+  .vh-js .vh-wallet-halo,
   .vh-js .vh-eyebrow-dot,
-  .vh-js .vh-ekg-line path,
+  .vh-js .vh-ekg-line path.vh-ekg-draw,
+  .vh-js .vh-ekg-line path.vh-ekg-spark,
   .vh-js .vh-monitor svg,
+  .vh-js .vh-monitor-beam,
   .vh-js .vh-monitor-label::before,
   .vh-js .vh-bar-fill,
-  .vh-js .vh-bar-fill::after,
+  .vh-js .vh-bar::after,
   .vh-js .vh-scan::after,
   .vh-js .vh-ring::after,
   .vh-js .vh-marquee-track,
@@ -502,7 +665,9 @@
     animation: none !important;
   }
   .vh-js .vh-bar-fill { width: var(--vh-bar, 72%); }
-  .vh-js .vh-ekg-line path { stroke-dasharray: none; stroke-dashoffset: 0; }
+  .vh-js .vh-bar::after { left: var(--vh-bar, 72%); transform: translateY(-50%) scale(1); }
+  .vh-js .vh-ekg-line path.vh-ekg-draw { stroke-dasharray: none; stroke-dashoffset: 0; }
+  .vh-js .vh-ekg-line path.vh-ekg-spark { display: none; }
   .vh-js .vh-in .vh-loop-connector { opacity: 1; transform: scaleX(1); }
   .vh-js .vh-wallet { transform: none; }
   .vh-lift:hover { transform: none; }

--- a/apps/web/styles/home-vitals.css
+++ b/apps/web/styles/home-vitals.css
@@ -635,6 +635,178 @@
   background: var(--vh-signal);
 }
 
+/* ============================================================
+   HERO STAGE — the hero rendered as a clinical monitor: a dark,
+   glowing device panel on the paper. Bezel, status LED, an EKG
+   across the header, a faint screen grid. Content inside flips to
+   light-on-dark via the .vh-dark token override so every child
+   component (NPI card, pills, wallet) adapts automatically.
+   ============================================================ */
+.vh-stage {
+  position: relative;
+  border-radius: 2rem;
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  /* Clear the device header (bezel + EKG occupy ~2.1–4.6rem) so the screen
+     content starts below it on every width. */
+  padding-top: clamp(4.75rem, 5vw, 5.5rem);
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(130% 120% at 78% -10%, #0c3b34 0%, #082722 42%, #05140f 100%);
+  border: 1px solid color-mix(in oklab, var(--vh-teal) 34%, #0a1f1c);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset,
+    0 1px 0 rgba(255, 255, 255, 0.06) inset,
+    0 50px 120px -30px color-mix(in oklab, var(--vh-teal) 34%, rgba(3, 12, 10, 0.7)),
+    0 24px 60px -30px rgba(0, 0, 0, 0.6);
+}
+/* Soft teal aura bleeding out from the device. */
+.vh-stage::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  z-index: -1;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    140deg,
+    color-mix(in oklab, var(--vh-mint) 55%, transparent),
+    transparent 34%,
+    transparent 66%,
+    color-mix(in oklab, var(--vh-cyan) 45%, transparent)
+  );
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0.8;
+}
+/* Screen grid + top glow inside the device. */
+.vh-stage-grid {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--vh-mint) 8%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--vh-mint) 8%, transparent) 1px, transparent 1px);
+  background-size: 40px 40px;
+  -webkit-mask-image: radial-gradient(120% 100% at 75% 0%, #000 0%, transparent 70%);
+  mask-image: radial-gradient(120% 100% at 75% 0%, #000 0%, transparent 70%);
+  opacity: 0.7;
+}
+/* Bezel header: status LED + running label, top-right of the device. */
+.vh-stage-bezel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  height: 2.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.25rem;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: color-mix(in oklab, var(--vh-mint) 78%, white);
+  border-bottom: 1px solid color-mix(in oklab, var(--vh-teal) 22%, transparent);
+  background: linear-gradient(color-mix(in oklab, var(--vh-teal) 10%, transparent), transparent);
+}
+.vh-stage-bezel .vh-stage-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  text-shadow: 0 0 8px color-mix(in oklab, var(--vh-mint) 50%, transparent);
+}
+.vh-stage-led {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--vh-mint);
+  box-shadow: 0 0 8px 1px var(--vh-mint);
+}
+.vh-js .vh-stage-led {
+  animation: vh-blink 1.6s ease-in-out infinite;
+}
+.vh-stage-bezel .vh-stage-dots {
+  display: inline-flex;
+  gap: 5px;
+  opacity: 0.7;
+}
+.vh-stage-bezel .vh-stage-dots i {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--vh-mint) 60%, transparent);
+}
+/* Full-width EKG across the device header. */
+.vh-stage-ekg {
+  position: absolute;
+  top: 2.1rem;
+  left: 0;
+  right: 0;
+  height: 40px;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 12%, #000 88%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 12%, #000 88%, transparent);
+  opacity: 0.7;
+}
+.vh-stage-ekg svg {
+  position: absolute;
+  inset: 0;
+  width: 200%;
+  height: 100%;
+}
+.vh-stage-ekg path {
+  fill: none;
+  stroke: color-mix(in oklab, var(--vh-mint) 85%, transparent);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 4px color-mix(in oklab, var(--vh-mint) 60%, transparent));
+}
+.vh-js .vh-stage-ekg svg {
+  animation: vh-trace 9s linear infinite;
+}
+.vh-stage > .vh-stage-content {
+  position: relative;
+  z-index: 3;
+}
+
+/* Token override: everything inside the device reads light-on-dark.
+   Child components (Card, Input, pills, wallet) resolve --vt-* to
+   these, so they adapt with no per-component edits. */
+.vh-dark {
+  --vt-bg: rgba(4, 20, 17, 0.55);
+  --vt-surface: rgba(216, 255, 246, 0.055);
+  --vt-surface-subtle: rgba(216, 255, 246, 0.035);
+  --vt-surface-dim: rgba(4, 20, 17, 0.5);
+  --vt-border: rgba(150, 240, 216, 0.22);
+  --vt-border-subtle: rgba(150, 240, 216, 0.12);
+  --vt-text-primary: #ecfdf7;
+  --vt-text-secondary: rgba(236, 253, 247, 0.82);
+  --vt-text-muted: rgba(236, 253, 247, 0.55);
+  --vt-focus-ring: var(--vh-mint);
+  --vt-accent-emerald: var(--vh-mint);
+  color: var(--vt-text-primary);
+}
+/* On the dark stage the hero EKG hairline is not needed (the device
+   header carries the trace) — hide it to avoid a double heartbeat. */
+.vh-dark .vh-ekg-line { display: none; }
+/* Wallet on the dark stage: a lit device, brighter edge + deeper aura. */
+.vh-dark .vh-wallet {
+  background: rgba(214, 255, 245, 0.05) !important;
+  border-color: rgba(150, 240, 216, 0.24) !important;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.12) inset,
+    0 40px 90px -24px rgba(0, 0, 0, 0.6),
+    0 0 60px -12px color-mix(in oklab, var(--vh-teal) 40%, transparent);
+}
+.vh-dark .vh-wallet-halo { opacity: 0.9; }
+
 /* ------------------------------------------------------------
    Reduced motion: kill continuous + entrance animation, keep the
    finished state fully visible.
@@ -655,6 +827,8 @@
   .vh-js .vh-monitor svg,
   .vh-js .vh-monitor-beam,
   .vh-js .vh-monitor-label::before,
+  .vh-js .vh-stage-ekg svg,
+  .vh-js .vh-stage-led,
   .vh-js .vh-bar-fill,
   .vh-js .vh-bar::after,
   .vh-js .vh-scan::after,

--- a/apps/web/styles/home-vitals.css
+++ b/apps/web/styles/home-vitals.css
@@ -644,41 +644,41 @@
    ============================================================ */
 .vh-stage {
   position: relative;
-  border-radius: 2rem;
-  padding: clamp(1.5rem, 3vw, 2.75rem);
-  /* Clear the device header (bezel + EKG occupy ~2.1–4.6rem) so the screen
-     content starts below it on every width. */
-  padding-top: clamp(4.75rem, 5vw, 5.5rem);
+  /* Full-bleed: span the viewport, pulled up flush under the navbar so the
+     dark nav + dark device read as one continuous surface. Content stays
+     centered in a readable column via --vh-stage-pad. */
+  --vh-stage-pad: max(1.5rem, calc((100vw - 72rem) / 2));
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  margin-top: -4rem; /* cancels main's py-16 top padding → meets the navbar */
+  border-radius: 0 0 2.25rem 2.25rem;
+  padding: clamp(1.5rem, 3vw, 2.75rem) var(--vh-stage-pad) clamp(2.75rem, 4vw, 3.75rem);
+  padding-top: clamp(5rem, 5vw, 6rem);
   overflow: hidden;
   isolation: isolate;
   background:
-    radial-gradient(130% 120% at 78% -10%, #0c3b34 0%, #082722 42%, #05140f 100%);
-  border: 1px solid color-mix(in oklab, var(--vh-teal) 34%, #0a1f1c);
+    radial-gradient(120% 130% at 72% -25%, #0c3b34 0%, #082722 45%, #05140f 100%);
   box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.03) inset,
     0 1px 0 rgba(255, 255, 255, 0.06) inset,
-    0 50px 120px -30px color-mix(in oklab, var(--vh-teal) 34%, rgba(3, 12, 10, 0.7)),
-    0 24px 60px -30px rgba(0, 0, 0, 0.6);
+    0 50px 120px -34px color-mix(in oklab, var(--vh-teal) 34%, rgba(3, 12, 10, 0.7));
 }
-/* Soft teal aura bleeding out from the device. */
+@media (min-width: 640px) {
+  .vh-stage { margin-top: -5rem; } /* sm:py-20 */
+}
+/* Luminous bottom edge where the device meets the paper body. */
 .vh-stage::before {
   content: '';
   position: absolute;
-  inset: -1px;
-  z-index: -1;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(
-    140deg,
-    color-mix(in oklab, var(--vh-mint) 55%, transparent),
-    transparent 34%,
-    transparent 66%,
-    color-mix(in oklab, var(--vh-cyan) 45%, transparent)
-  );
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  opacity: 0.8;
+  left: 12%;
+  right: 12%;
+  bottom: 0;
+  height: 2px;
+  z-index: 4;
+  border-radius: 999px;
+  background: var(--vh-signal);
+  box-shadow: 0 0 20px color-mix(in oklab, var(--vh-teal) 60%, transparent);
+  opacity: 0.85;
 }
 /* Screen grid + top glow inside the device. */
 .vh-stage-grid {
@@ -705,7 +705,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1.25rem;
+  padding: 0 var(--vh-stage-pad, 1.25rem);
   font-size: 9.5px;
   font-weight: 700;
   letter-spacing: 0.18em;
@@ -807,6 +807,93 @@
 }
 .vh-dark .vh-wallet-halo { opacity: 0.9; }
 
+/* Live instrument readout in the bezel — signal bars + a cycling
+   "READING <source>…" ticker + a LIVE lamp. Honest: it names the real
+   primary sources the product reads. SSR shows the first frame. */
+.vh-stage-readout {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+.vh-stage-bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 12px;
+}
+.vh-stage-bars i {
+  width: 2.5px;
+  height: 40%;
+  border-radius: 1px;
+  background: var(--vh-mint);
+  box-shadow: 0 0 4px color-mix(in oklab, var(--vh-mint) 70%, transparent);
+}
+.vh-js .vh-stage-bars i { animation: vh-bars 1.1s ease-in-out infinite; }
+.vh-js .vh-stage-bars i:nth-child(2) { animation-delay: 0.16s; }
+.vh-js .vh-stage-bars i:nth-child(3) { animation-delay: 0.32s; }
+.vh-js .vh-stage-bars i:nth-child(4) { animation-delay: 0.48s; }
+@keyframes vh-bars {
+  0%, 100% { height: 28%; }
+  50%      { height: 100%; }
+}
+.vh-stage-ticker {
+  display: inline-block;
+  height: 1.2em;
+  line-height: 1.2em;
+  overflow: hidden;
+  min-width: 13ch;
+  text-align: left;
+  color: color-mix(in oklab, var(--vh-mint) 60%, white);
+}
+.vh-stage-ticker-track { display: flex; flex-direction: column; }
+.vh-js .vh-stage-ticker-track { animation: vh-ticker 10s steps(1) infinite; }
+@keyframes vh-ticker {
+  0%, 18%   { transform: translateY(0); }
+  22%, 43%  { transform: translateY(-1.2em); }
+  47%, 68%  { transform: translateY(-2.4em); }
+  72%, 93%  { transform: translateY(-3.6em); }
+  97%, 100% { transform: translateY(-4.8em); }
+}
+.vh-stage-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: color-mix(in oklab, var(--vh-mint) 82%, white);
+}
+@media (max-width: 560px) {
+  .vh-stage-ticker { display: none; }
+}
+
+/* ------------------------------------------------------------
+   Navbar over the dark hero — transparent-dark so the nav + device
+   read as one continuous surface. Returns to the solid bar on scroll
+   (handled in Navbar.tsx). Scoped: only the nav sets .vh-nav-over.
+   ------------------------------------------------------------ */
+.vh-nav-over {
+  background: linear-gradient(180deg, #061e1a 0%, #05170f 100%) !important;
+  color: #ecfdf7;
+}
+.vh-nav-over a,
+.vh-nav-over button {
+  color: rgba(236, 253, 247, 0.9) !important;
+}
+.vh-nav-over .font-heading {
+  color: #ffffff !important;
+}
+.vh-nav-over a[href="/sign-in"] {
+  border-color: rgba(150, 240, 216, 0.3) !important;
+  color: rgba(236, 253, 247, 0.85) !important;
+}
+/* The navbar is rendered outside the homepage root, so the .vh-* palette
+   vars are not in scope here — use literal signal colors. */
+.vh-nav-over a[href="/passport"] {
+  background: linear-gradient(100deg, #059669, #0d9aa2 52%, #22aecb) !important;
+  border-color: transparent !important;
+  color: #04140f !important;
+  box-shadow: 0 0 18px rgba(13, 154, 162, 0.45);
+}
+
 /* ------------------------------------------------------------
    Reduced motion: kill continuous + entrance animation, keep the
    finished state fully visible.
@@ -829,6 +916,8 @@
   .vh-js .vh-monitor-label::before,
   .vh-js .vh-stage-ekg svg,
   .vh-js .vh-stage-led,
+  .vh-js .vh-stage-bars i,
+  .vh-js .vh-stage-ticker-track,
   .vh-js .vh-bar-fill,
   .vh-js .vh-bar::after,
   .vh-js .vh-scan::after,


### PR DESCRIPTION
## Why
The homepage read as a calm greige notebook: flat, monochrome, a near-black readiness bar on the wallet, no depth or motion. It didn't signal *healthcare*, and it didn't look like a product built by a serious team. This PR is a step-change in visual craft — same structure and messaging, a dramatically more alive, unmistakably-clinical skin.

This bundles a never-merged motion-layer branch with a substantial amplification pass into one coherent change, so it takes production's homepage from the old flat version all the way to the new one in a single PR.

## What changed (skin + motion only)
- **Clinical signal palette** — emerald → teal → monitor-cyan → luminous mint, unified into one signature gradient threaded across the readiness meter, EKG, icon chips, CTA, and connectors, so the page reads as one designed system.
- **The wallet is now a living vitals monitor** — a dark cardiac-monitor strip with a bright EKG trace and a running scan-beam, glass depth, a floating signal halo, and a luminous top edge. This is the "this is medicine" centerpiece Chris asked for.
- **The "black bar" is gone** — replaced by a segmented clinical readiness meter (emerald→cyan gradient, segment ticks, a glowing leading pulse dot). Verified in-browser: the fill is the gradient, not ink.
- **Luminous hero atmosphere** — a present emerald/teal aurora + a faint clinical signal grid, replacing the flat field. The hero EKG hairline draws itself, then a bright pulse rides the trace.
- **Motion system** — scroll-reveal choreography, staggered card entrances, a count-up readiness figure, pointer parallax tilt on the wallet, a marquee of primary-source registries, hover lifts that light each card's icon chip with the signal gradient, an animated loop connector, and a ready-state CTA glow.

## Honesty & safety (unchanged contract)
- The wallet stays an `aria-hidden` schematic — **no new product claims**. Source states remain the honest vocabulary (`Source-backed` / `Checked` / `Gated`); no status reads as a bare "verified".
- Every test-pinned copy string and `data-home-*` attribute is preserved.
- Fully `prefers-reduced-motion` safe (continuous + entrance animation disabled, finished states stay visible) and SSR/no-JS safe (hidden states only apply under a client-set `.vh-js` root, so search engines and the test renderer see everything).

## Verification
- `home-npi-role-doors` copy-guard + banned-phrase scan: **16/16 green**.
- `pnpm turbo run build --filter @vitalcv/web` (enforces TS + ESLint): **green**.
- Browser preview at 1440px: wallet meter computed background confirmed as the `emerald→teal→cyan` gradient; hero, monitor, and source states render as intended.

## Design Handoff References
No Claude Design handoff file used for this PR — visual system authored in-repo as the scoped `.vh-*` layer in `apps/web/styles/home-vitals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)