### PR TITLE
feat(ux): Calm Wave D56 + calm-glass — real fonts, career-moat homepage, all personas

### DIFF
--- a/apps/web/__tests__/home-npi-role-doors.test.tsx
+++ b/apps/web/__tests__/home-npi-role-doors.test.tsx
@@ -63,19 +63,24 @@ function assertNoBannedPhrases(html: string): void {
 }
 
 describe('HomePageClient — clinician-value hero', () => {
-  it('renders the network eyebrow and clinician-value headline', () => {
+  it('renders the network eyebrow and the career-velocity headline', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
     expect(html).toContain('data-home-eyebrow');
     expect(html).toContain('The Provider Career Evidence Network');
-    expect(html).toContain('Your clinical career evidence, in one wallet you own.');
+    // Career core, 2026-07-07 (Chris): find the opportunity → prove once
+    // (the moat) → start faster. The final beat is the italic accent.
+    expect(html).toContain('Find the opportunity. Prove your career once.');
+    expect(html).toContain('Start faster.');
   });
 
-  it('renders the NPI-first subhead', () => {
+  it('renders the NPI-first subhead with the career-network framing', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
     expect(html).toContain('data-home-hero-subhead');
+    expect(html).toContain('career evidence network for clinician careers');
     expect(html).toContain('Start with your NPI.');
     expect(html).toContain('employer-ready proof packet');
-    expect(html).toContain('reusable for every move');
+    expect(html).toContain('accept as a head start');
+    expect(html).toContain('for every move of your career');
   });
 
   it('renders "Check readiness" as the primary CTA label', () => {
@@ -140,6 +145,38 @@ describe('HomePageClient — value cards', () => {
   });
 });
 
+describe('HomePageClient — compounding-network (moat) section', () => {
+  it('renders the moat section with its three compounding cards', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('data-home-moat');
+    expect(html).toContain('data-home-moat-card="own"');
+    expect(html).toContain('data-home-moat-card="compound"');
+    expect(html).toContain('data-home-moat-card="network"');
+  });
+
+  it('makes the moat legible: owned evidence, compounding acceptance, network velocity', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('Career evidence that');
+    expect(html).toContain('makes every move faster than the last');
+    expect(html).toContain('Nothing resets when you move');
+    expect(html).toContain('Every yes makes the next yes easier');
+    expect(html).toContain('Time-to-Start');
+    expect(html).toContain('re-answering what a primary source already answered');
+  });
+
+  it('states the shared loop and frames 10× strictly as the goal, not a claim', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain('RECOGNITION → ACCEPTANCE → START');
+    expect(html).toContain('the loop every VitalCV user shares');
+    // Honesty guard: the 10× line must stay framed as the goal we build
+    // against — never an achieved/promised outcome.
+    expect(html).toContain(
+      'The goal we build against: starting your next role 10× faster than the credentialing status quo.',
+    );
+    expect(/10×\s+faster\s+guaranteed/i.test(html)).toBe(false);
+  });
+});
+
 describe('HomePageClient — role doors', () => {
   it('renders four role doors', () => {
     const html = renderToStaticMarkup(<HomePageClient />);
@@ -148,6 +185,13 @@ describe('HomePageClient — role doors', () => {
     expect(html).toContain('data-home-role-door="clinician"');
     expect(html).toContain('data-home-role-door="employer"');
     expect(html).toContain('data-home-role-door="issuer"');
+  });
+
+  it('states the shared outcome all four roles converge on', () => {
+    const html = renderToStaticMarkup(<HomePageClient />);
+    expect(html).toContain(
+      'Four doors, one shared outcome — a clinician hired and started, faster.',
+    );
   });
 
   it('each role door advertises its canonical action label', () => {

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -530,7 +530,7 @@ export default function HomePageClient() {
           <section
             aria-label="NPI lookup"
             data-home-hero=""
-            className="mz mz-paper relative isolate py-10 sm:py-14 grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
+            className="mz mz-paper mz-persona-holder mz-ambient relative isolate py-10 sm:py-14 grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
           >
             {/* Left: messaging + NPI entry */}
             <div className="max-w-2xl">
@@ -570,9 +570,10 @@ export default function HomePageClient() {
                 </ul>
               </div>
 
+              <div className="mz-glass mz-glass-interactive mt-8 max-w-xl rounded-[12px]">
               <Card
                 id="npi"
-                className="mt-8 max-w-xl scroll-mt-24 rounded-[3px] border-[var(--vt-border)] bg-[var(--vt-surface)] shadow-none"
+                className="scroll-mt-24 rounded-[12px] border-0 bg-transparent shadow-none"
               >
                 <CardContent className="space-y-5 px-5 py-5 sm:px-6 sm:py-6">
                   <form
@@ -669,6 +670,7 @@ export default function HomePageClient() {
                   </div>
                 </CardContent>
               </Card>
+              </div>
 
               {/* Secondary path — the wallet is free; the lookup is just the door */}
               <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px]">

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -28,6 +28,7 @@ import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
 import { cn } from '@/lib/utils';
 import { PublicMatchaExperience } from '@/components/matcha/PublicMatchaExperience';
 import { MatchaConstellation } from '@/components/matcha/MatchaConstellation';
+import { Reveal } from '@/components/motion/Reveal';
 
 function formatNpi(value: string): string {
   const digits = value.replace(/\D/g, '').slice(0, 10);
@@ -539,15 +540,18 @@ export default function HomePageClient() {
                   The Provider Career Evidence Network
                 </p>
                 <h1 className="mz-display">
-                  Your clinical career evidence, in one wallet you own.
+                  Find the opportunity. Prove your career once.{' '}
+                  <em className="mz-accent">Start faster.</em>
                 </h1>
                 <p
                   data-home-hero-subhead=""
                   className="max-w-2xl text-[18px] leading-[1.6] text-[var(--vt-text-secondary)]"
                 >
-                  Start with your NPI. VitalCV reads primary sources, builds your
-                  readiness snapshot, and gives you an employer-ready proof packet —
-                  free for clinicians, and reusable for every move.
+                  VitalCV is the career evidence network for clinician careers.
+                  Start with your NPI. Primary sources become your readiness
+                  snapshot and an employer-ready proof packet — evidence employers
+                  can accept as a head start, free for clinicians, and reusable
+                  for every move of your career.
                 </p>
 
                 {/* Capability rail — the product's breadth, above the fold */}
@@ -746,6 +750,79 @@ export default function HomePageClient() {
             </div>
           </section>
 
+          {/* The compounding network — the platform's moat, made legible.
+              Today every job change re-proves the same career from zero; VitalCV
+              replaces the restart with portable, owned evidence whose acceptance
+              compounds. This is the shared core all personas buy into. */}
+          <section
+            aria-label="Why the career evidence network compounds"
+            data-home-moat=""
+            className="mz mz-ambient mt-16"
+          >
+            <p className="mz-eyebrow">Why this compounds</p>
+            <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 700 }}>
+              Career evidence that <em className="mz-accent">follows you</em> makes
+              every move faster than the last.
+            </h2>
+            <p className="mz-body" style={{ marginTop: 14, maxWidth: 660 }}>
+              Today, every job change re-proves the same career from zero — and the
+              start date waits on it. VitalCV replaces that restart with a network
+              where your proof is portable, and each acceptance makes the next one
+              easier.
+            </p>
+            <div className="mt-6 grid gap-3 lg:grid-cols-3">
+              <Reveal delay={0}>
+                <div
+                  data-home-moat-card="own"
+                  className="mz-glass mz-glass-interactive flex h-full flex-col gap-2 rounded-[12px] px-5 py-5"
+                >
+                  <p className="mz-eyebrow">Yours to keep</p>
+                  <h3 className="mz-h2">Nothing resets when you move</h3>
+                  <p className="mz-small">
+                    Every source check, receipt, and Recognition lands in a wallet
+                    you own — not in an employer&apos;s filing cabinet. Your career
+                    record leaves with you, intact.
+                  </p>
+                </div>
+              </Reveal>
+              <Reveal delay={80}>
+                <div
+                  data-home-moat-card="compound"
+                  className="mz-glass mz-glass-interactive flex h-full flex-col gap-2 rounded-[12px] px-5 py-5"
+                >
+                  <p className="mz-eyebrow">Acceptance compounds</p>
+                  <h3 className="mz-h2">Every yes makes the next yes easier</h3>
+                  <p className="mz-small">
+                    Each employer that accepts your packet as a head start becomes
+                    part of your record. Recognition turns past acceptance into
+                    momentum for the next opportunity.
+                  </p>
+                </div>
+              </Reveal>
+              <Reveal delay={160}>
+                <div
+                  data-home-moat-card="network"
+                  className="mz-glass mz-glass-interactive flex h-full flex-col gap-2 rounded-[12px] px-5 py-5"
+                >
+                  <p className="mz-eyebrow">The network speeds up</p>
+                  <h3 className="mz-h2">Everyone shares the same win</h3>
+                  <p className="mz-small">
+                    Clinicians find and start roles sooner. Employers cut
+                    Time-to-Start. Credentialing teams stop re-answering what a
+                    primary source already answered.
+                  </p>
+                </div>
+              </Reveal>
+            </div>
+            <p className="mz-small" style={{ marginTop: 18 }}>
+              <span className="mz-mono" style={{ letterSpacing: '0.08em' }}>
+                RECOGNITION → ACCEPTANCE → START
+              </span>{' '}
+              — the loop every VitalCV user shares. The goal we build against:
+              starting your next role 10× faster than the credentialing status quo.
+            </p>
+          </section>
+
           {/* AI layer — MATCHA as the honest intelligence layer */}
           <section aria-label="How AI helps" data-home-ai="" className="mt-16">
             <div className="mz-card overflow-hidden">
@@ -914,6 +991,10 @@ export default function HomePageClient() {
             className="mt-16"
           >
             <p className="mz-eyebrow">By role</p>
+            <p className="mz-body" style={{ marginTop: 12, maxWidth: 620 }}>
+              Four doors, one shared outcome — a clinician hired and started,
+              faster.
+            </p>
             <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               {ROLE_DOORS.map((door) => (
                 <Link

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -886,13 +886,12 @@ export default function HomePageClient() {
             </div>
           </section>
 
-          {/* Career constellation — calm card on paper. The star map keeps its
-              own inner canvas; the frame is the same hairline card as the rest. */}
-          <section aria-label="Your career, in motion" data-home-network="" className="mz mt-16">
-              <div
-                className="mz mz-card mz-card-pad relative isolate overflow-hidden"
-                style={{ position: 'relative', overflow: 'hidden', borderRadius: 12 }}
-              >
+          {/* Career constellation — bleeds into the page (no box): the eyebrow +
+              heading sit on paper, the star map opens below and edge-fades into
+              the surrounding paper via its own radial mask. Part of the page,
+              not a framed panel. */}
+          <section aria-label="Your career, in motion" data-home-network="" className="mz mz-persona-holder relative isolate mt-20">
+              <div className="relative isolate">
                 <p className="mz-eyebrow">Your career, in motion</p>
                 <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 640 }}>
                   Your career isn&rsquo;t a timeline. It&rsquo;s a <span className="mz-accent">constellation you can travel</span>.

--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -523,29 +523,15 @@ export default function HomePageClient() {
       <main className="relative mx-auto w-full max-w-6xl px-6 py-16 sm:py-20">
         <div className="w-full">
 
-          {/* Hero — dark "instrument" panel: the Calm Wave system in its own
-              dark variant (warm charcoal + indigo), the one place the page keeps
-              the dark-glass drama. Everything inside flips via `.dark .mz`, so it
-              stays the same family as the calm body — no jade, no EKG. */}
-          <div className="dark">
+          {/* Hero — full Calm Wave D56: the Fraunces headline sits open on paper,
+              the NPI + wallet visual framed to the right. No dark panel, no glow,
+              no heavy shadow — the calm institutional substrate the design is
+              drawn in. */}
           <section
             aria-label="NPI lookup"
             data-home-hero=""
-            className="mz mz-paper relative isolate overflow-hidden rounded-[12px] border border-[var(--vt-border)] px-6 py-10 shadow-[0_50px_120px_-70px_rgba(0,0,0,0.85)] sm:px-10 sm:py-12 grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
+            className="mz mz-paper relative isolate py-10 sm:py-14 grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,26rem)]"
           >
-            {/* one dark-glass whisper — a soft indigo instrument glow + faint static grid */}
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-0 -z-10"
-              style={{
-                background:
-                  'radial-gradient(80% 120% at 12% -15%, color-mix(in oklab, var(--vt-accent) 22%, transparent), transparent 58%)',
-              }}
-            />
-            <div
-              aria-hidden="true"
-              className="mz-dotgrid pointer-events-none absolute inset-0 -z-10 opacity-[0.12]"
-            />
             {/* Left: messaging + NPI entry */}
             <div className="max-w-2xl">
               <div className="space-y-5">
@@ -702,7 +688,6 @@ export default function HomePageClient() {
               <WalletPreview />
             </div>
           </section>
-          </div>
 
           {/* Primary-source registry strip — breadth, stated calm. Names only;
               state vocabulary stays in the caption so nothing overclaims. */}
@@ -899,23 +884,13 @@ export default function HomePageClient() {
             </div>
           </section>
 
-          {/* Career constellation — the second dark "instrument" panel (blend):
-              the star map reads best on the calm system's dark charcoal, with an
-              indigo glow. Same `.dark .mz` family as the hero. */}
+          {/* Career constellation — calm card on paper. The star map keeps its
+              own inner canvas; the frame is the same hairline card as the rest. */}
           <section aria-label="Your career, in motion" data-home-network="" className="mz mt-16">
-            <div className="dark">
               <div
                 className="mz mz-card mz-card-pad relative isolate overflow-hidden"
                 style={{ position: 'relative', overflow: 'hidden', borderRadius: 12 }}
               >
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 -z-10"
-                  style={{
-                    background:
-                      'radial-gradient(90% 120% at 50% -12%, color-mix(in oklab, var(--vt-accent) 20%, transparent), transparent 60%)',
-                  }}
-                />
                 <p className="mz-eyebrow">Your career, in motion</p>
                 <h2 className="mz-h1" style={{ marginTop: 14, maxWidth: 640 }}>
                   Your career isn&rsquo;t a timeline. It&rsquo;s a <span className="mz-accent">constellation you can travel</span>.
@@ -929,7 +904,6 @@ export default function HomePageClient() {
                   <MatchaConstellation height={480} />
                 </div>
               </div>
-            </div>
           </section>
 
           {/* Role doors — four calm entry points, clinician first */}

--- a/apps/web/app/get-ready/GetReadySurface.tsx
+++ b/apps/web/app/get-ready/GetReadySurface.tsx
@@ -18,10 +18,10 @@
  * and a self-attested profession are NOT license/identity proofing, and nothing
  * here presents them as a completed license check or a bare "Verified" status.
  *
- * Calm Wave blend to match the homepage: a calm light "action" side (paper + ink,
- * Fraunces serif, mono labels, ink primary buttons — where the clinician acts) beside
- * a dark "instrument" panel (the same design system's dark variant — warm charcoal +
- * indigo, NOT jade) carrying the benefits rail.
+ * Full Calm Wave D56 — one calm paper-and-ink system, no dark surfaces: a calm light
+ * "action" side (paper + ink, Fraunces serif, mono labels, ink primary buttons — where
+ * the clinician acts) beside an equally calm-light benefits rail. The two columns are
+ * set apart only by a single hairline and a subtle paper-2 inset — no glow, no charcoal.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -485,7 +485,7 @@ export default function GetReadySurface() {
   );
 }
 
-/* ── Layout: Calm Wave split-panel (calm-light action left, dark instrument right) ── */
+/* ── Layout: Calm Wave split-panel (calm-light action left, calm-light benefits right) ── */
 
 // Ink primary — the Calm Wave `.mz-btn` look, stretched full-width for the gate.
 const primaryBtn =
@@ -506,41 +506,25 @@ function Shell({ children }: { children: React.ReactNode }) {
 }
 
 function BenefitsPanel() {
-  // Dark "instrument" panel — the Calm Wave system in its own dark variant
-  // (warm charcoal + indigo). Everything inside flips via `.dark .mz`, so it
-  // stays the same family as the light action side: no jade, no coral glass.
+  // Calm-light benefits rail — full Calm Wave D56, no dark surfaces. Sits as the
+  // second column on the shared paper canvas, set off from the action side by a
+  // single left hairline and a subtle paper-2 inset. No gradient, no glow, no
+  // drop-shadow — ink on paper, the same family as the action column.
   return (
-    <div className="dark hidden lg:block">
-      <div className="mz mz-paper relative flex h-full items-center justify-center overflow-hidden">
-        {/* one dark-glass whisper — a soft indigo instrument glow + faint static grid */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 -z-10"
-          style={{
-            background:
-              'radial-gradient(80% 120% at 20% -10%, color-mix(in oklab, var(--vt-accent) 20%, transparent), transparent 58%)',
-          }}
-        />
-        <div
-          aria-hidden
-          className="mz-dotgrid pointer-events-none absolute inset-0 -z-10 opacity-[0.12]"
-        />
-        <div className="relative z-10 mx-8 w-full max-w-sm rounded-[12px] border border-[var(--vt-border)] bg-[var(--vt-surface)] p-8 shadow-[0_50px_120px_-70px_rgba(0,0,0,0.85)]">
-          <p className="mz-eyebrow">VitalCV for Clinicians</p>
-          <p className="mz-body mt-2 text-[var(--vt-text-secondary)]">
-            Your free, source-backed career wallet
-          </p>
-          <ul className="mt-6 space-y-4">
-            {BENEFITS.map((b, i) => (
-              <li key={i} className="flex items-start gap-3 text-sm text-[var(--vt-text-secondary)]">
-                <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[3px] border border-[color-mix(in_oklab,var(--vt-accent)_45%,transparent)] bg-[color-mix(in_oklab,var(--vt-accent)_16%,transparent)] text-[var(--vt-accent)]">
-                  {b.icon}
-                </span>
-                <span className="leading-relaxed">{b.text}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+    <div className="hidden border-l border-[var(--rule)] px-8 py-12 lg:flex lg:items-center lg:justify-center">
+      <div className="mz-inset w-full max-w-sm p-8">
+        <p className="mz-eyebrow">VitalCV for Clinicians</p>
+        <p className="mz-body mt-3">Your free, source-backed career wallet</p>
+        <ul className="mt-6 space-y-4">
+          {BENEFITS.map((b, i) => (
+            <li key={i} className="flex items-start gap-3 text-sm text-[var(--ink-600)]">
+              <span className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[3px] border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[color-mix(in_oklab,var(--accent)_10%,transparent)] text-[var(--accent)]">
+                {b.icon}
+              </span>
+              <span className="leading-relaxed">{b.text}</span>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/apps/web/app/holder/layout.tsx
+++ b/apps/web/app/holder/layout.tsx
@@ -27,7 +27,7 @@ export default async function HolderLayout({
 
   return (
     <ClinicianMobileProvider initialData={initialData}>
-      <div className="flex min-h-screen flex-col bg-ops-gradient selection:bg-vt-info/30 text-foreground">
+      <div className="mz mz-persona-holder flex min-h-screen flex-col bg-ops-gradient selection:bg-vt-info/30 text-foreground">
         <ClinicianLaunchTracker />
         <NetworkStatusBanner />
         <div className="flex-1 pb-20 md:pb-0">{children}</div>

--- a/apps/web/app/holder/opportunities/[id]/OpportunityDetailSurface.tsx
+++ b/apps/web/app/holder/opportunities/[id]/OpportunityDetailSurface.tsx
@@ -79,13 +79,14 @@ function matchBandLabel(band: string): string {
 function matchBandTone(band: string): string {
   switch (band) {
     case 'CLEAR':
-      return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100';
+      return 'mz-chip mz-chip-ok';
+    // "Almost ready" is not fully clear — amber, matching the opportunity feed
+    // (ClinicianPanels.matchTone) so one band never shows two colors.
     case 'NEAR_CLEAR':
-      return 'border-sky-400/30 bg-sky-400/10 text-sky-100';
     case 'PARTIAL':
-      return 'border-amber-400/30 bg-amber-400/10 text-amber-100';
+      return 'mz-chip mz-chip-watch';
     default:
-      return 'border-white/15 bg-white/[0.05] text-white/70';
+      return 'mz-chip mz-chip-unknown';
   }
 }
 
@@ -144,8 +145,8 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
     return (
       <Shell>
         <div className="flex flex-col items-center gap-3 py-16" role="status" aria-live="polite">
-          <Loader2 className="h-7 w-7 animate-spin text-white/40" aria-hidden />
-          <p className="text-sm text-white/50">Loading role…</p>
+          <Loader2 className="h-7 w-7 animate-spin text-[var(--ink-400)]" aria-hidden />
+          <p className="mz-small">Loading role…</p>
         </div>
       </Shell>
     );
@@ -157,14 +158,14 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
       <Shell>
         <BackLink />
         <div className="space-y-4 py-12 text-center">
-          <h1 className="text-2xl font-semibold text-white">This role is no longer available</h1>
-          <p className="text-sm leading-6 text-white/60">
+          <h1 className="mz-h1">This role is no longer available</h1>
+          <p className="mz-body">
             It may have been filled or withdrawn by the employer. Your matched feed always shows
             what is live right now.
           </p>
           <Link
             href="/holder/opportunities"
-            className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-6 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400"
+            className="mz-btn min-h-12"
           >
             See live roles <ChevronRight className="h-4 w-4" aria-hidden />
           </Link>
@@ -179,8 +180,8 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
       <Shell>
         <BackLink />
         <div className="space-y-4 py-12 text-center">
-          <h1 className="text-xl font-semibold text-white">Couldn&apos;t load this role</h1>
-          <p className="text-sm leading-6 text-white/60">
+          <h1 className="mz-h1">Couldn&apos;t load this role</h1>
+          <p className="mz-body">
             This is a system state — not a change to the role or your match. Try again shortly.
           </p>
         </div>
@@ -194,8 +195,8 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
     return (
       <Shell>
         <div className="flex flex-col items-center gap-3 py-16" role="status" aria-live="polite">
-          <Loader2 className="h-7 w-7 animate-spin text-white/40" aria-hidden />
-          <p className="text-sm text-white/50">Loading role…</p>
+          <Loader2 className="h-7 w-7 animate-spin text-[var(--ink-400)]" aria-hidden />
+          <p className="mz-small">Loading role…</p>
         </div>
       </Shell>
     );
@@ -208,13 +209,13 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
     <Shell>
       <BackLink />
 
-      <header className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 sm:p-6">
-        <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.18em] text-white/50">
+      <header className="mz-glass p-5 sm:p-6">
+        <p className="mz-eyebrow">
           <Building2 className="h-3.5 w-3.5 opacity-60" aria-hidden />
           {opportunity.organizationName}
         </p>
-        <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{opportunity.title}</h1>
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-white/65">
+        <h1 className="mz-h1 mt-2">{opportunity.title}</h1>
+        <div className="mt-3 flex flex-wrap items-center gap-2 mz-small">
           <span className="inline-flex items-center gap-1">
             <MapPin className="h-3.5 w-3.5" aria-hidden />
             {opportunity.state}
@@ -228,7 +229,7 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
           {opportunity.payRange ? (
             <>
               <span className="opacity-40">·</span>
-              <span className="inline-flex items-center gap-1 font-medium text-emerald-100/90">
+              <span className="inline-flex items-center gap-1 font-medium text-[var(--ink-800)]">
                 <Banknote className="h-3.5 w-3.5 opacity-70" aria-hidden />
                 {opportunity.payRange}
               </span>
@@ -247,14 +248,14 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
           {application ? (
             <Link
               href={`/holder/applications/${encodeURIComponent(application.id)}`}
-              className="inline-flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-6 py-3 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/50"
+              className="mz-btn mz-btn-ghost min-h-12"
             >
               You applied — view your application <ChevronRight className="h-4 w-4" aria-hidden />
             </Link>
           ) : (
             <Link
               href={`/holder/opportunities?apply=${encodeURIComponent(opportunity.id)}`}
-              className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-6 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400"
+              className="mz-btn min-h-12"
             >
               Apply with your VitalCV <ChevronRight className="h-4 w-4" aria-hidden />
             </Link>
@@ -266,24 +267,25 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
       {match ? (
         <section
           aria-labelledby="match-heading"
-          className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5"
+          className="mz-glass p-5"
         >
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 id="match-heading" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+            <h2 id="match-heading" className="mz-eyebrow">
               Your match
             </h2>
-            <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${matchBandTone(match.band)}`}>
+            <span className={matchBandTone(match.band)}>
+              <span className="mz-gl" />
               {matchBandLabel(match.band)} · {match.score}/100
             </span>
           </div>
           {match.fitReasons.length > 0 && (
             <div className="mt-3">
-              <p className="text-xs font-semibold uppercase tracking-widest text-white/40">Why you fit</p>
+              <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">Why you fit</p>
               <ul className="mt-2 flex flex-wrap gap-2">
                 {match.fitReasons.map((reason) => (
                   <li
                     key={reason}
-                    className="rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-xs text-white/80"
+                    className="mz-inset px-2.5 py-1 text-xs text-[var(--ink-700)]"
                   >
                     {reason}
                   </li>
@@ -293,30 +295,30 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
           )}
           {match.blockers.length > 0 && (
             <div className="mt-4">
-              <p className="text-xs font-semibold uppercase tracking-widest text-amber-200/70">
+              <p className="mz-mono text-[11px] uppercase tracking-[0.18em] text-[var(--watch)]">
                 What would strengthen this match
               </p>
               <ul className="mt-2 space-y-2">
                 {match.blockers.map((blocker) => (
                   <li
                     key={blocker.label}
-                    className="rounded-2xl border border-amber-400/15 bg-amber-400/10 px-4 py-2.5 text-sm text-amber-50"
+                    className="mz-inset px-4 py-2.5 mz-body"
                   >
                     {blocker.label}
-                    {blocker.action ? <span className="text-amber-100/70"> — {blocker.action}</span> : null}
+                    {blocker.action ? <span className="text-[var(--ink-500)]"> — {blocker.action}</span> : null}
                   </li>
                 ))}
               </ul>
             </div>
           )}
-          <p className="mt-4 text-xs leading-relaxed text-white/40">
+          <p className="mt-4 mz-small leading-relaxed">
             Match scoring is deterministic and based on your recorded credentials and stated
             preferences. It is guidance, not a verification result and not an employer decision.
           </p>
         </section>
       ) : (
-        <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-          <p className="text-sm leading-6 text-white/60">
+        <section className="mz-card mz-card-pad">
+          <p className="mz-body">
             This role is not in your matched feed right now, so no match explanation is available.
             Your feed reflects your recorded credentials and preferences.
           </p>
@@ -324,14 +326,14 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
       )}
 
       {/* Role description */}
-      <section aria-labelledby="role-heading" className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-        <h2 id="role-heading" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+      <section aria-labelledby="role-heading" className="mz-card mz-card-pad">
+        <h2 id="role-heading" className="mz-eyebrow">
           About this role
         </h2>
         {opportunity.description ? (
-          <p className="mt-3 whitespace-pre-line text-sm leading-6 text-white/70">{opportunity.description}</p>
+          <p className="mt-3 whitespace-pre-line mz-body">{opportunity.description}</p>
         ) : (
-          <p className="mt-3 text-sm leading-6 text-white/50">
+          <p className="mt-3 mz-small">
             The employer has not published a description for this role yet.
           </p>
         )}
@@ -342,8 +344,10 @@ export default function OpportunityDetailSurface({ opportunityId }: { opportunit
 
 function Shell({ children }: { children: React.ReactNode }) {
   return (
-    <main className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12">
-      {children}
+    <main className="mz mz-paper mz-ambient min-h-screen w-full">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12">
+        {children}
+      </div>
     </main>
   );
 }
@@ -352,7 +356,7 @@ function BackLink() {
   return (
     <Link
       href="/holder/opportunities"
-      className="inline-flex w-fit items-center gap-1.5 text-sm text-white/55 transition hover:text-white"
+      className="inline-flex w-fit items-center gap-1.5 mz-small transition hover:text-[var(--ink-900)]"
     >
       <ArrowLeft className="h-4 w-4" aria-hidden /> All roles
     </Link>

--- a/apps/web/app/holder/settings/SettingsSurface.tsx
+++ b/apps/web/app/holder/settings/SettingsSurface.tsx
@@ -24,118 +24,116 @@ export default function SettingsSurface() {
   const name = [person?.firstName, person?.lastName].filter(Boolean).join(' ') || null;
 
   return (
-    <main className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12">
+    <main className="mz mz-paper mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12">
       <header className="flex items-center gap-3">
-        <div className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04]">
-          <SettingsIcon className="h-5 w-5 text-white/70" aria-hidden />
+        <div className="mz-inset inline-flex h-11 w-11 items-center justify-center">
+          <SettingsIcon className="h-5 w-5" style={{ color: 'var(--ink-700)' }} aria-hidden />
         </div>
         <div>
-          <h1 className="text-2xl font-semibold text-white">Settings</h1>
-          <p className="text-sm text-white/55">Account, identity binding, and sharing.</p>
+          <h1 className="mz-h1">Settings</h1>
+          <p className="mz-small">Account, identity binding, and sharing.</p>
         </div>
       </header>
 
       {/* Account (Clerk) */}
-      <section aria-labelledby="settings-account" className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-        <h2 id="settings-account" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
-          Account
-        </h2>
-        {clerkEnabled ? <AccountRow /> : (
-          <p className="mt-3 text-sm text-white/60">
-            Account management is unavailable in this environment (auth is not configured).
-          </p>
-        )}
+      <section aria-labelledby="settings-account" className="mz-card">
+        <div className="mz-card-hd">
+          <h2 id="settings-account" className="mz-eyebrow">
+            Account
+          </h2>
+        </div>
+        <div className="mz-card-pad">
+          {clerkEnabled ? <AccountRow /> : (
+            <p className="mz-body">
+              Account management is unavailable in this environment (auth is not configured).
+            </p>
+          )}
+        </div>
       </section>
 
       {/* Identity binding */}
-      <section aria-labelledby="settings-identity" className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-        <div className="flex items-center gap-2">
-          <IdCard className="h-4 w-4 text-white/45" aria-hidden />
-          <h2 id="settings-identity" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+      <section aria-labelledby="settings-identity" className="mz-card">
+        <div className="mz-card-hd">
+          <h2 id="settings-identity" className="mz-eyebrow">
+            <IdCard className="h-3.5 w-3.5" aria-hidden />
             Identity binding
           </h2>
         </div>
-        {npi ? (
-          <div className="mt-3 space-y-2">
-            <p className="text-sm text-white/80">
-              This workspace is bound to <span className="font-mono">NPI {npi}</span>
-              {name ? <> ({name})</> : null}.
-            </p>
-            <p className="text-xs leading-relaxed text-white/50">
-              Identity fields come from your NPPES registry record at connect time. NPI binding is
-              one-to-one with your account; to move an NPI between accounts, contact support so
-              ownership can be resolved deliberately.
-            </p>
-          </div>
-        ) : (
-          <div className="mt-3 space-y-3">
-            <p className="text-sm text-white/70">No NPI is connected to this workspace yet.</p>
-            <Link
-              href="/get-ready"
-              className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-emerald-400"
-            >
-              Connect your NPI <ChevronRight className="h-4 w-4" aria-hidden />
-            </Link>
-          </div>
-        )}
+        <div className="mz-card-pad">
+          {npi ? (
+            <div className="space-y-2">
+              <p className="mz-body">
+                This workspace is bound to <span className="mz-mono">NPI {npi}</span>
+                {name ? <> ({name})</> : null}.
+              </p>
+              <p className="mz-small">
+                Identity fields come from your NPPES registry record at connect time. NPI binding is
+                one-to-one with your account; to move an NPI between accounts, contact support so
+                ownership can be resolved deliberately.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <p className="mz-body">No NPI is connected to this workspace yet.</p>
+              <Link href="/get-ready" className="mz-btn mz-btn-sm">
+                Connect your NPI <ChevronRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </div>
+          )}
+        </div>
       </section>
 
       {/* Professional profile */}
-      <section aria-labelledby="settings-profile" className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-        <div className="flex items-center gap-2">
-          <UserRound className="h-4 w-4 text-white/45" aria-hidden />
-          <h2 id="settings-profile" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+      <section aria-labelledby="settings-profile" className="mz-card">
+        <div className="mz-card-hd">
+          <h2 id="settings-profile" className="mz-eyebrow">
+            <UserRound className="h-3.5 w-3.5" aria-hidden />
             Professional profile
           </h2>
         </div>
-        <p className="mt-3 text-sm leading-6 text-white/60">
-          Career links, resume link, and work authorization are self-attested fields you manage on
-          your profile. User-entered information is not verified until source-backed evidence is
-          attached.
-        </p>
-        <Link
-          href="/clinician/profile"
-          className="mt-3 inline-flex items-center gap-1.5 rounded-xl border border-white/15 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
-        >
-          Open your profile <ChevronRight className="h-4 w-4" aria-hidden />
-        </Link>
+        <div className="mz-card-pad">
+          <p className="mz-body">
+            Career links, resume link, and work authorization are self-attested fields you manage on
+            your profile. User-entered information is not verified until source-backed evidence is
+            attached.
+          </p>
+          <Link href="/clinician/profile" className="mz-btn mz-btn-ghost mz-btn-sm mt-3">
+            Open your profile <ChevronRight className="h-4 w-4" aria-hidden />
+          </Link>
+        </div>
       </section>
 
       {/* Data & sharing */}
-      <section aria-labelledby="settings-sharing" className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-        <div className="flex items-center gap-2">
-          <Share2 className="h-4 w-4 text-white/45" aria-hidden />
-          <h2 id="settings-sharing" className="text-[11px] uppercase tracking-[0.18em] text-white/45">
+      <section aria-labelledby="settings-sharing" className="mz-card">
+        <div className="mz-card-hd">
+          <h2 id="settings-sharing" className="mz-eyebrow">
+            <Share2 className="h-3.5 w-3.5" aria-hidden />
             Data &amp; sharing
           </h2>
         </div>
-        <ul className="mt-3 space-y-2 text-sm leading-6 text-white/60">
-          <li>
-            Your passport is shared only through links you create — from your wallet or when you
-            apply to a role. Nothing is published without an action you take.
-          </li>
-          <li>
-            Employers you apply to see your readiness packet and the self-attested fields you have
-            filled in, each labeled with its provenance.
-          </li>
-          <li>
-            Source checks (NPPES, exclusions, licensure) read public registries; results are
-            recorded with receipts you can review on your readiness surface.
-          </li>
-        </ul>
-        <div className="mt-3 flex flex-wrap gap-3">
-          <Link
-            href="/holder"
-            className="inline-flex items-center gap-1.5 rounded-xl border border-white/15 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
-          >
-            Your wallet &amp; sharing <ChevronRight className="h-4 w-4" aria-hidden />
-          </Link>
-          <Link
-            href="/holder/readiness"
-            className="inline-flex items-center gap-1.5 rounded-xl border border-white/15 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
-          >
-            Readiness &amp; receipts <ChevronRight className="h-4 w-4" aria-hidden />
-          </Link>
+        <div className="mz-card-pad">
+          <ul className="mz-body space-y-2">
+            <li>
+              Your passport is shared only through links you create — from your wallet or when you
+              apply to a role. Nothing is published without an action you take.
+            </li>
+            <li>
+              Employers you apply to see your readiness packet and the self-attested fields you have
+              filled in, each labeled with its provenance.
+            </li>
+            <li>
+              Source checks (NPPES, exclusions, licensure) read public registries; results are
+              recorded with receipts you can review on your readiness surface.
+            </li>
+          </ul>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link href="/holder" className="mz-btn mz-btn-ghost mz-btn-sm">
+              Your wallet &amp; sharing <ChevronRight className="h-4 w-4" aria-hidden />
+            </Link>
+            <Link href="/holder/readiness" className="mz-btn mz-btn-ghost mz-btn-sm">
+              Readiness &amp; receipts <ChevronRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
         </div>
       </section>
     </main>
@@ -147,26 +145,25 @@ function AccountRow() {
 
   if (!isLoaded) {
     return (
-      <p className="mt-3 animate-pulse text-sm text-white/50" role="status" aria-live="polite">
+      <p className="mz-small animate-pulse" role="status" aria-live="polite">
         Loading account…
       </p>
     );
   }
 
   return (
-    <div className="mt-3 flex flex-wrap items-center justify-between gap-4">
+    <div className="flex flex-wrap items-center justify-between gap-4">
       <div className="flex items-center gap-3">
         <UserButton afterSignOutUrl="/" />
         <div>
-          <p className="text-sm font-medium text-white">{user?.fullName ?? 'Your account'}</p>
-          <p className="text-xs text-white/50">{user?.primaryEmailAddress?.emailAddress ?? ''}</p>
+          <p className="text-sm font-medium" style={{ color: 'var(--ink-900)' }}>
+            {user?.fullName ?? 'Your account'}
+          </p>
+          <p className="mz-small">{user?.primaryEmailAddress?.emailAddress ?? ''}</p>
         </div>
       </div>
       <SignOutButton redirectUrl="/">
-        <button
-          type="button"
-          className="rounded-xl border border-white/15 px-4 py-2 text-sm font-semibold text-white/70 transition hover:border-rose-400/40 hover:text-rose-200"
-        >
+        <button type="button" className="mz-btn mz-btn-ghost mz-btn-sm">
           Sign out
         </button>
       </SignOutButton>

--- a/apps/web/app/holder/timeline/page.tsx
+++ b/apps/web/app/holder/timeline/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { MARKETPLACE_BACKEND, buildMarketplaceHeaders } from '@/lib/server/marketplace-proxy';
+import { Reveal } from '@/components/motion/Reveal';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -58,20 +59,17 @@ export default async function HolderTimelinePage() {
 
   // kind === 'error' — honest system-state page (redirect targets unknown).
   return (
-    <main className="flex min-h-screen items-center justify-center bg-zinc-950 px-6">
-      <div className="max-w-sm space-y-4 text-center">
-        <p className="font-medium text-foreground">Couldn&apos;t open your timeline</p>
-        <p className="text-sm text-zinc-400">
+    <main className="mz mz-paper flex min-h-screen items-center justify-center px-6">
+      <Reveal className="mz-glass max-w-sm space-y-4 p-8 text-center">
+        <p className="mz-h2">Couldn&apos;t open your timeline</p>
+        <p className="mz-body">
           Your workspace lookup is temporarily unavailable. This is a system state — not a finding
           about your record. Try again shortly.
         </p>
-        <Link
-          href="/holder/home"
-          className="inline-flex items-center justify-center rounded-lg border border-zinc-700 px-5 py-2 text-sm text-zinc-300 transition hover:text-white"
-        >
+        <Link href="/holder/home" className="mz-btn mz-btn-ghost mz-btn-sm">
           Back to your dashboard
         </Link>
-      </div>
+      </Reveal>
     </main>
   );
 }

--- a/apps/web/app/issuer/policy-review/[requestId]/page.tsx
+++ b/apps/web/app/issuer/policy-review/[requestId]/page.tsx
@@ -20,6 +20,7 @@ import type {
   PolicyReviewAction,
   VerificationClaimType,
 } from '@/lib/issuer-verification/types';
+import { Reveal } from '@/components/motion/Reveal';
 
 /**
  * ISSUER-3 — Policy Review Decision Surface (demo render).
@@ -175,7 +176,7 @@ export default async function PolicyReviewPage({ params }: PageProps) {
 
   return (
     <main
-      className="min-h-screen bg-background"
+      className="mz mz-paper mz-persona-issuer relative min-h-screen overflow-x-hidden"
       data-testid="policy-review-page"
       data-receipt-candidate-id={candidate.receiptCandidateId}
       data-review-state={candidate.reviewState}
@@ -185,144 +186,158 @@ export default async function PolicyReviewPage({ params }: PageProps) {
       data-persistence-status={writeOutcome.status}
       data-recorded-by={persistedRecordedBy}
     >
-      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
-        <header className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
-            Policy review
-          </p>
-          <h1 className="text-xl font-semibold text-foreground">
-            Receipt candidate {candidate.receiptCandidateId}
-          </h1>
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="policy-review-warning"
-          >
-            Policy review controls whether this candidate can become a PSV
-            receipt. The original issuer response remains evidence, even if the
-            candidate is rejected.
-          </p>
-          {writeOutcome.status === 'persisted' && (
+      {/* Hero — ambient wash + a clean, deliberate policy-desk header.
+          Glass is reserved for the single decision-moment panel below. */}
+      <section className="mz-ambient relative isolate">
+        <div className="mx-auto max-w-2xl px-4 pt-14 pb-2">
+          <Reveal as="header" variant="fade" className="space-y-3">
+            <p className="mz-eyebrow">Policy review</p>
+            <h1 className="mz-h1">
+              Receipt <span className="mz-accent">candidate</span>{' '}
+              <span className="mz-mono align-middle text-[0.5em] font-normal tracking-[0.06em] text-[var(--vt-text-secondary)]">
+                {candidate.receiptCandidateId}
+              </span>
+            </h1>
             <p
-              className="mt-2 inline-block rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-emerald-700"
-              data-testid="persistence-banner"
-              data-banner-state="persisted"
+              className="mz-body text-[var(--vt-text-secondary)]"
+              data-testid="policy-review-warning"
             >
-              Candidate row recorded (recordedBy: system)
+              Policy review controls whether this candidate can become a PSV
+              receipt. The original issuer response remains evidence, even if the
+              candidate is rejected.
             </p>
-          )}
-          {writeOutcome.status === 'tamper_detected' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-amber-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-amber-700"
-              data-testid="persistence-banner"
-              data-banner-state="tamper_detected"
-            >
-              Candidate row CHECK violation — render only (recordedBy: demo)
-            </p>
-          )}
-          {writeOutcome.status === 'transient_error' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-slate-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-700"
-              data-testid="persistence-banner"
-              data-banner-state="transient_error"
-            >
-              Persistence unavailable — render only (recordedBy: demo)
-            </p>
-          )}
-          {writeOutcome.status === 'disabled' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-slate-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600"
-              data-testid="persistence-banner"
-              data-banner-state="disabled"
-            >
-              Persistence disabled — render only (recordedBy: demo)
-            </p>
-          )}
-        </header>
+            {writeOutcome.status === 'persisted' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--ok-bg)', color: 'var(--ok)', borderColor: 'var(--ok-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="persisted"
+              >
+                Candidate row recorded (recordedBy: system)
+              </p>
+            )}
+            {writeOutcome.status === 'tamper_detected' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--watch-bg)', color: 'var(--watch)', borderColor: 'var(--watch-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="tamper_detected"
+              >
+                Candidate row CHECK violation — render only (recordedBy: demo)
+              </p>
+            )}
+            {writeOutcome.status === 'transient_error' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--unknown-bg)', color: 'var(--unknown)', borderColor: 'var(--unknown-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="transient_error"
+              >
+                Persistence unavailable — render only (recordedBy: demo)
+              </p>
+            )}
+            {writeOutcome.status === 'disabled' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--unknown-bg)', color: 'var(--unknown)', borderColor: 'var(--unknown-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="disabled"
+              >
+                Persistence disabled — render only (recordedBy: demo)
+              </p>
+            )}
+          </Reveal>
+        </div>
+      </section>
 
-        <section
-          className="rounded-2xl border border-border bg-card p-5 space-y-4"
+      <div className="mx-auto max-w-2xl px-4 pb-16 pt-6 space-y-5">
+        <Reveal
+          as="section"
+          className="mz-card p-6 space-y-5"
           aria-label="Receipt candidate summary"
         >
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Claim
             </p>
-            <p className="text-sm text-foreground">{request.claimSummary}</p>
-            <p className="text-xs text-muted-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">{request.claimSummary}</p>
+            <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
               Recommended route: {PARTNER_CATEGORY_LABEL[request.route.partnerCategory]}
             </p>
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Issuer response status
             </p>
-            <p className="text-sm text-foreground capitalize">
+            <p className="mz-body mt-1 capitalize text-[var(--vt-text-primary)]">
               {candidate.responseStatus?.replace(/_/g, ' ')}
             </p>
             {candidate.responseSummary && (
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 {candidate.responseSummary}
               </p>
             )}
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Review state
             </p>
-            <p className="text-sm text-foreground">{reviewCopy.label}</p>
-            <p className="text-xs text-muted-foreground">{reviewCopy.description}</p>
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">{reviewCopy.label}</p>
+            <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">{reviewCopy.description}</p>
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Responder attribution
             </p>
-            <p className="text-sm text-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">
               {candidate.attributedResponder?.name ?? '(unattributed)'}
             </p>
             {candidate.attributedResponder?.role && (
-              <p className="text-xs text-muted-foreground">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 {candidate.attributedResponder.role}
               </p>
             )}
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Source basis
             </p>
-            <p className="text-sm text-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">
               {candidate.sourceBasis?.sourceOrganizationName}
             </p>
             {candidate.sourceBasis?.isContractedAgent && (
-              <p className="text-xs text-muted-foreground">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 Responding agent: {candidate.sourceBasis.agentName}
               </p>
             )}
             {candidate.sourceBasis?.basisNote && (
-              <p className="text-xs text-muted-foreground italic mt-1">
+              <p className="mz-small mt-1 italic text-[var(--vt-text-secondary)]">
                 {candidate.sourceBasis.basisNote}
               </p>
             )}
           </div>
           {candidate.limitationNote && (
-            <div>
-              <p className="text-[10px] font-bold uppercase tracking-wider text-amber-500/80">
+            <div className="space-y-2">
+              <span className="mz-chip mz-chip-watch">
+                <span className="mz-gl" aria-hidden="true" />
                 Limitation
-              </p>
-              <p className="text-xs text-muted-foreground italic">
+              </span>
+              <p className="mz-small italic text-[var(--vt-text-secondary)]">
                 {candidate.limitationNote}
               </p>
             </div>
           )}
-        </section>
+        </Reveal>
 
-        <section
-          className="rounded-2xl border border-border bg-card p-5"
+        {/* Decision moment — the single elevated glass panel. */}
+        <Reveal
+          as="section"
+          delay={80}
+          className="mz-glass rounded-[12px] p-6"
           aria-label="Available policy review actions"
         >
-          <h2 className="text-sm font-semibold mb-3 text-foreground">
-            Available actions
-          </h2>
-          <ul className="space-y-2" data-testid="policy-review-actions">
+          <h2 className="mz-h2">Available actions</h2>
+          <ul className="mt-4 space-y-2.5" data-testid="policy-review-actions">
             {ACTIONS.map((entry) => {
               const decision = buildPolicyReviewDecision(candidate, entry.action, {
                 decisionId: `dry-${entry.action}`,
@@ -338,42 +353,44 @@ export default async function PolicyReviewPage({ params }: PageProps) {
               return (
                 <li
                   key={entry.action}
-                  className="rounded-xl border border-border/60 bg-background/40 p-3"
+                  className="mz-glass-inset rounded-[10px] p-4"
                   data-action={entry.action}
                   data-creates-psv-candidate={String(
                     decision.createdPsvReceiptCandidate,
                   )}
                   data-decision-status={decision.status}
                 >
-                  <p className="text-sm font-medium text-foreground">
+                  <p className="mz-body font-medium text-[var(--vt-text-primary)]">
                     {entry.label}
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="mz-small mt-0.5 text-[var(--vt-text-secondary)]">
                     {entry.description}
                   </p>
-                  <p className="text-[11px] mt-1 text-muted-foreground/80">
+                  <p className="mz-small mt-1 text-[var(--vt-text-muted)]">
                     Status: {copy.label} — {copy.description}
                   </p>
                 </li>
               );
             })}
           </ul>
-          <p className="mt-4 text-[11px] italic text-muted-foreground/80">
+          <p className="mt-5 mz-small italic text-[var(--vt-text-muted)]">
             Submitting on this page does not write an audit event and does not
             finalize verification. A PSV receipt candidate is not a global PSV
             receipt; promotion is gated by a separate review.
           </p>
-        </section>
+        </Reveal>
 
-        <section
-          className="rounded-2xl border border-border bg-card/60 p-4"
+        <Reveal
+          as="section"
+          delay={120}
+          className="mz-card p-6"
           aria-label="Dry-run outcome"
         >
-          <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
             Dry-run accept outcome
           </p>
           <p
-            className="text-xs text-muted-foreground"
+            className="mz-small mt-1 text-[var(--vt-text-secondary)]"
             data-testid="dry-run-outcome"
             data-creates-psv-candidate={String(
               dryRunAccept.decision.createdPsvReceiptCandidate,
@@ -383,7 +400,7 @@ export default async function PolicyReviewPage({ params }: PageProps) {
           </p>
           {dryRunAccept.psvReceiptCandidate && (
             <p
-              className="text-[11px] text-muted-foreground/80 mt-1"
+              className="mz-small mt-1 text-[var(--vt-text-muted)]"
               data-testid="psv-candidate-tier"
               data-proof-tier={dryRunAccept.psvReceiptCandidate.proofTier}
               data-decision-grade={String(
@@ -394,16 +411,23 @@ export default async function PolicyReviewPage({ params }: PageProps) {
               Not final credentialing proof.
             </p>
           )}
-        </section>
+        </Reveal>
 
-        <section className="text-[11px] text-muted-foreground/70">
-          <p data-testid="policy-review-copy">
+        <Reveal
+          as="section"
+          delay={160}
+          className="border-t border-[var(--vt-border-subtle)] pt-6"
+        >
+          <p
+            data-testid="policy-review-copy"
+            className="mz-small text-[var(--vt-text-muted)]"
+          >
             Policy review states keep the candidate distinct from finalized
             verification: {Object.values(POLICY_REVIEW_COPY)
               .map((s) => s.label)
               .join(' · ')}
           </p>
-        </section>
+        </Reveal>
       </div>
     </main>
   );

--- a/apps/web/app/issuer/review/[requestId]/page.tsx
+++ b/apps/web/app/issuer/review/[requestId]/page.tsx
@@ -15,6 +15,7 @@ import type {
   IssuerVerificationRequest,
   VerificationClaimType,
 } from '@/lib/issuer-verification/types';
+import { Reveal } from '@/components/motion/Reveal';
 
 /**
  * ISSUER-2 — Receipt-candidate review surface.
@@ -145,7 +146,7 @@ export default async function IssuerReviewPage({ params }: PageProps) {
 
   return (
     <main
-      className="min-h-screen bg-background"
+      className="mz mz-paper mz-persona-issuer relative min-h-screen overflow-x-hidden"
       data-testid="issuer-review-page"
       data-receipt-candidate-id={candidate.receiptCandidateId}
       data-review-state={candidate.reviewState}
@@ -154,188 +155,215 @@ export default async function IssuerReviewPage({ params }: PageProps) {
       data-persistence-status={writeOutcome.status}
       data-recorded-by={persistedRecordedBy}
     >
-      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
-        <header className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
-            Issuer review
-          </p>
-          <h1 className="text-xl font-semibold text-foreground">
-            Receipt candidate {candidate.receiptCandidateId}
-          </h1>
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="receipt-candidate-warning"
+      {/* Hero — ambient wash + weighted glass panel (the attester's desk). */}
+      <section className="mz-ambient relative isolate">
+        <div className="mx-auto max-w-2xl px-4 pt-14 pb-2">
+          <Reveal
+            as="header"
+            variant="fade"
+            className="mz-glass-strong space-y-3 rounded-[14px] p-6 sm:p-8"
           >
-            This is a receipt candidate, not final verification.
-          </p>
-          {writeOutcome.status === 'persisted' && (
+            <p className="mz-eyebrow">Issuer review</p>
+            <h1 className="mz-h1">
+              Receipt <span className="mz-accent">candidate</span>{' '}
+              <span className="mz-mono align-middle text-[0.5em] font-normal tracking-[0.06em] text-[var(--vt-text-secondary)]">
+                {candidate.receiptCandidateId}
+              </span>
+            </h1>
             <p
-              className="mt-2 inline-block rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-emerald-700"
-              data-testid="persistence-banner"
-              data-banner-state="persisted"
+              className="mz-body text-[var(--vt-text-secondary)]"
+              data-testid="receipt-candidate-warning"
             >
-              Candidate row recorded (recordedBy: system)
+              This is a receipt candidate, not final verification.
             </p>
-          )}
-          {writeOutcome.status === 'tamper_detected' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-amber-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-amber-700"
-              data-testid="persistence-banner"
-              data-banner-state="tamper_detected"
-            >
-              Candidate row CHECK violation — render only (recordedBy: demo)
-            </p>
-          )}
-          {writeOutcome.status === 'transient_error' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-slate-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-700"
-              data-testid="persistence-banner"
-              data-banner-state="transient_error"
-            >
-              Persistence unavailable — render only (recordedBy: demo)
-            </p>
-          )}
-          {writeOutcome.status === 'disabled' && (
-            <p
-              className="mt-2 inline-block rounded-md bg-slate-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600"
-              data-testid="persistence-banner"
-              data-banner-state="disabled"
-            >
-              Persistence disabled — render only (recordedBy: demo)
-            </p>
-          )}
-        </header>
+            {writeOutcome.status === 'persisted' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--ok-bg)', color: 'var(--ok)', borderColor: 'var(--ok-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="persisted"
+              >
+                Candidate row recorded (recordedBy: system)
+              </p>
+            )}
+            {writeOutcome.status === 'tamper_detected' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--watch-bg)', color: 'var(--watch)', borderColor: 'var(--watch-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="tamper_detected"
+              >
+                Candidate row CHECK violation — render only (recordedBy: demo)
+              </p>
+            )}
+            {writeOutcome.status === 'transient_error' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--unknown-bg)', color: 'var(--unknown)', borderColor: 'var(--unknown-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="transient_error"
+              >
+                Persistence unavailable — render only (recordedBy: demo)
+              </p>
+            )}
+            {writeOutcome.status === 'disabled' && (
+              <p
+                className="mt-2 inline-block rounded-[4px] border px-2.5 py-1 mz-mono text-[10px] font-medium uppercase tracking-[0.08em]"
+                style={{ background: 'var(--unknown-bg)', color: 'var(--unknown)', borderColor: 'var(--unknown-rule)' }}
+                data-testid="persistence-banner"
+                data-banner-state="disabled"
+              >
+                Persistence disabled — render only (recordedBy: demo)
+              </p>
+            )}
+          </Reveal>
+        </div>
+      </section>
 
-        <section
-          className="rounded-2xl border border-border bg-card p-5 space-y-4"
+      <div className="mx-auto max-w-2xl px-4 pb-16 pt-6 space-y-5">
+        <Reveal
+          as="section"
+          className="mz-glass space-y-5 rounded-[12px] p-6"
           aria-label="Request and claim summary"
         >
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Request
             </p>
-            <p className="text-sm text-foreground">{request.requestId}</p>
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">{request.requestId}</p>
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Claim
             </p>
-            <p className="text-sm text-foreground">{request.claimSummary}</p>
-            <p className="text-xs text-muted-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">{request.claimSummary}</p>
+            <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
               Recommended route: {PARTNER_CATEGORY_LABEL[request.route.partnerCategory]}
             </p>
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Issuer
             </p>
-            <p className="text-sm text-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">
               {request.issuerCandidate.organizationName}
             </p>
             {request.issuerCandidate.contactRole && (
-              <p className="text-xs text-muted-foreground">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 {request.issuerCandidate.contactRole}
               </p>
             )}
           </div>
-        </section>
+        </Reveal>
 
-        <section
-          className="rounded-2xl border border-border bg-card p-5 space-y-4"
+        <Reveal
+          as="section"
+          delay={80}
+          className="mz-glass space-y-5 rounded-[12px] p-6"
           aria-label="Issuer response"
         >
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Response status
             </p>
-            <p className="text-sm text-foreground capitalize">
+            <p className="mz-body mt-1 capitalize text-[var(--vt-text-primary)]">
               {candidate.responseStatus?.replace(/_/g, ' ')}
             </p>
             {candidate.responseSummary && (
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 {candidate.responseSummary}
               </p>
             )}
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Responder attribution
             </p>
-            <p className="text-sm text-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">
               {candidate.attributedResponder?.name ?? '(unattributed)'}
             </p>
             {candidate.attributedResponder?.role && (
-              <p className="text-xs text-muted-foreground">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 {candidate.attributedResponder.role}
               </p>
             )}
           </div>
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Source basis
             </p>
-            <p className="text-sm text-foreground">
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">
               {candidate.sourceBasis?.sourceOrganizationName}
             </p>
             {candidate.sourceBasis?.isContractedAgent && (
-              <p className="text-xs text-muted-foreground">
+              <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">
                 Responding agent: {candidate.sourceBasis.agentName}
               </p>
             )}
             {candidate.sourceBasis?.basisNote && (
-              <p className="text-xs text-muted-foreground italic mt-1">
+              <p className="mz-small mt-1 italic text-[var(--vt-text-secondary)]">
                 {candidate.sourceBasis.basisNote}
               </p>
             )}
           </div>
           {candidate.limitationNote && (
-            <div>
-              <p className="text-[10px] font-bold uppercase tracking-wider text-amber-500/80">
+            <div className="space-y-2">
+              <span className="mz-chip mz-chip-watch">
+                <span className="mz-gl" aria-hidden="true" />
                 Limitation
-              </p>
-              <p className="text-xs text-muted-foreground italic">
+              </span>
+              <p className="mz-small italic text-[var(--vt-text-secondary)]">
                 {candidate.limitationNote}
               </p>
             </div>
           )}
           <div>
-            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="mz-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vt-text-muted)]">
               Review state
             </p>
-            <p className="text-sm text-foreground">{reviewCopy.label}</p>
-            <p className="text-xs text-muted-foreground">{reviewCopy.description}</p>
+            <p className="mz-body mt-1 text-[var(--vt-text-primary)]">{reviewCopy.label}</p>
+            <p className="mz-small mt-1 text-[var(--vt-text-secondary)]">{reviewCopy.description}</p>
           </div>
-        </section>
+        </Reveal>
 
-        <section
-          className="rounded-2xl border border-border bg-card p-5"
+        <Reveal
+          as="section"
+          delay={120}
+          className="mz-glass rounded-[12px] p-6"
           aria-label="Next actions"
         >
-          <h2 className="text-sm font-semibold mb-3 text-foreground">Next actions</h2>
-          <ul className="space-y-2" data-testid="receipt-candidate-actions">
+          <h2 className="mz-h2">Next actions</h2>
+          <ul className="mt-4 space-y-2.5" data-testid="receipt-candidate-actions">
             {NEXT_ACTIONS.map((action) => (
               <li
                 key={action.key}
-                className="rounded-xl border border-border/60 bg-background/40 p-3"
+                className="mz-glass-inset rounded-[10px] p-4"
                 data-action-key={action.key}
               >
-                <p className="text-sm font-medium text-foreground">{action.label}</p>
-                <p className="text-xs text-muted-foreground">{action.description}</p>
+                <p className="mz-body font-medium text-[var(--vt-text-primary)]">{action.label}</p>
+                <p className="mz-small mt-0.5 text-[var(--vt-text-secondary)]">{action.description}</p>
               </li>
             ))}
           </ul>
-          <p className="mt-4 text-[11px] italic text-muted-foreground/80">
+          <p className="mt-5 mz-small italic text-[var(--vt-text-muted)]">
             Submitting on this page does not finalize verification. Only a
             policy-review decision can convert a candidate into a PSV receipt.
           </p>
-        </section>
+        </Reveal>
 
-        <section className="text-[11px] text-muted-foreground/70">
-          <p data-testid="review-state-copy">
+        <Reveal
+          as="section"
+          delay={160}
+          className="border-t border-[var(--vt-border-subtle)] pt-6"
+        >
+          <p
+            data-testid="review-state-copy"
+            className="mz-small text-[var(--vt-text-muted)]"
+          >
             All review states keep the candidate distinct from finalized
             verification: {Object.values(REVIEW_STATE_COPY).map((s) => s.label).join(' · ')}
           </p>
-        </section>
+        </Reveal>
       </div>
     </main>
   );

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,34 +7,49 @@ import { vdsCssVariables } from '@/src/styles';
 import { ClerkProvider } from '@clerk/nextjs';
 import { auth } from '@clerk/nextjs/server';
 import type { Metadata } from 'next';
+import { Fraunces, Geist, Geist_Mono } from 'next/font/google';
 import type React from 'react';
 import './globals.css';
 import '../styles/antigravity.css';
 import '../styles/typography.css';
 import Providers from './providers';
 
-const systemSansStack =
-  "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-const systemDisplayStack = "Georgia, 'Times New Roman', serif";
-const systemMonoStack =
-  "ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', monospace";
+/**
+ * Calm Wave D56 typography — the real webfonts the design system is drawn in.
+ * next/font self-hosts them (downloaded at build, served same-origin), so
+ * there is no runtime Google-Fonts CDN dependency and nothing to add to the
+ * CSP. Previously these variables resolved to system fallbacks (Georgia /
+ * system-ui), which is why the live app never matched the Fraunces + Geist
+ * design. Each carries its own size-adjusted fallback for zero-CLS swap.
+ */
+const geistSans = Geist({ subsets: ['latin'], display: 'swap' });
+const geistMono = Geist_Mono({ subsets: ['latin'], display: 'swap' });
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  display: 'swap',
+});
+
+const sansStack = `${geistSans.style.fontFamily}, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif`;
+const displayStack = `${fraunces.style.fontFamily}, 'Iowan Old Style', Georgia, serif`;
+const monoStack = `${geistMono.style.fontFamily}, ui-monospace, 'SFMono-Regular', Menlo, monospace`;
 
 const fontVariables = {
   ...vdsCssVariables,
-  '--font-fraunces': systemDisplayStack,
-  '--font-plus-jakarta': systemSansStack,
-  '--font-inter': systemSansStack,
-  '--font-jetbrains': systemMonoStack,
-  '--font-geist': systemSansStack,
-  '--font-geist-mono': systemMonoStack,
-  '--vt-font-body': systemSansStack,
-  '--vt-font-display': systemDisplayStack,
-  '--font-body': systemSansStack,
-  '--font-display': systemDisplayStack,
-  '--font-sans': systemSansStack,
-  '--font-heading': systemSansStack,
-  '--font-serif': systemDisplayStack,
-  '--font-mono': systemMonoStack,
+  '--font-fraunces': displayStack,
+  '--font-plus-jakarta': sansStack,
+  '--font-inter': sansStack,
+  '--font-jetbrains': monoStack,
+  '--font-geist': sansStack,
+  '--font-geist-mono': monoStack,
+  '--vt-font-body': sansStack,
+  '--vt-font-display': displayStack,
+  '--font-body': sansStack,
+  '--font-display': displayStack,
+  '--font-sans': sansStack,
+  '--font-heading': sansStack,
+  '--font-serif': displayStack,
+  '--font-mono': monoStack,
 } as React.CSSProperties;
 
 export const metadata: Metadata = {

--- a/apps/web/app/pilot/PilotRequestForm.tsx
+++ b/apps/web/app/pilot/PilotRequestForm.tsx
@@ -104,12 +104,12 @@ export function PilotRequestForm({
       <section
         data-testid="pilot-confirmation"
         aria-live="polite"
-        className="rounded-2xl border border-emerald-500/40 bg-emerald-500/5 p-6"
+        className="rounded-[10px] border border-[var(--ok-rule)] bg-[var(--ok-bg)] p-6"
       >
-        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-500">
+        <p className="mz-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--ok)]">
           {confirmation.headline}
         </p>
-        <p className="mt-2 text-base text-foreground/90">
+        <p className="mz-body mt-2 text-[var(--vt-text-primary)]">
           {confirmation.acknowledgement}
         </p>
 
@@ -136,7 +136,7 @@ export function PilotRequestForm({
           />
         </div>
 
-        <p className="mt-6 font-mono text-[11px] text-muted-foreground">
+        <p className="mz-mono mt-6 text-[11px] text-[var(--vt-text-muted)]">
           Reference: {confirmation.reference.pilotId} · {confirmation.reference.requestedAt}
         </p>
       </section>
@@ -146,7 +146,7 @@ export function PilotRequestForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-4" data-testid="pilot-request-form">
       <div>
-        <label htmlFor="org" className="block text-sm font-medium text-foreground mb-1.5">
+        <label htmlFor="org" className="block text-sm font-medium text-[var(--vt-text-primary)] mb-1.5">
           Organization
         </label>
         <input
@@ -154,13 +154,13 @@ export function PilotRequestForm({
           name="organization"
           type="text"
           required
-          className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+          className="mz-input"
           placeholder="Acme Health System"
         />
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-foreground mb-1.5">
+          <label htmlFor="name" className="block text-sm font-medium text-[var(--vt-text-primary)] mb-1.5">
             Contact name
           </label>
           <input
@@ -168,12 +168,12 @@ export function PilotRequestForm({
             name="name"
             type="text"
             required
-            className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            className="mz-input"
             placeholder="Jane Smith"
           />
         </div>
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-foreground mb-1.5">
+          <label htmlFor="email" className="block text-sm font-medium text-[var(--vt-text-primary)] mb-1.5">
             Work email
           </label>
           <input
@@ -181,27 +181,27 @@ export function PilotRequestForm({
             name="email"
             type="email"
             required
-            className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            className="mz-input"
             placeholder="jane@acme.com"
           />
         </div>
       </div>
       <div>
-        <label htmlFor="usecase" className="block text-sm font-medium text-foreground mb-1.5">
+        <label htmlFor="usecase" className="block text-sm font-medium text-[var(--vt-text-primary)] mb-1.5">
           Tell us about your baseline
         </label>
         <textarea
           id="usecase"
           name="usecase"
           rows={3}
-          className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 resize-none"
+          className="mz-input resize-none"
           placeholder="How many days does an application sit before first review today?"
         />
       </div>
       <button
         type="submit"
         disabled={phase === 'submitting'}
-        className="w-full mt-2 rounded-xl bg-emerald-600 px-4 py-3.5 text-sm font-semibold text-white hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors shadow-sm inline-flex items-center justify-center gap-2"
+        className="mz-btn w-full justify-center mt-2 disabled:opacity-60 disabled:cursor-not-allowed"
       >
         {phase === 'submitting' ? 'Submitting…' : 'Submit pilot request'}
         <ArrowRight className="h-4 w-4" aria-hidden />
@@ -209,7 +209,7 @@ export function PilotRequestForm({
 
       {phase === 'error' && errorMessage ? (
         <p
-          className="mt-3 rounded-lg border border-red-300 bg-red-50/70 px-3 py-2 text-sm text-red-800"
+          className="mt-3 rounded-[6px] border border-[var(--p0-rule)] bg-[var(--p0-bg)] px-3 py-2 text-sm text-[var(--p0)]"
           role="alert"
           data-testid="pilot-request-error"
         >
@@ -231,10 +231,10 @@ function ConfirmationList({
 }): React.ReactElement {
   return (
     <div data-testid={testId}>
-      <h4 className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground/80">
+      <h4 className="mz-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--vt-text-secondary)]">
         {title}
       </h4>
-      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--vt-text-secondary)]">
         {items.map((item) => (
           <li key={item}>{item}</li>
         ))}

--- a/apps/web/app/pilot/page.tsx
+++ b/apps/web/app/pilot/page.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
 } from 'lucide-react';
 import { PilotRequestForm } from './PilotRequestForm';
+import { Reveal } from '@/components/motion/Reveal';
 
 export const metadata: Metadata = {
   title: 'Start a Pilot',
@@ -100,29 +101,27 @@ const TRUST_CONTAINER_SAFE_COPY = [
 
 export default function PilotPage() {
   return (
-    <main className="bg-background px-6 py-16 text-foreground" data-testid="pilot-proof-page">
+    <main
+      className="mz mz-paper mz-persona-employer px-6 py-16"
+      data-testid="pilot-proof-page"
+    >
       <div className="mx-auto max-w-5xl space-y-12">
         {/* Headline + value prop */}
-        <header className="space-y-4">
-          <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-400">
-            Employer pilot
-          </span>
-          <h1
-            className="text-4xl sm:text-5xl font-semibold tracking-tight text-foreground/90"
-            data-testid="pilot-headline"
-          >
-            Cut credentialing uncertainty before the start date slips.
-          </h1>
-          <p
-            className="max-w-3xl text-lg leading-8 text-muted-foreground"
-            data-testid="pilot-value-prop"
-          >
-            VitalCV turns four source-backed lanes of clinician evidence into a
-            deterministic proof pack and an auditable trust container, so your
-            reviewers can see what is ready, what is missing, and what must
-            wait for primary source verification — without changing your
-            existing compliance stack.
-          </p>
+        <header className="mz-ambient">
+          <Reveal variant="fade" className="space-y-5">
+            <span className="mz-eyebrow">Employer pilot</span>
+            <h1 className="mz-display" data-testid="pilot-headline">
+              Cut credentialing uncertainty{' '}
+              <span className="mz-accent">before the start date slips.</span>
+            </h1>
+            <p className="mz-lede max-w-3xl" data-testid="pilot-value-prop">
+              VitalCV turns four source-backed lanes of clinician evidence into a
+              deterministic proof pack and an auditable trust container, so your
+              reviewers can see what is ready, what is missing, and what must
+              wait for primary source verification — without changing your
+              existing compliance stack.
+            </p>
+          </Reveal>
         </header>
 
         {/* KPI snapshot — honest labels only */}
@@ -131,54 +130,61 @@ export default function PilotPage() {
           data-testid="pilot-kpi-snapshot"
           className="grid grid-cols-2 lg:grid-cols-4 gap-4"
         >
-          {PILOT_KPI_SAMPLES.map((kpi) => (
-            <div
+          {PILOT_KPI_SAMPLES.map((kpi, i) => (
+            <Reveal
+              as="div"
               key={kpi.label}
-              className="rounded-xl border border-border/60 bg-muted/20 p-5"
+              delay={i * 80}
+              className="mz-glass mz-glass-interactive rounded-[12px] p-5"
               data-testid={`pilot-kpi-${kpi.label.toLowerCase().replace(/\s+/g, '-')}`}
             >
-              <div className="text-sm font-medium text-muted-foreground mb-2">
+              <div className="mz-mono mb-2 text-[11px] uppercase tracking-[0.16em] text-[var(--vt-text-muted)]">
                 {kpi.label}
               </div>
-              <div className="text-2xl font-bold tracking-tight text-foreground">
+              <div className="text-[1.7rem] font-semibold leading-none tracking-tight text-[var(--vt-text-primary)] [font-variant-numeric:tabular-nums]">
                 {kpi.value}
               </div>
-              <div className="text-[11px] uppercase tracking-wider text-muted-foreground/60 mt-1 font-mono">
+              <div className="mz-mono mt-2 text-[10.5px] uppercase tracking-[0.1em] text-[var(--vt-text-muted)]">
                 {kpi.note}
               </div>
-            </div>
+            </Reveal>
           ))}
         </section>
 
         {/* Pilot scope + buyer requirements */}
         <section className="grid gap-4 md:grid-cols-2" aria-label="Pilot scope">
-          {PILOT_SCOPE.map((step) => (
-            <article
+          {PILOT_SCOPE.map((step, i) => (
+            <Reveal
+              as="article"
               key={step.title}
-              className="rounded-2xl border border-border/70 bg-card p-6"
+              delay={i * 80}
+              className="mz-card mz-card-pad mz-interactive"
             >
-              <div className="mb-4 inline-flex rounded-full bg-emerald-500/10 p-2.5 text-emerald-400">
+              <div className="mb-4 inline-flex rounded-[3px] border border-[var(--rule)] bg-[var(--paper-2)] p-2.5 text-[var(--accent)]">
                 {step.icon}
               </div>
-              <h3 className="text-xl font-semibold text-foreground/90">{step.title}</h3>
-              <p className="mt-2 text-base leading-relaxed text-muted-foreground">
+              <h3 className="mz-h2">{step.title}</h3>
+              <p className="mz-body mt-2">
                 {step.body}
               </p>
-            </article>
+            </Reveal>
           ))}
         </section>
 
         {/* Proof object explanation */}
-        <section
+        <Reveal
+          as="section"
           aria-label="Proof pack explanation"
           data-testid="pilot-proof-object"
-          className="rounded-2xl border border-border bg-card p-6 md:p-8"
+          className="mz-card p-6 md:p-8"
         >
           <div className="flex items-center gap-3 mb-4">
-            <ShieldCheck className="h-6 w-6 text-indigo-500" aria-hidden />
-            <h2 className="text-2xl font-semibold text-foreground/90">The proof pack</h2>
+            <ShieldCheck className="h-6 w-6 text-[var(--accent)]" aria-hidden />
+            <h2 className="mz-h1">
+              The <span className="mz-accent">proof pack</span>
+            </h2>
           </div>
-          <p className="text-muted-foreground text-base leading-relaxed max-w-3xl mb-6">
+          <p className="mz-body max-w-3xl mb-6">
             Every clinician review generates a deterministic evidence packet with
             canonical source coverage, per-lane freshness, and a sha256 artifact
             hash. When your reviewer exports the packet, VitalCV writes an
@@ -186,109 +192,117 @@ export default function PilotPage() {
           </p>
           <div className="grid md:grid-cols-2 gap-6 text-sm">
             <div className="space-y-3" data-testid="pilot-live-now">
-              <div className="font-semibold text-foreground">What is live now</div>
-              <ul className="list-disc pl-5 space-y-1.5 text-muted-foreground">
+              <span className="mz-chip mz-chip-ok">
+                <span className="mz-gl" aria-hidden />
+                What is live now
+              </span>
+              <ul className="mz-body list-disc pl-5 space-y-1.5">
                 {PROOF_OBJECT_LIVE.map((item) => (
                   <li key={item}>{item}</li>
                 ))}
               </ul>
             </div>
             <div className="space-y-3" data-testid="pilot-partial-pending">
-              <div className="font-semibold text-foreground">
+              <span className="mz-chip mz-chip-watch">
+                <span className="mz-gl" aria-hidden />
                 What remains partial or pending
-              </div>
-              <ul className="list-disc pl-5 space-y-1.5 text-muted-foreground">
+              </span>
+              <ul className="mz-body list-disc pl-5 space-y-1.5">
                 {PROOF_OBJECT_PARTIAL.map((item) => (
                   <li key={item}>{item}</li>
                 ))}
               </ul>
             </div>
           </div>
-        </section>
+        </Reveal>
 
         {/* Trust container explanation — separate from proof object, overclaim-safe */}
-        <section
+        <Reveal
+          as="section"
           aria-label="Trust container explanation"
           data-testid="pilot-trust-container"
-          className="rounded-2xl border border-indigo-500/20 bg-indigo-500/5 p-6 md:p-8"
+          className="mz-card p-6 md:p-8"
         >
           <div className="flex items-center gap-3 mb-4">
-            <FileLock2 className="h-6 w-6 text-indigo-400" aria-hidden />
-            <h2 className="text-2xl font-semibold text-foreground/90">
+            <FileLock2 className="h-6 w-6 text-[var(--accent)]" aria-hidden />
+            <h2 className="mz-h1">
               The trust container
             </h2>
           </div>
-          <p className="text-muted-foreground text-base leading-relaxed max-w-3xl mb-4">
+          <p className="mz-body max-w-3xl mb-4">
             The trust container is a hidden backend record that binds the
             credential envelope id, artifact status, and issuer metadata to the
             proof pack. It is provider-pluggable — a deterministic mock today
             and a production-provider scaffold ready for future wiring.
           </p>
           <ul
-            className="list-disc pl-5 space-y-1.5 text-sm text-muted-foreground"
+            className="mz-body list-disc pl-5 space-y-1.5"
             data-testid="pilot-trust-container-disclaimers"
           >
             {TRUST_CONTAINER_SAFE_COPY.map((line) => (
               <li key={line}>{line}</li>
             ))}
           </ul>
-        </section>
+        </Reveal>
 
         {/* Limitation honesty */}
-        <section
+        <Reveal
+          as="section"
           aria-label="Limitation honesty"
           data-testid="pilot-limitations"
-          className="rounded-2xl border border-border bg-muted/30 p-6 md:p-8"
+          className="mz-inset p-6 md:p-8"
         >
-          <h2 className="flex items-center gap-2 text-lg font-semibold text-foreground mb-4">
-            <AlertTriangle className="h-5 w-5 text-amber-500" aria-hidden />
+          <h2 className="mz-h2 flex items-center gap-2 mb-4">
+            <AlertTriangle className="h-5 w-5 text-[var(--watch)]" aria-hidden />
             Limitation honesty
           </h2>
           <ul className="space-y-3 pl-2">
             {LIMITATION_HONESTY.map((item) => (
               <li
                 key={item}
-                className="text-base text-muted-foreground leading-relaxed flex gap-3"
+                className="mz-body flex gap-3"
               >
-                <span className="text-amber-500/50 mt-1" aria-hidden>
+                <span className="text-[var(--watch)] mt-1" aria-hidden>
                   •
                 </span>
                 <span>{item}</span>
               </li>
             ))}
           </ul>
-        </section>
+        </Reveal>
 
         {/* Pilot CTA */}
-        <section
+        <Reveal
+          as="section"
           aria-label="Request pilot"
           data-testid="pilot-cta"
-          className="rounded-3xl border border-emerald-400/30 bg-emerald-500/5 p-6 md:p-10 shadow-sm"
+          className="mz-glass-strong p-6 md:p-10"
         >
           <div className="grid lg:grid-cols-2 gap-10">
             <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-500">
+              <p className="mz-eyebrow">
                 The next step
               </p>
-              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground/90">
-                Request a 30-day PSV readiness pilot
+              <h2 className="mz-h1 mt-3">
+                Request a 30-day PSV{' '}
+                <span className="mz-accent">readiness pilot</span>
               </h2>
-              <p className="mt-4 text-base leading-relaxed text-muted-foreground max-w-md">
+              <p className="mz-lede mt-4 max-w-md">
                 We review every submission within two business days. If the
                 scope is a fit, we schedule a scoping call to confirm your
                 baseline metrics, the pilot NPIs, and the measurement window.
               </p>
-              <p className="mt-4 text-sm text-muted-foreground/80">
+              <p className="mz-small mt-4">
                 No auto-provisioning. You will see a signed scope document
                 before anything is measured.
               </p>
             </div>
 
-            <div className="bg-card rounded-2xl p-6 border border-border shadow-sm">
+            <div className="mz-card p-6">
               <PilotRequestForm sourceContext="/pilot" />
             </div>
           </div>
-        </section>
+        </Reveal>
       </div>
     </main>
   );

--- a/apps/web/app/pilot/page.tsx
+++ b/apps/web/app/pilot/page.tsx
@@ -158,7 +158,7 @@ export default function PilotPage() {
               as="article"
               key={step.title}
               delay={i * 80}
-              className="mz-card mz-card-pad mz-interactive"
+              className="mz-glass mz-glass-interactive rounded-[12px] p-5"
             >
               <div className="mb-4 inline-flex rounded-[3px] border border-[var(--rule)] bg-[var(--paper-2)] p-2.5 text-[var(--accent)]">
                 {step.icon}

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -16,6 +16,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Eye, ShieldAlert } from 'lucide-react';
+import { Reveal } from '@/components/motion/Reveal';
 import { ProvenanceStrip } from '@/components/verifier/ProvenanceStrip';
 import { ReceiptVerificationPane } from '@/components/verifier/ReceiptVerificationPane';
 import { IssuerContinuityPanel } from '@/components/verifier/IssuerContinuityPanel';
@@ -214,78 +215,97 @@ export default async function VerifierPage({
   const displayName = passport.identity?.displayName ?? `NPI ${npi}`;
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="mz mz-paper mz-persona-verifier min-h-screen overflow-hidden">
       {/* ── Read-Only Header ───────────────────────────────────────────────── */}
-      <div className="border-b border-gray-200 bg-gray-50">
+      <div className="border-b border-[var(--rule)] bg-[var(--paper-2)]">
         <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Eye className="w-4 h-4 text-gray-500" />
-            <span className="text-sm font-semibold text-gray-700">
+            <Eye className="w-4 h-4 text-[var(--accent)]" />
+            <span className="text-sm font-semibold text-[var(--ink-800)]">
               Credential Verification
             </span>
           </div>
-          <span className="text-[10px] font-mono text-gray-400 bg-gray-100 border border-gray-200 px-2 py-0.5 rounded">
+          <span className="mz-mono text-[10px] text-[var(--ink-500)] bg-[var(--ink-50)] border border-[var(--rule)] px-2 py-0.5 rounded-[3px]">
             NPI {npi}
           </span>
         </div>
       </div>
 
-      <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div className="mz-ambient max-w-4xl mx-auto px-4 py-6 space-y-6">
         {/* Verdict bar — per design R-01: verdict before content */}
-        <div className="border border-gray-900 bg-gray-900 rounded-lg">
-          <div className="px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+        <Reveal variant="fade">
+        <div className="mz-glass-strong rounded-[14px]">
+          <div className="px-5 py-4 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <span className="text-xs font-mono font-medium text-white/60 uppercase tracking-widest">
+              <span className="mz-mono text-[10px] font-medium text-[var(--ink-400)] uppercase tracking-[0.22em]">
                 Verdict
               </span>
-              <span className="text-sm font-mono font-semibold text-white">
+              <span
+                className={`mz-chip ${
+                  String(proofTier).toLowerCase().includes('decision')
+                    ? 'mz-chip-ok'
+                    : String(proofTier).toLowerCase().includes('partial')
+                    ? 'mz-chip-watch'
+                    : 'mz-chip-unknown'
+                }`}
+              >
+                <span className="mz-gl" aria-hidden="true" />
                 {String(proofTier).toLowerCase().includes('decision') ? 'Verifiable'
                   : String(proofTier).toLowerCase().includes('partial') ? 'Partial coverage'
                   : 'Pending'}
               </span>
             </div>
-            <div className="flex flex-wrap items-center gap-2 text-[11px] text-white/60 font-mono">
+            <div className="flex flex-wrap items-center gap-2 mz-mono text-[11px] text-[var(--ink-500)]">
               {lanes.filter(l => l.status === 'verified').length > 0 && (
                 <span>{lanes.filter(l => l.status === 'verified').length} of {lanes.length} sources confirmed</span>
               )}
               {passport.lastCheckedAt && (
-                <><span className="text-white/30">|</span><span>checked {formatUtc(passport.lastCheckedAt)}</span></>
+                <><span className="text-[var(--ink-300)]">|</span><span>checked {formatUtc(passport.lastCheckedAt)}</span></>
               )}
             </div>
           </div>
         </div>
+        </Reveal>
 
         {/* ── Identity + Proof Tier Hero ─────────────────────────────────── */}
-        <div className="border border-gray-200 rounded-lg p-4">
+        <Reveal delay={80}>
+        <div className="mz-glass rounded-[12px] p-5">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
-              <div className="flex items-baseline gap-3">
-                <h1 className="text-lg font-semibold text-gray-900">{displayName}</h1>
+              <div className="flex items-baseline gap-3 flex-wrap">
+                <h1 className="mz-h1">{displayName}</h1>
                 {passport.lastCheckedAt && (
-                  <span className="text-[11px] font-mono text-gray-400">{formatUtc(passport.lastCheckedAt)}</span>
+                  <span className="mz-mono text-[11px] text-[var(--ink-400)]">{formatUtc(passport.lastCheckedAt)}</span>
                 )}
               </div>
-              <div className="mt-1 flex items-center gap-2 flex-wrap">
-                <span className="text-sm text-gray-500">NPI: <span className="font-mono text-gray-700">{npi}</span></span>
+              <div className="mt-1.5 flex items-center gap-2 flex-wrap">
+                <span className="text-sm text-[var(--ink-500)]">NPI: <span className="mz-mono text-[var(--ink-700)]">{npi}</span></span>
                 {passport.identity?.specialty && (
-                  <span className="text-sm text-gray-400">·</span>
+                  <span className="text-sm text-[var(--ink-300)]">·</span>
                 )}
                 {passport.identity?.specialty && (
-                  <span className="text-sm text-gray-500">{passport.identity.specialty}</span>
+                  <span className="text-sm text-[var(--ink-500)]">{passport.identity.specialty}</span>
                 )}
               </div>
             </div>
 
             <div className="flex flex-col items-end gap-2">
               <span
-                className="inline-flex items-center px-2 py-0.5 rounded text-[10.5px] font-mono font-semibold bg-gray-900 text-white"
+                className={`mz-chip ${
+                  String(proofTier).toLowerCase().includes('decision')
+                    ? 'mz-chip-ok'
+                    : String(proofTier).toLowerCase().includes('partial')
+                    ? 'mz-chip-watch'
+                    : 'mz-chip-unknown'
+                }`}
               >
+                <span className="mz-gl" aria-hidden="true" />
                 {tierConfig.label}
               </span>
               {passport.readiness?.score != null && (
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-[var(--ink-500)]">
                   Readiness score:{' '}
-                  <span className="font-semibold text-gray-800">{passport.readiness.score}</span>
+                  <span className="font-semibold text-[var(--ink-800)]">{passport.readiness.score}</span>
                 </span>
               )}
             </div>
@@ -293,18 +313,24 @@ export default async function VerifierPage({
 
 
         </div>
+        </Reveal>
 
         {/* ── Section: Provenance Strip ──────────────────────────────────── */}
+        <Reveal delay={40}>
         <Section title="Source coverage">
           <ProvenanceStrip lanes={lanes} />
         </Section>
+        </Reveal>
 
         {/* ── Section: Employer acceptances (Recognition) ────────────────── */}
+        <Reveal delay={80}>
         <Section title="Employer acceptances">
           <AcceptancePanel history={acceptanceHistory} />
         </Section>
+        </Reveal>
 
         {/* ── Section: Receipt Verification ─────────────────────────────── */}
+        <Reveal delay={120}>
         <Section title="Verification receipt">
           {firstReceiptLane ? (
             <ReceiptVerificationPane
@@ -326,19 +352,24 @@ export default async function VerifierPage({
             <EmptyState message="No verified receipts found for this NPI." />
           )}
         </Section>
+        </Reveal>
 
         {/* ── Section: Issuer Continuity ─────────────────────────────────── */}
+        <Reveal delay={160}>
         <Section title="Issuer">
           <IssuerContinuityPanel
             did="did:web:vitalcv.com"
             signingKeyId="vcv-es256-1"
           />
         </Section>
+        </Reveal>
 
         {/* ── Section: Replay Chronology ─────────────────────────────────── */}
+        <Reveal delay={200}>
         <Section title="Verification history">
           <ReplayChronologyPanel lanes={lanes} />
         </Section>
+        </Reveal>
       </div>
     </div>
   );
@@ -354,8 +385,8 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-2">
-      <h2 className="text-[11px] font-semibold uppercase tracking-widest text-gray-400">
+    <div className="space-y-2.5">
+      <h2 className="mz-eyebrow">
         {title}
       </h2>
       {children}
@@ -366,15 +397,15 @@ function Section({
 function TimestampField({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[9px] uppercase tracking-wide text-gray-400">{label}</span>
-      <span className="font-mono text-gray-700">{value}</span>
+      <span className="text-[9px] uppercase tracking-wide text-[var(--ink-400)]">{label}</span>
+      <span className="mz-mono text-[var(--ink-700)]">{value}</span>
     </div>
   );
 }
 
 function EmptyState({ message }: { message: string }) {
   return (
-    <div className="border border-dashed border-gray-200 rounded px-3 py-4 text-sm text-gray-400 text-center">
+    <div className="mz-glass-inset border-dashed px-3 py-4 text-sm text-[var(--ink-400)] text-center">
       {message}
     </div>
   );
@@ -401,29 +432,29 @@ function AcceptancePanel({
   }
 
   return (
-    <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
-      <div className="px-4 py-3">
-        <p className="text-sm font-semibold text-gray-900">{history.summary.headline}</p>
+    <div className="mz-card divide-y divide-[var(--rule-soft)]">
+      <div className="px-4 py-3.5">
+        <p className="text-sm font-semibold text-[var(--ink-900)]">{history.summary.headline}</p>
         {history.summary.trustCopy && (
-          <p className="mt-1 text-xs leading-5 text-gray-500">{history.summary.trustCopy}</p>
+          <p className="mt-1 text-xs leading-5 text-[var(--ink-500)]">{history.summary.trustCopy}</p>
         )}
       </div>
       {history.history.map((entry, index) => (
         <div
           key={entry.acceptanceId ?? `${entry.acceptedAt}-${index}`}
-          className="px-4 py-3 flex flex-wrap items-center justify-between gap-2"
+          className="px-4 py-3.5 flex flex-wrap items-center justify-between gap-2"
         >
           <div>
-            <p className="text-sm text-gray-800">{entry.orgLabel}</p>
+            <p className="text-sm text-[var(--ink-800)]">{entry.orgLabel}</p>
             {entry.acceptanceReason && (
-              <p className="mt-0.5 text-xs text-gray-500">{entry.acceptanceReason}</p>
+              <p className="mt-0.5 text-xs text-[var(--ink-500)]">{entry.acceptanceReason}</p>
             )}
           </div>
-          <div className="flex items-center gap-2 text-xs text-gray-500">
-            <span className="border border-gray-200 rounded-full px-2 py-0.5">
+          <div className="flex items-center gap-2 text-xs text-[var(--ink-500)]">
+            <span className="mz-mono text-[10px] uppercase tracking-[0.06em] border border-[var(--rule)] rounded-full px-2.5 py-0.5 text-[var(--ink-600)]">
               {acceptanceScopeLabel(entry.acceptanceScope)}
             </span>
-            {formatAcceptedAt(entry.acceptedAt) && <span>{formatAcceptedAt(entry.acceptedAt)}</span>}
+            {formatAcceptedAt(entry.acceptedAt) && <span className="mz-mono">{formatAcceptedAt(entry.acceptedAt)}</span>}
           </div>
         </div>
       ))}
@@ -433,14 +464,14 @@ function AcceptancePanel({
 
 function NotFound({ npi }: { npi: string }) {
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center justify-center gap-4">
-      <ShieldAlert className="w-10 h-10 text-gray-300" />
+    <div className="mz mz-paper mz-persona-verifier min-h-screen flex flex-col items-center justify-center gap-4">
+      <ShieldAlert className="w-10 h-10 text-[var(--ink-300)]" />
       <div className="text-center">
-        <h1 className="text-lg font-semibold text-gray-700">NPI not found</h1>
-        <p className="text-sm text-gray-400 mt-1">
-          No verification data available for NPI <span className="font-mono">{npi}</span>.
+        <h1 className="mz-h1">NPI not found</h1>
+        <p className="text-sm text-[var(--ink-500)] mt-2">
+          No verification data available for NPI <span className="mz-mono text-[var(--ink-700)]">{npi}</span>.
         </p>
-        <p className="text-xs text-gray-400 mt-2">
+        <p className="text-xs text-[var(--ink-400)] mt-2">
           The clinician may not have initiated a VitalCV profile yet.
         </p>
       </div>

--- a/apps/web/app/verify/page.tsx
+++ b/apps/web/app/verify/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { Reveal } from '@/components/motion/Reveal';
 import { VerifierOnboardingGuide } from '@/components/verifier/VerifierOnboardingGuide';
 
 interface VerifyResult {
@@ -45,79 +46,80 @@ export default function VerifyPage() {
   }
 
   return (
-    <main className="mx-auto max-w-2xl px-6 py-16">
+    <main className="mz mz-paper mz-persona-verifier mz-ambient overflow-hidden mx-auto max-w-2xl px-6 py-16">
       {/* Verifier onboarding guide — collapsed by default */}
       <div className="mb-8">
         <VerifierOnboardingGuide collapsible compact={false} />
         <div className="mt-1.5 text-right">
           <Link
             href="/verify/guide"
-            className="text-[11px] text-blue-500 hover:text-blue-700 underline underline-offset-2"
+            className="text-[11px] text-[var(--accent)] hover:opacity-80 underline underline-offset-2"
           >
             Full guide + offline verification →
           </Link>
         </div>
       </div>
 
-      <h1 className="mb-2 text-3xl font-bold tracking-tight">Credential Verifier</h1>
-      <p className="mb-8 text-gray-500">
-        Paste a VitalCV JWT to verify its cryptographic signature and inspect its claims.
-      </p>
+      <Reveal variant="fade">
+        <h1 className="mz-display mb-3">Credential <span className="mz-accent">Verifier</span></h1>
+        <p className="mz-lede mb-8 max-w-xl">
+          Paste a VitalCV JWT to verify its cryptographic signature and inspect its claims.
+        </p>
+      </Reveal>
 
-      <div className="mb-4">
-        <label htmlFor="token-input" className="mb-2 block text-sm font-medium text-gray-700">
-          JWT Token
-        </label>
-        <textarea
-          id="token-input"
-          value={token}
-          onChange={(e) => setToken(e.target.value)}
-          rows={6}
-          placeholder="eyJhbGciOiJFUzI1NiIsImtpZCI6Ii4uLiJ9..."
-          className="w-full rounded-lg border border-gray-300 px-4 py-3 font-mono text-sm placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      <Reveal delay={80}>
+        <div className="mb-4">
+          <label htmlFor="token-input" className="mb-2 block mz-mono text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--ink-500)]">
+            JWT Token
+          </label>
+          <textarea
+            id="token-input"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            rows={6}
+            placeholder="eyJhbGciOiJFUzI1NiIsImtpZCI6Ii4uLiJ9..."
+            className="mz-input font-mono text-sm"
+          />
+        </div>
+
+        <button
+          onClick={handleVerify}
+          disabled={loading || !token.trim()}
+          className="mz-btn mb-8 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? 'Verifying…' : 'Verify'}
+        </button>
+      </Reveal>
+
+      <Reveal delay={120}>
+        <ReceiptReplaySection
+          receiptIdInput={receiptIdInput}
+          setReceiptIdInput={setReceiptIdInput}
+          onNavigate={() => {
+            const id = receiptIdInput.trim();
+            if (id) router.push(`/verify/receipt/${encodeURIComponent(id)}`);
+          }}
         />
-      </div>
-
-      <button
-        onClick={handleVerify}
-        disabled={loading || !token.trim()}
-        className="mb-8 inline-flex items-center rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        {loading ? 'Verifying…' : 'Verify'}
-      </button>
-
-      <ReceiptReplaySection
-        receiptIdInput={receiptIdInput}
-        setReceiptIdInput={setReceiptIdInput}
-        onNavigate={() => {
-          const id = receiptIdInput.trim();
-          if (id) router.push(`/verify/receipt/${encodeURIComponent(id)}`);
-        }}
-      />
+      </Reveal>
 
       {result !== null && (
-        <div
-          className={`rounded-lg border p-5 ${
-            result.verified
-              ? 'border-green-200 bg-green-50'
-              : 'border-red-200 bg-red-50'
-          }`}
-        >
-          <div className="mb-4 flex items-center gap-2">
+        <Reveal>
+        <div className="mz-glass mt-8 rounded-[12px] p-5">
+          <div className="mb-4 flex items-center gap-2.5">
             <span
-              className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-sm font-bold ${
-                result.verified ? 'bg-green-500 text-white' : 'bg-red-500 text-white'
+              className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-sm font-bold text-white ${
+                result.verified ? 'bg-[var(--ok)]' : 'bg-[var(--p0)]'
               }`}
             >
               {result.verified ? '✓' : '✗'}
             </span>
-            <span className={`font-semibold ${result.verified ? 'text-green-800' : 'text-red-800'}`}>
+            <span className={`mz-chip ${result.verified ? 'mz-chip-ok' : 'mz-chip-p0'}`}>
               {result.verified ? 'Valid credential' : 'Invalid credential'}
             </span>
           </div>
 
           {result.error && (
-            <p className="mb-2 text-sm text-red-700">
+            <p className="mb-2 text-sm text-[var(--p0)]">
               <strong>Error:</strong> {result.error}
             </p>
           )}
@@ -147,8 +149,8 @@ export default function VerifyPage() {
               )}
               {result.vcv && (
                 <div>
-                  <dt className="font-medium text-gray-600">VCV Claims</dt>
-                  <dd className="mt-1 rounded bg-white p-3 font-mono text-xs">
+                  <dt className="font-medium text-[var(--ink-600)]">VCV Claims</dt>
+                  <dd className="mt-1 mz-inset p-3 font-mono text-xs text-[var(--ink-700)]">
                     <pre>{JSON.stringify(result.vcv, null, 2)}</pre>
                   </dd>
                 </div>
@@ -156,6 +158,7 @@ export default function VerifyPage() {
             </dl>
           )}
         </div>
+        </Reveal>
       )}
     </main>
   );
@@ -171,11 +174,11 @@ function ReceiptReplaySection({
   onNavigate: () => void;
 }) {
   return (
-    <div className="mt-10 border-t border-gray-200 pt-8">
-      <h2 className="mb-2 text-xl font-bold tracking-tight">Inspect Receipt Replay</h2>
-      <p className="mb-5 text-gray-500 text-sm">
-        Enter a VitalCV receipt ID (<code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded">rcpt_…</code> or{' '}
-        <code className="font-mono text-xs bg-gray-100 px-1 py-0.5 rounded">rec-…</code>) to view its replay
+    <div className="mt-10 border-t border-[var(--rule)] pt-8">
+      <h2 className="mb-2 mz-h2 text-xl">Inspect Receipt Replay</h2>
+      <p className="mb-5 text-[var(--ink-500)] text-sm">
+        Enter a VitalCV receipt ID (<code className="mz-mono text-xs bg-[var(--ink-50)] border border-[var(--rule-soft)] px-1 py-0.5 rounded-[3px]">rcpt_…</code> or{' '}
+        <code className="mz-mono text-xs bg-[var(--ink-50)] border border-[var(--rule-soft)] px-1 py-0.5 rounded-[3px]">rec-…</code>) to view its replay
         chain, degradation ownership, and survivability score.
       </p>
       <div className="flex gap-3">
@@ -185,18 +188,18 @@ function ReceiptReplaySection({
           onChange={(e) => setReceiptIdInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && receiptIdInput.trim() && onNavigate()}
           placeholder="rcpt_1234567890_1234567890123"
-          className="flex-1 rounded-lg border border-gray-300 px-4 py-2.5 font-mono text-sm placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="mz-input flex-1 font-mono text-sm"
         />
         <button
           onClick={onNavigate}
           disabled={!receiptIdInput.trim()}
-          className="inline-flex items-center rounded-md bg-gray-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+          className="mz-btn disabled:cursor-not-allowed disabled:opacity-40"
         >
           Inspect
         </button>
       </div>
-      <p className="mt-2 text-[11px] text-gray-400">
-        Opens <code className="font-mono">/verify/receipt/{'{receiptId}'}</code> — public, no auth required.
+      <p className="mt-2 text-[11px] text-[var(--ink-400)]">
+        Opens <code className="mz-mono">/verify/receipt/{'{receiptId}'}</code> — public, no auth required.
       </p>
     </div>
   );
@@ -213,8 +216,8 @@ function Row({
 }) {
   return (
     <div className="flex items-start gap-2">
-      <dt className="min-w-[120px] font-medium text-gray-600">{label}</dt>
-      <dd className={mono ? 'break-all font-mono text-xs' : ''}>{value}</dd>
+      <dt className="min-w-[120px] font-medium text-[var(--ink-600)]">{label}</dt>
+      <dd className={mono ? 'break-all font-mono text-xs text-[var(--ink-800)]' : 'text-[var(--ink-800)]'}>{value}</dd>
     </div>
   );
 }

--- a/apps/web/components/holder/ProductLoopRail.tsx
+++ b/apps/web/components/holder/ProductLoopRail.tsx
@@ -92,24 +92,13 @@ export function ProductLoopRail({
   className,
 }: ProductLoopRailProps) {
   const stages = buildStages({ npi, profileComplete, hasReadiness, activeStage });
-  const dark = variant === 'dark';
   const doc = variant === 'doc';
 
-  const containerClass = doc
-    ? 'vcv-panel p-4 sm:p-5'
-    : [
-        'rounded-[28px] border p-4 sm:p-5',
-        dark
-          ? 'border-white/10 bg-white/[0.04] shadow-[0_20px_60px_rgba(0,0,0,0.28)]'
-          : 'border-[var(--vt-border-subtle)] bg-[color-mix(in_oklab,var(--vt-surface)_94%,white)]',
-      ].join(' ');
-
-  const headingClass = doc
-    ? 'vcv-eyebrow'
-    : [
-        'text-[11px] font-semibold uppercase tracking-[0.18em]',
-        dark ? 'text-white/45' : 'text-[var(--vt-text-muted)]',
-      ].join(' ');
+  // `doc` stays native to the `.vcv-doc` paper register (readiness / recognition).
+  // Every other mount is calm glass: `mz` on the root makes the Calm Wave tokens
+  // resolve wherever the rail lands, so it is self-contained.
+  const containerClass = doc ? 'vcv-panel p-4 sm:p-5' : 'mz mz-glass p-4 sm:p-5';
+  const headingClass = doc ? 'vcv-eyebrow' : 'mz-eyebrow';
 
   return (
     <nav aria-label="Your VitalCV loop" data-product-loop-rail="" className={[containerClass, className ?? ''].join(' ')}>
@@ -127,23 +116,33 @@ export function ProductLoopRail({
                 data-loop-stage={stage.key}
                 data-loop-status={stage.status}
                 aria-current={isCurrent ? 'step' : undefined}
-                className={stageLinkClass({ variant, isCurrent })}
-                style={doc ? stageDocStyle(isCurrent) : undefined}
+                className={stageLinkClass(doc)}
+                style={doc ? stageDocStyle(isCurrent) : stageCalmStyle(isCurrent)}
               >
-                <span className={badgeClass({ variant, isDone, isCurrent })} style={doc ? badgeDocStyle({ isDone, isCurrent }) : undefined}>
+                <span
+                  className={badgeClass(doc)}
+                  style={doc ? badgeDocStyle({ isDone, isCurrent }) : badgeCalmStyle({ isDone, isCurrent })}
+                >
                   <Icon className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <span className="flex min-w-0 flex-col">
                   <span
-                    className={['truncate text-[13px] font-semibold', dark ? 'text-white' : doc ? '' : 'text-[var(--vt-text-primary)]'].join(' ')}
+                    className="truncate text-[13px] font-semibold"
                     style={doc ? { color: 'var(--ink-strong)' } : undefined}
                   >
-                    <span aria-hidden="true" className={dark ? 'text-white/40' : doc ? 'vcv-subtle' : 'text-[var(--vt-text-muted)]'}>
+                    <span
+                      aria-hidden="true"
+                      className={doc ? 'vcv-subtle' : 'mz-mono'}
+                      style={doc ? undefined : { color: 'var(--ink-400)' }}
+                    >
                       {idx + 1}.
                     </span>{' '}
                     {stage.label}
                   </span>
-                  <span className={statusClass({ variant, isDone, isCurrent })} style={doc ? statusDocStyle({ isDone, isCurrent }) : undefined}>
+                  <span
+                    className={statusClass(doc)}
+                    style={doc ? statusDocStyle({ isDone, isCurrent }) : statusCalmStyle({ isDone, isCurrent })}
+                  >
                     {isDone ? 'Done' : isCurrent ? 'You are here' : 'Open'}
                   </span>
                 </span>
@@ -156,13 +155,11 @@ export function ProductLoopRail({
   );
 }
 
-function stageLinkClass({ variant, isCurrent }: { variant: LoopVariant; isCurrent: boolean }): string {
-  const base = 'group flex h-full items-center gap-2.5 rounded-2xl border px-3 py-2.5 transition-colors';
-  if (variant === 'doc') return base;
-  if (variant === 'dark') {
-    return [base, isCurrent ? 'border-emerald-400/40 bg-emerald-400/10 hover:border-emerald-300/60' : 'border-white/10 bg-black/20 hover:border-white/25'].join(' ');
-  }
-  return [base, isCurrent ? 'border-emerald-600/50 bg-emerald-500/10' : 'border-[var(--vt-border-subtle)] bg-[var(--vt-surface)] hover:border-[var(--vt-text-primary)]'].join(' ');
+function stageLinkClass(doc: boolean): string {
+  if (doc) return 'group flex h-full items-center gap-2.5 rounded-2xl border px-3 py-2.5 transition-colors';
+  // Calm inset step — recessed well, hairline that darkens on hover; the current
+  // step's accent border/wash is layered on top via stageCalmStyle.
+  return 'group flex h-full items-center gap-2.5 rounded-[3px] px-3 py-2.5 mz-inset mz-interactive';
 }
 
 function stageDocStyle(isCurrent: boolean): React.CSSProperties {
@@ -171,12 +168,17 @@ function stageDocStyle(isCurrent: boolean): React.CSSProperties {
     : { borderColor: 'var(--hairline-color, color-mix(in oklch, var(--ink) 14%, transparent))', background: 'transparent' };
 }
 
-function badgeClass({ variant, isDone, isCurrent }: { variant: LoopVariant; isDone: boolean; isCurrent: boolean }): string {
-  const base = 'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-[13px] font-semibold';
-  if (variant === 'doc') return base;
-  if (isDone) return [base, 'bg-emerald-400/20 text-emerald-200'].join(' ');
-  if (isCurrent) return [base, 'bg-emerald-400 text-zinc-950'].join(' ');
-  return [base, variant === 'dark' ? 'bg-white/10 text-white/70' : 'bg-[var(--vt-surface-subtle)] text-[var(--vt-text-muted)]'].join(' ');
+function stageCalmStyle(isCurrent: boolean): React.CSSProperties | undefined {
+  if (!isCurrent) return undefined;
+  return {
+    borderColor: 'color-mix(in oklch, var(--accent) 45%, transparent)',
+    background: 'color-mix(in oklch, var(--accent) 8%, transparent)',
+  };
+}
+
+function badgeClass(doc: boolean): string {
+  const base = 'flex h-8 w-8 shrink-0 items-center justify-center text-[13px] font-semibold';
+  return doc ? `${base} rounded-xl` : `${base} rounded-[3px]`;
 }
 
 function badgeDocStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
@@ -185,18 +187,28 @@ function badgeDocStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: bool
   return { background: 'color-mix(in oklch, var(--ink) 8%, transparent)', color: 'var(--ink-mute)' };
 }
 
-function statusClass({ variant, isDone, isCurrent }: { variant: LoopVariant; isDone: boolean; isCurrent: boolean }): string {
-  const base = 'truncate text-[11px]';
-  if (variant === 'doc') return base;
-  if (isDone) return [base, 'text-emerald-300'].join(' ');
-  if (isCurrent) return [base, variant === 'dark' ? 'text-emerald-200' : 'text-emerald-700'].join(' ');
-  return [base, variant === 'dark' ? 'text-white/45' : 'text-[var(--vt-text-muted)]'].join(' ');
+function badgeCalmStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
+  if (isDone) return { background: 'color-mix(in oklch, var(--ok) 18%, transparent)', color: 'var(--ok)' };
+  if (isCurrent) return { background: 'var(--accent)', color: 'var(--paper)' };
+  return { background: 'color-mix(in oklch, var(--ink-900) 8%, transparent)', color: 'var(--ink-400)' };
+}
+
+function statusClass(doc: boolean): string {
+  if (doc) return 'truncate text-[11px]';
+  // Mono, uppercase micro-label — the eyebrow idiom for the step's state.
+  return 'mz-mono truncate text-[10px] uppercase tracking-[0.14em]';
 }
 
 function statusDocStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
   if (isDone) return { color: 'var(--state-verified)' };
   if (isCurrent) return { color: 'var(--accent)' };
   return { color: 'var(--ink-mute)' };
+}
+
+function statusCalmStyle({ isDone, isCurrent }: { isDone: boolean; isCurrent: boolean }): React.CSSProperties {
+  if (isDone) return { color: 'var(--ok)' };
+  if (isCurrent) return { color: 'var(--accent)' };
+  return { color: 'var(--ink-400)' };
 }
 
 export default ProductLoopRail;

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -90,7 +90,7 @@ export default function Navbar() {
           </Link>
           <Link
             href="/passport"
-            style={{ backgroundColor: '#4f46e5' }}
+            style={{ backgroundColor: 'oklch(18% 0.012 265)' }}
             className="rounded-full px-4 py-1.5 text-sm font-semibold text-white hover:opacity-90 transition"
           >
             Check Readiness
@@ -141,7 +141,7 @@ export default function Navbar() {
             <Link
               href="/passport"
               onClick={closeMenu}
-              style={{ backgroundColor: '#4f46e5' }}
+              style={{ backgroundColor: 'oklch(18% 0.012 265)' }}
               className="flex-1 rounded-xl py-2.5 text-center text-sm font-semibold text-white"
             >
               Check Readiness

--- a/apps/web/components/matcha/CareerCompass.tsx
+++ b/apps/web/components/matcha/CareerCompass.tsx
@@ -26,12 +26,14 @@ import {
 
 const CLEARED_BANDS = new Set(['CLEAR', 'NEAR_CLEAR']);
 
+// Calm truth-token colors (resolve under `.mz`): source-green for strong,
+// indigo accent for progress, amber watch for attention, muted ink for absent.
 const METRIC_COLOR: Record<CompassTone, string> = {
-  strong: 'text-emerald-300',
-  progress: 'text-sky-300',
-  attention: 'text-amber-300',
-  empty: 'text-white/40',
-  unavailable: 'text-white/40',
+  strong: 'var(--ok)',
+  progress: 'var(--accent)',
+  attention: 'var(--watch)',
+  empty: 'var(--ink-400)',
+  unavailable: 'var(--ink-400)',
 };
 
 function greetingFor(hour: number): string {
@@ -108,13 +110,15 @@ export default function CareerCompass() {
   const { action } = compass;
 
   return (
-    <section className="rounded-[28px] border border-white/10 bg-gradient-to-b from-teal-400/[0.06] to-white/[0.02] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.28)] sm:p-6">
-      <div className="flex items-center gap-2 text-teal-200/80">
-        <Compass className="h-4 w-4" aria-hidden />
-        <p className="text-[11px] font-semibold uppercase tracking-[0.2em]">MATCHA Career Compass</p>
-      </div>
-      <h1 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
-        {greeting}, {firstName}.
+    // The signed-in centerpiece as a calm-glass moment: `mz` makes the Calm Wave
+    // tokens resolve wherever this mounts; indigo accent details via var(--accent).
+    <section className="mz mz-glass p-5 sm:p-6">
+      <p className="mz-eyebrow">
+        <Compass className="h-3 w-3" aria-hidden />
+        MATCHA Career Compass
+      </p>
+      <h1 className="mz-h1 mt-4">
+        {greeting}, <span className="mz-accent">{firstName}</span>.
       </h1>
 
       {/* Four honest metrics */}
@@ -125,64 +129,71 @@ export default function CareerCompass() {
       </div>
 
       {/* The one next action */}
-      <div className="mt-5 rounded-[22px] border border-white/10 bg-black/30 p-4 sm:p-5">
+      <div className="mz-glass-inset mt-5 p-4 sm:p-5">
         <div className="flex items-center justify-between gap-3">
-          <p className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/50">
-            <Sparkles className="h-3.5 w-3.5 text-teal-300" aria-hidden />
+          <p
+            className="mz-mono flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.18em]"
+            style={{ color: 'var(--ink-400)' }}
+          >
+            <Sparkles className="h-3.5 w-3.5" style={{ color: 'var(--accent)' }} aria-hidden />
             What should I do next?
           </p>
           <ConfidenceChip confidence={action.confidence} />
         </div>
 
-        <h2 className="mt-3 text-xl font-semibold text-white">{action.title}</h2>
-        <p className="mt-2 text-sm leading-6 text-white/65">{action.why}</p>
+        <h2 className="mz-h2 mt-3">{action.title}</h2>
+        <p className="mz-body mt-2">{action.why}</p>
 
         <ul className="mt-4 space-y-1.5">
           {action.impact.map((line) => (
-            <li key={line} className="flex items-start gap-2 text-sm text-white/75">
-              <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-teal-300" aria-hidden />
+            <li key={line} className="mz-body flex items-start gap-2">
+              <Check className="mt-0.5 h-4 w-4 flex-shrink-0" style={{ color: 'var(--ok)' }} aria-hidden />
               {line}
             </li>
           ))}
         </ul>
 
         <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <Link
-            href={action.href}
-            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-teal-300 px-5 text-sm font-semibold text-teal-950 transition hover:bg-teal-200"
-          >
+          <Link href={action.href} className="mz-btn min-h-11 justify-center">
             {action.ctaLabel}
             <ArrowRight className="h-4 w-4" aria-hidden />
           </Link>
-          <p className="text-xs text-white/40">{action.confidenceReason}</p>
+          <p className="mz-small" style={{ color: 'var(--ink-400)' }}>
+            {action.confidenceReason}
+          </p>
         </div>
       </div>
 
-      <p className="mt-4 text-[11px] leading-relaxed text-white/40">{compass.note}</p>
+      <p className="mz-small mt-4 leading-relaxed" style={{ color: 'var(--ink-400)' }}>
+        {compass.note}
+      </p>
     </section>
   );
 }
 
 function MetricCell({ metric }: { metric: CompassMetric }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-3">
-      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-white/40">{metric.label}</p>
-      <p className={`mt-1.5 text-xl font-semibold leading-none ${METRIC_COLOR[metric.tone]}`}>{metric.value}</p>
-      <p className="mt-1 text-[11px] text-white/45">{metric.sub}</p>
+    <div className="mz-glass-inset px-3 py-3">
+      <p className="mz-mono text-[10px] font-semibold uppercase tracking-[0.16em]" style={{ color: 'var(--ink-400)' }}>
+        {metric.label}
+      </p>
+      <p className="mt-1.5 text-xl font-semibold leading-none" style={{ color: METRIC_COLOR[metric.tone] }}>
+        {metric.value}
+      </p>
+      <p className="mt-1 text-[11px]" style={{ color: 'var(--ink-500)' }}>
+        {metric.sub}
+      </p>
     </div>
   );
 }
 
 function ConfidenceChip({ confidence }: { confidence: 'High' | 'Building' }) {
   const strong = confidence === 'High';
+  // Confidence tracks data coverage — mapped onto the calm truth-chip system:
+  // ok wash for High coverage, neutral unknown while it is still building.
   return (
-    <span
-      className={`rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${
-        strong
-          ? 'border-teal-300/30 bg-teal-300/10 text-teal-200'
-          : 'border-white/15 bg-white/5 text-white/55'
-      }`}
-    >
+    <span className={`mz-chip ${strong ? 'mz-chip-ok' : 'mz-chip-unknown'}`}>
+      <span className="mz-gl" />
       Confidence: {confidence}
     </span>
   );

--- a/apps/web/components/matcha/MatchaConstellation.tsx
+++ b/apps/web/components/matcha/MatchaConstellation.tsx
@@ -329,18 +329,19 @@ export function MatchaConstellation({ height = 460, profile }: { height?: number
         }}
       />
 
-      {/* era readout — top left */}
+      {/* era readout — top left. Ink tokens so the labels read on the calm paper
+          page (they adapt automatically under .dark .mz if ever shown on dark). */}
       <div style={{ position: 'absolute', left: 18, top: 16, pointerEvents: 'none' }}>
-        <div style={{ fontFamily: 'ui-monospace, "Geist Mono", monospace', fontSize: 9.5, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(139,140,240,0.85)' }}>
+        <div style={{ fontFamily: 'var(--font-geist-mono, ui-monospace, monospace)', fontSize: 9.5, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--accent, #4f46e5)' }}>
           {String(currentEra === 'origin' ? '← past' : currentEra === 'future' ? 'future →' : 'present')}
         </div>
-        <div style={{ marginTop: 4, fontFamily: 'var(--vt-font-display, Georgia, serif)', fontSize: 22, color: 'rgba(240,238,248,0.96)', letterSpacing: '-0.01em' }}>
+        <div style={{ marginTop: 4, fontFamily: 'var(--font-fraunces, var(--vt-font-display, Georgia, serif))', fontSize: 22, color: 'var(--ink-900, #14141a)', letterSpacing: '-0.01em' }}>
           {ERA_LABEL[currentEra]}
         </div>
       </div>
 
       {/* hover readout — top right */}
-      <div style={{ position: 'absolute', right: 18, top: 16, fontFamily: 'ui-monospace, "Geist Mono", monospace', fontSize: 11, color: 'rgba(233,232,240,0.65)', pointerEvents: 'none', minHeight: 14 }}>
+      <div style={{ position: 'absolute', right: 18, top: 16, fontFamily: 'var(--font-geist-mono, ui-monospace, monospace)', fontSize: 11, color: 'var(--ink-500, #6b6860)', pointerEvents: 'none', minHeight: 14 }}>
         {hoverLabel ? `→ ${hoverLabel}` : 'drag to rotate'}
       </div>
 

--- a/apps/web/components/matcha/MatchaHomeActivity.tsx
+++ b/apps/web/components/matcha/MatchaHomeActivity.tsx
@@ -5,7 +5,7 @@
  *
  * Additive and self-gating: renders nothing unless MATCHA_V2 is on. Every figure is real —
  * learning progress is preference completeness, "recently learned" comes from grounded memory
- * diffing, and the pipeline count is the live opportunity list. Styled to match the dark home
+ * diffing, and the pipeline count is the live opportunity list. Styled to match the calm home
  * surface. No fabricated activity.
  */
 
@@ -26,15 +26,16 @@ export function MatchaHomeActivity() {
   const started = completeness > 0;
 
   return (
-    <section className="rounded-[28px] border border-emerald-400/20 bg-gradient-to-br from-emerald-400/10 to-sky-400/[0.06] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.24)]">
+    <section className="mz mz-glass p-5">
       <div className="flex items-start justify-between gap-4">
-        <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-100">
+        <span className="mz-eyebrow">
           <Sparkles className="h-3.5 w-3.5" />
           MATCHA activity
-        </div>
+        </span>
         <Link
           href="/holder/matcha"
-          className="inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-100 transition hover:text-white"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold transition-opacity hover:opacity-80"
+          style={{ color: 'var(--accent)' }}
         >
           {started ? 'Open MATCHA' : 'Meet MATCHA'}
           <ArrowRight className="h-4 w-4" />
@@ -44,41 +45,38 @@ export function MatchaHomeActivity() {
       {started ? (
         <>
           <div className="mt-4 flex items-center gap-3">
-            <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-white/10">
-              <div
-                className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-sky-400 transition-[width] duration-500"
-                style={{ width: `${Math.max(4, completeness)}%` }}
-              />
+            <div className="mz-meter flex-1">
+              <span style={{ width: `${Math.max(4, completeness)}%` }} />
             </div>
-            <span className="text-sm font-semibold tabular-nums text-white">{completeness}% learned</span>
+            <span className="mz-mono text-sm font-semibold">{completeness}% learned</span>
           </div>
 
           <div className="mt-4 grid gap-3 sm:grid-cols-[1.4fr_0.6fr]">
-            <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Recently learned</p>
+            <div className="mz-glass-inset rounded-[8px] px-4 py-3">
+              <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Recently learned</p>
               {memory.length > 0 ? (
                 <ul className="mt-2 space-y-1">
                   {memory.slice(0, 2).map((note, i) => (
-                    <li key={`${note.field}-${i}`} className="text-sm leading-6 text-white/80">
+                    <li key={`${note.field}-${i}`} className="mz-body">
                       {note.message}
                     </li>
                   ))}
                 </ul>
               ) : (
-                <p className="mt-2 text-sm leading-6 text-white/60">
+                <p className="mt-2 mz-small">
                   Keep answering and MATCHA sharpens your matches. Every answer is yours.
                 </p>
               )}
             </div>
-            <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Opportunity pipeline</p>
-              <p className="mt-2 text-2xl font-semibold text-white tabular-nums">{pipeline}</p>
-              <p className="mt-1 text-xs text-white/50">live role{pipeline === 1 ? '' : 's'} in view</p>
+            <div className="mz-glass-inset rounded-[8px] px-4 py-3">
+              <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Opportunity pipeline</p>
+              <p className="mt-2 text-2xl font-semibold mz-mono">{pipeline}</p>
+              <p className="mt-1 mz-small">live role{pipeline === 1 ? '' : 's'} in view</p>
             </div>
           </div>
         </>
       ) : (
-        <p className="mt-4 max-w-2xl text-sm leading-6 text-white/70">
+        <p className="mt-4 max-w-2xl mz-body">
           MATCHA learns what you want next, then works in the background to surface roles worth your
           time. A short conversation gets it started.
         </p>

--- a/apps/web/components/mobile/ClinicianApplicationsSurface.tsx
+++ b/apps/web/components/mobile/ClinicianApplicationsSurface.tsx
@@ -9,16 +9,16 @@ import { buildApplicationProofMoments, buildClinicianProofSummary } from '@/lib/
 function toneClasses(tone: ReturnType<typeof applicationStatusTone>): string {
   switch (tone) {
     case 'emerald':
-      return 'border-emerald-400/20 bg-emerald-400/10 text-emerald-100';
+      return 'mz-chip mz-chip-ok';
     case 'sky':
-      return 'border-sky-400/20 bg-sky-400/10 text-sky-100';
+      return 'mz-chip mz-chip-unknown';
     case 'rose':
-      return 'border-rose-400/20 bg-rose-400/10 text-rose-100';
+      return 'mz-chip mz-chip-p0';
     case 'zinc':
-      return 'border-white/10 bg-white/5 text-white/70';
+      return 'mz-chip mz-chip-unknown';
     case 'amber':
     default:
-      return 'border-amber-400/20 bg-amber-400/10 text-amber-100';
+      return 'mz-chip mz-chip-watch';
   }
 }
 
@@ -62,190 +62,193 @@ export default function ClinicianApplicationsSurface() {
   const proof = buildClinicianProofSummary(data);
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
-      <header>
-        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-white/80">
-          <BriefcaseBusiness className="h-3.5 w-3.5" />
-          Live status
-        </div>
-        <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white">Applications</h1>
-        <p className="mt-2 max-w-2xl text-sm leading-6 text-white/65">
-          Track what is in motion, what needs action, and what happens next.
-        </p>
-      </header>
-
-      <section className="grid gap-3 sm:grid-cols-3">
-        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-4">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Active</p>
-          <p className="mt-2 text-3xl font-semibold text-white">{activeApplications.length}</p>
-        </div>
-        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-4">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Accepted</p>
-          <p className="mt-2 text-3xl font-semibold text-emerald-100">{acceptedCount}</p>
-        </div>
-        <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-4">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Needs follow-up</p>
-          <p className="mt-2 text-3xl font-semibold text-amber-100">{followUpCount}</p>
-        </div>
-      </section>
-
-      <section className="rounded-[32px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.28)]">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">What completed because of VitalCV</p>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-              Application progress is recorded against your source-backed profile, readiness, and follow-up state.
-            </p>
+    <main className="mz mz-paper mz-ambient min-h-screen w-full">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
+        <header>
+          <div className="mz-eyebrow">
+            <BriefcaseBusiness className="h-3.5 w-3.5" />
+            Live status
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-right">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">Moving now</p>
-            <p className="mt-2 text-2xl font-semibold text-white">{proof.applicationsMoving}</p>
-            <p className="mt-1 text-sm text-white/55">
-              {proof.applicationsSubmitted} total submitted
-            </p>
+          <h1 className="mz-h1 mt-4">Applications</h1>
+          <p className="mt-2 max-w-2xl mz-body">
+            Track what is in motion, what needs action, and what happens next.
+          </p>
+        </header>
+
+        <section className="grid gap-3 sm:grid-cols-3">
+          <div className="mz-glass p-4">
+            <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">Active</p>
+            <p className="mt-2 text-3xl font-semibold mz-mono">{activeApplications.length}</p>
           </div>
-        </div>
-
-        {proof.completedWithVitalCv.length > 0 ? (
-          <div className="mt-5 grid gap-3 lg:grid-cols-2">
-            {proof.completedWithVitalCv.map((item) => (
-              <div key={item} className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                <p className="text-sm text-white/80">{item}</p>
-              </div>
-            ))}
+          <div className="mz-glass p-4">
+            <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">Accepted</p>
+            <p className="mt-2 text-3xl font-semibold mz-mono text-[var(--ok)]">{acceptedCount}</p>
           </div>
-        ) : null}
-      </section>
+          <div className="mz-glass p-4">
+            <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">Needs follow-up</p>
+            <p className="mt-2 text-3xl font-semibold mz-mono text-[var(--watch)]">{followUpCount}</p>
+          </div>
+        </section>
 
-      {activeApplications.length > 0 ? (
-        <section className="space-y-4">
-          {activeApplications.map((application) => {
-            const relatedBlocker = data.blockers.find((blocker) => blocker.relatedApplicationId === application.id) ?? null;
-            const nextAction = nextActionForApplication(application.id, relatedBlocker?.href ?? null);
-            const proofMoments = buildApplicationProofMoments(application);
+        <section className="mz-glass p-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="mz-eyebrow">What completed because of VitalCV</p>
+              <p className="mt-2 max-w-3xl mz-body">
+                Application progress is recorded against your source-backed profile, readiness, and follow-up state.
+              </p>
+            </div>
+            <div className="mz-glass-inset rounded-[8px] px-4 py-3 text-right">
+              <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Moving now</p>
+              <p className="mt-2 text-2xl font-semibold mz-mono">{proof.applicationsMoving}</p>
+              <p className="mt-1 mz-small">
+                {proof.applicationsSubmitted} total submitted
+              </p>
+            </div>
+          </div>
 
-            return (
-              <article
-                key={application.id}
-                className="rounded-[32px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.28)]"
-              >
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="min-w-0">
-                    <p className="text-lg font-semibold text-white">{application.opportunity.title}</p>
-                    <p className="mt-1 text-sm text-white/65">
-                      {application.employer.name ?? application.opportunity.organizationName ?? 'Employer context'} · {application.opportunity.state}
-                    </p>
-                  </div>
-                  <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-xs font-semibold ${toneClasses(applicationStatusTone(application.status))}`}>
-                    {applicationStatusLabel(application.status)}
-                  </span>
+          {proof.completedWithVitalCv.length > 0 ? (
+            <div className="mt-5 grid gap-3 lg:grid-cols-2">
+              {proof.completedWithVitalCv.map((item) => (
+                <div key={item} className="mz-inset px-4 py-3">
+                  <p className="mz-body">{item}</p>
                 </div>
+              ))}
+            </div>
+          ) : null}
+        </section>
 
-                <div className="mt-5 grid gap-3 sm:grid-cols-4">
-                  <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                    <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">Submitted</p>
-                    <p className="mt-2 text-sm text-white">{formatTimestamp(application.createdAt)}</p>
-                  </div>
-                  <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                    <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">Updated</p>
-                    <p className="mt-2 text-sm text-white">{formatTimestamp(application.updatedAt)}</p>
-                  </div>
-                  <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                    <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">Readiness</p>
-                    <p className="mt-2 text-sm text-white">
-                      {application.readiness ? `${application.readiness.readinessLevel} · ${application.readiness.readinessScore}/100` : 'Pending'}
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                    <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">Next step</p>
-                    <p className="mt-2 text-sm text-white">
-                      {relatedBlocker?.detail ?? application.latestRecommendation?.label ?? 'Monitor employer review'}
-                    </p>
-                  </div>
-                </div>
+        {activeApplications.length > 0 ? (
+          <section className="space-y-4">
+            {activeApplications.map((application) => {
+              const relatedBlocker = data.blockers.find((blocker) => blocker.relatedApplicationId === application.id) ?? null;
+              const nextAction = nextActionForApplication(application.id, relatedBlocker?.href ?? null);
+              const proofMoments = buildApplicationProofMoments(application);
 
-                <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)]">
-                  <div className="rounded-3xl border border-white/10 bg-black/20 p-4">
-                    <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Readiness attached</p>
-                    <p className="mt-3 text-sm font-semibold text-white">
-                      {application.readiness?.readinessStatus ?? 'Pending refresh.'}
-                    </p>
-                    {application.readiness?.trustSignals.length ? (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {application.readiness.trustSignals.slice(0, 3).map((signal) => (
-                          <span
-                            key={signal}
-                            className="rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-xs text-white/75"
-                          >
-                            {signal}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
+              return (
+                <article
+                  key={application.id}
+                  className="mz-glass p-5"
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <p className="mz-h2">{application.opportunity.title}</p>
+                      <p className="mt-1 mz-small">
+                        {application.employer.name ?? application.opportunity.organizationName ?? 'Employer context'} · {application.opportunity.state}
+                      </p>
+                    </div>
+                    <span className={`w-fit ${toneClasses(applicationStatusTone(application.status))}`}>
+                      <span className="mz-gl" />
+                      {applicationStatusLabel(application.status)}
+                    </span>
                   </div>
 
-                  <div className="rounded-3xl border border-emerald-400/20 bg-emerald-400/10 p-4">
-                    <p className="text-[11px] uppercase tracking-[0.18em] text-emerald-100/80">Next step</p>
-                    <p className="mt-3 text-sm font-semibold text-white">
-                      {relatedBlocker?.title ?? application.latestRecommendation?.label ?? 'Open application detail'}
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-emerald-50/80">
-                      {relatedBlocker?.detail ?? application.latestRecommendation?.explanation ?? 'View application details for more info.'}
-                    </p>
-                  </div>
-                </div>
-
-                {proofMoments.length > 0 ? (
-                  <div className="mt-4 rounded-3xl border border-white/10 bg-black/20 p-4">
-                    <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">State change summary</p>
-                    <div className="mt-3 space-y-2">
-                      {proofMoments.map((moment) => (
-                        <p key={moment} className="text-sm leading-6 text-white/75">
-                          {moment}
-                        </p>
-                      ))}
+                  <div className="mt-5 grid gap-3 sm:grid-cols-4">
+                    <div className="mz-inset px-4 py-3">
+                      <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Submitted</p>
+                      <p className="mt-2 text-sm text-[var(--ink-800)]">{formatTimestamp(application.createdAt)}</p>
+                    </div>
+                    <div className="mz-inset px-4 py-3">
+                      <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Updated</p>
+                      <p className="mt-2 text-sm text-[var(--ink-800)]">{formatTimestamp(application.updatedAt)}</p>
+                    </div>
+                    <div className="mz-inset px-4 py-3">
+                      <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Readiness</p>
+                      <p className="mt-2 text-sm text-[var(--ink-800)]">
+                        {application.readiness ? `${application.readiness.readinessLevel} · ${application.readiness.readinessScore}/100` : 'Pending'}
+                      </p>
+                    </div>
+                    <div className="mz-inset px-4 py-3">
+                      <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Next step</p>
+                      <p className="mt-2 text-sm text-[var(--ink-800)]">
+                        {relatedBlocker?.detail ?? application.latestRecommendation?.label ?? 'Monitor employer review'}
+                      </p>
                     </div>
                   </div>
-                ) : null}
 
-                <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-                  <Link
-                    href={`/holder/applications/${encodeURIComponent(application.id)}`}
-                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-zinc-950 transition hover:bg-white/90"
-                  >
-                    View application
-                    <ArrowRight className="h-4 w-4" />
-                  </Link>
-                  <Link
-                    href={nextAction.href}
-                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
-                  >
-                    {nextAction.label}
-                    <ArrowRight className="h-4 w-4" />
-                  </Link>
-                </div>
-              </article>
-            );
-          })}
-        </section>
-      ) : (
-        <section className="rounded-[32px] border border-white/10 bg-white/[0.04] p-6">
-          <div className="flex h-14 w-14 items-center justify-center rounded-3xl bg-emerald-500/10 text-emerald-100">
-            <ClipboardList className="h-7 w-7" />
-          </div>
-          <h2 className="mt-5 text-2xl font-semibold text-white">No live applications yet</h2>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-white/70">
-            Your submitted applications and every status change will appear here.
-          </p>
-          <Link
-            href="/holder/opportunities"
-            className="mt-5 inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-zinc-950 transition hover:bg-white/90"
-          >
-            View opportunities
-            <ArrowRight className="h-4 w-4" />
-          </Link>
-        </section>
-      )}
+                  <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)]">
+                    <div className="mz-inset p-4">
+                      <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">Readiness attached</p>
+                      <p className="mt-3 text-sm font-semibold text-[var(--ink-900)]">
+                        {application.readiness?.readinessStatus ?? 'Pending refresh.'}
+                      </p>
+                      {application.readiness?.trustSignals.length ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {application.readiness.trustSignals.slice(0, 3).map((signal) => (
+                            <span
+                              key={signal}
+                              className="rounded-[2px] border border-[var(--rule)] bg-[var(--card)] px-2.5 py-1 text-[11px] text-[var(--ink-700)]"
+                            >
+                              {signal}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+
+                    <div className="mz-inset p-4">
+                      <p className="mz-mono text-[11px] uppercase tracking-[0.18em] text-[var(--accent)]">Next step</p>
+                      <p className="mt-3 text-sm font-semibold text-[var(--ink-900)]">
+                        {relatedBlocker?.title ?? application.latestRecommendation?.label ?? 'Open application detail'}
+                      </p>
+                      <p className="mt-2 mz-body">
+                        {relatedBlocker?.detail ?? application.latestRecommendation?.explanation ?? 'View application details for more info.'}
+                      </p>
+                    </div>
+                  </div>
+
+                  {proofMoments.length > 0 ? (
+                    <div className="mt-4 mz-inset p-4">
+                      <p className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">State change summary</p>
+                      <div className="mt-3 space-y-2">
+                        {proofMoments.map((moment) => (
+                          <p key={moment} className="mz-body">
+                            {moment}
+                          </p>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                    <Link
+                      href={`/holder/applications/${encodeURIComponent(application.id)}`}
+                      className="mz-btn min-h-11 justify-center"
+                    >
+                      View application
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                    <Link
+                      href={nextAction.href}
+                      className="mz-btn mz-btn-ghost min-h-11 justify-center"
+                    >
+                      {nextAction.label}
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </section>
+        ) : (
+          <section className="mz-glass p-6">
+            <div className="flex h-14 w-14 items-center justify-center rounded-[14px] border border-[var(--rule-soft)] bg-[var(--paper-2)] text-[var(--accent)]">
+              <ClipboardList className="h-7 w-7" />
+            </div>
+            <h2 className="mt-5 mz-h1">No live applications yet</h2>
+            <p className="mt-3 max-w-2xl mz-body">
+              Your submitted applications and every status change will appear here.
+            </p>
+            <Link
+              href="/holder/opportunities"
+              className="mt-5 mz-btn min-h-11 justify-center"
+            >
+              View opportunities
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </section>
+        )}
+      </div>
     </main>
   );
 }

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -30,6 +30,7 @@ import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider'
 import { RecognitionCard } from '@/components/recognition/RecognitionCard';
 import CareerCompass from '@/components/matcha/CareerCompass';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
+import { Reveal } from '@/components/motion/Reveal';
 import { FEATURES } from '@/lib/features';
 import { MatchaHomeActivity } from '@/components/matcha/MatchaHomeActivity';
 import { trackClinicianEventOncePerSession } from '@/lib/mobile/analytics';
@@ -272,346 +273,359 @@ export default function ClinicianHomeSurface() {
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
-      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-100">
-            <Wallet className="h-3.5 w-3.5" />
-            Your VitalCV Wallet
-          </div>
-          <h1 className="mt-4 truncate text-3xl font-semibold tracking-tight text-white">
-            {displayName}
-          </h1>
-          <p className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm leading-6 text-white/65">
-            {hasValidNpi ? (
-              <span className="font-mono text-white/50">NPI {npi}</span>
-            ) : (
-              <span>Add your NPI to build your source-backed readiness.</span>
-            )}
-            {profile?.specialty ? (
-              <>
-                <span aria-hidden="true" className="text-white/25">·</span>
-                <span>{profile.specialty}</span>
-              </>
-            ) : null}
-          </p>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-2">
-          <Link
-            href={shareHref}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/50 hover:bg-emerald-400/15"
-          >
-            <Share2 className="h-4 w-4" />
-            {hasValidNpi ? 'Share / prove' : 'Set up sharing'}
-          </Link>
-          <button
-            type="button"
-            onClick={() => void refresh()}
-            disabled={isRefreshing}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-            Refresh
-          </button>
-        </div>
-      </header>
-
-      <CareerCompass />
-
-      {refreshError ? (
-        <ClinicianStatusBanner
-          tone="error"
-          title="Home state could not refresh"
-          detail={refreshError}
-          onAction={() => { void refresh(); }}
-          onActionLabel={isRefreshing ? 'Retrying…' : 'Retry now'}
-          actionHref="/holder/readiness"
-          actionLabel="Open readiness"
-        />
-      ) : null}
-
-      <SelectedOpportunityBanner />
-
-      <MatchaHomeActivity />
-
-      <ProductLoopRail
-        npi={hasValidNpi ? npi : null}
-        profileComplete={profileComplete}
-        hasReadiness={Boolean(readiness)}
-      />
-
-      <section className={`rounded-[28px] border p-5 shadow-[0_20px_60px_rgba(0,0,0,0.24)] ${
-        primaryAction.tone === 'sky'
-          ? 'border-sky-400/20 bg-sky-400/10'
-          : 'border-emerald-400/20 bg-emerald-400/10'
-      }`}>
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/80">
-            <Sparkles className="h-3 w-3 text-emerald-300" aria-hidden="true" />
-            MATCHA · Your next step
-          </span>
-          <p className={`text-[11px] uppercase tracking-[0.18em] ${
-            primaryAction.tone === 'sky' ? 'text-sky-100/80' : 'text-emerald-100/80'
-          }`}>
-            {primaryAction.eyebrow}
-          </p>
-        </div>
-        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div className="max-w-3xl">
-            <h2 className="text-2xl font-semibold text-white">{primaryAction.title}</h2>
-            <p className={`mt-2 text-sm leading-6 ${
-              primaryAction.tone === 'sky' ? 'text-sky-50/85' : 'text-emerald-50/85'
-            }`}>
-              {primaryAction.detail}
-            </p>
-            <p className="mt-2 text-xs leading-5 text-white/45">
-              Reasoned from your source-backed readiness signals — VitalCV shows the evidence
-              behind every step and never invents a credential.
-            </p>
-            {highlightedChange?.occurredAt ? (
-              <p className={`mt-3 text-xs ${
-                primaryAction.tone === 'sky' ? 'text-sky-100/70' : 'text-emerald-100/70'
-              }`}>
-                Latest change recorded {new Date(highlightedChange.occurredAt).toLocaleString([], {
-                  month: 'short',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  minute: '2-digit',
-                })}
-              </p>
-            ) : null}
-          </div>
-          <Link
-            href={primaryAction.href}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-white px-5 text-sm font-semibold text-zinc-950 transition hover:bg-white/90"
-          >
-            {primaryAction.label}
-            <BriefcaseBusiness className="h-4 w-4" />
-          </Link>
-        </div>
-      </section>
-
-      <section className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
-        <div className="vh-scope vh-js relative overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Readiness</p>
-              <h2 className="mt-3 text-2xl font-semibold text-white">
-                {readiness?.readinessStatus ?? 'Readiness analysis in progress...'}
-              </h2>
-              <p className="mt-2 text-sm text-white/60">
-                Last synced {new Date(data.refreshedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
-              </p>
+    <main className="mz mz-paper mz-persona-holder mz-ambient min-h-screen w-full">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
+        <Reveal
+          as="header"
+          variant="fade"
+          className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
+        >
+          <div className="min-w-0">
+            <div className="mz-eyebrow">
+              <Wallet className="h-3.5 w-3.5" />
+              Your VitalCV Wallet
             </div>
-            <div className="rounded-2xl border border-emerald-400/25 bg-emerald-400/10 px-4 py-3 text-right shadow-[0_0_28px_-8px_rgba(45,212,191,0.55)]">
-              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Trust</p>
-              <p className="mt-2 text-2xl font-semibold text-white">
-                {readiness ? `${readiness.readinessScore}/100` : 'Pending'}
-              </p>
-              <p className="mt-1 text-sm text-emerald-100">{readiness?.readinessLevel ?? 'Setup'}</p>
-            </div>
-          </div>
-
-          {/* Vitals monitor — the clinical heartbeat of the readiness card,
-              matching the public wallet's living-monitor language. */}
-          <div className="vh-monitor mt-5">
-            <svg viewBox="0 0 320 44" preserveAspectRatio="none">
-              <path d={READINESS_EKG} />
-              <path d={READINESS_EKG} transform="translate(160 0)" />
-            </svg>
-            <span aria-hidden="true" className="vh-monitor-beam" />
-            <span className="vh-monitor-label">EVIDENCE · LIVE READ</span>
-          </div>
-
-          {/* Readiness meter — segmented clinical readout with a leading pulse,
-              replacing the flat gradient bar. */}
-          <div
-            className="vh-bar mt-4"
-            style={{ '--vh-bar': `${Math.max(8, readiness?.readinessScore ?? completeness)}%` } as React.CSSProperties}
-          >
-            <div className="vh-bar-fill" />
-          </div>
-
-          <div className="mt-4 flex flex-wrap items-center gap-3">
-            <span className="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs text-white/70">
-              {completedProfileChecks}/5 profile checks complete
-            </span>
-            <p className="text-sm text-white/70">{readinessMomentum}</p>
-          </div>
-
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            <MetricCard label="Active applications" value={`${data.activeApplications.length}`} />
-            <MetricCard label="Available roles" value={`${data.availableOpportunities.length}`} />
-            <MetricCard label="Unread updates" value={`${unreadNotifications.length}`} />
-          </div>
-        </div>
-
-        <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Momentum</p>
-          <h2 className="mt-3 text-xl font-semibold text-white">
-            {readinessMomentum}
-          </h2>
-          <p className="mt-3 text-sm leading-6 text-white/65">
-            {data.blockers[0]
-              ? 'Resolve what is left and we will reflect the change in readiness, blockers, and any active applications.'
-              : data.activeApplications[0]
-                ? 'Your application updates will continue to land here as the employer moves through review.'
-                : data.availableOpportunities[0]
-                  ? 'You have live roles waiting when you are ready to apply.'
-                  : 'Your workspace is set up and ready for the next update.'}
-          </p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-2">
-            <MetricCard label="What's left" value={`${data.blockers.length}`} />
-            <MetricCard label="Since last visit" value={`${changesSinceLastVisit.length}`} />
-          </div>
-        </div>
-      </section>
-
-      {/^\d{10}$/.test(npi) && <RecognitionCard npi={npi} />}
-
-      <section className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-        <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">What&apos;s left</p>
-          {data.blockers.length > 0 ? (
-            <div className="mt-4 space-y-3">
-              {data.blockers.slice(0, 5).map((blocker) => (
-                <Link
-                  key={blocker.id}
-                  href={blocker.href}
-                  className="block rounded-2xl border border-amber-400/15 bg-amber-400/10 px-4 py-3 text-sm text-amber-50 transition hover:border-amber-300/30"
-                >
-                  <p className="font-semibold text-white">{blocker.title}</p>
-                  <p className="mt-1">{blocker.detail}</p>
-                  <p className="mt-2 text-xs uppercase tracking-[0.16em] text-amber-100/70">
-                    {blocker.nextActionLabel}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <p className="mt-4 text-sm leading-6 text-white/60">Nothing is blocking your next step right now.</p>
-          )}
-        </div>
-
-        <NotificationList
-          notifications={visibleNotifications}
-          maxItems={3}
-          heading="Recent changes"
-        />
-      </section>
-
-      <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.3)]">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Proof of progress</p>
-            <h2 className="mt-3 text-2xl font-semibold text-white">Measured outcomes in your workspace</h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-              These changes are tied to recorded readiness, blocker, and application updates only.
+            <h1 className="mz-h1 mt-4 truncate">
+              {displayName}
+            </h1>
+            <p className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 mz-small">
+              {hasValidNpi ? (
+                <span className="mz-mono">NPI {npi}</span>
+              ) : (
+                <span>Add your NPI to build your source-backed readiness.</span>
+              )}
+              {profile?.specialty ? (
+                <>
+                  <span aria-hidden="true" className="opacity-40">·</span>
+                  <span>{profile.specialty}</span>
+                </>
+              ) : null}
             </p>
           </div>
-          {proof.readinessCurrentScore !== null ? (
-            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-4 py-3 text-right">
-              <p className="text-[10px] uppercase tracking-[0.16em] text-white/45">Current readiness</p>
-              <p className="mt-2 text-2xl font-semibold text-white">
-                {proof.readinessCurrentLevel ?? 'L0'} · {proof.readinessCurrentScore}/100
-              </p>
-              <p className="mt-1 text-sm text-emerald-100">
-                {proof.readinessDeltaScore === null
-                  ? 'Baseline established'
-                  : proof.readinessDeltaScore >= 0
-                    ? `+${proof.readinessDeltaScore} from baseline`
-                    : `${proof.readinessDeltaScore} from baseline`}
-              </p>
-            </div>
-          ) : null}
-        </div>
 
-        <div className="mt-5 grid gap-3 sm:grid-cols-4">
-          <MetricCard label="Blockers resolved" value={`${proof.blockersResolvedCount}`} />
-          <MetricCard label="Applications submitted" value={`${proof.applicationsSubmitted}`} />
-          <MetricCard label="Applications moving" value={`${proof.applicationsMoving}`} />
-          <MetricCard
-            label="Readiness change"
-            value={proof.readinessDeltaScore === null
-              ? 'Baseline'
-              : proof.readinessDeltaScore >= 0
-                ? `+${proof.readinessDeltaScore}`
-                : `${proof.readinessDeltaScore}`}
+          <div className="flex shrink-0 items-center gap-2">
+            <Link
+              href={shareHref}
+              className="mz-btn min-h-12"
+            >
+              <Share2 className="h-4 w-4" />
+              {hasValidNpi ? 'Share / prove' : 'Set up sharing'}
+            </Link>
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              disabled={isRefreshing}
+              className="mz-btn mz-btn-ghost min-h-12 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+              Refresh
+            </button>
+          </div>
+        </Reveal>
+
+        <CareerCompass />
+
+        {refreshError ? (
+          <ClinicianStatusBanner
+            tone="error"
+            title="Home state could not refresh"
+            detail={refreshError}
+            onAction={() => { void refresh(); }}
+            onActionLabel={isRefreshing ? 'Retrying…' : 'Retry now'}
+            actionHref="/holder/readiness"
+            actionLabel="Open readiness"
           />
-        </div>
+        ) : null}
 
-        {proof.completedWithVitalCv.length > 0 ? (
-          <div className="mt-5 grid gap-3 lg:grid-cols-2">
-            {proof.completedWithVitalCv.map((item) => (
-              <div key={item} className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-                <p className="text-sm text-white/80">{item}</p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="mt-5 rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-            <p className="text-sm text-white/60">
-              Measured proof will appear here as soon as readiness, blockers, or applications change.
-            </p>
-          </div>
-        )}
+        <SelectedOpportunityBanner />
 
-        {proof.recentChanges.length > 0 ? (
-          <div className="mt-5 space-y-3">
-            {proof.recentChanges.slice(0, 3).map((change) => (
-              <Link
-                key={change.id}
-                href={change.href}
-                className="block rounded-2xl border border-white/10 bg-white/[0.05] px-4 py-3 transition hover:border-white/20"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-white">{change.title}</p>
-                    <p className="mt-1 text-sm leading-6 text-white/65">{change.summary}</p>
-                  </div>
-                  <p className="text-xs text-white/40">
-                    {new Date(change.occurredAt).toLocaleDateString([], {
+        <MatchaHomeActivity />
+
+        <ProductLoopRail
+          npi={hasValidNpi ? npi : null}
+          profileComplete={profileComplete}
+          hasReadiness={Boolean(readiness)}
+        />
+
+        <Reveal>
+          <section className="mz-glass-strong mz-glass-interactive p-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="mz-eyebrow">
+                <Sparkles className="h-3 w-3" aria-hidden="true" />
+                MATCHA · Your next step
+              </span>
+              <span className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">
+                {primaryAction.eyebrow}
+              </span>
+            </div>
+            <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-3xl">
+                <h2 className="mz-h1">
+                  <span className="mz-accent">{primaryAction.title}</span>
+                </h2>
+                <p className="mt-2 mz-body">
+                  {primaryAction.detail}
+                </p>
+                <p className="mt-2 mz-small">
+                  Reasoned from your source-backed readiness signals — VitalCV shows the evidence
+                  behind every step and never invents a credential.
+                </p>
+                {highlightedChange?.occurredAt ? (
+                  <p className="mt-3 mz-small mz-mono">
+                    Latest change recorded {new Date(highlightedChange.occurredAt).toLocaleString([], {
                       month: 'short',
                       day: 'numeric',
+                      hour: 'numeric',
+                      minute: '2-digit',
                     })}
                   </p>
-                </div>
+                ) : null}
+              </div>
+              <Link
+                href={primaryAction.href}
+                className="mz-btn min-h-12"
+              >
+                {primaryAction.label}
+                <BriefcaseBusiness className="h-4 w-4" />
               </Link>
-            ))}
-          </div>
-        ) : null}
-      </section>
+            </div>
+          </section>
+        </Reveal>
 
-      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
-        <ApplicationList
-          applications={data.activeApplications}
-          maxItems={2}
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)]">
+          <Reveal className="vh-scope vh-js relative overflow-hidden mz-glass p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="mz-eyebrow">Readiness</p>
+                <h2 className="mz-h2 mt-3">
+                  {readiness?.readinessStatus ?? 'Readiness analysis in progress...'}
+                </h2>
+                <p className="mt-2 mz-small">
+                  Last synced {new Date(data.refreshedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+                </p>
+              </div>
+              <div className="mz-glass-inset rounded-[8px] px-4 py-3 text-right">
+                <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Trust</p>
+                <p className="mt-2 text-2xl font-semibold mz-mono">
+                  {readiness ? `${readiness.readinessScore}/100` : 'Pending'}
+                </p>
+                <p className="mt-1 mz-small">{readiness?.readinessLevel ?? 'Setup'}</p>
+              </div>
+            </div>
+
+            {/* Vitals monitor — the clinical heartbeat of the readiness card,
+                matching the public wallet's living-monitor language. */}
+            <div className="vh-monitor mt-5">
+              <svg viewBox="0 0 320 44" preserveAspectRatio="none">
+                <path d={READINESS_EKG} />
+                <path d={READINESS_EKG} transform="translate(160 0)" />
+              </svg>
+              <span aria-hidden="true" className="vh-monitor-beam" />
+              <span className="vh-monitor-label">EVIDENCE · LIVE READ</span>
+            </div>
+
+            {/* Readiness meter — segmented clinical readout with a leading pulse,
+                replacing the flat gradient bar. */}
+            <div
+              className="vh-bar mt-4"
+              style={{ '--vh-bar': `${Math.max(8, readiness?.readinessScore ?? completeness)}%` } as React.CSSProperties}
+            >
+              <div className="vh-bar-fill" />
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <span className="mz-inset mz-mono rounded-[2px] px-3 py-1 text-xs">
+                {completedProfileChecks}/5 profile checks complete
+              </span>
+              <p className="mz-body">{readinessMomentum}</p>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <MetricCard label="Active applications" value={`${data.activeApplications.length}`} />
+              <MetricCard label="Available roles" value={`${data.availableOpportunities.length}`} />
+              <MetricCard label="Unread updates" value={`${unreadNotifications.length}`} />
+            </div>
+          </Reveal>
+
+          <Reveal delay={80} className="mz-glass p-5">
+            <p className="mz-eyebrow">Momentum</p>
+            <h2 className="mz-h2 mt-3">
+              {readinessMomentum}
+            </h2>
+            <p className="mt-3 mz-body">
+              {data.blockers[0]
+                ? 'Resolve what is left and we will reflect the change in readiness, blockers, and any active applications.'
+                : data.activeApplications[0]
+                  ? 'Your application updates will continue to land here as the employer moves through review.'
+                  : data.availableOpportunities[0]
+                    ? 'You have live roles waiting when you are ready to apply.'
+                    : 'Your workspace is set up and ready for the next update.'}
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              <MetricCard label="What's left" value={`${data.blockers.length}`} />
+              <MetricCard label="Since last visit" value={`${changesSinceLastVisit.length}`} />
+            </div>
+          </Reveal>
+        </section>
+
+        {/^\d{10}$/.test(npi) && (
+          <Reveal>
+            <RecognitionCard npi={npi} />
+          </Reveal>
+        )}
+
+        <Reveal>
+          <section className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+            <div className="mz-glass p-5">
+              <p className="mz-eyebrow">What&apos;s left</p>
+              {data.blockers.length > 0 ? (
+                <div className="mt-4 space-y-3">
+                  {data.blockers.slice(0, 5).map((blocker) => (
+                    <Link
+                      key={blocker.id}
+                      href={blocker.href}
+                      className="block mz-glass-inset mz-glass-interactive rounded-[8px] px-4 py-3"
+                    >
+                      <p className="mz-h2">{blocker.title}</p>
+                      <p className="mt-1 mz-body">{blocker.detail}</p>
+                      <p className="mt-2">
+                        <span className="mz-chip mz-chip-watch">
+                          <span className="mz-gl" />
+                          {blocker.nextActionLabel}
+                        </span>
+                      </p>
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-4 mz-body">Nothing is blocking your next step right now.</p>
+              )}
+            </div>
+
+            <NotificationList
+              notifications={visibleNotifications}
+              maxItems={3}
+              heading="Recent changes"
+            />
+          </section>
+        </Reveal>
+
+        <Reveal>
+          <section className="mz-glass p-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <p className="mz-eyebrow">Proof of progress</p>
+                <h2 className="mz-h1 mt-3">Measured outcomes in your workspace</h2>
+                <p className="mt-2 max-w-3xl mz-small">
+                  These changes are tied to recorded readiness, blocker, and application updates only.
+                </p>
+              </div>
+              {proof.readinessCurrentScore !== null ? (
+                <div className="mz-glass-inset rounded-[8px] px-4 py-3 text-right">
+                  <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">Current readiness</p>
+                  <p className="mt-2 text-2xl font-semibold mz-mono">
+                    {proof.readinessCurrentLevel ?? 'L0'} · {proof.readinessCurrentScore}/100
+                  </p>
+                  <p className="mt-1 mz-small">
+                    {proof.readinessDeltaScore === null
+                      ? 'Baseline established'
+                      : proof.readinessDeltaScore >= 0
+                        ? `+${proof.readinessDeltaScore} from baseline`
+                        : `${proof.readinessDeltaScore} from baseline`}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-4">
+              <MetricCard label="Blockers resolved" value={`${proof.blockersResolvedCount}`} />
+              <MetricCard label="Applications submitted" value={`${proof.applicationsSubmitted}`} />
+              <MetricCard label="Applications moving" value={`${proof.applicationsMoving}`} />
+              <MetricCard
+                label="Readiness change"
+                value={proof.readinessDeltaScore === null
+                  ? 'Baseline'
+                  : proof.readinessDeltaScore >= 0
+                    ? `+${proof.readinessDeltaScore}`
+                    : `${proof.readinessDeltaScore}`}
+              />
+            </div>
+
+            {proof.completedWithVitalCv.length > 0 ? (
+              <div className="mt-5 grid gap-3 lg:grid-cols-2">
+                {proof.completedWithVitalCv.map((item) => (
+                  <div key={item} className="mz-inset px-4 py-3">
+                    <p className="mz-body">{item}</p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-5 mz-inset px-4 py-3">
+                <p className="mz-body">
+                  Measured proof will appear here as soon as readiness, blockers, or applications change.
+                </p>
+              </div>
+            )}
+
+            {proof.recentChanges.length > 0 ? (
+              <div className="mt-5 space-y-3">
+                {proof.recentChanges.slice(0, 3).map((change) => (
+                  <Link
+                    key={change.id}
+                    href={change.href}
+                    className="block mz-glass-inset mz-glass-interactive rounded-[8px] px-4 py-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="mz-h2">{change.title}</p>
+                        <p className="mt-1 mz-body">{change.summary}</p>
+                      </div>
+                      <p className="mz-small mz-mono">
+                        {new Date(change.occurredAt).toLocaleDateString([], {
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        </Reveal>
+
+        <Reveal>
+          <section className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+            <ApplicationList
+              applications={data.activeApplications}
+              maxItems={2}
+            />
+            <OpportunityGrid
+              opportunities={data.availableOpportunities}
+              maxItems={2}
+              heading="Opportunities available"
+            />
+          </section>
+        </Reveal>
+
+        <QuickActionGrid actions={quickActions} />
+
+        <ClinicianSupportCard
+          topic="clinician-home"
+          detail="Need help? We're here to assist."
+          primaryHref="/holder/readiness"
+          primaryLabel="View readiness"
         />
-        <OpportunityGrid
-          opportunities={data.availableOpportunities}
-          maxItems={2}
-          heading="Opportunities available"
-        />
-      </section>
-
-      <QuickActionGrid actions={quickActions} />
-
-      <ClinicianSupportCard
-        topic="clinician-home"
-        detail="Need help? We're here to assist."
-        primaryHref="/holder/readiness"
-        primaryLabel="View readiness"
-      />
+      </div>
     </main>
   );
 }
 
 function MetricCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
-      <p className="text-[10px] uppercase tracking-[0.16em] text-white/40">{label}</p>
-      <p className="mt-2 text-lg font-semibold text-white">{value}</p>
+    <div className="mz-glass-inset rounded-[8px] px-4 py-3">
+      <p className="mz-mono text-[10px] uppercase tracking-[0.16em] opacity-60">{label}</p>
+      <p className="mt-2 text-lg font-semibold mz-mono">{value}</p>
     </div>
   );
 }

--- a/apps/web/components/mobile/ClinicianOpportunitiesSurface.tsx
+++ b/apps/web/components/mobile/ClinicianOpportunitiesSurface.tsx
@@ -15,54 +15,56 @@ export default function ClinicianOpportunitiesSurface() {
   } = useClinicianMobile();
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
-      <header className="flex items-start justify-between gap-4">
-        <div>
-          <div className="inline-flex items-center gap-2 rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-100">
-            <Compass className="h-3.5 w-3.5" />
-            Matched opportunities
+    <main className="mz mz-paper mz-ambient min-h-screen w-full">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 pb-28 pt-6 sm:px-6 sm:pb-12 lg:px-8">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <div className="mz-eyebrow">
+              <Compass className="h-3.5 w-3.5" />
+              Matched opportunities
+            </div>
+            <h1 className="mz-h1 mt-4">View opportunities</h1>
+            <p className="mt-2 max-w-2xl mz-body">
+              Pick a role, apply when you are ready, and keep every update in one place.
+            </p>
           </div>
-          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white">View opportunities</h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/65">
-            Pick a role, apply when you are ready, and keep every update in one place.
-          </p>
-        </div>
 
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          disabled={isRefreshing}
-          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
-      </header>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={isRefreshing}
+            className="mz-btn mz-btn-ghost min-h-12 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </header>
 
-      {refreshError ? (
-        <ClinicianStatusBanner
-          tone="error"
-          title="Opportunities could not refresh"
-          detail={refreshError}
-          actionHref="/holder/home"
-          actionLabel="Return home"
+        {refreshError ? (
+          <ClinicianStatusBanner
+            tone="error"
+            title="Opportunities could not refresh"
+            detail={refreshError}
+            actionHref="/holder/home"
+            actionLabel="Return home"
+          />
+        ) : null}
+
+        <SelectedOpportunityBanner />
+
+        <OpportunityGrid
+          opportunities={data.opportunities}
+          heading="Live opportunity feed"
+          description="Choose a role, understand the fit, and move into apply without losing context."
         />
-      ) : null}
 
-      <SelectedOpportunityBanner />
-
-      <OpportunityGrid
-        opportunities={data.opportunities}
-        heading="Live opportunity feed"
-        description="Choose a role, understand the fit, and move into apply without losing context."
-      />
-
-      <ClinicianSupportCard
-        topic="opportunities"
-        detail="If the role feed is empty or a live role looks mismatched, return home to review readiness first, then contact support if the same role stays out of sync."
-        primaryHref="/holder/home"
-        primaryLabel="Review home state"
-      />
+        <ClinicianSupportCard
+          topic="opportunities"
+          detail="If the role feed is empty or a live role looks mismatched, return home to review readiness first, then contact support if the same role stays out of sync."
+          primaryHref="/holder/home"
+          primaryLabel="Review home state"
+        />
+      </div>
     </main>
   );
 }

--- a/apps/web/components/mobile/ClinicianPanels.tsx
+++ b/apps/web/components/mobile/ClinicianPanels.tsx
@@ -58,19 +58,20 @@ function formatTimestamp(value: string): string {
   });
 }
 
+/** Map an application-status tone onto a calm truth-state chip variant. */
 function toneClasses(tone: ReturnType<typeof applicationStatusTone>): string {
   switch (tone) {
     case 'emerald':
-      return 'border-emerald-400/20 bg-emerald-400/10 text-emerald-100';
+      return 'mz-chip-ok';
     case 'sky':
-      return 'border-sky-400/20 bg-sky-400/10 text-sky-100';
+      return 'mz-chip-unknown';
     case 'rose':
-      return 'border-rose-400/20 bg-rose-400/10 text-rose-100';
+      return 'mz-chip-p0';
     case 'zinc':
-      return 'border-white/10 bg-white/5 text-white/70';
+      return 'mz-chip-unknown';
     case 'amber':
     default:
-      return 'border-amber-400/20 bg-amber-400/10 text-amber-100';
+      return 'mz-chip-watch';
   }
 }
 
@@ -81,13 +82,13 @@ function matchTone(opportunity: MobileOpportunityCard): string {
 
   switch (opportunity.match?.band) {
     case 'CLEAR':
-      return 'border-emerald-400/20 bg-emerald-400/10 text-emerald-100';
+      return 'mz-chip-ok';
     case 'NEAR_CLEAR':
-      return 'border-sky-400/20 bg-sky-400/10 text-sky-100';
+      return 'mz-chip-watch';
     case 'PARTIAL':
-      return 'border-amber-400/20 bg-amber-400/10 text-amber-100';
+      return 'mz-chip-watch';
     default:
-      return 'border-white/10 bg-white/5 text-white/70';
+      return 'mz-chip-unknown';
   }
 }
 
@@ -107,20 +108,6 @@ function matchLabel(opportunity: MobileOpportunityCard): string {
       return 'Needs work';
     default:
       return 'Live role';
-  }
-}
-
-function quickActionToneClasses(tone: MobileQuickAction['tone']): string {
-  switch (tone) {
-    case 'emerald':
-      return 'border-emerald-400/15 bg-emerald-400/10 text-emerald-50';
-    case 'sky':
-      return 'border-sky-400/15 bg-sky-400/10 text-sky-50';
-    case 'amber':
-      return 'border-amber-400/15 bg-amber-400/10 text-amber-50';
-    case 'zinc':
-    default:
-      return 'border-white/10 bg-white/[0.05] text-white';
   }
 }
 
@@ -188,13 +175,13 @@ export function OpportunityGrid({
   }, [opportunities, searchParams, selectOpportunity, supportsApplyQuery, updateApplyQuery]);
 
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.25)]">
+    <section className="mz mz-card p-5">
       {heading ? (
         <div className="mb-4 flex items-start justify-between gap-3">
           <div>
-            <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">{heading}</p>
+            <p className="mz-eyebrow">{heading}</p>
           </div>
-          <Compass className="mt-0.5 h-5 w-5 text-white/45" />
+          <Compass className="mt-0.5 h-5 w-5 text-[var(--ink-400)]" />
         </div>
       ) : null}
 
@@ -205,11 +192,8 @@ export function OpportunityGrid({
             return (
               <article
                 key={opportunity.id}
-                className={`rounded-3xl border p-4 transition ${
-                  isSelected
-                    ? 'border-emerald-400/35 bg-emerald-400/10'
-                    : 'border-white/10 bg-black/20'
-                }`}
+                className={`mz-interactive p-4 ${isSelected ? 'mz-card' : 'mz-inset'}`}
+                style={isSelected ? { borderColor: 'var(--accent)' } : undefined}
               >
                 <div className="flex items-start justify-between gap-3">
                   <Link
@@ -217,26 +201,27 @@ export function OpportunityGrid({
                     onClick={() => selectOpportunity(opportunity.id)}
                     className="min-w-0 flex-1"
                   >
-                    <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.18em] text-white/50">
+                    <p className="mz-mono flex items-center gap-1.5 text-[11px] uppercase tracking-[0.18em] text-[var(--ink-500)]">
                       <Building2 className="h-3.5 w-3.5 opacity-60" />
                       {opportunity.organizationName}
                     </p>
-                    <h3 className="mt-2 text-lg font-semibold text-white transition hover:text-emerald-200">
+                    <h3 className="mz-h2 mt-2 transition hover:text-[var(--accent)]">
                       {opportunity.title}
                     </h3>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-white/65">
-                      <span className="inline-flex items-center gap-1"><MapPin className="h-3.5 w-3.5" />{opportunity.state}</span>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 mz-body">
+                      <span className="inline-flex items-center gap-1"><MapPin className="h-3.5 w-3.5 opacity-70" />{opportunity.state}</span>
                       <span className="opacity-40">·</span>
-                      <span className="inline-flex items-center gap-1"><Stethoscope className="h-3.5 w-3.5" />{opportunity.specialty}</span>
+                      <span className="inline-flex items-center gap-1"><Stethoscope className="h-3.5 w-3.5 opacity-70" />{opportunity.specialty}</span>
                       {opportunity.payRange ? (
                         <>
                           <span className="opacity-40">·</span>
-                          <span className="inline-flex items-center gap-1 font-medium text-emerald-100/90"><Banknote className="h-3.5 w-3.5 opacity-70" />{opportunity.payRange}</span>
+                          <span className="mz-mono inline-flex items-center gap-1 font-medium text-[var(--ink-800)]"><Banknote className="h-3.5 w-3.5 opacity-70" />{opportunity.payRange}</span>
                         </>
                       ) : null}
                     </div>
                   </Link>
-                  <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${matchTone(opportunity)}`}>
+                  <span className={`mz-chip ${matchTone(opportunity)}`}>
+                    <span className="mz-gl" />
                     {matchLabel(opportunity)}
                   </span>
                 </div>
@@ -246,7 +231,7 @@ export function OpportunityGrid({
                     {opportunity.match.fitReasons.slice(0, 3).map((reason) => (
                       <span
                         key={reason}
-                        className="rounded-full border border-white/10 bg-white/[0.05] px-2.5 py-1 text-xs text-white/80"
+                        className="rounded-[2px] border border-[var(--rule)] bg-[var(--paper-2)] px-2.5 py-1 text-xs text-[var(--ink-600)]"
                       >
                         {reason}
                       </span>
@@ -255,12 +240,12 @@ export function OpportunityGrid({
                 ) : null}
 
                 {opportunity.match?.blockers.length ? (
-                  <div className="mt-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-white/50">Requirements remaining</p>
+                  <div className="mt-3 mz-inset px-4 py-3">
+                    <p className="mz-mono text-xs font-semibold uppercase tracking-[0.12em] text-[var(--ink-500)]">Requirements remaining</p>
                     <ul className="mt-2 space-y-1.5">
                       {opportunity.match.blockers.slice(0, 2).map((blocker) => (
-                        <li key={blocker.label} className="flex items-start gap-2 text-xs text-amber-50/80">
-                          <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-amber-400/50" />
+                        <li key={blocker.label} className="flex items-start gap-2 text-xs text-[var(--ink-700)]">
+                          <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--watch)]" />
                           <span>{blocker.label}</span>
                         </li>
                       ))}
@@ -268,18 +253,18 @@ export function OpportunityGrid({
                   </div>
                 ) : null}
 
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-white/40">
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 mz-small">
                   <span className="inline-flex items-center gap-1.5">
                     <Clock4 className="h-3.5 w-3.5 opacity-60" />
                     Updated {formatTimestamp(opportunity.createdAt)}
                   </span>
                   {opportunity.hiringType === 'PERMANENT' ? (
-                    <span className="inline-flex items-center gap-1.5 text-sky-100/60">
+                    <span className="inline-flex items-center gap-1.5">
                       <Users className="h-3.5 w-3.5 opacity-60" />
                       Direct Hire
                     </span>
                   ) : opportunity.hiringType === 'LOCUM_TENENS' ? (
-                    <span className="inline-flex items-center gap-1.5 text-sky-100/60">
+                    <span className="inline-flex items-center gap-1.5">
                       <Users className="h-3.5 w-3.5 opacity-60" />
                       Locums
                     </span>
@@ -291,7 +276,7 @@ export function OpportunityGrid({
                     <Link
                       href={`/holder/applications/${encodeURIComponent(opportunity.application.id)}`}
                       onClick={() => selectOpportunity(opportunity.id)}
-                      className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-slate-950 transition hover:bg-white/90"
+                      className="mz-btn min-h-11 justify-center"
                     >
                       View application
                       <ArrowRight className="h-4 w-4" />
@@ -310,7 +295,7 @@ export function OpportunityGrid({
                         selectOpportunity(opportunity.id);
                         updateApplyQuery(opportunity.id);
                       }}
-                      className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-slate-950 transition hover:bg-white/90"
+                      className="mz-btn min-h-11 justify-center"
                     >
                       Apply now
                       <ArrowRight className="h-4 w-4" />
@@ -327,7 +312,7 @@ export function OpportunityGrid({
                       });
                       selectOpportunity(opportunity.id);
                     }}
-                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.05] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
+                    className="mz-btn mz-btn-ghost min-h-11 justify-center"
                   >
                     Role details
                   </Link>
@@ -391,60 +376,60 @@ export function NotificationList({
   const visibleNotifications = maxItems ? notifications.slice(0, maxItems) : notifications;
 
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.25)]">
+    <section className="mz mz-card p-5">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">{heading}</p>
+          <p className="mz-eyebrow">{heading}</p>
           {description ? (
-            <p className="mt-2 text-sm leading-6 text-white/60">{description}</p>
+            <p className="mt-2 mz-small">{description}</p>
           ) : null}
         </div>
-        <BellRing className="mt-0.5 h-5 w-5 text-white/45" />
+        <BellRing className="mt-0.5 h-5 w-5 text-[var(--ink-400)]" />
       </div>
 
       {visibleNotifications.length > 0 ? (
         <div className="space-y-3">
-          {visibleNotifications.map((notification) => (
-            <div
-              key={notification.id}
-              className={`relative rounded-3xl border p-4 ${
-                readNotificationIds.includes(notification.id)
-                  ? 'border-white/10 bg-black/20'
-                  : 'border-vt-info/30 bg-white/[0.07]'
-              }`}
-            >
-              {!readNotificationIds.includes(notification.id) ? (
-                <div className="absolute left-0 top-0 h-full w-1 rounded-l-3xl bg-vt-info" />
-              ) : null}
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold text-white">{notification.title}</p>
-                  <p className="mt-2 text-sm leading-6 text-white/65">{notification.body}</p>
-                </div>
-                {dismissible ? (
-                  <button
-                    type="button"
-                    onClick={() => dismissNotification(notification.id)}
-                    className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-white/[0.04] text-white/70 transition hover:bg-white/[0.08] hover:text-white"
-                    aria-label={`Dismiss ${notification.title}`}
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
+          {visibleNotifications.map((notification) => {
+            const isRead = readNotificationIds.includes(notification.id);
+            return (
+              <div
+                key={notification.id}
+                className={`relative p-4 ${isRead ? 'mz-inset' : 'mz-card'}`}
+                style={isRead ? undefined : { borderColor: 'var(--accent)' }}
+              >
+                {!isRead ? (
+                  <div className="absolute left-0 top-0 h-full w-1 rounded-l-[3px] bg-[var(--accent)]" />
                 ) : null}
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="mz-h2">{notification.title}</p>
+                    <p className="mt-2 mz-body">{notification.body}</p>
+                  </div>
+                  {dismissible ? (
+                    <button
+                      type="button"
+                      onClick={() => dismissNotification(notification.id)}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[var(--rule)] bg-[var(--card)] text-[var(--ink-500)] transition hover:border-[var(--ink-400)] hover:text-[var(--ink-800)]"
+                      aria-label={`Dismiss ${notification.title}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  ) : null}
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <span className="mz-small mz-mono">{formatTimestamp(notification.occurredAt)}</span>
+                  <Link
+                    href={notification.href}
+                    onClick={() => markNotificationRead(notification.id)}
+                    className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--accent)] transition hover:text-[var(--ink-900)]"
+                  >
+                    {notification.ctaLabel}
+                    <ChevronRight className="h-4 w-4" />
+                  </Link>
+                </div>
               </div>
-              <div className="mt-4 flex items-center justify-between gap-3">
-                <span className="text-xs text-white/40">{formatTimestamp(notification.occurredAt)}</span>
-                <Link
-                  href={notification.href}
-                  onClick={() => markNotificationRead(notification.id)}
-                  className="inline-flex items-center gap-1 text-sm font-semibold text-emerald-200 transition hover:text-white"
-                >
-                  {notification.ctaLabel}
-                  <ChevronRight className="h-4 w-4" />
-                </Link>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <ClinicianStatusBanner
@@ -473,56 +458,57 @@ export function ApplicationList({
   const visibleApplications = maxItems ? applications.slice(0, maxItems) : applications;
 
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.25)]">
+    <section className="mz mz-card p-5">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">{heading}</p>
+          <p className="mz-eyebrow">{heading}</p>
           {description ? (
-            <p className="mt-2 text-sm leading-6 text-white/60">{description}</p>
+            <p className="mt-2 mz-small">{description}</p>
           ) : null}
         </div>
-        <BriefcaseBusiness className="mt-0.5 h-5 w-5 text-white/45" />
+        <BriefcaseBusiness className="mt-0.5 h-5 w-5 text-[var(--ink-400)]" />
       </div>
 
       {visibleApplications.length > 0 ? (
         <div className="space-y-4">
           {visibleApplications.map((application) => (
-            <article key={application.id} className="rounded-3xl border border-white/10 bg-black/20 p-4">
+            <article key={application.id} className="mz-inset p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-[11px] uppercase tracking-[0.18em] text-white/40">
+                  <p className="mz-mono text-[11px] uppercase tracking-[0.18em] text-[var(--ink-400)]">
                     {application.employer.name ?? application.opportunity.organizationName ?? 'Employer context'}
                   </p>
-                  <h3 className="mt-2 text-lg font-semibold text-white">{application.opportunity.title}</h3>
-                  <p className="mt-2 text-sm text-white/65">
+                  <h3 className="mz-h2 mt-2">{application.opportunity.title}</h3>
+                  <p className="mt-2 mz-body">
                     {application.opportunity.state} · {application.opportunity.specialty}
                   </p>
                 </div>
-                <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${toneClasses(applicationStatusTone(application.status))}`}>
+                <span className={`mz-chip ${toneClasses(applicationStatusTone(application.status))}`}>
+                  <span className="mz-gl" />
                   {applicationStatusLabel(application.status)}
                 </span>
               </div>
 
-              <div className="mt-4 rounded-3xl border border-white/10 bg-white/[0.05] px-4 py-4">
+              <div className="mt-4 mz-card px-4 py-4">
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-semibold text-white">Passport Attached</p>
-                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+                  <p className="mz-h2">Passport Attached</p>
+                  <span className="mz-chip mz-chip-ok">
                     <ShieldCheck className="h-3.5 w-3.5" />
                     {application.readiness?.readinessLevel ?? 'L0'}
                   </span>
                 </div>
-                <p className="mt-3 text-sm text-white/70">
+                <p className="mt-3 mz-body">
                   {application.readiness?.readinessStatus ?? 'Your readiness will auto-refresh when reviewed.'}
                 </p>
                 {application.latestRecommendation?.label ? (
-                  <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs text-white/75">
+                  <div className="mt-3 inline-flex items-center gap-2 rounded-[2px] border border-[var(--rule)] bg-[var(--paper-2)] px-3 py-1 text-xs text-[var(--ink-700)]">
                     <CheckCircle2 className="h-3.5 w-3.5" />
                     {application.latestRecommendation.label}
                   </div>
                 ) : null}
               </div>
 
-              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-xs text-white/45">
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 mz-small">
                 <span className="inline-flex items-center gap-1">
                   <Clock3 className="h-3.5 w-3.5" />
                   Updated {formatTimestamp(application.updatedAt)}
@@ -530,14 +516,14 @@ export function ApplicationList({
                 <div className="flex flex-wrap items-center gap-3">
                   <Link
                     href={`/holder/applications/${encodeURIComponent(application.id)}`}
-                    className="inline-flex items-center gap-1 text-sm font-semibold text-emerald-200 transition hover:text-white"
+                    className="inline-flex items-center gap-1 text-sm font-semibold text-[var(--accent)] transition hover:text-[var(--ink-900)]"
                   >
                     View application
                     <ChevronRight className="h-4 w-4" />
                   </Link>
                   <Link
                     href={`/holder/opportunities/${application.opportunity.id}`}
-                    className="inline-flex items-center gap-1 text-sm text-white/55 transition hover:text-white"
+                    className="inline-flex items-center gap-1 text-sm text-[var(--ink-500)] transition hover:text-[var(--ink-900)]"
                   >
                     <Building2 className="h-4 w-4" />
                     Role details
@@ -562,12 +548,12 @@ export function ApplicationList({
 
 export function QuickActionGrid({ actions }: { actions: readonly MobileQuickAction[] }) {
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.25)]">
+    <section className="mz mz-card p-5">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <p className="text-[11px] uppercase tracking-[0.18em] text-white/45">Other actions</p>
+          <p className="mz-eyebrow">Other actions</p>
         </div>
-        <AlertTriangle className="mt-0.5 h-5 w-5 text-white/45" />
+        <AlertTriangle className="mt-0.5 h-5 w-5 text-[var(--ink-400)]" />
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
@@ -577,13 +563,13 @@ export function QuickActionGrid({ actions }: { actions: readonly MobileQuickActi
             <Link
               key={action.id}
               href={action.href}
-              className={`rounded-3xl border p-4 transition hover:border-white/20 ${quickActionToneClasses(action.tone)}`}
+              className="mz-inset mz-interactive p-4"
             >
-              <div className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/10 bg-black/20">
-                <Icon className="h-5 w-5" />
+              <div className="inline-flex h-10 w-10 items-center justify-center rounded-[8px] border border-[var(--rule)] bg-[var(--card)]">
+                <Icon className="h-5 w-5 text-[var(--ink-700)]" />
               </div>
-              <p className="mt-4 text-base font-semibold">{action.label}</p>
-              <p className="mt-2 text-sm leading-6 text-white/70">{action.description}</p>
+              <p className="mz-h2 mt-4">{action.label}</p>
+              <p className="mt-2 mz-body">{action.description}</p>
             </Link>
           );
         })}
@@ -608,28 +594,28 @@ export function SelectedOpportunityBanner() {
   const continueLabel = selectedOpportunity.application ? 'View application' : 'Continue application';
 
   return (
-    <section className="rounded-[28px] border border-emerald-400/20 bg-emerald-400/10 p-5 shadow-[0_18px_40px_rgba(0,0,0,0.2)]">
+    <section className="mz mz-glass p-5">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-[11px] uppercase tracking-[0.18em] text-emerald-50/80">Continuing where you left off</p>
-          <h2 className="mt-2 text-lg font-semibold text-white">{selectedOpportunity.title}</h2>
-          <p className="mt-2 text-sm text-emerald-50/85">
+          <p className="mz-eyebrow">Continuing where you left off</p>
+          <h2 className="mz-h2 mt-3">{selectedOpportunity.title}</h2>
+          <p className="mt-2 mz-body">
             {selectedOpportunity.organizationName} · {selectedOpportunity.state}
           </p>
         </div>
-        <Building2 className="mt-0.5 h-5 w-5 text-emerald-100/80" />
+        <Building2 className="mt-0.5 h-5 w-5 text-[var(--accent)]" />
       </div>
       <div className="mt-4 flex flex-wrap gap-3">
         <Link
           href={continueHref}
-          className="inline-flex min-h-11 items-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-slate-950 transition hover:bg-white/90"
+          className="mz-btn min-h-11 justify-center"
         >
           {continueLabel}
           <ArrowRight className="h-4 w-4" />
         </Link>
         <Link
           href={`/holder/opportunities/${selectedOpportunity.id}`}
-          className="inline-flex min-h-11 items-center gap-2 rounded-2xl border border-white/10 bg-black/20 px-4 text-sm font-semibold text-white transition hover:border-white/20"
+          className="mz-btn mz-btn-ghost min-h-11 justify-center"
         >
           Open role details
         </Link>

--- a/apps/web/components/mobile/ClinicianStatusBanner.tsx
+++ b/apps/web/components/mobile/ClinicianStatusBanner.tsx
@@ -5,22 +5,20 @@ import { AlertTriangle, ArrowRight, Info, TriangleAlert } from 'lucide-react';
 
 type ClinicianStatusTone = 'error' | 'warning' | 'info';
 
-const TONE_STYLES: Record<ClinicianStatusTone, string> = {
-  error: 'border-rose-400/20 bg-rose-400/10 text-rose-100',
-  warning: 'border-amber-400/20 bg-amber-400/10 text-amber-50',
-  info: 'border-sky-400/20 bg-sky-400/10 text-sky-100',
+const TONE_CHIP: Record<ClinicianStatusTone, string> = {
+  error: 'mz-chip-p0',
+  warning: 'mz-chip-watch',
+  info: 'mz-chip-unknown',
 };
 
 function StatusIcon({ tone }: { tone: ClinicianStatusTone }) {
-  if (tone === 'error') {
-    return <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />;
-  }
+  const Icon = tone === 'error' ? AlertTriangle : tone === 'warning' ? TriangleAlert : Info;
 
-  if (tone === 'warning') {
-    return <TriangleAlert className="mt-0.5 h-5 w-5 shrink-0" />;
-  }
-
-  return <Info className="mt-0.5 h-5 w-5 shrink-0" />;
+  return (
+    <span className={`mz-chip ${TONE_CHIP[tone]} mt-0.5 shrink-0`}>
+      <Icon className="h-3.5 w-3.5" />
+    </span>
+  );
 }
 
 export function ClinicianStatusBanner({
@@ -42,18 +40,18 @@ export function ClinicianStatusBanner({
   onActionLabel?: string;
 }) {
   return (
-    <div className={`rounded-3xl border px-4 py-4 ${TONE_STYLES[tone]}`} role="status" aria-live="polite">
+    <div className="mz mz-inset px-4 py-4" role="status" aria-live="polite">
       <div className="flex items-start gap-3">
         <StatusIcon tone={tone} />
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-white">{title}</p>
-          <p className="mt-1 text-sm leading-6">{detail}</p>
+          <p className="text-sm font-semibold">{title}</p>
+          <p className="mt-1 mz-body">{detail}</p>
           <div className="flex flex-wrap items-center gap-4">
             {onAction && onActionLabel ? (
               <button
                 type="button"
                 onClick={onAction}
-                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white underline underline-offset-4 transition hover:text-white/80"
+                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold underline underline-offset-4 transition-opacity hover:opacity-80"
               >
                 {onActionLabel}
               </button>
@@ -61,7 +59,8 @@ export function ClinicianStatusBanner({
             {actionHref && actionLabel ? (
               <Link
                 href={actionHref}
-                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white transition hover:text-white/80"
+                className="mt-3 inline-flex items-center gap-2 text-sm font-semibold transition-opacity hover:opacity-80"
+                style={{ color: 'var(--accent)' }}
               >
                 {actionLabel}
                 <ArrowRight className="h-4 w-4" />

--- a/apps/web/components/mobile/ClinicianSupportCard.tsx
+++ b/apps/web/components/mobile/ClinicianSupportCard.tsx
@@ -16,14 +16,17 @@ export function ClinicianSupportCard({
   primaryLabel?: string;
 }) {
   return (
-    <section className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5 shadow-[0_18px_40px_rgba(0,0,0,0.2)]">
+    <section className="mz mz-card mz-card-pad">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <div className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-sky-400/20 bg-sky-400/10 text-sky-100">
+          <div
+            className="mz-inset inline-flex h-10 w-10 items-center justify-center rounded-[8px]"
+            style={{ color: 'var(--ink-600)' }}
+          >
             <LifeBuoy className="h-5 w-5" />
           </div>
-          <h2 className="mt-4 text-lg font-semibold text-white">Need help?</h2>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/65">
+          <h2 className="mz-h2 mt-4">Need help?</h2>
+          <p className="mt-2 max-w-2xl mz-body">
             {detail}
           </p>
         </div>
@@ -33,7 +36,7 @@ export function ClinicianSupportCard({
         {primaryHref && primaryLabel ? (
           <Link
             href={primaryHref}
-            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-white px-4 text-sm font-semibold text-slate-950 transition hover:bg-white/90"
+            className="mz-btn min-h-12 justify-center"
           >
             {primaryLabel}
             <ArrowRight className="h-4 w-4" />
@@ -43,7 +46,7 @@ export function ClinicianSupportCard({
           label="Contact support"
           title={`Pilot support · ${topic}`}
           messagePrefill={detail}
-          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/[0.05] px-4 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-white/[0.08]"
+          className="mz-btn mz-btn-ghost min-h-12 justify-center"
         />
       </div>
     </section>

--- a/apps/web/components/motion/Reveal.tsx
+++ b/apps/web/components/motion/Reveal.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * Reveal — the platform's entrance-motion primitive (Calm Wave "calm glass").
+ *
+ * Wraps content and lets it rise+fade into place the first time it scrolls into
+ * view, once, calmly. Stagger siblings with `delay`. Motion is CSS (keyframes in
+ * matcha-zen.css: `.mz-reveal` / `.is-in`); this component only toggles the
+ * class via IntersectionObserver, so it is cheap and SSR-safe. Respects
+ * `prefers-reduced-motion` automatically (the CSS neutralizes the animation).
+ *
+ *   <Reveal>            — rise + fade
+ *   <Reveal variant="fade" delay={120}>  — fade only, 120ms after its neighbor
+ *   <Reveal as="li">    — render as a different element
+ *
+ * Anticipatory by default: `rootMargin` starts the reveal slightly before the
+ * element reaches the viewport edge, so content feels ready, never late.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { ElementType, ReactNode } from 'react';
+
+export interface RevealProps {
+  children: ReactNode;
+  /** Stagger offset in ms (pair with siblings for a cascade). */
+  delay?: number;
+  /** 'rise' (default) = rise + fade; 'fade' = opacity only. */
+  variant?: 'rise' | 'fade';
+  /** Element to render. Default 'div'. */
+  as?: ElementType;
+  className?: string;
+  /** Extra inline styles merged with the stagger var. */
+  style?: React.CSSProperties;
+  /** Passthrough (data-*, aria-*, etc.). */
+  [key: string]: unknown;
+}
+
+export function Reveal({
+  children,
+  delay = 0,
+  variant = 'rise',
+  as,
+  className = '',
+  style,
+  ...rest
+}: RevealProps) {
+  const Tag = (as ?? 'div') as ElementType;
+  const ref = useRef<HTMLElement | null>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || shown) return;
+    // If IntersectionObserver is unavailable, show immediately (never hide content).
+    if (typeof IntersectionObserver === 'undefined') {
+      setShown(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setShown(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [shown]);
+
+  return (
+    <Tag
+      ref={ref}
+      className={`mz-reveal${variant === 'fade' ? ' mz-reveal-fade' : ''}${shown ? ' is-in' : ''}${className ? ` ${className}` : ''}`}
+      style={{ ...(style ?? {}), ['--mz-delay' as string]: `${delay}ms` }}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+export default Reveal;

--- a/apps/web/components/recognition/RecognitionCard.tsx
+++ b/apps/web/components/recognition/RecognitionCard.tsx
@@ -37,15 +37,15 @@ export function RecognitionCard({ npi }: { npi: string }) {
   return (
     <section
       aria-label="Recognition"
-      className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+      className="mz mz-card mz-card-pad"
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Recognition</p>
-        <Award className="h-4 w-4 text-emerald-400" aria-hidden />
+        <p className="mz-eyebrow">Recognition</p>
+        <Award className="h-4 w-4" style={{ color: 'var(--accent)' }} aria-hidden />
       </div>
 
       {phase.state === 'loading' && (
-        <div className="mt-3 flex items-center gap-2 text-sm text-zinc-500">
+        <div className="mt-3 flex items-center gap-2 mz-small">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
           Checking your acceptance record…
         </div>
@@ -53,15 +53,15 @@ export function RecognitionCard({ npi }: { npi: string }) {
 
       {phase.state === 'unavailable' && (
         <div className="mt-3 space-y-2">
-          <p className="text-sm font-medium text-zinc-200">
+          <p className="mz-h2">
             Recognition status is temporarily unavailable
           </p>
-          <p className="text-sm leading-6 text-zinc-400">
+          <p className="mz-body">
             This is a system state — not a finding about your record. Try again shortly.
           </p>
           <button
             onClick={() => { void load(); }}
-            className="rounded-lg border border-zinc-700 px-4 py-1.5 text-sm text-zinc-300 transition hover:text-white"
+            className="mz-btn mz-btn-ghost mz-btn-sm"
           >
             Try again
           </button>
@@ -70,16 +70,17 @@ export function RecognitionCard({ npi }: { npi: string }) {
 
       {phase.state === 'none_recorded' && (
         <div className="mt-3 space-y-2">
-          <p className="text-base font-semibold text-zinc-100">
+          <p className="mz-h2">
             No employer acceptances recorded yet
           </p>
-          <p className="text-sm leading-6 text-zinc-400">
+          <p className="mz-body">
             When an employer accepts your evidence as a head start, the acceptance is
             recorded here and stays part of your career record.
           </p>
           <Link
             href="/holder/readiness"
-            className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+            className="inline-flex items-center gap-1 text-sm font-medium transition-opacity hover:opacity-80"
+            style={{ color: 'var(--accent)' }}
           >
             Keep your readiness current <ChevronRight className="h-3.5 w-3.5" aria-hidden />
           </Link>
@@ -103,11 +104,14 @@ function RecognizedBody({
 
   return (
     <div className="mt-3 space-y-3">
-      <p className="text-lg font-semibold text-zinc-100">{recognition.summary.headline}</p>
+      <div className="flex items-center gap-2">
+        <span className="mz-chip mz-chip-ok" aria-hidden="true"><span className="mz-gl" /></span>
+        <p className="mz-h2">{recognition.summary.headline}</p>
+      </div>
 
       {latest && (
-        <p className="text-sm leading-6 text-zinc-400">
-          Most recent: <span className="text-zinc-200">{latest.orgLabel}</span>
+        <p className="mz-body">
+          Most recent: <span style={{ color: 'var(--ink-900)' }}>{latest.orgLabel}</span>
           {' · '}
           {acceptanceScopeLabel(latest.acceptanceScope)}
           {latestDate ? ` · ${latestDate}` : ''}
@@ -115,12 +119,13 @@ function RecognizedBody({
       )}
 
       {recognition.summary.trustCopy && (
-        <p className="text-sm leading-6 text-zinc-500">{recognition.summary.trustCopy}</p>
+        <p className="mz-small">{recognition.summary.trustCopy}</p>
       )}
 
       <Link
         href="/holder/recognition"
-        className="inline-flex items-center gap-1 text-sm font-medium text-emerald-400 transition hover:text-emerald-300"
+        className="inline-flex items-center gap-1 text-sm font-medium transition-opacity hover:opacity-80"
+        style={{ color: 'var(--accent)' }}
       >
         View your recognition record <ChevronRight className="h-3.5 w-3.5" aria-hidden />
       </Link>

--- a/apps/web/components/ui/CommandPalette.tsx
+++ b/apps/web/components/ui/CommandPalette.tsx
@@ -8,10 +8,10 @@ import { useEffect, useRef, useState } from 'react';
 import { CommandParamsModal } from './CommandParamsModal';
 
 // Maps backend entity types to UI groups.
-// Calm Wave dark instrument: one indigo accent, no jade/teal/coral. Icon chips are a
-// faint charcoal fill (var(--vt-surface-subtle)) with muted ink; the selected row's
-// icon is recolored to indigo in the row itself.
-const ICON_CHIP = 'text-[var(--vt-text-secondary)] bg-[var(--vt-surface-subtle)]';
+// Calm Wave D56 light: paper + ink + one ink-indigo accent, no jade/teal/coral. Icon chips
+// are a light paper fill (var(--paper-2)) with muted ink; the selected row's icon is
+// recolored to ink-indigo (var(--accent)) in the row itself.
+const ICON_CHIP = 'text-[var(--ink-600)] bg-[var(--paper-2)]';
 const TYPE_MAPPING: Record<string, { group: string, icon: any, color: string }> = {
   PUBLIC_PAGE: { group: 'Policy & Docs', icon: Globe, color: ICON_CHIP },
   FAQ_DOC: { group: 'Policy & Docs', icon: FileText, color: ICON_CHIP },
@@ -228,13 +228,13 @@ export function CommandPalette() {
     <>
       <AnimatePresence>
         {open && !activeCommand && (
-          <div className="dark fixed inset-0 z-[100] flex items-start justify-center pt-[10vh] sm:pt-[15vh]">
+          <div className="mz fixed inset-0 z-[100] flex items-start justify-center pt-[10vh] sm:pt-[15vh]">
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}
-              className="fixed inset-0 bg-black/70 backdrop-blur-sm"
+              className="fixed inset-0 bg-[color-mix(in_oklch,var(--ink-900)_28%,transparent)] backdrop-blur-sm"
               onClick={() => setOpen(false)}
             />
 
@@ -243,26 +243,31 @@ export function CommandPalette() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}
+              style={{
+                background: 'var(--card)',
+                border: '1px solid var(--rule)',
+                boxShadow: '0 24px 60px -30px oklch(20% 0.02 265 / 0.28)',
+              }}
               className={cn(
-                "mz relative flex flex-col w-full max-w-2xl overflow-hidden rounded-[8px] border border-[var(--vt-border)] bg-[var(--card)] shadow-[0_32px_90px_-28px_rgba(0,0,0,0.85)]",
+                "mz relative flex flex-col w-full max-w-2xl overflow-hidden rounded-[8px]",
                 isResultsMode ? "h-[80vh] max-h-[800px]" : "h-auto"
               )}
             >
               {/* Sticky Search Header */}
-              <div className="flex-none p-4 pb-2 border-b border-[var(--vt-border)] shrink-0 bg-transparent z-10 sticky top-0">
-                <div className="flex items-center gap-3 bg-[var(--vt-surface-subtle)] border border-[var(--vt-border)] rounded-[6px] px-4 py-3 focus-within:border-[var(--vt-accent)] transition-colors">
-                  <Search className="w-5 h-5 text-[var(--vt-text-secondary)] shrink-0" />
+              <div className="flex-none p-4 pb-2 border-b border-[var(--rule)] shrink-0 bg-transparent z-10 sticky top-0">
+                <div className="flex items-center gap-3 bg-[var(--ink-50)] border border-[var(--rule)] rounded-[6px] px-4 py-3 focus-within:border-[var(--accent)] transition-colors">
+                  <Search className="w-5 h-5 text-[var(--ink-500)] shrink-0" />
                   <input
                     ref={inputRef}
-                    className="flex-1 bg-transparent border-none outline-none text-lg text-[var(--vt-text-primary)] placeholder:text-[var(--vt-text-muted)]"
+                    className="flex-1 bg-transparent border-none outline-none text-lg text-[var(--ink-900)] placeholder:text-[var(--ink-400)] placeholder:font-[family-name:var(--font-geist-mono)]"
                     placeholder="Jump to your wallet, readiness, or Recognition — or ask VitalCV"
                     value={search}
                     onChange={(e) => { setSearch(e.target.value); setSelectedIndex(0); }}
                     onKeyDown={handleKeyDown}
                   />
-                  {loading && <div className="w-4 h-4 rounded-full border-2 border-[var(--vt-accent)] border-t-transparent animate-spin shrink-0" />}
+                  {loading && <div className="w-4 h-4 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin shrink-0" />}
                   <div className="flex gap-1 shrink-0 ml-2">
-                    <kbd className="hidden sm:inline-flex items-center justify-center h-6 px-2 text-[10px] uppercase font-[family-name:var(--font-geist-mono)] text-[var(--vt-text-muted)] bg-[var(--vt-surface-subtle)] rounded-[4px] border border-[var(--vt-border)]">ESC</kbd>
+                    <kbd className="hidden sm:inline-flex items-center justify-center h-6 px-2 text-[10px] uppercase font-[family-name:var(--font-geist-mono)] text-[var(--ink-500)] bg-[var(--card)] rounded-[4px] border border-[var(--rule)]">ESC</kbd>
                   </div>
                 </div>
 
@@ -273,8 +278,8 @@ export function CommandPalette() {
                       className={cn(
                         "px-3 py-1 text-[11px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] rounded-[4px] whitespace-nowrap border transition-colors",
                         activeFilter === null
-                          ? "bg-[color-mix(in_oklab,var(--vt-accent)_16%,transparent)] border-[var(--vt-accent)] text-[var(--vt-text-primary)]"
-                          : "bg-transparent border-[var(--vt-border)] text-[var(--vt-text-muted)] hover:text-[var(--vt-text-primary)] hover:border-[var(--vt-text-muted)]"
+                          ? "bg-[color-mix(in_oklch,var(--accent)_12%,transparent)] border-[var(--accent)] text-[var(--accent)]"
+                          : "bg-transparent border-[var(--rule)] text-[var(--ink-500)] hover:text-[var(--ink-900)] hover:border-[var(--ink-400)]"
                       )}
                     >
                       All Results
@@ -286,8 +291,8 @@ export function CommandPalette() {
                         className={cn(
                           "px-3 py-1 text-[11px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] rounded-[4px] whitespace-nowrap flex items-center gap-1.5 border transition-colors",
                           activeFilter === g
-                            ? "bg-[color-mix(in_oklab,var(--vt-accent)_16%,transparent)] border-[var(--vt-accent)] text-[var(--vt-text-primary)]"
-                            : "bg-transparent border-[var(--vt-border)] text-[var(--vt-text-muted)] hover:text-[var(--vt-text-primary)] hover:border-[var(--vt-text-muted)]"
+                            ? "bg-[color-mix(in_oklch,var(--accent)_12%,transparent)] border-[var(--accent)] text-[var(--accent)]"
+                            : "bg-transparent border-[var(--rule)] text-[var(--ink-500)] hover:text-[var(--ink-900)] hover:border-[var(--ink-400)]"
                         )}
                       >
                         {g} <span className="text-[10px] opacity-60">({groupedResults[g].length})</span>
@@ -302,8 +307,8 @@ export function CommandPalette() {
                 {!isResultsMode ? (
                   <div className="px-2 py-4">
                     <div className="flex items-center justify-between px-2 mb-3">
-                      <h3 className="text-[11px] font-[family-name:var(--font-geist-mono)] font-medium uppercase tracking-[0.14em] text-[var(--vt-text-muted)]">Quick actions</h3>
-                      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] text-[var(--vt-text-muted)] bg-[var(--vt-surface-subtle)] px-2.5 py-1 rounded-[4px] border border-[var(--vt-border)]">
+                      <h3 className="text-[11px] font-[family-name:var(--font-geist-mono)] font-medium uppercase tracking-[0.14em] text-[var(--ink-500)]">Quick actions</h3>
+                      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] text-[var(--ink-500)] bg-[var(--paper-2)] px-2.5 py-1 rounded-[4px] border border-[var(--rule)]">
                         ↑↓ move · ↵ open · esc close
                       </div>
                     </div>
@@ -323,29 +328,29 @@ export function CommandPalette() {
                               // left indigo accent bar on the selected row
                               "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:transition-colors",
                               selected
-                                ? "bg-[color-mix(in_oklab,var(--vt-accent)_14%,transparent)] border-[var(--vt-accent)] before:bg-[var(--vt-accent)]"
-                                : "bg-transparent border-[var(--vt-border)] hover:bg-[var(--vt-surface-subtle)] before:bg-transparent"
+                                ? "bg-[color-mix(in_oklch,var(--accent)_10%,transparent)] border-[var(--accent)] before:bg-[var(--accent)]"
+                                : "bg-transparent border-[var(--rule)] hover:bg-[var(--ink-50)] before:bg-transparent"
                             )}
                           >
                             <div className="flex items-center gap-3 mb-2 w-full">
-                              <div className={cn("p-2 rounded-[4px] transition-colors", selected ? "bg-[color-mix(in_oklab,var(--vt-accent)_18%,transparent)] text-[var(--vt-accent)]" : "bg-[var(--vt-surface-subtle)] text-[var(--vt-text-secondary)]")}>
+                              <div className={cn("p-2 rounded-[4px] transition-colors", selected ? "bg-[color-mix(in_oklch,var(--accent)_15%,transparent)] text-[var(--accent)]" : "bg-[var(--paper-2)] text-[var(--ink-600)]")}>
                                 <Icon className="w-5 h-5" />
                               </div>
-                              <div className="font-medium text-[var(--vt-text-primary)] flex-1">{action.label}</div>
-                              {selected && <ArrowRight className="w-4 h-4 text-[var(--vt-accent)]" />}
+                              <div className="font-medium text-[var(--ink-900)] flex-1">{action.label}</div>
+                              {selected && <ArrowRight className="w-4 h-4 text-[var(--accent)]" />}
                             </div>
-                            <div className="text-xs font-[family-name:var(--font-geist-mono)] text-[var(--vt-text-muted)] line-clamp-2">{action.desc}</div>
+                            <div className="text-xs font-[family-name:var(--font-geist-mono)] text-[var(--ink-500)] line-clamp-2">{action.desc}</div>
                           </button>
                         );
                       })}
                     </div>
 
                     <div className="mt-8 px-2">
-                      <div className="p-4 rounded-[6px] bg-[var(--vt-surface-subtle)] border border-[var(--vt-border)] flex gap-4 items-start">
-                        <Sparkles className="w-6 h-6 text-[var(--vt-accent)] shrink-0 mt-1" />
+                      <div className="p-4 rounded-[6px] bg-[var(--paper-2)] border border-[var(--rule)] flex gap-4 items-start">
+                        <Sparkles className="w-6 h-6 text-[var(--accent)] shrink-0 mt-1" />
                         <div>
-                          <h4 className="text-sm font-medium text-[var(--vt-text-primary)] mb-1">Ask in plain language</h4>
-                          <p className="text-xs text-[var(--vt-text-secondary)]">
+                          <h4 className="text-sm font-medium text-[var(--ink-900)] mb-1">Ask in plain language</h4>
+                          <p className="text-xs text-[var(--ink-600)]">
                             &ldquo;What&rsquo;s blocking my readiness?&rdquo; or &ldquo;Which sources are still gated for my NPI?&rdquo;
                           </p>
                         </div>
@@ -356,13 +361,13 @@ export function CommandPalette() {
                   <div className="space-y-6 pt-2">
                     {groups.length === 0 && !loading && (
                       <div className="py-12 text-center flex flex-col items-center">
-                        <div className="w-12 h-12 rounded-full bg-[var(--vt-surface-subtle)] border border-[var(--vt-border)] flex items-center justify-center mb-4">
-                          <Search className="w-5 h-5 text-[var(--vt-text-muted)]" />
+                        <div className="w-12 h-12 rounded-full bg-[var(--paper-2)] border border-[var(--rule)] flex items-center justify-center mb-4">
+                          <Search className="w-5 h-5 text-[var(--ink-400)]" />
                         </div>
-                        <p className="text-sm text-[var(--vt-text-primary)] mb-4">No specific entities found.</p>
+                        <p className="text-sm text-[var(--ink-900)] mb-4">No specific entities found.</p>
                         <button
                           onClick={() => { setOpen(false); router.push(`/ask?q=${encodeURIComponent(search)}`); }}
-                          className="flex items-center gap-2 px-4 py-2 rounded-[6px] bg-[var(--vt-accent)] text-[var(--card)] text-sm font-medium hover:bg-[color-mix(in_oklab,var(--vt-accent)_85%,#000)] transition-colors"
+                          className="flex items-center gap-2 px-4 py-2 rounded-[6px] bg-[var(--accent)] text-[var(--card)] text-sm font-medium hover:bg-[color-mix(in_oklch,var(--accent)_85%,var(--ink-900))] transition-colors"
                         >
                           <Sparkles className="w-4 h-4" />
                           Ask VitalCV instead
@@ -372,9 +377,9 @@ export function CommandPalette() {
 
                     {groups.map(group => (
                       <div key={group} className="px-2">
-                        <h3 className="text-[11px] font-[family-name:var(--font-geist-mono)] font-medium uppercase tracking-[0.14em] text-[var(--vt-text-muted)] mb-2 px-2 flex justify-between items-center">
+                        <h3 className="text-[11px] font-[family-name:var(--font-geist-mono)] font-medium uppercase tracking-[0.14em] text-[var(--ink-500)] mb-2 px-2 flex justify-between items-center">
                           {group}
-                          <span className="text-[var(--vt-text-muted)] opacity-70 text-[10px]">Source earmark active</span>
+                          <span className="text-[var(--ink-400)] opacity-70 text-[10px]">Source earmark active</span>
                         </h3>
                         <div className="space-y-1">
                           {groupedResults[group].map((item: any) => {
@@ -391,25 +396,25 @@ export function CommandPalette() {
                                   "relative w-full flex items-start gap-3 p-3 pl-4 rounded-[6px] text-left border transition-colors group",
                                   "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:transition-colors",
                                   selected
-                                    ? "bg-[color-mix(in_oklab,var(--vt-accent)_14%,transparent)] border-[var(--vt-accent)] before:bg-[var(--vt-accent)]"
-                                    : "bg-transparent border-transparent hover:bg-[var(--vt-surface-subtle)] before:bg-transparent"
+                                    ? "bg-[color-mix(in_oklch,var(--accent)_10%,transparent)] border-[var(--accent)] before:bg-[var(--accent)]"
+                                    : "bg-transparent border-transparent hover:bg-[var(--ink-50)] before:bg-transparent"
                                 )}
                               >
-                                <div className={cn("p-1.5 rounded-[4px] shrink-0 mt-0.5 transition-colors", selected ? "bg-[color-mix(in_oklab,var(--vt-accent)_18%,transparent)] text-[var(--vt-accent)]" : item._meta.color)}>
+                                <div className={cn("p-1.5 rounded-[4px] shrink-0 mt-0.5 transition-colors", selected ? "bg-[color-mix(in_oklch,var(--accent)_15%,transparent)] text-[var(--accent)]" : item._meta.color)}>
                                   <Icon className="w-4 h-4" />
                                 </div>
                                 <div className="flex-1 min-w-0">
                                   <div className="flex items-center justify-between gap-2 mb-0.5">
-                                    <span className={cn("font-medium truncate transition-colors", selected ? "text-[var(--vt-text-primary)]" : "text-[var(--vt-text-secondary)]")}>
+                                    <span className={cn("font-medium truncate transition-colors", selected ? "text-[var(--ink-900)]" : "text-[var(--ink-700)]")}>
                                       {item.title}
                                     </span>
                                   </div>
-                                  <p className="text-xs font-[family-name:var(--font-geist-mono)] text-[var(--vt-text-muted)] line-clamp-1 transition-colors">
+                                  <p className="text-xs font-[family-name:var(--font-geist-mono)] text-[var(--ink-500)] line-clamp-1 transition-colors">
                                     {item.snippet}
                                   </p>
                                 </div>
                                 {selected && (
-                                  <div className="shrink-0 flex items-center justify-center h-full text-[var(--vt-accent)] mt-1">
+                                  <div className="shrink-0 flex items-center justify-center h-full text-[var(--accent)] mt-1">
                                     <ChevronRight className="w-4 h-4" />
                                   </div>
                                 )}
@@ -424,12 +429,12 @@ export function CommandPalette() {
               </div>
 
               {/* Footer */}
-              <div className="flex-none p-2 border-t border-[var(--vt-border)] bg-transparent text-[10px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] text-[var(--vt-text-muted)] flex items-center justify-between px-4">
+              <div className="flex-none p-2 border-t border-[var(--rule)] bg-transparent text-[10px] uppercase tracking-wide font-[family-name:var(--font-geist-mono)] text-[var(--ink-500)] flex items-center justify-between px-4">
                 <div className="flex items-center gap-3">
-                  <span className="flex items-center gap-1"><kbd className="bg-[var(--vt-surface-subtle)] border border-[var(--vt-border)] px-1 rounded-[3px]">↑↓</kbd> to navigate</span>
-                  <span className="flex items-center gap-1"><kbd className="bg-[var(--vt-surface-subtle)] border border-[var(--vt-border)] px-1 rounded-[3px]">↵</kbd> to select</span>
+                  <span className="flex items-center gap-1"><kbd className="bg-[var(--paper-2)] border border-[var(--rule)] px-1 rounded-[3px]">↑↓</kbd> to navigate</span>
+                  <span className="flex items-center gap-1"><kbd className="bg-[var(--paper-2)] border border-[var(--rule)] px-1 rounded-[3px]">↵</kbd> to select</span>
                 </div>
-                <div className="flex items-center gap-1.5"><span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--vt-accent)]" /> VitalCV · your career wallet</div>
+                <div className="flex items-center gap-1.5"><span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent)]" /> VitalCV · your career wallet</div>
               </div>
             </motion.div>
           </div>

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -295,15 +295,19 @@
 /* Frosted paper glass. Reads best over ambient washes / imagery / the
    constellation; over flat paper it's a soft raised card with a light top edge. */
 .mz-glass {
-  background: color-mix(in oklch, var(--card) 74%, transparent);
+  /* Legible on flat paper (whiter fill, defined hairline, a close grounding
+     shadow) while staying frosted — the blur still refracts over ambient
+     washes / imagery / the constellation. */
+  background: color-mix(in oklch, var(--card) 88%, transparent);
   -webkit-backdrop-filter: blur(18px) saturate(150%);
   backdrop-filter: blur(18px) saturate(150%);
-  border: 1px solid color-mix(in oklch, var(--ink-900) 9%, transparent);
+  border: 1px solid color-mix(in oklch, var(--ink-900) 13%, transparent);
   border-radius: 10px;
   box-shadow:
-    inset 0 1px 0 0 color-mix(in oklch, white 55%, transparent),      /* top inner light — neuromorphic lift */
+    inset 0 1px 0 0 color-mix(in oklch, white 62%, transparent),      /* top inner light — neuromorphic lift */
     inset 0 -1px 0 0 color-mix(in oklch, var(--ink-900) 4%, transparent),
-    0 22px 55px -30px color-mix(in oklch, var(--ink-900) 42%, transparent); /* soft float */
+    0 2px 6px -3px color-mix(in oklch, var(--ink-900) 10%, transparent),   /* close grounding */
+    0 24px 55px -32px color-mix(in oklch, var(--ink-900) 40%, transparent); /* soft float */
 }
 /* A deeper elevation for modals / hero moments. */
 .mz-glass-strong {

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -11,32 +11,33 @@
  */
 
 .mz {
-  /* Paper & ink */
-  --paper: #f4f2ec;
-  --paper-2: #efede7;
-  --card: #ffffff;
-  --ink-950: #050504;
-  --ink-900: #0f0e0c;
-  --ink-800: #1a1916;
-  --ink-700: #2d2c28;
-  --ink-600: #474540;
-  --ink-500: #6b6860;
-  --ink-400: #96938a;
-  --ink-300: #c2bfb5;
-  --ink-200: #dddbd3;
-  --ink-100: #efede7;
-  --ink-50: #f7f6f2;
-  --rule: #dddbd3;
-  --rule-soft: #eceae4;
+  /* Paper & ink — Calm Wave D56 exact tokens. Warm near-white paper (hue 85),
+     cool blue-black ink (hue 265). oklch, as the source design authored them. */
+  --paper:   oklch(98.5% 0.004 85);
+  --paper-2: oklch(97% 0.008 85);
+  --card:    oklch(99.4% 0.002 85);
+  --ink-950: oklch(12% 0.012 265);
+  --ink-900: oklch(18% 0.012 265);
+  --ink-800: oklch(26% 0.012 265);
+  --ink-700: oklch(34% 0.011 265);
+  --ink-600: oklch(46% 0.010 265);
+  --ink-500: oklch(62% 0.008 265);
+  --ink-400: oklch(72% 0.007 265);
+  --ink-300: oklch(82% 0.007 265);
+  --ink-200: oklch(88% 0.007 265);
+  --ink-100: oklch(93% 0.006 265);
+  --ink-50:  oklch(96.5% 0.005 85);
+  --rule:      oklch(86% 0.008 265 / 0.9);
+  --rule-soft: oklch(90% 0.007 265 / 0.7);
 
-  /* Truth states */
-  --ok: #1c5c38;        --ok-bg: #f0faf5;      --ok-rule: #86c9a6;
-  --watch: #7d5a1e;     --watch-bg: #fdf4e7;   --watch-rule: #c9a84c;
-  --unknown: #3f3d38;   --unknown-bg: #f1efe9; --unknown-rule: #c8c4ba;
-  --p0: #7a1414;        --p0-bg: #fef2f2;      --p0-rule: #f5a5a5;
+  /* Truth states — paired ink + wash + rule (design values, never neon) */
+  --ok: oklch(46% 0.10 152);        --ok-bg: oklch(94% 0.03 152);       --ok-rule: oklch(80% 0.06 152);
+  --watch: oklch(54% 0.10 78);      --watch-bg: oklch(95% 0.04 78);     --watch-rule: oklch(82% 0.07 78);
+  --unknown: oklch(48% 0.008 265);  --unknown-bg: oklch(94% 0.005 265); --unknown-rule: oklch(85% 0.006 265);
+  --p0: oklch(48% 0.16 25);         --p0-bg: oklch(94% 0.04 25);        --p0-rule: oklch(82% 0.09 25);
 
-  /* Editorial accent (italic display words) */
-  --accent: #4f46e5;
+  /* Single accent — ink-indigo (deep, muted — not the old bright #4f46e5) */
+  --accent: oklch(38% 0.14 274);
 
   /* Fonts — reuse the app's exposed variables (Geist/serif/mono → system fallbacks) */
   --mz-sans: var(--font-geist, var(--vt-font-body, ui-sans-serif, system-ui, sans-serif));

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -283,8 +283,114 @@
   background-size: 22px 22px;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════════
+   CALM GLASS — the "calm glass" synthesis layer (2026-07-07).
+   Calm Wave stays the substrate (paper, ink, Fraunces/Geist, hairlines); this
+   adds a restrained frosted-translucent + soft-neuromorphic treatment for the
+   FLOATING surfaces only (nav, cards, modals, hero card, constellation frame).
+   Light-palette glass — paper-tinted translucency, never dark, never glossy-
+   plasticky. Reusable across every persona so the platform reads as one system.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Frosted paper glass. Reads best over ambient washes / imagery / the
+   constellation; over flat paper it's a soft raised card with a light top edge. */
+.mz-glass {
+  background: color-mix(in oklch, var(--card) 74%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  backdrop-filter: blur(18px) saturate(150%);
+  border: 1px solid color-mix(in oklch, var(--ink-900) 9%, transparent);
+  border-radius: 10px;
+  box-shadow:
+    inset 0 1px 0 0 color-mix(in oklch, white 55%, transparent),      /* top inner light — neuromorphic lift */
+    inset 0 -1px 0 0 color-mix(in oklch, var(--ink-900) 4%, transparent),
+    0 22px 55px -30px color-mix(in oklch, var(--ink-900) 42%, transparent); /* soft float */
+}
+/* A deeper elevation for modals / hero moments. */
+.mz-glass-strong {
+  background: color-mix(in oklch, var(--card) 82%, transparent);
+  -webkit-backdrop-filter: blur(26px) saturate(160%);
+  backdrop-filter: blur(26px) saturate(160%);
+  border: 1px solid color-mix(in oklch, var(--ink-900) 10%, transparent);
+  border-radius: 14px;
+  box-shadow:
+    inset 0 1px 0 0 color-mix(in oklch, white 62%, transparent),
+    0 40px 90px -44px color-mix(in oklch, var(--ink-900) 50%, transparent);
+}
+/* A faint recessed glass — inputs, insets (soft neuromorphic press). */
+.mz-glass-inset {
+  background: color-mix(in oklch, var(--paper-2) 70%, transparent);
+  border: 1px solid var(--rule-soft);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 3px color-mix(in oklch, var(--ink-900) 6%, transparent);
+}
+/* Interactive glass: a natural spring lift on hover, accent-tinted rim. */
+.mz-glass-interactive {
+  transition: transform var(--mz-dur) var(--mz-ease),
+    box-shadow var(--mz-dur) var(--mz-ease),
+    border-color var(--mz-dur) var(--mz-ease);
+  will-change: transform;
+}
+.mz-glass-interactive:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in oklch, var(--accent) 40%, var(--rule));
+  box-shadow:
+    inset 0 1px 0 0 color-mix(in oklch, white 60%, transparent),
+    0 30px 70px -34px color-mix(in oklch, var(--ink-900) 48%, transparent),
+    0 0 0 4px color-mix(in oklch, var(--accent) 8%, transparent);
+}
+
+/* Ambient wash — a calm, static color field that gives glass something to
+   refract. Never a hard gradient band; fades to nothing. Persona-accent tinted. */
+.mz-ambient { position: relative; isolation: isolate; }
+.mz-ambient::before {
+  content: '';
+  position: absolute; inset: -10% -5% auto -5%; height: 60%;
+  z-index: -1; pointer-events: none;
+  background:
+    radial-gradient(60% 80% at 18% 0%, color-mix(in oklch, var(--accent) 10%, transparent), transparent 60%),
+    radial-gradient(50% 70% at 88% 8%, color-mix(in oklch, var(--ok) 7%, transparent), transparent 62%);
+}
+
+/* ── Natural motion — entrance reveals + calm springs ─────────────────────── */
+
+@keyframes mz-rise {
+  from { opacity: 0; transform: translateY(16px) scale(0.985); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes mz-fade { from { opacity: 0; } to { opacity: 1; } }
+
+/* Reveal-on-view: paired with the <Reveal> component, which adds `.is-in` when
+   the element scrolls into view. Staggerable via --mz-delay. The default state
+   is hidden so nothing flashes before the observer fires. */
+.mz-reveal { opacity: 0; }
+.mz-reveal.is-in {
+  animation: mz-rise var(--mz-rise-dur, 720ms) var(--mz-ease) var(--mz-delay, 0ms) both;
+}
+.mz-reveal-fade.is-in { animation-name: mz-fade; }
+
+/* A calm attention pulse for "a pleasant surprise" moments (new evidence, a
+   state settling). One shot, never looping. */
+@keyframes mz-settle {
+  0% { transform: scale(0.96); opacity: 0.4; }
+  60% { transform: scale(1.015); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+.mz-settle { animation: mz-settle 560ms var(--mz-ease) both; }
+
+/* ── Per-persona accent identity — one system, four voices ─────────────────
+   Each persona surface sets --accent (the single accent the whole .mz layer
+   already threads through chips, links, glass rims, selected states). Distinct
+   hue per audience, all at the same calm depth/chroma so they read as siblings. */
+.mz-persona-holder   { --accent: oklch(38% 0.14 274); } /* indigo — the clinician's home */
+.mz-persona-verifier { --accent: oklch(44% 0.11 235); } /* trust-blue — the reader */
+.mz-persona-issuer   { --accent: oklch(46% 0.13 300); } /* violet — the attester */
+.mz-persona-employer { --accent: oklch(46% 0.10 152); } /* source-green — the hirer / start */
+
 /* ── Motion respect ───────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
   .mz *, .mz *::before, .mz *::after { transition: none !important; animation: none !important; }
+  .mz-reveal, .mz-reveal.is-in { opacity: 1 !important; animation: none !important; }
+  .mz-glass-interactive:hover { transform: none; }
+  .mz-settle { animation: none !important; }
 }


### PR DESCRIPTION
## What

Adopts the **Calm Wave D56** design bundle **in full** + the **"calm glass" synthesis** across the entire platform — one cohesive, investor-legible system, four persona voices.

## Root fixes
- **Real fonts** (Fraunces / Geist / Geist Mono via `next/font`, self-hosted/CSP-safe) — the app was rendering system stacks; this was most of "the font problem."
- **Design-exact oklch color** — warm paper, cool blue-black ink, deep ink-indigo accent, source-truthful truth-state chips.

## Foundation (reusable)
`matcha-zen.css`: `.mz-glass`/`-strong`/`-inset`/`-interactive` (frosted translucency + soft neuromorphic light/float, tuned to hold weight on flat paper), `.mz-ambient` wash, per-persona accents (`.mz-persona-{holder|verifier|issuer|employer}` = indigo · trust-blue · violet · source-green). `components/motion/Reveal.tsx`: IntersectionObserver entrance primitive (rise+fade, staggerable, reduced-motion-safe).

## Homepage — now a clinician-career story with a legible moat
- Hero: **"Find the opportunity. Prove your career once. *Start faster.*"** + career-network subhead.
- **New "Why this compounds" moat section**: portable/owned evidence → compounding acceptance → network velocity, with the shared `RECOGNITION → ACCEPTANCE → START` loop and "start 10× faster" framed strictly as the goal. This is the cohesive core all three personas share.
- Full calm (dark hero/constellation panels removed), frosted NPI card, wallet preview truth chips, constellation bleeds into the page.

## Every persona (two orchestrated workflows, both cohesion-reviewed **GO/SHIP**)
- **Holder**: home surface + **all child components** (ClinicianPanels, CareerCompass, ProductLoopRail, RecognitionCard, MATCHA activity, status/support) + dark siblings (settings, timeline, opportunity detail, applications).
- **Verifier**: `/verify` + `/verify/[npi]` calm reading room (trust-blue).
- **Issuer**: `/issuer/review` **and** `/issuer/policy-review` (violet) — every "recordedBy: demo" / "not final verification" disclaimer preserved verbatim.
- **Employer**: `/pilot` source-green ROI / Time-to-Start landing with glass KPI tiles.

## Verification
- `pnpm turbo run build --filter @vitalcv/web` **green**.
- Tests green across every affected suite: homepage guards (updated deliberately with the new copy), holder-home, holder-route-contract 150/150, recognition-card, issuer-policy, pilot/buyer proof, mobile-launch-analytics, matcha-career-compass (220+ total).
- No banned strings; no bare "Verified"; no hardcoded hex; every honesty disclaimer, `data-*`, `href`, `aria-*` preserved verbatim (styling-only).
- Verified live: homepage (real Fraunces, moat section, wallet chips), employer page, constellation (pixel-sampled), glass definition (computed styles).

## Still open (owner action)
- Signed-in surfaces (holder, verifier) are Clerk-gated — I can't preview them; a browser pass would be the final confirmation.
- Verifier child panels (ProvenanceStrip etc.) + admin surfaces not yet swept (lower-traffic; can be a follow-up).

## Design Handoff References
Implements the Calm Wave D56 bundle (`vitalcv (11).zip`) via the in-repo `.mz` layer, extended with the approved calm-glass synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)