### PR TITLE
feat(web): forward server-sourced x-org-role to guarded verifier routes (RBAC rollout step 2)

### DIFF
--- a/apps/web/app/api/verifier/accept/route.ts
+++ b/apps/web/app/api/verifier/accept/route.ts
@@ -1,0 +1,36 @@
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildMarketplaceHeaders,
+  MARKETPLACE_BACKEND,
+} from '@/lib/server/marketplace-proxy';
+
+export const runtime = 'nodejs';
+
+/**
+ * POST /api/verifier/accept — server-side proxy to the backend credential-
+ * presentation acceptance route (a verifier *mutation*).
+ *
+ * This proxy exists so the caller's org-role reaches the backend from a trusted
+ * source: buildMarketplaceHeaders derives `x-org-role` from the verified Clerk
+ * session's `org_role` claim (never a client-supplied value), which feeds the
+ * backend `requireOrgRole` guard. A browser calling the backend directly could
+ * only supply a spoofable header, so verifier UI must go through here.
+ */
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.text();
+  const res = await fetch(`${MARKETPLACE_BACKEND}/api/verifier/accept`, {
+    method: 'POST',
+    headers: buildMarketplaceHeaders(session, { 'Content-Type': 'application/json' }),
+    body,
+    cache: 'no-store',
+    signal: AbortSignal.timeout(12_000),
+  });
+
+  return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
+}

--- a/apps/web/components/verifier/AcceptancePanel.tsx
+++ b/apps/web/components/verifier/AcceptancePanel.tsx
@@ -123,7 +123,11 @@ export function AcceptancePanel({ className = '', defaultPresentationId = '' }: 
     setAcceptError(null);
     setReport(null);
     try {
-      const r = await fetch(`${base}/api/verifier/accept`, {
+      // Same-origin Next proxy (app/api/verifier/accept) — routes server-side so
+      // the verifier's org-role reaches the backend guard from the verified Clerk
+      // session (x-org-role), not a spoofable client header. Do NOT point this at
+      // the backend directly.
+      const r = await fetch('/api/verifier/accept', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ presentationId: presentationId.trim() }),
@@ -136,7 +140,7 @@ export function AcceptancePanel({ className = '', defaultPresentationId = '' }: 
     } finally {
       setLoading(false);
     }
-  }, [base, presentationId]);
+  }, [presentationId]);
 
   // ── OID4VP Request handler (Wave 110) ────────────────────────────
 

--- a/apps/web/lib/server/marketplace-proxy.ts
+++ b/apps/web/lib/server/marketplace-proxy.ts
@@ -3,6 +3,54 @@ import { getBackendBase } from '@/lib/api';
 
 export const MARKETPLACE_BACKEND = getBackendBase();
 
+type SessionClaims = Record<string, unknown> | undefined;
+
+function sessionClaims(session: Awaited<ReturnType<typeof auth>>): SessionClaims {
+  return session.sessionClaims as SessionClaims;
+}
+
+/**
+ * App-level role (clinician | employer | super-admin | …) read server-side from
+ * the verified Clerk session. Mirrors parseSessionRole in
+ * app/api/intelligence/_shared.ts and parseInitialClerkRole in app/layout.tsx.
+ *
+ * Forwarded as `x-user-role` so the backend can resolve platform super-admins
+ * (`isSuperAdminRequest` reads `x-user-role`) — which is what lets a super-admin
+ * bypass the verifier org-role guard's org-role requirement. Non-super values
+ * are inert for authz on the backend (super-admin is the only elevation from
+ * this header; search role hints read `x-clerk-user-role`, which we do not set).
+ */
+function parseSessionAppRole(claims: SessionClaims): string | null {
+  const vitalcv = claims?.vitalcv;
+  const vitalcvRole =
+    vitalcv && typeof vitalcv === 'object' && 'role' in vitalcv && typeof vitalcv.role === 'string'
+      ? vitalcv.role
+      : null;
+
+  return typeof claims?.role === 'string'
+    ? claims.role
+    : typeof claims?.org_role === 'string'
+      ? claims.org_role
+      : vitalcvRole;
+}
+
+/**
+ * Organization-membership role (admin | reviewer | read_only vocabulary) read
+ * server-side from the verified Clerk session's `org_role` claim — never a
+ * client-supplied value.
+ *
+ * Forwarded as `x-org-role` to feed the backend `requireOrgRole` guard
+ * (apps/api/backend/src/middleware/orgRoleGuard.ts), which normalizes the
+ * vocabulary. This is deliberately the org-membership role, NOT the app role
+ * above: `parseSessionAppRole` would answer "clinician"/"employer" here, which
+ * the guard would reject. See docs/security/verifier-rbac-rollout.md (step 2).
+ */
+function parseSessionOrgRole(claims: SessionClaims): string | null {
+  return typeof claims?.org_role === 'string' && claims.org_role.trim().length > 0
+    ? claims.org_role
+    : null;
+}
+
 export function buildMarketplaceHeaders(
   session: Awaited<ReturnType<typeof auth>>,
   init?: HeadersInit,
@@ -14,9 +62,21 @@ export function buildMarketplaceHeaders(
     headers.set('x-clerk-user-id', session.userId);
   }
 
-  const emailClaim = (session.sessionClaims as Record<string, unknown> | undefined)?.email;
+  const claims = sessionClaims(session);
+
+  const emailClaim = claims?.email;
   if (typeof emailClaim === 'string' && emailClaim.length > 0) {
     headers.set('x-clerk-user-email', emailClaim);
+  }
+
+  const appRole = parseSessionAppRole(claims);
+  if (appRole) {
+    headers.set('x-user-role', appRole);
+  }
+
+  const orgRole = parseSessionOrgRole(claims);
+  if (orgRole) {
+    headers.set('x-org-role', orgRole);
   }
 
   return headers;


### PR DESCRIPTION
## Verifier org-role RBAC — rollout step 2 (web header plumbing)

Plumbs `x-org-role` from the **verified Clerk session** (`org_role` claim) into every Next.js web proxy that reaches the three `requireOrgRole`-guarded backend routes. This is **step 2** of `docs/security/verifier-rbac-rollout.md` and the companion to the backend guard in **#591**. After both land, flipping `VERIFIER_RBAC_MODE` → `shadow` → `enforce` is a pure Railway env change that does **not** deny legitimate `admin`/`reviewer` traffic.

The header is sourced **server-side only** — never a client-supplied value (a browser could only send a spoofable one).

### Routes covered

| Guarded backend route | Web path | How the header is set |
|---|---|---|
| `PATCH /api/applications/:id/review` | `app/api/applications/[appId]/review` | `buildMarketplaceHeaders` |
| `POST /api/applications/:id/workflow-action` | `app/api/applications/[appId]/workflow` | `buildMarketplaceHeaders` |
| `POST /api/verifier/accept` | **new** `app/api/verifier/accept` | `buildMarketplaceHeaders` |

### Changes

- **`apps/web/lib/server/marketplace-proxy.ts`** — `buildMarketplaceHeaders` now forwards:
  - `x-org-role` from the `org_role` claim (the org-membership role — the guard's input; backend normalizes the vocabulary). This is deliberately **not** the app role, which the guard would reject.
  - `x-user-role` from the app role, so the guard's documented **super-admin bypass** (`isSuperAdminRequest`) keeps working on these proxied routes. Verified safe: `super-admin` is the *only* elevation from `x-user-role`; search role-hints read `x-clerk-user-role`, which is left unset.
- **`apps/web/app/api/verifier/accept/route.ts`** *(new)* — `POST /api/verifier/accept` had no server proxy; the only caller hit the backend directly from the browser (no trusted header possible). New proxy mirrors the `review`/`workflow` pattern.
- **`apps/web/components/verifier/AcceptancePanel.tsx`** — repointed the accept call to the same-origin `/api/verifier/accept` proxy. *(This panel is mounted only under `app/_archive/` — non-routable today — so accept is forward-looking plumbing; `review` + `workflow` are the live paths.)*

Extraction modeled on `parseInitialClerkRole` (`app/layout.tsx`) and `parseSessionRole` (`app/api/intelligence/_shared.ts`).

### Verification

- **Backend `orgRoleGuard` jest suite: 11/11 pass.**
- **`apps/web` typecheck: 0 new errors** — stashed baseline vs. with-changes produce an identical set of pre-existing, unrelated errors.
- ESLint clean on all changed files; `marketplace-proxies.test.ts` 4/4 pass.

### Notes / out of scope

- `docs/security/verifier-rbac-rollout.md` step 2 is **not** ticked here — that doc lives on the #591 branch; check it off there to avoid a divergent copy.
- Backend CORS `allowedHeaders` intentionally **not** extended with `x-org-role`: forwarding is server-to-server (CORS doesn't apply) and the header must never be accepted from a browser cross-origin request.
- No behavior change while `VERIFIER_RBAC_MODE=off` (default). Trust boundary hardens fully once G1 (`CLERK_JWT_VERIFICATION=enforce`) strips client identity headers.

Design Handoff References: no new design-handoff file — non-visual security/proxy change; the only UI touch is a `fetch` URL in an archived, non-routable panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
