### PR TITLE
feat(matcha): persist structured opportunity fields so employer nuance drives matching

### DIFF
--- a/apps/api/backend/prisma/migrations/20260708120000_opportunity_matching_fields/migration.sql
+++ b/apps/api/backend/prisma/migrations/20260708120000_opportunity_matching_fields/migration.sql
@@ -1,0 +1,8 @@
+-- Structured matching inputs on opportunities so employer-posted nuance drives
+-- MATCHA scoring (comp via pay_max, urgency via start_urgency, employer-fit via
+-- employer_type) instead of being defaulted in the mapper. Additive + nullable
+-- + IF NOT EXISTS → safe and idempotent on any environment.
+ALTER TABLE "Opportunity" ADD COLUMN IF NOT EXISTS "pay_min" INTEGER;
+ALTER TABLE "Opportunity" ADD COLUMN IF NOT EXISTS "pay_max" INTEGER;
+ALTER TABLE "Opportunity" ADD COLUMN IF NOT EXISTS "employer_type" TEXT;
+ALTER TABLE "Opportunity" ADD COLUMN IF NOT EXISTS "start_urgency" TEXT;

--- a/apps/api/backend/prisma/schema.prisma
+++ b/apps/api/backend/prisma/schema.prisma
@@ -337,6 +337,14 @@ model Opportunity {
   hiringType       String   @map("hiring_type")
   state            String
   payRange         String?  @map("pay_range")
+  // Structured matching inputs — the MATCHA engine scores comp (payMax vs the
+  // clinician's desired minimum), urgency (startUrgency), and employer-fit
+  // (employerType). Nullable so the mapper falls back to defaults for older
+  // postings that predate these columns.
+  payMin           Int?     @map("pay_min")
+  payMax           Int?     @map("pay_max")
+  employerType     String?  @map("employer_type")
+  startUrgency     String?  @map("start_urgency")
   requirementLevel String   @default("L1") @map("requirement_level")
   description      String?
   remote           Boolean  @default(false)

--- a/apps/api/backend/src/routes/opportunities.ts
+++ b/apps/api/backend/src/routes/opportunities.ts
@@ -158,6 +158,10 @@ export function registerOpportunityRoutes(app: Express): void {
         hiringType?: string;
         state?: string;
         payRange?: string;
+        payMin?: number;
+        payMax?: number;
+        employerType?: string;
+        startUrgency?: string;
         requirementLevel?: string;
         description?: string;
         remote?: boolean;
@@ -168,12 +172,21 @@ export function registerOpportunityRoutes(app: Express): void {
       if (!body.hiringType?.trim()) throw new HttpError(400, 'hiringType is required.');
       if (!body.state?.trim()) throw new HttpError(400, 'state is required.');
 
+      const toPosInt = (v: unknown): number | undefined => {
+        const n = typeof v === 'number' ? v : Number(v);
+        return Number.isFinite(n) && n > 0 ? Math.round(n) : undefined;
+      };
+
       const opp = await createOpportunity(clerkUserId, {
         title: body.title.trim(),
         specialty: body.specialty.trim(),
         hiringType: body.hiringType.trim(),
         state: body.state.trim(),
         payRange: body.payRange?.trim(),
+        payMin: toPosInt(body.payMin),
+        payMax: toPosInt(body.payMax),
+        employerType: body.employerType?.trim() || undefined,
+        startUrgency: body.startUrgency?.trim() || undefined,
         requirementLevel: body.requirementLevel ?? 'L1',
         description: body.description?.trim(),
         remote: Boolean(body.remote),

--- a/apps/api/backend/src/services/matcha/liveMatchaService.ts
+++ b/apps/api/backend/src/services/matcha/liveMatchaService.ts
@@ -224,6 +224,17 @@ function requirementsFromLevel(
   return base;
 }
 
+// Employer-posted enums → engine enums, with a safe fallback for older postings
+// (or free-text) that predate the structured columns.
+const EMPLOYER_TYPES = new Set(['hospital', 'practice', 'telehealth', 'agency', 'health_system']);
+function normalizeEmployerType(v: string | null | undefined): MatchaOpportunity['employerType'] {
+  return v && EMPLOYER_TYPES.has(v) ? (v as MatchaOpportunity['employerType']) : 'hospital';
+}
+const START_URGENCIES = new Set(['immediate', 'within_2_weeks', 'within_month', 'flexible']);
+function normalizeStartUrgency(v: string | null | undefined): MatchaOpportunity['startUrgency'] {
+  return v && START_URGENCIES.has(v) ? (v as MatchaOpportunity['startUrgency']) : 'flexible';
+}
+
 function dbOppToMatcha(opp: {
   id: string;
   title: string;
@@ -231,6 +242,10 @@ function dbOppToMatcha(opp: {
   hiringType: string;
   state: string;
   payRange: string | null;
+  payMin?: number | null;
+  payMax?: number | null;
+  employerType?: string | null;
+  startUrgency?: string | null;
   requirementLevel: string;
   remote: boolean;
   status: string;
@@ -248,10 +263,14 @@ function dbOppToMatcha(opp: {
     state: opp.state,
     specialty: opp.specialty,
     hiringType: (opp.hiringType as HiringType) || 'perm',
-    employerType: 'hospital',
-    startUrgency: 'flexible',
+    // Employer-posted structured fields drive real scoring (comp/urgency/
+    // employer-fit); fall back to the old defaults when a posting omits them.
+    employerType: normalizeEmployerType(opp.employerType),
+    startUrgency: normalizeStartUrgency(opp.startUrgency),
     urgency: 'within_90_days',
     payRange: opp.payRange ?? undefined,
+    payMin: opp.payMin ?? undefined,
+    payMax: opp.payMax ?? undefined,
     remote: opp.remote ?? false,
     requirements: requirementsFromLevel(opp.requirementLevel, opp.specialty, opp.state),
     minimumTrustBand: opp.requirementLevel === 'L3'

--- a/apps/api/backend/src/services/opportunities/opportunityService.ts
+++ b/apps/api/backend/src/services/opportunities/opportunityService.ts
@@ -43,6 +43,10 @@ export interface CreateOpportunityInput {
   hiringType: string;
   state: string;
   payRange?: string;
+  payMin?: number;
+  payMax?: number;
+  employerType?: string;
+  startUrgency?: string;
   requirementLevel?: string;
   description?: string;
   remote?: boolean;
@@ -344,6 +348,10 @@ export async function createOpportunity(
       hiringType: input.hiringType,
       state: input.state,
       payRange: input.payRange ?? null,
+      payMin: input.payMin ?? null,
+      payMax: input.payMax ?? null,
+      employerType: input.employerType ?? null,
+      startUrgency: input.startUrgency ?? null,
       requirementLevel: input.requirementLevel ?? 'L1',
       description: input.description ?? null,
       remote: input.remote ?? false,

--- a/apps/web/app/employer/post/page.tsx
+++ b/apps/web/app/employer/post/page.tsx
@@ -46,6 +46,23 @@ const REQUIREMENT_LEVELS = [
   { value: 'L3', label: 'Full source-verified', hint: 'All primary sources' },
 ] as const;
 
+// These drive real MATCHA scoring (employer-fit + urgency). Values match the
+// engine's enums exactly.
+const EMPLOYER_TYPES = [
+  { value: 'hospital', label: 'Hospital' },
+  { value: 'practice', label: 'Practice / group' },
+  { value: 'health_system', label: 'Health system' },
+  { value: 'telehealth', label: 'Telehealth' },
+  { value: 'agency', label: 'Staffing agency' },
+] as const;
+
+const START_URGENCIES = [
+  { value: 'immediate', label: 'Immediate' },
+  { value: 'within_2_weeks', label: 'Within 2 weeks' },
+  { value: 'within_month', label: 'Within a month' },
+  { value: 'flexible', label: 'Flexible' },
+] as const;
+
 const HIRING_LABEL: Record<string, string> = Object.fromEntries(
   HIRING_TYPES.map((h) => [h.value, h.label]),
 );
@@ -60,6 +77,10 @@ export default function EmployerPostPage() {
   const [hiringType, setHiringType] = useState<string>('perm');
   const [state, setState] = useState('');
   const [payRange, setPayRange] = useState('');
+  const [payMin, setPayMin] = useState('');
+  const [payMax, setPayMax] = useState('');
+  const [employerType, setEmployerType] = useState<string>('hospital');
+  const [startUrgency, setStartUrgency] = useState<string>('flexible');
   const [requirementLevel, setRequirementLevel] = useState('L1');
   const [description, setDescription] = useState('');
   const [remote, setRemote] = useState(false);
@@ -97,6 +118,10 @@ export default function EmployerPostPage() {
     setHiringType('perm');
     setState('');
     setPayRange('');
+    setPayMin('');
+    setPayMax('');
+    setEmployerType('hospital');
+    setStartUrgency('flexible');
     setRequirementLevel('L1');
     setDescription('');
     setRemote(false);
@@ -120,6 +145,10 @@ export default function EmployerPostPage() {
         hiringType,
         state: state.trim().toUpperCase(),
         payRange: payRange.trim() || undefined,
+        payMin: payMin.trim() ? Number(payMin.trim()) : undefined,
+        payMax: payMax.trim() ? Number(payMax.trim()) : undefined,
+        employerType,
+        startUrgency,
         requirementLevel,
         description: description.trim() || undefined,
         remote,
@@ -272,6 +301,68 @@ export default function EmployerPostPage() {
                       placeholder="$220k–$260k"
                     />
                   </label>
+                </div>
+
+                <div className="flex flex-wrap gap-4">
+                  <label className="block flex-1 min-w-[8rem]">
+                    <span className="mz-eyebrow">Pay min · matching</span>
+                    <input
+                      className="mz-input mt-1.5"
+                      inputMode="numeric"
+                      value={payMin}
+                      onChange={(e) => setPayMin(e.target.value.replace(/[^0-9]/g, ''))}
+                      placeholder="220000"
+                      aria-label="Pay minimum for matching"
+                    />
+                  </label>
+                  <label className="block flex-1 min-w-[8rem]">
+                    <span className="mz-eyebrow">Pay max · matching</span>
+                    <input
+                      className="mz-input mt-1.5"
+                      inputMode="numeric"
+                      value={payMax}
+                      onChange={(e) => setPayMax(e.target.value.replace(/[^0-9]/g, ''))}
+                      placeholder="260000"
+                      aria-label="Pay maximum for matching"
+                    />
+                  </label>
+                </div>
+                <p className="mz-small" style={{ marginTop: -6 }}>
+                  Numbers let VitalCV match on comp against what clinicians ask for.
+                </p>
+
+                <div>
+                  <span className="mz-eyebrow">Employer type</span>
+                  <div className="mt-1.5 flex flex-wrap gap-2">
+                    {EMPLOYER_TYPES.map((t) => (
+                      <button
+                        key={t.value}
+                        type="button"
+                        className="mz-opt"
+                        aria-pressed={employerType === t.value}
+                        onClick={() => setEmployerType(t.value)}
+                      >
+                        {t.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <span className="mz-eyebrow">Start urgency</span>
+                  <div className="mt-1.5 flex flex-wrap gap-2">
+                    {START_URGENCIES.map((u) => (
+                      <button
+                        key={u.value}
+                        type="button"
+                        className="mz-opt"
+                        aria-pressed={startUrgency === u.value}
+                        onClick={() => setStartUrgency(u.value)}
+                      >
+                        {u.label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
 
                 <div>


### PR DESCRIPTION
## What
The biggest matching-quality win that needs **no AI key**. The MATCHA engine already scores **comp** (`payMax` vs the clinician's desired minimum), **urgency** (`startUrgency`), and **employer-fit** (`employerType`) — but the DB `Opportunity` only stored title/specialty/state/payRange, so `dbOppToMatcha` **hardcoded** `employerType:'hospital'`, `startUrgency:'flexible'`, and dropped pay numbers entirely. Employer-posted nuance never reached the scorer.

## Changes
- **Schema**: add nullable `pay_min`, `pay_max`, `employer_type`, `start_urgency` to `Opportunity`, with an additive `IF NOT EXISTS` migration. (Caught + fixed a real bug: the model has **no `@@map`**, so the table is `"Opportunity"`, not `opportunities` — the migration now targets the right table; verified idempotent so it's safe on prod's `migrate deploy`.)
- **Create path**: `createOpportunity` + `POST /api/opportunities` accept and persist the fields (`pay_min/max` coerced to positive ints).
- **Mapper**: `liveMatchaService.dbOppToMatcha` reads the real fields, normalizes `employer_type`/`start_urgency` to the engine enums, and **falls back to the old defaults for postings that predate the columns** — old rows still score.
- **Form** (`/employer/post`): captures pay min/max (numbers, for comp matching) + employer-type and start-urgency chips whose values match the engine enums exactly.

## Why it matters
This makes the (deterministic, source-honest) matching genuinely reflect what employers post — a real quality jump with zero model dependency. When an AI layer lands later, it re-ranks on top of *these* richer signals.

## Verification
Backend `tsc` + web `turbo build` green; opportunity/matcha suites **28/28**; migration applies idempotently on a scratch DB; graceful fallback for legacy rows.

## Design Handoff References
Uses the shipped calm-glass `.mz` system on the form; no new assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)