### PR TITLE
feat: career-profile sharing + public profile page, employer apply embed, dev-keys guard rail

### DIFF
--- a/apps/api/backend/src/routes/intake.ts
+++ b/apps/api/backend/src/routes/intake.ts
@@ -13,13 +13,17 @@ import {
   bootstrapNpiIntake,
   clearResume,
   getProfileCompleteness,
+  getProfileSharing,
+  getPublicCareerProfile,
   ingestLinks,
   ingestResumeUpload,
   ingestWorkAuth,
+  updateProfileSharing,
   updateSelfAttested,
   type ClearableLinkField,
 } from '../services/intake/intakeService';
 import { ensureWorkspaceUser } from '../services/workspace/workspaceService';
+import { publicApiRateLimit } from '../middleware/publicSafety';
 import { HttpError } from '../utils/httpError';
 
 const NPI_RE = /^\d{10}$/;
@@ -191,6 +195,51 @@ export function registerIntakeRoutes(app: Express): void {
         attestationVersion,
       });
       res.status(201).json(result);
+    }),
+  );
+
+  /**
+   * GET /api/profile/sharing — current career-profile visibility (default
+   * private). Auth-scoped to the signed-in clinician.
+   */
+  app.get(
+    '/api/profile/sharing',
+    asyncHandler(async (req, res) => {
+      const userId = await requireInternalUserId(req);
+      res.json(await getProfileSharing(userId));
+    }),
+  );
+
+  /**
+   * POST /api/profile/sharing  { careerProfile: 'public' | 'private' }
+   * Publishes or unpublishes the clinician's public career-profile page.
+   */
+  app.post(
+    '/api/profile/sharing',
+    asyncHandler(async (req, res) => {
+      const userId = await requireInternalUserId(req);
+      const body = req.body as { careerProfile?: unknown } | undefined;
+      res.json(await updateProfileSharing(userId, body?.careerProfile));
+    }),
+  );
+
+  /**
+   * GET /api/profile/public/:npi — the clinician-published career profile.
+   * Public read; 404 unless the holder has explicitly set sharing to public.
+   */
+  app.get(
+    '/api/profile/public/:npi',
+    publicApiRateLimit,
+    asyncHandler(async (req, res) => {
+      const npi = req.params.npi?.trim() ?? '';
+      if (!NPI_RE.test(npi)) {
+        throw new HttpError(404, 'Career profile not found.');
+      }
+      const profile = await getPublicCareerProfile(npi);
+      if (!profile) {
+        throw new HttpError(404, 'This career profile is not shared.');
+      }
+      res.json({ shared: true, profile });
     }),
   );
 

--- a/apps/api/backend/src/services/intake/__tests__/selfAttestedSharing.test.ts
+++ b/apps/api/backend/src/services/intake/__tests__/selfAttestedSharing.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Career-profile sharing — pure sanitization contract.
+ *
+ * The sharing key rides in the selfAttested JSON column (no migration).
+ * sanitizeSelfAttested must accept exactly 'public' | 'private' and drop
+ * everything else, so a hostile payload can never publish a profile with a
+ * garbage visibility value.
+ */
+import { sanitizeSelfAttested } from '../intakeService';
+
+describe('sanitizeSelfAttested — sharing', () => {
+  it('accepts public and private', () => {
+    expect(sanitizeSelfAttested({ sharing: { careerProfile: 'public' } }).sharing)
+      .toEqual({ careerProfile: 'public' });
+    expect(sanitizeSelfAttested({ sharing: { careerProfile: 'private' } }).sharing)
+      .toEqual({ careerProfile: 'private' });
+  });
+
+  it('drops unknown visibility values entirely', () => {
+    for (const bad of ['PUBLIC', 'shared', 1, true, null, { nested: true }, ['public']]) {
+      const out = sanitizeSelfAttested({ sharing: { careerProfile: bad } });
+      expect(out.sharing).toBeUndefined();
+    }
+  });
+
+  it('drops a non-object sharing payload', () => {
+    expect(sanitizeSelfAttested({ sharing: 'public' }).sharing).toBeUndefined();
+    expect(sanitizeSelfAttested({ sharing: ['public'] }).sharing).toBeUndefined();
+  });
+
+  it('keeps sharing independent of content sections', () => {
+    const out = sanitizeSelfAttested({
+      subspecialty: 'Cardiology',
+      sharing: { careerProfile: 'public', extraneous: 'dropped' },
+    });
+    expect(out.subspecialty).toBe('Cardiology');
+    expect(out.sharing).toEqual({ careerProfile: 'public' });
+  });
+});

--- a/apps/api/backend/src/services/intake/intakeService.ts
+++ b/apps/api/backend/src/services/intake/intakeService.ts
@@ -422,6 +422,13 @@ export interface SelfAttestedAffiliation {
  * USER_ENTERED — typed by the clinician and never source-verified. Source-
  * checked facts (identity, licensure, board) are held separately.
  */
+export type CareerProfileVisibility = 'public' | 'private';
+
+export interface SelfAttestedSharing {
+  /** Public career-profile page (/profile/[npi]). Default private. */
+  careerProfile?: CareerProfileVisibility;
+}
+
 export interface SelfAttestedProfile {
   contact?:        SelfAttestedContact;
   medicalSchool?:  SelfAttestedEducation;
@@ -430,6 +437,7 @@ export interface SelfAttestedProfile {
   affiliations?:   SelfAttestedAffiliation[];
   careerGoals?:    string;
   researchSummary?: string;
+  sharing?:        SelfAttestedSharing;
 }
 
 const MAX_ROWS = 40;
@@ -526,6 +534,11 @@ export function sanitizeSelfAttested(input: unknown): SelfAttestedProfile {
   const researchSummary = cleanStr(src.researchSummary);
   if (researchSummary) out.researchSummary = researchSummary;
 
+  const sharingSrc = (src.sharing && typeof src.sharing === 'object' ? src.sharing : {}) as Record<string, unknown>;
+  if (sharingSrc.careerProfile === 'public' || sharingSrc.careerProfile === 'private') {
+    out.sharing = { careerProfile: sharingSrc.careerProfile };
+  }
+
   return out;
 }
 
@@ -540,6 +553,21 @@ export async function updateSelfAttested(
   input:  unknown,
 ): Promise<SelfAttestedProfile> {
   const clean = sanitizeSelfAttested(input);
+
+  // Sharing is a setting, not a content section: the editor's full-document
+  // replace must not silently flip a published profile back to private (or
+  // vice versa) just because the payload omitted the key.
+  if (!clean.sharing) {
+    const existing = await prisma.personProfile.findFirst({
+      where: { userId },
+      select: { selfAttested: true },
+    });
+    const prior = (existing?.selfAttested ?? null) as SelfAttestedProfile | null;
+    if (prior?.sharing?.careerProfile) {
+      clean.sharing = { careerProfile: prior.sharing.careerProfile };
+    }
+  }
+
   const result = await prisma.personProfile.updateMany({
     where: { userId },
     data:  { selfAttested: clean as object, updatedAt: new Date() },
@@ -549,6 +577,87 @@ export async function updateSelfAttested(
   }
   await emitAudit('self_attested_updated', userId, { sections: Object.keys(clean) });
   return clean;
+}
+
+/** Current career-profile sharing state (default private). */
+export async function getProfileSharing(
+  userId: string,
+): Promise<{ careerProfile: CareerProfileVisibility }> {
+  const profile = await prisma.personProfile.findFirst({
+    where: { userId },
+    select: { selfAttested: true },
+  });
+  if (!profile) {
+    throw new HttpError(404, 'No profile yet. Connect your NPI first.');
+  }
+  const doc = (profile.selfAttested ?? null) as SelfAttestedProfile | null;
+  return { careerProfile: doc?.sharing?.careerProfile === 'public' ? 'public' : 'private' };
+}
+
+/**
+ * Flip the public career-profile page on or off. Audit-first mutation: the
+ * visibility change is recorded before the caller sees a 2xx.
+ */
+export async function updateProfileSharing(
+  userId: string,
+  visibility: unknown,
+): Promise<{ careerProfile: CareerProfileVisibility }> {
+  if (visibility !== 'public' && visibility !== 'private') {
+    throw new HttpError(400, "careerProfile must be 'public' or 'private'.");
+  }
+  const profile = await prisma.personProfile.findFirst({
+    where: { userId },
+    select: { id: true, selfAttested: true },
+  });
+  if (!profile) {
+    throw new HttpError(404, 'No profile yet. Connect your NPI first.');
+  }
+  const doc = sanitizeSelfAttested(profile.selfAttested ?? {});
+  doc.sharing = { careerProfile: visibility };
+  await prisma.personProfile.update({
+    where: { id: profile.id },
+    data:  { selfAttested: doc as object, updatedAt: new Date() },
+  });
+  await emitAudit('career_profile_sharing_updated', userId, { visibility });
+  return { careerProfile: visibility };
+}
+
+/**
+ * Public career-profile read: the clinician-published subset only, and only
+ * when the holder has explicitly set sharing to public. Excludes resume
+ * document refs and work-authorization status — those stay in-app.
+ */
+export interface PublicCareerProfile {
+  npi: string;
+  firstName: string | null;
+  lastName: string | null;
+  specialty: string | null;
+  stateOfPractice: string | null;
+  linkedinUrl: string | null;
+  portfolioUrl: string | null;
+  selfAttested: Omit<SelfAttestedProfile, 'sharing'>;
+  updatedAt: string | null;
+}
+
+export async function getPublicCareerProfile(
+  npi: string,
+): Promise<PublicCareerProfile | null> {
+  const profile = await prisma.personProfile.findFirst({ where: { npi } });
+  if (!profile) return null;
+  const doc = (profile.selfAttested ?? null) as SelfAttestedProfile | null;
+  if (doc?.sharing?.careerProfile !== 'public') return null;
+  const { sharing: _sharing, ...publishable } = doc;
+  return {
+    npi,
+    firstName: profile.firstName ?? null,
+    lastName: profile.lastName ?? null,
+    specialty: profile.specialty ?? null,
+    stateOfPractice: profile.stateOfPractice ?? null,
+    linkedinUrl: profile.linkedinUrl ?? null,
+    portfolioUrl: profile.portfolioUrl ?? null,
+    selfAttested: publishable,
+    updatedAt: profile.updatedAt ? profile.updatedAt.toISOString() : null,
+  };
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/apps/web/__tests__/apply-embed-badge.test.ts
+++ b/apps/web/__tests__/apply-embed-badge.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Apply-with-VitalCV embed badge — served SVG must be valid, cacheable,
+ * cross-origin loadable, and free of banned truth-contract strings.
+ */
+import { describe, expect, it } from 'vitest';
+import { GET } from '@/app/api/embed/apply-badge.svg/route';
+
+const BANNED = [
+  'automatically verified',
+  'guaranteed verification',
+  'complete credentialing',
+  'instant credentialing',
+  'legally accepted',
+  'certified compliant',
+];
+
+describe('GET /api/embed/apply-badge.svg', () => {
+  it('serves a cacheable, cross-origin SVG badge', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('image/svg+xml');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(res.headers.get('Cache-Control')).toContain('max-age');
+
+    const body = await res.text();
+    expect(body).toContain('<svg');
+    expect(body).toContain('Apply with VitalCV');
+  });
+
+  it('contains no banned claims and no bare Verified label', async () => {
+    const body = await (await GET()).text();
+    for (const phrase of BANNED) {
+      expect(body.toLowerCase()).not.toContain(phrase);
+    }
+    expect(body).not.toMatch(/>\s*Verified\s*</);
+  });
+});

--- a/apps/web/__tests__/dev-keys-notice.test.ts
+++ b/apps/web/__tests__/dev-keys-notice.test.ts
@@ -1,0 +1,48 @@
+/**
+ * DevKeysNotice decision helpers — the guard rail against the silent
+ * local-auth failure mode (pk_live keys off their bound domain).
+ */
+import { describe, expect, it } from 'vitest';
+import { liveKeyDomain, shouldWarnAboutLiveKeys } from '@/components/auth/DevKeysNotice';
+
+// pk_live_ + base64("clerk.vitalcv.com$") — the real production key shape.
+const LIVE_KEY = `pk_live_${Buffer.from('clerk.vitalcv.com$').toString('base64')}`;
+const TEST_KEY = `pk_test_${Buffer.from('funky-mole-42.clerk.accounts.dev$').toString('base64')}`;
+
+describe('liveKeyDomain', () => {
+  it('decodes the bound apex domain from a pk_live key', () => {
+    expect(liveKeyDomain(LIVE_KEY)).toBe('vitalcv.com');
+  });
+
+  it('returns null for pk_test keys', () => {
+    expect(liveKeyDomain(TEST_KEY)).toBeNull();
+  });
+
+  it('returns null for missing or malformed keys', () => {
+    expect(liveKeyDomain(undefined)).toBeNull();
+    expect(liveKeyDomain('')).toBeNull();
+    expect(liveKeyDomain('pk_live_not-base64!!!')).toBeNull();
+  });
+});
+
+describe('shouldWarnAboutLiveKeys', () => {
+  it('warns on localhost with live keys', () => {
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, 'localhost')).toBe(true);
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, '127.0.0.1')).toBe(true);
+  });
+
+  it('stays quiet on the bound domain and its subdomains', () => {
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, 'vitalcv.com')).toBe(false);
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, 'www.vitalcv.com')).toBe(false);
+  });
+
+  it('never warns for pk_test keys anywhere', () => {
+    expect(shouldWarnAboutLiveKeys(TEST_KEY, 'localhost')).toBe(false);
+    expect(shouldWarnAboutLiveKeys(TEST_KEY, 'vitalcv.com')).toBe(false);
+  });
+
+  it('does not treat lookalike domains as bound', () => {
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, 'evilvitalcv.com')).toBe(true);
+    expect(shouldWarnAboutLiveKeys(LIVE_KEY, 'vitalcv.com.attacker.io')).toBe(true);
+  });
+});

--- a/apps/web/__tests__/public-career-profile.test.tsx
+++ b/apps/web/__tests__/public-career-profile.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * /profile/[npi] — the clinician-published public career profile page.
+ * Contract: renders ONLY when the backend says shared; 404s otherwise;
+ * self-attested content is labeled self-attested; links to /verify/[npi].
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import PublicCareerProfilePage from '@/app/profile/[npi]/page';
+
+const NPI = '1234567890';
+
+const SHARED_PAYLOAD = {
+  shared: true,
+  profile: {
+    npi: NPI,
+    firstName: 'Macie',
+    lastName: 'Miller',
+    specialty: 'Physician Assistant',
+    stateOfPractice: 'CA',
+    linkedinUrl: 'https://www.linkedin.com/in/macie',
+    portfolioUrl: null,
+    selfAttested: {
+      medicalSchool: { institutionName: 'UC Davis', degree: 'MPAS', graduationYear: 2019 },
+      workHistory: [{ employer: 'Cedar Health', role: 'PA-C', startYear: 2020 }],
+      careerGoals: 'Cardiology team lead.',
+    },
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  },
+};
+
+function mockFetch(sharedStatus: number, sharedBody: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/profile/public/')) {
+      return new Response(JSON.stringify(sharedBody), { status: sharedStatus });
+    }
+    // passport identity fetch — always degrade gracefully in tests
+    return new Response('{}', { status: 503 });
+  }) as unknown as typeof fetch;
+}
+
+describe('/profile/[npi]', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('renders the shared career profile with self-attested labeling', async () => {
+    global.fetch = mockFetch(200, SHARED_PAYLOAD);
+    const el = await PublicCareerProfilePage({ params: Promise.resolve({ npi: NPI }) });
+    const html = renderToStaticMarkup(el);
+
+    expect(html).toContain('Macie Miller');
+    expect(html).toContain('Cedar Health');
+    expect(html).toContain('Self-attested by the clinician');
+    expect(html).toContain(`/verify/${NPI}`);
+    expect(html).toContain('shared by the clinician');
+    // truth contract: no bare Verified label
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+
+  it('404s when the profile is not shared', async () => {
+    global.fetch = mockFetch(404, { error: { code: 'NOT_FOUND' } });
+    await expect(
+      PublicCareerProfilePage({ params: Promise.resolve({ npi: NPI }) }),
+    ).rejects.toThrowError();
+  });
+
+  it('404s on a malformed NPI without calling the backend', async () => {
+    const spy = vi.fn();
+    global.fetch = spy as unknown as typeof fetch;
+    await expect(
+      PublicCareerProfilePage({ params: Promise.resolve({ npi: 'not-an-npi' }) }),
+    ).rejects.toThrowError();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/embed/apply-badge.svg/route.ts
+++ b/apps/web/app/api/embed/apply-badge.svg/route.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/embed/apply-badge.svg — the hosted "Apply with VitalCV" badge for
+ * employer careers-page embeds (see OpportunityEmbedPanel). Pure static SVG:
+ * no user input reaches the markup. Long-cacheable; served with a permissive
+ * CORS header so <img> loads work from any employer origin.
+ */
+import { NextResponse } from 'next/server';
+
+const BADGE = `<svg xmlns="http://www.w3.org/2000/svg" width="196" height="44" viewBox="0 0 196 44" role="img" aria-label="Apply with VitalCV">
+  <rect x="0.5" y="0.5" width="195" height="43" rx="8" fill="#14141a" stroke="#2c2c36"/>
+  <circle cx="22" cy="22" r="9" fill="none" stroke="#8b8cf0" stroke-width="1.5"/>
+  <circle cx="22" cy="22" r="3" fill="#f4c76b"/>
+  <text x="40" y="19" font-family="ui-monospace, 'Geist Mono', monospace" font-size="9" letter-spacing="1.5" fill="#9aa0b5">APPLY WITH</text>
+  <text x="40" y="33" font-family="Georgia, 'Times New Roman', serif" font-size="15" fill="#f4f3ee">VitalCV</text>
+</svg>
+`;
+
+export async function GET() {
+  return new NextResponse(BADGE, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/svg+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      'Access-Control-Allow-Origin': '*',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/apps/web/app/api/profile/sharing/route.ts
+++ b/apps/web/app/api/profile/sharing/route.ts
@@ -1,0 +1,38 @@
+/**
+ * /api/profile/sharing — career-profile visibility for the signed-in clinician.
+ * GET returns { careerProfile: 'public' | 'private' }; POST sets it.
+ * Thin auth-scoped proxy: identity comes from the verified Clerk session only.
+ */
+import { auth } from '@clerk/nextjs/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import { getApiBase } from '@/lib/api';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
+
+const BACKEND = getApiBase();
+
+async function proxy(req: NextRequest, method: 'GET' | 'POST') {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(await buildIdentityHeaders({ userId: session.userId })),
+  };
+  const res = await fetch(`${BACKEND}/api/profile/sharing`, {
+    method,
+    headers,
+    body: method === 'POST' ? await req.text() : undefined,
+    signal: AbortSignal.timeout(15_000),
+  });
+  const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, 'GET');
+}
+
+export async function POST(req: NextRequest) {
+  return proxy(req, 'POST');
+}

--- a/apps/web/app/clinician/profile/ProfileSurface.tsx
+++ b/apps/web/app/clinician/profile/ProfileSurface.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import { ClinicianProfileSections } from '@/components/profile/ClinicianProfileSections';
 import SelfAttestedEditor from '@/components/profile/SelfAttestedEditor';
+import CareerProfileSharingCard from '@/components/profile/CareerProfileSharingCard';
 import { isPassportData, type PassportData } from '@/lib/trust/passport-contract';
 import { PROVENANCE_META, type ProfileProvenance } from '@/lib/profile/provenance';
 import {
@@ -705,6 +706,9 @@ export default function ProfileSurface() {
 
       {/* Self-attested structured sections — editable */}
       <SelfAttestedEditor initial={profile.selfAttested} onSaved={handleSelfAttestedSaved} />
+
+      {/* Share or don't share — the public career profile page */}
+      {profile.npi ? <CareerProfileSharingCard npi={profile.npi} /> : null}
 
       {/* Passport-backed + self-attested profile sections (read projection) */}
       {passport ? (

--- a/apps/web/app/employer/post/page.tsx
+++ b/apps/web/app/employer/post/page.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Reveal } from '@/components/motion/Reveal';
+import OpportunityEmbedPanel from '@/components/employer/OpportunityEmbedPanel';
 
 interface Opportunity {
   id: string;
@@ -661,6 +662,7 @@ export default function EmployerPostPage() {
                               Close
                             </button>
                           )}
+                          <OpportunityEmbedPanel opportunityId={o.id} title={o.title} />
                         </div>
                       ) : null}
                       {closeError && closeError.id === o.id ? (

--- a/apps/web/app/opportunities/[id]/page.tsx
+++ b/apps/web/app/opportunities/[id]/page.tsx
@@ -1,0 +1,140 @@
+/**
+ * /opportunities/[id] — public landing page for one ACTIVE opening.
+ *
+ * This is where employer-embedded "Apply with VitalCV" buttons land (see
+ * OpportunityEmbedPanel): a no-login view of the role plus the apply path.
+ * "Apply with VitalCV" deep-links into the signed-in role page —
+ * /holder/opportunities/[id] — and the middleware walks a signed-out
+ * clinician through sign-in and back. New clinicians get the /get-ready lane.
+ * Honest copy: a posting is a plain listing; nothing here implies VitalCV
+ * verified the employer.
+ */
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getBackendBase } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface PublicOpportunity {
+  id: string;
+  title: string;
+  specialty?: string | null;
+  hiringType?: string | null;
+  state?: string | null;
+  payRange?: string | null;
+  description?: string | null;
+  remote?: boolean;
+  status?: string;
+  organizationName?: string | null;
+  organization?: { name?: string | null } | null;
+}
+
+const HIRING_LABEL: Record<string, string> = {
+  perm: 'Permanent',
+  locums: 'Locums',
+  travel: 'Travel',
+  telehealth: 'Telehealth',
+  per_diem: 'Per diem',
+};
+
+async function fetchOpportunity(id: string): Promise<PublicOpportunity | null> {
+  try {
+    const res = await fetch(`${getBackendBase()}/api/opportunities/${encodeURIComponent(id)}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { opportunity?: PublicOpportunity };
+    return body.opportunity ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Metadata> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return { title: 'Opportunity' };
+  const opp = await fetchOpportunity(id);
+  return {
+    title: opp ? `${opp.title} — Apply with VitalCV` : 'Opportunity',
+    description: opp
+      ? 'Apply with your VitalCV career evidence wallet — readiness snapshot attached, no résumé re-typing.'
+      : undefined,
+  };
+}
+
+export default async function PublicOpportunityPage(
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) notFound();
+
+  const opp = await fetchOpportunity(id);
+  if (!opp || (opp.status && opp.status !== 'ACTIVE')) notFound();
+
+  const orgName = opp.organizationName ?? opp.organization?.name ?? null;
+  const facts = [
+    opp.specialty,
+    opp.hiringType ? HIRING_LABEL[opp.hiringType] ?? opp.hiringType : null,
+    opp.state,
+    opp.remote ? 'Remote' : null,
+    opp.payRange,
+  ].filter(Boolean);
+
+  return (
+    <div className="mz mz-persona-holder min-h-screen">
+      <main className="mx-auto w-full max-w-2xl px-5 pb-16 pt-12">
+        <p className="mz-eyebrow">Open role{orgName ? ` · ${orgName}` : ''}</p>
+        <h1 className="mz-h1 mt-2">{opp.title}</h1>
+        {facts.length > 0 ? (
+          <p className="mz-small mt-2 opacity-80">{facts.join(' · ')}</p>
+        ) : null}
+
+        {opp.description ? (
+          <div className="mz-card mz-card-pad mt-6">
+            <p className="mz-body whitespace-pre-line">{opp.description}</p>
+          </div>
+        ) : null}
+
+        <div className="mz-card mz-card-pad mt-6">
+          <h2 className="mz-h2">Apply with your career evidence, not a résumé</h2>
+          <p className="mz-body mt-2">
+            VitalCV is the clinician-owned career wallet: your NPI-backed
+            readiness snapshot and source-backed evidence travel with your
+            application, so this employer can act on it as a head start.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              href={`/holder/opportunities/${opp.id}`}
+              className="mz-btn"
+              data-testid="apply-with-vitalcv"
+            >
+              Apply with VitalCV →
+            </Link>
+            <Link href="/get-ready" className="mz-btn-ghost">
+              New here? Set up your wallet first
+            </Link>
+          </div>
+          <p className="mz-small mt-3 opacity-70">
+            Signing in keeps your application tied to your own wallet. Applying
+            shares your readiness snapshot with this employer — nothing more.
+          </p>
+        </div>
+
+        <p className="mz-small mt-8 opacity-60">
+          This posting is a listing created by the employer. VitalCV verifies
+          clinician career evidence against primary sources; it does not verify
+          employers or endorse openings.{' '}
+          <Link href="/employer/post" className="underline underline-offset-4">
+            Employers: post and embed your own roles.
+          </Link>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/profile/[npi]/page.tsx
+++ b/apps/web/app/profile/[npi]/page.tsx
@@ -1,0 +1,269 @@
+/**
+ * /profile/[npi] — the clinician-published public career profile.
+ *
+ * This page exists ONLY when the holder has set their career profile to
+ * public (selfAttested.sharing.careerProfile === 'public'); otherwise 404.
+ * It is the shareable "beautiful career profile" artifact: identity resolved
+ * at the source, the clinician's self-attested career story clearly labeled
+ * as self-attested, and a path to the full source-backed verification record
+ * at /verify/[npi]. Provenance honesty: self-attested content is never
+ * presented as source-checked, and no status renders a bare "Verified".
+ */
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getBackendBase } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+
+const NPI_RE = /^\d{10}$/;
+
+interface PublicCareerProfile {
+  npi: string;
+  firstName: string | null;
+  lastName: string | null;
+  specialty: string | null;
+  stateOfPractice: string | null;
+  linkedinUrl: string | null;
+  portfolioUrl: string | null;
+  selfAttested: {
+    contact?: { practiceEmail?: string; practicePhone?: string; practiceWebsite?: string };
+    medicalSchool?: { institutionName?: string; degree?: string; graduationYear?: number };
+    subspecialty?: string;
+    workHistory?: Array<{ employer: string; role?: string; startYear?: number; endYear?: number }>;
+    affiliations?: Array<{ organization: string; role?: string }>;
+    careerGoals?: string;
+    researchSummary?: string;
+  };
+  updatedAt: string | null;
+}
+
+interface PassportIdentity {
+  identityVerified: boolean;
+  licensureStatus: string;
+  exclusionStatus: string;
+}
+
+async function fetchCareerProfile(npi: string): Promise<PublicCareerProfile | null> {
+  try {
+    const res = await fetch(`${getBackendBase()}/api/profile/public/${npi}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { shared?: boolean; profile?: PublicCareerProfile };
+    return body.shared && body.profile ? body.profile : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort source-coverage summary; the page renders honestly without it. */
+async function fetchPassportIdentity(npi: string): Promise<PassportIdentity | null> {
+  try {
+    const res = await fetch(`${getBackendBase()}/api/passport/npi/${npi}`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as Record<string, unknown>;
+    const trust = (body.trustState ?? body) as Record<string, unknown>;
+    return {
+      identityVerified: trust.identityVerified === true,
+      licensureStatus: typeof trust.licensureStatus === 'string' ? trust.licensureStatus : 'unknown',
+      exclusionStatus: typeof trust.exclusionStatus === 'string' ? trust.exclusionStatus : 'UNCHECKED',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ npi: string }> },
+): Promise<Metadata> {
+  const { npi } = await params;
+  if (!NPI_RE.test(npi)) return { title: 'Career Profile' };
+  const profile = await fetchCareerProfile(npi);
+  if (!profile) return { title: 'Career Profile' };
+  const name = [profile.firstName, profile.lastName].filter(Boolean).join(' ') || `NPI ${npi}`;
+  return {
+    title: `${name} — Career Profile`,
+    description: `Clinician-published career profile, backed by the VitalCV career evidence wallet.`,
+  };
+}
+
+function yearsLabel(start?: number, end?: number): string | null {
+  if (!start && !end) return null;
+  return `${start ?? '…'} – ${end ?? 'present'}`;
+}
+
+export default async function PublicCareerProfilePage(
+  { params }: { params: Promise<{ npi: string }> },
+) {
+  const { npi } = await params;
+  if (!NPI_RE.test(npi)) notFound();
+
+  const profile = await fetchCareerProfile(npi);
+  if (!profile) notFound();
+
+  const passport = await fetchPassportIdentity(npi);
+  const name = [profile.firstName, profile.lastName].filter(Boolean).join(' ') || `NPI ${npi}`;
+  const sa = profile.selfAttested ?? {};
+  const links = [
+    profile.linkedinUrl ? { label: 'LinkedIn', href: profile.linkedinUrl } : null,
+    profile.portfolioUrl ? { label: 'Portfolio', href: profile.portfolioUrl } : null,
+    sa.contact?.practiceWebsite ? { label: 'Practice site', href: sa.contact.practiceWebsite } : null,
+  ].filter((l): l is { label: string; href: string } => l !== null);
+
+  const chips: string[] = [];
+  if (passport?.identityVerified) chips.push('Identity source-backed · NPPES');
+  if (passport && passport.licensureStatus === 'active') chips.push('Licensure active on record');
+  if (passport && passport.exclusionStatus === 'CLEAR') chips.push('Exclusions checked · OIG');
+
+  return (
+    <div className="vcv-doc min-h-screen">
+      <main className="mx-auto w-full max-w-3xl px-5 pb-16 pt-10">
+        <p className="vcv-mono text-[10px] uppercase tracking-[0.22em] vcv-muted">
+          Career profile · shared by the clinician
+        </p>
+
+        {/* Identity card */}
+        <section className="vcv-panel mt-4 p-6">
+          <h1 className="text-3xl" style={{ fontFamily: 'var(--font-fraunces, Georgia, serif)' }}>
+            {name}
+          </h1>
+          <p className="vcv-mono mt-2 text-sm vcv-muted">
+            {[profile.specialty, profile.stateOfPractice].filter(Boolean).join(' · ') || 'Clinician'}
+          </p>
+          <p className="vcv-mono mt-1 text-xs vcv-muted">NPI {profile.npi}</p>
+          {chips.length > 0 ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {chips.map((chip) => (
+                <span
+                  key={chip}
+                  className="vcv-mono rounded-full border px-3 py-1 text-[11px]"
+                  style={{ borderColor: 'var(--paper-edge)' }}
+                >
+                  {chip}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {sa.subspecialty ? (
+            <p className="mt-4 text-sm">Subspecialty: {sa.subspecialty}</p>
+          ) : null}
+          {links.length > 0 ? (
+            <p className="mt-3 flex flex-wrap gap-4 text-sm">
+              {links.map((l) => (
+                <a key={l.label} href={l.href} rel="noopener noreferrer nofollow" target="_blank" className="underline underline-offset-4">
+                  {l.label}
+                </a>
+              ))}
+            </p>
+          ) : null}
+        </section>
+
+        {/* Self-attested career story */}
+        <section className="vcv-panel mt-5 p-6">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2 className="text-lg" style={{ fontFamily: 'var(--font-fraunces, Georgia, serif)' }}>
+              Career history
+            </h2>
+            <span className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">
+              Self-attested by the clinician
+            </span>
+          </div>
+
+          {sa.medicalSchool?.institutionName ? (
+            <div className="mt-4">
+              <p className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">Education</p>
+              <p className="mt-1 text-sm">
+                {sa.medicalSchool.institutionName}
+                {sa.medicalSchool.degree ? ` — ${sa.medicalSchool.degree}` : ''}
+                {sa.medicalSchool.graduationYear ? ` (${sa.medicalSchool.graduationYear})` : ''}
+              </p>
+            </div>
+          ) : null}
+
+          {sa.workHistory && sa.workHistory.length > 0 ? (
+            <div className="mt-4">
+              <p className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">Experience</p>
+              <ul className="mt-1 space-y-2">
+                {sa.workHistory.map((row, i) => (
+                  <li key={`${row.employer}-${i}`} className="text-sm">
+                    <span className="font-medium">{row.employer}</span>
+                    {row.role ? ` — ${row.role}` : ''}
+                    {yearsLabel(row.startYear, row.endYear) ? (
+                      <span className="vcv-mono vcv-muted"> · {yearsLabel(row.startYear, row.endYear)}</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {sa.affiliations && sa.affiliations.length > 0 ? (
+            <div className="mt-4">
+              <p className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">Affiliations</p>
+              <ul className="mt-1 space-y-1">
+                {sa.affiliations.map((row, i) => (
+                  <li key={`${row.organization}-${i}`} className="text-sm">
+                    {row.organization}
+                    {row.role ? ` — ${row.role}` : ''}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {sa.careerGoals ? (
+            <div className="mt-4">
+              <p className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">Career direction</p>
+              <p className="mt-1 text-sm">{sa.careerGoals}</p>
+            </div>
+          ) : null}
+
+          {sa.researchSummary ? (
+            <div className="mt-4">
+              <p className="vcv-mono text-[10px] uppercase tracking-[0.18em] vcv-muted">Research</p>
+              <p className="mt-1 text-sm">{sa.researchSummary}</p>
+            </div>
+          ) : null}
+
+          {!sa.medicalSchool?.institutionName
+            && (!sa.workHistory || sa.workHistory.length === 0)
+            && (!sa.affiliations || sa.affiliations.length === 0)
+            && !sa.careerGoals
+            && !sa.researchSummary ? (
+            <p className="mt-4 text-sm vcv-muted">
+              This clinician hasn&apos;t published career details yet.
+            </p>
+          ) : null}
+        </section>
+
+        {/* Provenance + the source-backed record */}
+        <section className="vcv-panel mt-5 p-6">
+          <h2 className="text-lg" style={{ fontFamily: 'var(--font-fraunces, Georgia, serif)' }}>
+            What&apos;s behind this profile
+          </h2>
+          <p className="mt-2 text-sm vcv-muted">
+            Career history above is self-attested by the clinician and is not
+            source-checked. Identity, licensure, and exclusion signals come from
+            primary sources and live on the verification record.
+          </p>
+          <Link
+            href={`/verify/${profile.npi}`}
+            className="vcv-mono mt-4 inline-block rounded-[6px] border px-4 py-2 text-xs uppercase tracking-[0.14em]"
+            style={{ borderColor: 'var(--ink)', color: 'var(--ink)' }}
+          >
+            View the source-backed record →
+          </Link>
+        </section>
+
+        <p className="vcv-mono mt-6 text-center text-[10px] uppercase tracking-[0.18em] vcv-muted">
+          Published by the clinician via VitalCV · sharing can be turned off anytime
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { SignIn } from '@clerk/nextjs';
 import { AuthDisclosureCard } from '@/components/auth/AuthDisclosureCard';
+import DevKeysNotice from '@/components/auth/DevKeysNotice';
 
 export const metadata: Metadata = {
   title: 'Sign In',
@@ -10,8 +11,11 @@ export const metadata: Metadata = {
 
 export default function SignInPage() {
   return (
-    <AuthDisclosureCard mode="sign-in">
-      <SignIn />
-    </AuthDisclosureCard>
+    <>
+      <DevKeysNotice />
+      <AuthDisclosureCard mode="sign-in">
+        <SignIn />
+      </AuthDisclosureCard>
+    </>
   );
 }

--- a/apps/web/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/app/sign-up/[[...sign-up]]/page.tsx
@@ -9,6 +9,7 @@
 import type { Metadata } from 'next';
 import { SignUp } from '@clerk/nextjs';
 import { AuthDisclosureCard } from '@/components/auth/AuthDisclosureCard';
+import DevKeysNotice from '@/components/auth/DevKeysNotice';
 
 export const metadata: Metadata = {
   title: 'Sign Up',
@@ -18,8 +19,11 @@ export const metadata: Metadata = {
 
 export default function SignUpPage() {
   return (
-    <AuthDisclosureCard mode="sign-up">
-      <SignUp />
-    </AuthDisclosureCard>
+    <>
+      <DevKeysNotice />
+      <AuthDisclosureCard mode="sign-up">
+        <SignUp />
+      </AuthDisclosureCard>
+    </>
   );
 }

--- a/apps/web/components/auth/DevKeysNotice.tsx
+++ b/apps/web/components/auth/DevKeysNotice.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+/**
+ * DevKeysNotice — kills the silent local-auth failure mode.
+ *
+ * Clerk production keys (pk_live_…) are domain-bound: off their bound domain
+ * ClerkJS refuses to initialize and the sign-in/sign-up widgets render but
+ * silently do nothing. That reads as "auth is broken" on localhost when the
+ * real cause is prod keys in .env.local. When the inlined publishable key is
+ * a live key and the page host isn't the key's domain, say so loudly and give
+ * the fix. Renders nothing in production or with pk_test keys.
+ */
+
+import { useEffect, useState } from 'react';
+
+function decodeBase64(value: string): string | null {
+  try {
+    if (typeof atob === 'function') return atob(value);
+  } catch {
+    return null;
+  }
+  try {
+    return Buffer.from(value, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** The apex domain a pk_live key is bound to (null for pk_test/invalid keys). */
+export function liveKeyDomain(publishableKey: string | undefined): string | null {
+  if (!publishableKey?.startsWith('pk_live_')) return null;
+  const decoded = decodeBase64(publishableKey.slice('pk_live_'.length));
+  if (!decoded) return null;
+  const host = decoded.replace(/\$+$/, '').trim().toLowerCase();
+  if (!host.includes('.')) return null;
+  return host.replace(/^clerk\./, '');
+}
+
+/** True when live keys are being served from a host they can never work on. */
+export function shouldWarnAboutLiveKeys(
+  publishableKey: string | undefined,
+  hostname: string,
+): boolean {
+  const domain = liveKeyDomain(publishableKey);
+  if (!domain) return false;
+  const host = hostname.trim().toLowerCase();
+  return host !== domain && !host.endsWith(`.${domain}`);
+}
+
+export function DevKeysNotice() {
+  const [warn, setWarn] = useState(false);
+
+  useEffect(() => {
+    setWarn(
+      shouldWarnAboutLiveKeys(
+        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+        window.location.hostname,
+      ),
+    );
+  }, []);
+
+  if (!warn) return null;
+
+  const domain = liveKeyDomain(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) ?? 'its bound domain';
+
+  return (
+    <div
+      role="alert"
+      data-testid="dev-keys-notice"
+      className="mx-auto mb-6 w-full max-w-md rounded-lg border-2 px-4 py-3 text-sm"
+      style={{ borderColor: '#b45309', background: 'rgba(180,83,9,0.08)', color: 'inherit' }}
+    >
+      <p className="font-semibold">Sign-in can&apos;t work on this host</p>
+      <p className="mt-1">
+        This build is using <code>pk_live</code> Clerk keys, which only run on{' '}
+        <strong>{domain}</strong>. On {typeof window !== 'undefined' ? window.location.hostname : 'this host'}{' '}
+        the auth widget renders but every attempt is silently refused.
+      </p>
+      <p className="mt-2">
+        Fix for local development: put the <strong>Development instance</strong>{' '}
+        keys (<code>pk_test_…</code> / <code>sk_test_…</code>) from the Clerk
+        dashboard into <code>apps/web/.env.local</code>, then restart the dev
+        server. Production on {domain} is unaffected.
+      </p>
+    </div>
+  );
+}
+
+export default DevKeysNotice;

--- a/apps/web/components/employer/OpportunityEmbedPanel.tsx
+++ b/apps/web/components/employer/OpportunityEmbedPanel.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * OpportunityEmbedPanel — self-serve "Apply with VitalCV" embed for one opening.
+ *
+ * Gives the employer a copyable link and an HTML anchor + hosted-badge snippet
+ * for their own careers page. Deliberately NOT an iframe: the app ships
+ * frame-ancestors 'none' / X-Frame-Options DENY as a security posture, and a
+ * plain anchor works on any site with zero clickjacking surface. The badge is
+ * served from /api/embed/apply-badge.svg on this origin.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { Check, Code2, Copy, Link2 } from 'lucide-react';
+
+export function OpportunityEmbedPanel({ opportunityId, title }: { opportunityId: string; title: string }) {
+  const [open, setOpen] = useState(false);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://vitalcv.com';
+  const applyUrl = `${origin}/opportunities/${opportunityId}?src=embed`;
+  const badgeUrl = `${origin}/api/embed/apply-badge.svg`;
+
+  const snippet = useMemo(
+    () =>
+      [
+        `<!-- Apply with VitalCV — ${title.replace(/--/g, '—')} -->`,
+        `<a href="${applyUrl}" rel="noopener">`,
+        `  <img src="${badgeUrl}" alt="Apply with VitalCV" height="44" />`,
+        `</a>`,
+      ].join('\n'),
+    [applyUrl, badgeUrl, title],
+  );
+
+  const copy = useCallback(async (key: string, text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      window.setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      setCopiedKey(null);
+    }
+  }, []);
+
+  if (!open) {
+    return (
+      <button type="button" className="mz-btn-ghost mz-btn-sm" onClick={() => setOpen(true)}>
+        <Code2 className="mr-1 inline h-3.5 w-3.5" aria-hidden />
+        Embed apply
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-3 w-full rounded-[8px] border p-3" style={{ borderColor: 'var(--edge, rgba(0,0,0,0.12))' }} data-testid="opportunity-embed-panel">
+      <div className="flex items-center justify-between gap-2">
+        <p className="mz-small font-medium">Put this opening on your own careers page</p>
+        <button type="button" className="mz-btn-ghost mz-btn-sm" onClick={() => setOpen(false)}>
+          Hide
+        </button>
+      </div>
+
+      <p className="mz-small mt-2 opacity-80">
+        Candidates land on a public VitalCV page for this role and apply with
+        their career evidence wallet — readiness snapshot attached, no résumé
+        re-typing.
+      </p>
+
+      <div className="mt-3 space-y-3">
+        <div>
+          <p className="mz-small font-medium">
+            <Link2 className="mr-1 inline h-3.5 w-3.5" aria-hidden /> Direct link
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <code className="mz-small block overflow-x-auto rounded border px-2 py-1.5" style={{ borderColor: 'var(--edge, rgba(0,0,0,0.12))' }}>
+              {applyUrl}
+            </code>
+            <button type="button" className="mz-btn-ghost mz-btn-sm" onClick={() => void copy('link', applyUrl)}>
+              {copiedKey === 'link' ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+              <span className="ml-1">{copiedKey === 'link' ? 'Copied' : 'Copy'}</span>
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <p className="mz-small font-medium">
+            <Code2 className="mr-1 inline h-3.5 w-3.5" aria-hidden /> Badge snippet (HTML)
+          </p>
+          <div className="mt-1">
+            <pre className="mz-small overflow-x-auto rounded border px-2 py-1.5" style={{ borderColor: 'var(--edge, rgba(0,0,0,0.12))' }}>
+              {snippet}
+            </pre>
+            <button type="button" className="mz-btn-ghost mz-btn-sm mt-1" onClick={() => void copy('snippet', snippet)}>
+              {copiedKey === 'snippet' ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+              <span className="ml-1">{copiedKey === 'snippet' ? 'Copied' : 'Copy snippet'}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OpportunityEmbedPanel;

--- a/apps/web/components/profile/CareerProfileSharingCard.tsx
+++ b/apps/web/components/profile/CareerProfileSharingCard.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+/**
+ * CareerProfileSharingCard — the holder's share-or-don't-share control for the
+ * public career profile page (/profile/[npi]).
+ *
+ * Default is private: the public page 404s until the clinician explicitly
+ * publishes. The toggle is a real audited mutation (career_profile_sharing_
+ * updated) via POST /api/profile/sharing. Honest copy: publishing shares the
+ * self-attested career story; the source-backed verification record at
+ * /verify/[npi] is a separate, always-public surface.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Check, Copy, ExternalLink, Globe2, Loader2, Lock } from 'lucide-react';
+
+type Visibility = 'public' | 'private';
+type Phase = 'loading' | 'ready' | 'unavailable';
+
+export function CareerProfileSharingCard({ npi }: { npi: string }) {
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [visibility, setVisibility] = useState<Visibility>('private');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/profile/sharing', { cache: 'no-store' });
+        if (!res.ok) throw new Error(String(res.status));
+        const body = (await res.json()) as { careerProfile?: string };
+        if (!cancelled) {
+          setVisibility(body.careerProfile === 'public' ? 'public' : 'private');
+          setPhase('ready');
+        }
+      } catch {
+        if (!cancelled) setPhase('unavailable');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setSharing = useCallback(async (next: Visibility) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/profile/sharing', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ careerProfile: next }),
+      });
+      const body = (await res.json().catch(() => ({}))) as { careerProfile?: string; error?: unknown };
+      if (!res.ok) {
+        const message = typeof body.error === 'string'
+          ? body.error
+          : (body.error as { message?: string } | undefined)?.message;
+        throw new Error(message ?? 'Could not update sharing.');
+      }
+      setVisibility(body.careerProfile === 'public' ? 'public' : 'private');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not update sharing.');
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const publicUrl = typeof window !== 'undefined'
+    ? `${window.location.origin}/profile/${npi}`
+    : `/profile/${npi}`;
+
+  const copyLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(publicUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — copy the link text manually.');
+    }
+  }, [publicUrl]);
+
+  if (phase === 'loading') {
+    return (
+      <section className="vcv-panel p-5" aria-label="Career profile sharing">
+        <p className="vcv-mono flex items-center gap-2 text-xs vcv-muted">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> Loading sharing state…
+        </p>
+      </section>
+    );
+  }
+
+  if (phase === 'unavailable') {
+    return (
+      <section className="vcv-panel p-5" aria-label="Career profile sharing">
+        <h2 className="text-base font-medium">Public career profile</h2>
+        <p className="mt-2 text-sm vcv-muted">
+          Sharing controls are temporarily unavailable. Your profile stays private
+          until you explicitly publish it.
+        </p>
+      </section>
+    );
+  }
+
+  const isPublic = visibility === 'public';
+
+  return (
+    <section className="vcv-panel p-5" aria-label="Career profile sharing" data-testid="career-profile-sharing">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="flex items-center gap-2 text-base font-medium">
+            {isPublic ? <Globe2 className="h-4 w-4" aria-hidden /> : <Lock className="h-4 w-4" aria-hidden />}
+            Public career profile
+          </h2>
+          <p className="mt-1 text-sm vcv-muted">
+            {isPublic
+              ? 'Anyone with the link can view your career profile page.'
+              : 'Private — your career profile page is off. Only you can see this content.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void setSharing(isPublic ? 'private' : 'public')}
+          className="vcv-mono shrink-0 rounded-[6px] border px-3 py-2 text-[11px] uppercase tracking-[0.14em] transition disabled:opacity-50"
+          style={{ borderColor: 'var(--ink)', color: isPublic ? 'var(--paper, #fff)' : 'var(--ink)', background: isPublic ? 'var(--ink)' : 'transparent' }}
+        >
+          {saving ? 'Saving…' : isPublic ? 'Make private' : 'Publish page'}
+        </button>
+      </div>
+
+      {isPublic ? (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <code className="vcv-mono rounded-[6px] border px-3 py-2 text-xs" style={{ borderColor: 'var(--paper-edge)' }}>
+            {publicUrl}
+          </code>
+          <button
+            type="button"
+            onClick={() => void copyLink()}
+            className="vcv-mono inline-flex items-center gap-1.5 rounded-[6px] border px-3 py-2 text-[11px] uppercase tracking-[0.12em]"
+            style={{ borderColor: 'var(--paper-edge)' }}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+            {copied ? 'Copied' : 'Copy link'}
+          </button>
+          <a
+            href={`/profile/${npi}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="vcv-mono inline-flex items-center gap-1.5 rounded-[6px] border px-3 py-2 text-[11px] uppercase tracking-[0.12em]"
+            style={{ borderColor: 'var(--paper-edge)' }}
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden /> Preview
+          </a>
+        </div>
+      ) : null}
+
+      <p className="mt-3 text-xs vcv-muted">
+        The page shows your self-attested career story, labeled as self-attested.
+        Your source-backed verification record at /verify is a separate surface.
+        Unpublishing takes effect immediately.
+      </p>
+      {error ? <p className="mt-2 text-xs" style={{ color: 'var(--warn, #b45309)' }}>{error}</p> : null}
+    </section>
+  );
+}
+
+export default CareerProfileSharingCard;


### PR DESCRIPTION
## What — three founder asks

### 1. Clinicians: create + customize a beautiful career profile, and choose to share it or not
- **Share control (default private):** `selfAttested.sharing.careerProfile` rides in the existing Json column — **no migration**. Publish/unpublish is a real audited mutation (`career_profile_sharing_updated`) via auth-scoped `GET/POST /api/profile/sharing`; `updateSelfAttested` carries the setting across the editor's full-document replace so saving CV edits can never silently flip visibility.
- **The page** — `/profile/[npi]`: the published career profile in the `.vcv-doc` paper/ink language from the design handoff's Clinician Profile mock. Identity card (name, specialty, NPI mono), best-effort source-backed chips from the passport read (never a bare "Verified"), self-attested sections **labeled self-attested**, and a CTA to the source-backed record at `/verify/[npi]`. 404s fail-closed when private, malformed, or backend-unreachable.
- **The control** — `CareerProfileSharingCard` on `/clinician/profile`: toggle, copy-link, preview, honest copy ("unpublishing takes effect immediately").

### 2. Employers: embed the Apply button on their own careers pages
- **`/opportunities/[id]`** — public landing for one ACTIVE role; Apply deep-links into the signed-in flow (`/holder/opportunities/[id]`, middleware round-trips sign-in); `/get-ready` lane for new clinicians; honest "listing ≠ verified employer" disclaimer.
- **`/api/embed/apply-badge.svg`** — hosted badge (static SVG, 24h cache, `Access-Control-Allow-Origin: *`), constellation mark + "APPLY WITH VitalCV".
- **`OpportunityEmbedPanel`** on `/employer/post` — per-opening direct link + copyable HTML anchor snippet. **Deliberately no iframe variant**: `frame-ancestors 'none'` / XFO DENY stay intact; an anchor+badge works on any site with zero clickjacking surface. (Truvera's browser-wallet thesis — no-install, embeddable web flows — is exactly this pattern.)

### 3. Sign-in clarity: kill the silent local-auth failure for good
`DevKeysNotice` on `/sign-in` + `/sign-up`: when the build's publishable key is `pk_live_` and the page host isn't the key's **bound domain (decoded from the key itself)**, an explicit banner says why every auth attempt is being refused and gives the fix (pk_test keys in `.env.local`). Renders nothing on vitalcv.com or with test keys. This is the failure mode that has read as "sign-in doesn't work" three sessions running — Clerk's real error only ever appeared in the browser console.

## Verification
- Backend `tsc --noEmit` green; targeted jest green (sharing sanitization 4/4 — hostile visibility values dropped).
- Web vitest **163/163**: new `dev-keys-notice` (7), `apply-embed-badge` (2), `public-career-profile` (3, incl. fail-closed 404s + no-bare-Verified) + full `banned-verified-label` and `holder-route-contract` guards.
- `turbo build` green; all new routes in the manifest.
- Live dev-server walkthrough (worktree on :3054): the notice fires on localhost with live keys (screenshot in session); `/opportunities/[id]` rendered a real production seed role (Kaiser NorCal Staff Internist) against `api.vitalcv.com`; badge SVG renders; `/profile/[real-prod-npi]` and `/profile/abc` both 404.

## Truth contract
- No bare `Verified`; chips read "Identity source-backed · NPPES", "Exclusions checked · OIG".
- Self-attested content is always labeled self-attested and never presented as source-checked.
- Public profile is opt-in, default private, fail-closed; the always-public verification record stays a separate, unchanged surface.
- Postings remain plain listings ("VitalCV does not verify employers or endorse openings").

## Design Handoff References
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Clinician Profile.html` — public career profile identity card, mono microtext, action-rail language.
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Career Mobility Engine W230.html` — opportunity → readiness → apply framing on the landing page.
- `design-handoff/claude-design-2026-06-26/vitalcv/project/Executive Share.html` — share-artifact provenance footer pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)