### PR TITLE
feat(ai): make AI flip-ready — documented ANTHROPIC_API_KEY + single shared gate

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -63,6 +63,18 @@ NEXT_PUBLIC_API_BASE=https://api.vitalcv.com
 # NEXT_PUBLIC_SENTRY_DSN=
 # SENTRY_AUTH_TOKEN=
 
+# ── AI (optional) ───────────────────────────────────────────────────
+# AI features are OFF unless ANTHROPIC_API_KEY is set. When unset,
+# every AI path degrades honestly (the cover-letter drafter returns
+# { configured: false } and the UI shows "AI drafting isn't enabled
+# here"); matching runs fully on the deterministic engine regardless.
+# Setting this key is the ONLY step to turn AI on — no code change.
+# Single gate: apps/web/lib/ai/anthropic.ts. Create a key at
+# https://console.anthropic.com/ and set it in the Railway web service.
+# ANTHROPIC_API_KEY=
+# Optional model override for the cover-letter drafter (default claude-opus-4-8).
+# COVER_LETTER_MODEL=
+
 # Prisma. The web app prisma schema is read-only (generates the
 # typed client). DATABASE_URL is only required if any runtime
 # code path actually executes a Prisma query. For a public-only

--- a/apps/web/app/api/matcha/cover-letter/route.ts
+++ b/apps/web/app/api/matcha/cover-letter/route.ts
@@ -12,16 +12,19 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { buildCoverLetterMessages, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
+import {
+  ANTHROPIC_MESSAGES_URL,
+  ANTHROPIC_VERSION,
+  anthropicModel,
+  getAnthropicKey,
+} from '@/lib/ai/anthropic';
 
 export const runtime = 'nodejs';
 
-const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
-const DEFAULT_MODEL = 'claude-opus-4-8';
-
 export async function POST(req: NextRequest) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = getAnthropicKey();
   if (!apiKey) {
-    // Honest: the feature isn't wired up in this environment.
+    // Honest: AI isn't wired up in this environment (no ANTHROPIC_API_KEY).
     return NextResponse.json({ configured: false }, { status: 200 });
   }
 
@@ -35,15 +38,15 @@ export async function POST(req: NextRequest) {
   const { system, user } = buildCoverLetterMessages({ profileSummary, opportunity });
 
   try {
-    const res = await fetch(ANTHROPIC_URL, {
+    const res = await fetch(ANTHROPIC_MESSAGES_URL, {
       method: 'POST',
       headers: {
         'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
+        'anthropic-version': ANTHROPIC_VERSION,
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        model: process.env.COVER_LETTER_MODEL || DEFAULT_MODEL,
+        model: anthropicModel(),
         max_tokens: 1024,
         system,
         messages: [{ role: 'user', content: user }],

--- a/apps/web/lib/ai/anthropic.ts
+++ b/apps/web/lib/ai/anthropic.ts
@@ -1,0 +1,36 @@
+/**
+ * Anthropic (Claude) config — the single, documented gate for VitalCV's optional
+ * AI features.
+ *
+ * AI is OFF unless `ANTHROPIC_API_KEY` is set. Every AI feature MUST degrade
+ * honestly when `isAnthropicConfigured()` is false — the deterministic path keeps
+ * working, the UI says AI isn't enabled, and nothing is fabricated or errored.
+ *
+ * Today this gates the MATCHA cover-letter drafter. The planned LLM
+ * match-explanation / re-ranking layer will import the same gate, so turning AI
+ * on across the product is a single env var with no code change.
+ *
+ * Env (set in the Railway *web* service Variables — never commit a key):
+ *   ANTHROPIC_API_KEY   enables AI. Create one at https://console.anthropic.com/.
+ *   COVER_LETTER_MODEL  optional model override (default below).
+ */
+
+export const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+export const ANTHROPIC_VERSION = '2023-06-01';
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-opus-4-8';
+
+/** The configured key, or undefined when AI is not enabled in this environment. */
+export function getAnthropicKey(): string | undefined {
+  const key = process.env.ANTHROPIC_API_KEY?.trim();
+  return key && key.length > 0 ? key : undefined;
+}
+
+/** True when a model key is present — the gate every AI feature checks first. */
+export function isAnthropicConfigured(): boolean {
+  return getAnthropicKey() !== undefined;
+}
+
+/** The model to call, honoring COVER_LETTER_MODEL, else the default. */
+export function anthropicModel(): string {
+  return process.env.COVER_LETTER_MODEL?.trim() || DEFAULT_ANTHROPIC_MODEL;
+}


### PR DESCRIPTION
## What
Closes the AI audit gap: the only real product LLM (cover-letter drafting) read `ANTHROPIC_API_KEY` inline and the key was **completely undocumented** — not in any `.env.example` — so nobody would know AI exists or how to enable it.

- **`apps/web/lib/ai/anthropic.ts`** — one documented gate (`getAnthropicKey` / `isAnthropicConfigured` / `anthropicModel` + URL/version). The planned LLM match-explanation / re-ranking layer will import the *same* gate, so turning AI on across the product is a single env var, no code change.
- **Cover-letter route** refactored onto the shared gate — identical honest degradation (`{ configured: false }` when no key).
- **`apps/web/.env.example`** now documents `ANTHROPIC_API_KEY` + `COVER_LETTER_MODEL` and states the honest-degradation contract.

## Why now
You're out of Anthropic credits, so AI is parked — but this makes it a **one-env-var flip** the moment credits return, and documents the key that was invisible. Zero behavior change without a key (AI stays off; matching is unaffected).

## Verification
`next lint` + `turbo build` green; no behavior change with no key.

## Design Handoff References
No design — config/documentation + a shared gate module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)