### PR TITLE
chore(security): SCA critical-gate + dependabot + protobufjs/shell-quote overrides (B1/G8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Dependabot — enterprise-map B1 / ASVS G8.
+# Keeps the dependency tree patched so the SCA gate (.github/workflows/security-audit.yml)
+# stays green on criticals and the high backlog trends down instead of up.
+#
+# NOTE: this file configures *version* updates. Dependabot *security* updates
+# (immediate PRs for GHSA alerts) also require the repo-level toggle:
+#   Settings → Code security → Dependabot security updates → Enable.
+version: 2
+updates:
+  # npm ecosystem covers the whole pnpm workspace via the single root lockfile.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Batch routine minor/patch bumps into one PR to cut review noise.
+      # Majors and security fixes still open as focused, individual PRs.
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep CI action pins current — GitHub Actions are part of the supply chain.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,56 @@
+name: SCA (dependency audit)
+
+# Software Composition Analysis gate — enterprise-map B1 / ASVS G8.
+# Policy lives in scripts/security/audit-gate.mjs: FAIL ONLY ON CRITICAL.
+# High/moderate/low are reported (job summary) but non-blocking — the repo
+# carries a large pre-existing high backlog that is burned down separately in
+# docs/security/dependency-remediation.md. A high/moderate bar would be
+# permanently red and would train reviewers to ignore the signal.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/security/**'
+      - '.github/workflows/security-audit.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/security/**'
+      - '.github/workflows/security-audit.yml'
+  schedule:
+    # Weekly, Monday 06:17 UTC. Surfaces advisories newly disclosed against the
+    # current lockfile even when no dependency file changed this week.
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sca-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  sca:
+    name: SCA — critical-only gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # pnpm version resolved from packageManager field in package.json (pnpm@10.6.1)
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      # `pnpm audit` reads pnpm-lock.yaml + the registry advisory DB directly;
+      # no install of the (potentially vulnerable) tree is required to audit it.
+      - name: Audit production dependencies (fails only on critical; high reported)
+        run: node scripts/security/audit-gate.mjs

--- a/docs/security/dependency-remediation.md
+++ b/docs/security/dependency-remediation.md
@@ -1,0 +1,123 @@
+# Dependency remediation & burn-down
+
+**Enterprise-map B1 (supply chain) · ASVS G8 (SCA).**
+Owner: platform security · Last updated: 2026-07-06
+
+This is the living register for third-party dependency vulnerabilities. The
+**[SCA gate](../../.github/workflows/security-audit.yml)** blocks new
+**criticals**; everything else is tracked here and burned down deliberately so
+the signal stays actionable instead of permanently red.
+
+## Policy
+
+| Severity | CI behavior | Rationale |
+|---|---|---|
+| **Critical** | ❌ **blocks merge** (`scripts/security/audit-gate.mjs` exits 1) | A critical in a shipped dependency is never acceptable. Fix with an upgrade or `pnpm.overrides` before merge. |
+| High | ⚠️ reported, non-blocking | 75 pre-existing highs; a hard gate here would be permanently red and train reviewers to ignore it. Burned down in waves (below). |
+| Moderate / Low | reported, non-blocking | Batched via Dependabot version updates. |
+
+The gate reads `pnpm audit --prod` (production tree only — dev-only tooling
+advisories are excluded from the merge signal). Run it locally:
+
+```bash
+node scripts/security/audit-gate.mjs
+```
+
+## Status
+
+| Date | Critical | High | Moderate | Low | Total | Note |
+|---|---:|---:|---:|---:|---:|---|
+| 2026-07-05 (baseline, `origin/main`) | 4 | 85 | 72 | 14 | 175 | pre-remediation |
+| + PR #569 (`@clerk/nextjs` → 6.39.5) | 2 | 80 | 72 | 14 | 168 | cleared Clerk cluster crit + 5 highs |
+| + this PR (protobufjs / shell-quote overrides) | **0** | **75** | **67** | **14** | **156** | **criticals eliminated** |
+
+### Criticals — DONE (0 remaining)
+
+| Package | Fix | Advisory |
+|---|---|---|
+| `@clerk/nextjs` (+ `@clerk/shared`) | bump `apps/web` → `^6.39.5` | GHSA-vqx2-fgx2-5wq9 — middleware route-protection **bypass** (P0, auth boundary) |
+| `protobufjs` | `pnpm.overrides` → `^7.5.5` (resolves 7.6.5) | GHSA-xq3m-2v4x-88gg — arbitrary code execution. Transitive via `posthog-js` → OTLP exporter (apps/web). |
+| `shell-quote` | `pnpm.overrides` → `^1.8.4` (resolves 1.9.0) | GHSA-w7jw-789q-3m8p — `quote()` newline-escape bypass. Transitive via `react-native` → `react-devtools-core` (apps/mobile). |
+
+## High-severity backlog (75 advisories, 21 modules)
+
+Ordered by remediation priority. **~45 of 69 distinct high advisories reach a
+shipped surface (`apps/web`, `apps/api/*`, `packages/*`); the rest are
+`apps/mobile` only.** Path counts are dominated by mobile transitives (e.g.
+`minimatch` has 4,179 install paths, almost all under React Native) — path count
+is *reach*, not *risk*; prioritize by runtime exposure of the affected surface.
+
+### P1 — direct deps in shipped apps (low effort, do first)
+
+| Package | Where | Current | Target | Highs cleared | Notes |
+|---|---|---|---|---:|---|
+| `axios` | `apps/web` **direct** | `^1.14.0` (froze <1.15) | `^1.16.0` | 11 | Prototype pollution, proxy-auth credential leak, MITM, ReDoS, SSRF. `^1.14.0` already permits the fix — bump the spec (or `pnpm update axios`) + reinstall. Cheap, high value. |
+| `next` | `apps/web`, `apps/marketing` **direct** | `15.2.8` | `>=15.5.18` | 8 | Includes **App Router middleware / proxy bypass** (same class as the Clerk P0), plus DoS (Server Components / `connect`), SSRF, cache-request deserialization. **Framework minor bump — needs full web build + e2e + middleware re-verification.** Highest security value in the backlog; schedule as its own PR. |
+
+### P2 — transitive in `apps/api/*` (server runtime; override + backend gate)
+
+Server-side exposure is real. Fix with `pnpm.overrides` (prefer same-major),
+then verify against the backend Postgres gate (PR #568) since backend jest is
+not a PR gate.
+
+| Package | Target | Highs | Advisory class |
+|---|---|---:|---|
+| `undici` | `>=7.28.0` | 5 | WebSocket 64-bit length overflow, unbounded memory, DoS |
+| `minimatch` | `>=9.0.7` (and `>=5.1.8`) | 3+ | ReDoS (matchOne backtracking, nested extglobs) |
+| `path-to-regexp` | `>=8.4.0` / `>=0.1.13` | 2 | ReDoS (Express routing) |
+| `ws` | `>=8.21.0` | 1 | Memory-exhaustion DoS from tiny fragments |
+| `lodash` | `>=4.18.0` | 1 | Code injection via `_.template` |
+| `defu` | `>=6.1.5` | 1 | Prototype pollution via `__proto__` |
+| `effect` | `>=3.20.0` | 1 | `AsyncLocalStorage` context contamination |
+| `multer` | `>=2.2.0` | 1 | DoS via deeply nested fields |
+| `apollo-server` | **investigate** | 1 | DoS. `apollo-server` is deprecated (no clean patch line → shows `<0.0.0`); likely a migration to `@apollo/server`, not a bump. Needs an owner decision. |
+
+### P3 — transitive in `apps/web` (browser/edge + build; override)
+
+| Package | Target | Highs | Advisory class |
+|---|---|---:|---|
+| `picomatch` | `>=4.0.4` (and `>=2.3.2`) | 2 | ReDoS via extglob |
+| `fast-uri` | `>=3.1.2` | 2 | Path traversal / host confusion via percent-encoding |
+| `form-data` | `>=4.0.6` | 1 | CRLF injection |
+| `serialize-javascript` | `>=7.0.3` | 1 | RCE via RegExp (build-time) |
+| `rollup` | `>=4.59.0` | 1 | Arbitrary file write via path traversal (build-time) |
+| `d3-color` | `>=3.1.0` | 1 | ReDoS |
+
+### P4 — `apps/mobile` only (Expo / React Native transitive; deferred + tracked)
+
+`@xmldom/xmldom` (5), `node-forge` (4), `tar` (6), `@babel/plugin-transform-modules-systemjs` (1),
+plus the bulk of `minimatch` / `picomatch` install paths.
+
+These sit under React Native / Expo and **cannot be safely force-overridden**
+without risking the RN toolchain. `apps/mobile` is **not currently on the
+production deployment path** for the trust platform. **Accepted risk, tracked** —
+revisit when either (a) `apps/mobile` ships, or (b) RN/Expo publishes patched
+transitives. Needs an explicit owner sign-off to keep as accepted risk.
+
+## How to burn one down
+
+```bash
+# 1. Locate it
+pnpm why <package>
+
+# 2a. Direct dep → bump the range in the owning package.json
+# 2b. Transitive → add to root package.json "pnpm.overrides"
+#     (prefer the same major to avoid breaking the consumer):
+#       "pnpm.overrides": { "<package>": ">=<patched-version>" }
+
+pnpm install
+
+# 3. Rebuild + test the affected workspace(s)
+pnpm turbo build --filter=@vitalcv/<workspace>
+
+# 4. Confirm: no new criticals, high count dropped
+node scripts/security/audit-gate.mjs
+
+# 5. Delete the row above. Fix-and-remove — never let this table rot.
+```
+
+## Guardrails
+
+- **[SCA gate](../../.github/workflows/security-audit.yml)** keeps criticals at 0 while the backlog burns down.
+- **[Dependabot](../../.github/dependabot.yml)** opens weekly npm + github-actions update PRs. Enable repo-level **Dependabot security updates** (Settings → Code security) for immediate GHSA-alert PRs.
+- Never add an override just to silence the gate for a *critical* — fix the root cause. Overrides are for transitive fixes where the direct consumer hasn't shipped a patched range yet.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "pnpm": {
     "overrides": {
       "@types/react": "^19",
-      "@types/react-dom": "^19"
+      "@types/react-dom": "^19",
+      "protobufjs": "^7.5.5",
+      "shell-quote": "^1.8.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   '@types/react': ^19
   '@types/react-dom': ^19
+  protobufjs: ^7.5.5
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -3993,11 +3995,20 @@ packages:
   '@protobufjs/codegen@2.0.4':
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
 
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
   '@protobufjs/fetch@1.1.0':
     resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
@@ -4013,6 +4024,9 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -10149,8 +10163,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10738,8 +10752,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -15441,7 +15455,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.6.5
 
   '@opentelemetry/redis-common@0.38.2': {}
 
@@ -15938,12 +15952,20 @@ snapshots:
 
   '@protobufjs/codegen@2.0.4': {}
 
+  '@protobufjs/codegen@2.0.5': {}
+
   '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
 
@@ -15954,6 +15976,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -23750,18 +23774,17 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 20.19.27
       long: 5.3.2
 
@@ -23861,7 +23884,7 @@ snapshots:
 
   react-devtools-core@5.3.2(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -24551,7 +24574,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.9.0: {}
 
   shelljs@0.8.5:
     dependencies:

--- a/scripts/security/audit-gate.mjs
+++ b/scripts/security/audit-gate.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * SCA gate — Software Composition Analysis for the production dependency tree.
+ * Enterprise-map B1 / ASVS G8.
+ *
+ * Policy: FAIL ONLY ON CRITICAL.
+ *   - critical > 0  → exit 1 (blocks merge). A critical advisory in a shipped
+ *                     dependency is never acceptable; fix with an upgrade or a
+ *                     pnpm.overrides entry.
+ *   - high/moderate/low → reported, non-blocking. The repo carries a large
+ *                     pre-existing high backlog (tracked + burned down in
+ *                     docs/security/dependency-remediation.md); a high/moderate
+ *                     bar would be permanently red and train everyone to ignore it.
+ *
+ * Fails CLOSED: if the audit can't run or its output can't be parsed, exit 2
+ * (a gate that cannot evaluate must not report "clean").
+ *
+ * Usage:
+ *   node scripts/security/audit-gate.mjs                 # runs `pnpm audit --prod --json`
+ *   AUDIT_JSON_FILE=audit.json node scripts/security/audit-gate.mjs   # parse a captured file
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+function runAudit() {
+  try {
+    // `pnpm audit` exits non-zero whenever advisories exist — that's expected.
+    // We want its stdout regardless of exit code, so capture and fall through.
+    return execFileSync('pnpm', ['audit', '--prod', '--json'], {
+      encoding: 'utf8',
+      maxBuffer: 128 * 1024 * 1024,
+    });
+  } catch (err) {
+    if (err && err.stdout) return err.stdout.toString();
+    console.error('SCA gate: `pnpm audit --prod --json` could not run.');
+    console.error(String((err && err.message) || err));
+    process.exit(2);
+  }
+}
+
+const raw = process.env.AUDIT_JSON_FILE
+  ? fs.readFileSync(process.env.AUDIT_JSON_FILE, 'utf8')
+  : runAudit();
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  console.error('SCA gate: could not parse audit JSON (fail-closed).');
+  console.error(raw.slice(0, 800));
+  process.exit(2);
+}
+
+const v = data?.metadata?.vulnerabilities ?? {};
+const counts = {
+  critical: v.critical ?? 0,
+  high: v.high ?? 0,
+  moderate: v.moderate ?? 0,
+  low: v.low ?? 0,
+  info: v.info ?? 0,
+};
+const total = counts.critical + counts.high + counts.moderate + counts.low + counts.info;
+
+console.log(
+  `\nProduction dependency advisories → ` +
+    `critical=${counts.critical}  high=${counts.high}  ` +
+    `moderate=${counts.moderate}  low=${counts.low}  (total ${total})\n`
+);
+
+// GitHub Actions step summary (markdown) when available.
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+  const md = [
+    '## SCA — production dependency audit',
+    '',
+    '| Severity | Count | Gate |',
+    '|---|---:|---|',
+    `| 🔴 Critical | ${counts.critical} | ${counts.critical > 0 ? '**❌ blocks merge**' : '✅ clean'} |`,
+    `| 🟠 High | ${counts.high} | ⚠️ non-blocking — see \`docs/security/dependency-remediation.md\` |`,
+    `| 🟡 Moderate | ${counts.moderate} | non-blocking |`,
+    `| ⚪ Low | ${counts.low} | non-blocking |`,
+    '',
+    counts.critical > 0
+      ? '**A critical advisory is present in the production dependency tree. This is blocked until it is remediated (upgrade the package or add a `pnpm.overrides` entry).**'
+      : '_No critical advisories. The high-severity backlog is tracked separately and burned down over time._',
+    '',
+  ].join('\n');
+  try {
+    fs.appendFileSync(summaryPath, md + '\n');
+  } catch {
+    /* summary is best-effort */
+  }
+}
+
+if (counts.critical > 0) {
+  console.error(
+    `✖ ${counts.critical} CRITICAL advisory(ies) in the production dependency tree — failing the SCA gate.`
+  );
+  console.error(
+    '  Remediate with a version upgrade or a pnpm.overrides entry in the root package.json, then re-run.'
+  );
+  console.error('  Details: pnpm audit --prod');
+  process.exit(1);
+}
+
+console.log('✓ No critical advisories in the production dependency tree.');
+if (counts.high > 0) {
+  console.log(
+    `  (${counts.high} high advisories are non-blocking; see docs/security/dependency-remediation.md)`
+  );
+}
+process.exit(0);


### PR DESCRIPTION
## What & why (enterprise task B1 — supply-chain hardening)

Second half of the B1 sweep. **[PR #569](https://github.com/ctol3r/vitalcv/pull/569) shipped the urgent Clerk P0 separately**; this PR clears the **two residual criticals** and stands up the machinery to keep criticals at zero going forward.

> 📌 **Stacked on #569** — base branch is `claude/priceless-williams-4697f7`. GitHub retargets this to `main` automatically when #569 merges. Review/merge #569 first.

## 1. Residual criticals → 0 (pnpm overrides)

Both are transitive, so they're pinned via `pnpm.overrides` in the root `package.json`, staying **within the current major** (no consumer API breakage):

| Package | Was | Now | Advisory | Pulled by |
|---|---|---|---|---|
| `protobufjs` | 7.5.4 | **7.6.5** (`^7.5.5`) | [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) — arbitrary code execution | `posthog-js` → OTLP exporter (apps/web) |
| `shell-quote` | 1.8.3 | **1.9.0** (`^1.8.4`) | [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `quote()` newline bypass | `react-native` → `react-devtools-core` (apps/mobile) |

## 2. SCA CI gate — fails only on critical

[`.github/workflows/security-audit.yml`](.github/workflows/security-audit.yml) → [`scripts/security/audit-gate.mjs`](scripts/security/audit-gate.mjs):

- Runs `pnpm audit --prod`. **Critical → job fails (blocks merge). High / moderate / low → reported to the job summary, non-blocking.** The repo has **75 pre-existing highs**; a moderate/high bar would be permanently red and would train reviewers to ignore the gate.
- **Fails closed**: if the audit can't run or its JSON can't be parsed, exit 2 (a gate that can't evaluate must not report "clean").
- Triggers: dependency-file PRs, pushes to `main`, and weekly (catches newly-disclosed advisories against the frozen lockfile).
- No install of the (potentially vulnerable) tree — `pnpm audit` reads the lockfile + registry directly.

Behavior-tested locally: clean → exit 0, fabricated critical → exit 1, unparseable → exit 2.

> After merge: add **SCA — critical-only gate** as a required check in branch protection.

## 3. Dependabot (none existed)

[`.github/dependabot.yml`](.github/dependabot.yml): `npm` (whole pnpm workspace via the single root lockfile) + `github-actions`, weekly, grouped minor/patch to cut noise. Enable repo-level **Dependabot security updates** (Settings → Code security) for immediate GHSA-alert PRs.

## 4. Remediation backlog

[`docs/security/dependency-remediation.md`](docs/security/dependency-remediation.md) tracks the 75 highs as a prioritized **4-wave burn-down** rather than one unreviewable mega-bump:

- **P1** direct-dep bumps in shipped apps: `axios ^1.14.0→^1.16.0` (11 highs), `next 15.2.8→≥15.5.18` (8 highs, **incl. a Next App-Router middleware/proxy bypass** — same class as the Clerk P0; own PR + QA).
- **P2** `apps/api/*` server transitives via overrides (undici, minimatch, ws, path-to-regexp, lodash, defu, effect, multer; apollo-server needs a migration decision).
- **P3** `apps/web` transitives via overrides (picomatch, fast-uri, form-data, serialize-javascript, rollup, d3-color).
- **P4** `apps/mobile`-only Expo/RN transitives — **deferred/accepted-risk** (not on the prod deploy path; can't be safely force-overridden).

## Audit delta (combined with #569)

| | critical | high | moderate | low | total |
|---|---:|---:|---:|---:|---:|
| baseline (`origin/main`, 2026-07-05) | 4 | 85 | 72 | 14 | 175 |
| after #569 + this PR | **0** | **75** | **67** | **14** | **156** |

## Verification

- `turbo build --filter=@vitalcv/web`: **13/13** with protobufjs 7.6.5 (protobufjs is in the web tree).
- Lockfile churn is protobufjs/shell-quote-scoped only.

## Canon Checklist

- [ ] Recognition / Receipt — N/A (dependency + CI tooling; no trust-state emission)
- [x] CRS determinism — unaffected (no CRS/product source touched)
- [x] Revocation/expiry fail-closed — unaffected
- [x] Canonical state truth — unaffected

Refs enterprise-map B1 (supply chain), ASVS G8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
