### PR TITLE
fix(db): realign verification_receipt_records to schema (prod drift broke all source lanes)

### DIFF
--- a/apps/api/backend/prisma/migrations/20260708021500_fix_verification_receipt_records_prod_drift/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260708021500_fix_verification_receipt_records_prod_drift/migration.sql
@@ -1,0 +1,27 @@
+-- Prod `verification_receipt_records` had drifted from the Prisma schema:
+--   * match_confidence was `double precision` (schema: text) → the Prisma
+--     client's binary bind desynced and every verificationReceiptRecord.create()
+--     failed with Postgres 08P01 "insufficient data left in message";
+--   * id had no `gen_random_uuid()` default (schema: dbgenerated) → null-id
+--     violation once the type mismatch was fixed;
+--   * retrieved_at was `timestamp` (schema: timestamptz(6)).
+-- The net effect: every identity source (NPPES/OIG/PECOS) reported
+-- "temporarily unavailable" on a fresh passport ingest, and readiness stuck low.
+-- This realigns the columns to the schema. Idempotent + guarded so it is a
+-- no-op on databases already at the correct types (e.g. fresh migrate deploy).
+DO $$
+BEGIN
+  IF (SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'verification_receipt_records' AND column_name = 'match_confidence') = 'double precision' THEN
+    ALTER TABLE "verification_receipt_records"
+      ALTER COLUMN "match_confidence" TYPE text USING "match_confidence"::text;
+  END IF;
+
+  IF (SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'verification_receipt_records' AND column_name = 'retrieved_at') = 'timestamp without time zone' THEN
+    ALTER TABLE "verification_receipt_records"
+      ALTER COLUMN "retrieved_at" TYPE timestamptz(6) USING "retrieved_at" AT TIME ZONE 'UTC';
+  END IF;
+
+  ALTER TABLE "verification_receipt_records" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+END $$;


### PR DESCRIPTION
## The user-visible bug
On the passport (`/passport?npi=…`), **OIG/LEIE and CMS PECOS showed "temporarily unavailable"** and readiness stuck at **14/100** — even though the public sources fetch fine.

## Root cause (prod-only schema drift on one table)
Surfaced by the `identity_source_failed` logging added in #602, then confirmed by reading the prod table directly: prod's `verification_receipt_records` had **drifted from the Prisma schema**, so `verificationReceiptRecord.create()` failed on every identity source:
- `match_confidence` was **`double precision`** (schema: `text`) → binary-bind desync → Postgres **`08P01` "insufficient data left in message"** on every create.
- `id` had **no `gen_random_uuid()` default** (schema: `dbgenerated`) → null-id violation once the type was fixed.
- `retrieved_at` was **`timestamp`** (schema: `timestamptz(6)`).

Because all three lanes write a receipt record, all three failed → `sourcesFailed=3, claimsTotal=0` → "temporarily unavailable".

## Fix
Applied the column realignment to prod **live** (the drifted columns were **100% NULL** across 133 rows — zero data risk), then captured it here as a **guarded, idempotent migration** (`DO $$ … information_schema checks … $$`) so it's tracked and any rebuilt / other environment self-heals. It re-runs as a clean no-op on an already-correct DB (validated against prod).

## Verified in prod
After the fix, a fresh ingest went **`sourcesFailed 3 → 0`, `claimsTotal 0 → 7`, credentials `0 → 4`**; trust-state now reports NPPES **checked**, PECOS **checked**, OIG/LEIE **review-required** (its honest state) — no more "temporarily unavailable".

## Follow-up (flagged, not in scope here)
Prod shows the same historical `db push` drift pattern elsewhere (`learning_events.id` uuid write, a `residency_programs` field-name query in copilot) — worth a broader **prod-vs-schema audit** to catch other silently-broken writes.

## Design Handoff References
No design handoff — a database schema realignment; no UI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)