### PR TITLE
fix(ux): per-diem option, accent meters, KPI token fit, icon micro-interactions

### DIFF
--- a/apps/web/app/HomePageClient.tsx
+++ b/apps/web/app/HomePageClient.tsx
@@ -854,7 +854,7 @@ export default function HomePageClient() {
                       >
                         <span
                           aria-hidden="true"
-                          className="flex h-8 w-8 items-center justify-center rounded-[3px] bg-[color-mix(in_oklab,var(--vt-accent-emerald)_14%,transparent)] text-[var(--vt-accent-emerald)]"
+                          className="mz-pop flex h-8 w-8 items-center justify-center rounded-[3px] bg-[color-mix(in_oklab,var(--vt-accent-emerald)_14%,transparent)] text-[var(--vt-accent-emerald)]"
                         >
                           <Icon size={16} />
                         </span>
@@ -890,7 +890,7 @@ export default function HomePageClient() {
                   >
                     <span
                       aria-hidden="true"
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
+                      className="mz-pop flex h-9 w-9 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
                     >
                       <Icon size={17} />
                     </span>
@@ -929,7 +929,7 @@ export default function HomePageClient() {
                   >
                     <span
                       aria-hidden="true"
-                      className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
+                      className="mz-pop mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--vt-border)] text-[var(--vt-text-primary)]"
                     >
                       <Icon size={16} />
                     </span>

--- a/apps/web/app/pilot/page.tsx
+++ b/apps/web/app/pilot/page.tsx
@@ -69,11 +69,13 @@ const PILOT_KPI_SAMPLES = [
     label: 'Proof-pack export formats',
     value: 'JSON · ZIP · PDF',
     note: 'Manifest references in every export',
+    token: true,
   },
   {
     label: 'Audit record per export',
     value: 'ARTIFACT_EXPORTED',
     note: 'Records an audit event before the bundle returns',
+    token: true,
   },
 ] as const;
 
@@ -141,7 +143,15 @@ export default function PilotPage() {
               <div className="mz-mono mb-2 text-[11px] uppercase tracking-[0.16em] text-[var(--vt-text-muted)]">
                 {kpi.label}
               </div>
-              <div className="text-[1.7rem] font-semibold leading-none tracking-tight text-[var(--vt-text-primary)] [font-variant-numeric:tabular-nums]">
+              {/* System tokens (event names, format lists) render as mono at a
+                  size that stays inside the tile; numbers keep the big stat cut. */}
+              <div
+                className={
+                  'token' in kpi && kpi.token
+                    ? 'mz-mono text-[1.05rem] font-semibold leading-snug tracking-[0.01em] text-[var(--vt-text-primary)] [overflow-wrap:anywhere]'
+                    : 'text-[1.7rem] font-semibold leading-none tracking-tight text-[var(--vt-text-primary)] [font-variant-numeric:tabular-nums]'
+                }
+              >
                 {kpi.value}
               </div>
               <div className="mz-mono mt-2 text-[10.5px] uppercase tracking-[0.1em] text-[var(--vt-text-muted)]">
@@ -160,7 +170,7 @@ export default function PilotPage() {
               delay={i * 80}
               className="mz-glass mz-glass-interactive rounded-[12px] p-5"
             >
-              <div className="mb-4 inline-flex rounded-[3px] border border-[var(--rule)] bg-[var(--paper-2)] p-2.5 text-[var(--accent)]">
+              <div className="mz-pop mb-4 inline-flex rounded-[3px] border border-[var(--rule)] bg-[var(--paper-2)] p-2.5 text-[var(--accent)]">
                 {step.icon}
               </div>
               <h3 className="mz-h2">{step.title}</h3>

--- a/apps/web/components/matcha/PublicMatchaExperience.tsx
+++ b/apps/web/components/matcha/PublicMatchaExperience.tsx
@@ -67,9 +67,10 @@ const QUESTIONS: QuickQuestion[] = [
     multi: true,
     options: [
       { value: 'full_time', label: 'Full time' },
+      { value: 'part_time', label: 'Part time' },
+      { value: 'per_diem', label: 'Per diem' },
       { value: 'locums', label: 'Locums' },
       { value: 'telehealth', label: 'Telehealth' },
-      { value: 'part_time', label: 'Part time' },
     ],
   },
   {

--- a/apps/web/styles/matcha-zen.css
+++ b/apps/web/styles/matcha-zen.css
@@ -271,10 +271,14 @@
 .mz-opt:hover { border-color: var(--ink-400); }
 .mz-opt[aria-pressed='true'] { border-color: var(--ink-900); background: var(--ink-900); color: #fff; }
 
-/* ── Progress meter (ink, no gradient) ────────────────────────────────────── */
+/* ── Progress meter (accent fill, no gradient) ────────────────────────────── */
 
 .mz-meter { height: 5px; border-radius: 999px; background: var(--ink-100); overflow: hidden; }
-.mz-meter > span { display: block; height: 100%; background: var(--ink-800); border-radius: 999px; transition: width var(--mz-dur) var(--mz-ease); }
+/* Accent, not ink: a near-black bar reads as an error/void. The fill follows
+   the surface persona (holder indigo, employer green, …). */
+.mz-meter > span { display: block; height: 100%; background: var(--accent); border-radius: 999px; transition: width var(--mz-dur) var(--mz-ease); }
+/* Source-backed contexts can opt into the ok-green fill. */
+.mz-meter-ok > span { background: var(--ok); }
 
 /* ── Dotted grid backdrop (static, calm) ──────────────────────────────────── */
 
@@ -391,6 +395,36 @@
 .mz-persona-employer { --accent: oklch(46% 0.10 152); } /* source-green — the hirer / start */
 .mz-persona-admin    { --accent: oklch(46% 0.03 250); } /* steel-graphite — internal control room, not a customer surface */
 
+/* ── Micro-interactions — icons + small elements answer the hand ──────────── */
+
+/* .mz-pop on an icon (or icon chip) makes it respond when its interactive
+   parent is hovered: a small lift + tilt toward the accent. Natural, one-shot,
+   never looping — the "pleasant surprise" register. */
+.mz-pop {
+  transition:
+    transform var(--mz-dur) var(--mz-ease),
+    color var(--mz-dur) var(--mz-ease),
+    border-color var(--mz-dur) var(--mz-ease),
+    background var(--mz-dur) var(--mz-ease);
+  will-change: transform;
+}
+.mz-glass-interactive:hover .mz-pop,
+.mz-interactive:hover .mz-pop,
+a:hover .mz-pop,
+button:hover .mz-pop {
+  transform: translateY(-2px) scale(1.07) rotate(-3deg);
+  color: var(--accent);
+  border-color: color-mix(in oklch, var(--accent) 45%, var(--rule));
+}
+
+/* CTA arrows nudge forward on hover. */
+.mz-btn svg, .mz-btn-ghost svg { transition: transform var(--mz-dur) var(--mz-ease); }
+.mz-btn:hover svg, .mz-btn-ghost:hover svg { transform: translateX(3px); }
+
+/* Selectable chips answer with a tiny lift. */
+.mz-opt { will-change: transform; transition: border-color var(--mz-dur) var(--mz-ease), background var(--mz-dur) var(--mz-ease), transform var(--mz-dur) var(--mz-ease); }
+.mz-opt:hover { transform: translateY(-1px); }
+
 /* ── Motion respect ───────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -398,4 +432,10 @@
   .mz-reveal, .mz-reveal.is-in { opacity: 1 !important; animation: none !important; }
   .mz-glass-interactive:hover { transform: none; }
   .mz-settle { animation: none !important; }
+  .mz-glass-interactive:hover .mz-pop,
+  .mz-interactive:hover .mz-pop,
+  a:hover .mz-pop,
+  button:hover .mz-pop { transform: none; }
+  .mz-opt:hover { transform: none; }
+  .mz-btn:hover svg, .mz-btn-ghost:hover svg { transform: none; }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
@@ -342,7 +342,7 @@ importers:
         version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       stripe:
         specifier: ^20.4.0
-        version: 20.4.0(@types/node@20.19.27)
+        version: 20.4.0(@types/node@25.2.1)
       supercluster:
         specifier: ^7.1.3
         version: 7.1.5
@@ -351,7 +351,7 @@ importers:
         version: 5.0.1(express@4.22.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.2.1)(typescript@5.9.3)
       web-did-resolver:
         specifier: ^2.0.30
         version: 2.0.32
@@ -379,7 +379,7 @@ importers:
         version: 4.1.8
       jest:
         specifier: ^29.0.0
-        version: 29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+        version: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -391,7 +391,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.0.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -14705,6 +14705,41 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.27
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -19320,6 +19355,21 @@ snapshots:
       - supports-color
       - ts-node
 
+  create-jest@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-require@1.1.1: {}
 
   cross-fetch@3.2.0:
@@ -21684,6 +21734,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
@@ -21711,6 +21780,68 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.27
       ts-node: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.27
+      ts-node: 10.9.2(@types/node@25.2.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.2.1
+      ts-node: 10.9.2(@types/node@25.2.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21942,6 +22073,18 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24771,9 +24914,9 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@20.4.0(@types/node@20.19.27):
+  stripe@20.4.0(@types/node@25.2.1):
     optionalDependencies:
-      '@types/node': 20.19.27
+      '@types/node': 25.2.1
 
   structured-headers@0.4.1: {}
 
@@ -25130,12 +25273,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.5)
       jest-util: 29.7.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.27)(ts-node@10.9.2(@types/node@20.19.27)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.2.1)(ts-node@10.9.2(@types/node@25.2.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
## What — four product-feedback fixes

1. **Per diem in MATCHA's "How do you want to work?"** — the homepage public quiz omitted it even though the type union, the engine mapping (`per_diem → prn`), and the signed-in onboarding all support it. Added, and options reordered to match the signed-in onboarding. Verified live in preview.
2. **Progress bars are never black** — `.mz-meter` now fills with the persona **accent** (was `--ink-800` near-black); new `.mz-meter-ok` variant for source-backed contexts. Wallet-preview meter verified `oklch(0.38 0.14 274)` indigo.
3. **`ARTIFACT_EXPORTED` fits its KPI tile** — token values (event names, format lists) render as wrap-safe Geist Mono sized to the tile; numeric stats keep the big cut. Pixel-verified zero overflow.
4. **Icons + elements answer the hand** — new `.mz-pop` micro-interaction (icon chips lift/tilt toward the accent when their card/link is hovered), CTA arrow nudge on `.mz-btn` hover, tiny lift on `.mz-opt` chips. Applied across homepage AI/value/role-door cards + pilot scope chips; all neutralized under `prefers-reduced-motion`.

## Verification
- pilot-proof + buyer-proof + homepage guards: **31/31 green**; lint clean; `pnpm turbo run build` green.
- Preview-verified all four (quiz chip present at the work-style step; meter computed style; KPI tile scrollWidth == clientWidth; 15 pop-wired icons on the homepage).

## Design Handoff References
Extends the shipped Calm Wave D56 + calm-glass `.mz` system (#598/#599); no new design assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)