### PR TITLE
feat(home): micro-interactions phase 1 — NPI validation checkmark + palette polish

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -742,6 +742,19 @@ export default function HomePageClient() {
                         aria-describedby={error ? 'home-npi-error' : undefined}
                         className="h-14 flex-1 border-0 bg-transparent px-4 text-[18px] font-medium tracking-[0.14em] text-[var(--vt-text-primary)] shadow-none placeholder:text-[var(--vt-text-muted)]/40 focus-visible:ring-0"
                       />
+                      {/* Validation micro-interaction: a jade check springs in on a full NPI. */}
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          'flex items-center justify-center pb-4 pl-4 pr-4 sm:pb-0 sm:pl-0 sm:pr-2 transition-transform duration-300 ease-[cubic-bezier(.34,1.56,.64,1)]',
+                          isFull ? 'scale-100' : 'scale-0',
+                        )}
+                      >
+                        <CheckCircle2
+                          size={22}
+                          className="text-[var(--vt-accent-emerald)] drop-shadow-[0_0_10px_color-mix(in_oklab,var(--vt-accent-emerald)_50%,transparent)]"
+                        />
+                      </span>
                       <button
                         type="submit"
                         data-home-primary-cta=""

--- a/apps/web/components/ui/CommandPalette.tsx
+++ b/apps/web/components/ui/CommandPalette.tsx
@@ -240,7 +240,7 @@ export function CommandPalette() {
               exit={{ opacity: 0, scale: 0.98, y: -10 }}
               transition={{ duration: 0.2, ease: "easeOut" }}
               className={cn(
-                "relative flex flex-col w-full max-w-2xl overflow-hidden rounded-3xl border border-white/15 bg-[linear-gradient(160deg,rgba(20,32,48,0.9),rgba(9,16,26,0.95))] backdrop-blur-2xl shadow-[0_40px_120px_-30px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.12)] transition-all duration-300",
+                "relative flex flex-col w-full max-w-2xl overflow-hidden rounded-3xl border border-white/15 bg-[linear-gradient(160deg,rgba(16,25,39,0.975),rgba(8,13,22,0.985))] backdrop-blur-2xl shadow-[0_40px_120px_-30px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.12)] transition-all duration-300",
                 isResultsMode ? "h-[80vh] max-h-[800px]" : "h-auto"
               )}
             >
@@ -307,8 +307,8 @@ export function CommandPalette() {
                             className={cn(
                               "flex flex-col items-start p-4 rounded-xl text-left transition-all border",
                               selected
-                                ? "bg-muted border-border shadow-[0_0_15px_rgba(255,255,255,0.05)]"
-                                : "bg-transparent border-transparent hover:bg-muted"
+                                ? "bg-white/[0.08] border-white/15 shadow-[0_0_22px_-6px_rgba(52,230,176,0.4)]"
+                                : "bg-white/[0.03] border-white/[0.06] hover:bg-white/[0.07]"
                             )}
                           >
                             <div className="flex items-center gap-3 mb-2 w-full">


### PR DESCRIPTION
## What & why

First slice of the micro-interaction system from the approved concept — starting with the interaction *every visitor touches*.

- **Hero NPI validation checkmark** — a jade check **springs in** (scale-0 → spring scale-1) the instant the NPI hits 10 digits, and the CTA activates. Exactly the concept's "validation as you type." (Verified in preview — screenshot in session.)
- **Command palette polish** — action cards now have a visible resting fill and a **jade glow on selection** (they were washing out on the glass), and the panel is near-opaque so the actions read clearly.

## Verification
Typecheck + `next lint` clean. NPI checkmark verified live (types to 10 digits → check springs in, button activates).

## Follow-ups
- Palette panel readability is improved but worth one more pass (the frosted panel can still look see-through over busy content).
- Rest of the micro-interaction system: **toggle slides · animated skeletons · progress bars · toasts** (the app already has a toast layer) across the signed-in surfaces (holder, readiness, applications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)