### PR TITLE
feat: clinician identity tiers — gate clinician-only powers on verifiable signals (code red)

### DIFF
--- a/apps/api/backend/src/routes/applications.ts
+++ b/apps/api/backend/src/routes/applications.ts
@@ -14,6 +14,8 @@
  *   POST   /api/applications/:appId/workflow-action — verifier runs accept/request_info/reject
  */
 
+import prisma from '../graphql/prisma_client';
+import { requireIdentityTier } from '../services/identity/identityGate';
 import type { Express, NextFunction, Request, Response } from 'express';
 import {
   applyToOpportunity,
@@ -63,6 +65,12 @@ export function registerApplicationRoutes(app: Express): void {
       const clerkUserId = requireClerkUserId(req);
       const opportunityId = requireUuidParam(req.params.id, 'Opportunity');
       const { npi, coverNote } = req.body as { npi?: string; coverNote?: string };
+
+      // Applications carry the clinician's readiness snapshot to an employer —
+      // they unlock at the work_email_confirmed identity tier.
+      const applicant = await prisma.user.findUnique({ where: { clerkUserId } });
+      if (!applicant) throw new HttpError(404, 'User not found. Complete onboarding first.');
+      await requireIdentityTier(applicant.id, 'work_email_confirmed');
 
       const application = await applyToOpportunity({ opportunityId, clerkUserId, npi, coverNote });
       res.status(201).json(application);

--- a/apps/api/backend/src/routes/identity.ts
+++ b/apps/api/backend/src/routes/identity.ts
@@ -73,8 +73,9 @@ export function registerEmailOtpRoutes(app: Express): void {
           'Email delivery is not configured on this environment yet, so a code cannot be sent. This optional step can be skipped for now.',
         );
       }
-      // Never echo the code; delivery is out of band.
-      res.status(200).json({ sent: true });
+      // Never echo the code; delivery is out of band. The domain class lets
+      // the UI steer toward a work email (free/personal confirms contact only).
+      res.status(200).json({ sent: true, domainClass: result.domainClass ?? 'unknown' });
     }),
   );
 

--- a/apps/api/backend/src/routes/intake.ts
+++ b/apps/api/backend/src/routes/intake.ts
@@ -23,6 +23,7 @@ import {
   type ClearableLinkField,
 } from '../services/intake/intakeService';
 import { ensureWorkspaceUser } from '../services/workspace/workspaceService';
+import { identityStateForUser, requireIdentityTier } from '../services/identity/identityGate';
 import { publicApiRateLimit } from '../middleware/publicSafety';
 import { HttpError } from '../utils/httpError';
 
@@ -219,7 +220,25 @@ export function registerIntakeRoutes(app: Express): void {
     asyncHandler(async (req, res) => {
       const userId = await requireInternalUserId(req);
       const body = req.body as { careerProfile?: unknown } | undefined;
+      // Publishing a page under a clinician's registry name is an
+      // impersonation vector — it unlocks at work_email_confirmed. Going
+      // private is always allowed.
+      if (body?.careerProfile === 'public') {
+        await requireIdentityTier(userId, 'work_email_confirmed');
+      }
       res.json(await updateProfileSharing(userId, body?.careerProfile));
+    }),
+  );
+
+  /**
+   * GET /api/profile/identity — the derived clinician-identity tier and the
+   * exact signals behind it (nothing here is a license verification).
+   */
+  app.get(
+    '/api/profile/identity',
+    asyncHandler(async (req, res) => {
+      const userId = await requireInternalUserId(req);
+      res.json(await identityStateForUser(userId));
     }),
   );
 

--- a/apps/api/backend/src/services/identity/__tests__/identityTier.test.ts
+++ b/apps/api/backend/src/services/identity/__tests__/identityTier.test.ts
@@ -1,0 +1,102 @@
+/**
+ * identityTier — the derived clinician-identity ladder must be strict and
+ * honest: free/disposable inboxes never reach work_email_confirmed, malformed
+ * input degrades to the lowest tier, and the license lane is always reported
+ * as not source-verified (it is not live).
+ */
+import {
+  classifyEmailDomain,
+  deriveIdentityState,
+  emailDomainOf,
+  tierAtLeast,
+  tierRequirementMessage,
+} from '../identityTier';
+
+describe('classifyEmailDomain', () => {
+  it('classifies institutional domains', () => {
+    expect(classifyEmailDomain('m.miller@cedarhealth.org')).toBe('institutional');
+    expect(classifyEmailDomain('doc@stanfordhealthcare.org')).toBe('institutional');
+    expect(classifyEmailDomain('a@sub.hospital.edu')).toBe('institutional');
+  });
+
+  it('classifies consumer free-mail', () => {
+    for (const d of ['gmail.com', 'yahoo.com', 'outlook.com', 'icloud.com', 'proton.me', 'aol.com']) {
+      expect(classifyEmailDomain(`user@${d}`)).toBe('free');
+    }
+  });
+
+  it('classifies disposable providers', () => {
+    expect(classifyEmailDomain('x@mailinator.com')).toBe('disposable');
+    expect(classifyEmailDomain('x@yopmail.com')).toBe('disposable');
+  });
+
+  it('degrades malformed input to unknown', () => {
+    expect(classifyEmailDomain('')).toBe('unknown');
+    expect(classifyEmailDomain(null)).toBe('unknown');
+    expect(classifyEmailDomain('not-an-email')).toBe('unknown');
+    expect(classifyEmailDomain('trailing@')).toBe('unknown');
+    expect(classifyEmailDomain('@nodomain')).toBe('unknown');
+  });
+
+  it('is case-insensitive on the domain', () => {
+    expect(classifyEmailDomain('USER@GMAIL.COM')).toBe('free');
+    expect(emailDomainOf('A@Cedar.ORG')).toBe('cedar.org');
+  });
+});
+
+describe('deriveIdentityState', () => {
+  it('account tier with no profile', () => {
+    expect(deriveIdentityState(null).tier).toBe('account');
+  });
+
+  it('npi_bound with an NPI but no confirmed email', () => {
+    const s = deriveIdentityState({ npi: '1234567890', verifiedEmail: null });
+    expect(s.tier).toBe('npi_bound');
+    expect(s.signals.emailConfirmed).toBe(false);
+  });
+
+  it('npi_bound (NOT confirmed) when the confirmed email is free-mail', () => {
+    const s = deriveIdentityState({ npi: '1234567890', verifiedEmail: 'doc@gmail.com' });
+    expect(s.tier).toBe('npi_bound');
+    expect(s.signals.emailConfirmed).toBe(true);
+    expect(s.signals.emailDomainClass).toBe('free');
+  });
+
+  it('npi_bound when the confirmed email is disposable', () => {
+    const s = deriveIdentityState({ npi: '1234567890', verifiedEmail: 'x@mailinator.com' });
+    expect(s.tier).toBe('npi_bound');
+  });
+
+  it('work_email_confirmed only with NPI + institutional email', () => {
+    const s = deriveIdentityState({ npi: '1234567890', verifiedEmail: 'm.miller@cedarhealth.org' });
+    expect(s.tier).toBe('work_email_confirmed');
+    expect(s.signals.emailDomain).toBe('cedarhealth.org');
+  });
+
+  it('institutional email WITHOUT an NPI stays account tier', () => {
+    const s = deriveIdentityState({ npi: null, verifiedEmail: 'm.miller@cedarhealth.org' });
+    expect(s.tier).toBe('account');
+  });
+
+  it('always reports the license lane as not source-verified', () => {
+    const s = deriveIdentityState({ npi: '1234567890', verifiedEmail: 'a@b.org' });
+    expect(s.signals.licenseSourceVerified).toBe(false);
+  });
+});
+
+describe('tierAtLeast + gate copy', () => {
+  it('orders the ladder strictly', () => {
+    expect(tierAtLeast('work_email_confirmed', 'npi_bound')).toBe(true);
+    expect(tierAtLeast('npi_bound', 'work_email_confirmed')).toBe(false);
+    expect(tierAtLeast('account', 'npi_bound')).toBe(false);
+    expect(tierAtLeast('npi_bound', 'npi_bound')).toBe(true);
+  });
+
+  it('gate copy never claims verification of the person', () => {
+    for (const min of ['npi_bound', 'work_email_confirmed'] as const) {
+      const msg = tierRequirementMessage(min).toLowerCase();
+      expect(msg).not.toContain('verified clinician');
+      expect(msg).not.toContain('identity verified');
+    }
+  });
+});

--- a/apps/api/backend/src/services/identity/emailOtpService.ts
+++ b/apps/api/backend/src/services/identity/emailOtpService.ts
@@ -14,6 +14,7 @@ import {
   getNotificationProvider,
   isEmailDeliveryConfigured,
 } from '../providers/notificationProvider';
+import { classifyEmailDomain, type EmailDomainClass } from './identityTier';
 import {
   emailDomain,
   evaluateOtpAttempt,
@@ -44,7 +45,7 @@ export type IssueOutcome = 'sent' | 'invalid_email' | 'rate_limited' | 'delivery
 export async function issueEmailOtp(
   userId: string,
   rawEmail: string,
-): Promise<{ outcome: IssueOutcome; email: string }> {
+): Promise<{ outcome: IssueOutcome; email: string; domainClass?: EmailDomainClass }> {
   const email = normalizeEmail(rawEmail);
   if (!isPlausibleEmail(email)) {
     return { outcome: 'invalid_email', email };
@@ -104,7 +105,7 @@ export async function issueEmailOtp(
   // Audit records only the domain — never the code or full address.
   await emitAudit('identity_email_otp_issued', userId, { emailDomain: emailDomain(email) });
 
-  return { outcome: 'sent', email };
+  return { outcome: 'sent', email, domainClass: classifyEmailDomain(email) };
 }
 
 export async function verifyEmailOtp(

--- a/apps/api/backend/src/services/identity/identityGate.ts
+++ b/apps/api/backend/src/services/identity/identityGate.ts
@@ -1,0 +1,41 @@
+/**
+ * identityGate — route-level enforcement of derived clinician-identity tiers.
+ *
+ * Wraps the pure identityTier derivation with the profile lookup and the
+ * honest 403. Used by the clinician-only powers: publishing the public career
+ * profile, applying to openings, and the AI matching/drafting features.
+ */
+
+import prisma from '../../graphql/prisma_client';
+import { HttpError } from '../../utils/httpError';
+import {
+  deriveIdentityState,
+  tierAtLeast,
+  tierRequirementMessage,
+  type IdentityState,
+  type IdentityTier,
+} from './identityTier';
+
+/** Identity state for an internal User.id (never a raw Clerk id). */
+export async function identityStateForUser(userId: string): Promise<IdentityState> {
+  const profile = await prisma.personProfile.findFirst({
+    where: { userId },
+    select: { npi: true, verifiedEmail: true },
+  });
+  return deriveIdentityState(profile);
+}
+
+/**
+ * Throws an honest 403 when the user's derived tier is below `min`.
+ * Returns the state so callers can log or enrich responses.
+ */
+export async function requireIdentityTier(
+  userId: string,
+  min: IdentityTier,
+): Promise<IdentityState> {
+  const state = await identityStateForUser(userId);
+  if (!tierAtLeast(state.tier, min)) {
+    throw new HttpError(403, tierRequirementMessage(min));
+  }
+  return state;
+}

--- a/apps/api/backend/src/services/identity/identityTier.ts
+++ b/apps/api/backend/src/services/identity/identityTier.ts
@@ -1,0 +1,126 @@
+/**
+ * identityTier — derived clinician-identity tiers over existing signals.
+ *
+ * VitalCV cannot (yet) assert "this person is a licensed clinician" — that is
+ * the source-verified license lane (state board / FSMB), which stays honestly
+ * gated. What it CAN do today, from columns that already exist:
+ *
+ *   account               signed in; nothing bound
+ *   npi_bound             an NPI from the public registry is exclusively bound
+ *                         to this account (PersonProfile.npi is unique)
+ *   work_email_confirmed  npi_bound + a confirmed email at an institutional
+ *                         domain (free-mail and disposable domains do not
+ *                         qualify — they prove contact, not affiliation)
+ *
+ * Tier names and labels deliberately state the checked fact. Nothing here may
+ * ever be rendered as a bare "Verified" or "verified clinician" claim.
+ */
+
+export type EmailDomainClass = 'institutional' | 'free' | 'disposable' | 'unknown';
+
+export type IdentityTier = 'account' | 'npi_bound' | 'work_email_confirmed';
+
+/** Consumer mailbox providers — prove contact, not institutional affiliation. */
+const FREE_EMAIL_DOMAINS = new Set([
+  'gmail.com', 'googlemail.com', 'yahoo.com', 'ymail.com', 'rocketmail.com',
+  'outlook.com', 'hotmail.com', 'live.com', 'msn.com', 'aol.com',
+  'icloud.com', 'me.com', 'mac.com', 'proton.me', 'protonmail.com', 'pm.me',
+  'gmx.com', 'gmx.net', 'mail.com', 'zoho.com', 'yandex.com', 'yandex.ru',
+  'fastmail.com', 'hey.com', 'duck.com', 'mail.ru', 'qq.com', '163.com',
+  '126.com', 'comcast.net', 'att.net', 'verizon.net', 'sbcglobal.net',
+]);
+
+/** Throwaway providers — never a meaningful signal. */
+const DISPOSABLE_EMAIL_DOMAINS = new Set([
+  'mailinator.com', 'guerrillamail.com', '10minutemail.com', 'tempmail.com',
+  'temp-mail.org', 'throwawaymail.com', 'yopmail.com', 'sharklasers.com',
+  'getnada.com', 'trashmail.com', 'dispostable.com', 'maildrop.cc',
+]);
+
+export function emailDomainOf(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const at = email.lastIndexOf('@');
+  if (at < 1 || at === email.length - 1) return null;
+  return email.slice(at + 1).trim().toLowerCase();
+}
+
+function inSetOrSubdomain(domain: string, set: Set<string>): boolean {
+  if (set.has(domain)) return true;
+  for (const known of set) {
+    if (domain.endsWith(`.${known}`)) return true;
+  }
+  return false;
+}
+
+export function classifyEmailDomain(email: string | null | undefined): EmailDomainClass {
+  const domain = emailDomainOf(email);
+  if (!domain || !domain.includes('.')) return 'unknown';
+  if (inSetOrSubdomain(domain, DISPOSABLE_EMAIL_DOMAINS)) return 'disposable';
+  if (inSetOrSubdomain(domain, FREE_EMAIL_DOMAINS)) return 'free';
+  return 'institutional';
+}
+
+export interface IdentitySignals {
+  npiBound: boolean;
+  emailConfirmed: boolean;
+  emailDomain: string | null;
+  emailDomainClass: EmailDomainClass | null;
+  /** The source-verified license lane is not live; stated so UIs stay honest. */
+  licenseSourceVerified: false;
+}
+
+export interface IdentityState {
+  tier: IdentityTier;
+  signals: IdentitySignals;
+}
+
+const TIER_ORDER: Record<IdentityTier, number> = {
+  account: 0,
+  npi_bound: 1,
+  work_email_confirmed: 2,
+};
+
+export function tierAtLeast(tier: IdentityTier, min: IdentityTier): boolean {
+  return TIER_ORDER[tier] >= TIER_ORDER[min];
+}
+
+export function deriveIdentityState(profile: {
+  npi: string | null;
+  verifiedEmail: string | null;
+} | null): IdentityState {
+  const npiBound = Boolean(profile?.npi);
+  const emailDomain = emailDomainOf(profile?.verifiedEmail);
+  const emailDomainClass = profile?.verifiedEmail
+    ? classifyEmailDomain(profile.verifiedEmail)
+    : null;
+  const emailConfirmed = Boolean(profile?.verifiedEmail);
+  const institutional = emailConfirmed && emailDomainClass === 'institutional';
+
+  const tier: IdentityTier = npiBound
+    ? institutional
+      ? 'work_email_confirmed'
+      : 'npi_bound'
+    : 'account';
+
+  return {
+    tier,
+    signals: {
+      npiBound,
+      emailConfirmed,
+      emailDomain,
+      emailDomainClass,
+      licenseSourceVerified: false,
+    },
+  };
+}
+
+/** Honest gate copy, reused by every enforcement point. */
+export function tierRequirementMessage(min: IdentityTier): string {
+  if (min === 'work_email_confirmed') {
+    return 'This clinician feature unlocks after you confirm a work email at your organization (a personal or free email confirms contact only). Add it in Get Ready → email confirmation.';
+  }
+  if (min === 'npi_bound') {
+    return 'This feature unlocks after you connect your NPI in Get Ready.';
+  }
+  return 'Sign in to continue.';
+}

--- a/apps/api/backend/src/services/intake/intakeService.ts
+++ b/apps/api/backend/src/services/intake/intakeService.ts
@@ -304,6 +304,21 @@ export async function bootstrapNpiIntake(
   const inferredPersona = detected.npiType === 'TYPE_2' ? 'VERIFIER' : 'CLINICIAN';
 
   // Upsert PersonProfile
+  // PersonProfile.npi is unique: a second account claiming the same NPI
+  // must get an honest conflict, not a raw constraint error. Conflicting
+  // claims are an impersonation signal and are audited.
+  const existingHolder = await prisma.personProfile.findUnique({
+    where: { npi },
+    select: { userId: true },
+  });
+  if (existingHolder && existingHolder.userId !== userId) {
+    await emitAudit('npi_claim_conflict', userId, { npi });
+    throw new HttpError(
+      409,
+      'This NPI is already connected to another VitalCV account. If this is your NPI, contact support — conflicting claims are routed to review.',
+    );
+  }
+
   await prisma.personProfile.upsert({
     where:  { userId },
     create: {

--- a/apps/web/__tests__/clinician-tier-gate.test.ts
+++ b/apps/web/__tests__/clinician-tier-gate.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Clinician-tier gate on the AI routes — the "clinicians only" enforcement.
+ * Contract: below work_email_confirmed (or unreadable identity state) the
+ * routes 403 with honest copy BEFORE any model call; the gate composes after
+ * auth and rate-limiting.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMock = vi.fn();
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => authMock() }));
+vi.mock('@/lib/auth/forwardIdentity', () => ({
+  buildIdentityHeaders: async () => ({ 'x-clerk-user-id': 'user_test' }),
+}));
+
+import { CLINICIAN_TIER_MESSAGE, userMeetsTier } from '@/lib/auth/clinicianTier';
+import { POST as coverLetterPOST } from '@/app/api/matcha/cover-letter/route';
+
+function identityFetchMock(tier: string | null, status = 200) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/profile/identity')) {
+      if (tier === null) return new Response('{}', { status: 503 });
+      return new Response(JSON.stringify({ tier, signals: {} }), { status });
+    }
+    throw new Error(`unexpected fetch in test: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+describe('userMeetsTier', () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('true at or above the minimum tier', async () => {
+    global.fetch = identityFetchMock('work_email_confirmed');
+    expect(await userMeetsTier('user_test', 'work_email_confirmed')).toBe(true);
+  });
+
+  it('false below the minimum tier', async () => {
+    global.fetch = identityFetchMock('npi_bound');
+    expect(await userMeetsTier('user_test', 'work_email_confirmed')).toBe(false);
+  });
+
+  it('fails closed when the identity state is unreadable', async () => {
+    global.fetch = identityFetchMock(null);
+    expect(await userMeetsTier('user_test', 'work_email_confirmed')).toBe(false);
+  });
+});
+
+describe('POST /api/matcha/cover-letter — tier gate', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = 'test-key-not-used';
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it('403s below tier with the honest message, before any model call', async () => {
+    authMock.mockResolvedValue({ userId: 'user_test' });
+    const fetchSpy = identityFetchMock('npi_bound');
+    global.fetch = fetchSpy;
+
+    const req = new Request('http://localhost/api/matcha/cover-letter', {
+      method: 'POST',
+      body: JSON.stringify({ opportunity: { title: 'Role' }, profileSummary: 'x' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await coverLetterPOST(req as any);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe(CLINICIAN_TIER_MESSAGE);
+    // Only the identity lookup was fetched — never the Anthropic API.
+    const urls = (fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(urls.every((u) => u.includes('/api/profile/identity'))).toBe(true);
+  });
+
+  it('401s signed-out before the tier check', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    const fetchSpy = identityFetchMock('work_email_confirmed');
+    global.fetch = fetchSpy;
+
+    const req = new Request('http://localhost/api/matcha/cover-letter', {
+      method: 'POST',
+      body: '{}',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await coverLetterPOST(req as any);
+    expect(res.status).toBe(401);
+    expect((fetchSpy as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+});

--- a/apps/web/app/api/matcha/cover-letter/route.ts
+++ b/apps/web/app/api/matcha/cover-letter/route.ts
@@ -13,6 +13,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { checkAiLimit } from '@/lib/ai/rateLimit';
+import { CLINICIAN_TIER_MESSAGE, userMeetsTier } from '@/lib/auth/clinicianTier';
 import { buildCoverLetterMessages, type CoverLetterOpportunity } from '@/lib/matcha/coverLetter';
 import {
   ANTHROPIC_MESSAGES_URL,
@@ -40,6 +41,11 @@ export async function POST(req: NextRequest) {
   const limit = checkAiLimit(session.userId);
   if (!limit.ok) {
     return NextResponse.json({ error: limit.reason }, { status: 429 });
+  }
+  // Clinician-only power: requires the work_email_confirmed identity tier
+  // (fail-closed if the identity state can't be read).
+  if (!(await userMeetsTier(session.userId, 'work_email_confirmed'))) {
+    return NextResponse.json({ error: CLINICIAN_TIER_MESSAGE }, { status: 403 });
   }
 
   const body = (await req.json().catch(() => ({}))) as {

--- a/apps/web/app/api/matcha/explain-match/route.ts
+++ b/apps/web/app/api/matcha/explain-match/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { checkAiLimit } from '@/lib/ai/rateLimit';
+import { CLINICIAN_TIER_MESSAGE, userMeetsTier } from '@/lib/auth/clinicianTier';
 import {
   buildMatchExplanationMessages,
   type MatchExplanationInput,
@@ -44,6 +45,11 @@ export async function POST(req: NextRequest) {
   const limit = checkAiLimit(session.userId);
   if (!limit.ok) {
     return NextResponse.json({ error: limit.reason }, { status: 429 });
+  }
+  // Clinician-only power: requires the work_email_confirmed identity tier
+  // (fail-closed if the identity state can't be read).
+  if (!(await userMeetsTier(session.userId, 'work_email_confirmed'))) {
+    return NextResponse.json({ error: CLINICIAN_TIER_MESSAGE }, { status: 403 });
   }
 
   const body = (await req.json().catch(() => ({}))) as Partial<MatchExplanationInput>;

--- a/apps/web/app/api/profile/identity/route.ts
+++ b/apps/web/app/api/profile/identity/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/profile/identity — the signed-in clinician's derived identity tier
+ * and the exact signals behind it. Thin auth-scoped proxy.
+ */
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { getApiBase } from '@/lib/api';
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await auth();
+  if (!session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const headers = await buildIdentityHeaders({ userId: session.userId });
+  const res = await fetch(`${getApiBase()}/api/profile/identity`, {
+    headers,
+    cache: 'no-store',
+    signal: AbortSignal.timeout(15_000),
+  });
+  const data = await res.json().catch(() => ({ error: 'Invalid response from backend' }));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/components/explore/ApplyModal.tsx
+++ b/apps/web/components/explore/ApplyModal.tsx
@@ -286,9 +286,17 @@ export default function ApplyModal({
       }
 
       const errorPayload = payload && typeof payload === 'object'
-        ? payload as { error?: string }
+        ? payload as { error?: unknown }
         : null;
-      const nextError = errorPayload?.error ?? 'Something went wrong. Please try again.';
+      // Backend errors arrive as { error: { code, message } } or { error: string }
+      // — coerce so an object never reaches JSX or string interpolation.
+      const rawError = errorPayload?.error;
+      const nextError = typeof rawError === 'string'
+        ? rawError
+        : rawError && typeof rawError === 'object'
+            && typeof (rawError as { message?: unknown }).message === 'string'
+          ? (rawError as { message: string }).message
+          : 'Something went wrong. Please try again.';
       void trackPilotEvent({
         eventType: 'route_failure',
         severity: 'high',

--- a/apps/web/components/get-ready/EmailVerification.tsx
+++ b/apps/web/components/get-ready/EmailVerification.tsx
@@ -40,6 +40,7 @@ export default function EmailVerification() {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [domainClass, setDomainClass] = useState<string | null>(null);
 
   async function issue(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -62,6 +63,8 @@ export default function EmailVerification() {
         setStep('email');
         return;
       }
+      const okBody = (await res.json().catch(() => ({}))) as { domainClass?: string };
+      setDomainClass(typeof okBody.domainClass === 'string' ? okBody.domainClass : null);
       setStep('code');
     } catch {
       setError('Could not send a code. Try again shortly.');
@@ -131,6 +134,14 @@ export default function EmailVerification() {
           <p className="text-xs text-[var(--ink-500)]">
             We sent a 6-digit code to <span className="text-[var(--ink-800)]">{email.trim()}</span>.
           </p>
+          {domainClass === 'free' || domainClass === 'disposable' ? (
+            <p className="mt-2 text-xs" style={{ color: 'var(--warn, #b45309)' }}>
+              Heads up: this looks like a personal email. It confirms contact,
+              but clinician features (publishing your career profile, applying,
+              AI matching) unlock with a work email at your organization. You
+              can add one here anytime.
+            </p>
+          ) : null}
           <input
             inputMode="numeric"
             autoComplete="one-time-code"

--- a/apps/web/components/profile/CareerProfileSharingCard.tsx
+++ b/apps/web/components/profile/CareerProfileSharingCard.tsx
@@ -23,16 +23,27 @@ export function CareerProfileSharingCard({ npi }: { npi: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [meetsTier, setMeetsTier] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/profile/sharing', { cache: 'no-store' });
-        if (!res.ok) throw new Error(String(res.status));
-        const body = (await res.json()) as { careerProfile?: string };
+        const [sharingRes, identityRes] = await Promise.all([
+          fetch('/api/profile/sharing', { cache: 'no-store' }),
+          fetch('/api/profile/identity', { cache: 'no-store' }),
+        ]);
+        if (!sharingRes.ok) throw new Error(String(sharingRes.status));
+        const body = (await sharingRes.json()) as { careerProfile?: string };
+        // Fail-closed: unreadable identity state counts as below-tier.
+        let meets = false;
+        if (identityRes.ok) {
+          const identity = (await identityRes.json()) as { tier?: string };
+          meets = identity.tier === 'work_email_confirmed';
+        }
         if (!cancelled) {
           setVisibility(body.careerProfile === 'public' ? 'public' : 'private');
+          setMeetsTier(meets);
           setPhase('ready');
         }
       } catch {
@@ -122,7 +133,7 @@ export function CareerProfileSharingCard({ npi }: { npi: string }) {
         </div>
         <button
           type="button"
-          disabled={saving}
+          disabled={saving || (!isPublic && !meetsTier)}
           onClick={() => void setSharing(isPublic ? 'private' : 'public')}
           className="vcv-mono shrink-0 rounded-[6px] border px-3 py-2 text-[11px] uppercase tracking-[0.14em] transition disabled:opacity-50"
           style={{ borderColor: 'var(--ink)', color: isPublic ? 'var(--paper, #fff)' : 'var(--ink)', background: isPublic ? 'var(--ink)' : 'transparent' }}
@@ -157,6 +168,14 @@ export function CareerProfileSharingCard({ npi }: { npi: string }) {
         </div>
       ) : null}
 
+      {!isPublic && !meetsTier ? (
+        <p className="mt-3 text-xs" style={{ color: 'var(--warn, #b45309)' }}>
+          Publishing unlocks after you confirm a work email at your organization
+          in <a href="/get-ready" className="underline underline-offset-2">Get Ready</a>.
+          A personal or free email confirms contact only — this keeps career
+          profile pages from being published under someone else&apos;s NPI.
+        </p>
+      ) : null}
       <p className="mt-3 text-xs vcv-muted">
         The page shows your self-attested career story, labeled as self-attested.
         Your source-backed verification record at /verify is a separate surface.

--- a/apps/web/lib/auth/clinicianTier.ts
+++ b/apps/web/lib/auth/clinicianTier.ts
@@ -1,0 +1,54 @@
+/**
+ * clinicianTier — server-side check of the backend-derived identity tier.
+ *
+ * Used by routes that guard clinician-only powers (AI drafting/matching).
+ * Fail-closed: if the identity state can't be read, the caller treats the
+ * user as below-tier rather than assuming clinician standing.
+ */
+
+import { buildIdentityHeaders } from '@/lib/auth/forwardIdentity';
+import { getApiBase } from '@/lib/api';
+
+export type IdentityTier = 'account' | 'npi_bound' | 'work_email_confirmed';
+
+export interface IdentityStatePayload {
+  tier: IdentityTier;
+  signals: {
+    npiBound: boolean;
+    emailConfirmed: boolean;
+    emailDomain: string | null;
+    emailDomainClass: 'institutional' | 'free' | 'disposable' | 'unknown' | null;
+    licenseSourceVerified: false;
+  };
+}
+
+const TIER_ORDER: Record<IdentityTier, number> = {
+  account: 0,
+  npi_bound: 1,
+  work_email_confirmed: 2,
+};
+
+export const CLINICIAN_TIER_MESSAGE =
+  'Clinician features unlock after you confirm a work email at your organization in Get Ready. A personal or free email confirms contact only.';
+
+export async function fetchIdentityState(userId: string): Promise<IdentityStatePayload | null> {
+  try {
+    const headers = await buildIdentityHeaders({ userId });
+    const res = await fetch(`${getApiBase()}/api/profile/identity`, {
+      headers,
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as IdentityStatePayload;
+  } catch {
+    return null;
+  }
+}
+
+/** True only when the state is readable AND meets the minimum tier. */
+export async function userMeetsTier(userId: string, min: IdentityTier): Promise<boolean> {
+  const state = await fetchIdentityState(userId);
+  if (!state) return false;
+  return TIER_ORDER[state.tier] >= TIER_ORDER[min];
+}


### PR DESCRIPTION
## Why

Founder question: *"can it verify the user is a clinician like 'ChatGPT for clinicians'? prob not. can we make that happen — code red."*

Honest answer: full clinician verification is the source-verified license lane (state board / FSMB — launch blocker #6, external agreements required), and no same-day build can conjure it. What CAN ship today: stop treating every signed-up account as a clinician, derive strict tiers from the signals that already exist, and gate the clinician-only powers on them. This PR does that, with zero migrations (tiers are computed at read time, never stored).

## The ladder

| Tier | Meaning | Evidence |
|---|---|---|
| `account` | signed in | Clerk session |
| `npi_bound` | an NPI is exclusively bound to this account | `PersonProfile.npi` unique + NPPES registry match |
| `work_email_confirmed` | + confirmed email at an **institutional** domain | OTP-confirmed email whose domain is not one of 33 consumer or 12 disposable providers (subdomain suffix matching included) |
| *(future)* `source_verified` | license verified at the primary source | **not live — reported as `licenseSourceVerified: false` everywhere, honestly** |

## Enforcement points (honest 403 copy at each)

- **Publish public career profile** (`POST /api/profile/sharing` → public): requires `work_email_confirmed`. This is the anti-impersonation gate — nobody publishes a page under someone else's registry name from a gmail burner. Going private always allowed.
- **Apply to an opening** (`POST /api/opportunities/:id/apply`): same tier — applications carry a readiness snapshot to a real employer.
- **AI features** (cover-letter + explain-match): tier check composes after #621's auth + spend caps; fail-closed when identity state is unreadable; runs before any model call.
- **NPI double-claim**: second account claiming a bound NPI → honest `409` + `npi_claim_conflict` audit event (was a raw unique-constraint 500).

## Signals surface

- `GET /api/profile/identity` (backend + web proxy) — tier + the exact signals behind it.
- OTP issue now returns the email's `domainClass`; `/get-ready` steers to a work email when a personal inbox is used.
- SharingCard disables publish below tier and shows the unlock path.
- **Truth contract**: labels state checked facts ("NPI record matched", "work email confirmed"); nothing anywhere renders "verified clinician" — the gate-copy test pins this.

## Review fixes baked in

- `ApplyModal` rendered `body.error` objects directly — the new 403 would have crash-rendered React children; coerced `{error:{code,message}}` safely.
- Domain classifier hardened with subdomain suffix matching (`user@mail.gmail.com` cannot classify as institutional).

## Verification

- Backend `tsc` green; jest **18/18** (ladder strictness, classifier edge cases incl. case-insensitivity + malformed input, gate-copy honesty).
- Web vitest green incl. new `clinician-tier-gate` suite: 403 below tier with **zero model-API calls made**, 401 signed-out before the tier check, fail-closed unreadable identity; #621's `ai-rate-limit` suite untouched and green; `banned-verified-label` + `holder-route-contract` guards pass.
- `turbo build` green; `/api/profile/identity` in the route manifest.
- Not browser-verified signed-in (all gated surfaces require a clinician session; I cannot create accounts) — enforcement is proven at the route-contract level by the new tests.

## What this does NOT claim

An institutional email is affiliation evidence, not licensure. The real "verified clinician" tier needs the license lane (blocker #6) or an IDV vendor (Persona/ID.me class — procurement decision). Both remain honestly gated; this PR makes the gap enforceable instead of invisible.

## Design Handoff References

No design-handoff file applies (enforcement + copy; no new visual surface). Gate copy follows the truth-contract language system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)