### PR TITLE
Pending-lanes wave 1: alert delivery, status honesty, CA board lane (dark), Nursys flag repair, container ADR

### DIFF
--- a/apps/api/backend/__tests__/caBreezeLiveLookup.test.ts
+++ b/apps/api/backend/__tests__/caBreezeLiveLookup.test.ts
@@ -1,0 +1,225 @@
+/**
+ * caBreezeLiveLookup.test.ts — fail-closed contract for the CA DCA BreEZe
+ * live lookup (ships dark behind STATE_BOARD_MODE=live).
+ *
+ * Structure-faithful fixtures: the HTML shapes below mirror the BreEZe
+ * results table the parser targets (`tr.searchResults` rows). They are NOT
+ * recorded from the live site — live validation is a documented go-live
+ * precondition. Until then the contract under test is the honesty rules:
+ * nothing ambiguous may ever parse into a definitive license status.
+ */
+
+import {
+  createCaBreezeLiveLookup,
+  type ProviderNameRecord,
+} from '../src/services/providers/connectors/caBreezeLiveLookup';
+
+const FIXED_NOW = new Date('2026-07-12T00:00:00.000Z');
+
+const NAME: ProviderNameRecord = { firstName: 'Sarah', lastName: 'Chen' };
+
+function resultsPage(rows: string): string {
+  return `<html><body><table class="table">${rows}</table></body></html>`;
+}
+
+function physicianRow(input: {
+  name?: string;
+  licenseNumber?: string;
+  licenseType?: string;
+  status?: string;
+  expiration?: string;
+}): string {
+  const {
+    name = 'SARAH CHEN',
+    licenseNumber = 'A123456',
+    licenseType = 'Physician and Surgeon A',
+    status = 'License Active',
+    expiration = '2027-05-31',
+  } = input;
+  return `<tr class="searchResults"><td>${name}</td><td>${licenseNumber}</td><td>${licenseType}</td><td>${status}</td><td>SAN FRANCISCO, CA</td><td>${expiration}</td></tr>`;
+}
+
+const NO_RESULTS_PAGE = '<html><body><div>No results found for your search criteria.</div></body></html>';
+const WAF_PAGE = '<html><body><h1>Access denied</h1><p>Your request was blocked.</p></body></html>';
+
+function htmlResponse(html: string, status = 200): Response {
+  return new Response(html, { status, headers: { 'Content-Type': 'text/html' } });
+}
+
+function buildLookup(overrides: {
+  html?: string;
+  status?: number;
+  fetchImpl?: typeof fetch;
+  name?: ProviderNameRecord | null;
+  nameError?: Error;
+}) {
+  const fetchImpl =
+    overrides.fetchImpl ??
+    (jest.fn().mockResolvedValue(htmlResponse(overrides.html ?? '', overrides.status ?? 200)) as unknown as typeof fetch);
+
+  return createCaBreezeLiveLookup({
+    fetchImpl,
+    resolveProviderName: overrides.nameError
+      ? jest.fn().mockRejectedValue(overrides.nameError)
+      : jest.fn().mockResolvedValue(overrides.name === undefined ? NAME : overrides.name),
+    now: () => FIXED_NOW,
+  });
+}
+
+describe('caBreezeLiveLookup (dark until STATE_BOARD_MODE=live)', () => {
+  test('single active MBC match parses to a definitive ACTIVE result', async () => {
+    const lookup = buildLookup({ html: resultsPage(physicianRow({})) });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('ACTIVE');
+    expect(result.licenseNumber).toBe('A123456');
+    expect(result.licensee).toBe('SARAH CHEN');
+    expect(result.expirationDate).toBe('2027-05-31');
+    expect(result.decisionGrade).toBe(true);
+    expect(result.degradationReason).toBeNull();
+    expect(result.sourceDisclaimer).toContain('Board-reported status: "License Active"');
+    expect(result.lastVerifiedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  test('revoked and surrendered board statuses map to REVOKED (fails closed downstream)', async () => {
+    for (const status of ['License Revoked', 'License Surrendered']) {
+      const lookup = buildLookup({ html: resultsPage(physicianRow({ status })) });
+      const result = await lookup('1003000126');
+      expect(result.licenseStatus).toBe('REVOKED');
+      expect(result.decisionGrade).toBe(true);
+    }
+  });
+
+  test('delinquent and cancelled statuses map to EXPIRED, never ACTIVE', async () => {
+    for (const status of ['Delinquent', 'License Cancelled']) {
+      const lookup = buildLookup({ html: resultsPage(physicianRow({ status })) });
+      const result = await lookup('1003000126');
+      expect(result.licenseStatus).toBe('EXPIRED');
+    }
+  });
+
+  test('unrecognized page shape degrades as PARSER_FAILURE, never as absence', async () => {
+    const lookup = buildLookup({ html: WAF_PAGE });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.degradationReason).toBe('PARSER_FAILURE');
+    expect(result.decisionGrade).toBe(false);
+  });
+
+  test('unrecognized board status text on a matching row degrades as PARSER_FAILURE', async () => {
+    const lookup = buildLookup({
+      html: resultsPage(physicianRow({ status: 'Probationary — see order' })),
+    });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.degradationReason).toBe('PARSER_FAILURE');
+    expect(result.sourceDisclaimer).toContain('Probationary — see order');
+  });
+
+  test('genuine no-results page returns NOT_AVAILABLE without degradation so the lane cascades', async () => {
+    const lookup = buildLookup({ html: NO_RESULTS_PAGE });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.degradationReason).toBeNull();
+    expect(result.decisionGrade).toBe(false);
+    expect(result.sourceDisclaimer).toContain('not proof of absence');
+  });
+
+  test('results page with only non-physician rows cascades as NOT_AVAILABLE', async () => {
+    const lookup = buildLookup({
+      html: resultsPage(physicianRow({ licenseType: 'Registered Nurse', licenseNumber: 'RN9999' })),
+    });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.degradationReason).toBeNull();
+  });
+
+  test('multiple distinct matching license numbers is ambiguous — refuses a definitive status', async () => {
+    const lookup = buildLookup({
+      html: resultsPage(
+        physicianRow({ licenseNumber: 'A123456' }) +
+          physicianRow({ licenseNumber: 'A654321', status: 'License Revoked' }),
+      ),
+    });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.sourceDisclaimer).toContain('cannot disambiguate');
+  });
+
+  test('a provided license number scopes an ambiguous multi-match to one definitive row', async () => {
+    const lookup = buildLookup({
+      html: resultsPage(
+        physicianRow({ licenseNumber: 'A123456' }) +
+          physicianRow({ licenseNumber: 'A654321', status: 'License Revoked' }),
+      ),
+    });
+
+    const result = await lookup('1003000126', 'A654321');
+
+    expect(result.licenseStatus).toBe('REVOKED');
+    expect(result.licenseNumber).toBe('A654321');
+  });
+
+  test('rows that do not match the NPPES name are ignored', async () => {
+    const lookup = buildLookup({
+      html: resultsPage(physicianRow({ name: 'JOHN SMITH' })),
+    });
+
+    const result = await lookup('1003000126');
+
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+    expect(result.degradationReason).toBeNull();
+  });
+
+  test('unresolvable provider name degrades as IDENTITY_UNRESOLVED without fetching', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const lookup = buildLookup({ name: null, fetchImpl });
+
+    const result = await lookup('1003000126');
+
+    expect(result.degradationReason).toBe('IDENTITY_UNRESOLVED');
+    expect(result.decisionGrade).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test('NPPES resolution failure degrades as IDENTITY_UNRESOLVED', async () => {
+    const lookup = buildLookup({ nameError: new Error('nppes unavailable') });
+
+    const result = await lookup('1003000126');
+
+    expect(result.degradationReason).toBe('IDENTITY_UNRESOLVED');
+    expect(result.sourceDisclaimer).toContain('nppes unavailable');
+  });
+
+  test('non-OK HTTP response degrades as OUTAGE', async () => {
+    const lookup = buildLookup({ html: 'blocked', status: 403 });
+
+    const result = await lookup('1003000126');
+
+    expect(result.degradationReason).toBe('OUTAGE');
+    expect(result.sourceDisclaimer).toContain('HTTP 403');
+  });
+
+  test('timeout degrades as OUTAGE', async () => {
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetchImpl = jest.fn().mockRejectedValue(abortError) as unknown as typeof fetch;
+    const lookup = buildLookup({ fetchImpl });
+
+    const result = await lookup('1003000126');
+
+    expect(result.degradationReason).toBe('OUTAGE');
+    expect(result.sourceDisclaimer).toContain('timed out');
+  });
+});

--- a/apps/api/backend/__tests__/monitoringAlertDispatch.test.ts
+++ b/apps/api/backend/__tests__/monitoringAlertDispatch.test.ts
@@ -1,0 +1,204 @@
+/**
+ * monitoringAlertDispatch.test.ts — monitoring alerts must reach real inboxes.
+ *
+ * Locks the delivery contract for continuousMonitor's alert dispatch:
+ *   - recipients are real email addresses (ops inbox + resolved employer
+ *     contacts), never `employer:<id>` pseudo-addresses
+ *   - non-UUID employerIds never reach a prisma @db.Uuid query
+ *   - one failed send does not abort delivery to remaining recipients
+ *   - zero deliverable recipients short-circuits without a send
+ */
+
+const sendMock = jest.fn<Promise<void>, [string, string, string]>();
+let emailConfigured = true;
+
+jest.mock('../src/graphql/prisma_client', () => ({
+  __esModule: true,
+  Prisma: {},
+  default: {
+    acceptance: {
+      findMany: jest.fn(),
+    },
+    verifierOrg: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../src/services/providers/notificationProvider', () => ({
+  __esModule: true,
+  getNotificationProvider: () => ({
+    send: (to: string, subject: string, body: string) => sendMock(to, subject, body),
+  }),
+  isEmailDeliveryConfigured: () => emailConfigured,
+}));
+
+jest.mock('../src/services/alerts/trustAlerts', () => ({
+  __esModule: true,
+  emitMonitoringAlert: jest.fn().mockResolvedValue({ alertId: 'alert-1' }),
+}));
+
+jest.mock('../src/services/psv/oigLeieChecker', () => ({
+  __esModule: true,
+  checkExclusion: jest.fn(),
+}));
+
+jest.mock('../src/services/ledger/statusListManager', () => ({
+  __esModule: true,
+  setRevoked: jest.fn(),
+}));
+
+jest.mock('../src/services/revocation/propagationEngine', () => ({
+  __esModule: true,
+  propagateCredentialLifecycleChange: jest.fn(),
+}));
+
+jest.mock('../src/services/trust-state/trustStateService', () => ({
+  __esModule: true,
+  computeTrustState: jest.fn(),
+}));
+
+jest.mock('../src/services/identity/npiDidBinding', () => ({
+  __esModule: true,
+  getBindingByNpi: jest.fn(),
+}));
+
+jest.mock('@vitalcv/psv-adapters', () => ({
+  __esModule: true,
+  NursysENotifyAdapter: class {},
+}));
+
+import prisma from '../src/graphql/prisma_client';
+import { _testing } from '../src/workers/continuousMonitor';
+
+const acceptanceFindMany = prisma.acceptance.findMany as jest.Mock;
+const verifierOrgFindMany = prisma.verifierOrg.findMany as jest.Mock;
+
+const EMPLOYER_UUID = '4f3b2a1c-9d8e-4f00-b1a2-c3d4e5f60789';
+
+const ALERT_INPUT = {
+  kind: 'SANCTION_DETECTED' as const,
+  npi: '1841498016',
+  title: 'Federal exclusion detected',
+  description: 'OIG/LEIE match found for monitored clinician.',
+  recommendedAction: 'Review the exclusion and suspend reliance on this passport.',
+};
+
+describe('monitoring alert dispatch', () => {
+  const originalOpsInbox = process.env.MONITORING_ALERT_EMAIL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    emailConfigured = true;
+    delete process.env.MONITORING_ALERT_EMAIL;
+  });
+
+  afterAll(() => {
+    if (originalOpsInbox === undefined) {
+      delete process.env.MONITORING_ALERT_EMAIL;
+    } else {
+      process.env.MONITORING_ALERT_EMAIL = originalOpsInbox;
+    }
+  });
+
+  describe('resolveEmployerAlertEmails', () => {
+    test('resolves VerifierOrg contact emails for UUID employerIds only', async () => {
+      acceptanceFindMany.mockResolvedValue([
+        { employerId: EMPLOYER_UUID },
+        { employerId: 'legacy-employer-slug' },
+        { employerId: EMPLOYER_UUID },
+      ]);
+      verifierOrgFindMany.mockResolvedValue([
+        { contactEmail: ' credentialing@employer.example ' },
+      ]);
+
+      const emails = await _testing.resolveEmployerAlertEmails('1841498016');
+
+      expect(verifierOrgFindMany).toHaveBeenCalledWith({
+        where: { id: { in: [EMPLOYER_UUID] } },
+        select: { contactEmail: true },
+      });
+      expect(emails).toEqual(['credentialing@employer.example']);
+    });
+
+    test('never queries VerifierOrg when no employerId is UUID-shaped', async () => {
+      acceptanceFindMany.mockResolvedValue([
+        { employerId: 'employer-alpha' },
+        { employerId: 'employer-beta' },
+      ]);
+
+      const emails = await _testing.resolveEmployerAlertEmails('1841498016');
+
+      expect(verifierOrgFindMany).not.toHaveBeenCalled();
+      expect(emails).toEqual([]);
+    });
+
+    test('drops contact values that are not email-shaped', async () => {
+      acceptanceFindMany.mockResolvedValue([{ employerId: EMPLOYER_UUID }]);
+      verifierOrgFindMany.mockResolvedValue([{ contactEmail: 'not-an-email' }]);
+
+      const emails = await _testing.resolveEmployerAlertEmails('1841498016');
+
+      expect(emails).toEqual([]);
+    });
+  });
+
+  describe('dispatchMonitoringAlert', () => {
+    test('sends to ops inbox and resolved employer emails, never pseudo-addresses', async () => {
+      process.env.MONITORING_ALERT_EMAIL = 'founder-ops@vitalcv.com';
+      acceptanceFindMany.mockResolvedValue([{ employerId: EMPLOYER_UUID }]);
+      verifierOrgFindMany.mockResolvedValue([
+        { contactEmail: 'credentialing@employer.example' },
+      ]);
+      sendMock.mockResolvedValue(undefined);
+
+      await _testing.dispatchMonitoringAlert(ALERT_INPUT);
+
+      const recipients = sendMock.mock.calls.map(([to]) => to);
+      expect(recipients).toEqual([
+        'founder-ops@vitalcv.com',
+        'credentialing@employer.example',
+      ]);
+      for (const to of recipients) {
+        expect(to).toContain('@');
+        expect(to.startsWith('employer:')).toBe(false);
+      }
+    });
+
+    test('short-circuits without sending when no deliverable recipient exists', async () => {
+      acceptanceFindMany.mockResolvedValue([]);
+
+      await _testing.dispatchMonitoringAlert(ALERT_INPUT);
+
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    test('a failed send does not abort delivery to remaining recipients', async () => {
+      process.env.MONITORING_ALERT_EMAIL = 'founder-ops@vitalcv.com';
+      acceptanceFindMany.mockResolvedValue([{ employerId: EMPLOYER_UUID }]);
+      verifierOrgFindMany.mockResolvedValue([
+        { contactEmail: 'credentialing@employer.example' },
+      ]);
+      sendMock
+        .mockRejectedValueOnce(new Error('resend 500'))
+        .mockResolvedValueOnce(undefined);
+
+      await _testing.dispatchMonitoringAlert(ALERT_INPUT);
+
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      expect(sendMock.mock.calls[1][0]).toBe('credentialing@employer.example');
+    });
+
+    test('still attempts stub delivery (with real addresses) when email is unconfigured', async () => {
+      emailConfigured = false;
+      process.env.MONITORING_ALERT_EMAIL = 'founder-ops@vitalcv.com';
+      acceptanceFindMany.mockResolvedValue([]);
+      sendMock.mockResolvedValue(undefined);
+
+      await _testing.dispatchMonitoringAlert(ALERT_INPUT);
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(sendMock.mock.calls[0][0]).toBe('founder-ops@vitalcv.com');
+    });
+  });
+});

--- a/apps/api/backend/__tests__/sourceRegistryNursysFlag.test.ts
+++ b/apps/api/backend/__tests__/sourceRegistryNursysFlag.test.ts
@@ -1,0 +1,73 @@
+/**
+ * sourceRegistryNursysFlag.test.ts — REAL_NURSYS_ENABLED must never crash
+ * callers, and must never let the deterministic stub masquerade as live.
+ *
+ * Old behavior: flag on → getVerificationSource('NURSYS') THREW, taking
+ * down monitoring sweeps and artifact issuance the moment the flag flipped.
+ * New behavior: flag on with no live adapter serves an honest
+ * access-pending placeholder whose UNKNOWN status maps to needs_review.
+ */
+
+import {
+  getVerificationSource,
+  registerVerificationSource,
+} from '../src/services/sourceRegistry';
+import type {
+  VerificationResult,
+  VerificationSource,
+} from '../src/interfaces/verificationSource';
+
+describe('sourceRegistry NURSYS flag semantics', () => {
+  const originalFlag = process.env.REAL_NURSYS_ENABLED;
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.REAL_NURSYS_ENABLED;
+    } else {
+      process.env.REAL_NURSYS_ENABLED = originalFlag;
+    }
+  });
+
+  test('flag off serves the deterministic stub (legacy behavior unchanged)', () => {
+    delete process.env.REAL_NURSYS_ENABLED;
+
+    const source = getVerificationSource('NURSYS');
+
+    expect(source.name).toBe('NURSYS_STUB');
+  });
+
+  test('flag on without a live adapter serves the honest access-pending placeholder, not a throw', async () => {
+    process.env.REAL_NURSYS_ENABLED = 'true';
+
+    const source = getVerificationSource('NURSYS');
+    expect(source.name).toBe('NURSYS_ACCESS_PENDING');
+
+    const result = await source.verify('1234567890');
+    expect(result.licenseStatus).toBe('UNKNOWN');
+    expect((result.rawPayload as { unavailable?: boolean }).unavailable).toBe(true);
+  });
+
+  test('flag on with a registered live NURSYS adapter serves the live adapter', () => {
+    process.env.REAL_NURSYS_ENABLED = 'true';
+
+    const liveAdapter: VerificationSource = {
+      name: 'NURSYS',
+      async verify(): Promise<VerificationResult> {
+        return {
+          licenseStatus: 'ACTIVE',
+          jurisdiction: 'CA',
+          lastUpdated: new Date(),
+          sourceUrl: 'https://api.nursys.com',
+          rawPayload: { live: true },
+        };
+      },
+    };
+    registerVerificationSource(liveAdapter);
+
+    expect(getVerificationSource('NURSYS')).toBe(liveAdapter);
+  });
+
+  test('unknown source names still throw', () => {
+    expect(() => getVerificationSource('NOT_A_SOURCE')).toThrow(/Unknown verification source/);
+  });
+});

--- a/apps/api/backend/__tests__/stateBoardConnectorLiveGrade.test.ts
+++ b/apps/api/backend/__tests__/stateBoardConnectorLiveGrade.test.ts
@@ -1,0 +1,104 @@
+/**
+ * stateBoardConnectorLiveGrade.test.ts — the connector must never stamp
+ * decisionGrade:true over a degraded live adapter result.
+ *
+ * Before this wave the live branch unconditionally rewrote
+ * decisionGrade:true / degradationReason:null onto whatever the liveLookup
+ * returned, which would have graded parser failures and outages as
+ * decision-grade the moment a live adapter existed.
+ */
+
+const mockCaLiveLookup = jest.fn();
+
+jest.mock('../src/services/providers/connectors/caBreezeLiveLookup', () => ({
+  __esModule: true,
+  CA_BREEZE_SEARCH_URL: 'https://search.dca.ca.gov/results',
+  createCaBreezeLiveLookup: () => mockCaLiveLookup,
+}));
+
+jest.mock('../src/services/providers/providerSourceProvenance', () => ({
+  __esModule: true,
+  recordProvenance: jest.fn(),
+}));
+
+import {
+  lookupStateBoard,
+  type StateBoardResult,
+} from '../src/services/providers/connectors/stateBoardConnector';
+
+function liveResult(overrides: Partial<StateBoardResult>): StateBoardResult {
+  return {
+    npi: '1003000126',
+    state: 'CA',
+    licenseNumber: null,
+    licenseStatus: 'NOT_AVAILABLE',
+    licensee: null,
+    expirationDate: null,
+    boardName: 'Medical Board of California',
+    lastVerifiedAt: new Date().toISOString(),
+    sourceUrl: 'https://search.dca.ca.gov/results',
+    sourceMode: 'live',
+    decisionGrade: false,
+    degradationReason: null,
+    sourceDisclaimer: null,
+    ...overrides,
+  };
+}
+
+describe('lookupStateBoard live-mode decision grading', () => {
+  const originalMode = process.env.STATE_BOARD_MODE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STATE_BOARD_MODE = 'live';
+  });
+
+  afterAll(() => {
+    if (originalMode === undefined) {
+      delete process.env.STATE_BOARD_MODE;
+    } else {
+      process.env.STATE_BOARD_MODE = originalMode;
+    }
+  });
+
+  test('a degraded live result stays non-decision-grade with its degradation reason intact', async () => {
+    mockCaLiveLookup.mockResolvedValue(
+      liveResult({
+        degradationReason: 'PARSER_FAILURE',
+        sourceDisclaimer: 'DCA BreEZe returned a page the parser does not recognize.',
+      }),
+    );
+
+    const result = await lookupStateBoard('1003000126', 'CA');
+
+    expect(result.sourceMode).toBe('live');
+    expect(result.decisionGrade).toBe(false);
+    expect(result.degradationReason).toBe('PARSER_FAILURE');
+  });
+
+  test('a NOT_AVAILABLE live result (no-match cascade) is never decision-grade', async () => {
+    mockCaLiveLookup.mockResolvedValue(liveResult({ licenseStatus: 'NOT_AVAILABLE' }));
+
+    const result = await lookupStateBoard('1003000126', 'CA');
+
+    expect(result.decisionGrade).toBe(false);
+    expect(result.licenseStatus).toBe('NOT_AVAILABLE');
+  });
+
+  test('a definitive live result is decision-grade', async () => {
+    mockCaLiveLookup.mockResolvedValue(
+      liveResult({
+        licenseStatus: 'ACTIVE',
+        licenseNumber: 'A123456',
+        licensee: 'SARAH CHEN',
+        decisionGrade: true,
+      }),
+    );
+
+    const result = await lookupStateBoard('1003000126', 'CA');
+
+    expect(result.decisionGrade).toBe(true);
+    expect(result.licenseStatus).toBe('ACTIVE');
+    expect(result.degradationReason).toBeNull();
+  });
+});

--- a/apps/api/backend/src/services/adapters/nursysAccessPendingAdapter.ts
+++ b/apps/api/backend/src/services/adapters/nursysAccessPendingAdapter.ts
@@ -1,0 +1,35 @@
+import type { VerificationSource, VerificationResult } from '../../interfaces/verificationSource';
+
+/**
+ * Honest placeholder served when REAL_NURSYS_ENABLED=true but no live
+ * Nursys adapter has been registered yet (institutional e-Notify access
+ * is an agreement + credentials, not a flag).
+ *
+ * Returns licenseStatus UNKNOWN — downstream computeTrustState maps that
+ * to needs_review, never to a positive band. This keeps callers alive
+ * (the registry used to throw, crashing monitoring sweeps and artifact
+ * issuance at runtime) without letting the deterministic stub's
+ * fabricated statuses masquerade as live verification.
+ */
+export class NursysAccessPendingAdapter implements VerificationSource {
+  readonly name = 'NURSYS_ACCESS_PENDING';
+
+  async verify(npi: string): Promise<VerificationResult> {
+    const now = new Date();
+    return {
+      licenseStatus: 'UNKNOWN',
+      jurisdiction: 'UNKNOWN',
+      lastUpdated: now,
+      sourceUrl: 'https://www.nursys.com/',
+      rawPayload: {
+        npi,
+        adapterName: this.name,
+        unavailable: true,
+        reason:
+          'REAL_NURSYS_ENABLED is set but no live Nursys adapter is registered. '
+          + 'Nursys verification requires institutional e-Notify access; this result is a placeholder, not a verification.',
+        sourceQueriedAt: now.toISOString(),
+      },
+    };
+  }
+}

--- a/apps/api/backend/src/services/domains/domainRegistry.ts
+++ b/apps/api/backend/src/services/domains/domainRegistry.ts
@@ -94,7 +94,7 @@ const HEALTHCARE: DomainDefinition = {
     { id: 'NPPES',     label: 'CMS NPI Registry',        url: 'https://npiregistry.cms.hhs.gov/api/',   credentialTypes: ['NPI_IDENTITY'],        envFlag: 'NPPES_ENABLED',   liveCallAvailable: true,  stubBehavior: 'PASS'    },
     { id: 'OIG_LEIE',  label: 'OIG Exclusion Registry',  url: 'https://oig.hhs.gov/exclusions/api',    credentialTypes: ['SANCTION_CLEAR'],      envFlag: 'OIG_LEIE_ENABLED', liveCallAvailable: true, stubBehavior: 'UNKNOWN' },
     { id: 'STATE_BOARD',label: 'State Medical Boards',   url: 'https://www.fsmb.org/licensure/',       credentialTypes: ['STATE_LICENSE'],       envFlag: 'STATE_BOARD_ENABLED', liveCallAvailable: false, stubBehavior: 'UNKNOWN' },
-    { id: 'NURSYS',    label: 'Nursys Nursing Compact',  url: 'https://www.nursys.com/',               credentialTypes: ['STATE_LICENSE'],       envFlag: 'NURSYS_ENABLED',  liveCallAvailable: false, stubBehavior: 'UNKNOWN' },
+    { id: 'NURSYS',    label: 'Nursys Nursing Compact',  url: 'https://www.nursys.com/',               credentialTypes: ['STATE_LICENSE'],       envFlag: 'REAL_NURSYS_ENABLED',  liveCallAvailable: false, stubBehavior: 'UNKNOWN' },
     { id: 'ABIM',      label: 'ABIM Certification',      url: 'https://www.abim.org/',                 credentialTypes: ['BOARD_CERTIFICATION'], envFlag: 'ABIM_ENABLED',    liveCallAvailable: false, stubBehavior: 'UNKNOWN' },
   ],
   scoringWeights:         { identity: 20, primaryLicense: 30, sanctions: 25, certifications: 15, continuingEd: 10 },

--- a/apps/api/backend/src/services/identity/physicianLicensureLaunchLane.ts
+++ b/apps/api/backend/src/services/identity/physicianLicensureLaunchLane.ts
@@ -62,6 +62,8 @@ function stateBoardDegradationReason(result: StateBoardResult, launchState: stri
       return `${launchState} state-board lookup failed or timed out. Treat this lane as unavailable until the source recovers or is manually verified.`;
     case 'PARSER_FAILURE':
       return `${launchState} state-board response could not be parsed safely. Manual verification is required until the parser is repaired.`;
+    case 'IDENTITY_UNRESOLVED':
+      return `${launchState} state-board search requires the provider's legal name, which could not be resolved from NPPES for this NPI. Manual verification is required.`;
     case 'STALE':
       return `${launchState} state-board verification returned stale data. Treat this lane as unresolved until a fresh board result is available.`;
     case 'NOT_IMPLEMENTED':
@@ -266,7 +268,8 @@ function buildStateBoardLicenseClaim(input: {
     participationStatus: authorityFields.participationStatus,
     boardOrderSeverity: authorityFields.boardOrderSeverity,
     connectorState: authorityFields.connectorState,
-    sourceDisclaimer: 'California live state-board lane only. No sandbox or scraper fallback.',
+    sourceDisclaimer: input.result.sourceDisclaimer
+      ?? 'California live state-board lane only. No sandbox fallback.',
   };
 
   const reviewRequired = input.result.licenseStatus === 'NOT_FOUND';

--- a/apps/api/backend/src/services/identity/sourceCatalog.ts
+++ b/apps/api/backend/src/services/identity/sourceCatalog.ts
@@ -195,7 +195,10 @@ export const SOURCE_CATALOG: Record<string, SourceDefinition> = {
     baseUrl: 'https://www.nursys.com/',
     bulkFileUrl: null,
     claimTypes: ['NURSING_LICENSE', 'NURSING_DISCIPLINE'],
-    parserVersion: 'v1.0.0', envFlag: 'NURSYS_ENABLED', liveAvailable: false,
+    // REAL_NURSYS_ENABLED is the flag the pilot runbook and ingest
+    // orchestrator actually use; the catalog previously read NURSYS_ENABLED,
+    // which nothing else set, so ops reporting could never match runtime.
+    parserVersion: 'v1.0.0', envFlag: 'REAL_NURSYS_ENABLED', liveAvailable: false,
     decisionGrade: true,
     notes: 'e-Notify for real-time alerts. Participating jurisdictions only. UNI/NCSBN ID is the canonical nurse identifier.',
   },

--- a/apps/api/backend/src/services/missionOps/__tests__/sourceOpsService.test.ts
+++ b/apps/api/backend/src/services/missionOps/__tests__/sourceOpsService.test.ts
@@ -24,7 +24,7 @@ describe('sourceOpsService', () => {
     process.env.OIG_LEIE_ENABLED = 'true';
     process.env.PECOS_ENABLED = 'true';
     process.env.STATE_BOARD_ENABLED = 'true';
-    process.env.NURSYS_ENABLED = 'true';
+    process.env.REAL_NURSYS_ENABLED = 'true';
     delete process.env.OFAC_SDN_ENABLED;
     mockIntegrationHealth();
   });
@@ -35,7 +35,7 @@ describe('sourceOpsService', () => {
     delete process.env.OIG_LEIE_ENABLED;
     delete process.env.PECOS_ENABLED;
     delete process.env.STATE_BOARD_ENABLED;
-    delete process.env.NURSYS_ENABLED;
+    delete process.env.REAL_NURSYS_ENABLED;
     delete process.env.OFAC_SDN_ENABLED;
   });
 

--- a/apps/api/backend/src/services/providers/connectors/caBreezeLiveLookup.ts
+++ b/apps/api/backend/src/services/providers/connectors/caBreezeLiveLookup.ts
@@ -1,0 +1,323 @@
+/**
+ * caBreezeLiveLookup.ts — live CA DCA BreEZe lookup for the physician
+ * licensure launch lane.
+ *
+ * SHIPS DARK. This module is only reachable when STATE_BOARD_MODE=live,
+ * which stays unset/sandbox until (a) the DCA public-search usage decision
+ * is approved and (b) the parser has been validated against a real BreEZe
+ * response. Until then every caller sees the connector's sandbox/gated
+ * behavior, unchanged.
+ *
+ * Fail-closed contract:
+ *   - The DCA search is name-based. The provider's legal name comes from
+ *     the NPPES record for the NPI; if no individual name resolves, the
+ *     lookup degrades (IDENTITY_UNRESOLVED) instead of guessing.
+ *   - A response that does not look like a BreEZe results page (no results
+ *     table, no no-results marker) degrades as PARSER_FAILURE. A WAF
+ *     interstitial or a page redesign must never read as "no license".
+ *   - A name search that finds nothing, or that matches conflicting
+ *     records, returns NOT_AVAILABLE with no degradation reason so the
+ *     launch lane cascades to FSMB / manual review. Absence from a fuzzy
+ *     name search is never treated as proof of absence.
+ *   - An unrecognized board status string degrades as PARSER_FAILURE.
+ *   - Only an unambiguous Medical Board of California row produces a
+ *     definitive status, and the board-reported status text is preserved
+ *     verbatim in the source disclaimer for audit.
+ */
+
+import { log } from '../../../obs/logger';
+import { fetchNppesProviderRecord } from '../../identity/nppesApi';
+import type { StateBoardResult } from './stateBoardConnector';
+
+export const CA_BREEZE_SEARCH_URL = 'https://search.dca.ca.gov/results';
+const CA_BOARD_NAME = 'Medical Board of California';
+
+/** Markers proving the HTML is a genuine BreEZe results page. */
+const RESULTS_TABLE_MARKER = /searchresult/i;
+const NO_RESULTS_MARKER = /no\s+(?:results|records)\s+(?:found|matched)/i;
+
+const ROW_PATTERN = /<tr[^>]*class="[^"]*[Ss]earch[Rr]esult[^"]*"[^>]*>([\s\S]*?)<\/tr>/gi;
+const CELL_PATTERN = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+
+type BreezeRowStatus =
+  | 'ACTIVE'
+  | 'INACTIVE'
+  | 'DELINQUENT'
+  | 'CANCELLED'
+  | 'SURRENDERED'
+  | 'REVOKED'
+  | 'UNRECOGNIZED';
+
+interface BreezeRow {
+  name: string;
+  licenseNumber: string;
+  licenseType: string;
+  statusRaw: string;
+  status: BreezeRowStatus;
+  expirationDate: string | null;
+}
+
+export interface ProviderNameRecord {
+  firstName: string;
+  lastName: string;
+}
+
+export interface CaBreezeLookupDeps {
+  fetchImpl?: typeof fetch;
+  resolveProviderName?: (npi: string) => Promise<ProviderNameRecord | null>;
+  timeoutMs?: number;
+  now?: () => Date;
+}
+
+async function resolveProviderNameFromNppes(npi: string): Promise<ProviderNameRecord | null> {
+  const record = await fetchNppesProviderRecord(npi);
+  if (record.providerType !== 'INDIVIDUAL') return null;
+  const firstName = record.firstName?.trim();
+  const lastName = record.lastName?.trim();
+  if (!firstName || !lastName) return null;
+  return { firstName, lastName };
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&nbsp;/g, ' ');
+}
+
+function normalizeRowStatus(raw: string): BreezeRowStatus {
+  const upper = raw.toUpperCase().trim();
+  if (upper.includes('ACTIVE') && !upper.includes('INACTIVE')) return 'ACTIVE';
+  if (upper.includes('INACTIVE')) return 'INACTIVE';
+  if (upper.includes('DELINQUENT')) return 'DELINQUENT';
+  if (upper.includes('CANCEL')) return 'CANCELLED';
+  if (upper.includes('SURRENDER')) return 'SURRENDERED';
+  if (upper.includes('REVOK')) return 'REVOKED';
+  return 'UNRECOGNIZED';
+}
+
+/**
+ * Map a board-reported row status to the connector's result status.
+ * Adverse and lapsed states never widen toward ACTIVE:
+ *   DELINQUENT / CANCELLED → EXPIRED (lapsed, not disciplinary)
+ *   SURRENDERED / REVOKED → REVOKED (fails closed downstream)
+ */
+function toStateBoardStatus(
+  status: Exclude<BreezeRowStatus, 'UNRECOGNIZED'>,
+): StateBoardResult['licenseStatus'] {
+  switch (status) {
+    case 'ACTIVE':
+      return 'ACTIVE';
+    case 'INACTIVE':
+      return 'INACTIVE';
+    case 'DELINQUENT':
+    case 'CANCELLED':
+      return 'EXPIRED';
+    case 'SURRENDERED':
+    case 'REVOKED':
+      return 'REVOKED';
+  }
+}
+
+function isPhysicianLicenseType(licenseType: string): boolean {
+  const upper = licenseType.toUpperCase();
+  return (
+    upper.includes('PHYSICIAN') ||
+    upper.includes(' MD') ||
+    upper.startsWith('MD') ||
+    upper.includes(' DO') ||
+    upper.startsWith('DO') ||
+    upper.includes('OSTEOPATH')
+  );
+}
+
+function nameMatches(resultName: string, name: ProviderNameRecord): boolean {
+  const normalized = resultName.toUpperCase();
+  return (
+    normalized.includes(name.firstName.toUpperCase()) &&
+    normalized.includes(name.lastName.toUpperCase())
+  );
+}
+
+function parseBreezeRows(html: string, name: ProviderNameRecord): BreezeRow[] {
+  const rows: BreezeRow[] = [];
+  const rowPattern = new RegExp(ROW_PATTERN.source, 'gi');
+
+  let rowMatch: RegExpExecArray | null;
+  while ((rowMatch = rowPattern.exec(html)) !== null) {
+    const cellPattern = new RegExp(CELL_PATTERN.source, 'gi');
+    const cells: string[] = [];
+    let cellMatch: RegExpExecArray | null;
+    while ((cellMatch = cellPattern.exec(rowMatch[1])) !== null) {
+      cells.push(stripHtml(cellMatch[1]).trim());
+    }
+
+    if (cells.length < 5) continue;
+
+    const [rowName, licenseNumber, licenseType, statusRaw] = cells;
+    const expirationDate = cells[5]?.trim() || null;
+    if (!nameMatches(rowName, name)) continue;
+
+    rows.push({
+      name: rowName,
+      licenseNumber,
+      licenseType,
+      statusRaw,
+      status: normalizeRowStatus(statusRaw),
+      expirationDate,
+    });
+  }
+
+  return rows;
+}
+
+function baseResult(
+  npi: string,
+  now: Date,
+  overrides: Partial<StateBoardResult>,
+): StateBoardResult {
+  return {
+    npi,
+    state: 'CA',
+    licenseNumber: null,
+    licenseStatus: 'NOT_AVAILABLE',
+    licensee: null,
+    expirationDate: null,
+    boardName: CA_BOARD_NAME,
+    lastVerifiedAt: now.toISOString(),
+    sourceUrl: CA_BREEZE_SEARCH_URL,
+    sourceMode: 'live',
+    decisionGrade: false,
+    degradationReason: null,
+    sourceDisclaimer: null,
+    ...overrides,
+  };
+}
+
+export function createCaBreezeLiveLookup(deps: CaBreezeLookupDeps = {}) {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const resolveProviderName = deps.resolveProviderName ?? resolveProviderNameFromNppes;
+  const timeoutMs = deps.timeoutMs ?? 10_000;
+  const now = deps.now ?? (() => new Date());
+
+  return async function caBreezeLiveLookup(
+    npi: string,
+    licenseNumber?: string,
+  ): Promise<StateBoardResult> {
+    const checkedAt = now();
+
+    let name: ProviderNameRecord | null = null;
+    try {
+      name = await resolveProviderName(npi);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'IDENTITY_UNRESOLVED',
+        sourceDisclaimer: `NPPES name resolution failed before the board search could run (${message}). Manual verification required.`,
+      });
+    }
+
+    if (!name) {
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'IDENTITY_UNRESOLVED',
+        sourceDisclaimer:
+          'No individual provider name could be resolved from NPPES for this NPI, so the name-based DCA BreEZe search cannot run. Manual verification required.',
+      });
+    }
+
+    const formData = new URLSearchParams();
+    formData.append('boardCode', '0');
+    formData.append('licenseType', '0');
+    formData.append('licenseNumber', licenseNumber ?? '');
+    formData.append('firstName', name.firstName);
+    formData.append('lastName', name.lastName);
+    formData.append('registryNumber', '');
+
+    let response: Response;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      response = await fetchImpl(CA_BREEZE_SEARCH_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': 'VitalCV/1.0 (credentialing-readiness-check)',
+        },
+        body: formData.toString(),
+        signal: controller.signal,
+      }).finally(() => clearTimeout(timeout));
+    } catch (error) {
+      const isAbort = error instanceof Error && error.name === 'AbortError';
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'OUTAGE',
+        sourceDisclaimer: isAbort
+          ? 'DCA BreEZe search timed out. Manual verification required until the source recovers.'
+          : `DCA BreEZe search failed (${error instanceof Error ? error.message : String(error)}). Manual verification required until the source recovers.`,
+      });
+    }
+
+    if (!response.ok) {
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'OUTAGE',
+        sourceDisclaimer: `DCA BreEZe responded with HTTP ${response.status}. Manual verification required until the source recovers.`,
+      });
+    }
+
+    const html = await response.text();
+    const looksLikeResultsPage = RESULTS_TABLE_MARKER.test(html);
+    const looksLikeNoResultsPage = NO_RESULTS_MARKER.test(html);
+
+    if (!looksLikeResultsPage && !looksLikeNoResultsPage) {
+      log('warn', 'ca_breeze: unrecognized response page shape', {
+        npi,
+        htmlLength: html.length,
+      });
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'PARSER_FAILURE',
+        sourceDisclaimer:
+          'DCA BreEZe returned a page the parser does not recognize (possible redesign or bot interstitial). Refusing to interpret it. Manual verification required.',
+      });
+    }
+
+    const matchedRows = looksLikeResultsPage ? parseBreezeRows(html, name) : [];
+    const requestedLicense = licenseNumber?.trim();
+    const scopedRows = requestedLicense
+      ? matchedRows.filter((row) => row.licenseNumber === requestedLicense)
+      : matchedRows;
+    const physicianRows = scopedRows.filter((row) => isPhysicianLicenseType(row.licenseType));
+
+    if (physicianRows.length === 0) {
+      return baseResult(npi, checkedAt, {
+        // No degradation reason: the launch lane treats plain NOT_AVAILABLE
+        // as "this lane could not resolve it" and cascades to FSMB/manual.
+        sourceDisclaimer:
+          'Name-based DCA BreEZe search found no unambiguous Medical Board of California record for this provider. Absence from a name search is not proof of absence — manual or FSMB verification required.',
+      });
+    }
+
+    const distinctLicenseNumbers = new Set(physicianRows.map((row) => row.licenseNumber));
+    if (distinctLicenseNumbers.size > 1) {
+      return baseResult(npi, checkedAt, {
+        sourceDisclaimer:
+          'Multiple distinct Medical Board of California records match this provider name. A name search cannot disambiguate them. Manual verification required.',
+      });
+    }
+
+    const row = physicianRows[0];
+    if (row.status === 'UNRECOGNIZED') {
+      return baseResult(npi, checkedAt, {
+        degradationReason: 'PARSER_FAILURE',
+        sourceDisclaimer: `DCA BreEZe reported a license status the parser does not recognize ("${row.statusRaw}"). Refusing to interpret it. Manual verification required.`,
+      });
+    }
+
+    return baseResult(npi, checkedAt, {
+      licenseNumber: row.licenseNumber,
+      licenseStatus: toStateBoardStatus(row.status),
+      licensee: row.name,
+      expirationDate: row.expirationDate,
+      decisionGrade: true,
+      sourceDisclaimer: `Live DCA BreEZe public search, name-matched to the NPPES record. Board-reported status: "${row.statusRaw}".`,
+    });
+  };
+}

--- a/apps/api/backend/src/services/providers/connectors/stateBoardConnector.ts
+++ b/apps/api/backend/src/services/providers/connectors/stateBoardConnector.ts
@@ -10,6 +10,7 @@
 import { createHash } from 'node:crypto';
 import { log } from '../../../obs/logger';
 import { recordProvenance } from '../providerSourceProvenance';
+import { createCaBreezeLiveLookup } from './caBreezeLiveLookup';
 import { getConnectorMode } from './connectorFactory';
 import { runConnectorWithReliability } from './connectorReliability';
 
@@ -25,7 +26,7 @@ export interface StateBoardResult {
   sourceUrl: string;
   sourceMode?: 'live' | 'sandbox';
   decisionGrade?: boolean;
-  degradationReason?: 'OUTAGE' | 'ACCESS_REQUIRED' | 'STALE' | 'PARSER_FAILURE' | 'NOT_IMPLEMENTED' | null;
+  degradationReason?: 'OUTAGE' | 'ACCESS_REQUIRED' | 'STALE' | 'PARSER_FAILURE' | 'NOT_IMPLEMENTED' | 'IDENTITY_UNRESOLVED' | null;
   sourceDisclaimer?: string | null;
 }
 
@@ -49,7 +50,14 @@ const STATE_BOARD_SCHEMA_POLICY = {
 // ── State Board Configs ─────────────────────────────────────────────
 
 const STATE_CONFIGS: Record<string, StateBoardAdapterConfig> = {
-  CA: { state: 'CA', boardName: 'Medical Board of California', sourceUrl: 'https://mbc.ca.gov/breeze/' },
+  CA: {
+    state: 'CA',
+    boardName: 'Medical Board of California',
+    sourceUrl: 'https://mbc.ca.gov/breeze/',
+    // Reachable only when STATE_BOARD_MODE=live; fail-closed parser, see
+    // caBreezeLiveLookup.ts for the go-live preconditions.
+    liveLookup: createCaBreezeLiveLookup(),
+  },
   NY: { state: 'NY', boardName: 'New York State Education Department', sourceUrl: 'http://www.op.nysed.gov/opsearches.htm' },
   TX: { state: 'TX', boardName: 'Texas Medical Board', sourceUrl: 'https://www.tmb.state.tx.us/page/look-up-a-license' },
   FL: { state: 'FL', boardName: 'Florida Department of Health', sourceUrl: 'https://mqa-internet.doh.state.fl.us/MQASearchServices/HealthCareProviders' },
@@ -140,11 +148,16 @@ export async function lookupStateBoard(
     schemaPolicy: STATE_BOARD_SCHEMA_POLICY,
     execute: async () => {
       if (mode === 'live' && config.liveLookup) {
+        const liveResult = await config.liveLookup(npi, licenseNumber);
+        // Respect the adapter's own degradation report: a degraded or
+        // unresolved live result must never be stamped decision-grade.
+        const degraded =
+          liveResult.degradationReason != null
+          || liveResult.licenseStatus === 'NOT_AVAILABLE';
         return {
-          ...(await config.liveLookup(npi, licenseNumber)),
+          ...liveResult,
           sourceMode: 'live',
-          decisionGrade: true,
-          degradationReason: null,
+          decisionGrade: degraded ? false : liveResult.decisionGrade ?? true,
         };
       }
 

--- a/apps/api/backend/src/services/sourceRegistry.ts
+++ b/apps/api/backend/src/services/sourceRegistry.ts
@@ -1,35 +1,52 @@
 import type { VerificationSource } from '../interfaces/verificationSource';
+import { log } from '../obs/logger';
+import { NursysAccessPendingAdapter } from './adapters/nursysAccessPendingAdapter';
 import { NursysStubAdapter } from './adapters/nursysStubAdapter';
 
 /**
  * Verification source registry.
  *
  * Maps source names to adapter instances. The stub adapter is always
- * available. When REAL_NURSYS_ENABLED=true, the registry throws an
- * explicit error — real adapters must be implemented before enabling.
+ * available. Flag semantics for 'NURSYS' (REAL_NURSYS_ENABLED, the same
+ * flag the pilot runbook and ingest orchestrator use):
+ *
+ *   - flag on + a live 'NURSYS' adapter registered  → the live adapter
+ *   - flag on + no live adapter                     → NursysAccessPendingAdapter
+ *     (honest UNKNOWN placeholder; previously this THREW, crashing
+ *     monitoring sweeps and artifact issuance the moment the flag flipped)
+ *   - flag off                                      → deterministic stub
  */
 
 const adapters = new Map<string, VerificationSource>();
 
-// Register built-in stub
+// Register built-in adapters
 adapters.set('NURSYS_STUB', new NursysStubAdapter());
+adapters.set('NURSYS_ACCESS_PENDING', new NursysAccessPendingAdapter());
+
+function isRealNursysEnabled(): boolean {
+  const enabled = process.env.REAL_NURSYS_ENABLED?.trim().toLowerCase();
+  return enabled === 'true' || enabled === '1';
+}
 
 /**
  * Retrieve a verification source adapter by name.
- *
- * Checks REAL_NURSYS_ENABLED when requesting the live adapter.
- * Throws if the adapter is not registered.
+ * Throws only for names that were never registered.
  */
 export function getVerificationSource(sourceName: string): VerificationSource {
-  // Guard: if requesting live Nursys, check env flag
   if (sourceName === 'NURSYS') {
-    const enabled = process.env.REAL_NURSYS_ENABLED?.trim().toLowerCase();
-    if (enabled === 'true' || enabled === '1') {
-      throw new Error(
-        'Real Nursys adapter not implemented. Set REAL_NURSYS_ENABLED=false or implement the live adapter.',
-      );
+    const liveAdapter = adapters.get('NURSYS');
+    if (isRealNursysEnabled()) {
+      if (liveAdapter) {
+        return liveAdapter;
+      }
+      log('error', 'source_registry: REAL_NURSYS_ENABLED set but no live Nursys adapter registered', {
+        served: 'NURSYS_ACCESS_PENDING',
+      });
+      return getVerificationSource('NURSYS_ACCESS_PENDING');
     }
-    // Fall through to NURSYS_STUB when live adapter is not enabled
+    // Flag off: legacy deterministic stub (fabricated statuses — see
+    // NursysStubAdapter header; live callers of this path are tracked
+    // as a separate honesty follow-up).
     return getVerificationSource('NURSYS_STUB');
   }
 

--- a/apps/api/backend/src/workers/continuousMonitor.ts
+++ b/apps/api/backend/src/workers/continuousMonitor.ts
@@ -34,7 +34,10 @@ import { setRevoked } from '../services/ledger/statusListManager';
 import { propagateCredentialLifecycleChange } from '../services/revocation/propagationEngine';
 import { emitMonitoringAlert, type MonitoringAlertKind } from '../services/alerts/trustAlerts';
 import { checkExclusion, type ExclusionResult } from '../services/psv/oigLeieChecker';
-import { getNotificationProvider } from '../services/providers/notificationProvider';
+import {
+  getNotificationProvider,
+  isEmailDeliveryConfigured,
+} from '../services/providers/notificationProvider';
 import { computeTrustState } from '../services/trust-state/trustStateService';
 import { getBindingByNpi } from '../services/identity/npiDidBinding';
 import { sha256ForPayload } from '../utils/deterministic';
@@ -118,6 +121,40 @@ async function writeMonitoringAuditEvent(input: {
 
 // ── Alert + notification dispatch ──────────────────────────────────────────
 
+const EMPLOYER_ID_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve the employers that accepted this clinician to real contact emails.
+ * Acceptance.employerId is a plain string; only UUID-shaped ids can be
+ * VerifierOrg rows, and only rows that resolve get an email. Anything that
+ * does not resolve is skipped (never invent a recipient).
+ */
+async function resolveEmployerAlertEmails(npi: string): Promise<string[]> {
+  const acceptances = await prisma.acceptance.findMany({
+    where: { subjectId: npi },
+    select: { employerId: true },
+  });
+
+  const uniqueEmployerIds = [...new Set(acceptances.map((a) => a.employerId))].filter((id) =>
+    EMPLOYER_ID_UUID_RE.test(id),
+  );
+  if (uniqueEmployerIds.length === 0) return [];
+
+  const orgs = await prisma.verifierOrg.findMany({
+    where: { id: { in: uniqueEmployerIds } },
+    select: { contactEmail: true },
+  });
+
+  return [
+    ...new Set(
+      orgs
+        .map((org) => org.contactEmail.trim())
+        .filter((email) => email.includes('@')),
+    ),
+  ];
+}
+
 async function dispatchMonitoringAlert(input: {
   kind: MonitoringAlertKind;
   npi: string;
@@ -129,27 +166,66 @@ async function dispatchMonitoringAlert(input: {
   // Emit in-app alert (persisted + cached)
   await emitMonitoringAlert(input);
 
-  // Dispatch email/notification to stakeholders
-  const provider = getNotificationProvider();
-  try {
-    // Notify affected employers
-    const acceptances = await prisma.acceptance.findMany({
-      where: { subjectId: input.npi },
-      select: { employerId: true },
-    });
+  const maskedNpi = `${input.npi.slice(0, 4)}****`;
 
-    const uniqueEmployerIds = [...new Set(acceptances.map((a) => a.employerId))];
-    for (const employerId of uniqueEmployerIds) {
-      await provider.send(
-        `employer:${employerId}`,
-        `[VitalCV Alert] ${input.title}`,
-        `${input.description}\n\nRecommended action: ${input.recommendedAction}`,
-      );
+  try {
+    const employerEmails = await resolveEmployerAlertEmails(input.npi);
+    const opsInbox = process.env.MONITORING_ALERT_EMAIL?.trim();
+    const recipients = [
+      ...new Set([...(opsInbox && opsInbox.includes('@') ? [opsInbox] : []), ...employerEmails]),
+    ];
+
+    if (recipients.length === 0) {
+      log('warn', 'monitoring_alert_no_deliverable_recipients', {
+        kind: input.kind,
+        npi: maskedNpi,
+        opsInboxConfigured: Boolean(opsInbox),
+      });
+      return;
     }
+
+    if (!isEmailDeliveryConfigured()) {
+      // Stub provider only logs; make the delivery gap explicit rather than
+      // letting the alert look sent.
+      log('warn', 'monitoring_alert_delivery_unconfigured', {
+        kind: input.kind,
+        npi: maskedNpi,
+        recipientCount: recipients.length,
+      });
+    }
+
+    const provider = getNotificationProvider();
+    const subject = `[VitalCV Alert] ${input.title}`;
+    const body = `${input.description}\n\nRecommended action: ${input.recommendedAction}`;
+
+    let delivered = 0;
+    let failed = 0;
+    for (const to of recipients) {
+      try {
+        await provider.send(to, subject, body);
+        delivered += 1;
+      } catch (err) {
+        failed += 1;
+        log('warn', 'monitoring_alert_send_failed', {
+          kind: input.kind,
+          npi: maskedNpi,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    log('info', 'monitoring_alert_dispatch_summary', {
+      kind: input.kind,
+      npi: maskedNpi,
+      recipientCount: recipients.length,
+      delivered,
+      failed,
+      emailDeliveryConfigured: isEmailDeliveryConfigured(),
+    });
   } catch (err) {
     log('warn', 'monitoring_notification_dispatch_error', {
       kind: input.kind,
-      npi: `${input.npi.slice(0, 4)}****`,
+      npi: maskedNpi,
       error: err instanceof Error ? err.message : String(err),
     });
   }
@@ -747,4 +823,6 @@ export const _testing = {
   runOigLeieSweep,
   handleAdverseAction,
   recomputeCrsForNpi,
+  resolveEmployerAlertEmails,
+  dispatchMonitoringAlert,
 };

--- a/apps/web/__tests__/status-source-lanes.test.ts
+++ b/apps/web/__tests__/status-source-lanes.test.ts
@@ -1,0 +1,32 @@
+/**
+ * status-source-lanes.test.ts — /api/status must report source lanes
+ * honestly in BOTH directions: live lanes may not read as pending
+ * (understating erodes the trust registry the same way overstating does),
+ * and gated lanes may never read as live.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { GET } from '../app/api/status/route';
+
+describe('GET /api/status source_lanes honesty', () => {
+  test('live lanes report active/operational; gated lanes stay pending', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    const lanes = body.source_lanes;
+
+    // Live today: NPPES lookups, OIG/LEIE sweep + cache, PECOS snapshot.
+    expect(lanes.nppes_identity.lifecycle).toBe('active');
+    expect(lanes.nppes_identity.status).toBe('operational');
+    expect(lanes.oig_exclusions.lifecycle).toBe('active');
+    expect(lanes.oig_exclusions.status).toBe('operational');
+    expect(lanes.pecos_enrollment.lifecycle).toBe('active');
+    expect(lanes.pecos_enrollment.status).toBe('operational');
+
+    // Genuinely not live: state board (board/FSMB access), employment
+    // history (demo only), board certification (unintegrated standalone).
+    expect(lanes.state_license.status).toBe('pending_integration');
+    expect(lanes.employment_history.lifecycle).toBe('demo_only');
+    expect(lanes.board_certification.status).toBe('not_implemented');
+  });
+});

--- a/apps/web/app/api/status/route.ts
+++ b/apps/web/app/api/status/route.ts
@@ -111,14 +111,17 @@ export async function GET() {
       nppes_identity: {
         lifecycle: 'active',
         status: 'operational',
+        detail: 'Live NPPES registry lookups.',
       },
       oig_exclusions: {
-        lifecycle: 'planned',
-        status: 'pending_integration',
+        lifecycle: 'active',
+        status: 'operational',
+        detail: 'Monthly LEIE snapshot cache with nightly exclusion sweep; fails closed when the cache is stale.',
       },
       state_license: {
         lifecycle: 'planned',
         status: 'pending_integration',
+        detail: 'Launch-state board lane requires live board or FSMB institutional access.',
       },
       employment_history: {
         lifecycle: 'demo_only',
@@ -129,8 +132,9 @@ export async function GET() {
         status: 'not_implemented',
       },
       pecos_enrollment: {
-        lifecycle: 'planned',
-        status: 'pending_integration',
+        lifecycle: 'active',
+        status: 'operational',
+        detail: 'Quarterly PECOS snapshot; snapshot age is surfaced as staleness on trust surfaces.',
       },
     },
 

--- a/docs/architecture/adr-credential-container-provider.md
+++ b/docs/architecture/adr-credential-container-provider.md
@@ -1,0 +1,90 @@
+# ADR — Credential Container Provider: Self-issue on the ES256 stack
+
+**Status:** Proposed (M8-6 companion) · **Date:** 2026-07-12 · **Decider:** Founder
+
+## Context
+
+The trust-container subsystem (`apps/api/backend/src/services/trust/container/`)
+issues a "credential container" into every exported employer evidence packet
+(`routes/passport.ts` export path, `employerActions.ts`). It has a clean
+provider contract (`TrustContainerProvider`), overclaim guards, and secret
+scrubbing — but only two providers exist:
+
+- **`mock`** (the default; production runs this today): a deterministic,
+  **unsigned** pseudo-VC whose only integrity primitive is a SHA-256 envelope
+  hash. Honestly labeled "Mock/dev credential container" in the UI.
+- **`dock`**: a scaffold that never calls Dock. Even with `DOCK_API_URL`,
+  `DOCK_API_KEY`, and `DOCK_ISSUER_DID` configured it emits an unsigned
+  `dock_vc_scaffold_*` envelope and `verifyCredential()` returns
+  `valid: false, "not yet implemented"`.
+
+So "production credential-container issuance after provider configuration" is
+**not** a configuration gap — the production provider does not exist yet.
+
+Meanwhile two *real* signing stacks already run or exist in-repo:
+
+1. **ES256 receipt issuer** (live in prod): `apps/web/lib/crypto/receiptIssuer.ts`,
+   key `vcv-es256-prod-1`, issuer `did:web:vitalcv.com`, public JWKS at
+   `/.well-known/jwks.json`, fail-closed in production. This is the
+   `signed_issuance: attributable` path on `/api/status`.
+2. **`apps/issuer-api`** (orphaned, deployed nowhere): a genuine OIDC4VCI ES256
+   VC issuer (`vcIssuer.ts` signs real VC-JWTs; `validateVitalVC()` verifies).
+
+## Options
+
+**A. Self-issue (recommended):** implement a `vitalcv` container provider that
+signs the credential envelope as an ES256 VC-JWT under `did:web:vitalcv.com`,
+verifiable against the already-published JWKS. Reuse the issuer-api signing
+code (or the receiptIssuer pattern) behind the existing
+`TrustContainerProvider` contract. No external vendor, no new agreement; key
+custody is the same `RECEIPT_PRIVATE_KEY_JWK`-class discipline already in
+production. Anchoring stays out of scope per the substrate ADR (park;
+signed receipts + Merkle proofs).
+
+**B. Integrate Dock for real:** finish the Dock HTTP integration (issuance,
+verification, DID resolution, anchoring). Requires a Dock account/agreement,
+network choice (testnet default today), vendor key custody, and ongoing vendor
+risk. Adds an external dependency the product story does not currently need —
+public copy promises "cryptographically signed", not any vendor chain.
+
+**C. Park the container entirely:** keep the mock/dev label, rely on
+ES256-signed receipts as the only cryptographic artifact. Zero build cost, but
+the employer packet keeps shipping an unsigned placeholder container, and the
+"production credential-container issuance" pending item never closes.
+
+## Decision (proposed)
+
+**Option A.** Self-issue via the ES256 stack:
+
+1. Add a `vitalcv` provider implementing `TrustContainerProvider`:
+   `issueCredential()` returns a VC-JWT signed with the production ES256 key
+   (`kid: vcv-es256-prod-1`), `verifyCredential()` verifies against local JWKS,
+   `resolveDid()` resolves `did:web:vitalcv.com`, `anchorReceipt()` stays a
+   documented no-op per the substrate ADR.
+2. Select with `TRUST_CONTAINER_PROVIDER=vitalcv`; keep `mock` as the default
+   until the provider passes verification, then flip the env on Railway.
+3. UI: the manifest entry stops being `mock-dev`; label reflects a signed
+   container with issuer DID + kid; TrustContainerPanel already renders
+   provider/environment honestly.
+4. `apps/issuer-api` remains undeployed; only its signing/validation code is
+   reused in-process. Deploying it as a service is a separate decision.
+
+## Consequences
+
+- The pending posture item "Production credential-container issuance after
+  provider configuration" becomes closable with build work only — no external
+  agreement on the critical path.
+- Key compromise blast radius now covers containers as well as receipts —
+  same key, same rotation runbook (acceptable: one issuer identity is the
+  point of `did:web`).
+- Dock (or any VC-substrate vendor) remains a clean future swap behind the
+  same provider contract if a buyer demands third-party anchoring.
+
+## Verification gate (before flipping `TRUST_CONTAINER_PROVIDER`)
+
+- Container VC-JWT from a staging export verifies against
+  `https://vitalcv.com/.well-known/jwks.json` with an external `jose` script.
+- `assertLimitationConsistency` still blocks DECISION_GRADE when limitations
+  exist; manifest secret guard passes; no banned strings in new copy.
+- Packet export with the provider failing (missing key) degrades to a
+  `failed` manifest entry, never a silent mock fallback.


### PR DESCRIPTION
## What this closes (from the four perennial "partial/pending" posture items)

Follow-up to the 2026-07-11 pending-lanes audit: everything code-side that could move without an external agreement, shipped honestly.

### 1. Monitoring alerts now deliverable (was: alerts died at a pseudo-address)
`dispatchMonitoringAlert` sent to `employer:<uuid>` strings — with Resend configured every send would 422. Now:
- `Acceptance.employerId → VerifierOrg.contactEmail` resolution (UUID-guarded so legacy string ids never hit the `@db.Uuid` query)
- `MONITORING_ALERT_EMAIL` ops inbox as an always-on recipient when set
- per-recipient sends, delivery-honesty logs (`unconfigured` / `no recipients` / summary)
- **Still needs from founder:** `RESEND_API_KEY` + `MONITORING_ALERT_EMAIL` on Railway backend to actually deliver.

### 2. /api/status source_lanes truth-drift fixed + guard-tested
OIG/LEIE and PECOS read `pending_integration` though both are live. Now `active/operational` with per-lane `detail` strings; genuinely-pending lanes unchanged. New vitest executes the handler and pins honesty in both directions.

### 3. CA state-board live lookup wired — SHIPS DARK
`STATE_CONFIGS.CA.liveLookup` was never implemented (live mode = permanent ACCESS_REQUIRED). Wired a fail-closed DCA BreEZe lookup:
- NPI → legal name via cached NPPES; unresolvable name degrades as new `IDENTITY_UNRESOLVED` reason
- unrecognized page shape (WAF/redesign) → `PARSER_FAILURE`, never "no license"
- no-match / ambiguous multi-match → `NOT_AVAILABLE` (no degradation) so the lane cascades to FSMB/manual — name-search absence is not proof of absence
- adverse statuses map fail-closed (`SURRENDERED→REVOKED`); board-reported status preserved verbatim
- fixed latent connector bug: live branch stamped `decisionGrade:true` over degraded adapter results
- **Go-live preconditions (module header):** founder decision on DCA public-search usage (ToS) + parser validation against a real BreEZe response, then `STATE_BOARD_MODE=live`. Until then behavior is unchanged (sandbox default).

### 4. Nursys flag repair
Catalog/ops read `NURSYS_ENABLED` (nothing sets it) while runbook/orchestrator use `REAL_NURSYS_ENABLED` — aligned. And `getVerificationSource('NURSYS')` THREW when the flag was on (the exact flag the runbook says to flip when the e-Notify agreement lands), which would have crashed monitoring sweeps and artifact issuance. Flag-on now serves a registered live adapter if present, else an honest `NURSYS_ACCESS_PENDING` placeholder (`UNKNOWN → needs_review`). Flag-off unchanged. (The stub's fabricated-status seam in legacy routes is chipped as a separate follow-up.)

### 5. ADR: credential-container provider (Proposed — founder decision)
`docs/architecture/adr-credential-container-provider.md` — records that the container is build-blocked, not config-blocked (mock default unsigned; Dock provider never calls Dock), and proposes self-issuing VC-JWTs on the live ES256 stack (`did:web:vitalcv.com`) so no vendor agreement sits on the critical path.

## Verification
- Backend: 24 new jest tests across 4 new suites; all touched suites green (53 tests / 7 suites); `tsc --noEmit` clean. `physicianLicensureLaunchLane.test.ts` remains quarantined with its pre-existing failure (verified identical on origin/main).
- Web: `turbo run build --filter @vitalcv/web` green (typecheck+lint enforced); new status vitest executes the route handler.
- Ops (already applied, independent of this PR): `OIG_LEIE_ENABLED=true`, `PECOS_ENABLED=true`, `NPPES_API_ENABLED=true` set on Railway backend per pilot runbook — verified behavior-safe (OIG checker defaults on when unset; the others are reporting-only), fixes ops-dashboard under-reporting and the `exclusionSource: 'stub'` mislabel.

## Explicitly NOT in this PR
- No gated lane is enabled: `STATE_BOARD_MODE`, `REAL_NURSYS_ENABLED`, `FSMB_ENABLED`, `MONITORING_ENABLED` all stay off.
- Wave 245 async engine stays parked (untested/redundant; per audit).
- FSMB / Nursys e-Notify agreements, `RESEND_API_KEY`, SAM.gov key + copy decision — founder queue.

## Design Handoff References
No Claude Design handoff file used for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)