### PR TITLE
fix(identity): honest email-OTP delivery — Resend provider + delivery_unavailable outcome

### DIFF
--- a/apps/api/backend/src/routes/identity.ts
+++ b/apps/api/backend/src/routes/identity.ts
@@ -67,6 +67,12 @@ export function registerEmailOtpRoutes(app: Express): void {
       if (result.outcome === 'rate_limited') {
         throw new HttpError(429, 'Too many codes requested. Try again later.');
       }
+      if (result.outcome === 'delivery_unavailable') {
+        throw new HttpError(
+          503,
+          'Email delivery is not configured on this environment yet, so a code cannot be sent. This optional step can be skipped for now.',
+        );
+      }
       // Never echo the code; delivery is out of band.
       res.status(200).json({ sent: true });
     }),

--- a/apps/api/backend/src/services/identity/emailOtpService.ts
+++ b/apps/api/backend/src/services/identity/emailOtpService.ts
@@ -10,7 +10,10 @@
 import prisma from '../../graphql/prisma_client';
 import { log } from '../../obs/logger';
 import { sha256ForPayload } from '../../utils/deterministic';
-import { getNotificationProvider } from '../providers/notificationProvider';
+import {
+  getNotificationProvider,
+  isEmailDeliveryConfigured,
+} from '../providers/notificationProvider';
 import {
   emailDomain,
   evaluateOtpAttempt,
@@ -36,7 +39,7 @@ async function emitAudit(
   });
 }
 
-export type IssueOutcome = 'sent' | 'invalid_email' | 'rate_limited';
+export type IssueOutcome = 'sent' | 'invalid_email' | 'rate_limited' | 'delivery_unavailable';
 
 export async function issueEmailOtp(
   userId: string,
@@ -45,6 +48,16 @@ export async function issueEmailOtp(
   const email = normalizeEmail(rawEmail);
   if (!isPlausibleEmail(email)) {
     return { outcome: 'invalid_email', email };
+  }
+
+  // Honesty gate: never mint a challenge (or tell the user a code was sent)
+  // in an environment that cannot deliver email at all.
+  if (!isEmailDeliveryConfigured()) {
+    log('warn', 'email_otp_delivery_unconfigured', {
+      userId,
+      emailDomain: emailDomain(email),
+    });
+    return { outcome: 'delivery_unavailable', email };
   }
 
   // Rate limit: cap challenges per (user, email) within the window.
@@ -70,8 +83,8 @@ export async function issueEmailOtp(
     },
   });
 
-  // Delivery is best-effort via the notification provider. A send failure does
-  // not roll back the challenge (dev stub logs; prod uses the wired provider).
+  // The challenge row is only useful if the code reaches an inbox: a failed
+  // send reports delivery_unavailable instead of pretending the code is out.
   try {
     await getNotificationProvider().send(
       email,
@@ -85,6 +98,7 @@ export async function issueEmailOtp(
       emailDomain: emailDomain(email),
       error: err instanceof Error ? err.message : String(err),
     });
+    return { outcome: 'delivery_unavailable', email };
   }
 
   // Audit records only the domain — never the code or full address.

--- a/apps/api/backend/src/services/providers/notificationProvider.ts
+++ b/apps/api/backend/src/services/providers/notificationProvider.ts
@@ -1,5 +1,11 @@
 /**
  * Wave 196 — Notification Provider Interface
+ *
+ * Delivery honesty: callers can ask whether a REAL provider is wired
+ * (isEmailDeliveryConfigured) so user-facing flows never claim "code sent"
+ * when the environment can only log. Production wiring is Resend via
+ * RESEND_API_KEY (+ optional NOTIFY_FROM_EMAIL); without it, the stub
+ * provider logs and delivery counts as unconfigured.
  */
 
 import { log } from '../../obs/logger';
@@ -14,15 +20,59 @@ class StubNotificationProvider implements INotificationProvider {
   }
 }
 
+const RESEND_API_URL = 'https://api.resend.com/emails';
+const DEFAULT_FROM = 'VitalCV <no-reply@vitalcv.com>';
+
+class ResendNotificationProvider implements INotificationProvider {
+  constructor(
+    private readonly apiKey: string,
+    private readonly from: string,
+  ) {}
+
+  async send(to: string, subject: string, body: string): Promise<void> {
+    const res = await fetch(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from: this.from, to: [to], subject, text: body }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`Resend send failed (${res.status}): ${detail.slice(0, 200)}`);
+    }
+  }
+}
+
 let _provider: INotificationProvider | null = null;
+let _configured = false;
 
 export function getNotificationProvider(): INotificationProvider {
   if (_provider) return _provider;
-  // TODO: wire SendGrid / Postmark when SENDGRID_API_KEY or POSTMARK_API_KEY is set
-  _provider = new StubNotificationProvider();
+  const resendKey = process.env.RESEND_API_KEY?.trim();
+  if (resendKey) {
+    _provider = new ResendNotificationProvider(
+      resendKey,
+      process.env.NOTIFY_FROM_EMAIL?.trim() || DEFAULT_FROM,
+    );
+    _configured = true;
+    log('info', 'notification_provider_configured', { provider: 'resend' });
+  } else {
+    _provider = new StubNotificationProvider();
+    _configured = false;
+  }
   return _provider;
+}
+
+/** True when a real delivery provider is active (or one was injected). */
+export function isEmailDeliveryConfigured(): boolean {
+  getNotificationProvider();
+  return _configured;
 }
 
 export function setNotificationProvider(provider: INotificationProvider): void {
   _provider = provider;
+  _configured = true;
 }

--- a/apps/web/components/get-ready/EmailVerification.tsx
+++ b/apps/web/components/get-ready/EmailVerification.tsx
@@ -16,6 +16,25 @@ type Step = 'email' | 'sending' | 'code' | 'verifying' | 'verified';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Backend errors arrive as `{ error: { code, message } }` (HttpError shape),
+ * `{ error: string }`, or `{ reason: string }` — coerce to a renderable string
+ * so an object never reaches JSX.
+ */
+function errorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === 'object') {
+    const err = (body as { error?: unknown }).error;
+    if (typeof err === 'string') return err;
+    if (err && typeof err === 'object') {
+      const msg = (err as { message?: unknown }).message;
+      if (typeof msg === 'string') return msg;
+    }
+    const reason = (body as { reason?: unknown }).reason;
+    if (typeof reason === 'string') return reason;
+  }
+  return fallback;
+}
+
 export default function EmailVerification() {
   const [step, setStep] = useState<Step>('email');
   const [email, setEmail] = useState('');
@@ -39,7 +58,7 @@ export default function EmailVerification() {
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        setError(body.error ?? 'Could not send a code. Try again shortly.');
+        setError(errorMessage(body, 'Could not send a code. Try again shortly.'));
         setStep('email');
         return;
       }
@@ -67,7 +86,7 @@ export default function EmailVerification() {
       });
       const body = await res.json().catch(() => ({}));
       if (!res.ok || !body.verified) {
-        setError(body.reason ?? 'Verification failed. Try again.');
+        setError(errorMessage(body, 'Verification failed. Try again.'));
         setStep('code');
         return;
       }


### PR DESCRIPTION
## What

The `/get-ready` email-OTP corroboration step told users "We sent a 6-digit code" in **every** environment — but the notification provider was a logging stub (`TODO: wire SendGrid / Postmark`) and `issueEmailOtp` returned `'sent'` even when the send failed. In production no code could ever arrive; the optional identity-strengthening step was a silent dead end, and it reads as "sign-up doesn't work."

- **notificationProvider** — adds a real Resend-backed provider, activated by `RESEND_API_KEY` (optional `NOTIFY_FROM_EMAIL`, defaults to `VitalCV <no-reply@vitalcv.com>`); exposes `isEmailDeliveryConfigured()` so flows can tell the truth about delivery. No new dependency (plain fetch). Stub remains for dev.
- **issueEmailOtp** — new `'delivery_unavailable'` outcome: returned *without minting a challenge* when no real provider is configured, and when the provider send throws. The `identity_email_otp_issued` audit row is no longer written for codes that never left the building.
- **identity route** — maps `delivery_unavailable` to an honest 503: "Email delivery is not configured on this environment yet, so a code cannot be sent. This optional step can be skipped for now."
- **EmailVerification (web)** — backend errors arrive as `{error:{code,message}}`; the component rendered `body.error` directly, which crashes React with "Objects are not valid as a React child" on any 4xx/5xx (rate limit, invalid email). Coerced to a string with safe fallbacks on both issue and verify paths.

## Ops note

Until `RESEND_API_KEY` is provisioned on the backend service, the step now says delivery is unavailable instead of lying. Once the key is added (and the vitalcv.com sending domain is verified in Resend), codes actually send — no further deploy needed.

## Verification

- Backend `tsc --noEmit` green (after `prisma generate`).
- Web `pnpm turbo run build --filter @vitalcv/web` green.
- Behavior matrix traced: no key → 503 + no challenge row + no audit; key + send failure → 503, challenge row retained for retry, no audit; key + send OK → 200 `{sent:true}` + audit (unchanged).

## Design Handoff References

No design-handoff file applies to this change (backend delivery honesty + error-string hardening; no visual surface altered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)