### PR TITLE
feat(holder): desktop nav + real-data Career Evidence Graph + honest share

### DIFF
--- a/apps/web/app/holder/layout.tsx
+++ b/apps/web/app/holder/layout.tsx
@@ -5,6 +5,7 @@ import { ClinicianMobileProvider } from '@/components/mobile/ClinicianMobileProv
 import ClinicianLaunchTracker from '@/components/mobile/ClinicianLaunchTracker';
 import NetworkStatusBanner from '@/components/mobile/NetworkStatusBanner';
 import { MobileBottomNav } from '@/components/clinician/MobileBottomNav';
+import { HolderDesktopNav } from '@/components/holder/HolderDesktopNav';
 import { loadClinicianMobileData } from '@/lib/mobile/server';
 
 export const metadata: Metadata = {
@@ -30,6 +31,7 @@ export default async function HolderLayout({
       <div className="mz mz-persona-holder flex min-h-screen flex-col bg-ops-gradient selection:bg-vt-info/30 text-foreground">
         <ClinicianLaunchTracker />
         <NetworkStatusBanner />
+        <HolderDesktopNav />
         <div className="flex-1 pb-20 md:pb-0">{children}</div>
         <MobileBottomNav />
       </div>

--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -182,10 +182,7 @@ export default function HolderPage() {
         </details>
       </div>
 
-      {/* Share — the real public verifier link, not a demo presentation. The
-          previous CredentialPresentationActions minted hardcoded demo
-          credentials and copied a /verify/presentation/... link that 404s in
-          production; this panel hands out the working /verify/[npi] link. */}
+      {/* Share — hands out the public read-only /verify/[npi] link. */}
       <div className="mx-auto max-w-5xl px-4 pb-4 sm:px-6">
         <ShareRecognitionPanel npi={npi!} />
       </div>

--- a/apps/web/app/holder/page.tsx
+++ b/apps/web/app/holder/page.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 import { ShieldCheck, ChevronRight, Loader2, AlertCircle, Upload, UserRound } from 'lucide-react';
 import { WalletPassport } from '@/components/wallet/WalletPassport';
 import { CredentialWallet } from '@/components/wallet/CredentialWallet';
-import { CredentialPresentationActions } from '@/components/clinician/CredentialPresentationActions';
+import { ShareRecognitionPanel } from '@/components/recognition/ShareRecognitionPanel';
 import EvidenceUploadPanel from '@/components/mobile/EvidenceUploadPanel';
 import { ClinicianSupportCard } from '@/components/mobile/ClinicianSupportCard';
 import { TrustStatePanel } from '@/components/trust-state/TrustStatePanel';
@@ -182,9 +182,12 @@ export default function HolderPage() {
         </details>
       </div>
 
-      {/* Presentation actions */}
-      <div className="mx-auto hidden max-w-5xl justify-end px-4 pb-4 sm:flex sm:px-6">
-        <CredentialPresentationActions holderNpi={npi!} />
+      {/* Share — the real public verifier link, not a demo presentation. The
+          previous CredentialPresentationActions minted hardcoded demo
+          credentials and copied a /verify/presentation/... link that 404s in
+          production; this panel hands out the working /verify/[npi] link. */}
+      <div className="mx-auto max-w-5xl px-4 pb-4 sm:px-6">
+        <ShareRecognitionPanel npi={npi!} />
       </div>
       <div id="evidence-upload" className="mx-auto max-w-5xl scroll-mt-6 px-4 py-2 sm:px-6">
         <EvidenceUploadPanel

--- a/apps/web/components/holder/CareerEvidenceGraph.tsx
+++ b/apps/web/components/holder/CareerEvidenceGraph.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+/**
+ * CareerEvidenceGraph — the holder's own Career Evidence Graph (W220/W221).
+ *
+ * Projects the clinician's REAL professional-memory timeline (Wave 225
+ * /api/timeline/[npi]: evidence checks, licensure, screening, recognition,
+ * acceptances) into the constellation sky, replacing the illustrative demo
+ * stars used on marketing surfaces. Every lit star traces to an evidence-backed
+ * career event; the "future" era renders open roles and projections and is
+ * always labeled as projected, never asserted.
+ *
+ * Degrades honestly: while the timeline loads — or when no dated evidence
+ * exists yet — the sky falls back to the illustrative layout and says so.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, Sparkles, Waypoints } from 'lucide-react';
+import {
+  MatchaConstellation,
+  type ConstellationStarDef,
+  type Kind,
+} from '@/components/matcha/MatchaConstellation';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { Reveal } from '@/components/motion/Reveal';
+import { FEATURES } from '@/lib/features';
+
+const NPI_RE = /^\d{10}$/;
+
+/** The slice of a Wave 225 CareerEvent this projection reads. */
+interface TimelineEventSlice {
+  eventId: string;
+  occurredAt: string | null;
+  type: string;
+  label: string;
+  recognitionImpact: 'recognition' | 'acceptance' | 'start' | 'none';
+}
+
+interface TimelineSlice {
+  events: TimelineEventSlice[];
+  firstAt: string | null;
+  lastAt: string | null;
+}
+
+const CREDENTIAL_TYPES = new Set([
+  'identity_verification',
+  'licensure',
+  'certification',
+  'screening',
+  'enrollment',
+]);
+
+function kindForEvent(event: TimelineEventSlice): Kind {
+  if (event.recognitionImpact !== 'none') return 'recognition';
+  if (CREDENTIAL_TYPES.has(event.type)) return 'credential';
+  return 'origin';
+}
+
+/**
+ * Project dated career events onto the constellation's temporal axis.
+ * Real events span t ∈ [0.08, 0.58] (origin → now); the future era
+ * (t > 0.62) is reserved for clearly-projected entries.
+ */
+function projectStars(
+  timeline: TimelineSlice,
+  opts: { readinessScore: number | null; specialty?: string; openRoles: number },
+): ConstellationStarDef[] | null {
+  const dated = timeline.events.filter((e) => e.occurredAt);
+  if (dated.length === 0) return null;
+
+  // Latest event per label wins — repeated checks of the same source stay one star.
+  const byLabel = new Map<string, TimelineEventSlice>();
+  for (const event of dated) {
+    const existing = byLabel.get(event.label);
+    if (!existing || (event.occurredAt ?? '') > (existing.occurredAt ?? '')) {
+      byLabel.set(event.label, event);
+    }
+  }
+
+  // Recognition outranks credentials outranks the rest; recent outranks old.
+  const significance = (e: TimelineEventSlice) =>
+    e.recognitionImpact !== 'none' ? 2 : CREDENTIAL_TYPES.has(e.type) ? 1 : 0;
+  const picked = [...byLabel.values()]
+    .sort((a, b) => significance(b) - significance(a) || (b.occurredAt ?? '').localeCompare(a.occurredAt ?? ''))
+    .slice(0, 12);
+
+  const times = picked.map((e) => Date.parse(e.occurredAt!)).filter(Number.isFinite);
+  const minT = Math.min(...times);
+  const maxT = Math.max(Date.now(), ...times);
+  const span = Math.max(1, maxT - minT);
+
+  const rings: Array<2 | 3> = [2, 3, 3, 2];
+  const stars: ConstellationStarDef[] = picked.map((event, i) => {
+    const at = Date.parse(event.occurredAt!);
+    const t = 0.08 + ((Number.isFinite(at) ? at : maxT) - minT) / span * 0.5;
+    return {
+      id: event.eventId,
+      label: event.label,
+      kind: kindForEvent(event),
+      era: t < 0.35 ? 'origin' : 'now',
+      t,
+      ring: rings[i % rings.length],
+    };
+  });
+
+  // "Now" anchors from live wallet state.
+  if (opts.readinessScore != null) {
+    stars.push({ id: 'readiness', label: `Readiness ${opts.readinessScore}`, kind: 'readiness', era: 'now', t: 0.5, ring: 1 });
+  }
+  if (opts.specialty) {
+    stars.push({ id: 'specialty', label: opts.specialty, kind: 'readiness', era: 'now', t: 0.54, ring: 3 });
+  }
+
+  // Future era — projected, and labeled as such.
+  if (opts.openRoles > 0) {
+    stars.push({
+      id: 'open-roles',
+      label: `${opts.openRoles} open role${opts.openRoles === 1 ? '' : 's'}`,
+      kind: 'future',
+      era: 'future',
+      t: 0.74,
+      ring: 2,
+    });
+  }
+  stars.push({ id: 'projected-role', label: 'Projected: next role', kind: 'future', era: 'future', t: 0.84, ring: 3 });
+  stars.push({ id: 'projected-growth', label: 'Projected: what compounds next', kind: 'future', era: 'future', t: 0.92, ring: 2 });
+
+  return stars;
+}
+
+export function CareerEvidenceGraph() {
+  const { data } = useClinicianMobile();
+  const npi = data.workspace?.personProfile?.npi ?? null;
+  const specialty = data.workspace?.personProfile?.specialty ?? undefined;
+  const readinessScore = data.trustState?.readinessScore ?? null;
+  const openRoles = data.availableOpportunities.length;
+
+  const [timeline, setTimeline] = useState<TimelineSlice | null>(null);
+  const [state, setState] = useState<'loading' | 'live' | 'illustrative'>('loading');
+
+  useEffect(() => {
+    if (!npi || !NPI_RE.test(npi)) {
+      setState('illustrative');
+      return;
+    }
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(`/api/timeline/${npi}`, { cache: 'no-store', signal: controller.signal });
+        if (!res.ok) throw new Error(`timeline ${res.status}`);
+        const body = (await res.json()) as TimelineSlice;
+        if (Array.isArray(body.events)) {
+          setTimeline(body);
+          setState('live');
+        } else {
+          setState('illustrative');
+        }
+      } catch {
+        if (!controller.signal.aborted) setState('illustrative');
+      }
+    })();
+    return () => controller.abort();
+  }, [npi]);
+
+  const starDefs = useMemo(() => {
+    if (!timeline) return undefined;
+    return projectStars(timeline, { readinessScore, specialty, openRoles }) ?? undefined;
+  }, [timeline, readinessScore, specialty, openRoles]);
+
+  const live = state === 'live' && starDefs && starDefs.length > 0;
+  const evidenceCount = live
+    ? starDefs.filter((s) => s.era !== 'future' && s.id !== 'readiness' && s.id !== 'specialty').length
+    : 0;
+
+  return (
+    <Reveal>
+      <section aria-label="Career evidence graph" className="mz-glass-strong overflow-hidden p-0">
+        <div className="flex flex-wrap items-center justify-between gap-2 px-5 pt-5">
+          <span className="mz-eyebrow">
+            <Waypoints className="h-3 w-3" aria-hidden="true" />
+            Career evidence graph
+          </span>
+          <span className="mz-mono text-[11px] uppercase tracking-[0.18em] opacity-60">
+            {live
+              ? `${evidenceCount} evidence-backed event${evidenceCount === 1 ? '' : 's'}`
+              : state === 'loading'
+                ? 'Projecting your evidence…'
+                : 'Illustrative sky — evidence lights up as checks complete'}
+          </span>
+        </div>
+
+        <div className="px-2 sm:px-4">
+          <MatchaConstellation
+            height={400}
+            starDefs={live ? starDefs : undefined}
+            profile={{ specialty, readinessScore, matchCount: openRoles }}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--rule)] px-5 py-4">
+          <p className="mz-small max-w-xl">
+            Each lit star traces to a career event in your wallet — checks, licensure,
+            recognition. The future era is projected, never asserted. Scrub time to travel it.
+          </p>
+          <div className="flex shrink-0 items-center gap-2">
+            <Link href="/holder/timeline" className="mz-btn mz-btn-ghost mz-btn-sm">
+              Open timeline
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+            {FEATURES.MATCHA_V2 ? (
+              <Link href="/holder/matcha" className="mz-btn mz-btn-sm">
+                <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+                Explore in MATCHA
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    </Reveal>
+  );
+}

--- a/apps/web/components/holder/CareerEvidenceGraph.tsx
+++ b/apps/web/components/holder/CareerEvidenceGraph.tsx
@@ -66,7 +66,9 @@ function projectStars(
   timeline: TimelineSlice,
   opts: { readinessScore: number | null; specialty?: string; openRoles: number },
 ): ConstellationStarDef[] | null {
-  const dated = timeline.events.filter((e) => e.occurredAt);
+  const dated = timeline.events.filter(
+    (e) => e.occurredAt && Number.isFinite(Date.parse(e.occurredAt)),
+  );
   if (dated.length === 0) return null;
 
   // Latest event per label wins — repeated checks of the same source stay one star.
@@ -85,7 +87,7 @@ function projectStars(
     .sort((a, b) => significance(b) - significance(a) || (b.occurredAt ?? '').localeCompare(a.occurredAt ?? ''))
     .slice(0, 12);
 
-  const times = picked.map((e) => Date.parse(e.occurredAt!)).filter(Number.isFinite);
+  const times = picked.map((e) => Date.parse(e.occurredAt!));
   const minT = Math.min(...times);
   const maxT = Math.max(Date.now(), ...times);
   const span = Math.max(1, maxT - minT);
@@ -93,7 +95,7 @@ function projectStars(
   const rings: Array<2 | 3> = [2, 3, 3, 2];
   const stars: ConstellationStarDef[] = picked.map((event, i) => {
     const at = Date.parse(event.occurredAt!);
-    const t = 0.08 + ((Number.isFinite(at) ? at : maxT) - minT) / span * 0.5;
+    const t = 0.08 + ((at - minT) / span) * 0.5;
     return {
       id: event.eventId,
       label: event.label,
@@ -168,6 +170,14 @@ export function CareerEvidenceGraph() {
     return projectStars(timeline, { readinessScore, specialty, openRoles }) ?? undefined;
   }, [timeline, readinessScore, specialty, openRoles]);
 
+  // Stable identity: an inline object would invalidate the constellation's
+  // useMemo/useEffect chain on every provider re-render and visibly restart
+  // the canvas animation.
+  const profile = useMemo(
+    () => ({ specialty, readinessScore, matchCount: openRoles }),
+    [specialty, readinessScore, openRoles],
+  );
+
   const live = state === 'live' && starDefs && starDefs.length > 0;
   const evidenceCount = live
     ? starDefs.filter((s) => s.era !== 'future' && s.id !== 'readiness' && s.id !== 'specialty').length
@@ -194,7 +204,7 @@ export function CareerEvidenceGraph() {
           <MatchaConstellation
             height={400}
             starDefs={live ? starDefs : undefined}
-            profile={{ specialty, readinessScore, matchCount: openRoles }}
+            profile={profile}
           />
         </div>
 

--- a/apps/web/components/holder/HolderDesktopNav.tsx
+++ b/apps/web/components/holder/HolderDesktopNav.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * HolderDesktopNav — persistent workspace navigation for signed-in clinicians
+ * at md+ widths.
+ *
+ * The holder shell previously had ONLY the mobile bottom tab bar (md:hidden),
+ * which left desktop users with no persistent way to reach the job board,
+ * wallet, applications, recognition, or the CV profile — every surface existed
+ * but was undiscoverable. This is the md+ complement to MobileBottomNav: same
+ * destinations plus the two that never had a nav home (Recognition, Profile).
+ *
+ * Styled with Calm Wave ink/paper tokens so it reads correctly over both the
+ * paper (mz-paper) and dark instrument holder pages.
+ */
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+
+interface NavItem {
+  name: string;
+  href: string;
+  matchPrefix: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { name: 'Home', href: '/holder/home', matchPrefix: false },
+  { name: 'Wallet', href: '/holder', matchPrefix: false },
+  { name: 'Readiness', href: '/holder/readiness', matchPrefix: true },
+  { name: 'Roles', href: '/holder/opportunities', matchPrefix: true },
+  { name: 'Updates', href: '/holder/applications', matchPrefix: true },
+  { name: 'Recognition', href: '/holder/recognition', matchPrefix: true },
+  { name: 'Profile', href: '/clinician/profile', matchPrefix: true },
+];
+
+function isItemActive(item: NavItem, pathname: string): boolean {
+  if (item.href === '/holder/readiness') {
+    return pathname.startsWith('/holder/readiness') || pathname.startsWith('/holder/blockers/');
+  }
+  return item.matchPrefix ? pathname.startsWith(item.href) : pathname === item.href;
+}
+
+export function HolderDesktopNav() {
+  const pathname = usePathname();
+  const { unreadNotifications } = useClinicianMobile();
+
+  return (
+    <nav
+      aria-label="Clinician workspace"
+      className="sticky top-0 z-40 hidden w-full border-b border-[var(--rule)] backdrop-blur-md md:block"
+      style={{ background: 'color-mix(in oklch, var(--card) 88%, transparent)' }}
+    >
+      <div className="mx-auto flex h-14 w-full max-w-6xl items-center gap-6 px-6 lg:px-8">
+        <Link
+          href="/holder/home"
+          className="shrink-0 text-[17px] font-semibold tracking-tight text-[var(--ink-900)]"
+          style={{ fontFamily: 'var(--font-fraunces, var(--vt-font-display, Georgia, serif))' }}
+        >
+          VitalCV
+        </Link>
+
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          {NAV_ITEMS.map((item) => {
+            const active = isItemActive(item, pathname);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={active ? 'page' : undefined}
+                className={`relative whitespace-nowrap rounded-md px-3 py-2 font-mono text-[11.5px] uppercase tracking-[0.14em] transition-colors ${
+                  active
+                    ? 'text-[var(--accent)]'
+                    : 'text-[var(--ink-500)] hover:text-[var(--ink-900)]'
+                }`}
+              >
+                {item.name}
+                {item.href === '/holder/applications' && unreadNotifications.length > 0 ? (
+                  <span className="absolute -right-0.5 top-0.5 inline-flex min-h-4 min-w-4 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[9px] font-bold text-[var(--card)]">
+                    {Math.min(unreadNotifications.length, 9)}
+                  </span>
+                ) : null}
+                {active ? (
+                  <span
+                    aria-hidden="true"
+                    className="absolute inset-x-3 -bottom-[9px] h-[2px] rounded-full bg-[var(--accent)]"
+                  />
+                ) : null}
+              </Link>
+            );
+          })}
+        </div>
+
+        <Link href="/holder/recognition" className="mz-btn mz-btn-sm shrink-0">
+          Share / prove
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/components/matcha/MatchaConstellation.tsx
+++ b/apps/web/components/matcha/MatchaConstellation.tsx
@@ -17,8 +17,8 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-type Era = 'origin' | 'now' | 'future';
-type Kind = 'you' | 'origin' | 'credential' | 'readiness' | 'recognition' | 'opportunity' | 'future';
+export type Era = 'origin' | 'now' | 'future';
+export type Kind = 'you' | 'origin' | 'credential' | 'readiness' | 'recognition' | 'opportunity' | 'future';
 
 interface Star {
   id: string;
@@ -77,9 +77,30 @@ export interface ConstellationProfile {
   matchCount?: number;
 }
 
+/**
+ * A caller-supplied star: real career-evidence events projected into the sky.
+ * When a `stars` list is passed, it fully replaces the illustrative defaults
+ * (the "You" center star is always added). Callers own the honesty of their
+ * labels — evidence-backed events as facts, future entries clearly projected.
+ */
+export interface ConstellationStarDef {
+  id: string;
+  label: string;
+  kind: Kind;
+  era: Era;
+  /** temporal position 0 (earliest) … 1 (furthest future) */
+  t: number;
+  ring: 1 | 2 | 3;
+}
+
 // Deterministic layout (no Math.random at module scope; twinkle phase derived from index).
-function buildStars(profile?: ConstellationProfile): Star[] {
-  const defs: Array<Omit<Star, 'angle' | 'twinkle'>> = [
+function buildStars(profile?: ConstellationProfile, starDefs?: ConstellationStarDef[]): Star[] {
+  const defs: Array<Omit<Star, 'angle' | 'twinkle'>> = starDefs
+    ? [
+        { id: 'you', label: 'You', kind: 'you', era: 'now', t: 0.5, ring: 1 },
+        ...starDefs.filter((s) => s.id !== 'you'),
+      ]
+    : [
     { id: 'you', label: 'You', kind: 'you', era: 'now', t: 0.5, ring: 1 },
     // origin era
     { id: 'residency', label: 'Residency', kind: 'origin', era: 'origin', t: 0.08, ring: 3 },
@@ -137,10 +158,19 @@ function eraForTime(t: number): Era {
   return 'now';
 }
 
-export function MatchaConstellation({ height = 460, profile }: { height?: number; profile?: ConstellationProfile }) {
+export function MatchaConstellation({
+  height = 460,
+  profile,
+  starDefs,
+}: {
+  height?: number;
+  profile?: ConstellationProfile;
+  /** Real career-evidence stars; replaces the illustrative sky when provided. */
+  starDefs?: ConstellationStarDef[];
+}) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
-  const stars = useMemo(() => buildStars(profile), [profile]);
+  const stars = useMemo(() => buildStars(profile, starDefs), [profile, starDefs]);
   const [time, setTime] = useState(0.5);
   const [hoverLabel, setHoverLabel] = useState<string | null>(null);
   const timeRef = useRef(0.5);

--- a/apps/web/components/mobile/ClinicianHomeSurface.tsx
+++ b/apps/web/components/mobile/ClinicianHomeSurface.tsx
@@ -30,6 +30,7 @@ import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider'
 import { RecognitionCard } from '@/components/recognition/RecognitionCard';
 import CareerCompass from '@/components/matcha/CareerCompass';
 import ProductLoopRail from '@/components/holder/ProductLoopRail';
+import { CareerEvidenceGraph } from '@/components/holder/CareerEvidenceGraph';
 import { Reveal } from '@/components/motion/Reveal';
 import { FEATURES } from '@/lib/features';
 import { MatchaHomeActivity } from '@/components/matcha/MatchaHomeActivity';
@@ -340,6 +341,8 @@ export default function ClinicianHomeSurface() {
         <SelectedOpportunityBanner />
 
         <MatchaHomeActivity />
+
+        <CareerEvidenceGraph />
 
         <ProductLoopRail
           npi={hasValidNpi ? npi : null}


### PR DESCRIPTION
## What

Three fixes that answer the founder punch-list on the signed-in clinician workspace:

1. **Desktop holder navigation** (`HolderDesktopNav`) — the holder shell previously rendered ONLY the mobile bottom tab bar (`md:hidden`), so on desktop there was **no persistent navigation at all**: the job board (`/holder/opportunities`), wallet, applications, recognition, and the editable CV (`/clinician/profile`) all existed in production but were unreachable by clicking. New sticky md+ nav in Calm Wave ink/paper tokens: Home · Wallet · Readiness · Roles · Updates · Recognition · Profile + a Share / prove action, with the unread-updates badge carried over from the mobile nav.

2. **Career Evidence Graph as a holder feature** (`CareerEvidenceGraph` on `/holder/home`) — the constellation stops being marketing-only: it now projects the clinician's **real Wave 225 professional-memory timeline** (`/api/timeline/[npi]`: evidence checks, licensure, screening, recognition, employer acceptances) into the sky. `MatchaConstellation` gains an optional `starDefs` input — fully backward-compatible, public homepage untouched. Honesty preserved: header counts only evidence-backed events; with no dated evidence it falls back to the illustrative sky and says so; the future era is always labeled projected, never asserted.

3. **/holder share dead-end removed** — `CredentialPresentationActions` minted hardcoded demo credentials and its "Share Link" copied `/verify/presentation/{id}`, which **404s in production**. Replaced with `ShareRecognitionPanel`, which hands out the real public `/verify/[npi]` link (read-only verifier view + recorded acceptances).

## Verification

- `pnpm turbo run build --filter @vitalcv/web` green (typecheck + eslint enforced by next.config).
- vitest: **195 tests green** across `banned-verified-label`, `holder-route-contract` (150-test link/namespace contract, scans the new nav), `holder-home-page`, `home-npi-role-doors`, `homepage-public-truth`, `release-monitor-holder-routes`, `recognition-share-verify`, `matcha-components`.
- Visual QA on a live dev server against the production backend: live mode renders "1 evidence-backed event" for an NPI with dated evidence; illustrative fallback exercised for NPIs with only undated coverage placeholders; nav verified at desktop width.

## Design Handoff References

- `design-handoff/claude-design-2026-06-26/vitalcv/project/Career Evidence Graph W220.html` — graph-as-holder-feature substrate (nodes are nouns, edges are evidence; per-persona graph experiences)
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Evidence Graph Projector W221.html` — projection model (evidence → node/edge; "projection is total and reversible; the graph stores nothing the evidence does not already carry")
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Clinician Profile.html` — paper/ink/mono workspace chrome language for the desktop nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)