### PR TITLE
polish(employer): let edit clear an optional pay range / description

### DIFF
--- a/apps/web/app/employer/post/page.tsx
+++ b/apps/web/app/employer/post/page.tsx
@@ -258,9 +258,12 @@ export default function EmployerPostPage() {
         specialty: specialty.trim(),
         hiringType,
         state: state.trim().toUpperCase(),
-        payRange: payRange.trim() || undefined,
+        // In edit mode, an emptied optional field sends `null` (not undefined) so
+        // the backend actually clears it — undefined would be omitted from the
+        // partial patch and leave the old value in place.
+        payRange: payRange.trim() || null,
         requirementLevel,
-        description: description.trim() || undefined,
+        description: description.trim() || null,
         remote,
       });
       setSaving(false);


### PR DESCRIPTION
## What
Closes the one polish item from the edit/close work (#611). In edit mode the form sent `undefined` for emptied optional fields, which the partial PATCH omitted — so an employer couldn't *remove* a pay range or description once set. Edit mode now sends `null` for cleared optionals; the backend PATCH already maps `null` → clears the column (`trimmedOrNull` at `routes/opportunities.ts`). Create mode still omits empties (nothing to clear).

One-line-per-field change; `next lint` + `turbo build` green.

## Design Handoff References
No new design — behavior fix on the existing `/employer/post` calm-glass surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)