### PR TITLE
feat: employer doorway on /verify/[npi] — the share→accept seam closes

### DIFF
--- a/apps/web/__tests__/verify-npi-page.test.tsx
+++ b/apps/web/__tests__/verify-npi-page.test.tsx
@@ -45,6 +45,29 @@ describe('/verify/[npi] — invalid-id path', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('renders the employer review doorway on a resolvable NPI (share→accept seam)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/api/passport/npi/')) {
+          return new Response(JSON.stringify({ identity: { displayName: 'Test Clinician' } }), { status: 200 });
+        }
+        return new Response('{}', { status: 404 });
+      }),
+    );
+
+    const html = renderToStaticMarkup(
+      (await renderPage('1234567890')) as React.ReactElement,
+    );
+    expect(html).toContain('data-testid="employer-review-cta"');
+    expect(html).toContain('/review/1234567890');
+    expect(html).toContain('Reviewing this clinician for a role?');
+    expect(html).toContain('Requires a signed-in employer account');
+    // the doorway never overclaims: decisions are recorded, not auto-approved
+    expect(html).not.toMatch(/>\s*Verified\s*</);
+  });
+
   it('keeps the in-page not-found state for a well-formed NPI the backend does not know', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/app/verify/[npi]/page.tsx
+++ b/apps/web/app/verify/[npi]/page.tsx
@@ -14,6 +14,7 @@
  */
 
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Eye, ShieldAlert } from 'lucide-react';
 import { Reveal } from '@/components/motion/Reveal';
@@ -409,6 +410,32 @@ export default async function VerifierPage({
         <Reveal delay={80}>
         <Section title="Employer acceptances">
           <AcceptancePanel history={acceptanceHistory} />
+        </Section>
+        </Reveal>
+
+        {/* ── Section: Act on this record (employer CTA) ──────────────────
+            Closes the share→accept seam: the link a clinician shares is this
+            read-only page, and the decision surface is /review/[npi]. Actions
+            there are Clerk-authenticated, attributable, and audited — this is
+            a doorway, not a bypass. */}
+        <Reveal delay={100}>
+        <Section title="Reviewing this clinician for a role?">
+          <div className="mz-card px-5 py-4 flex flex-wrap items-center justify-between gap-3" data-testid="employer-review-cta">
+            <p className="text-sm text-[var(--ink-600)] max-w-xl">
+              Employers can act on this record — accept it as a head start,
+              request a source refresh, or route it to review. Decisions are
+              recorded, attributable, and visible to the clinician.
+            </p>
+            <Link
+              href={`/review/${npi}`}
+              className="mz-btn shrink-0"
+            >
+              Open the review surface →
+            </Link>
+          </div>
+          <p className="mz-mono mt-2 text-[10px] uppercase tracking-[0.14em] text-[var(--ink-400)]">
+            Requires a signed-in employer account · viewing never requires one
+          </p>
         </Section>
         </Reveal>
 

--- a/docs/ops/REBASELINE-2026-07-04.md
+++ b/docs/ops/REBASELINE-2026-07-04.md
@@ -17,6 +17,9 @@
 | No env validation | Web: `apps/web/lib/env.ts` (SEC-ENV-1 typed contract). Backend: `apps/api/backend/src/config/env.ts` + `envValidation.ts` (Zod) |
 | Nursys throws when flagged on | `apps/api/backend/src/services/nursysAdapter.ts` is an honest gated stub: returns NOT_AVAILABLE, never fabricates, no throw path in the default flow |
 | No ASVS scorecard | `docs/security/asvs-scorecard.md` exists (L1, evidence-cited). L2 mapping remains open |
+| Self-serve clinician signup gate (blocker #1) | Closed 2026-07-11: gate PRs #538/#539/#542 + e2e #595 (clerk-id/uuid + tenant-guard fixes, 1361 backend tests green); email-OTP anchor DELIVERS in prod (Resend key + vitalcv.com domain verified, PR #615 honest delivery states); identity tiers enforce it (PR #622: publish/apply/AI gated on work_email_confirmed; NPI double-claim → 409 + audit). Identity PROOFING (license lane / IDV) intentionally stays open under blocker #6 — the gate never claimed it. |
+| Prod auth / Google OAuth verification (blocker #3) | Closed 2026-07-11: live walkthrough — Clerk FAPI 200, all 5 DNS CNAMEs (incl. clkmail/DKIM), Google OAuth redirects into consent for vitalcv.com, resolve-role round-trip healthy; founder account signs in. Local-dev failure mode (pk_live keys off-domain) fixed by DevKeysNotice (PR #618) + dev-instance keys in .env.local. |
+| E2E signup happy-path + fail-closed (blocker #4) | Closed by PR #595 (signup golden path + BLOCKED-passport-cannot-be-accepted e2e); runs in the required Backend Tests (Postgres) CI job. |
 
 ## Corrected premises (the plan docs were stale here)
 

--- a/docs/ops/launch-blockers.md
+++ b/docs/ops/launch-blockers.md
@@ -1,6 +1,6 @@
 # Launch blockers — canonical open list
 
-**Status date:** 2026-07-05 · **Baseline:** `f7bdbe158` (origin/main)
+**Status date:** 2026-07-11 · **Baseline:** `f7bdbe158` (origin/main)
 **Provenance:** re-baselined on-disk by Wave 0; see `docs/ops/REBASELINE-2026-07-04.md` for what was verified-resolved and which older premises were corrected. `docs/LAUNCH_GATE.md` (2026-03-28) is historical.
 
 This file lists **only genuinely-open items**, each with its owning wave from the god-mode plan (`docs/research/god-mode-research-report.md`). When an item closes, move it to the resolved table in the re-baseline doc of the closing wave — do not leave ghosts here.
@@ -9,10 +9,7 @@ This file lists **only genuinely-open items**, each with its owning wave from th
 
 | # | Item | Evidence it is open | Owning wave |
 |---|---|---|---|
-| 1 | Self-serve clinician signup gate completion — NPI confirm screen, identity-binding factor (work-email OTP), attestation flow, wallet provisioning | `apps/web/lib/commercial/selfServeSignupFoundation.ts` pins `accountCreationProductionReady: false`, `identityProofingComplete: false`; gate PRs 1/4 merged (#538), 2/4 open (#539), 3/4–4/4 unstarted | A (in flight) |
 | 2 | Verifier org-role RBAC enforcement | `apps/web/lib/verifier/orgRolesFoundation.ts` pins `rbacEnforced: false` (literal); no role checks on mutating verifier routes | B |
-| 3 | Prod auth / Google OAuth verification on Clerk | Unverified in Clerk prod config; sign-in CSP fixed (#536) but OAuth provider state unconfirmed; needs `.env.example` documentation | B |
-| 4 | E2E signup happy-path + fail-closed test | No e2e covering role→NPI→confirm→attest→wallet, nor a BLOCKED-passport-cannot-be-accepted case | B (gates A's acceptance) |
 | 6 | STATE_BOARD / FSMB physician-licensure lane | Gated, no live adapter behind `STATE_BOARD_ENABLED`; license claims must stay `gated`, never `checked` | C |
 | 7 | SAM.gov exclusions adapter | Honest gated adapter landed (`services/samGovAdapter.ts`, `SAM_GOV_ENABLED` default false); live API key + fetcher wiring outstanding — coverage stays `gated`/`accessRequired`, OIG/LEIE remains the only live exclusion source | C |
 | 8 | Nursys institutional access | Adapter is an honest gated stub (`nursysAdapter.ts`) — real E-Notify agreement + fetcher wiring outstanding; must stay `gated`/`accessRequired` | C |
@@ -22,7 +19,7 @@ This file lists **only genuinely-open items**, each with its owning wave from th
 | 12 | Compliance proof-pack surfaces | JC survey-ready export, NIST 800-63-4 IAL mapping doc, passkey/DPoP AAL2 path — none present | F |
 | 13 | Certifications (SOC 2 Type II / HITRUST / NCQA accreditation) | Business-level procurement blocker; copy stays "aligned", never "certified" | GTM (not a code wave) |
 
-**Closed since baseline:** item #5 (OWASP ASVS **L2** mapping) — closed 2026-07-05 by `docs/security/ASVS-scorecard-2026-07.md` (Wave B task 6; 151 rows, evidence-cited, gap register G1–G12). The security gaps it surfaces stay tracked as items #2/#4 above and in the scorecard's gap register. Item numbers are stable; closed numbers are not reused.
+**Closed since baseline:** items #1 (self-serve signup gate — OTP delivery live via Resend, tiers enforced by PR #622), #3 (prod auth/Google OAuth — verified live 2026-07-11), #4 (signup e2e — PR #595), and #5 (OWASP ASVS **L2** mapping) — closed 2026-07-05 by `docs/security/ASVS-scorecard-2026-07.md` (Wave B task 6; 151 rows, evidence-cited, gap register G1–G12). The security gaps it surfaces stay tracked as items #2/#4 above and in the scorecard's gap register. Item numbers are stable; closed numbers are not reused.
 
 ## Standing guardrails (apply to every closing PR)
 


### PR DESCRIPTION
## What

The link a clinician shares (`/verify/[npi]`) was **read-only** — an employer holding it had no path to record a decision, because the accept-capable surface (`/review/[entityId]`) was only reachable through employer-minted 24h packet tokens. The seam turned out to be a missing doorway, not missing authorization: `/review/*` is already a public route and `ReviewPageClient` already accepts a raw NPI directly (token resolution only engages for `chk_…` strings). Actions on that surface remain Clerk-authenticated, attributable, and audited.

So the verify page now carries an honest employer CTA (after the acceptances panel): **"Reviewing this clinician for a role?" → Open the review surface**, with *"Requires a signed-in employer account · viewing never requires one"* in mono microtext.

**The canonical loop is now clickable end to end:** clinician shares `/verify/[npi]` → employer opens `/review/[npi]` → signs in → accepts as a head start / requests refresh / routes to review → the acceptance lands back on this page's acceptances panel and in the clinician's Recognition timeline.

## Guard against regression

`verify-npi-page.test.tsx` gains a resolvable-NPI render asserting the doorway (testid, `/review/[npi]` href, honest sub-copy, no bare "Verified") — pinned specifically because copy-polish waves have silently dropped test-unpinned strings before.

## Bookkeeping (move-to-resolved convention, no ghosts)

Launch blockers **#1** (self-serve signup gate — OTP delivery live via Resend, tiers enforced by #622), **#3** (prod auth / Google OAuth — verified live 2026-07-11), **#4** (signup e2e — PR #595) moved from `docs/ops/launch-blockers.md` to the REBASELINE resolved table with evidence. Open list: 9 items.

## Verification

- Web vitest: verify-npi-page 3/3 (incl. new seam pin), recognition-share-verify 4/4, banned-verified-label, holder-route-contract 150/150.
- `turbo build` green.

## Design Handoff References

`design-handoff/claude-design-2026-06-26/vitalcv/project/Acceptance Proof.html` — the accept-as-head-start action language; CTA follows the verifier-persona Calm Wave instrument style already on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)