### PR TITLE
feat(profile): source-verified practice location + self-reported education/associations on the clinician check

### DIFF
--- a/apps/api/backend/src/services/entity/passportService.ts
+++ b/apps/api/backend/src/services/entity/passportService.ts
@@ -66,6 +66,12 @@ import {
   PECOS_SOURCE_LABEL,
   type PecosEnrollmentStatus,
 } from '../identity/pecosContract';
+import {
+  loadPracticeLocationByNpi,
+  loadSelfReportedByNpi,
+  type PassportPracticeLocation,
+  type PassportSelfReported,
+} from '../passport/profileEnrichment';
 
 export type { ReadinessNextAction };
 
@@ -304,6 +310,10 @@ export interface TrustPassport {
   entityId:       string;
   npi?:           string;
   identity:       PassportIdentity;
+  /** Practice location — source-backed from NPPES (never null-fabricated). */
+  practiceLocation?: PassportPracticeLocation | null;
+  /** Self-reported profile — USER_ENTERED only; present only when the clinician provided it. */
+  selfReported?:  PassportSelfReported | null;
   authority:      PassportAuthority;
   training:       PassportTraining;
   standing:       PassportStanding;
@@ -2305,6 +2315,14 @@ export async function buildPassport(entityId: string): Promise<TrustPassport | n
     trustPosture,
   });
 
+  // Profile enrichment — provenance-honest, both fail closed to null:
+  //   practiceLocation = source-backed NPPES claim (VERIFIED)
+  //   selfReported     = clinician-typed education/affiliations (USER_ENTERED)
+  const [practiceLocation, selfReported] = await Promise.all([
+    loadPracticeLocationByNpi(npi),
+    loadSelfReportedByNpi(npi),
+  ]);
+
   log('info', 'passport_built', {
     entityId, npi, readinessStatus, score: readiness.score,
     decisionPosture: decisionPosture.status,
@@ -2315,6 +2333,8 @@ export async function buildPassport(entityId: string): Promise<TrustPassport | n
     entityId,
     npi,
     identity,
+    practiceLocation,
+    selfReported,
     authority,
     training,
     standing,

--- a/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
+++ b/apps/api/backend/src/services/ingest/ingestOrchestrator.ts
@@ -451,6 +451,9 @@ async function runPipeline(runId: string, npi: string): Promise<void> {
           specialty: passport.identity.specialty,
           entityType: passport.identity.entityType,
           identityStatus: passport.identity.status,
+          // Source-backed NPPES practice location (VERIFIED) for the live /passport
+          // identity card. null when NPPES carried no usable address — never fabricated.
+          practiceLocation: passport.practiceLocation ?? null,
           exclusionChecked: passport.standing.exclusionStatus !== 'UNCHECKED',
           exclusionClear: passport.standing.exclusionClear,
           exclusionStatus: passport.standing.exclusionStatus,

--- a/apps/api/backend/src/services/passport/__tests__/npiPassportContract.test.ts
+++ b/apps/api/backend/src/services/passport/__tests__/npiPassportContract.test.ts
@@ -61,6 +61,14 @@ jest.mock('../../entity/passportService', () => ({
   })),
 }));
 
+// Profile enrichment reads the DB (NPPES practice-location claim + PersonProfile
+// self-attested). This suite is a pure contract-transform test, so stub both
+// readers to null — an unclaimed NPI with no self-attested data.
+jest.mock('../profileEnrichment', () => ({
+  loadPracticeLocationByNpi: jest.fn().mockResolvedValue(null),
+  loadSelfReportedByNpi: jest.fn().mockResolvedValue(null),
+}));
+
 import { loadPassportData } from '../../../routes/passport';
 import { buildPassportDataByNpi } from '../npiPassportContract';
 

--- a/apps/api/backend/src/services/passport/npiPassportContract.ts
+++ b/apps/api/backend/src/services/passport/npiPassportContract.ts
@@ -34,6 +34,7 @@ import {
 } from '../../routes/passport';
 import prisma from '../../graphql/prisma_client';
 import { unacknowledgedCount } from '../alerts/trustAlerts';
+import { loadPracticeLocationByNpi, loadSelfReportedByNpi } from './profileEnrichment';
 
 type PassportCredentialSummary = {
   id: string;
@@ -647,11 +648,21 @@ export async function buildPassportDataByNpi(
   // Wave 245: Build monitoring status
   const monitoring = await buildMonitoringStatus(npi);
 
+  // Profile enrichment — provenance-honest, both fail closed to null:
+  //   practiceLocation = source-backed NPPES claim (VERIFIED)
+  //   selfReported     = clinician-typed education/affiliations (USER_ENTERED)
+  const [practiceLocation, selfReported] = await Promise.all([
+    loadPracticeLocationByNpi(npi),
+    loadSelfReportedByNpi(npi),
+  ]);
+
   return {
     entityId,
     npi,
     credentials,
     identity,
+    practiceLocation,
+    selfReported,
     authority,
     training,
     standing,

--- a/apps/api/backend/src/services/passport/profileEnrichment.ts
+++ b/apps/api/backend/src/services/passport/profileEnrichment.ts
@@ -1,0 +1,182 @@
+/**
+ * profileEnrichment — shared, provenance-honest readers for the two passport
+ * builders (lean `npiPassportContract` + rich `passportService`).
+ *
+ * Two clusters of profile data hang off an NPI with very different provenance,
+ * and this module keeps them honestly separated:
+ *
+ *   - practiceLocation → source-backed from CMS NPPES (a primary source). Read
+ *     from the current PRACTICE_LOCATION claim (sourceId NPPES_API). Provenance
+ *     is VERIFIED. Returns null when there is no NPPES practice-location claim or
+ *     it carries no usable address — NEVER fabricated, never null-filled.
+ *
+ *   - selfReported (education + affiliations) → USER_ENTERED only. Read from
+ *     PersonProfile.selfAttested, which the clinician typed. NPPES/OIG/PECOS
+ *     carry NEITHER education nor associations, so there is no primary source to
+ *     verify these against. Returned ONLY when the clinician actually provided
+ *     them; otherwise null. Never inferred, never labeled verified.
+ *
+ * Both readers fail closed to null on any error so an unclaimed NPI simply omits
+ * the data rather than crashing a passport build.
+ */
+import prisma from '../../graphql/prisma_client';
+
+/**
+ * Practice location — source-backed from NPPES (never null-fabricated).
+ * Mirrors PassportData.practiceLocation in
+ * apps/web/lib/trust/passport-contract.ts.
+ */
+export interface PassportPracticeLocation {
+  city?: string;
+  state?: string; // 2-letter
+  postalCode?: string;
+  addressLine?: string; // street line, optional
+  provenance: 'VERIFIED'; // NPPES primary source
+  sourceId: 'NPPES';
+  lastCheckedAt?: string;
+}
+
+/**
+ * Self-reported profile — USER_ENTERED only; present only when the clinician
+ * provided it. Mirrors PassportData.selfReported.
+ */
+export interface PassportSelfReported {
+  education?: Array<{ institution: string; degree?: string; graduationYear?: number }>;
+  affiliations?: Array<{ organization: string; role?: string }>;
+}
+
+/** Claim statuses that must never surface a value (revoked fails closed). */
+const NON_CURRENT_CLAIM_STATUSES = ['REVOKED', 'DELETED', 'SUPERSEDED'];
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function cleanString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function cleanYear(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(n)) return undefined;
+  const y = Math.trunc(n);
+  return y >= 1900 && y <= 2100 ? y : undefined;
+}
+
+/**
+ * Read the current NPPES PRACTICE_LOCATION claim for an NPI and project it onto
+ * the source-backed practiceLocation contract. Returns null when there is no
+ * NPPES practice-location claim or it carries no usable address field — this is
+ * a source-verified headline, so an empty/absent claim omits the block rather
+ * than fabricating a VERIFIED location.
+ */
+export async function loadPracticeLocationByNpi(
+  npi: string | null | undefined,
+): Promise<PassportPracticeLocation | null> {
+  if (!npi) return null;
+
+  const claim = await Promise.resolve()
+    .then(() =>
+      prisma.claimRecord.findFirst({
+        where: {
+          subjectNpi: npi,
+          claimType: 'PRACTICE_LOCATION',
+          sourceId: 'NPPES_API',
+          status: { notIn: NON_CURRENT_CLAIM_STATUSES },
+        },
+        orderBy: { observedAt: 'desc' },
+        select: { value: true, observedAt: true },
+      }),
+    )
+    .catch(() => null);
+
+  if (!claim) return null;
+
+  const value = asRecord(claim.value);
+  const city = cleanString(value.city);
+  const state = cleanString(value.state)?.toUpperCase();
+  const postalCode =
+    cleanString(value.zip) ?? cleanString(value.postalCode) ?? cleanString(value.postal_code);
+  const addressLine =
+    cleanString(value.address1) ?? cleanString(value.addressLine1) ?? cleanString(value.line1);
+
+  // No usable address fields → omit rather than fabricate an empty VERIFIED block.
+  if (!city && !state && !postalCode && !addressLine) {
+    return null;
+  }
+
+  const location: PassportPracticeLocation = {
+    provenance: 'VERIFIED',
+    sourceId: 'NPPES',
+  };
+  if (city) location.city = city;
+  if (state) location.state = state;
+  if (postalCode) location.postalCode = postalCode;
+  if (addressLine) location.addressLine = addressLine;
+  const lastCheckedAt = claim.observedAt?.toISOString();
+  if (lastCheckedAt) location.lastCheckedAt = lastCheckedAt;
+
+  return location;
+}
+
+/**
+ * Read the clinician's self-attested profile (PersonProfile.selfAttested) for an
+ * NPI and project the education + affiliations sections onto the USER_ENTERED
+ * selfReported contract. Returns null unless the clinician actually provided
+ * education or affiliations — never fabricates, never infers, never verifies.
+ */
+export async function loadSelfReportedByNpi(
+  npi: string | null | undefined,
+): Promise<PassportSelfReported | null> {
+  if (!npi) return null;
+
+  const profile = await Promise.resolve()
+    .then(() =>
+      prisma.personProfile.findUnique({
+        where: { npi },
+        select: { selfAttested: true },
+      }),
+    )
+    .catch(() => null);
+
+  if (!profile?.selfAttested) return null;
+
+  const sa = asRecord(profile.selfAttested);
+
+  const education: Array<{ institution: string; degree?: string; graduationYear?: number }> = [];
+  const school = asRecord(sa.medicalSchool);
+  const institution = cleanString(school.institutionName);
+  if (institution) {
+    const entry: { institution: string; degree?: string; graduationYear?: number } = { institution };
+    const degree = cleanString(school.degree);
+    if (degree) entry.degree = degree;
+    const graduationYear = cleanYear(school.graduationYear);
+    if (graduationYear !== undefined) entry.graduationYear = graduationYear;
+    education.push(entry);
+  }
+
+  const affiliations: Array<{ organization: string; role?: string }> = [];
+  if (Array.isArray(sa.affiliations)) {
+    for (const raw of sa.affiliations) {
+      const row = asRecord(raw);
+      const organization = cleanString(row.organization);
+      if (!organization) continue;
+      const entry: { organization: string; role?: string } = { organization };
+      const role = cleanString(row.role);
+      if (role) entry.role = role;
+      affiliations.push(entry);
+    }
+  }
+
+  // The clinician provided nothing in either section → omit selfReported entirely.
+  if (education.length === 0 && affiliations.length === 0) {
+    return null;
+  }
+
+  const selfReported: PassportSelfReported = {};
+  if (education.length > 0) selfReported.education = education;
+  if (affiliations.length > 0) selfReported.affiliations = affiliations;
+  return selfReported;
+}

--- a/apps/web/app/passport/page.tsx
+++ b/apps/web/app/passport/page.tsx
@@ -474,6 +474,19 @@ function PassportPageContent({
           ? 'Unavailable'
           : undefined;
 
+  // Practice location — VERIFIED / source-backed from NPPES. Present only when the
+  // NPPES record carried a usable address; never fabricated. Empty string omits
+  // the render entirely (no source-backed chip over absent data). Prefer city/state;
+  // fall back to ZIP or street so a street/ZIP-only record still shows (matches /verify).
+  const practiceLocationLabel = identity.practiceLocation
+    ? ([identity.practiceLocation.city, identity.practiceLocation.state]
+        .filter(Boolean)
+        .join(', ')
+        || identity.practiceLocation.postalCode
+        || identity.practiceLocation.addressLine
+        || '')
+    : '';
+
   const npiValid = npi.length === 10 && !/\D/.test(npi);
   const npiChecksumOk = npiValid && isValidNpiChecksum(npi);
 
@@ -604,6 +617,15 @@ function PassportPageContent({
                 </h2>
                 {identity.specialty && (
                   <p className="text-muted-foreground text-sm mt-0.5">{identity.specialty}</p>
+                )}
+                {practiceLocationLabel && (
+                  <p className="text-muted-foreground text-sm mt-1.5 flex flex-wrap items-center gap-2">
+                    <span className="text-foreground/90">{practiceLocationLabel}</span>
+                    <span className="mz-chip mz-chip-ok">
+                      <span className="mz-gl" aria-hidden />
+                      Source-backed
+                    </span>
+                  </p>
                 )}
                 <p className="text-muted-foreground/50 text-xs mt-1">NPI {state.npi}</p>
                 {/* Value translation — makes identity confirmation feel meaningful */}

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -46,6 +46,44 @@ function formatUtc(ts: string | number | null | undefined): string {
   return d.toISOString().slice(0, 19) + 'Z';
 }
 
+/** True only when a string has visible content — keeps empty fields honest. */
+function nonBlank(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Compose one display line from an NPPES practice-location record. Returns ''
+ * when no usable address text is present, so the caller omits the block rather
+ * than render an empty source-backed field.
+ */
+function formatPracticeLocation(
+  location: NonNullable<PassportData['practiceLocation']>,
+): string {
+  const cityState = [location.city, location.state].filter(nonBlank).join(', ');
+  const cityStateZip = [cityState, location.postalCode].filter(nonBlank).join(' ');
+  return [location.addressLine, cityStateZip].filter(nonBlank).join(' · ');
+}
+
+/** Self-reported education entry → single display line (institution + detail). */
+function formatEducationEntry(entry: {
+  institution: string;
+  degree?: string;
+  graduationYear?: number;
+}): string {
+  const detail = [
+    entry.degree,
+    entry.graduationYear != null ? String(entry.graduationYear) : undefined,
+  ]
+    .filter(nonBlank)
+    .join(', ');
+  return detail ? `${entry.institution} — ${detail}` : entry.institution;
+}
+
+/** Self-reported affiliation entry → single display line (organization + role). */
+function formatAffiliationEntry(entry: { organization: string; role?: string }): string {
+  return nonBlank(entry.role) ? `${entry.organization} — ${entry.role}` : entry.organization;
+}
+
 const TIER_CONFIG: Record<string, { label: string; cls: string }> = {
   DECISION_GRADE: {
     label: 'Decision Grade',
@@ -214,6 +252,23 @@ export default async function VerifierPage({
 
   const displayName = passport.identity?.displayName ?? `NPI ${npi}`;
 
+  // New profile fields — both optional/nullable on PassportData. Render only
+  // what is actually present: practiceLocation is source-backed (NPPES);
+  // selfReported education/affiliations are user-entered. Never fabricate.
+  const practiceLocationText = passport.practiceLocation
+    ? formatPracticeLocation(passport.practiceLocation)
+    : '';
+  const selfReportedEducation = (passport.selfReported?.education ?? []).filter((e) =>
+    nonBlank(e.institution),
+  );
+  const selfReportedAffiliations = (passport.selfReported?.affiliations ?? []).filter((a) =>
+    nonBlank(a.organization),
+  );
+  const hasProfileDetail =
+    practiceLocationText.length > 0 ||
+    selfReportedEducation.length > 0 ||
+    selfReportedAffiliations.length > 0;
+
   return (
     <div className="mz mz-paper mz-persona-verifier min-h-screen overflow-hidden">
       {/* ── Read-Only Header ───────────────────────────────────────────────── */}
@@ -311,7 +366,35 @@ export default async function VerifierPage({
             </div>
           </div>
 
-
+          {/* ── Practice location (source-backed) + self-reported detail ──── */}
+          {hasProfileDetail && (
+            <div className="mt-4 pt-4 border-t border-[var(--rule-soft)] space-y-3.5">
+              {practiceLocationText && (
+                <ProfileDetailGroup
+                  title="Practice location"
+                  chipLabel="Source-backed"
+                  chipClass="mz-chip-ok"
+                  rows={[practiceLocationText]}
+                />
+              )}
+              {selfReportedEducation.length > 0 && (
+                <ProfileDetailGroup
+                  title="Education"
+                  chipLabel="Self-reported"
+                  chipClass="mz-chip-unknown"
+                  rows={selfReportedEducation.map(formatEducationEntry)}
+                />
+              )}
+              {selfReportedAffiliations.length > 0 && (
+                <ProfileDetailGroup
+                  title="Affiliations"
+                  chipLabel="Self-reported"
+                  chipClass="mz-chip-unknown"
+                  rows={selfReportedAffiliations.map(formatAffiliationEntry)}
+                />
+              )}
+            </div>
+          )}
         </div>
         </Reveal>
 
@@ -399,6 +482,46 @@ function TimestampField({ label, value }: { label: string; value: string }) {
     <div className="flex flex-col gap-0.5">
       <span className="text-[9px] uppercase tracking-wide text-[var(--ink-400)]">{label}</span>
       <span className="mz-mono text-[var(--ink-700)]">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Compact identity-detail group: a labelled provenance chip over one or more
+ * plain display rows. Provenance is carried entirely by the chip — mz-chip-ok
+ * for the source-backed practice location, mz-chip-unknown for the
+ * self-reported education / affiliations — so a self-reported value is never
+ * shown with a verified label.
+ */
+function ProfileDetailGroup({
+  title,
+  chipLabel,
+  chipClass,
+  rows,
+}: {
+  title: string;
+  chipLabel: string;
+  chipClass: string;
+  rows: string[];
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2 mb-1.5">
+        <span className="mz-mono text-[10px] uppercase tracking-[0.14em] text-[var(--ink-400)]">
+          {title}
+        </span>
+        <span className={`mz-chip ${chipClass}`}>
+          <span className="mz-gl" aria-hidden="true" />
+          {chipLabel}
+        </span>
+      </div>
+      <ul className="space-y-0.5">
+        {rows.map((row, index) => (
+          <li key={`${index}-${row}`} className="text-sm text-[var(--ink-700)] break-words">
+            {row}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/components/profile/ClinicianProfileSections.tsx
+++ b/apps/web/components/profile/ClinicianProfileSections.tsx
@@ -157,6 +157,14 @@ export function ClinicianProfileSections({
     ? `mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3 ${className}`
     : 'mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3';
 
+  const practiceLocation = passport.practiceLocation;
+  const hasPracticeLocation = Boolean(
+    practiceLocation
+      && (practiceLocation.addressLine
+        || practiceLocation.city
+        || practiceLocation.state
+        || practiceLocation.postalCode),
+  );
   const licences = passport.authority?.credentials.filter((c) => c.domain === 'LICENSURE') ?? [];
   const boards = passport.authority?.credentials.filter((c) => c.domain === 'BOARD_CERTIFICATION') ?? [];
   const trainingRecords = passport.training?.records ?? [];
@@ -191,7 +199,24 @@ export function ClinicianProfileSections({
         title="Practice locations"
         description="Addresses listed on NPPES for the NPI. Address accuracy is NPPES-dependent."
       >
-        <EmptyList label="No NPPES practice addresses hydrated on this passport yet." />
+        {hasPracticeLocation && practiceLocation ? (
+          <div className="space-y-1">
+            {practiceLocation.addressLine ? (
+              <Field label="Street address" value={practiceLocation.addressLine} provenance="VERIFIED" />
+            ) : null}
+            {practiceLocation.city ? (
+              <Field label="City" value={practiceLocation.city} provenance="VERIFIED" />
+            ) : null}
+            {practiceLocation.state ? (
+              <Field label="State" value={practiceLocation.state} provenance="VERIFIED" />
+            ) : null}
+            {practiceLocation.postalCode ? (
+              <Field label="Postal code" value={practiceLocation.postalCode} provenance="VERIFIED" />
+            ) : null}
+          </div>
+        ) : (
+          <EmptyList label="No NPPES practice addresses hydrated on this passport yet." />
+        )}
       </Section>
 
       <Section

--- a/apps/web/hooks/ingestStreamState.ts
+++ b/apps/web/hooks/ingestStreamState.ts
@@ -39,6 +39,20 @@ export interface StreamIdentity {
   lastUpdated?: string;
   taxonomies?: Array<{ code: string; desc: string; primary: boolean }>;
   address?: { line1: string; city: string; state: string; zip: string; country: string; phone?: string };
+  /**
+   * Source-backed NPPES practice location (VERIFIED) attached to the passport_ready
+   * event. Mirrors PassportData.practiceLocation. null / absent when NPPES carried
+   * no usable address — never fabricated.
+   */
+  practiceLocation?: {
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    addressLine?: string;
+    provenance: 'VERIFIED';
+    sourceId: 'NPPES';
+    lastCheckedAt?: string;
+  } | null;
   entityType?: string;
   npiType?: string;
   status?: string;
@@ -197,6 +211,14 @@ function mergeIdentity(
     address = payload.address as { line1: string; city: string; state: string; zip: string; country: string; phone?: string };
   }
 
+  // Source-backed NPPES practice location. Only replace when the payload carries an
+  // object — a null payload (NPPES had no usable address) keeps prior state and is
+  // never treated as a verified value.
+  let practiceLocation = prev.practiceLocation;
+  if (payload.practiceLocation && typeof payload.practiceLocation === 'object') {
+    practiceLocation = payload.practiceLocation as StreamIdentity['practiceLocation'];
+  }
+
   return {
     entityId: readString(payload, 'entityId') ?? prev.entityId,
     displayName,
@@ -206,6 +228,7 @@ function mergeIdentity(
     lastUpdated: readString(payload, 'lastUpdated') ?? prev.lastUpdated,
     taxonomies,
     address,
+    practiceLocation,
     entityType: readString(payload, 'entityType') ?? prev.entityType,
     npiType: readString(payload, 'npiType') ?? prev.npiType,
     status: identityStatus,

--- a/apps/web/lib/trust/passport-contract.ts
+++ b/apps/web/lib/trust/passport-contract.ts
@@ -104,6 +104,21 @@ export interface PassportData {
     status:      string;
     npi?:        string | null;
   };
+  /** Practice location — source-backed from NPPES (never null-fabricated). */
+  practiceLocation?: {
+    city?: string;
+    state?: string;          // 2-letter
+    postalCode?: string;
+    addressLine?: string;    // street line, optional
+    provenance: 'VERIFIED';  // NPPES primary source
+    sourceId: 'NPPES';
+    lastCheckedAt?: string;
+  } | null;
+  /** Self-reported profile — USER_ENTERED only; present only when the clinician provided it. */
+  selfReported?: {
+    education?: Array<{ institution: string; degree?: string; graduationYear?: number }>;
+    affiliations?: Array<{ organization: string; role?: string }>;
+  } | null;
   authority: {
     credentials: Array<{
       id:                string;


### PR DESCRIPTION
## What (your ask: "every clinician check should have location of practice, education, and any other associations — similar to Doximity")

Adds a Doximity-style profile to the clinician check across all three surfaces you picked — but **provenance-honest**, which is the deliberate contrast to Doximity (it shows unverified data as fact):

- **Practice location — SOURCE-VERIFIED (NPPES).** The practice address was already being fetched (`NormalizedProvider.practice_address`) and claimed (`PRACTICE_LOCATION`, confidence 0.90) — it was just never plumbed to the UI. Now surfaced with a **"Source-backed"** chip. Rendered **only** when NPPES returned a usable address; fails closed to null, never fabricated.
- **Education + associations — SELF-REPORTED (USER_ENTERED).** These are in *no* public source (NPPES/OIG/PECOS carry neither), so they come only from the clinician's self-attested profile, labeled **"Self-reported"**, shown **only** when actually provided. Never inferred, never verified.

## How
Shared contract first so every surface reads identical, optional+nullable fields:
- `apps/web/lib/trust/passport-contract.ts` + backend `profileEnrichment.ts` (`practiceLocation` / `selfReported`), wired through **both** passport builders (`npiPassportContract`, `passportService`) and the **live ingest stream** (`ingestStreamState` → `state.identity.practiceLocation`).
- Surfaces: **`/passport`** (live NPI-lookup check), **`/verify/[npi]`** (verifier read), **`/clinician/profile`** (owner — the empty "Practice locations" card is now wired).

## Verification
- Web + backend `turbo build` green; passport-contract suites **8/8**; `tsc` clean.
- Cohesion/doctrine review: **GO, no blockers** — no banned strings, no bare "Verified" label, no empty-but-verified render path, per-NPI stream reset prevents location leak.
- Real NPPES data flow will be confirmed on prod post-deploy (curling the passport API for a live NPI).

## Honest scope notes (from the review, non-blocking)
- Unclaimed NPIs simply omit `selfReported` (no self-attested data) — location + specialty still show source-backed. Claiming the profile is the incentive to add education/affiliations.
- `/clinician/profile` still sources education/affiliations from its existing `extended` prop (both honestly USER_ENTERED) rather than the new `selfReported` field — a small adoption gap to unify later.
- True *verification* of education/board (vs self-reported) would need a new source (ABMS / a residency registrar) — a data-partnership decision, out of scope here.

## Design Handoff References
Reuses the shipped calm-glass `.mz` system + the profile provenance primitives (`ProfileProvenance`, `PROVENANCE_META`, `Field`/`ProvenanceBadge`, `.mz-chip`); no new design assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)