### PR TITLE
feat(verifier): org-role RBAC guard on mutating routes (blocker #2, gated off)

### DIFF
--- a/apps/api/backend/src/middleware/__tests__/orgRoleGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/orgRoleGuard.test.ts
@@ -1,0 +1,157 @@
+import type { Request, Response } from 'express';
+import {
+  getRbacMode,
+  parseRequestOrgRole,
+  requireOrgRole,
+  VERIFIER_MUTATION_ROLES,
+} from '../orgRoleGuard';
+
+function createRequest(headers: Record<string, string> = {}): Request {
+  return {
+    method: 'POST',
+    path: '/api/applications/app_1/review',
+    get(name: string) {
+      return headers[name.toLowerCase()] ?? headers[name] ?? undefined;
+    },
+  } as unknown as Request;
+}
+
+function createResponse(): Response & { status: jest.Mock; json: jest.Mock } {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as Response & { status: jest.Mock; json: jest.Mock };
+}
+
+const ORIGINAL_MODE = process.env.VERIFIER_RBAC_MODE;
+
+afterEach(() => {
+  if (ORIGINAL_MODE === undefined) {
+    delete process.env.VERIFIER_RBAC_MODE;
+  } else {
+    process.env.VERIFIER_RBAC_MODE = ORIGINAL_MODE;
+  }
+});
+
+describe('orgRoleGuard — getRbacMode', () => {
+  it('defaults to off when unset or unrecognized', () => {
+    delete process.env.VERIFIER_RBAC_MODE;
+    expect(getRbacMode()).toBe('off');
+    process.env.VERIFIER_RBAC_MODE = 'nonsense';
+    expect(getRbacMode()).toBe('off');
+  });
+
+  it('reads shadow and enforce case-insensitively', () => {
+    process.env.VERIFIER_RBAC_MODE = 'SHADOW';
+    expect(getRbacMode()).toBe('shadow');
+    process.env.VERIFIER_RBAC_MODE = ' Enforce ';
+    expect(getRbacMode()).toBe('enforce');
+  });
+});
+
+describe('orgRoleGuard — parseRequestOrgRole', () => {
+  it('maps canonical roles and common synonyms', () => {
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'admin' }))).toBe('admin');
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'OWNER' }))).toBe('admin');
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'reviewer' }))).toBe('reviewer');
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'read-only' }))).toBe('read_only');
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'readonly' }))).toBe('read_only');
+    expect(parseRequestOrgRole(createRequest({ 'x-organization-role': 'viewer' }))).toBe('read_only');
+  });
+
+  it('returns null for missing or unknown roles', () => {
+    expect(parseRequestOrgRole(createRequest())).toBeNull();
+    expect(parseRequestOrgRole(createRequest({ 'x-org-role': 'wizard' }))).toBeNull();
+  });
+});
+
+describe('orgRoleGuard — requireOrgRole', () => {
+  it('is a no-op in off mode (default): read_only passes an admin/reviewer route', () => {
+    delete process.env.VERIFIER_RBAC_MODE;
+    const req = createRequest({ 'x-org-role': 'read_only' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('enforce: allows admin', () => {
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    const req = createRequest({ 'x-org-role': 'admin' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('enforce: allows reviewer', () => {
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    const req = createRequest({ 'x-org-role': 'reviewer' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('enforce: blocks read_only with a 403', () => {
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    const req = createRequest({ 'x-org-role': 'read_only' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'insufficient_org_role' }),
+    );
+  });
+
+  it('enforce: blocks a request with no org-role at all', () => {
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    const req = createRequest();
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('enforce: super-admin bypasses the org-role check even with no org-role', () => {
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    const req = createRequest({ 'x-user-role': 'super-admin' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('shadow: allows a would-be-denied read_only through (observe-only)', () => {
+    process.env.VERIFIER_RBAC_MODE = 'shadow';
+    const req = createRequest({ 'x-org-role': 'read_only' });
+    const res = createResponse();
+    const next = jest.fn();
+
+    requireOrgRole(VERIFIER_MUTATION_ROLES)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/backend/src/middleware/orgRoleGuard.ts
+++ b/apps/api/backend/src/middleware/orgRoleGuard.ts
@@ -1,0 +1,137 @@
+/**
+ * orgRoleGuard.ts — Verifier org-role RBAC enforcement (launch blocker #2).
+ *
+ * Closes the "no role check on mutating verifier routes" gap. The canonical
+ * org-role vocabulary lives in apps/web/lib/verifier/orgRolesFoundation.ts
+ * (admin | reviewer | read_only); this mirrors it on the backend and turns the
+ * vocabulary into an actual guard.
+ *
+ * Rollout is env-gated via VERIFIER_RBAC_MODE, mirroring the verified-identity
+ * rollout (G1 / CLERK_JWT_VERIFICATION):
+ *   - off     (default) — no-op; zero behaviour change on merge.
+ *   - shadow  — evaluate + structured-log the denials enforce *would* make,
+ *               but allow the request through (observe before you enforce).
+ *   - enforce — 403 on an insufficient or missing org-role.
+ *
+ * TRUST BOUNDARY — read before trusting this as a security control. The guard
+ * reads the caller's org-role from the `x-org-role` request header. That header
+ * is only trustworthy when a layer that has *verified* the caller sets it: the
+ * Next.js proxy (which verifies the Clerk session) on the UI path today, and
+ * the verified-identity middleware (G1, PR #589) once it reaches `enforce` and
+ * strips/rewrites client-supplied identity headers. Until G1 is at enforce,
+ * treat this as defense-in-depth for the UI path — NOT a hard boundary against
+ * a crafted direct-to-backend request. Full sequence + honesty notes:
+ * docs/security/verifier-rbac-rollout.md.
+ */
+import type { NextFunction, Request, Response } from 'express';
+import { isSuperAdminRequest } from './tenantGuard';
+import { log } from '../obs/logger';
+
+/**
+ * Mirrors the OrgRole union in apps/web/lib/verifier/orgRolesFoundation.ts.
+ * Keep the two in sync — the web file is the canonical vocabulary.
+ */
+export type OrgRole = 'admin' | 'reviewer' | 'read_only';
+
+export type RbacMode = 'off' | 'shadow' | 'enforce';
+
+/**
+ * Roles permitted to run verifier *mutations* (review an application, run a
+ * workflow action, accept a credential presentation). `read_only` members are
+ * intentionally excluded — the whole point of the role is view-without-mutate.
+ */
+export const VERIFIER_MUTATION_ROLES: readonly OrgRole[] = ['admin', 'reviewer'];
+
+/** Headers a verified upstream may use to declare the caller's org-role. */
+const ORG_ROLE_HEADERS = ['x-org-role', 'x-organization-role'] as const;
+
+/** Resolve the rollout mode at call time (env is read per-request, so an ops
+ * flag flip takes effect without a redeploy and tests can set it per-case). */
+export function getRbacMode(): RbacMode {
+  const raw = (process.env.VERIFIER_RBAC_MODE ?? '').trim().toLowerCase();
+  if (raw === 'enforce' || raw === 'shadow') {
+    return raw;
+  }
+  return 'off';
+}
+
+/** Map a raw header value onto the canonical OrgRole union, tolerating the
+ * common synonyms an IdP or org-membership system might emit. */
+function normalizeOrgRole(value: string | undefined | null): OrgRole | null {
+  if (!value) {
+    return null;
+  }
+  const v = value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (v === 'admin' || v === 'owner') {
+    return 'admin';
+  }
+  if (v === 'reviewer' || v === 'member' || v === 'editor') {
+    return 'reviewer';
+  }
+  if (v === 'read_only' || v === 'readonly' || v === 'viewer') {
+    return 'read_only';
+  }
+  return null;
+}
+
+export function parseRequestOrgRole(req: Request): OrgRole | null {
+  for (const header of ORG_ROLE_HEADERS) {
+    const role = normalizeOrgRole(req.get(header));
+    if (role) {
+      return role;
+    }
+  }
+  return null;
+}
+
+/**
+ * Express middleware factory: require the caller's org-role to be one of
+ * `allowed`. Behaviour depends on VERIFIER_RBAC_MODE (see file header).
+ */
+export function requireOrgRole(allowed: readonly OrgRole[]) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const mode = getRbacMode();
+    if (mode === 'off') {
+      next();
+      return;
+    }
+
+    // Platform operators (super-admin) bypass org-scoped role checks.
+    if (isSuperAdminRequest(req)) {
+      next();
+      return;
+    }
+
+    const role = parseRequestOrgRole(req);
+    const permitted = role !== null && allowed.includes(role);
+    if (permitted) {
+      next();
+      return;
+    }
+
+    const detail = {
+      mode,
+      method: req.method,
+      path: req.path,
+      role: role ?? 'none',
+      allowed: allowed.join(','),
+    };
+
+    if (mode === 'shadow') {
+      // Observe-only: record what enforce would have blocked, then allow through.
+      log('warn', 'verifier_rbac_shadow_would_block', detail);
+      next();
+      return;
+    }
+
+    // enforce
+    log('warn', 'verifier_rbac_denied', detail);
+    res.status(403).json({
+      error: 'insufficient_org_role',
+      error_description:
+        role === null
+          ? 'Your organization role could not be determined for this action.'
+          : `Your organization role (${role}) is not permitted to perform this action.`,
+    });
+  };
+}

--- a/apps/api/backend/src/routes/applications.ts
+++ b/apps/api/backend/src/routes/applications.ts
@@ -31,6 +31,7 @@ import {
 import { capsuleEngine } from '../services/decision/capsuleEngine';
 import { HttpError } from '../utils/httpError';
 import { log } from '../obs/logger';
+import { requireOrgRole, VERIFIER_MUTATION_ROLES } from '../middleware/orgRoleGuard';
 
 function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
   return (req: Request, res: Response, next: NextFunction) => fn(req, res, next).catch(next);
@@ -123,6 +124,7 @@ export function registerApplicationRoutes(app: Express): void {
   /* ── Verifier: review application ── */
   app.patch(
     '/api/applications/:appId/review',
+    requireOrgRole(VERIFIER_MUTATION_ROLES),
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
       const applicationId = requireUuidParam(req.params.appId, 'Application');
@@ -179,6 +181,7 @@ export function registerApplicationRoutes(app: Express): void {
   /* ── Verifier: workflow action ── */
   app.post(
     '/api/applications/:appId/workflow-action',
+    requireOrgRole(VERIFIER_MUTATION_ROLES),
     asyncHandler(async (req, res) => {
       const clerkUserId = requireClerkUserId(req);
       const appId = requireUuidParam(req.params.appId, 'Application');

--- a/apps/api/backend/src/routes/verifier.ts
+++ b/apps/api/backend/src/routes/verifier.ts
@@ -16,11 +16,16 @@ import {
 } from '../services/verifier/credentialAcceptance';
 import { getPresentation } from '../services/credentials/credentialPresentation';
 import { log } from '../obs/logger';
+import { requireOrgRole, VERIFIER_MUTATION_ROLES } from '../middleware/orgRoleGuard';
 
 export function registerVerifierAcceptanceRoutes(app: Express): void {
 
   // ── POST /api/verifier/accept ──────────────────────────────────────
-  app.post('/api/verifier/accept', async (req: Request, res: Response) => {
+  // RBAC (blocker #2): mutating verifier action — gated by org-role once
+  // VERIFIER_RBAC_MODE reaches shadow/enforce. Note this route is also
+  // whitelisted from the tenant guard (tenantGuard.ts) — the org-role guard is
+  // the authz control here, and inherits the same header-trust caveat until G1.
+  app.post('/api/verifier/accept', requireOrgRole(VERIFIER_MUTATION_ROLES), async (req: Request, res: Response) => {
     try {
       const { presentationId, presentation: presentationBody } = req.body ?? {};
 

--- a/apps/web/lib/verifier/orgRolesFoundation.ts
+++ b/apps/web/lib/verifier/orgRolesFoundation.ts
@@ -3,6 +3,12 @@
  *
  * This module is a typed vocabulary only. It does not provision accounts,
  * enforce RBAC, or activate invitations.
+ *
+ * Enforcement now EXISTS on the backend: `requireOrgRole(...)` in
+ * apps/api/backend/src/middleware/orgRoleGuard.ts mirrors this OrgRole union
+ * and guards the mutating verifier routes, gated by `VERIFIER_RBAC_MODE`
+ * (off | shadow | enforce). `rbacEnforced` below stays `false` until that flag
+ * reaches `enforce` in production — see docs/security/verifier-rbac-rollout.md.
  */
 
 export type OrgRole = 'admin' | 'reviewer' | 'read_only';

--- a/docs/security/verifier-rbac-rollout.md
+++ b/docs/security/verifier-rbac-rollout.md
@@ -1,0 +1,61 @@
+# Verifier org-role RBAC — enforcement & rollout
+
+**Closes:** launch blocker #2 (`docs/ops/launch-blockers.md`) — *"Verifier org-role RBAC enforcement — no role checks on mutating verifier routes."*
+
+**Status:** mechanism landed, gated **off** by default (zero runtime change). Reaching `enforce` in production is the ops sequence below.
+
+---
+
+## What this adds
+
+A backend guard, `requireOrgRole(...)`, in `apps/api/backend/src/middleware/orgRoleGuard.ts`, applied to the three verifier **mutation** routes that previously had *no* role check:
+
+| Route | Mutates | Guard |
+|---|---|---|
+| `PATCH /api/applications/:appId/review` | application status → REVIEWED/ACCEPTED/DECLINED + decision capsule | `requireOrgRole(VERIFIER_MUTATION_ROLES)` |
+| `POST /api/applications/:appId/workflow-action` | accept / request_info / reject workflow | `requireOrgRole(VERIFIER_MUTATION_ROLES)` |
+| `POST /api/verifier/accept` | credential-presentation acceptance + audit entry | `requireOrgRole(VERIFIER_MUTATION_ROLES)` |
+
+## Role model
+
+The canonical vocabulary lives in `apps/web/lib/verifier/orgRolesFoundation.ts` and is mirrored on the backend as `OrgRole`:
+
+| Role | May mutate? | Intent |
+|---|---|---|
+| `admin` | ✅ | org owner — full verifier authority |
+| `reviewer` | ✅ | can review applications and run workflow actions |
+| `read_only` | ❌ | view-only member; the whole point is view-without-mutate |
+
+`VERIFIER_MUTATION_ROLES = ['admin', 'reviewer']`. `super-admin` (platform operator, resolved from the existing `x-user-role` header via `isSuperAdminRequest`) bypasses org-role checks.
+
+## Modes — `VERIFIER_RBAC_MODE`
+
+Read per-request (an ops flip takes effect without a redeploy):
+
+- **`off`** (default) — no-op. Guard calls `next()` immediately. **This is what merges.**
+- **`shadow`** — evaluate the check; on a would-be denial, emit a structured `verifier_rbac_shadow_would_block` log line and **allow the request through**. Observe before enforcing.
+- **`enforce`** — on an insufficient or missing org-role, respond `403 { error: 'insufficient_org_role' }`. **Fail-closed:** a request with no resolvable org-role is denied.
+
+## Trust boundary — read before trusting this as a control
+
+The guard reads the caller's org-role from the **`x-org-role`** request header. A header is only as trustworthy as the layer that sets it:
+
+- **Today (UI path):** the Next.js proxy verifies the Clerk session before forwarding, so for real UI traffic the header reflects a verified `org_role` claim. This is genuine defense-in-depth.
+- **The gap:** the Express backend does not itself verify the caller yet, so a crafted request sent **directly** to the backend with a spoofed `x-org-role` would pass. That is the same header-trust gap tracked as **G1 / verified-identity middleware (PR #589, `CLERK_JWT_VERIFICATION`)**.
+- **Hard boundary:** reached when G1 is at `enforce` and strips/rewrites client-supplied identity headers (populating `x-org-role` from the verified JWT). This guard is forward-compatible: it already reads `x-org-role`, so G1 becomes its trusted source with no change here.
+
+**Do not describe this as a complete authorization boundary until G1 is at enforce.** Until then it is: (a) a real fix for the "no role check at all" gap, and (b) defense-in-depth for the UI path.
+
+## Rollout sequence
+
+1. **[this PR]** Land the guard, gated `off`. Backend unit tests green (`orgRoleGuard.test.ts`, 11 cases). No runtime change.
+2. **Plumb `x-org-role`** from the verified Clerk session (`org_role` claim) in the web proxies that reach the guarded routes. There is no central header-builder — each proxy sets its own forward headers — so this is a per-route addition. Source it server-side from the verified session; never from a client-supplied value.
+3. **`VERIFIER_RBAC_MODE=shadow`** on Railway (web + backend). Watch `verifier_rbac_shadow_would_block` logs: confirm legitimate `admin`/`reviewer` traffic is **not** appearing (i.e., the header is arriving and correct), and that only genuine read-only/anonymous attempts show up.
+4. **`VERIFIER_RBAC_MODE=enforce`** once shadow is quiet for legitimate traffic. Flip `orgRolesFoundation.rbacEnforced` → `true` in the same change (and update its foundation test).
+5. **Tighten with G1**: once `CLERK_JWT_VERIFICATION=enforce`, confirm G1 sets `x-org-role` from the verified claim and strips client-supplied identity headers — that closes the trust-boundary caveat above.
+
+## Guardrails preserved
+
+- Audit-first mutations, canonical path, revoked/expired/missing fail-closed — unchanged; this only adds an authz gate in front.
+- Default `off` ⇒ no behavior change on merge; safe to land ahead of the rollout.
+- Fail-closed in `enforce`: missing/unknown org-role ⇒ 403, never an implicit allow.


### PR DESCRIPTION
## What & why

Closes **launch blocker #2** — *"Verifier org-role RBAC enforcement — no role checks on mutating verifier routes"* (`docs/ops/launch-blockers.md`).

Today the three verifier **mutation** routes have **no role check** — any authenticated org member (or, for `/api/verifier/accept`, an org-less caller) can review, action, or accept. This adds a real guard.

**⚠️ This is a security change I did NOT self-merge — it's for your merge call.** Codex is rate-limited until August, so I took it to CI-green + self-reviewed + test-proven and am handing it to you.

## The change

A backend guard `requireOrgRole(...)` (`apps/api/backend/src/middleware/orgRoleGuard.ts`) on:

| Route | Guard |
|---|---|
| `PATCH /api/applications/:appId/review` | `requireOrgRole(['admin','reviewer'])` |
| `POST /api/applications/:appId/workflow-action` | `requireOrgRole(['admin','reviewer'])` |
| `POST /api/verifier/accept` | `requireOrgRole(['admin','reviewer'])` |

- `read_only` members **cannot** mutate; `admin`/`reviewer` can; `super-admin` bypasses.
- Gated by **`VERIFIER_RBAC_MODE`**: `off` (default) → `shadow` (observe-only, logs would-be denials) → `enforce` (403, **fail-closed** on missing/insufficient role).

## Why it's safe to land now

**Default `off` = a no-op** — the guard calls `next()` immediately, so there is **zero runtime behavior change on merge**. This is exactly how G1/#589 shipped. Reaching `enforce` is the ops sequence in `docs/security/verifier-rbac-rollout.md`.

## Honest trust boundary (important)

The guard reads the caller's org-role from the `x-org-role` header. That's trustworthy on the **UI path** (the Next proxy verifies the Clerk session) but **not** against a crafted request sent *directly* to the backend — the same header-trust gap tracked as **G1 verified-identity (#589)**. It becomes a hard boundary once G1 is at `enforce` and strips/rewrites client headers. **I've documented this rather than overclaiming** — until G1 enforce, this is (a) a real fix for "no role check at all" and (b) defense-in-depth for the UI path.

## Rollout (in the doc)

1. **[this PR]** guard, gated `off`.
2. Plumb `x-org-role` from the verified session in the web proxies (per-route; no central builder exists).
3. `VERIFIER_RBAC_MODE=shadow` → watch `verifier_rbac_shadow_would_block` logs.
4. `VERIFIER_RBAC_MODE=enforce` + flip `orgRolesFoundation.rbacEnforced=true`.
5. Tighten with G1 enforce.

## Verification

- **Backend jest: 11/11** (`orgRoleGuard.test.ts`) — off no-op, enforce allow admin/reviewer, block read_only, block missing-role (fail-closed), super-admin bypass, shadow observe-only, synonym normalization.
- **Backend `tsc --noEmit`: clean** (0 errors).
- **Web foundation vitest: 57/57** (docstring-only change to `orgRolesFoundation.ts`; shape unchanged).

## Design Handoff References

No new design-handoff file — backend authz middleware, no UI surface. Composes with G1 verified-identity (#589) and the existing `tenantGuard` / `orgRolesFoundation` vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)