### PR TITLE
feat(readiness): skeletons, not spinners — shaped loading state

### DIFF
--- a/apps/web/app/holder/readiness/ReadinessSurface.tsx
+++ b/apps/web/app/holder/readiness/ReadinessSurface.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Award, Building2, Share2, TrendingUp } from 'lucide-react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
@@ -183,10 +184,28 @@ export default function ReadinessSurface() {
         {/* Live state log */}
         {loadState !== 'no-npi' && <LiveStateLog entries={logEntries} maxHeight={160} />}
 
-        {/* Loading */}
+        {/* Loading — a readiness-shaped skeleton, not a spinner */}
         {loadState === 'loading' && (
-          <div className="vcv-panel p-8 text-center">
-            <p className="vcv-mono text-sm vcv-muted animate-pulse">Checking sources…</p>
+          <div className="space-y-4" aria-busy="true" aria-live="polite">
+            <span className="sr-only">Checking sources…</span>
+            <div className="vcv-panel px-5 py-4">
+              <Skeleton className="h-3 w-28" />
+              <Skeleton className="mt-3 h-4 w-3/4" />
+            </div>
+            <div className="vcv-panel overflow-hidden">
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between gap-4 border-t border-black/5 px-5 py-4 first:border-t-0"
+                >
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-3.5 w-32" />
+                    <Skeleton className="h-2.5 w-24" />
+                  </div>
+                  <Skeleton className="h-6 w-20 rounded-full" />
+                </div>
+              ))}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## What & why

Next micro-interaction from the concept: **"skeletons, not spinners."** The signed-in readiness surface showed a bare "Checking sources…" pulse; now it shows a **readiness-shaped skeleton** while the passport loads — a header panel + four lane rows (label / sublabel / state-chip placeholders) built from the existing `Skeleton` primitive. The wait now previews the content that's coming instead of a blank flash. Accessible (`aria-busy` + `sr-only` status).

First surface of the skeleton rollout; **applications / holder home / opportunities** are the same pattern next.

## Verification
Typecheck + `next lint` clean. `/holder/readiness` is route-gated (CLINICIAN), so it can't be previewed unauthenticated here — the change reuses a tested primitive with a standard shaped-skeleton pattern; best confirmed live signed-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)