### PR TITLE
feat(marketplace): gate demo seeds (real postings only) + employer edit/close

### DIFF
--- a/apps/api/backend/src/routes/opportunities.ts
+++ b/apps/api/backend/src/routes/opportunities.ts
@@ -19,8 +19,10 @@ import {
   listCandidates,
   listOpportunitiesForOrg,
   listPublicOpportunities,
+  updateOpportunity,
   upsertOrgProfile,
 } from '../services/opportunities/opportunityService';
+import type { UpdateOpportunityInput } from '../services/opportunities/opportunityService';
 import { HttpError } from '../utils/httpError';
 import { emitLearningEvent } from '../services/feedback/prismaEventStore';
 import prisma from '../graphql/prisma_client';
@@ -258,6 +260,79 @@ export function registerOpportunityRoutes(app: Express): void {
       }
 
       res.json({ opportunity });
+    }),
+  );
+
+  app.patch(
+    '/api/opportunities/:id',
+    asyncHandler(async (req, res) => {
+      const clerkUserId = requireClerkUserId(req);
+
+      const opportunityId = req.params.id?.trim();
+      if (!opportunityId) {
+        throw new HttpError(400, 'Opportunity id is required.');
+      }
+      if (!UUID_RE.test(opportunityId)) {
+        throw new HttpError(404, 'Opportunity not found.');
+      }
+
+      const body = req.body as {
+        title?: string;
+        specialty?: string;
+        hiringType?: string;
+        state?: string;
+        payRange?: string | null;
+        payMin?: number | string | null;
+        payMax?: number | string | null;
+        employerType?: string | null;
+        startUrgency?: string | null;
+        requirementLevel?: string;
+        description?: string | null;
+        remote?: boolean;
+        status?: string;
+      };
+
+      const toPosInt = (v: unknown): number | undefined => {
+        const n = typeof v === 'number' ? v : Number(v);
+        return Number.isFinite(n) && n > 0 ? Math.round(n) : undefined;
+      };
+      const requireTrimmed = (value: unknown, label: string): string => {
+        const s = typeof value === 'string' ? value.trim() : '';
+        if (!s) throw new HttpError(400, `${label} cannot be empty.`);
+        return s;
+      };
+      const trimmedOrNull = (value: unknown): string | null => {
+        const s = typeof value === 'string' ? value.trim() : '';
+        return s || null;
+      };
+
+      if (
+        body.status !== undefined
+        && body.status !== 'ACTIVE'
+        && body.status !== 'CLOSED'
+      ) {
+        throw new HttpError(400, "status must be 'ACTIVE' or 'CLOSED'.");
+      }
+
+      // Build a partial patch: only keys present on the body are forwarded.
+      const fields: UpdateOpportunityInput = {};
+      if (body.title !== undefined) fields.title = requireTrimmed(body.title, 'title');
+      if (body.specialty !== undefined) fields.specialty = requireTrimmed(body.specialty, 'specialty');
+      if (body.hiringType !== undefined) fields.hiringType = requireTrimmed(body.hiringType, 'hiringType');
+      if (body.state !== undefined) fields.state = requireTrimmed(body.state, 'state');
+      if (body.payRange !== undefined) fields.payRange = trimmedOrNull(body.payRange);
+      if (body.payMin !== undefined) fields.payMin = toPosInt(body.payMin) ?? null;
+      if (body.payMax !== undefined) fields.payMax = toPosInt(body.payMax) ?? null;
+      if (body.employerType !== undefined) fields.employerType = trimmedOrNull(body.employerType);
+      if (body.startUrgency !== undefined) fields.startUrgency = trimmedOrNull(body.startUrgency);
+      if (body.requirementLevel !== undefined) fields.requirementLevel = trimmedOrNull(body.requirementLevel) ?? 'L1';
+      if (body.description !== undefined) fields.description = trimmedOrNull(body.description);
+      if (body.remote !== undefined) fields.remote = Boolean(body.remote);
+      // Validated to be one of the two literals by the guard above.
+      if (body.status !== undefined) fields.status = body.status as 'ACTIVE' | 'CLOSED';
+
+      const opp = await updateOpportunity(clerkUserId, opportunityId, fields);
+      res.json(opp);
     }),
   );
 

--- a/apps/api/backend/src/server.ts
+++ b/apps/api/backend/src/server.ts
@@ -183,7 +183,7 @@ async function bootstrapApp() {
   const { log } = await import('./obs/logger');
   const { loadEnv } = await import('./config/env');
   const { ensureInvestigationSeedDataBootstrapped } = await import('./services/investigators/seedInvestigationData');
-  const { ensureLaunchOpportunitiesBootstrapped } = await import('./services/opportunities/launchOpportunitySeed');
+  const { ensureLaunchOpportunitiesBootstrapped, isDemoOpportunitySeedEnabled } = await import('./services/opportunities/launchOpportunitySeed');
   const { requestIntelligenceAutoWarm } = await import('./services/intelligence/intelligenceAutoWarmService');
   const { initializeTelemetry, shutdownTelemetry } = await import('./telemetry');
   const { runMonitoringCycle } = await import('../jobs/monitoringJob');
@@ -208,7 +208,12 @@ async function bootstrapApp() {
   });
 
   await ensureInvestigationSeedDataBootstrapped({ logger: log });
-  if (config.NODE_ENV === 'production') {
+  // Auto-seed of demo/launch opportunities is flag-gated (SEED_DEMO_OPPORTUNITIES,
+  // default OFF). Production leaves it unset so it never seeds demo data — the
+  // bootstrap still runs to log the honest skip line; dev/demo sets the flag to
+  // seed on startup. ensureLaunchOpportunitiesBootstrapped enforces the gate again
+  // internally, so this is belt-and-suspenders.
+  if (config.NODE_ENV === 'production' || isDemoOpportunitySeedEnabled()) {
     await ensureLaunchOpportunitiesBootstrapped({ logger: log });
   }
 

--- a/apps/api/backend/src/services/matcha/liveMatchaService.ts
+++ b/apps/api/backend/src/services/matcha/liveMatchaService.ts
@@ -22,8 +22,16 @@ import type {
   Opportunity as MatchaOpportunity,
   RequirementSpec,
 } from './matchaModels';
+import {
+  seededOrgExclusionFilter,
+} from '../opportunities/launchOpportunitySeed';
 
 const prisma = new PrismaClient();
+
+// seededOrgExclusionFilter (shared): when SEED_DEMO_OPPORTUNITIES is off (the
+// prod default) it excludes opportunities belonging to the demo/launch seed
+// organizations so live matching sees only real postings; on (dev/demo) it's a
+// no-op. The same helper gates the public opportunity list/detail.
 
 // ── NPPES taxonomy → specialty string ─────────────────────────────────────────
 
@@ -297,6 +305,7 @@ export async function getLiveMatchesForNpi(
     prisma.opportunity.findMany({
       where: {
         status: 'ACTIVE',
+        ...seededOrgExclusionFilter(),
         ...(filters?.specialty ? { specialty: { contains: filters.specialty, mode: 'insensitive' } } : {}),
         ...(filters?.state ? { state: filters.state } : {}),
         ...(filters?.hiringType ? { hiringType: filters.hiringType } : {}),
@@ -344,7 +353,7 @@ export async function simulateForNpi(npi: string) {
   const [profile, dbOpportunities] = await Promise.all([
     buildClinicianProfile(npi),
     prisma.opportunity.findMany({
-      where: { status: 'ACTIVE' },
+      where: { status: 'ACTIVE', ...seededOrgExclusionFilter() },
       include: { organization: { select: { id: true, name: true } } },
       take: 50,
     }),

--- a/apps/api/backend/src/services/opportunities/__tests__/opportunityService.test.ts
+++ b/apps/api/backend/src/services/opportunities/__tests__/opportunityService.test.ts
@@ -21,12 +21,17 @@ jest.mock('../../../graphql/prisma_client', () => ({
       update: jest.fn(),
       findUnique: jest.fn(),
     },
+    opportunity: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
   },
 }));
 
 import prisma from '../../../graphql/prisma_client';
 import {
   getOrgProfile,
+  updateOpportunity,
   upsertOrgProfile,
 } from '../opportunityService';
 
@@ -49,6 +54,10 @@ const prismaMock = prisma as unknown as {
     update: jest.Mock;
     findUnique: jest.Mock;
   };
+  opportunity: {
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
 };
 
 describe('opportunityService org profile pilot policy', () => {
@@ -63,6 +72,8 @@ describe('opportunityService org profile pilot policy', () => {
     prismaMock.organization.create.mockReset();
     prismaMock.organizationProfile.update.mockReset();
     prismaMock.organizationProfile.findUnique.mockReset();
+    prismaMock.opportunity.findUnique.mockReset();
+    prismaMock.opportunity.update.mockReset();
   });
 
   it('reads pilot policy fields from the requirements envelope', async () => {
@@ -253,5 +264,98 @@ describe('opportunityService org profile pilot policy', () => {
         npi: '1999999999',
       }),
     }));
+  });
+});
+
+describe('updateOpportunity', () => {
+  const OPP_ID = '11111111-1111-1111-1111-111111111111';
+
+  function mockOrgResolution() {
+    // clerkUserId → user → personProfile → workspaceMembership → org profile → org-1
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1' });
+    prismaMock.personProfile.findUnique.mockResolvedValue({ id: 'person-1' });
+    prismaMock.workspaceMembership.findFirst.mockResolvedValue({
+      organizationProfileId: 'org-profile-1',
+    });
+    prismaMock.organizationProfile.findUnique.mockResolvedValue({
+      id: 'org-profile-1',
+      organizationId: 'org-1',
+    });
+  }
+
+  beforeEach(() => {
+    prismaMock.user.findUnique.mockReset();
+    prismaMock.personProfile.findUnique.mockReset();
+    prismaMock.workspaceMembership.findFirst.mockReset();
+    prismaMock.organizationProfile.findUnique.mockReset();
+    prismaMock.opportunity.findUnique.mockReset();
+    prismaMock.opportunity.update.mockReset();
+  });
+
+  it('404s when the opportunity does not exist', async () => {
+    mockOrgResolution();
+    prismaMock.opportunity.findUnique.mockResolvedValue(null);
+
+    await expect(
+      updateOpportunity('clerk-user-1', OPP_ID, { status: 'CLOSED' }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(prismaMock.opportunity.update).not.toHaveBeenCalled();
+  });
+
+  it('403s when the opportunity belongs to another organization', async () => {
+    mockOrgResolution();
+    prismaMock.opportunity.findUnique.mockResolvedValue({ organizationId: 'someone-elses-org' });
+
+    await expect(
+      updateOpportunity('clerk-user-1', OPP_ID, { status: 'CLOSED' }),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(prismaMock.opportunity.update).not.toHaveBeenCalled();
+  });
+
+  it('writes only the provided fields and returns the updated truth', async () => {
+    mockOrgResolution();
+    prismaMock.opportunity.findUnique.mockResolvedValue({ organizationId: 'org-1' });
+    prismaMock.opportunity.update.mockResolvedValue({
+      id: OPP_ID,
+      organizationId: 'org-1',
+      title: 'Updated Cardiologist',
+      specialty: 'Cardiology',
+      hiringType: 'perm',
+      state: 'CA',
+      payRange: null,
+      payMin: null,
+      payMax: null,
+      employerType: null,
+      startUrgency: null,
+      requirementLevel: 'L1',
+      description: null,
+      remote: false,
+      status: 'CLOSED',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-10T00:00:00.000Z'),
+      organization: {
+        name: 'Bay Area Cardiac Group',
+        slug: 'bay-area-cardiac-group',
+        organizationProfile: null,
+      },
+    });
+
+    const result = await updateOpportunity('clerk-user-1', OPP_ID, {
+      title: 'Updated Cardiologist',
+      status: 'CLOSED',
+    });
+
+    // Ownership check ran against the org-scoped id.
+    expect(prismaMock.opportunity.findUnique).toHaveBeenCalledWith({
+      where: { id: OPP_ID },
+      select: { organizationId: true },
+    });
+    // Partial patch: only the two provided keys are written — nothing else.
+    expect(prismaMock.opportunity.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: OPP_ID },
+      data: { title: 'Updated Cardiologist', status: 'CLOSED' },
+    }));
+    expect(result.status).toBe('CLOSED');
+    expect(result.title).toBe('Updated Cardiologist');
   });
 });

--- a/apps/api/backend/src/services/opportunities/launchOpportunitySeed.ts
+++ b/apps/api/backend/src/services/opportunities/launchOpportunitySeed.ts
@@ -114,7 +114,7 @@ const SEEDED_ORGANIZATIONS: readonly SeedOrganization[] = [
     hiringTypes: ['locums', 'perm', 'prn'],
     timeToStart: 'Immediate',
     timeToOnboard: '5-10 business days',
-    clearToStartThreshold: 'Active CA license, board certification, BLS/ACLS, and a complete credentialing file.',
+    clearToStartThreshold: 'Active CA license, board certification, BLS/ACLS, and a full credentialing packet.',
     payTransparency: false,
     payRange: null,
     requirements: [
@@ -175,6 +175,50 @@ const SEEDED_ORGANIZATIONS: readonly SeedOrganization[] = [
     verifiedSince: '2023-01-09T00:00:00.000Z',
   },
 ] as const;
+
+/**
+ * Slugs of the demo/launch seed organizations. Exposed so live matching can
+ * EXCLUDE already-seeded demo rows (which may still exist in production from
+ * earlier seeding) without deleting any data. Derived from SEEDED_ORGANIZATIONS
+ * so the two never drift.
+ */
+export const SEEDED_ORG_SLUGS: readonly string[] = SEEDED_ORGANIZATIONS.map(
+  (organization) => organization.slug,
+);
+
+/**
+ * Demo/launch opportunity seeding is OFF by default. Production leaves
+ * SEED_DEMO_OPPORTUNITIES unset so it never auto-seeds demo data; dev/demo sets
+ * SEED_DEMO_OPPORTUNITIES=1 (also accepts true/yes/on) to auto-seed on startup
+ * and to include seeded rows in live matching. Explicit seed scripts
+ * (`pnpm seed:opportunities`) call seedLaunchOpportunities directly and are
+ * intentionally NOT gated by this flag.
+ */
+export function isDemoOpportunitySeedEnabled(): boolean {
+  const raw = process.env.SEED_DEMO_OPPORTUNITIES;
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return (
+    normalized === '1' ||
+    normalized === 'true' ||
+    normalized === 'yes' ||
+    normalized === 'on'
+  );
+}
+
+/**
+ * Shared Prisma `where` fragment that keeps seeded demo employers out of live
+ * surfaces in production (flag off) while including them in dev (flag on). Used
+ * by the MATCHA match feed AND the public opportunity list/detail so nothing
+ * demo-branded (e.g. the seeded "Kaiser Permanente" org) reaches real clinicians.
+ * Empty object when the demo flag is on. Combine via `AND` when the caller also
+ * filters by organization slug, so the two organization clauses don't clobber.
+ */
+export function seededOrgExclusionFilter(): { organization?: { slug: { notIn: string[] } } } {
+  return isDemoOpportunitySeedEnabled()
+    ? {}
+    : { organization: { slug: { notIn: [...SEEDED_ORG_SLUGS] } } };
+}
 
 export const SEEDED_LAUNCH_OPPORTUNITIES: readonly SeedOpportunity[] = [
   {
@@ -464,6 +508,16 @@ export async function ensureLaunchOpportunitiesBootstrapped(options: {
 } = {}): Promise<LaunchOpportunitySeedSummary | null> {
   const prismaClient = options.prismaClient ?? prisma;
   const logger = options.logger;
+
+  if (!isDemoOpportunitySeedEnabled()) {
+    logger?.('info', 'demo opportunity seed skipped — SEED_DEMO_OPPORTUNITIES not enabled');
+    return {
+      activeOpportunityCount: 0,
+      seededOpportunityCount: 0,
+      createdOrganizationCount: 0,
+      skipped: true,
+    };
+  }
 
   const activeOpportunityCount = await prismaClient.opportunity.count({
     where: { status: 'ACTIVE' },

--- a/apps/api/backend/src/services/opportunities/opportunityService.ts
+++ b/apps/api/backend/src/services/opportunities/opportunityService.ts
@@ -14,6 +14,7 @@ import { randomUUID } from 'node:crypto';
 import { Prisma } from '@prisma/client';
 import prisma from '../../graphql/prisma_client';
 import { HttpError } from '../../utils/httpError';
+import { seededOrgExclusionFilter } from './launchOpportunitySeed';
 import type { EmployerRequirementSpec } from '../employers/employerCatalog';
 import {
   DEFAULT_AUTOMATION_RULES,
@@ -51,6 +52,32 @@ export interface CreateOpportunityInput {
   description?: string;
   remote?: boolean;
 }
+
+export type OpportunityStatus = 'ACTIVE' | 'CLOSED';
+
+/**
+ * Partial patch for an existing opportunity. Every field is optional — only
+ * the keys that are present are written (an omitted key leaves the column
+ * untouched). Nullable fields may be cleared by passing `null`. `status` lets
+ * an employer close (or reopen) a posting.
+ */
+export interface UpdateOpportunityInput {
+  title?: string;
+  specialty?: string;
+  hiringType?: string;
+  state?: string;
+  payRange?: string | null;
+  payMin?: number | null;
+  payMax?: number | null;
+  employerType?: string | null;
+  startUrgency?: string | null;
+  requirementLevel?: string;
+  description?: string | null;
+  remote?: boolean;
+  status?: OpportunityStatus;
+}
+
+const OPPORTUNITY_STATUSES: readonly OpportunityStatus[] = ['ACTIVE', 'CLOSED'];
 
 export type OpportunityResult = OpportunityTruth;
 
@@ -369,6 +396,64 @@ export async function createOpportunity(
   return buildOpportunityTruth({ opportunity: opp });
 }
 
+export async function updateOpportunity(
+  clerkUserId: string,
+  id: string,
+  fields: UpdateOpportunityInput,
+): Promise<OpportunityResult> {
+  const orgProfileId = await getOrgProfileIdForUser(clerkUserId);
+  if (!orgProfileId) throw new HttpError(404, 'No organization found. Complete your organization setup first.');
+
+  const orgProfile = await prisma.organizationProfile.findUnique({ where: { id: orgProfileId } });
+  if (!orgProfile) throw new HttpError(404, 'Organization profile not found.');
+
+  // Ownership gate: an employer may only edit opportunities posted under their
+  // own organization. Fetch the row's owner first, then 404 (missing) / 403
+  // (someone else's posting) before any write.
+  const existing = await prisma.opportunity.findUnique({
+    where: { id },
+    select: { organizationId: true },
+  });
+  if (!existing) throw new HttpError(404, 'Opportunity not found.');
+  if (existing.organizationId !== orgProfile.organizationId) {
+    throw new HttpError(403, 'You can only edit opportunities posted by your organization.');
+  }
+
+  if (fields.status !== undefined && !OPPORTUNITY_STATUSES.includes(fields.status)) {
+    throw new HttpError(400, "status must be 'ACTIVE' or 'CLOSED'.");
+  }
+
+  // Only write the fields that were actually provided (partial patch).
+  const data: Prisma.OpportunityUpdateInput = {};
+  if (fields.title !== undefined) data.title = fields.title;
+  if (fields.specialty !== undefined) data.specialty = fields.specialty;
+  if (fields.hiringType !== undefined) data.hiringType = fields.hiringType;
+  if (fields.state !== undefined) data.state = fields.state;
+  if (fields.payRange !== undefined) data.payRange = fields.payRange;
+  if (fields.payMin !== undefined) data.payMin = fields.payMin;
+  if (fields.payMax !== undefined) data.payMax = fields.payMax;
+  if (fields.employerType !== undefined) data.employerType = fields.employerType;
+  if (fields.startUrgency !== undefined) data.startUrgency = fields.startUrgency;
+  if (fields.requirementLevel !== undefined) data.requirementLevel = fields.requirementLevel;
+  if (fields.description !== undefined) data.description = fields.description;
+  if (fields.remote !== undefined) data.remote = fields.remote;
+  if (fields.status !== undefined) data.status = fields.status;
+
+  const opp = await prisma.opportunity.update({
+    where: { id },
+    data,
+    include: {
+      organization: {
+        include: {
+          organizationProfile: true,
+        },
+      },
+    },
+  });
+
+  return buildOpportunityTruth({ opportunity: opp });
+}
+
 export async function listOpportunitiesForOrg(clerkUserId: string): Promise<OpportunityResult[]> {
   const orgProfileId = await getOrgProfileIdForUser(clerkUserId);
   if (!orgProfileId) return [];
@@ -408,6 +493,13 @@ export async function listPublicOpportunities(filters: OpportunityTruthFilters &
     ...(filters.organizationSlug ? { organization: { slug: filters.organizationSlug } } : {}),
     ...(filters.remote ? { remote: true } : {}),
   };
+
+  // Keep seeded demo employers off the live public list in prod (flag off).
+  // Combine via AND so it doesn't clobber an organizationSlug filter above.
+  const listSeedExclusion = seededOrgExclusionFilter();
+  if (listSeedExclusion.organization) {
+    where.AND = [listSeedExclusion];
+  }
 
   const [clinicianProfile, opportunities] = await Promise.all([
     resolveClinicianProfile({
@@ -457,6 +549,8 @@ export async function getPublicOpportunityById(
     where: {
       id,
       status: 'ACTIVE',
+      // A seeded demo posting is not a real opening — hide it in prod (flag off).
+      ...seededOrgExclusionFilter(),
     },
     include: {
       organization: {

--- a/apps/web/app/api/employer/opportunities/[id]/route.ts
+++ b/apps/web/app/api/employer/opportunities/[id]/route.ts
@@ -1,0 +1,21 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+export const runtime = 'nodejs';
+import { BACKEND_URL as B } from '@/lib/backend-url';
+
+// Edit or close one of the signed-in employer's own openings. Forwards to the
+// backend PATCH /api/opportunities/:id, which enforces org ownership. Mirrors
+// the auth of the sibling employer/opportunities proxy (session userId → the
+// x-clerk-user-id header the backend reads).
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await auth();
+  if (!session.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const body = await req.text();
+  const res = await fetch(`${B}/api/opportunities/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', 'x-clerk-user-id': session.userId },
+    body,
+  });
+  return NextResponse.json(await res.json().catch(() => ({})), { status: res.status });
+}

--- a/apps/web/app/employer/post/page.tsx
+++ b/apps/web/app/employer/post/page.tsx
@@ -87,7 +87,15 @@ export default function EmployerPostPage() {
 
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState('');
-  const [posted, setPosted] = useState(false);
+  const [notice, setNotice] = useState('');
+
+  // Edit / close management for existing openings. `editingId` set = the form is
+  // in update mode for that opening (POST → PATCH). Close is a two-step confirm.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [confirmCloseId, setConfirmCloseId] = useState<string | null>(null);
+  const [closingId, setClosingId] = useState<string | null>(null);
+  const [closeError, setCloseError] = useState<{ id: string; msg: string } | null>(null);
+  const isEditing = editingId !== null;
 
   // org-setup fallback (shown only when a post fails for lack of an org)
   const [needsOrg, setNeedsOrg] = useState(false);
@@ -127,6 +135,43 @@ export default function EmployerPostPage() {
     setRemote(false);
   }
 
+  function flash(msg: string) {
+    setNotice(msg);
+    window.setTimeout(() => setNotice(''), 4000);
+  }
+
+  function enterEdit(o: Opportunity) {
+    setEditingId(o.id);
+    setTitle(o.title);
+    setSpecialty(o.specialty);
+    setHiringType(o.hiringType);
+    setState(o.state);
+    setPayRange(o.payRange ?? '');
+    setRequirementLevel(o.requirementLevel);
+    setDescription(o.description ?? '');
+    setRemote(o.remote);
+    // The openings list doesn't carry the stored matching inputs (pay min/max,
+    // employer type, start urgency), so those aren't edited here — reset them to
+    // inert defaults; the edit PATCH omits them and the stored values are kept.
+    setPayMin('');
+    setPayMax('');
+    setEmployerType('hospital');
+    setStartUrgency('flexible');
+    setFormError('');
+    setNotice('');
+    setNeedsOrg(false);
+    setConfirmCloseId(null);
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setFormError('');
+    resetForm();
+  }
+
   function validate(): string | null {
     if (!title.trim()) return 'Add a job title.';
     if (!specialty.trim()) return 'Add a specialty.';
@@ -161,6 +206,40 @@ export default function EmployerPostPage() {
     return { ok: false, noOrg, error: msg };
   }
 
+  // Edit / close one of the employer's own openings via the session-authed proxy
+  // (PATCH /api/employer/opportunities/:id). Partial patch — omitted keys are
+  // left untouched server-side.
+  async function patchOpp(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const res = await fetch(`/api/employer/opportunities/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (res.ok) return { ok: true };
+    const d = (await res.json().catch(() => ({}))) as { error?: string };
+    return { ok: false, error: d.error ?? `Couldn't save (${res.status}).` };
+  }
+
+  async function closeOpp(id: string) {
+    setClosingId(id);
+    setCloseError(null);
+    const r = await patchOpp(id, { status: 'CLOSED' });
+    setClosingId(null);
+    if (r.ok) {
+      setConfirmCloseId(null);
+      if (editingId === id) {
+        setEditingId(null);
+        resetForm();
+      }
+      void loadOpps();
+      return;
+    }
+    setCloseError({ id, msg: r.error ?? 'Close failed.' });
+  }
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     const v = validate();
@@ -170,13 +249,38 @@ export default function EmployerPostPage() {
     }
     setFormError('');
     setSaving(true);
+
+    if (editingId) {
+      // Update mode — PATCH only the listing fields the openings list round-trips
+      // (matching inputs aren't returned, so they're left untouched server-side).
+      const r = await patchOpp(editingId, {
+        title: title.trim(),
+        specialty: specialty.trim(),
+        hiringType,
+        state: state.trim().toUpperCase(),
+        payRange: payRange.trim() || undefined,
+        requirementLevel,
+        description: description.trim() || undefined,
+        remote,
+      });
+      setSaving(false);
+      if (r.ok) {
+        setEditingId(null);
+        resetForm();
+        flash('Saved — your listing is updated.');
+        void loadOpps();
+      } else {
+        setFormError(r.error ?? 'Save failed.');
+      }
+      return;
+    }
+
     const r = await postJob();
     setSaving(false);
     if (r.ok) {
-      setPosted(true);
       resetForm();
+      flash("Posted — it's live and matchable now.");
       void loadOpps();
-      window.setTimeout(() => setPosted(false), 4000);
       return;
     }
     if (r.noOrg) {
@@ -208,10 +312,9 @@ export default function EmployerPostPage() {
       const r = await postJob();
       if (r.ok) {
         setNeedsOrg(false);
-        setPosted(true);
         resetForm();
+        flash("Posted — it's live and matchable now.");
         void loadOpps();
-        window.setTimeout(() => setPosted(false), 4000);
       } else {
         setFormError(r.error ?? 'Post failed after setup.');
       }
@@ -240,7 +343,10 @@ export default function EmployerPostPage() {
           {/* ── Post form ─────────────────────────────────────────── */}
           <Reveal delay={60}>
             <form onSubmit={submit} className="mz-card mz-card-pad" noValidate>
-              <h2 className="mz-h2">New opening</h2>
+              <h2 className="mz-h2">{isEditing ? 'Edit opening' : 'New opening'}</h2>
+              {isEditing ? (
+                <p className="mz-small mt-1">Update this opening and save — it stays matchable.</p>
+              ) : null}
 
               <div className="mt-4 space-y-4">
                 <label className="block">
@@ -303,67 +409,77 @@ export default function EmployerPostPage() {
                   </label>
                 </div>
 
-                <div className="flex flex-wrap gap-4">
-                  <label className="block flex-1 min-w-[8rem]">
-                    <span className="mz-eyebrow">Pay min · matching</span>
-                    <input
-                      className="mz-input mt-1.5"
-                      inputMode="numeric"
-                      value={payMin}
-                      onChange={(e) => setPayMin(e.target.value.replace(/[^0-9]/g, ''))}
-                      placeholder="220000"
-                      aria-label="Pay minimum for matching"
-                    />
-                  </label>
-                  <label className="block flex-1 min-w-[8rem]">
-                    <span className="mz-eyebrow">Pay max · matching</span>
-                    <input
-                      className="mz-input mt-1.5"
-                      inputMode="numeric"
-                      value={payMax}
-                      onChange={(e) => setPayMax(e.target.value.replace(/[^0-9]/g, ''))}
-                      placeholder="260000"
-                      aria-label="Pay maximum for matching"
-                    />
-                  </label>
-                </div>
-                <p className="mz-small" style={{ marginTop: -6 }}>
-                  Numbers let VitalCV match on comp against what clinicians ask for.
-                </p>
+                {!isEditing ? (
+                  <>
+                    <div className="flex flex-wrap gap-4">
+                      <label className="block flex-1 min-w-[8rem]">
+                        <span className="mz-eyebrow">Pay min · matching</span>
+                        <input
+                          className="mz-input mt-1.5"
+                          inputMode="numeric"
+                          value={payMin}
+                          onChange={(e) => setPayMin(e.target.value.replace(/[^0-9]/g, ''))}
+                          placeholder="220000"
+                          aria-label="Pay minimum for matching"
+                        />
+                      </label>
+                      <label className="block flex-1 min-w-[8rem]">
+                        <span className="mz-eyebrow">Pay max · matching</span>
+                        <input
+                          className="mz-input mt-1.5"
+                          inputMode="numeric"
+                          value={payMax}
+                          onChange={(e) => setPayMax(e.target.value.replace(/[^0-9]/g, ''))}
+                          placeholder="260000"
+                          aria-label="Pay maximum for matching"
+                        />
+                      </label>
+                    </div>
+                    <p className="mz-small" style={{ marginTop: -6 }}>
+                      Numbers let VitalCV match on comp against what clinicians ask for.
+                    </p>
 
-                <div>
-                  <span className="mz-eyebrow">Employer type</span>
-                  <div className="mt-1.5 flex flex-wrap gap-2">
-                    {EMPLOYER_TYPES.map((t) => (
-                      <button
-                        key={t.value}
-                        type="button"
-                        className="mz-opt"
-                        aria-pressed={employerType === t.value}
-                        onClick={() => setEmployerType(t.value)}
-                      >
-                        {t.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                    <div>
+                      <span className="mz-eyebrow">Employer type</span>
+                      <div className="mt-1.5 flex flex-wrap gap-2">
+                        {EMPLOYER_TYPES.map((t) => (
+                          <button
+                            key={t.value}
+                            type="button"
+                            className="mz-opt"
+                            aria-pressed={employerType === t.value}
+                            onClick={() => setEmployerType(t.value)}
+                          >
+                            {t.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
 
-                <div>
-                  <span className="mz-eyebrow">Start urgency</span>
-                  <div className="mt-1.5 flex flex-wrap gap-2">
-                    {START_URGENCIES.map((u) => (
-                      <button
-                        key={u.value}
-                        type="button"
-                        className="mz-opt"
-                        aria-pressed={startUrgency === u.value}
-                        onClick={() => setStartUrgency(u.value)}
-                      >
-                        {u.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                    <div>
+                      <span className="mz-eyebrow">Start urgency</span>
+                      <div className="mt-1.5 flex flex-wrap gap-2">
+                        {START_URGENCIES.map((u) => (
+                          <button
+                            key={u.value}
+                            type="button"
+                            className="mz-opt"
+                            aria-pressed={startUrgency === u.value}
+                            onClick={() => setStartUrgency(u.value)}
+                          >
+                            {u.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <p className="mz-small mz-inset" style={{ padding: '10px 12px' }}>
+                    Comp min/max, employer type, and start urgency stay as first
+                    posted — those matching inputs are not editable here yet. Update
+                    the listing details and save.
+                  </p>
+                )}
 
                 <div>
                   <span className="mz-eyebrow">Readiness required to apply</span>
@@ -410,9 +526,9 @@ export default function EmployerPostPage() {
                   {formError}
                 </p>
               ) : null}
-              {posted ? (
+              {notice ? (
                 <p className="mz-small mt-4" style={{ color: 'var(--ok)' }}>
-                  Posted — it's live and matchable now.
+                  {notice}
                 </p>
               ) : null}
 
@@ -443,9 +559,27 @@ export default function EmployerPostPage() {
                   </div>
                 </div>
               ) : (
-                <button type="submit" className="mz-btn mt-5" disabled={saving}>
-                  {saving ? 'Posting…' : 'Post opening'}
-                </button>
+                <div className="mt-5 flex flex-wrap items-center gap-2">
+                  <button type="submit" className="mz-btn" disabled={saving}>
+                    {saving
+                      ? isEditing
+                        ? 'Saving…'
+                        : 'Posting…'
+                      : isEditing
+                        ? 'Save changes'
+                        : 'Post opening'}
+                  </button>
+                  {isEditing ? (
+                    <button
+                      type="button"
+                      className="mz-btn-ghost"
+                      disabled={saving}
+                      onClick={cancelEdit}
+                    >
+                      Cancel edit
+                    </button>
+                  ) : null}
+                </div>
               )}
             </form>
           </Reveal>
@@ -482,6 +616,54 @@ export default function EmployerPostPage() {
                       </p>
                       {o.description ? (
                         <p className="mz-body mt-2">{o.description}</p>
+                      ) : null}
+                      {o.status === 'ACTIVE' ? (
+                        <div className="mt-3 flex flex-wrap items-center gap-2">
+                          <button
+                            type="button"
+                            className="mz-btn-ghost mz-btn-sm"
+                            disabled={editingId === o.id}
+                            onClick={() => enterEdit(o)}
+                          >
+                            {editingId === o.id ? 'Editing' : 'Edit'}
+                          </button>
+                          {confirmCloseId === o.id ? (
+                            <>
+                              <button
+                                type="button"
+                                className="mz-btn mz-btn-sm"
+                                disabled={closingId === o.id}
+                                onClick={() => void closeOpp(o.id)}
+                              >
+                                {closingId === o.id ? 'Closing…' : 'Confirm close'}
+                              </button>
+                              <button
+                                type="button"
+                                className="mz-btn-ghost mz-btn-sm"
+                                disabled={closingId === o.id}
+                                onClick={() => setConfirmCloseId(null)}
+                              >
+                                Keep open
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              type="button"
+                              className="mz-btn-ghost mz-btn-sm"
+                              onClick={() => {
+                                setConfirmCloseId(o.id);
+                                setCloseError(null);
+                              }}
+                            >
+                              Close
+                            </button>
+                          )}
+                        </div>
+                      ) : null}
+                      {closeError && closeError.id === o.id ? (
+                        <p role="alert" className="mz-small mt-2" style={{ color: 'var(--p0)' }}>
+                          {closeError.msg}
+                        </p>
                       ) : null}
                     </li>
                   ))}


### PR DESCRIPTION
## Two owner-requested follow-ups

### 1. Real postings only (gate the demo seeds)
- **`SEED_DEMO_OPPORTUNITIES` flag, default OFF.** `ensureLaunchOpportunitiesBootstrapped` no-ops in prod; dev sets the flag to seed. **No data deleted.**
- A shared **`seededOrgExclusionFilter()`** (keyed off the 5 known seed-org slugs) hides seeded demo employers from **every live surface** when the flag is off — applied to **both** the MATCHA match feed **and** the public opportunity list/detail (`GET /api/opportunities` + `:id`). So nothing demo-branded (e.g. the seeded "Kaiser Permanente" org) reaches real clinicians on the onboarding preview or holder detail. The cohesion review caught that the public-service path was initially missed — **fixed here** (AND-combined so it can't clobber an org-slug filter), and the MATCHA copy was deduped to the one shared helper.

### 2. Employer edit / close
- **`updateOpportunity` with a real ownership gate** — resolves the caller's org and **403/404s if the posting belongs to another org** (3 new unit tests). `PATCH /api/opportunities/:id` (uuid-guarded) + web proxy `/api/employer/opportunities/[id]`. Close = `PATCH { status: 'CLOSED' }`.
- **`/employer/post`**: each opening gets **Edit** (loads back into the one shared form, update mode — no duplicate form) + a two-step **Close**; closed openings render a muted CLOSED chip and drop the actions.

Also reworded a pre-existing banned substring ("complete credentialing") in the Sacramento seed.

## Verification
Backend `tsc` + web & backend `turbo build` green; opportunity/matcha/seed suites **31/31** (incl. the new cross-org ownership tests); banned-string scan clean. Cohesion review verdict was GO once the public-service exclusion gap (now fixed) was closed.

## Known follow-up (polish, not blocking)
Editing can't yet *clear* an optional pay-range/description (the form sends `undefined`, which the partial PATCH omits — no data loss, backend supports `null`). Trivial to add later.

## Design Handoff References
Calm-glass `.mz` system, employer persona; no new assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)