### PR TITLE
fix(ai): guardrails on AI routes — auth required + spend caps before any model call

### DIFF
--- a/apps/web/__tests__/ai-rate-limit.test.ts
+++ b/apps/web/__tests__/ai-rate-limit.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { checkAiLimit, resetAiLimits } from '@/lib/ai/rateLimit';
+
+describe('checkAiLimit — AI spend guardrails', () => {
+  beforeEach(() => {
+    resetAiLimits();
+    delete process.env.AI_CALLS_PER_USER_PER_HOUR;
+    delete process.env.AI_CALLS_GLOBAL_PER_DAY;
+  });
+
+  it('allows calls under the per-user cap and blocks at the cap', () => {
+    process.env.AI_CALLS_PER_USER_PER_HOUR = '3';
+    expect(checkAiLimit('user_a').ok).toBe(true);
+    expect(checkAiLimit('user_a').ok).toBe(true);
+    expect(checkAiLimit('user_a').ok).toBe(true);
+    const fourth = checkAiLimit('user_a');
+    expect(fourth.ok).toBe(false);
+    if (!fourth.ok) expect(fourth.reason).toMatch(/hourly/i);
+  });
+
+  it('caps are per-user — one user at the cap does not block another', () => {
+    process.env.AI_CALLS_PER_USER_PER_HOUR = '1';
+    expect(checkAiLimit('user_a').ok).toBe(true);
+    expect(checkAiLimit('user_a').ok).toBe(false);
+    expect(checkAiLimit('user_b').ok).toBe(true);
+  });
+
+  it('enforces the global daily ceiling across users', () => {
+    process.env.AI_CALLS_GLOBAL_PER_DAY = '2';
+    expect(checkAiLimit('user_a').ok).toBe(true);
+    expect(checkAiLimit('user_b').ok).toBe(true);
+    const third = checkAiLimit('user_c');
+    expect(third.ok).toBe(false);
+    if (!third.ok) expect(third.reason).toMatch(/daily/i);
+  });
+});

--- a/apps/web/app/api/matcha/cover-letter/route.ts
+++ b/apps/web/app/api/matcha/cover-letter/route.ts
@@ -11,6 +11,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { checkAiLimit } from '@/lib/ai/rateLimit';
 import { buildCoverLetterMessages, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
 import {
   ANTHROPIC_MESSAGES_URL,
@@ -26,6 +28,18 @@ export async function POST(req: NextRequest) {
   if (!apiKey) {
     // Honest: AI isn't wired up in this environment (no ANTHROPIC_API_KEY).
     return NextResponse.json({ configured: false }, { status: 200 });
+  }
+
+  // Guardrails: AI costs real money per call — require a signed-in user and
+  // enforce per-user + global caps BEFORE any model call. The UI only shows AI
+  // affordances to signed-in users; this closes the direct-POST path.
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Sign in to use AI features.' }, { status: 401 });
+  }
+  const limit = checkAiLimit(session.userId);
+  if (!limit.ok) {
+    return NextResponse.json({ error: limit.reason }, { status: 429 });
   }
 
   const body = (await req.json().catch(() => ({}))) as {

--- a/apps/web/app/api/matcha/explain-match/route.ts
+++ b/apps/web/app/api/matcha/explain-match/route.ts
@@ -12,6 +12,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { checkAiLimit } from '@/lib/ai/rateLimit';
 import {
   buildMatchExplanationMessages,
   type MatchExplanationInput,
@@ -30,6 +32,18 @@ export async function POST(req: NextRequest) {
   if (!apiKey) {
     // Honest: AI isn't wired up here — the UI keeps the deterministic reasons.
     return NextResponse.json({ configured: false }, { status: 200 });
+  }
+
+  // Guardrails: AI costs real money per call — require a signed-in user and
+  // enforce per-user + global caps BEFORE any model call. The UI only shows AI
+  // affordances to signed-in users; this closes the direct-POST path.
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Sign in to use AI features.' }, { status: 401 });
+  }
+  const limit = checkAiLimit(session.userId);
+  if (!limit.ok) {
+    return NextResponse.json({ error: limit.reason }, { status: 429 });
   }
 
   const body = (await req.json().catch(() => ({}))) as Partial<MatchExplanationInput>;

--- a/apps/web/lib/ai/rateLimit.ts
+++ b/apps/web/lib/ai/rateLimit.ts
@@ -1,0 +1,62 @@
+/**
+ * AI-route guardrails — bounds worst-case model spend.
+ *
+ * Every AI endpoint requires a signed-in Clerk user and passes through two
+ * caps before any Anthropic call:
+ *   - per-user sliding window (default 20 calls/hour), and
+ *   - a global daily ceiling (default 500 calls/day across all users),
+ * so even under abuse the daily spend is bounded (~$10-15/day at Opus rates;
+ * typical usage is pennies). In-memory is correct here: the web app runs as a
+ * single long-lived Railway process, and the caps are safety bounds, not
+ * billing-grade metering. Tunable via env (AI_CALLS_PER_USER_PER_HOUR,
+ * AI_CALLS_GLOBAL_PER_DAY).
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function envInt(name: string, fallback: number): number {
+  const n = Number(process.env[name]);
+  return Number.isFinite(n) && n > 0 ? Math.round(n) : fallback;
+}
+
+const perUser = new Map<string, number[]>();
+let globalDay: number[] = [];
+
+export type AiLimitResult = { ok: true } | { ok: false; reason: string };
+
+export function checkAiLimit(userId: string): AiLimitResult {
+  const now = Date.now();
+  const userMax = envInt('AI_CALLS_PER_USER_PER_HOUR', 20);
+  const globalMax = envInt('AI_CALLS_GLOBAL_PER_DAY', 500);
+
+  globalDay = globalDay.filter((t) => now - t < DAY_MS);
+  if (globalDay.length >= globalMax) {
+    return { ok: false, reason: 'AI is at its daily capacity. Try again tomorrow.' };
+  }
+
+  const mine = (perUser.get(userId) ?? []).filter((t) => now - t < HOUR_MS);
+  if (mine.length >= userMax) {
+    perUser.set(userId, mine);
+    return { ok: false, reason: 'You have reached the hourly AI limit. Try again in a bit.' };
+  }
+
+  mine.push(now);
+  perUser.set(userId, mine);
+  globalDay.push(now);
+
+  // Opportunistic cleanup so the map can't grow unboundedly.
+  if (perUser.size > 5000) {
+    for (const [k, v] of perUser) {
+      if (v.every((t) => now - t >= HOUR_MS)) perUser.delete(k);
+    }
+  }
+
+  return { ok: true };
+}
+
+/** Test hook — reset all counters. */
+export function resetAiLimits(): void {
+  perUser.clear();
+  globalDay = [];
+}


### PR DESCRIPTION
## Why now
Chris is about to add `ANTHROPIC_API_KEY`. The two AI endpoints (`/api/matcha/cover-letter`, `/api/matcha/explain-match`) were **publicly callable** — the UI only shows AI buttons to signed-in users, but a direct POST bypassed that, so anyone could script against them and drain credits once a key exists. This closes that before the key goes in.

## Changes
- Both AI routes now **require a signed-in Clerk session** (401 otherwise).
- **Spend caps enforced before any Anthropic call**: per-user sliding window (default **20 calls/hour**) + global daily ceiling (default **500 calls/day**), returning 429 with honest copy. Worst-case daily spend is bounded (~$10–15/day at Opus rates); typical usage is pennies. Tunable via `AI_CALLS_PER_USER_PER_HOUR` / `AI_CALLS_GLOBAL_PER_DAY`.
- The honest `configured: false` fast-path stays first (no auth needed to learn AI is off — `/api/ai/status` reports the same).

In-memory limiter is appropriate here: the web app is a single long-lived Railway process, and these are safety bounds, not billing-grade metering.

## Verification
Limiter tests 3/3 (per-user cap, per-user isolation, global ceiling); lint + `turbo build` green. No behavior change while no key is set.

## Design Handoff References
No design — API guardrails only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)