### PR TITLE
feat(holder): clinical-monitor readiness card on the signed-in wallet

### DIFF
--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -35,6 +35,11 @@ import { MatchaHomeActivity } from '@/components/matcha/MatchaHomeActivity';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
 import { buildClinicianProofSummary } from '@/lib/proof/proof-model';
 
+/** One heartbeat cycle for the readiness-card vitals monitor, tiled for a
+ *  seamless loop. Matches the homepage wallet's clinical-monitor language. */
+const READINESS_EKG =
+  'M0 22 H26 L34 22 L40 12 L46 30 L52 6 L58 34 L64 22 L72 22 H104 L112 22 L118 14 L124 28 L130 22 H160';
+
 function resumeLabel(path: string | null): { title: string; href: string } | null {
   if (!path || path === '/holder/home') {
     return null;
@@ -388,7 +393,7 @@ export default function ClinicianHomeSurface() {
       </section>
 
       <section className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
-        <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
+        <div className="vh-scope vh-js relative overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
           <div className="flex items-start justify-between gap-3">
             <div>
               <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Readiness</p>
@@ -399,7 +404,7 @@ export default function ClinicianHomeSurface() {
                 Last synced {new Date(data.refreshedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
               </p>
             </div>
-            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-4 py-3 text-right">
+            <div className="rounded-2xl border border-emerald-400/25 bg-emerald-400/10 px-4 py-3 text-right shadow-[0_0_28px_-8px_rgba(45,212,191,0.55)]">
               <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Trust</p>
               <p className="mt-2 text-2xl font-semibold text-white">
                 {readiness ? `${readiness.readinessScore}/100` : 'Pending'}
@@ -408,11 +413,24 @@ export default function ClinicianHomeSurface() {
             </div>
           </div>
 
-          <div className="mt-5 h-3 overflow-hidden rounded-full bg-white/10">
-            <div
-              className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-sky-400 to-cyan-300"
-              style={{ width: `${Math.max(8, readiness?.readinessScore ?? completeness)}%` }}
-            />
+          {/* Vitals monitor — the clinical heartbeat of the readiness card,
+              matching the public wallet's living-monitor language. */}
+          <div className="vh-monitor mt-5">
+            <svg viewBox="0 0 320 44" preserveAspectRatio="none">
+              <path d={READINESS_EKG} />
+              <path d={READINESS_EKG} transform="translate(160 0)" />
+            </svg>
+            <span aria-hidden="true" className="vh-monitor-beam" />
+            <span className="vh-monitor-label">EVIDENCE · LIVE READ</span>
+          </div>
+
+          {/* Readiness meter — segmented clinical readout with a leading pulse,
+              replacing the flat gradient bar. */}
+          <div
+            className="vh-bar mt-4"
+            style={{ '--vh-bar': `${Math.max(8, readiness?.readinessScore ?? completeness)}%` } as React.CSSProperties}
+          >
+            <div className="vh-bar-fill" />
           </div>
 
           <div className="mt-4 flex flex-wrap items-center gap-3">

--- a/apps/web/styles/home-vitals.css
+++ b/apps/web/styles/home-vitals.css
@@ -47,6 +47,31 @@
   --vh-amber: #fbbf24;
 }
 
+/* Reusable scope for the clinical-monitor components (meter, EKG,
+   glow) on ANY dark surface outside the homepage — e.g. the signed-in
+   /holder readiness card. Self-contained: bright signal palette +
+   dark --vt tokens so .vh-bar / .vh-monitor render correctly without
+   a .vh-root ancestor. Animations still require .vh-js; without it the
+   finished (filled / static-trace) state shows. */
+.vh-scope {
+  --vh-emerald: #34d399;
+  --vh-teal: #2dd4bf;
+  --vh-cyan: #38bdf8;
+  --vh-mint: #6ee7b7;
+  --vh-amber: #fbbf24;
+  --vh-pulse: var(--vh-emerald);
+  --vh-pulse-soft: color-mix(in oklab, var(--vh-mint) 42%, transparent);
+  --vh-ink: #ecfdf7;
+  --vh-signal: linear-gradient(100deg, var(--vh-emerald), var(--vh-teal) 52%, var(--vh-cyan));
+  --vh-glow: 0 0 22px color-mix(in oklab, var(--vh-teal) 40%, transparent);
+  --vt-surface-subtle: rgba(255, 255, 255, 0.10);
+  --vt-bg: rgba(4, 20, 17, 0.5);
+  --vt-border-subtle: rgba(150, 240, 216, 0.14);
+  --vt-text-primary: #ecfdf7;
+  --vt-text-muted: rgba(236, 253, 247, 0.55);
+  --vt-accent-emerald: var(--vh-mint);
+}
+
 /* ------------------------------------------------------------
    Luminous clinical atmosphere — three slow drifts + a soft
    signal wash behind the hero. Present, not a whisper.


### PR DESCRIPTION
## Why
The homepage now reads as a premium clinical monitor ([#566](https://github.com/ctol3r/vitalcv/pull/566)). This brings the same living-monitor language to the surface a clinician actually lives in — the signed-in `/holder` home. That surface is already dark-themed, so the treatment fits natively.

## What changed (purely visual)
- **Reusable `.vh-scope`** — makes the `.vh-*` clinical-monitor components (segmented meter, EKG monitor, glow) work on any dark surface outside the homepage. Self-contained: bright signal palette + dark `--vt` tokens, no `.vh-root` ancestor required. This is the vehicle for rolling the language across the app.
- **Readiness card** (`ClinicianHomeSurface`) — adds the vitals EKG monitor strip (`EVIDENCE · LIVE READ`, with the scan-beam) and replaces the flat gradient bar with the **segmented luminous readiness meter** (emerald→teal→cyan, segment ticks, a leading pulse dot that sits at the score head). The Trust chip gains a signal glow.

The readiness/trust numbers, copy, and data flow are untouched.

## Verification note (please confirm signed-in)
`/holder` is Clerk-gated and can't render in dev preview (the provider errors without auth), so I verified the new card two ways:
1. **Static replica in-browser** — rendered the exact `.vh-scope` + `.vh-monitor` + `.vh-bar` markup with sample values; the meter fills to score with the segmented gradient + leading pulse, the EKG monitor and Trust glow render correctly (screenshot in the working session).
2. `holder-home-page` + `holder-route-contract` **151/151**, `pnpm turbo run build --filter @vitalcv/web` (TS + ESLint) **green**.

Because I can't load the authed surface myself, a quick signed-in look from you is the final check before this is "confirmed immaculate."

## Design Handoff References
No Claude Design handoff file used — reuses the in-repo `.vh-*` clinical-monitor system from `apps/web/styles/home-vitals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)