### PR TITLE
fix(ingest): non-UUID ids crash source lanes + unique replay runId + surface identity errors

### DIFF
--- a/apps/api/backend/src/services/identity/identityIngestionPipeline.ts
+++ b/apps/api/backend/src/services/identity/identityIngestionPipeline.ts
@@ -1385,6 +1385,14 @@ async function executeSourceIngestion(input: {
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // Surface the per-source failure: it is otherwise only written to DB
+    // columns (quarantineReason/lastError), invisible in logs — which hid the
+    // prod "sourcesFailed" root cause. Now every failed lane says why.
+    log('warn', 'identity_source_failed', {
+      source: input.sourceId,
+      npi: input.npi,
+      error: message,
+    });
 
     if (sourceRecordId) {
       await identityPrisma.sourceRecord.update({

--- a/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
+++ b/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
@@ -40,7 +40,7 @@ async function persistRunIdOnSourceRun(
   startedAt: Date,
 ): Promise<void> {
   if (!sourceRunId || !UUID_RE.test(sourceRunId)) return;
-  const runId = deriveRunId(`${npi}:${startedAt.toISOString()}`);
+  const runId = deriveRunId(`${npi}:${sourceRunId}:${startedAt.toISOString()}`);
 
   // Chain linker: find the most recent prior run for the same NPI + source
   // to establish replay continuity: new_run.priorRunId = latest_prior.runId
@@ -225,10 +225,18 @@ async function finalizeSourceResult(
       ? effectiveStatus
       : (result?.status ?? effectiveStatus);
 
+  // The source_run FK column is @db.Uuid: a non-UUID synthetic id (e.g. a
+  // launch-lane placeholder) would throw and fail the ENTIRE lane. Only
+  // persist a real UUID; otherwise null (the lane has no identity SourceRun).
+  const persistSourceRunId =
+    result?.sourceRunId && UUID_RE.test(result.sourceRunId) ? result.sourceRunId : null;
+  const persistArtifactId =
+    result?.artifactId && UUID_RE.test(result.artifactId) ? result.artifactId : null;
+
   await updateIngestSourceRun(runId, sourceId, {
     status: persistStatus,
-    sourceRunId: result?.sourceRunId ?? null,
-    artifactId: result?.artifactId ?? null,
+    sourceRunId: persistSourceRunId,
+    artifactId: persistArtifactId,
     claimCount: result?.claimsEmitted ?? 0,
     credentialCount: credentialIds.length,
     errorCode: effectiveStatus === 'FAILED' ? 'SOURCE_FAILED' : null,
@@ -342,7 +350,7 @@ async function runPipeline(runId: string, npi: string): Promise<void> {
           credentialIds: nursysCredIds,
           claimIds:      nursysClaim ? [nursysClaim.claimId] : [],
           artifactId:    nursysClaim?.artifactId ?? null,
-          sourceRunId:   `nursys-${npi}`,
+          sourceRunId:   undefined, // launch lane — no identity SourceRun row
           deltaEvents:   [],
           latencyMs:     0,
         });
@@ -394,7 +402,7 @@ async function runPipeline(runId: string, npi: string): Promise<void> {
           credentialIds,
           claimIds: licensureResult.claims.map((claim) => claim.claimId),
           artifactId: licensureResult.claims[0]?.artifactId ?? null,
-          sourceRunId: `physician-licensure-${npi}`,
+          sourceRunId: undefined, // launch lane — no identity SourceRun row
           deltaEvents: [],
           latencyMs: 0,
           error:


### PR DESCRIPTION
## Diagnosis (from the passport screenshot: OIG/LEIE + CMS PECOS "temporarily unavailable", readiness 14/100)

The public-source **fetches all succeed** (NPPES/OIG/PECOS return data — confirmed by a local run of the real pipeline: 7 claims, `sourcesFailed=0`, and the prod `trust-state` API shows good persisted data). The failures are **post-fetch persistence writes** that crash lanes and, in prod, leave a fresh ingest reporting sources as unavailable.

## Three fixes (all persistence-hardening — no source-fetch / truth-state / issuer-chain logic touched)

1. **Non-UUID ids crash whole lanes.** The physician-licensure (`fsmb`) and `nursys` launch lanes pass synthetic ids (`physician-licensure-${npi}`, `nursys-${npi}`) and non-UUID artifact ids (`psv-…`) into `ingest_source_runs.source_run_id` / `artifact_id` — **both `@db.Uuid`** — so `updateIngestSourceRun` throws *"Error creating UUID, invalid character"* and the lane is marked `ERROR`. `finalizeSourceResult` now guards **both** UUID FK columns (persist only a real UUID, else `null` — these launch lanes have no identity `SourceRun`/artifact to reference), and the two synthetic ids are nulled at source. **Repro: `fsmb` went `ERROR → DONE`, all UUID errors gone.**

2. **Replay `runId` `@unique` collision.** `deriveRunId(npi:startedAt)` produced the *same* id for every source in a run (shared `startedAt`), so the 2nd/3rd source's `sourceRun.update({ runId })` violated the unique constraint (`replay_writer_failed`) — leaving `run_id` NULL and breaking replay chronology. Now the per-source `sourceRunId` is folded into the derivation.

3. **Swallowed identity errors.** The identity pipeline wrote per-source failures only to DB columns (`quarantineReason`/`lastError`) — invisible in logs, which hid the prod `sourcesFailed=3` root cause. Added an `identity_source_failed` warn log so every failed lane says why. **This will surface the exact prod OIG/PECOS reason on the next deploy** (that specific failure does not reproduce locally — it's environment-specific — so this is the diagnostic hook to close it out).

## Verification
- Local orchestrator repro (the passport's exact path): all lanes `DONE`, **zero** UUID/constraint/`replay_writer_failed` errors.
- Backend ingest suites **24/24** (`ingestOrchestrator`, `ingestStream`, `identityIngestionPipeline`, `ingest.routes`); `tsc` clean; backend build 15/15.

## Follow-up
Prod OIG/PECOS "unavailable" is not yet fully root-caused (doesn't repro locally; prod DB is on an internal host). Fix #3's new log will reveal it post-deploy for a targeted follow-up. Separately noted (non-fatal, out of scope): a `learningEvent` `evt_…`→uuid write and a copilot `acgme_code` field-name query error appear in prod logs.

## Design Handoff References
No design handoff — backend persistence fix only; no UI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)