### PR TITLE
docs(ops): DR runbook — PITR + backup schedule live (gap fully remediated)

### DIFF
--- a/docs/ops/dr-runbook.md
+++ b/docs/ops/dr-runbook.md
@@ -3,23 +3,26 @@
 **Date:** 2026-07-06 (updated 2026-07-07) · **Owner:** founder (team of one)
 · **Status:** procedures written; **first restore drill NOT yet executed.**
 
-> ## ⚠️ 2026-07-07 backup audit — CRITICAL, PARTIALLY REMEDIATED
+> ## ✅ 2026-07-07 backup audit — CRITICAL GAP FOUND, FULLY REMEDIATED SAME DAY
 > A live check of the Railway Postgres **Backups** tab found the production
 > database had **NO backup coverage at all**: Point-in-time recovery **OFF**,
 > **no** volume-backup schedule, **zero** existing backups. Every clinician,
 > credential, and audit-event row was unprotected (RPO = total loss on volume
-> failure). The prior assumption below ("Railway provides daily automated
-> backups") was **false for this project** — nothing is on by default.
+> failure). Railway does **not** enable backups by default.
 >
-> **Taken (non-disruptive):** one on-demand volume backup —
-> `2026-07-07 13:28 UTC · 1.25 GB · manual`. Prod now has ONE recovery point.
+> **Remediation (all owner-authorized, verified live the same day):**
+> 1. On-demand volume backup — `2026-07-07 13:28 UTC · 1.25 GB · manual`.
+> 2. **Backup schedule enabled:** Daily (kept 6 days) + Weekly (kept 1 month)
+>    + Monthly (kept 3 months) — active immediately, no redeploy needed.
+> 3. **PITR enabled:** staged changes (Postgres-PITR bucket + 6 `WAL_ARCHIVE_*`
+>    vars) deployed; Postgres redeployed once (~7 min, zero downtime — old
+>    instance served until the new one was healthy; api/web stayed 200
+>    throughout). **WAL archiving verified live** — green coverage timeline
+>    from `2026-07-07 06:44:51 PT`, "Restore to this moment" enabled, no
+>    credential warnings.
 >
-> **Still required by the owner (both redeploy the DB / need dashboard access):**
-> 1. **Enable PITR** (Backups → *Enable PITR* — redeploys once) for continuous
->    WAL archiving → RPO drops to minutes.
-> 2. **Set a volume-backup schedule** (Backups → *Edit schedule*) — daily, with
->    a retention window; record it in the table below.
-> Until both are on, coverage is a single manual snapshot that will go stale.
+> Effective posture: **RPO ≈ minutes** (PITR) with a Daily/Weekly/Monthly
+> snapshot ladder behind it. Remaining: the quarterly **restore drill** below.
 
 ## What we run on
 
@@ -30,21 +33,20 @@
 
 ## Backup posture (VERIFIED 2026-07-07 — do not assume)
 
-Railway does **NOT** enable backups by default for this project (verified in the
-dashboard, not assumed). Current state after the 2026-07-07 audit:
+Railway does **NOT** enable backups by default; everything below was switched on
+manually on 2026-07-07 and verified in the dashboard:
 
-| Control | State | Action |
+| Control | State | Notes |
 |---|---|---|
-| Point-in-time recovery | **OFF** | owner: Enable PITR (redeploys once) |
-| Volume-backup schedule | **none** | owner: set daily schedule + retention |
-| Existing backups | **1 manual** (2026-07-07 13:28 UTC, 1.25 GB) | will go stale without a schedule |
+| Point-in-time recovery | **ON** (verified archiving) | WAL → `Postgres-PITR` bucket; coverage from 2026-07-07 06:44 PT; restore creates a new copy, current data untouched |
+| Volume-backup schedule | **Daily / Weekly / Monthly** | retention: 6 days / 1 month / 3 months |
+| Manual backups | 1 (2026-07-07 13:28 UTC, 1.25 GB) | taken during the audit, before PITR |
 
-Owner checklist (one-time, ~10 min):
+Remaining hardening:
 
-1. Railway → Postgres → **Backups**: click **Enable PITR**, then **Edit schedule**
-   for daily volume backups; note retention window here: `retention = ____ days`.
-2. Confirm the plan supports restore-to-new-service (that is the restore path).
-3. **Belt-and-suspenders logical dump** (recommended until drilled): weekly
+1. Run the **quarterly restore drill** (section below) — targets are estimates
+   until the first drill is timed.
+2. **Belt-and-suspenders logical dump** (optional now that PITR is on): weekly
    `pg_dump` to object storage:
    ```bash
    pg_dump "$DATABASE_URL" --format=custom --no-owner \


### PR DESCRIPTION
## Summary
Follow-up to #596. The backup gap found this morning is now **fully remediated and verified live**:
- **PITR enabled** — staged `Postgres-PITR` bucket + `WAL_ARCHIVE_*` vars deployed; one zero-downtime Postgres redeploy (~7 min; api/web stayed 200 throughout); **green WAL coverage timeline verified** with "Restore to this moment" active.
- **Volume-backup schedule** — Daily (6d) / Weekly (1mo) / Monthly (3mo), active immediately.
- Effective posture: **RPO ≈ minutes** + snapshot ladder. Remaining: first quarterly restore drill.

Docs-only.

## Design Handoff References
No design handoff applies (ops documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)