### PR TITLE
feat(web): forward verified bearer on ALL remaining backend proxies (G1 enforce prep, complete)

### DIFF
--- a/apps/web/app/api/auth/resolve-role/route.ts
+++ b/apps/web/app/api/auth/resolve-role/route.ts
@@ -22,6 +22,7 @@ import {
   ROLE_COOKIE_TTL_SECONDS,
   signRoleCookie,
 } from '@/lib/auth/roleCookie';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -55,7 +56,7 @@ export async function GET() {
   // 3. Resolve the role from the backend.
   let role: string;
   try {
-    const headers: Record<string, string> = { 'x-clerk-user-id': userId };
+    const headers: Record<string, string> = { ...(await buildIdentityHeaders({ userId })) };
     if (email) headers['x-clerk-user-email'] = email;
 
     const res = await fetch(`${BACKEND}/api/me/role`, { headers });

--- a/apps/web/app/api/candidates/route.ts
+++ b/apps/web/app/api/candidates/route.ts
@@ -2,11 +2,12 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const { searchParams } = req.nextUrl;
   const qs = searchParams.toString();
-  const res = await fetch(`${B}/api/candidates${qs ? '?' + qs : ''}`, { headers: { 'x-clerk-user-id': session.userId } });
+  const res = await fetch(`${B}/api/candidates${qs ? '?' + qs : ''}`, { headers: { ...(await buildIdentityHeaders({ userId: session.userId })) } });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
 }

--- a/apps/web/app/api/capacity/[organizationId]/route.ts
+++ b/apps/web/app/api/capacity/[organizationId]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export const runtime = 'nodejs';
 
 const B =
@@ -20,7 +21,7 @@ export async function GET(
   const { organizationId } = await context.params;
   try {
     const res = await fetch(`${B}/api/capacity/${organizationId}`, {
-      headers: { 'x-clerk-user-id': session.userId },
+      headers: { ...(await buildIdentityHeaders({ userId: session.userId })) },
     });
     const data = await res.json().catch(() => ({}));
     return NextResponse.json(data, { status: res.status });

--- a/apps/web/app/api/employer-review/[entityId]/[action]/route.ts
+++ b/apps/web/app/api/employer-review/[entityId]/[action]/route.ts
@@ -8,6 +8,7 @@ import {
   normalizeEmployerReviewStatusResponse,
 } from '@/lib/employer-review-actions';
 import { assertEmployerEvidencePacket } from '@/lib/trust/employer-packet-contract';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -396,7 +397,7 @@ export async function POST(
         Accept: 'application/json',
         'x-correlation-id': resolveCorrelationId(req),
         ...optionalVerifierRoleHeader(req),
-        ...(userId ? { 'x-clerk-user-id': userId } : {}),
+        ...(await buildIdentityHeaders({ userId })),
       },
       body: JSON.stringify(sanitizedBody),
       cache: 'no-store',
@@ -470,7 +471,7 @@ export async function GET(
         Accept: req.headers.get('accept') ?? 'application/json',
         'x-correlation-id': resolveCorrelationId(req),
         ...optionalVerifierRoleHeader(req),
-        ...(userId ? { 'x-clerk-user-id': userId } : {}),
+        ...(await buildIdentityHeaders({ userId })),
       },
       cache: 'no-store',
       signal: AbortSignal.timeout(8_000),

--- a/apps/web/app/api/employer-review/batch/route.ts
+++ b/apps/web/app/api/employer-review/batch/route.ts
@@ -10,6 +10,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -100,7 +101,7 @@ export async function POST(req: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'x-clerk-user-id': userId,
+        ...(await buildIdentityHeaders({ userId })),
       },
       body: JSON.stringify(sanitized),
       cache: 'no-store',

--- a/apps/web/app/api/employer-review/queue/route.ts
+++ b/apps/web/app/api/employer-review/queue/route.ts
@@ -9,6 +9,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -31,7 +32,7 @@ export async function GET(req: NextRequest) {
     const response = await fetch(`${BACKEND}/api/employer-review/queue${limit}`, {
       headers: {
         Accept: 'application/json',
-        'x-clerk-user-id': userId,
+        ...(await buildIdentityHeaders({ userId })),
       },
       cache: 'no-store',
       signal: AbortSignal.timeout(15_000),

--- a/apps/web/app/api/employer/opportunities/route.ts
+++ b/apps/web/app/api/employer/opportunities/route.ts
@@ -2,16 +2,17 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export async function GET() {
   const session = await auth();
   if (!session.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const res = await fetch(`${B}/api/employer/opportunities`, { headers: { 'x-clerk-user-id': session.userId } });
+  const res = await fetch(`${B}/api/employer/opportunities`, { headers: { ...(await buildIdentityHeaders({ userId: session.userId })) } });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
 }
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const body = await req.text();
-  const res = await fetch(`${B}/api/opportunities`, { method: 'POST', headers: { 'content-type': 'application/json', 'x-clerk-user-id': session.userId }, body });
+  const res = await fetch(`${B}/api/opportunities`, { method: 'POST', headers: { 'content-type': 'application/json', ...(await buildIdentityHeaders({ userId: session.userId })) }, body });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
 }

--- a/apps/web/app/api/employer/profile/route.ts
+++ b/apps/web/app/api/employer/profile/route.ts
@@ -2,9 +2,10 @@ import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export async function GET() {
   const session = await auth();
   if (!session.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const res = await fetch(`${B}/api/employer/profile`, { headers: { 'x-clerk-user-id': session.userId } });
+  const res = await fetch(`${B}/api/employer/profile`, { headers: { ...(await buildIdentityHeaders({ userId: session.userId })) } });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
 }

--- a/apps/web/app/api/employer/setup/route.ts
+++ b/apps/web/app/api/employer/setup/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const NPI_RE = /^\d{10}$/;
 
@@ -54,7 +55,7 @@ export async function POST(req: NextRequest) {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
-      'x-clerk-user-id': session.userId,
+      ...(await buildIdentityHeaders({ userId: session.userId })),
     },
     body: JSON.stringify(nextPayload),
   });

--- a/apps/web/app/api/export/packet/route.ts
+++ b/apps/web/app/api/export/packet/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/export/employer-proof-packet';
 import { renderEmployerProofPacketPdf } from '@/lib/export/employer-proof-packet-pdf';
 import { assertPassportData } from '@/lib/trust/passport-contract';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -77,7 +78,7 @@ export async function GET(req: NextRequest) {
       cache: 'no-store',
       headers: {
         Accept: 'application/json',
-        'x-clerk-user-id': userId,
+        ...(await buildIdentityHeaders({ userId })),
       },
       signal: AbortSignal.timeout(8_000),
     });

--- a/apps/web/app/api/marketplace/pool/route.ts
+++ b/apps/web/app/api/marketplace/pool/route.ts
@@ -8,6 +8,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 import { BACKEND_URL } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -19,7 +20,7 @@ export async function GET(req: NextRequest) {
   const qs = req.nextUrl.searchParams.toString();
   try {
     const res = await fetch(`${BACKEND_URL}/api/marketplace/pool${qs ? `?${qs}` : ''}`, {
-      headers: { 'x-clerk-user-id': session.userId },
+      headers: { ...(await buildIdentityHeaders({ userId: session.userId })) },
       signal: AbortSignal.timeout(16_000),
     });
     const data = await res.json().catch(() => ({ error: 'Invalid response from backend', pool: [] }));

--- a/apps/web/app/api/organization-context/route.ts
+++ b/apps/web/app/api/organization-context/route.ts
@@ -2,10 +2,11 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { applyIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (userId) headers['x-clerk-user-id'] = userId;
+  if (userId) await applyIdentityHeaders(headers, { userId });
   const body = await req.text();
   const res = await fetch(`${B}/api/organization-context`, { method: 'POST', headers, body });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });

--- a/apps/web/app/api/ownership/claim/route.ts
+++ b/apps/web/app/api/ownership/claim/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest) {
     method: 'POST',
     headers: {
       'Content-Type':    'application/json',
-      'x-clerk-user-id': userId,
+      ...(await buildIdentityHeaders({ userId })),
     },
     body,
   });

--- a/apps/web/app/api/ownership/me/route.ts
+++ b/apps/web/app/api/ownership/me/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -15,7 +16,7 @@ export async function GET(_req: NextRequest) {
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const res = await fetch(`${B}/api/ownership/me`, {
-    headers: { 'x-clerk-user-id': userId },
+    headers: { ...(await buildIdentityHeaders({ userId })) },
   });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
 }

--- a/apps/web/app/api/profile/completeness/route.ts
+++ b/apps/web/app/api/profile/completeness/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { getApiBase } from '@/lib/api';
 import { type NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const BACKEND = getApiBase();
 
@@ -12,7 +13,7 @@ export async function GET(_req: NextRequest) {
 
   const url = `${BACKEND}/api/profile/completeness`;
   const headers: Record<string, string> = {
-    'x-clerk-user-id': session.userId,
+    ...(await buildIdentityHeaders({ userId: session.userId })),
   };
   const res = await fetch(url, { method: 'GET', headers });
   const data = await res.json().catch(() => ({}));

--- a/apps/web/app/api/profile/links/route.ts
+++ b/apps/web/app/api/profile/links/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { getApiBase } from '@/lib/api';
 import { type NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const BACKEND = getApiBase();
 
@@ -13,7 +14,7 @@ export async function POST(req: NextRequest) {
   const url = `${BACKEND}/api/profile/links`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'x-clerk-user-id': session.userId,
+    ...(await buildIdentityHeaders({ userId: session.userId })),
   };
   const body = await req.text();
   const res = await fetch(url, { method: "POST", headers, body });

--- a/apps/web/app/api/profile/resume/upload/route.ts
+++ b/apps/web/app/api/profile/resume/upload/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { getApiBase } from '@/lib/api';
 import { type NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const BACKEND = getApiBase();
 
@@ -13,7 +14,7 @@ export async function POST(req: NextRequest) {
   const url = `${BACKEND}/api/profile/resume/upload`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'x-clerk-user-id': session.userId,
+    ...(await buildIdentityHeaders({ userId: session.userId })),
   };
   const body = await req.text();
   const res = await fetch(url, { method: 'POST', headers, body });

--- a/apps/web/app/api/profile/self-attested/route.ts
+++ b/apps/web/app/api/profile/self-attested/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { getApiBase } from '@/lib/api';
 import { type NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const BACKEND = getApiBase();
 
@@ -13,7 +14,7 @@ export async function POST(req: NextRequest) {
   const url = `${BACKEND}/api/profile/self-attested`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'x-clerk-user-id': session.userId,
+    ...(await buildIdentityHeaders({ userId: session.userId })),
   };
   const body = await req.text();
   const res = await fetch(url, { method: 'POST', headers, body });

--- a/apps/web/app/api/profile/work-auth/route.ts
+++ b/apps/web/app/api/profile/work-auth/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { getApiBase } from '@/lib/api';
 import { type NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const BACKEND = getApiBase();
 
@@ -13,7 +14,7 @@ export async function POST(req: NextRequest) {
   const url = `${BACKEND}/api/profile/work-auth`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'x-clerk-user-id': session.userId,
+    ...(await buildIdentityHeaders({ userId: session.userId })),
   };
   const body = await req.text();
   const res = await fetch(url, { method: 'POST', headers, body });

--- a/apps/web/app/api/psv/oig/batch/route.ts
+++ b/apps/web/app/api/psv/oig/batch/route.ts
@@ -4,6 +4,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export const runtime = 'nodejs';
 
 const B =
@@ -24,7 +25,7 @@ export async function POST(req: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-clerk-user-id': session.userId,
+        ...(await buildIdentityHeaders({ userId: session.userId })),
       },
       body: JSON.stringify(body),
     });

--- a/apps/web/app/api/psv/oig/check/[npi]/route.ts
+++ b/apps/web/app/api/psv/oig/check/[npi]/route.ts
@@ -4,6 +4,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export const runtime = 'nodejs';
 
 const B =
@@ -25,7 +26,7 @@ export async function GET(
 
   try {
     const res = await fetch(`${B}/api/psv/oig/check/${npi}`, {
-      headers: { 'x-clerk-user-id': session.userId },
+      headers: { ...(await buildIdentityHeaders({ userId: session.userId })) },
     });
     const data = await res.json().catch(() => ({}));
     return NextResponse.json(data, { status: res.status });

--- a/apps/web/app/api/request-review/route.ts
+++ b/apps/web/app/api/request-review/route.ts
@@ -30,6 +30,7 @@ import {
 export const runtime = 'nodejs';
 
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 const NPI_RE = /^\d{10}$/;
 
@@ -103,7 +104,7 @@ export async function POST(req: NextRequest) {
   // Create organization context
   const orgHeaders = new Headers({
     'Content-Type': 'application/json',
-    'x-clerk-user-id': userId,
+    ...(await buildIdentityHeaders({ userId })),
     'x-org-id': activeOrg.organizationId,
   });
   if (email) {

--- a/apps/web/app/api/share/route.ts
+++ b/apps/web/app/api/share/route.ts
@@ -2,13 +2,14 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 import { BACKEND_URL as B } from '@/lib/backend-url';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const body = await req.text();
   const res = await fetch(`${B}/api/share`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'x-clerk-user-id': userId },
+    headers: { 'Content-Type': 'application/json', ...(await buildIdentityHeaders({ userId })) },
     body,
   });
   return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });

--- a/apps/web/app/api/trust-state/[npi]/refresh/route.ts
+++ b/apps/web/app/api/trust-state/[npi]/refresh/route.ts
@@ -4,6 +4,7 @@
  */
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -28,7 +29,7 @@ export async function POST(
     const res = await fetch(`${B}/api/trust-state/${npi}/refresh`, {
       method: 'POST',
       headers: {
-        'x-clerk-user-id': session.userId,
+        ...(await buildIdentityHeaders({ userId: session.userId })),
         'Content-Type': 'application/json',
       },
     });

--- a/apps/web/app/api/trust/events/route.ts
+++ b/apps/web/app/api/trust/events/route.ts
@@ -4,6 +4,7 @@
  * POST /api/trust/events/batch (handled by Next.js via subpath)
  */
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 
 export const runtime = 'nodejs';
 
@@ -16,12 +17,14 @@ const B =
 export async function POST(req: NextRequest) {
   try {
     const body = await req.text();
-    const clerkUserId = req.headers.get('x-clerk-user-id') ?? '';
+    // Identity is derived from the SERVER-side Clerk session (G1) — previously
+    // this proxy forwarded the client-supplied x-clerk-user-id header verbatim,
+    // which was spoofable by any caller.
     const res = await fetch(`${B}/api/trust/events`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-clerk-user-id': clerkUserId,
+        ...(await buildIdentityHeaders()),
       },
       body,
     });

--- a/apps/web/app/api/velocity/[organizationId]/route.ts
+++ b/apps/web/app/api/velocity/[organizationId]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
 export const runtime = 'nodejs';
 const B =
   process.env.BACKEND_URL ||
@@ -20,7 +21,7 @@ export async function GET(
   const res = await fetch(`${B}/api/velocity/${organizationId}`, {
     headers: {
       'Content-Type': 'application/json',
-      'x-clerk-user-id': session.userId,
+      ...(await buildIdentityHeaders({ userId: session.userId })),
     },
   });
   return NextResponse.json(await res.json().catch(() => ({})), {

--- a/docs/security/verified-jwt-rollout.md
+++ b/docs/security/verified-jwt-rollout.md
@@ -45,19 +45,24 @@ Watch `jwt_auth_verification` events by `outcome`:
   object). It forwards the bearer via `auth().getToken()` and degrades to
   id-only if minting is unavailable (behavior-preserving).
 
-### Call-site conversion status (as of 2026-07-06)
+### Call-site conversion status — COMPLETE (2026-07-10)
 
-- **Converted:** the 12-file `headers.set(...)` cohort (credentials ingest/mine/
-  confirm, documents parse/verify/[id], profile email-OTP issue/verify + npi
-  bootstrap, watch, watch/[id]) + the already-token-forwarding intelligence/
-  workspace/search proxies (~40 sites via `_shared.ts`).
-- **Remaining (~21, telemetry-driven):** object-property and conditional-spread
-  shapes — employer-review queue/batch/[action], employer opportunities/profile/
-  setup, psv/oig check+batch, ownership claim/me, profile links/self-attested/
-  work-auth/completeness/resume, capacity, velocity, marketplace pool, request-
-  review, share, export/packet, trust/events, organization-context,
-  auth/resolve-role, candidates. Shadow's `header_without_token` events will
-  prioritize these by real traffic; convert with the same helper before enforce.
+- **2026-07-06:** the 12-file `headers.set(...)` cohort + the ~40 sites already
+  forwarding via `_shared.ts`.
+- **2026-07-10:** the remaining 26 ad-hoc sites converted (object-property,
+  inline, conditional-spread, and bracket-assign shapes) — employer-review
+  queue/batch/[action], employer opportunities/profile/setup, psv/oig
+  check+batch, ownership claim/me, profile links/self-attested/work-auth/
+  completeness/resume, capacity, velocity, marketplace pool, request-review,
+  share, export/packet, organization-context, auth/resolve-role, candidates,
+  trust-state refresh, trust/events. `trust/events` additionally stopped
+  forwarding the CLIENT-supplied `x-clerk-user-id` verbatim (spoofable) —
+  identity is now server-derived.
+- **Every web→backend proxy now forwards the bearer** (flip criterion #3 met
+  code-side). Remaining flip criteria are telemetry-only: watch
+  `header_without_token` → ≈0 confirms it empirically, plus zero unexplained
+  `verified_mismatch`, and confirm no server-to-server caller sends
+  `x-clerk-user-id` without a token.
 
 ## Step 3 — Flip criteria for `enforce`
 


### PR DESCRIPTION
## Summary
Completes the web side of the G1 rollout: the final **26 ad-hoc proxy call sites** now attach `Authorization: Bearer <clerk session jwt>` (via `lib/auth/forwardIdentity.ts`) alongside `x-clerk-user-id`. Strictly additive — the helper degrades to id-only when token minting is unavailable, so nothing changes until the backend flips to enforce.

**Security fix in passing:** `/api/trust/events` forwarded the *client-supplied* `x-clerk-user-id` header verbatim (a spoofable passthrough). Identity there is now derived from the server-side Clerk session.

With this, **every** web→backend proxy forwards the bearer (enforce flip criterion #3 met code-side). Remaining flip criteria are telemetry-only — see `docs/security/verified-jwt-rollout.md`.

## Verify
- Web typecheck: 0 errors · `next lint` clean
- 34/34 targeted proxy tests green (forward-identity, employer-review-proxy, employer-review-queue, marketplace-proxies)

## Design Handoff References
No design handoff applies to this change (backend proxy plumbing; no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)