### PR TITLE
test(e2e): signup golden path + blocked-passport fail-closed (launch blocker #4)

### DIFF
--- a/apps/api/backend/__tests__/e2e.signup-wallet-fail-closed.test.ts
+++ b/apps/api/backend/__tests__/e2e.signup-wallet-fail-closed.test.ts
@@ -1,0 +1,337 @@
+/**
+ * e2e.signup-wallet-fail-closed.test.ts — launch blocker #4 (2026-07-06)
+ *
+ * End-to-end contract for the clinician signup golden path and its
+ * fail-closed counterpart, exercised over real HTTP against the real
+ * Express app and a real Postgres (the CI backend-tests gate provisions
+ * one; locally the suite skips without DATABASE_URL).
+ *
+ *   Happy path:   role → NPI → attest → wallet
+ *     POST /api/profile/npi/bootstrap  (profession + attestation payload)
+ *       → 201 NpiBootstrapIntakeResult
+ *       → PersonProfile row (profession, attestedAt, attestationVersion)
+ *       → 'npi_bootstrapped' + 'clinician_attestation' audit rows
+ *     GET  /api/me/workspaces
+ *       → wallet exists: personProfile populated, CLINICIAN persona
+ *
+ *   Fail-closed:  a BLOCKED passport cannot be accepted
+ *     POST /api/verifier/accept with a REVOKED-status credential   → REJECTED
+ *     POST /api/verifier/accept with a registry-revoked credential → REJECTED
+ *     POST /api/verifier/accept under VERIFIER_RBAC_MODE=enforce
+ *       without an org role                                        → 403
+ *
+ * The only mock is the NPPES registry fetch (`src/modules/identity`) — the
+ * one true external boundary in the chain. Everything else (routing, tenant
+ * guard, org-role guard, service, Prisma, audit writes) runs real.
+ */
+
+// ── Mocks (hoisted above the SUT import) ──────────────────────────────────
+
+const mockFetchNpiFromCMS = jest.fn();
+const mockNormalizeProvider = jest.fn();
+
+// Override ONLY the registry fetchers — app.ts imports other members of this
+// barrel (registerIdentityRoutes et al.), which must stay real for boot.
+jest.mock('../src/modules/identity', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/modules/identity'),
+  fetchNpiFromCMS: (...args: unknown[]) => mockFetchNpiFromCMS(...args),
+  normalizeProvider: (...args: unknown[]) => mockNormalizeProvider(...args),
+}));
+
+// ── SUT imports (after mocks) ─────────────────────────────────────────────
+
+import request from 'supertest';
+import app from '../src/app';
+import prisma from '../src/graphql/prisma_client';
+import { revokeCredential } from '../src/services/revocation/revocationRegistry';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const VALID_NPI = '1558302470';
+const SIGNUP_USER = 'user:e2e:signup-wallet:001';
+const OTHER_USER = 'user:e2e:signup-wallet:002';
+
+/**
+ * NormalizedProvider fixture matching the real snake_case shape emitted by
+ * `normalizeProvider()` (see intakeService.bootstrapNpi.test.ts, which pins
+ * that shape against camelCase regressions).
+ */
+function buildNormalizedProvider() {
+  return {
+    npi: VALID_NPI,
+    enumeration_type: 'NPI-1',
+    first_name: 'Dana',
+    last_name: 'Reyes',
+    primary_taxonomy_code: '163W00000X',
+    practice_address: {
+      address_1: '100 Main St',
+      city: 'Austin',
+      state: 'TX',
+      postal_code: '78701',
+    },
+  };
+}
+
+/** Structurally-valid unsigned compact JWS (decodeJwt-parseable). */
+function unsignedJws(payload: Record<string, unknown>): string {
+  const b64 = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64({ alg: 'ES256', typ: 'JWT' })}.${b64(payload)}.e2e-no-signature`;
+}
+
+/** A presentation bundling a single credential with the given overrides. */
+function buildPresentation(credential: Record<string, unknown>) {
+  const holder = 'did:vitalcv:holder:e2e-blocked';
+  return {
+    presentationId: `pres-e2e-${String(credential.credentialId)}`,
+    holder,
+    credentials: [
+      {
+        credentialId: 'cred-e2e-default',
+        issuer: 'did:vitalcv:issuer:e2e',
+        subject: holder,
+        claims: { licenseType: 'RN', state: 'TX' },
+        signature: unsignedJws({ iss: 'did:vitalcv:issuer:e2e', sub: holder }),
+        status: 'ACTIVE',
+        issuedAt: '2026-01-01T00:00:00.000Z',
+        ...credential,
+      },
+    ],
+    signature: unsignedJws({ iss: holder }),
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+// ── Suite (DB-gated, same idiom as pilot.routes.test.ts) ─────────────────
+
+const runE2eSuite = process.env.DATABASE_URL ? describe : describe.skip;
+
+/** Internal User.id for a Clerk id, or null when no row exists. */
+async function internalUserId(clerkUserId: string): Promise<string | null> {
+  const user = await prisma.user.findUnique({ where: { clerkUserId } });
+  return user?.id ?? null;
+}
+
+beforeEach(async () => {
+  if (!process.env.DATABASE_URL) return;
+
+  const testUsers = await prisma.user.findMany({
+    where: { clerkUserId: { in: [SIGNUP_USER, OTHER_USER] } },
+    select: { id: true },
+  });
+  const testUserIds = testUsers.map((u) => u.id);
+
+  await prisma.auditEvent.deleteMany();
+  await prisma.personProfile.deleteMany();
+  if (testUserIds.length > 0) {
+    await prisma.workspacePreference.deleteMany({ where: { userId: { in: testUserIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: testUserIds } } });
+  }
+
+  mockFetchNpiFromCMS.mockReset();
+  mockNormalizeProvider.mockReset();
+  mockFetchNpiFromCMS.mockResolvedValue({
+    rawPayload: { result_count: 1, results: [buildNormalizedProvider()] },
+    payloadHash: 'sha256:e2e-fixture',
+  });
+  mockNormalizeProvider.mockReturnValue(buildNormalizedProvider());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+runE2eSuite('e2e: clinician signup — role → NPI → attest → wallet', () => {
+  it('bootstraps the profile, records the attestation audit-first, and provisions the wallet', async () => {
+    // Step 1 — role + NPI + attestation, exactly what the /get-ready web
+    // proxy forwards (x-clerk-user-id identity + x-clerk-user-email claim,
+    // self-attested profession). The email lets the backend mint the internal
+    // User row on first touch, as /api/me/workspaces does for the UI.
+    const bootstrap = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .set('x-clerk-user-id', SIGNUP_USER)
+      .set('x-clerk-user-email', 'dana.reyes@example.org')
+      .send({
+        npi: VALID_NPI,
+        profession: 'registered_nurse',
+        attested: true,
+        attestationVersion: 'v1',
+      });
+
+    expect(bootstrap.status).toBe(201);
+    expect(bootstrap.body).toMatchObject({
+      npi: VALID_NPI,
+      npiType: 'TYPE_1',
+      inferredPersona: 'CLINICIAN',
+      alreadyRegistered: false,
+      firstName: 'Dana',
+      lastName: 'Reyes',
+      stateOfPractice: 'TX',
+    });
+
+    // Step 2 — the profile row exists in the INTERNAL id-space (User.id UUID,
+    // not the raw Clerk id) and carries the self-attested claims.
+    const internalId = await internalUserId(SIGNUP_USER);
+    expect(internalId).toBeTruthy();
+
+    const profile = await prisma.personProfile.findUnique({
+      where: { userId: internalId as string },
+    });
+    expect(profile).not.toBeNull();
+    expect(profile?.npi).toBe(VALID_NPI);
+    expect(profile?.profession).toBe('registered_nurse');
+    expect(profile?.attestedAt).not.toBeNull();
+    expect(profile?.attestationVersion).toBe('v1');
+
+    // Step 3 — audit-first: both the bootstrap and the distinct attestation
+    // event are durable rows, each with a payload hash.
+    const bootstrapEvents = await prisma.auditEvent.findMany({
+      where: { type: 'npi_bootstrapped', referenceId: internalId as string },
+    });
+    expect(bootstrapEvents).toHaveLength(1);
+    expect(bootstrapEvents[0]?.hash).toBeTruthy();
+
+    const attestationEvents = await prisma.auditEvent.findMany({
+      where: { type: 'clinician_attestation', referenceId: internalId as string },
+    });
+    expect(attestationEvents).toHaveLength(1);
+    expect(attestationEvents[0]?.hash).toBeTruthy();
+
+    // Step 4 — the wallet exists: the workspace read-back surfaces the
+    // bootstrapped profile under the CLINICIAN persona.
+    const workspaces = await request(app)
+      .get('/api/me/workspaces')
+      .set('x-clerk-user-id', SIGNUP_USER)
+      .set('x-clerk-user-email', 'dana.reyes@example.org');
+
+    expect(workspaces.status).toBe(200);
+    expect(workspaces.body.userId).toBe(internalId);
+    expect(workspaces.body.personProfile?.npi).toBe(VALID_NPI);
+    expect(workspaces.body.activePersona).toBe('CLINICIAN');
+    expect(Array.isArray(workspaces.body.memberships)).toBe(true);
+  });
+
+  it('rejects the bootstrap without a signed-in identity (401)', async () => {
+    const res = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .send({ npi: VALID_NPI, profession: 'registered_nurse', attested: true });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a malformed NPI (400) before any registry call or row creation', async () => {
+    const res = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .set('x-clerk-user-id', SIGNUP_USER)
+      .set('x-clerk-user-email', 'dana.reyes@example.org')
+      .send({ npi: '123', profession: 'registered_nurse', attested: true });
+
+    expect(res.status).toBe(400);
+    expect(mockFetchNpiFromCMS).not.toHaveBeenCalled();
+    // Validation precedes user provisioning — no row was minted.
+    expect(await internalUserId(SIGNUP_USER)).toBeNull();
+  });
+
+  it('drops professions outside the attestable vocabulary instead of storing them', async () => {
+    const res = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .set('x-clerk-user-id', SIGNUP_USER)
+      .set('x-clerk-user-email', 'dana.reyes@example.org')
+      .send({ npi: VALID_NPI, profession: 'astronaut', attested: true });
+
+    expect(res.status).toBe(201);
+    const profile = await prisma.personProfile.findFirst({
+      where: { npi: VALID_NPI },
+    });
+    expect(profile).not.toBeNull();
+    expect(profile?.profession).toBeNull();
+  });
+
+  it('fails closed when the NPI is already claimed by another account', async () => {
+    const first = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .set('x-clerk-user-id', SIGNUP_USER)
+      .set('x-clerk-user-email', 'dana.reyes@example.org')
+      .send({ npi: VALID_NPI, profession: 'registered_nurse', attested: true });
+    expect(first.status).toBe(201);
+
+    const second = await request(app)
+      .post('/api/profile/npi/bootstrap')
+      .set('x-clerk-user-id', OTHER_USER)
+      .set('x-clerk-user-email', 'sam.chen@example.org')
+      .send({ npi: VALID_NPI, profession: 'physician', attested: true });
+
+    expect(second.status).toBeGreaterThanOrEqual(400);
+
+    // The claim did not move.
+    const owner = await prisma.personProfile.findFirst({ where: { npi: VALID_NPI } });
+    expect(owner?.userId).toBe(await internalUserId(SIGNUP_USER));
+  });
+});
+
+runE2eSuite('e2e: fail-closed — a blocked passport cannot be accepted', () => {
+  it('REJECTS a presentation whose credential status is REVOKED', async () => {
+    const res = await request(app)
+      .post('/api/verifier/accept')
+      .send({
+        presentation: buildPresentation({
+          credentialId: 'cred-e2e-status-revoked',
+          status: 'REVOKED',
+        }),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.report?.decision).toBe('REJECTED');
+    expect(res.body.report?.decision).not.toBe('ACCEPTED');
+    expect(res.body.report?.summary).toContain('revoked');
+
+    const result = res.body.report?.credentialResults?.[0];
+    expect(result?.valid).toBe(false);
+    expect(result?.checks?.statusActive).toBe(false);
+  });
+
+  it('REJECTS an otherwise-ACTIVE credential that the revocation registry has revoked', async () => {
+    revokeCredential({
+      credentialId: 'cred-e2e-registry-revoked',
+      issuer: 'did:vitalcv:issuer:e2e',
+      reason: 'license revoked by state board',
+    });
+
+    const res = await request(app)
+      .post('/api/verifier/accept')
+      .send({
+        presentation: buildPresentation({
+          credentialId: 'cred-e2e-registry-revoked',
+          status: 'ACTIVE',
+        }),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.report?.decision).toBe('REJECTED');
+
+    const result = res.body.report?.credentialResults?.[0];
+    expect(result?.checks?.statusActive).toBe(false);
+    expect(String(result?.errors)).toContain('has been revoked');
+  });
+
+  it('blocks the accept mutation entirely for a caller without an org role under RBAC enforce', async () => {
+    const prev = process.env.VERIFIER_RBAC_MODE;
+    process.env.VERIFIER_RBAC_MODE = 'enforce';
+    try {
+      const res = await request(app)
+        .post('/api/verifier/accept')
+        .send({
+          presentation: buildPresentation({
+            credentialId: 'cred-e2e-rbac',
+            status: 'ACTIVE',
+          }),
+        });
+
+      expect(res.status).toBe(403);
+    } finally {
+      if (prev === undefined) delete process.env.VERIFIER_RBAC_MODE;
+      else process.env.VERIFIER_RBAC_MODE = prev;
+    }
+  });
+});

--- a/apps/api/backend/__tests__/pilot.routes.test.ts
+++ b/apps/api/backend/__tests__/pilot.routes.test.ts
@@ -47,7 +47,7 @@ runPilotRouteSuite('pilot routes', () => {
   });
 
   it('records verifier acceptance payloads', async () => {
-    const res = await request(app).post('/api/verifier/accept').send({
+    const res = await request(app).post('/api/pilot/acceptance').send({
       organization: 'Regional Health Center',
     });
 
@@ -60,7 +60,7 @@ runPilotRouteSuite('pilot routes', () => {
   });
 
   it('rejects invalid verifier acceptance requests without crashing the process', async () => {
-    const res = await request(app).post('/api/verifier/accept').send({});
+    const res = await request(app).post('/api/pilot/acceptance').send({});
 
     expect(res.status).toBe(400);
     expect(res.body).toEqual({

--- a/apps/api/backend/src/app.ts
+++ b/apps/api/backend/src/app.ts
@@ -2677,7 +2677,13 @@ function registerPilotRoutes(app: Express): void {
     }
   });
 
-  app.post('/api/verifier/accept', walletRateLimit, async (req: Request, res: Response) => {
+  // Pilot KPI acceptance marker. This lived at /api/verifier/accept, where —
+  // by registering first — it silently shadowed the credential-presentation
+  // acceptance route (routes/verifier.ts), leaving that route's revocation
+  // fail-closed logic and org-role guard unreachable. The verifier namespace
+  // keeps verification semantics (didRegistry advertises it as
+  // PresentationVerification); the KPI marker lives with its pilot siblings.
+  app.post('/api/pilot/acceptance', walletRateLimit, async (req: Request, res: Response) => {
     const body = (req.body ?? {}) as Record<string, unknown>;
     let acceptedAt = new Date();
 

--- a/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
+++ b/apps/api/backend/src/middleware/__tests__/tenantGuard.test.ts
@@ -50,6 +50,17 @@ describe('tenantGuard', () => {
     expect(shouldSkipTenantContext('/api/me/workspaces/extra')).toBe(false);
   });
 
+  it('skips tenant context for the clinician personal-profile intake family', () => {
+    // Onboarding-time, Clerk-user-scoped routes: a brand-new clinician has no
+    // org, so org context here dead-ends the signup golden path (blocker #4).
+    expect(shouldSkipTenantContext('/api/profile/npi/bootstrap')).toBe(true);
+    expect(shouldSkipTenantContext('/api/profile/links')).toBe(true);
+    expect(shouldSkipTenantContext('/api/profile/work-auth')).toBe(true);
+    expect(shouldSkipTenantContext('/api/profile/self-attested')).toBe(true);
+    expect(shouldSkipTenantContext('/api/profile/completeness')).toBe(true);
+    expect(shouldSkipTenantContext('/api/profile/identity/email-otp/issue')).toBe(true);
+  });
+
   it('skips tenant context for public verifier reads (trust proof)', () => {
     expect(shouldSkipTenantContext('/api/trust-proof/1003000126')).toBe(true);
   });

--- a/apps/api/backend/src/middleware/tenantGuard.ts
+++ b/apps/api/backend/src/middleware/tenantGuard.ts
@@ -62,9 +62,14 @@ export function shouldSkipTenantContext(path: string): boolean {
     // when the middleware asks "what role is this?", so requiring tenant
     // context here 401s and dead-ends the entire signed-in experience.
     || normalized === '/api/me/role'
-    // Email-OTP identity binding: an onboarding-time possession factor scoped to
-    // the Clerk user alone (no org context yet). Same rationale as /api/me/role.
-    || normalized.startsWith('/api/profile/identity/')
+    // Clinician personal-profile intake family (npi/bootstrap, links,
+    // work-auth, resume, self-attested, completeness, identity/email-otp):
+    // every route here is scoped to the Clerk user alone and authenticates
+    // itself via x-clerk-user-id → internal User.id resolution. These are
+    // onboarding-time surfaces — a brand-new clinician has no org yet, so
+    // requiring org context 401s the signup golden path at its first write
+    // (launch blocker #4 e2e pins this). Same rationale as /api/me/role.
+    || normalized.startsWith('/api/profile/')
     // Workspace bootstrap: resolves by Clerk user id alone (x-clerk-user-id
     // header) and *produces* the persona/org context the rest of the app runs
     // on. Requiring org context before the workspace lookup is a chicken-and-

--- a/apps/api/backend/src/routes/identity.ts
+++ b/apps/api/backend/src/routes/identity.ts
@@ -11,6 +11,7 @@ import type { Express, NextFunction, Request, Response } from 'express';
 
 import { HttpError } from '../utils/httpError';
 import { issueEmailOtp, verifyEmailOtp } from '../services/identity/emailOtpService';
+import { ensureWorkspaceUser } from '../services/workspace/workspaceService';
 
 function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
   return (req: Request, res: Response, next: NextFunction) => fn(req, res, next).catch(next);
@@ -27,6 +28,20 @@ function requireUserId(req: Request): string {
   return id;
 }
 
+/**
+ * Resolve the signed-in Clerk identity to the internal `User.id` UUID (same
+ * rationale as intake.ts): the verify success writes the possession signal to
+ * `PersonProfile.userId`, a UUID column keyed to `User.id` — the raw Clerk id
+ * can never match it. EmailOtp challenge rows are keyed by the same internal
+ * id so issue and verify stay in one id-space.
+ */
+async function requireInternalUserId(req: Request): Promise<string> {
+  const clerkUserId = requireUserId(req);
+  const email = getHeader(req, 'x-clerk-user-email') || undefined;
+  const user = await ensureWorkspaceUser(clerkUserId, email);
+  return user.id;
+}
+
 const VERIFY_FAILURES: Record<string, [number, string]> = {
   no_challenge: [400, 'No active code — request a new one.'],
   expired: [400, 'That code expired — request a new one.'],
@@ -39,7 +54,7 @@ export function registerEmailOtpRoutes(app: Express): void {
   app.post(
     '/api/profile/identity/email-otp/issue',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const { email } = req.body as { email?: string };
       if (!email || typeof email !== 'string') {
         throw new HttpError(400, 'email is required.');
@@ -60,7 +75,7 @@ export function registerEmailOtpRoutes(app: Express): void {
   app.post(
     '/api/profile/identity/email-otp/verify',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const { email, code } = req.body as { email?: string; code?: string };
       if (!email || typeof email !== 'string' || !code || typeof code !== 'string') {
         throw new HttpError(400, 'email and code are required.');

--- a/apps/api/backend/src/routes/intake.ts
+++ b/apps/api/backend/src/routes/intake.ts
@@ -19,6 +19,7 @@ import {
   updateSelfAttested,
   type ClearableLinkField,
 } from '../services/intake/intakeService';
+import { ensureWorkspaceUser } from '../services/workspace/workspaceService';
 import { HttpError } from '../utils/httpError';
 
 const NPI_RE = /^\d{10}$/;
@@ -38,6 +39,24 @@ function requireUserId(req: Request): string {
   return id;
 }
 
+/**
+ * Resolve the signed-in Clerk identity to the internal `User.id` UUID.
+ *
+ * `PersonProfile.userId` is a UUID column keyed to `User.id` (that is how the
+ * workspace read side hydrates the wallet). Passing the raw Clerk id
+ * (`user_…`) into these queries can never succeed — the query engine rejects
+ * it before the row is touched. `ensureWorkspaceUser` creates the User row on
+ * first touch when the proxy forwards `x-clerk-user-email` (the /get-ready
+ * flow loads /api/me/workspaces first, which does the same), and fails with a
+ * clean 404 when it cannot resolve one.
+ */
+async function requireInternalUserId(req: Request): Promise<string> {
+  const clerkUserId = requireUserId(req);
+  const email = getHeader(req, 'x-clerk-user-email') || undefined;
+  const user = await ensureWorkspaceUser(clerkUserId, email);
+  return user.id;
+}
+
 export function registerIntakeRoutes(app: Express): void {
 
   /**
@@ -48,7 +67,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.post(
     '/api/profile/resume/upload',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const { fileName, fileUrl, clear } = req.body as {
         fileName?: string;
         fileUrl?: string;
@@ -80,7 +99,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.post(
     '/api/profile/links',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const { linkedinUrl, portfolioUrl, otherUrls, clear } =
         req.body as {
           linkedinUrl?: string;
@@ -107,7 +126,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.post(
     '/api/profile/work-auth',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const { workAuthStatus, clear } = req.body as { workAuthStatus?: string; clear?: boolean };
 
       if (clear === true) {
@@ -136,7 +155,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.post(
     '/api/profile/self-attested',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const body = req.body as { selfAttested?: unknown } | undefined;
       const input = body && typeof body === 'object' && 'selfAttested' in body
         ? body.selfAttested
@@ -153,7 +172,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.post(
     '/api/profile/npi/bootstrap',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      requireUserId(req); // 401 before any validation or row creation
       const { npi, profession, attested, attestationVersion } = req.body as {
         npi?: string;
         profession?: string;
@@ -165,6 +184,7 @@ export function registerIntakeRoutes(app: Express): void {
         throw new HttpError(400, 'npi must be exactly 10 digits.');
       }
 
+      const userId = await requireInternalUserId(req);
       const result = await bootstrapNpiIntake(userId, npi, {
         profession,
         attested,
@@ -181,7 +201,7 @@ export function registerIntakeRoutes(app: Express): void {
   app.get(
     '/api/profile/completeness',
     asyncHandler(async (req, res) => {
-      const userId = requireUserId(req);
+      const userId = await requireInternalUserId(req);
       const result = await getProfileCompleteness(userId);
       res.json(result);
     }),

--- a/docs/verifier-integration.md
+++ b/docs/verifier-integration.md
@@ -32,7 +32,7 @@ Notes:
 
 ## Verifier Acceptance Endpoint
 
-### `POST /api/verifier/accept`
+### `POST /api/pilot/acceptance`
 
 Posts a verifier acceptance marker from employer-side review.
 
@@ -88,5 +88,5 @@ Returns the same aggregate payload used for reporting and dashboarding.
 
 ## Safety and operations
 
-- `/api/verify/:shareId` and `/api/verifier/accept` are intentionally API-path-light and remain deterministic.
+- `/api/verify/:shareId` and `/api/pilot/acceptance` are intentionally API-path-light and remain deterministic.
 - All reads are synthetic-safe for pilot deployment where data persistence is expected to drive real-time reporting.


### PR DESCRIPTION
## What

Closes **launch blocker #4**: adds the missing E2E covering the clinician signup golden path (**role → NPI → attest → wallet**) and the fail-closed case (**a BLOCKED passport cannot be accepted**) — over the real Express app + real Postgres (CI's backend gate). Only the NPPES registry fetch is mocked.

**Writing the e2e immediately caught three real breaks in the live path** — the exact failure mode this blocker existed to expose. All three are fixed in this PR:

### 1. Signup writes could never succeed (Clerk-id → UUID mismatch)
`PersonProfile.userId` is a **UUID** column keyed to `User.id`, but every `/api/profile/*` intake + email-OTP route passed the **raw Clerk id** (`user_…`) into it — Prisma's query engine rejects the value, so the bootstrap (and links/work-auth/resume/self-attested/completeness/OTP-verify writes) 500'd unconditionally. Unit tests mocked Prisma, so this was invisible. Routes now resolve the internal `User.id` via `ensureWorkspaceUser` (minted on first touch from `x-clerk-user-email`, exactly like `/api/me/workspaces`), with NPI validation still preceding any row creation.

### 2. Tenant guard dead-ended signup (`organization_context_required`)
`/api/profile/*` was never in the tenant-guard skip list — a brand-new clinician has no org, so the first signup write 401'd. The personal-profile intake family is now skip-listed with the same chicken-and-egg rationale the list already documents for `/api/me/workspaces`. These routes self-authenticate via Clerk-id → internal-user resolution (header-trust caveat unchanged until G1 enforce).

### 3. `POST /api/verifier/accept` was the wrong endpoint entirely (route shadowing)
An inline pilot-KPI recorder in `app.ts` registered `POST /api/verifier/accept` **before** `routes/verifier.ts` — so the credential-presentation acceptance route, carrying the revocation fail-closed logic **and the #591 org-role guard**, was unreachable dead code. The KPI marker moves to **`/api/pilot/acceptance`** (beside its `/api/pilot/*` siblings; doc + tests updated). `/api/verifier/accept` now genuinely serves presentation verification — as `didRegistry` advertises and the #591/#593 RBAC stack assumes. **This makes the just-merged RBAC guard live instead of shadowed.**

## The e2e contract (8 tests)

Happy path: bootstrap 201 with NPPES-hydrated result → PersonProfile in the internal id-space with `profession`/`attestedAt`/`attestationVersion` → distinct `npi_bootstrapped` + `clinician_attestation` audit rows (audit-first) → `/api/me/workspaces` surfaces the wallet under the CLINICIAN persona. Edges: 401 without identity; 400 malformed NPI **before** any row creation; unknown professions dropped, never stored; an NPI claimed by another account fails closed and the claim does not move.

Fail-closed: REVOKED-status credential → decision `REJECTED`; an otherwise-ACTIVE credential the revocation registry has revoked → `REJECTED` (revoked fails closed); under `VERIFIER_RBAC_MODE=enforce` a caller with no org role → **403** before any evaluation.

## Verification
- New e2e: **8/8** against local Postgres (same `prisma db push` flow as CI).
- Blast radius (`intake|identity|otp|workspace|verifier|revocation|acceptance|credential` + pilot + tenantGuard): **42 suites / 244 tests green**.
- Backend `tsc --noEmit` clean. Full suite runs in this PR's Backend Tests (Postgres) gate.
- Migration note: in-flight email-OTP challenges at deploy re-key to the internal id — they live minutes; a re-issue recovers. No schema change.

## Design Handoff References
No design handoff applies — backend contract tests + route fixes only; no UI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)