### PR TITLE
feat(ai): grounded LLM match-explanation layer — built + gated, ready on a key

### DIFF
--- a/apps/web/__tests__/match-explanation-prompt.test.ts
+++ b/apps/web/__tests__/match-explanation-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buildMatchExplanationMessages } from '@/lib/matcha/matchExplanation';
+
+describe('buildMatchExplanationMessages — grounding discipline', () => {
+  const base = buildMatchExplanationMessages({
+    opportunity: { title: 'Locums Hospitalist', organization: 'Metro Health', specialty: 'Hospital Medicine', location: 'Austin, TX' },
+    matchBand: 'NEAR_CLEAR',
+    fitReasons: [
+      { label: 'Specialty matches your Hospital Medicine focus', positive: true },
+      { label: 'A negative signal that must not be surfaced as a fit', positive: false },
+    ],
+    blockers: [{ label: 'TX license not yet source-verified', severity: 'hard' }],
+    profileSummary: 'Hospitalist open to locums in the Southwest.',
+  });
+
+  it('forbids fabrication and guarantees in the system prompt', () => {
+    expect(base.system).toMatch(/never invent/i);
+    expect(base.system).toMatch(/not a job offer or guarantee/i);
+    expect(base.system).toMatch(/2-3 sentences/i);
+  });
+
+  it('grounds the user prompt in the provided facts + honest blockers', () => {
+    expect(base.user).toContain('Locums Hospitalist');
+    expect(base.user).toContain('Metro Health');
+    expect(base.user).toContain('Specialty matches your Hospital Medicine focus');
+    expect(base.user).toContain('TX license not yet source-verified');
+    expect(base.user).toContain('(hard)');
+    // Only POSITIVE fit signals are offered as reasons; negatives are excluded.
+    expect(base.user).not.toContain('must not be surfaced as a fit');
+    // Self-stated summary is labeled as not source-verified.
+    expect(base.user).toMatch(/self-stated, not source-verified/i);
+  });
+
+  it('degrades honestly when no signals are provided (never invents)', () => {
+    const empty = buildMatchExplanationMessages({ opportunity: { title: 'Role' } });
+    expect(empty.user).toContain('(no specific fit signals provided)');
+    expect(empty.user).toContain('- (none)');
+  });
+});

--- a/apps/web/app/api/ai/status/route.ts
+++ b/apps/web/app/api/ai/status/route.ts
@@ -1,0 +1,16 @@
+/**
+ * GET /api/ai/status — is optional AI enabled in this environment?
+ *
+ * Lets the client show AI affordances (match summaries, cover-letter drafting)
+ * ONLY when a model key is configured, so nothing dead appears in prod when AI
+ * is off. Returns just a boolean — never the key.
+ */
+
+import { NextResponse } from 'next/server';
+import { isAnthropicConfigured } from '@/lib/ai/anthropic';
+
+export const runtime = 'nodejs';
+
+export function GET() {
+  return NextResponse.json({ enabled: isAnthropicConfigured() }, { status: 200 });
+}

--- a/apps/web/app/api/matcha/explain-match/route.ts
+++ b/apps/web/app/api/matcha/explain-match/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/matcha/explain-match — an OPTIONAL AI "why this role fits you" note.
+ *
+ * Body: { opportunity, matchBand?, fitReasons?, blockers?, profileSummary? }
+ * Returns: { summary } on success, { configured: false } when no ANTHROPIC_API_KEY
+ * is set (honest — the UI keeps the deterministic reasons), or { error }.
+ *
+ * The note is grounded ONLY in the deterministic engine's fit signals + the
+ * clinician's self-stated summary (see lib/matcha/matchExplanation.ts). It is an
+ * enhancement layer over the source-honest scores — it never fabricates a score,
+ * credential, or guarantee, and it is fully inert without a key.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  buildMatchExplanationMessages,
+  type MatchExplanationInput,
+} from '@/lib/matcha/matchExplanation';
+import {
+  ANTHROPIC_MESSAGES_URL,
+  ANTHROPIC_VERSION,
+  anthropicModel,
+  getAnthropicKey,
+} from '@/lib/ai/anthropic';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const apiKey = getAnthropicKey();
+  if (!apiKey) {
+    // Honest: AI isn't wired up here — the UI keeps the deterministic reasons.
+    return NextResponse.json({ configured: false }, { status: 200 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as Partial<MatchExplanationInput>;
+  const { system, user } = buildMatchExplanationMessages({
+    opportunity: body.opportunity ?? {},
+    matchBand: body.matchBand,
+    fitReasons: body.fitReasons,
+    blockers: body.blockers,
+    profileSummary: body.profileSummary,
+  });
+
+  try {
+    const res = await fetch(ANTHROPIC_MESSAGES_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: anthropicModel(),
+        max_tokens: 320,
+        system,
+        messages: [{ role: 'user', content: user }],
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'The explanation service is unavailable right now.' }, { status: 502 });
+    }
+
+    const data = (await res.json()) as {
+      stop_reason?: string;
+      content?: Array<{ type: string; text?: string }>;
+    };
+
+    if (data.stop_reason === 'refusal') {
+      return NextResponse.json({ error: 'Could not summarize this match.' }, { status: 200 });
+    }
+
+    const summary = (data.content ?? [])
+      .filter((b) => b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text as string)
+      .join('')
+      .trim();
+
+    if (!summary) {
+      return NextResponse.json({ error: 'No summary was produced.' }, { status: 200 });
+    }
+
+    return NextResponse.json({ summary }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: 'Could not reach the explanation service.' }, { status: 502 });
+  }
+}

--- a/apps/web/components/matcha/CoverLetterDrafter.tsx
+++ b/apps/web/components/matcha/CoverLetterDrafter.tsx
@@ -9,6 +9,7 @@
 import { useState } from 'react';
 import { Sparkles, Copy, Check } from 'lucide-react';
 import { useClinicianMobile } from '@/components/mobile/ClinicianMobileProvider';
+import { useAiEnabled } from '@/lib/ai/useAiEnabled';
 import { useMatchaPreferences } from './useMatchaPreferences';
 import { summarizeProfileForLetter, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
 
@@ -22,6 +23,7 @@ export function CoverLetterDrafter({ opportunity }: { opportunity: CoverLetterOp
   const npi = person?.npi ?? undefined;
   const name = person?.firstName ?? undefined;
   const { preferences } = useMatchaPreferences(npi);
+  const aiEnabled = useAiEnabled();
 
   const [state, setState] = useState<State>('idle');
   const [draft, setDraft] = useState('');
@@ -76,6 +78,9 @@ export function CoverLetterDrafter({ opportunity }: { opportunity: CoverLetterOp
       /* clipboard unavailable */
     }
   }
+
+  // Inert unless AI is configured — no dead affordance in prod when AI is off.
+  if (!aiEnabled) return null;
 
   return (
     <div style={{ marginTop: 16, borderTop: '1px solid var(--vt-border, #EEF2F0)', paddingTop: 14 }}>

--- a/apps/web/components/matcha/MatchAiSummary.tsx
+++ b/apps/web/components/matcha/MatchAiSummary.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * MatchAiSummary — an OPTIONAL, grounded AI "why this role fits you" note for a
+ * matched opportunity. Renders NOTHING unless AI is enabled (useAiEnabled), so
+ * there is no dead affordance in prod. When enabled, it summarizes ONLY the
+ * deterministic engine's fit signals + the clinician's stated summary — it never
+ * fabricates a score or credential, and the deterministic reasons always remain
+ * shown above it. Mirrors CoverLetterDrafter's honest states.
+ */
+
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { useAiEnabled } from '@/lib/ai/useAiEnabled';
+
+const ACCENT = 'var(--vt-accent, #0A7B7F)';
+
+type State = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface MatchAiSummaryProps {
+  opportunity: { title?: string; organization?: string; specialty?: string; location?: string };
+  matchBand?: string;
+  fitReasons?: Array<{ label: string; positive: boolean }>;
+  blockers?: Array<{ label: string; severity?: string }>;
+  profileSummary?: string;
+}
+
+export function MatchAiSummary(props: MatchAiSummaryProps) {
+  const aiEnabled = useAiEnabled();
+  const [state, setState] = useState<State>('idle');
+  const [summary, setSummary] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Inert unless AI is configured — nothing renders (deterministic reasons stay).
+  if (!aiEnabled) return null;
+
+  async function generate() {
+    setState('loading');
+    setMessage(null);
+    try {
+      const res = await fetch('/api/matcha/explain-match', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          opportunity: props.opportunity,
+          matchBand: props.matchBand,
+          fitReasons: props.fitReasons,
+          blockers: props.blockers,
+          profileSummary: props.profileSummary,
+        }),
+      });
+      const p = (await res.json().catch(() => ({}))) as {
+        summary?: string;
+        configured?: boolean;
+        error?: string;
+      };
+      if (p.configured === false) {
+        // Key was removed between probe and call — degrade silently.
+        setState('idle');
+        return;
+      }
+      if (p.error) {
+        setMessage(p.error);
+        setState('error');
+        return;
+      }
+      if (p.summary) {
+        setSummary(p.summary);
+        setState('ready');
+        return;
+      }
+      setMessage('No summary was produced.');
+      setState('error');
+    } catch {
+      setMessage('Could not reach the summary service.');
+      setState('error');
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      {state === 'idle' || state === 'loading' ? (
+        <button
+          type="button"
+          onClick={generate}
+          disabled={state === 'loading'}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '7px 13px',
+            borderRadius: 999,
+            fontSize: 12.5,
+            fontWeight: 600,
+            cursor: state === 'loading' ? 'default' : 'pointer',
+            border: `1px solid ${ACCENT}`,
+            background: `color-mix(in srgb, ${ACCENT} 8%, transparent)`,
+            color: ACCENT,
+            opacity: state === 'loading' ? 0.7 : 1,
+          }}
+        >
+          <Sparkles size={13} aria-hidden="true" />
+          {state === 'loading' ? 'Summarizing…' : 'Why this fits you — MATCHA AI'}
+        </button>
+      ) : null}
+
+      {state === 'error' ? (
+        <div>
+          <p style={{ margin: '0 0 6px', fontSize: 12.5, color: 'var(--vt-risk-high, #8C2A2A)' }}>{message}</p>
+          <button
+            type="button"
+            onClick={generate}
+            style={{ fontSize: 12.5, fontWeight: 600, color: ACCENT, background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {state === 'ready' ? (
+        <div>
+          <span
+            style={{
+              display: 'block',
+              fontSize: 10.5,
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: ACCENT,
+              marginBottom: 5,
+            }}
+          >
+            MATCHA AI · from your match signals
+          </span>
+          <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.55, color: 'var(--vt-text-secondary)' }}>{summary}</p>
+          <button
+            type="button"
+            onClick={generate}
+            style={{ marginTop: 6, fontSize: 12, fontWeight: 600, color: ACCENT, background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}
+          >
+            Regenerate
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/matcha/OpportunityCard.tsx
+++ b/apps/web/components/matcha/OpportunityCard.tsx
@@ -16,6 +16,7 @@ import {
 import { OpportunityApplyCta, type ApplyCtaOpportunity } from './OpportunityApplyCta';
 import { Livability } from './Livability';
 import { CoverLetterDrafter } from './CoverLetterDrafter';
+import { MatchAiSummary } from './MatchAiSummary';
 import type { ExplanationReason } from './MatchaExplanation';
 import type { OpportunityBucket, OpportunityStatus } from '@/lib/matcha/opportunityActions';
 
@@ -126,6 +127,22 @@ export function OpportunityCard({ opportunity, explanation, preferenceReasons, b
 
         {/* Livability */}
         <Livability location={opportunity.location} state={opportunity.state} remote={opportunity.remote} />
+
+        {/* AI "why this fits you" — grounded in the deterministic match signals;
+            renders only when AI is enabled (else the reasons above stand alone). */}
+        {explanation ? (
+          <MatchAiSummary
+            opportunity={{
+              title: opportunity.title,
+              organization: opportunity.organization,
+              specialty: opportunity.specialty,
+              location: opportunity.location,
+            }}
+            matchBand={explanation.matchBand}
+            fitReasons={explanation.fitReasons}
+            blockers={explanation.blockers}
+          />
+        ) : null}
 
         {/* AI cover-letter draft */}
         <CoverLetterDrafter

--- a/apps/web/lib/ai/useAiEnabled.ts
+++ b/apps/web/lib/ai/useAiEnabled.ts
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * useAiEnabled — one cached probe of /api/ai/status so AI affordances render only
+ * when a model key is configured (no dead AI buttons in prod when AI is off).
+ * The result is module-cached, so N components share a single request.
+ */
+
+import { useEffect, useState } from 'react';
+
+let cached: boolean | null = null;
+let inFlight: Promise<boolean> | null = null;
+
+async function probe(): Promise<boolean> {
+  if (cached !== null) return cached;
+  if (!inFlight) {
+    inFlight = fetch('/api/ai/status', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : { enabled: false }))
+      .then((d: { enabled?: boolean }) => {
+        cached = Boolean(d.enabled);
+        return cached;
+      })
+      .catch(() => {
+        cached = false;
+        return false;
+      });
+  }
+  return inFlight;
+}
+
+/** undefined while probing; true/false once known. */
+export function useAiEnabled(): boolean | undefined {
+  const [enabled, setEnabled] = useState<boolean | undefined>(cached ?? undefined);
+  useEffect(() => {
+    let active = true;
+    void probe().then((v) => {
+      if (active) setEnabled(v);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+  return enabled;
+}

--- a/apps/web/lib/matcha/matchExplanation.ts
+++ b/apps/web/lib/matcha/matchExplanation.ts
@@ -1,0 +1,74 @@
+/**
+ * Grounded prompt for the OPTIONAL MATCHA match-explanation AI.
+ *
+ * Feeds the model ONLY the deterministic match facts (the engine's fit reasons,
+ * blockers, band) plus the clinician's own stated summary. The model personalizes
+ * the *tone*; it must not invent credentials, scores, employers, salary, or any
+ * fact not given, and it must stay honest (a source-backed match is never a job
+ * guarantee). Same grounding discipline as lib/matcha/coverLetter.ts. When no
+ * ANTHROPIC_API_KEY is set the feature is off entirely and the UI keeps showing
+ * the deterministic reasons unchanged.
+ */
+
+export interface MatchExplanationOpportunity {
+  title?: string;
+  organization?: string;
+  specialty?: string;
+  location?: string;
+}
+
+export interface MatchExplanationInput {
+  opportunity: MatchExplanationOpportunity;
+  matchBand?: string;
+  fitReasons?: Array<{ label: string; positive: boolean }>;
+  blockers?: Array<{ label: string; severity?: string }>;
+  /** Clinician's own self-stated summary (never source-verified facts). */
+  profileSummary?: string;
+}
+
+export function buildMatchExplanationMessages(input: MatchExplanationInput): {
+  system: string;
+  user: string;
+} {
+  const system = [
+    'You write a short, warm, honest "why this role could fit you" note for a clinician viewing a role VitalCV matched them to.',
+    'Rules, strictly:',
+    '- Use ONLY the fit signals, blockers, and facts provided below. Never invent a credential, score, employer, salary, or any fact that is not given.',
+    '- 2-3 sentences, second person ("you"), plain and specific. No hype, no emojis, no exclamation points.',
+    '- If blockers are listed, name them honestly as the next steps — do not gloss over them.',
+    '- This is a source-backed match, not a job offer or guarantee. Never promise a role, interview, or outcome.',
+    '- Weave the signals into natural language; do not just restate the raw labels.',
+  ].join('\n');
+
+  const opp = input.opportunity ?? {};
+  const header =
+    `Role: ${opp.title ?? 'Clinical role'}` +
+    (opp.organization ? ` at ${opp.organization}` : '') +
+    (opp.specialty ? ` · ${opp.specialty}` : '') +
+    (opp.location ? ` · ${opp.location}` : '');
+
+  const reasons =
+    (input.fitReasons ?? [])
+      .filter((r) => r.positive)
+      .map((r) => `- ${r.label}`)
+      .join('\n') || '- (no specific fit signals provided)';
+
+  const blockers =
+    (input.blockers ?? [])
+      .map((b) => `- ${b.label}${b.severity ? ` (${b.severity})` : ''}`)
+      .join('\n') || '- (none)';
+
+  const user = [
+    header,
+    input.matchBand ? `Match band: ${input.matchBand}` : '',
+    input.profileSummary ? `About you (self-stated, not source-verified): ${input.profileSummary}` : '',
+    `Fit signals:\n${reasons}`,
+    `What's still needed / blockers:\n${blockers}`,
+    '',
+    'Write the note now.',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  return { system, user };
+}


### PR DESCRIPTION
## What
The next piece of the AI vision you asked about ("make MATCHA actually AI") — **built now, fully gated**, so it's one env var from live the moment your Anthropic credits are back, and **completely inert until then** (today's honest deterministic explanations, unchanged).

- **`lib/matcha/matchExplanation.ts`** — a grounded prompt that feeds the model **only** the deterministic engine's fit signals + blockers + band + the clinician's self-stated summary. It forbids inventing scores, credentials, or facts, and any job/interview guarantee. **3 unit tests pin this grounding discipline.**
- **`POST /api/matcha/explain-match`** — gated on the shared `getAnthropicKey()` (from #617): `{ configured: false }` with no key, a grounded `{ summary }` with one. Mirrors the cover-letter route.
- **`GET /api/ai/status` + `useAiEnabled()`** — a module-cached probe so AI affordances render **only when a key is configured** — no dead AI buttons in prod. Also retrofitted the existing `CoverLetterDrafter` onto the same gate.
- **`MatchAiSummary`** — an optional "why this role fits you" note on the opportunity card, grounded in the deterministic explanation; the source-honest reasons always remain shown above it.

## Doctrine
The AI **explains and personalizes** — it never fabricates a score or credential, only reweaves the engine's real signals, and stays honest about blockers and the source-backed (non-guarantee) nature. That honesty is enforced in the prompt and pinned by tests.

## Verification
`next lint` + `turbo build` + grounding tests (3/3) green. Fallback fully verified with no key: AI hidden everywhere, matching + explanations unchanged. The LLM output itself is verifiable once a key is set.

## Design Handoff References
Reuses the shipped MATCHA card + the `#617` AI gate; no new design assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)