### PR TITLE
Forward verified bearer on backend proxies (G1 enforce prep, cohort 1/2)

### DIFF
--- a/apps/web/__tests__/forward-identity.test.ts
+++ b/apps/web/__tests__/forward-identity.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// G1 enforce-flip prerequisite: web proxy handlers must forward BOTH
+// x-clerk-user-id AND a verified Authorization bearer, so they survive the
+// backend's verifiedIdentity enforce mode (which 401s header-without-token).
+
+const authMock = vi.fn();
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => authMock() }));
+
+import { buildIdentityHeaders, applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
+
+beforeEach(() => authMock.mockReset());
+
+describe('buildIdentityHeaders', () => {
+  it('forwards both the user id and a bearer token when the session mints one', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1', getToken: async () => 'jwt-abc' });
+    const h = await buildIdentityHeaders();
+    expect(h['x-clerk-user-id']).toBe('user_1');
+    expect(h.Authorization).toBe('Bearer jwt-abc');
+  });
+
+  it('falls back to id-only when getToken is unavailable (behavior-preserving)', async () => {
+    authMock.mockResolvedValue({ userId: 'user_1', getToken: undefined });
+    const h = await buildIdentityHeaders();
+    expect(h['x-clerk-user-id']).toBe('user_1');
+    expect(h.Authorization).toBeUndefined();
+  });
+
+  it('falls back to id-only when getToken throws', async () => {
+    authMock.mockResolvedValue({
+      userId: 'user_1',
+      getToken: async () => {
+        throw new Error('token minting failed');
+      },
+    });
+    const h = await buildIdentityHeaders();
+    expect(h['x-clerk-user-id']).toBe('user_1');
+    expect(h.Authorization).toBeUndefined();
+  });
+
+  it('returns an empty map for an anonymous session', async () => {
+    authMock.mockResolvedValue({ userId: null, getToken: async () => null });
+    expect(await buildIdentityHeaders()).toEqual({});
+  });
+
+  it('uses pre-resolved inputs without calling auth() again', async () => {
+    const h = await buildIdentityHeaders({ userId: 'user_9', token: 'jwt-xyz' });
+    expect(authMock).not.toHaveBeenCalled();
+    expect(h).toEqual({ 'x-clerk-user-id': 'user_9', Authorization: 'Bearer jwt-xyz' });
+  });
+});
+
+describe('applyIdentityHeaders', () => {
+  it('mutates a Headers object in place', async () => {
+    const headers = new Headers({ 'content-type': 'application/json' });
+    await applyIdentityHeaders(headers, { userId: 'user_1', token: 'jwt-abc' });
+    expect(headers.get('x-clerk-user-id')).toBe('user_1');
+    expect(headers.get('authorization')).toBe('Bearer jwt-abc');
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('mutates a plain record in place', async () => {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    await applyIdentityHeaders(headers, { userId: 'user_1', token: 'jwt-abc' });
+    expect(headers['x-clerk-user-id']).toBe('user_1');
+    expect(headers.Authorization).toBe('Bearer jwt-abc');
+    expect(headers.Accept).toBe('application/json');
+  });
+});

--- a/apps/web/app/api/credentials/[id]/confirm/route.ts
+++ b/apps/web/app/api/credentials/[id]/confirm/route.ts
@@ -7,6 +7,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -21,7 +22,7 @@ export async function PATCH(
 
   const headers = new Headers({ 'Content-Type': 'application/json' });
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const body = await req.text();

--- a/apps/web/app/api/credentials/ingest-npi/route.ts
+++ b/apps/web/app/api/credentials/ingest-npi/route.ts
@@ -8,6 +8,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -18,7 +19,7 @@ export async function POST(req: NextRequest) {
 
   const headers = new Headers({ 'Content-Type': 'application/json' });
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const body = await req.text();

--- a/apps/web/app/api/credentials/ingest/route.ts
+++ b/apps/web/app/api/credentials/ingest/route.ts
@@ -7,6 +7,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -17,7 +18,7 @@ export async function POST(req: NextRequest) {
 
   const headers = new Headers({ 'Content-Type': 'application/json' });
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const body = await req.text();

--- a/apps/web/app/api/credentials/mine/route.ts
+++ b/apps/web/app/api/credentials/mine/route.ts
@@ -6,6 +6,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -16,7 +17,7 @@ export async function GET() {
 
   const headers = new Headers();
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const res = await fetch(`${BACKEND_URL}/api/credentials/mine`, {

--- a/apps/web/app/api/documents/[id]/route.ts
+++ b/apps/web/app/api/documents/[id]/route.ts
@@ -7,6 +7,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -21,7 +22,7 @@ export async function GET(
 
   const headers = new Headers();
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const res = await fetch(`${BACKEND_URL}/api/documents/${id}`, {

--- a/apps/web/app/api/documents/parse/route.ts
+++ b/apps/web/app/api/documents/parse/route.ts
@@ -7,6 +7,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -17,7 +18,7 @@ export async function POST(req: NextRequest) {
 
   const headers = new Headers();
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   // Forward raw multipart body — do NOT set Content-Type (browser must set boundary)

--- a/apps/web/app/api/documents/verify/route.ts
+++ b/apps/web/app/api/documents/verify/route.ts
@@ -7,6 +7,7 @@
 
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest) {
   const headers = new Headers();
   headers.set('content-type', 'application/json');
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const res = await fetch(`${BACKEND_URL}/api/documents/verify`, {

--- a/apps/web/app/api/profile/identity/email-otp/issue/route.ts
+++ b/apps/web/app/api/profile/identity/email-otp/issue/route.ts
@@ -5,6 +5,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -21,7 +22,7 @@ export async function POST(req: NextRequest) {
   }
 
   const headers = new Headers({ 'Content-Type': 'application/json' });
-  headers.set('x-clerk-user-id', session.userId);
+  await applyIdentityHeaders(headers, { userId: session.userId });
 
   const body = await req.text();
   const res = await fetch(`${BACKEND}/api/profile/identity/email-otp/issue`, {

--- a/apps/web/app/api/profile/identity/email-otp/verify/route.ts
+++ b/apps/web/app/api/profile/identity/email-otp/verify/route.ts
@@ -5,6 +5,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -21,7 +22,7 @@ export async function POST(req: NextRequest) {
   }
 
   const headers = new Headers({ 'Content-Type': 'application/json' });
-  headers.set('x-clerk-user-id', session.userId);
+  await applyIdentityHeaders(headers, { userId: session.userId });
 
   const body = await req.text();
   const res = await fetch(`${BACKEND}/api/profile/identity/email-otp/verify`, {

--- a/apps/web/app/api/profile/npi/bootstrap/route.ts
+++ b/apps/web/app/api/profile/npi/bootstrap/route.ts
@@ -5,6 +5,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -20,7 +21,7 @@ export async function POST(req: NextRequest) {
   const headers = new Headers({ 'Content-Type': 'application/json' });
   // Inject Clerk session — required by backend requireUserId()
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
   const emailClaim = (session.sessionClaims as Record<string, unknown> | undefined)?.email;
   if (typeof emailClaim === 'string' && emailClaim.length > 0) {

--- a/apps/web/app/api/watch/[id]/route.ts
+++ b/apps/web/app/api/watch/[id]/route.ts
@@ -1,17 +1,18 @@
 import { getApiBase } from '@/lib/api';
 import { auth } from '@clerk/nextjs/server';
 import { NextResponse, type NextRequest } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
 const BACKEND = getApiBase();
 
-function buildHeaders(session: Awaited<ReturnType<typeof auth>>): Headers {
+async function buildHeaders(session: Awaited<ReturnType<typeof auth>>): Promise<Headers> {
   const headers = new Headers();
   headers.set('Content-Type', 'application/json');
 
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const orgId = typeof (session as { orgId?: unknown }).orgId === 'string'
@@ -50,7 +51,7 @@ export async function DELETE(
   try {
     const res = await fetch(`${BACKEND}/api/watch/${encodeURIComponent(id)}`, {
       method: 'DELETE',
-      headers: buildHeaders(session),
+      headers: await buildHeaders(session),
       signal: AbortSignal.timeout(8000),
     });
 

--- a/apps/web/app/api/watch/route.ts
+++ b/apps/web/app/api/watch/route.ts
@@ -1,17 +1,18 @@
 import { getApiBase } from '@/lib/api';
 import { auth } from '@clerk/nextjs/server';
 import { type NextRequest, NextResponse } from 'next/server';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
 const BACKEND = getApiBase();
 
-function buildHeaders(session: Awaited<ReturnType<typeof auth>>): Headers {
+async function buildHeaders(session: Awaited<ReturnType<typeof auth>>): Promise<Headers> {
   const headers = new Headers();
   headers.set('Content-Type', 'application/json');
 
   if (session.userId) {
-    headers.set('x-clerk-user-id', session.userId);
+    await applyIdentityHeaders(headers, { userId: session.userId });
   }
 
   const orgId = typeof (session as { orgId?: unknown }).orgId === 'string'
@@ -42,7 +43,7 @@ export async function POST(req: NextRequest) {
     const body = await req.text();
     const res = await fetch(`${BACKEND}/api/watch`, {
       method: 'POST',
-      headers: buildHeaders(session),
+      headers: await buildHeaders(session),
       body,
       signal: AbortSignal.timeout(8000),
     });

--- a/apps/web/lib/auth/forwardIdentity.ts
+++ b/apps/web/lib/auth/forwardIdentity.ts
@@ -1,0 +1,77 @@
+/**
+ * G1 enforce-flip prerequisite — verified-token forwarding for backend proxies.
+ *
+ * The backend's verified-identity middleware
+ * (apps/api/backend/src/middleware/verifiedIdentity.ts) will, in `enforce`
+ * mode, 401 any request that carries `x-clerk-user-id` WITHOUT a matching
+ * verified `Authorization: Bearer <clerk session jwt>`. Many web route
+ * handlers historically set only `x-clerk-user-id`. This helper attaches BOTH,
+ * so those handlers survive the enforce flip.
+ *
+ * Usage — replace ad-hoc `{ 'x-clerk-user-id': userId }` with:
+ *
+ *   const { userId } = await auth();
+ *   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+ *   const headers = await buildIdentityHeaders();          // plain object
+ *   // or, to extend an existing Headers/record:
+ *   await applyIdentityHeaders(headers, { userId });
+ *
+ * The bearer is minted via Clerk's `auth().getToken()`; if token minting is
+ * unavailable (older Clerk session, edge cases) we still forward
+ * `x-clerk-user-id` alone — identical to today's behavior, so this is
+ * strictly additive and safe to land before the backend flips to enforce.
+ */
+
+import { auth } from '@clerk/nextjs/server';
+
+export interface IdentityHeaderInput {
+  /** Pre-resolved Clerk user id (skips a second auth() call). */
+  userId?: string | null;
+  /** Pre-resolved session token (skips getToken()). */
+  token?: string | null;
+}
+
+/**
+ * Resolve `{ 'x-clerk-user-id', Authorization }` for the current Clerk session.
+ * Returns `{}` when there is no signed-in user (caller should have already
+ * guarded on that and returned 401).
+ */
+export async function buildIdentityHeaders(
+  input: IdentityHeaderInput = {},
+): Promise<Record<string, string>> {
+  let { userId, token } = input;
+
+  if (userId === undefined || token === undefined) {
+    const session = await auth();
+    if (userId === undefined) userId = session.userId;
+    if (token === undefined) {
+      try {
+        token = typeof session.getToken === 'function' ? await session.getToken() : null;
+      } catch {
+        token = null;
+      }
+    }
+  }
+
+  const headers: Record<string, string> = {};
+  if (userId) headers['x-clerk-user-id'] = userId;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Mutate an existing plain-object header map (or a `Headers`) in place with the
+ * identity pair. Convenience for handlers that build a `Record<string,string>`
+ * or `new Headers()` before fetching.
+ */
+export async function applyIdentityHeaders(
+  target: Record<string, string> | Headers,
+  input: IdentityHeaderInput = {},
+): Promise<void> {
+  const identity = await buildIdentityHeaders(input);
+  if (target instanceof Headers) {
+    for (const [k, v] of Object.entries(identity)) target.set(k, v);
+  } else {
+    Object.assign(target, identity);
+  }
+}

--- a/docs/security/verified-jwt-rollout.md
+++ b/docs/security/verified-jwt-rollout.md
@@ -38,9 +38,26 @@ Watch `jwt_auth_verification` events by `outcome`:
 - `verified_match` — healthy; the token path works end-to-end.
 - `verified_mismatch` / `invalid_token` — **forgery or bug signals; investigate every one.**
 - `header_without_token` — a web call site not forwarding the bearer. The `path`
-  field identifies which of the ~19 ad-hoc proxy sites (employer-review, ingest,
-  psv/oig, employers, pilot-ops, snapshot…) still needs `Authorization`
-  forwarding added. Fix by routing them through the shared helper.
+  field identifies which proxy site still needs `Authorization` forwarding added.
+  **Fix helper: `apps/web/lib/auth/forwardIdentity.ts`** — replace an ad-hoc
+  `{ 'x-clerk-user-id': userId }` with `await buildIdentityHeaders({ userId })`
+  (object spread) or `await applyIdentityHeaders(headers, { userId })` (Headers
+  object). It forwards the bearer via `auth().getToken()` and degrades to
+  id-only if minting is unavailable (behavior-preserving).
+
+### Call-site conversion status (as of 2026-07-06)
+
+- **Converted:** the 12-file `headers.set(...)` cohort (credentials ingest/mine/
+  confirm, documents parse/verify/[id], profile email-OTP issue/verify + npi
+  bootstrap, watch, watch/[id]) + the already-token-forwarding intelligence/
+  workspace/search proxies (~40 sites via `_shared.ts`).
+- **Remaining (~21, telemetry-driven):** object-property and conditional-spread
+  shapes — employer-review queue/batch/[action], employer opportunities/profile/
+  setup, psv/oig check+batch, ownership claim/me, profile links/self-attested/
+  work-auth/completeness/resume, capacity, velocity, marketplace pool, request-
+  review, share, export/packet, trust/events, organization-context,
+  auth/resolve-role, candidates. Shadow's `header_without_token` events will
+  prioritize these by real traffic; convert with the same helper before enforce.
 
 ## Step 3 — Flip criteria for `enforce`
 


### PR DESCRIPTION
## Summary
Prerequisite for flipping `CLERK_JWT_VERIFICATION=enforce` (gap G1). Web proxy handlers that set only `x-clerk-user-id` would 401 under enforce; this adds verified-bearer forwarding.

- **`apps/web/lib/auth/forwardIdentity.ts`** — `buildIdentityHeaders` / `applyIdentityHeaders` attach both `x-clerk-user-id` and `Authorization: Bearer <session jwt>` (via `auth().getToken()`), degrading to id-only if minting is unavailable. **Strictly additive** — safe with the backend flag still `off`/`shadow`.
- Converted the uniform `headers.set(...)` cohort (12 credentials/documents/profile/watch routes). `watch` + `watch/[id]` `buildHeaders` made async.
- 7-case helper unit test; web typecheck clean (0 errors).

## Remaining
~21 object-property / conditional-spread call sites are listed in `docs/security/verified-jwt-rollout.md` as a **shadow-telemetry-driven checklist** — converted with the same helper before enforce, prioritized by real `header_without_token` traffic. Doing them ahead of shadow data would be speculative.

## Risk
None to current prod behavior — bearer forwarding is additive; the backend ignores the extra header until shadow/enforce is enabled.

## Design Handoff References
No design handoff applies (backend proxy plumbing; no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)