### PR TITLE
feat(design): wave1505 system-pages & governance port at /design/wave1505

### DIFF
--- a/apps/web/__tests__/design-wave1505.test.tsx
+++ b/apps/web/__tests__/design-wave1505.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Wave1505Client from '@/components/design-wave1505/Wave1505Client';
+import { parseRoute5 } from '@/components/design-wave1505/shared';
+import {
+  ContactRoute, IndexRoute, PricingRoute, Sys404, SysError,
+} from '@/components/design-wave1505/views-core';
+import { AuditRoute } from '@/components/design-wave1505/views-governance';
+import { WAVE1505_CSS } from '@/components/design-wave1505/styles';
+
+/**
+ * Wave 1505 port contract — /design/wave1505.
+ *
+ * Pins the fail-closed copy the design wave recorded as reusable verbatim
+ * (CHANGES.md "Decisions recorded"), the port's honesty adaptations (design
+ * reference strip, no fabricated receipts, no bare "Verified" label), and the
+ * .w1505 style scoping that keeps the paper theme out of the app shell.
+ */
+
+describe('wave1505 hash router', () => {
+  it('parses the wave routes', () => {
+    expect(parseRoute5('#/').name).toBe('index');
+    expect(parseRoute5('#/auth')).toEqual({ name: 'auth', sub: 'overview' });
+    expect(parseRoute5('#/auth/sign-in')).toEqual({ name: 'auth', sub: 'sign-in' });
+    expect(parseRoute5('#/auth/loading')).toEqual({ name: 'auth', sub: 'loading' });
+    expect(parseRoute5('#/legal/dpa')).toEqual({ name: 'legal', doc: 'dpa' });
+    expect(parseRoute5('#/system').name).toBe('system');
+    expect(parseRoute5('#/contact').name).toBe('contact');
+    expect(parseRoute5('#/pricing').name).toBe('pricing');
+    expect(parseRoute5('#/audit').name).toBe('audit');
+    expect(parseRoute5('#/dev/design').name).toBe('devdesign');
+    expect(parseRoute5('#/governance').name).toBe('governance');
+  });
+
+  it('routes unknown paths to the designed 404 with the requested path echoed', () => {
+    const r = parseRoute5('#/definitely/not/a/route');
+    expect(r.name).toBe('404');
+    expect(r.requested).toBe('#/definitely/not/a/route');
+    expect(parseRoute5('#/legal/not-a-doc').name).toBe('404');
+    expect(parseRoute5('#/auth/nope').name).toBe('404');
+  });
+});
+
+describe('wave1505 fail-closed system copy (CHANGES.md decisions, verbatim)', () => {
+  it('404 keeps the recorded headline and echoes the request', () => {
+    const html = renderToStaticMarkup(<Sys404 requested="/passport/old-share-link" />);
+    expect(html).toContain('This page isn’t part of the record.');
+    expect(html).toContain('/passport/old-share-link');
+    expect(html).toContain('404 · NOT FOUND');
+  });
+
+  it('error page keeps the fail-closed doctrine line', () => {
+    const html = renderToStaticMarkup(<SysError />);
+    expect(html).toContain('Nothing was recorded as successful.');
+    expect(html).toContain('Something failed on our side.');
+    // errors are stated, never dressed up — no cheerful copy
+    expect(html).not.toMatch(/almost there|oops/i);
+  });
+});
+
+describe('wave1505 port honesty adaptations', () => {
+  it('the chromed shell carries the design-reference disclaimer', () => {
+    const html = renderToStaticMarkup(<Wave1505Client />);
+    expect(html).toContain('Design reference · wave 1505');
+    expect(html).toContain('illustrative fixture data');
+    expect(html).toContain('Skip to content');
+  });
+
+  it('the contact demo success state transmits nothing and says so', () => {
+    const html = renderToStaticMarkup(<ContactRoute />);
+    // pristine form renders; the demo-success copy ships in the module either way
+    expect(html).toContain('A person reads');
+    const source = String(ContactRoute);
+    expect(source).toContain('nothing was sent');
+  });
+
+  it('the pricing figure is labeled illustrative via HonestyLabel copy', () => {
+    const html = renderToStaticMarkup(<PricingRoute />);
+    expect(html).toContain('$1,500');
+    expect(html).toContain('Illustrative figure — actual pilot pricing is set in the signed pilot scope');
+    expect(html).toContain('$0');
+  });
+
+  it('audit rows never use the banned bare "Verified" label', () => {
+    const html = renderToStaticMarkup(<AuditRoute />);
+    expect(html).not.toMatch(/>Verified</);
+    expect(html).toContain('Re-checked');
+  });
+});
+
+describe('wave1505 index hub', () => {
+  it('renders the six deliverables and acceptance list', () => {
+    const html = renderToStaticMarkup(<IndexRoute />);
+    expect(html).toContain('The pages nobody designs —');
+    expect(html).toContain('Six deliverables');
+    expect(html).toContain('Auth surfaces');
+    expect(html).toContain('Error &amp; system states');
+    expect(html).toContain('Legal prose template');
+    expect(html).toContain('Governance artifacts');
+    expect(html).toContain('Checked against the brief');
+  });
+});
+
+describe('wave1505 style scoping', () => {
+  it('defines tokens under .w1505, never :root/html/body', () => {
+    expect(WAVE1505_CSS).not.toMatch(/:root\s*\{/);
+    expect(WAVE1505_CSS).not.toMatch(/(^|\}|\n)\s*html[\s.{]/);
+    expect(WAVE1505_CSS).not.toMatch(/(^|\}|\n)\s*body\s*\{/);
+    expect(WAVE1505_CSS).toContain('.w1505 {');
+  });
+
+  it('keeps keyframes namespaced so they cannot collide with app animations', () => {
+    const names = [...WAVE1505_CSS.matchAll(/@keyframes\s+([a-zA-Z0-9_-]+)/g)].map((m) => m[1]);
+    expect(names.length).toBeGreaterThan(0);
+    for (const n of names) expect(n.startsWith('w1505-')).toBe(true);
+  });
+
+  it('scopes every rule selector under the .w1505 root', () => {
+    // strip comments, then check each top-level selector chunk
+    const css = WAVE1505_CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    const selectorRe = /(?:^|\})\s*([^@{}]+?)\s*\{/g;
+    let m: RegExpExecArray | null;
+    const offenders: string[] = [];
+    while ((m = selectorRe.exec(css)) !== null) {
+      const sel = m[1].trim();
+      if (!sel) continue;
+      // keyframe steps (from/to/percentages) live inside @keyframes blocks
+      if (/^(from|to|\d+%)/.test(sel)) continue;
+      for (const part of sel.split(',')) {
+        const p = part.trim();
+        if (p && !p.startsWith('.w1505')) offenders.push(p);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/app/design/wave1505/Wave1505Mount.tsx
+++ b/apps/web/app/design/wave1505/Wave1505Mount.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// The surface routes off window.location.hash from first render, so it only
+// evaluates in the browser — ssr:false keeps it off the server render path
+// (same mount pattern as the wave1400 /operations-engine port).
+const Wave1505Client = dynamic(() => import('@/components/design-wave1505/Wave1505Client'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex min-h-screen items-center justify-center" style={{ background: '#f4f2ec', color: '#6b6860' }}>
+      <span style={{ fontFamily: 'ui-monospace, monospace', fontSize: 12, letterSpacing: '0.16em', textTransform: 'uppercase' }}>
+        Loading wave 1505…
+      </span>
+    </div>
+  ),
+});
+
+export default function Wave1505Mount() {
+  return <Wave1505Client />;
+}

--- a/apps/web/app/design/wave1505/page.tsx
+++ b/apps/web/app/design/wave1505/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * /design/wave1505 — Wave 1505 · System Pages & Governance (design reference)
+ *
+ * Self-contained, client-rendered port of the wave1505 Claude Design handoff
+ * (system pages, auth theming spec, legal template, contact, pricing,
+ * responsive/a11y audit, /dev/design style guide, governance specs). Renders
+ * without the global Navbar/Footer (it carries its own chrome) via the
+ * OPS_SURFACE_PREFIXES registration in components/layout/publicSurfaceRoutes.ts.
+ *
+ * Design Handoff References:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/index.html
+ *   (+ the wave1500–1504 kit files alongside it)
+ */
+
+import type { Metadata } from 'next';
+import Wave1505Mount from './Wave1505Mount';
+
+export const metadata: Metadata = {
+  title: 'Wave 1505 · System Pages & Governance — design reference',
+  description:
+    'Design reference implementation of the wave 1505 closing wave: system states, auth theming spec, legal template, contact, pricing doctrine, quality gates, and governance artifacts.',
+  robots: { index: false, follow: false },
+};
+
+export default function DesignWave1505Page() {
+  return <Wave1505Mount />;
+}

--- a/apps/web/components/design-wave1505/Wave1505Client.tsx
+++ b/apps/web/components/design-wave1505/Wave1505Client.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * VitalCV — Wave 1505 · System Pages & Governance (design reference)
+ *
+ * Ported from the wave1505 Claude Design handoff (standalone React-18 + Babel
+ * bundle) into a scoped client island, following the wave1400 →
+ * /operations-engine precedent. The prototype's hash router runs against this
+ * route's #hash; all tokens and element styles are scoped under the `.w1505`
+ * root so the paper theme cannot leak into the app shell.
+ *
+ * Handoff source (verbatim, in-repo):
+ *   design-handoff/claude-design-2026-07-12-wave1505/
+ *
+ * Deliberate port adaptations — every one is marked at its site:
+ *   - cross-wave prototype links → real app routes ('/', '/status',
+ *     '/get-ready');
+ *   - a DesignRefNote strip labels all content as illustrative fixtures;
+ *   - the contact/feedback success states say plainly that the prototype
+ *     transmits nothing (no fabricated receipts);
+ *   - audit rows use the Re-checked label, never the banned bare
+ *     Verified status label.
+ */
+
+import * as React from 'react';
+import { WAVE1505_CSS } from './styles';
+import { DesignRefNote, FeedbackWidget, S5Footer, S5Nav, useRoute5 } from './shared';
+import {
+  AuthRoute, ContactRoute, IndexRoute, LegalRoute, PricingRoute, Sys404, SysError, SystemRoute,
+} from './views-core';
+import { AuditRoute, DevDesignRoute, GovernanceRoute } from './views-governance';
+
+export default function Wave1505Client() {
+  const route = useRoute5();
+  const authFull = route.name === 'auth' && route.sub !== 'overview';
+  const chromeless = authFull || route.name === '404' || route.name === 'error';
+
+  return (
+    <div className="w1505">
+      <style dangerouslySetInnerHTML={{ __html: WAVE1505_CSS }} />
+      {chromeless ? (
+        route.name === '404' ? <Sys404 requested={route.requested} />
+          : route.name === 'error' ? <SysError />
+            : <AuthRoute route={route} />
+      ) : (
+        <React.Fragment>
+          <a className="skip-link" href="#main">Skip to content</a>
+          <S5Nav route={route} />
+          <DesignRefNote />
+          <main id="main" className="s5-main">
+            {route.name === 'index' ? <IndexRoute /> : null}
+            {route.name === 'auth' ? <AuthRoute route={route} /> : null}
+            {route.name === 'system' ? <SystemRoute /> : null}
+            {route.name === 'legal' ? <LegalRoute doc={route.doc} /> : null}
+            {route.name === 'contact' ? <ContactRoute /> : null}
+            {route.name === 'pricing' ? <PricingRoute /> : null}
+            {route.name === 'audit' ? <AuditRoute /> : null}
+            {route.name === 'devdesign' ? <DevDesignRoute /> : null}
+            {route.name === 'governance' ? <GovernanceRoute /> : null}
+          </main>
+          <FeedbackWidget />
+          <S5Footer />
+        </React.Fragment>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/design-wave1505/kit.tsx
+++ b/apps/web/components/design-wave1505/kit.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+/**
+ * Wave 1505 port — shared component kit.
+ *
+ * Faithful port of the prototype primitives this wave consumes, from the
+ * design handoff at design-handoff/claude-design-2026-07-12-wave1505/:
+ *   - wave1500/w15-glyphs.jsx + w15-primitives.jsx (TrustGlyph, StateChip,
+ *     buttons, ring, HonestyLabel, SourceRow, NpiInput)
+ *   - wave1502/w1502-shared.jsx (form kit, validators, ErrorSummary,
+ *     SuccessCard, HonestyPanel)
+ *   - wave1503/w1503-shared.jsx (RecognitionRow)
+ *   - wave1504/w1504-shared.jsx (CopyBtn, TokenRow)
+ *   - wave1504/brand/logo.jsx (VtMark, VtLogo)
+ *
+ * The prototype published these on `window`; here they are module exports.
+ * Inline styles consume only the --vt- / --font- / --space- tokens defined
+ * by the scoped .w1505 stylesheet.
+ */
+
+import * as React from 'react';
+
+/* ---------- TrustGlyph set (DG-4.2) ---------- */
+const G = ({ children, size = 14, ...rest }: { children: React.ReactNode; size?: number } & React.SVGProps<SVGSVGElement>) => (
+  <svg width={size} height={size} viewBox="0 0 14 14" fill="none"
+    stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+    aria-hidden="true" {...rest}>{children}</svg>
+);
+
+const TRUST_GLYPHS: Record<string, (s: number) => React.ReactElement> = {
+  checked: (s) => <G size={s}><path d="M2.5 7.5 L5.5 10.5 L11.5 3.5" /></G>,
+  stale: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" /><path d="M7 4.2 V7 L9 8.6" /></G>,
+  pending: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" strokeDasharray="2.4 2.2" /></G>,
+  gated: (s) => <G size={s}><rect x="3" y="6.2" width="8" height="5.6" rx="1" /><path d="M4.8 6.2 V4.6 a2.2 2.2 0 0 1 4.4 0 V6.2" /></G>,
+  unavailable: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" /><path d="M3.3 10.7 L10.7 3.3" /></G>,
+  accessRequired: (s) => <G size={s}><circle cx="4.6" cy="9.4" r="2.6" /><path d="M6.6 7.4 L11.5 2.5 M9.4 4.6 L11.2 6.4" /></G>,
+  reviewRequired: (s) => <G size={s}><path d="M1.8 7 C3.2 4.4 5 3.2 7 3.2 C9 3.2 10.8 4.4 12.2 7 C10.8 9.6 9 10.8 7 10.8 C5 10.8 3.2 9.6 1.8 7 Z" /><circle cx="7" cy="7" r="1.6" /></G>,
+  notDecisionGrade: (s) => <G size={s}><path d="M7 2.2 V11.8 M2.9 4.6 L11.1 9.4 M11.1 4.6 L2.9 9.4" /></G>,
+  previewOnly: (s) => <G size={s}><rect x="2.2" y="2.2" width="9.6" height="9.6" rx="2" strokeDasharray="2.6 2.2" /></G>,
+  p0: (s) => <G size={s}><path d="M7 2 L12.6 11.6 H1.4 Z" /><path d="M7 6 V8.4 M7 10.1 V10.2" /></G>,
+  contradicted: (s) => <G size={s}><path d="M5.6 7 H1.8 M1.8 7 L3.6 5.2 M1.8 7 L3.6 8.8 M8.4 7 H12.2 M12.2 7 L10.4 5.2 M12.2 7 L10.4 8.8" /></G>,
+};
+
+const TIER_GLYPHS: Record<string, (s: number) => React.ReactElement> = {
+  T1: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="9.5" width="10" height="2.5" fill="currentColor" stroke="none" /></G>,
+  T2: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="7" width="10" height="5" fill="currentColor" stroke="none" /></G>,
+  T3: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="4.5" width="10" height="7.5" fill="currentColor" stroke="none" /></G>,
+  T4: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" fill="currentColor" /></G>,
+};
+
+export const TrustGlyph = ({ state, size = 14 }: { state: string; size?: number }) => {
+  const fn = TRUST_GLYPHS[state] || TIER_GLYPHS[state];
+  return fn ? fn(size) : null;
+};
+
+/* ---------- state metadata (DG-3.2 single table) ---------- */
+export const STATE_META: Record<string, { label: string; tone: string; def: string }> = {
+  checked:          { label: 'Checked',            tone: 'checked',      def: 'Source-backed and within freshness threshold.' },
+  stale:            { label: 'Stale',              tone: 'stale',        def: 'Previously checked; past freshness threshold. Refresh available.' },
+  pending:          { label: 'Pending',            tone: 'pending',      def: 'Check in flight. Result not yet available.' },
+  gated:            { label: 'Gated',              tone: 'gated',        def: 'Source requires enrollment or agreement before access.' },
+  unavailable:      { label: 'Unavailable',        tone: 'unavailable',  def: 'Source not reachable or out of scope.' },
+  accessRequired:   { label: 'Access required',    tone: 'access',       def: 'Holder must grant access before this source is read.' },
+  reviewRequired:   { label: 'Review required',    tone: 'review',       def: 'Human review needed before decision-grade.' },
+  notDecisionGrade: { label: 'Not decision-grade', tone: 'ndg',          def: 'Informational only. Not for credentialing decisions.' },
+  previewOnly:      { label: 'Preview only',       tone: 'preview',      def: 'Anonymous preview plane. Not an owned snapshot.' },
+  p0:               { label: 'Blocker',            tone: 'p0',           def: 'Blocks readiness until resolved.' },
+  contradicted:     { label: 'Contradicted',       tone: 'contradicted', def: 'Sources disagree. Both values shown side-by-side.' },
+};
+
+/* ---------- StateChip (DG-6.1) — THE atomic visual unit ---------- */
+export const StateChip = ({ state, size = 'md', source, freshness, label }: {
+  state: string; size?: 'sm' | 'md'; source?: string; freshness?: string; label?: string;
+}) => {
+  const m = STATE_META[state] || STATE_META.pending;
+  const t = m.tone;
+  const dashed = state === 'previewOnly' || state === 'pending';
+  const sm = size === 'sm';
+  return (
+    <span
+      title={`${m.label}${source ? ` · ${source}` : ''}${freshness ? ` · ${freshness}` : ''} — ${m.def}`}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: sm ? 4 : 6,
+        fontFamily: 'var(--font-mono)', fontSize: sm ? 9 : 10, fontWeight: 600,
+        textTransform: 'uppercase', letterSpacing: '0.1em', whiteSpace: 'nowrap',
+        padding: sm ? '2px 6px' : '3px 8px',
+        color: `var(--vt-state-${t})`,
+        background: `var(--vt-state-${t}-bg)`,
+        border: `1px ${dashed ? 'dashed' : 'solid'} var(--vt-state-${t}-rule)`,
+        borderRadius: 'var(--radius-1)',
+      }}>
+      <TrustGlyph state={state} size={sm ? 11 : 13} />
+      {label || m.label}
+    </span>
+  );
+};
+
+/* ---------- ProofTierBadge (DG-6.6) ---------- */
+export const TIER_DEFS: Record<string, string> = {
+  T1: 'Self-attested. Holder statement, no external source.',
+  T2: 'Source-backed. Read from a primary source; freshness tracked.',
+  T3: 'Reviewed. Source-backed plus human review.',
+  T4: 'Signed institutional artifact. Cryptographically signed record.',
+};
+export const ProofTierBadge = ({ tier }: { tier: string }) => (
+  <span title={`${tier} — ${TIER_DEFS[tier]}`}
+    style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-mono)',
+      fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', padding: '3px 8px',
+      color: 'var(--vt-text)', border: '1px solid var(--vt-rule-strong)', borderRadius: 'var(--radius-1)' }}>
+    <TrustGlyph state={tier} size={12} />{tier}
+  </span>
+);
+
+/* ---------- FreshnessStamp (DG-6.8) ---------- */
+export const FreshnessStamp = ({ rel, iso, stale }: { rel: string; iso?: string; stale?: boolean }) => (
+  <time className="vt-num" dateTime={iso} title={iso}
+    style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.04em',
+      color: stale ? 'var(--vt-state-stale)' : 'var(--vt-text-muted)' }}>
+    {rel}
+  </time>
+);
+
+/* ---------- HonestyLabel (DG-17.2) — first-class UI, not fine print ---------- */
+export const HonestyLabel = ({ children }: { children: React.ReactNode }) => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7,
+    fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.08em',
+    color: 'var(--vt-text-secondary)', borderBottom: '1px solid var(--vt-degraded-border)',
+    paddingBottom: 3 }}>
+    <span style={{ width: 6, height: 6, border: '1px solid var(--vt-degraded-border)', borderRadius: '50%', flexShrink: 0 }}></span>
+    {children}
+  </span>
+);
+
+/* ---------- SourceRow (DG-6.4) ---------- */
+export const SourceRow = ({ label, source, state, freshness, iso, action, chipLabel }: {
+  label: string; source: string; state: string; freshness?: string; iso?: string; action?: string; chipLabel?: string;
+}) => (
+  <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center',
+    gap: 12, padding: '10px 0', borderBottom: '1px solid var(--vt-rule-soft)' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+      <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--vt-text)' }}>{label}</span>
+      <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.1em',
+          textTransform: 'uppercase', color: 'var(--vt-text-muted)' }}>{source}</span>
+        {freshness ? <FreshnessStamp rel={freshness} iso={iso} stale={state === 'stale'} /> : null}
+      </span>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <StateChip state={state} size="sm" source={source} freshness={freshness} label={chipLabel} />
+      {action ? <QuietButton small>{action}</QuietButton> : null}
+    </div>
+  </div>
+);
+
+/* ---------- ReadinessRing (DG-6.5) ---------- */
+export const ReadinessRing = ({ value = 72, size = 96, label = 'Readiness' }: { value?: number; size?: number; label?: string }) => {
+  const r = (size - 10) / 2;
+  const c = 2 * Math.PI * r;
+  const band = value >= 80 ? 'var(--vt-state-checked)' : value >= 50 ? 'var(--vt-brand)' : 'var(--vt-state-stale)';
+  return (
+    <div role="meter" aria-valuenow={value} aria-valuemin={0} aria-valuemax={100}
+      aria-label={`${label}: ${value} percent`}
+      style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--vt-rule-soft)" strokeWidth="5" />
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={band} strokeWidth="5"
+          strokeLinecap="butt" strokeDasharray={`${c * value / 100} ${c}`}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+          style={{ transition: 'stroke-dasharray var(--dur-slow) var(--ease-house)' }} />
+      </svg>
+      <div style={{ position: 'absolute', inset: 0, display: 'grid', placeItems: 'center' }}>
+        <div style={{ textAlign: 'center' }}>
+          <div className="vt-num" style={{ fontFamily: 'var(--font-display)', fontSize: size * 0.26, fontWeight: 560, lineHeight: 1 }}>{value}<span style={{ fontSize: size * 0.14 }}>%</span></div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 8.5, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--vt-text-muted)', marginTop: 2 }}>{label}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ---------- Buttons (DG-6.3) ---------- */
+type BtnSize = 'sm' | 'md' | 'lg' | undefined;
+type BtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { size?: BtnSize; loading?: boolean };
+
+const btnBase = (sz: BtnSize): React.CSSProperties => ({
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+  fontFamily: 'var(--font-body)', fontWeight: 500, cursor: 'pointer',
+  fontSize: sz === 'sm' ? 12 : sz === 'lg' ? 15 : 13.5,
+  padding: sz === 'sm' ? '6px 14px' : sz === 'lg' ? '13px 26px' : '9px 20px',
+  borderRadius: 'var(--radius-1)', border: '1px solid transparent',
+  transition: 'background var(--dur-fast) var(--ease-house), border-color var(--dur-fast) var(--ease-house), color var(--dur-fast) var(--ease-house)',
+});
+
+export const PrimaryButton = ({ children, size, disabled, loading, ...rest }: BtnProps) => (
+  <button disabled={disabled || loading} {...rest}
+    onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = 'var(--vt-brand-strong)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.background = disabled ? 'var(--vt-rule)' : 'var(--ink-900)'; }}
+    style={{ ...btnBase(size), background: disabled ? 'var(--vt-rule)' : 'var(--ink-900)',
+      color: disabled ? 'var(--vt-text-muted)' : 'var(--vt-text-inverse)',
+      cursor: disabled ? 'not-allowed' : 'pointer' }}>
+    {loading ? <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>···</span> : null}{children}
+  </button>
+);
+
+export const SecondaryButton = ({ children, size, ...rest }: BtnProps) => (
+  <button {...rest}
+    onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--vt-surface-card)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    style={{ ...btnBase(size), background: 'transparent', color: 'var(--vt-text)', borderColor: 'var(--vt-rule-strong)' }}>
+    {children}
+  </button>
+);
+
+export const QuietButton = ({ children, small, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { small?: boolean }) => (
+  <button {...rest}
+    onMouseEnter={(e) => { e.currentTarget.style.textDecorationColor = 'var(--vt-brand)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.textDecorationColor = 'transparent'; }}
+    style={{ background: 'none', border: 'none', cursor: 'pointer', padding: small ? '2px 4px' : '6px 8px',
+      fontFamily: 'var(--font-body)', fontSize: small ? 11.5 : 13, fontWeight: 500, color: 'var(--vt-text)',
+      textDecoration: 'underline', textDecorationColor: 'transparent', textUnderlineOffset: 3,
+      transition: 'text-decoration-color var(--dur-fast) var(--ease-house)' }}>
+    {children}
+  </button>
+);
+
+export const DestructiveButton = ({ children, size, ...rest }: BtnProps) => (
+  <button {...rest} style={{ ...btnBase(size), background: 'transparent',
+    color: 'var(--vt-state-p0)', borderColor: 'var(--vt-state-p0-rule)' }}>
+    {children}
+  </button>
+);
+
+/* ---------- NPI segmented input (DG-6.7 / DG-7.2) ---------- */
+export const NpiInput = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => {
+  const digits = (value || '').replace(/\D/g, '').slice(0, 10);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, background: 'var(--vt-surface-card)',
+      border: '1px solid var(--vt-rule-strong)', borderRadius: 'var(--radius-2)', padding: '4px 6px 4px 16px' }}>
+      <input
+        value={digits} inputMode="numeric" pattern="[0-9]*" placeholder="Enter your NPI"
+        aria-label="National Provider Identifier, 10 digits"
+        onChange={(e) => onChange(e.target.value.replace(/\D/g, '').slice(0, 10))}
+        style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', background: 'transparent',
+          fontFamily: 'var(--font-mono)', fontSize: 16, letterSpacing: '0.18em',
+          color: 'var(--vt-text)', padding: '10px 0' }} />
+      <span className="vt-num" style={{ fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: digits.length === 10 ? 'var(--vt-state-checked)' : 'var(--vt-text-muted)', flexShrink: 0 }}
+        aria-live="polite">{digits.length}/10</span>
+      <PrimaryButton disabled={digits.length !== 10}>Check readiness</PrimaryButton>
+    </div>
+  );
+};
+
+/* ---------- form kit (wave1502) ---------- */
+export const Field = ({ id, label, required, hint, error, children }: {
+  id: string; label: string; required?: boolean; hint?: string; error?: string | null; children: React.ReactNode;
+}) => (
+  <div className="fk-field">
+    <label className="fk-label" htmlFor={id}>
+      {label}{required ? <span className="fk-req" aria-hidden="true">*</span> : null}
+    </label>
+    {children}
+    {hint && !error ? <p className="fk-hint">{hint}</p> : null}
+    {error ? (
+      <p className="fk-err" id={`${id}-err`}>
+        <TrustGlyph state="p0" size={11} />
+        <span>{error}</span>
+      </p>
+    ) : null}
+  </div>
+);
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> & { error?: string | null };
+export const TextInput = React.forwardRef<HTMLInputElement, InputProps>(function TextInput({ id, error, ...rest }, ref) {
+  return (
+    <input ref={ref} id={id} className={`fk-input${error ? ' err' : ''}`}
+      aria-invalid={!!error} aria-describedby={error ? `${id}-err` : undefined} {...rest} />
+  );
+});
+
+type AreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & { error?: string | null };
+export const TextArea = React.forwardRef<HTMLTextAreaElement, AreaProps>(function TextArea({ id, error, rows = 4, ...rest }, ref) {
+  return (
+    <textarea ref={ref} id={id} rows={rows} className={`fk-input${error ? ' err' : ''}`}
+      aria-invalid={!!error} aria-describedby={error ? `${id}-err` : undefined} {...rest} />
+  );
+});
+
+const FREEMAIL = ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com', 'aol.com', 'icloud.com', 'proton.me', 'protonmail.com'];
+export const validateWorkEmail = (v: string): string | null => {
+  const t = (v || '').trim();
+  if (!t) return 'Work email is required.';
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]{2,}$/.test(t)) return 'Enter a valid email — e.g. name@organization.org.';
+  const dom = t.split('@')[1].toLowerCase();
+  if (FREEMAIL.includes(dom)) return 'Use your work address — pilot scope is tied to your organization’s domain.';
+  return null;
+};
+export const validateRequired = (v: string, label: string): string | null =>
+  ((v || '').trim() ? null : `${label} is required.`);
+
+/* Error summary — designed failure state, role=alert, links focus fields */
+export const ErrorSummary = ({ errors, order, labels, refs }: {
+  errors: Record<string, string | null | undefined>;
+  order: string[];
+  labels: Record<string, string>;
+  refs: Record<string, React.RefObject<HTMLElement | HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null>>;
+}) => {
+  const keys = order.filter((k) => errors[k]);
+  if (!keys.length) return null;
+  return (
+    <div className="fk-summary" role="alert">
+      <span className="t"><TrustGlyph state="p0" size={12} /> {keys.length} field{keys.length > 1 ? 's' : ''} need{keys.length > 1 ? '' : 's'} attention</span>
+      <ul>
+        {keys.map((k) => (
+          <li key={k}>
+            <button type="button" onClick={() => { const el = refs[k] && refs[k].current; if (el) (el as HTMLElement).focus(); }}>
+              {labels[k]} — {errors[k]}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+/* Success card — designed success state */
+export const SuccessCard = ({ title, receipt, children, onReset, resetLabel }: {
+  title: string; receipt: string; children?: React.ReactNode; onReset?: () => void; resetLabel?: string;
+}) => (
+  <div className="fk-success" role="status">
+    <StateChip state="checked" label="Recorded" />
+    <h3>{title}</h3>
+    <span className="receipt vt-num">{receipt}</span>
+    {children}
+    {onReset ? <QuietButton onClick={onReset}>{resetLabel || 'Submit another request'}</QuietButton> : null}
+  </div>
+);
+
+/* ---------- HonestyPanel (DG-8.4) — signature side-by-side pair ---------- */
+export const HonestyPanel = ({ tone, title, items, foot }: {
+  tone: 'ok' | 'watch';
+  title: string;
+  items: Array<{ label: string; source: string; state: string; chipLabel?: string; note?: string }>;
+  foot?: string;
+}) => (
+  <section className={`hn-panel ${tone}`} aria-label={title}>
+    <header className="hn-panel-head">
+      <TrustGlyph state={tone === 'ok' ? 'checked' : 'stale'} size={14} />
+      <span className="t">{title}</span>
+      <span className="n vt-num">{items.length} lanes</span>
+    </header>
+    <ul className="hn-items">
+      {items.map((it) => (
+        <li className="hn-item" key={it.label}>
+          <div>
+            <span className="lab">{it.label}</span>
+            <span className="src">{it.source}</span>
+            {it.note ? <p className="note">{it.note}</p> : null}
+          </div>
+          <StateChip state={it.state} size="sm" label={it.chipLabel} />
+        </li>
+      ))}
+    </ul>
+    {foot ? <div className="hn-panel-foot"><HonestyLabel>{foot}</HonestyLabel></div> : null}
+  </section>
+);
+
+/* ---------- RecognitionRow (DG-10.5) — the one reserved matcha moment ---------- */
+export const RecognitionRow = ({ employer, iso, packet, n, entered }: {
+  employer: string; iso: string; packet: string; n: string; entered?: boolean;
+}) => (
+  <div className={`rec-row${entered ? ' s3-enter' : ''}`}>
+    <span className="rec-seal" aria-hidden="true"><TrustGlyph state="checked" size={15} /></span>
+    <div className="rec-body">
+      <span className="rec-emp">{employer}</span>
+      <span className="rec-line">Accepted as head start — committee review continued on their side.</span>
+      <span className="rec-meta vt-num">{iso} · packet {packet}</span>
+    </div>
+    <span className="rec-stamp" aria-hidden="true">Recognition Nº {n}</span>
+  </div>
+);
+
+/* ---------- copy affordance (wave1504) ---------- */
+const copyFallback = (text: string) => {
+  const ta = document.createElement('textarea');
+  ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+  document.body.appendChild(ta); ta.select();
+  try { document.execCommand('copy'); } catch { /* noop */ }
+  document.body.removeChild(ta);
+};
+export const copyText = (text: string): Promise<void> => {
+  if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => copyFallback(text));
+  }
+  return Promise.resolve(copyFallback(text));
+};
+
+export const CopyBtn = ({ text, label = 'Copy' }: { text: string; label?: string }) => {
+  const [copied, setCopied] = React.useState(false);
+  const tRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  React.useEffect(() => () => clearTimeout(tRef.current), []);
+  return (
+    <button type="button" className={`cp-btn${copied ? ' copied' : ''}`}
+      aria-label={`Copy ${text}`} aria-live="polite"
+      onClick={() => copyText(text).then(() => {
+        setCopied(true);
+        clearTimeout(tRef.current);
+        tRef.current = setTimeout(() => setCopied(false), 1600);
+      })}>
+      {copied ? 'Copied ✓' : label}
+    </button>
+  );
+};
+
+/* ---------- mono token row (key · value · copy) ---------- */
+export const TokenRow = ({ k, value, display, href, children }: {
+  k: string; value: string; display?: string; href?: string; children?: React.ReactNode;
+}) => (
+  <div className="tok-row">
+    <span className="tok-key">{k}</span>
+    <span className="tok-val vt-num">
+      {href ? <a href={href} onClick={(e) => e.preventDefault()} title="Live endpoint — stubbed in prototype">{display || value}</a> : (display || value)}
+      {children}
+    </span>
+    <CopyBtn text={value} />
+  </div>
+);
+
+/* ---------- brand lockup (wave1504/brand/logo.jsx — DG-4.3) ---------- */
+export const VtMark = ({ size = 22, inverse = false }: { size?: number; inverse?: boolean }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">
+    <rect x="0" y="0" width="32" height="32"
+      fill={inverse ? 'var(--ink-900)' : 'var(--paper-100)'} />
+    <rect x="0.5" y="0.5" width="31" height="31" fill="none"
+      stroke={inverse ? 'var(--ink-700)' : 'var(--ink-200)'} strokeWidth="1" />
+    <path d="M8 8 L16 25 L24 8" fill="none"
+      stroke={inverse ? 'var(--paper-50)' : 'var(--ink-900)'}
+      strokeWidth="3.4" strokeLinecap="butt" strokeLinejoin="miter" />
+  </svg>
+);
+
+export const VtLogo = ({ size = 19, variant = 'ink', mark = true, sub }: {
+  size?: number; variant?: 'ink' | 'inverse'; mark?: boolean; sub?: string;
+}) => {
+  const inverse = variant === 'inverse';
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: Math.round(size * 0.5), whiteSpace: 'nowrap' }}>
+      {mark ? <VtMark size={Math.round(size * 1.18)} inverse={inverse} /> : null}
+      <span style={{
+        fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: size,
+        letterSpacing: '-0.01em', lineHeight: 1,
+        color: inverse ? 'var(--paper-50)' : 'var(--ink-900)' }}>
+        VitalCV
+      </span>
+      {sub ? (
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: Math.max(8, Math.round(size * 0.47)),
+          letterSpacing: '0.14em', textTransform: 'uppercase', alignSelf: 'flex-end',
+          color: inverse ? 'var(--ink-300)' : 'var(--ink-500)', paddingBottom: 1 }}>
+          {sub}
+        </span>
+      ) : null}
+    </span>
+  );
+};

--- a/apps/web/components/design-wave1505/shared.tsx
+++ b/apps/web/components/design-wave1505/shared.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+/**
+ * Wave 1505 port — shell: hash router, nav, footer, prototype bar,
+ * FeedbackWidget (DG-12.5), OfflineBanner (DG-12.2.3), EmptyState,
+ * SkeletonStack, page scaffold. Ported from wave1505/w1505-shared.jsx.
+ *
+ * Port adaptations (each documented at the site):
+ *  - cross-wave prototype links (../wave1501/index.html etc.) point at the
+ *    real app routes ('/', '/status') instead;
+ *  - a DesignRefNote strip marks the whole surface as a design reference so
+ *    its fixture content is never mistaken for live product pages;
+ *  - the FeedbackWidget "sent" state says plainly that the prototype
+ *    transmits nothing.
+ */
+
+import * as React from 'react';
+import Link from 'next/link';
+import { PrimaryButton, QuietButton, SecondaryButton, StateChip, TrustGlyph, VtLogo } from './kit';
+
+/* ---------- hash router ---------- */
+export interface Route5 {
+  name: string;
+  sub?: string;
+  doc?: string;
+  requested?: string;
+}
+
+export const parseRoute5 = (h?: string): Route5 => {
+  const hash = h || (typeof window === 'undefined' ? '#/' : window.location.hash || '#/');
+  const seg = hash.replace(/^#\/?/, '').split('?')[0].split('/').filter(Boolean);
+  if (!seg.length) return { name: 'index' };
+  if (seg[0] === 'auth') {
+    const sub = seg[1] || 'overview';
+    if (['sign-in', 'sign-up', 'verify', 'loading', 'overview'].includes(sub)) return { name: 'auth', sub };
+    return { name: '404', requested: hash };
+  }
+  if (seg[0] === '404') return { name: '404', requested: '/passport/old-share-link' };
+  if (seg[0] === 'error') return { name: 'error' };
+  if (seg[0] === 'system') return { name: 'system' };
+  if (seg[0] === 'legal') {
+    const doc = seg[1] || 'privacy';
+    if (['privacy', 'terms', 'dpa', 'cookies'].includes(doc)) return { name: 'legal', doc };
+    return { name: '404', requested: hash };
+  }
+  if (seg[0] === 'contact') return { name: 'contact' };
+  if (seg[0] === 'pricing') return { name: 'pricing' };
+  if (seg[0] === 'audit') return { name: 'audit' };
+  if (seg[0] === 'dev') return { name: 'devdesign' };
+  if (seg[0] === 'governance') return { name: 'governance' };
+  return { name: '404', requested: hash };
+};
+
+export const useRoute5 = (): Route5 => {
+  const [route, setRoute] = React.useState<Route5>(() => parseRoute5());
+  React.useEffect(() => {
+    // The initial state was computed before hydration could see the hash on
+    // first client render; recompute once on mount, then follow hash changes.
+    setRoute(parseRoute5());
+    const fn = () => { setRoute(parseRoute5()); window.scrollTo(0, 0); };
+    window.addEventListener('hashchange', fn);
+    return () => window.removeEventListener('hashchange', fn);
+  }, []);
+  return route;
+};
+
+/* ---------- nav ---------- */
+export const S5_ROUTES = [
+  { hash: '#/', label: 'Index', match: 'index' },
+  { hash: '#/auth', label: 'Auth', match: 'auth' },
+  { hash: '#/system', label: 'System states', match: 'system' },
+  { hash: '#/legal/privacy', label: 'Legal', match: 'legal' },
+  { hash: '#/contact', label: 'Contact', match: 'contact' },
+  { hash: '#/pricing', label: 'Pricing', match: 'pricing' },
+  { hash: '#/audit', label: 'Audit', match: 'audit' },
+  { hash: '#/dev/design', label: '/dev/design', match: 'devdesign' },
+  { hash: '#/governance', label: 'Governance', match: 'governance' },
+];
+
+export const S5Nav = ({ route }: { route: Route5 }) => (
+  <header className="s5-nav">
+    <div className="s5-container s5-nav-inner">
+      {/* port: brand exits to the real app home, not the wave1501 prototype */}
+      <Link className="s5-brand-link" href="/" aria-label="VitalCV home">
+        <VtLogo size={18} />
+      </Link>
+      <span className="vt-eyebrow" style={{ whiteSpace: 'nowrap' }}>Wave 1505 · system &amp; governance</span>
+      <nav className="s5-tabs" aria-label="Wave 1505 surfaces">
+        {S5_ROUTES.map((r) => (
+          <a key={r.hash} className="s5-tab" href={r.hash}
+            aria-current={route.name === r.match ? 'page' : undefined}>{r.label}</a>
+        ))}
+      </nav>
+    </div>
+  </header>
+);
+
+/* ---------- design-reference strip (port addition) ----------
+   Mirrors the wave1503 DemoStrip grammar. Keeps the surface honest: the
+   legal text, pricing figures, receipts, and audit results below are design
+   fixtures, not the live product pages. */
+export const DesignRefNote = () => (
+  <div className="s5-ref no-print" role="note" aria-label="Design reference notice">
+    <div className="s5-container s5-ref-inner">
+      <span className="glyph"><TrustGlyph state="notDecisionGrade" size={12} /></span>
+      <span>Design reference · wave 1505 · content is illustrative fixture data — the live product pages remain canonical</span>
+    </div>
+  </div>
+);
+
+/* ---------- footer ---------- */
+export const S5Footer = () => (
+  <footer className="s5-foot">
+    <div className="s5-container">
+      <p className="s5-boundary">
+        <TrustGlyph state="notDecisionGrade" size={16} />
+        <span>Every state designed — <span className="vt-accent-i">especially</span> the ones nobody sees twice.</span>
+      </p>
+      <ul className="s5-foot-links">
+        <li><a href="#/legal/privacy">Privacy</a></li>
+        <li><a href="#/legal/terms">Terms</a></li>
+        <li><a href="#/legal/dpa">DPA</a></li>
+        <li><a href="#/legal/cookies">Cookies</a></li>
+        <li><a href="#/contact">Contact</a></li>
+        {/* port: the wave1504 prototype status page → the real /status route */}
+        <li><Link href="/status">Status</Link></li>
+        <li><a href="#/dev/design">/dev/design</a></li>
+      </ul>
+      <p className="s5-foot-base">© 2026 VitalCV · did:web:vitalcv.com · Doctrine v1.0 · A partial proof stays partial.</p>
+    </div>
+  </footer>
+);
+
+/* ---------- prototype bar (chrome-less full-page states) ---------- */
+export const ProtoBar = ({ viewing }: { viewing?: { href: string; label: string } }) => (
+  <nav className="s5-proto no-print" aria-label="Prototype navigation">
+    <a href="#/">← Wave 1505 index</a>
+    {viewing ? <a href={viewing.href} aria-current="page">{viewing.label}</a> : null}
+  </nav>
+);
+
+/* ---------- page scaffold ---------- */
+export const S5Page = ({ eyebrow, title, lede, children, label }: {
+  eyebrow?: string; title: React.ReactNode; lede?: string; children?: React.ReactNode; label?: string;
+}) => (
+  <div className="s5-fade" data-screen-label={label || (typeof title === 'string' ? title : undefined)}>
+    <div className="s5-container s5-doctrine">
+      {eyebrow ? <span className="vt-eyebrow">{eyebrow}</span> : null}
+      <h1>{title}</h1>
+      {lede ? <p className="lede">{lede}</p> : null}
+    </div>
+    {children}
+  </div>
+);
+
+export const S5Section = ({ eyebrow, title, lede, first, children, id }: {
+  eyebrow?: string; title?: string; lede?: string; first?: boolean; children?: React.ReactNode; id?: string;
+}) => (
+  <section id={id} className={`s5-section${first ? ' first' : ''}`}>
+    <div className="s5-container">
+      {(eyebrow || title || lede) ? (
+        <div className="s5-sechead">
+          {eyebrow ? <span className="vt-eyebrow">{eyebrow}</span> : null}
+          {title ? <h2>{title}</h2> : null}
+          {lede ? <p className="lede">{lede}</p> : null}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  </section>
+);
+
+/* ---------- OfflineBanner (DG-12.2.3) ----------
+   Dashed rule = degraded semantics (never opacity). role="status",
+   polite announcement. `inline` renders the pattern inside flow for
+   the gallery; default is sticky under the nav at --vt-z-banner. */
+export const OfflineBanner = ({ inline, onRetry }: { inline?: boolean; onRetry?: () => void }) => (
+  <div className={`off-banner${inline ? ' inline' : ''}`} role="status" aria-live="polite">
+    <div className={inline ? 'off-inner' : 's5-container off-inner'}>
+      <span className="off-glyph"><TrustGlyph state="unavailable" size={14} /></span>
+      <span className="off-label">Connection lost</span>
+      <span className="off-copy">Showing the last checked data — freshness stamps stay honest.</span>
+      <span className="off-act"><QuietButton small onClick={onRetry}>Retry now</QuietButton></span>
+    </div>
+  </div>
+);
+
+/* ---------- EmptyState (DG-12.2.4) ----------
+   Honest and calm: glyph in a plain frame (solid rule — dashed is
+   reserved for degraded), one Fraunces line, one reason, ONE action. */
+export const EmptyState = ({ glyph = 'pending', title, why, action, onAction, secondary }: {
+  glyph?: string; title: string; why: string; action?: string; onAction?: () => void; secondary?: boolean;
+}) => (
+  <div className="empty-card" role="status">
+    <span className="empty-glyph"><TrustGlyph state={glyph} size={20} /></span>
+    <h3>{title}</h3>
+    <p className="why">{why}</p>
+    {action ? (
+      <span className="act">
+        {secondary
+          ? <SecondaryButton onClick={onAction}>{action}</SecondaryButton>
+          : <PrimaryButton onClick={onAction}>{action}</PrimaryButton>}
+      </span>
+    ) : null}
+  </div>
+);
+
+/* ---------- SkeletonStack — loading placeholder (allowed shimmer) ---------- */
+export const SkeletonStack = ({ lines = ['w80', 'w60', 'w40'] }: { lines?: string[] }) => (
+  <div className="sk-stack" role="status" aria-label="Loading">
+    {lines.map((w, i) => <span key={i} className={`sk-line ${w}`}></span>)}
+  </div>
+);
+
+/* ---------- FeedbackWidget (DG-12.5) ----------
+   Right-edge vertical tab at mid-height: never overlaps bottom CTAs at
+   360px by construction. z from the token scale. Non-modal panel,
+   Escape closes, focus returns to the tab. */
+export const FeedbackWidget = () => {
+  const [open, setOpen] = React.useState(false);
+  const [sent, setSent] = React.useState(false);
+  const [msg, setMsg] = React.useState('');
+  const tabRef = React.useRef<HTMLButtonElement>(null);
+  const areaRef = React.useRef<HTMLTextAreaElement>(null);
+  // port fix: the prototype focused the tab synchronously on close, but the
+  // tab is unmounted while the panel is open, so focus never returned. Honor
+  // the documented contract (Esc closes, focus returns to the tab) by
+  // focusing after the tab has re-rendered.
+  const returnFocus = React.useRef(false);
+  React.useEffect(() => {
+    if (!open && returnFocus.current) {
+      returnFocus.current = false;
+      if (tabRef.current) tabRef.current.focus();
+    }
+  }, [open]);
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { returnFocus.current = true; setOpen(false); }
+    };
+    document.addEventListener('keydown', onKey);
+    if (areaRef.current) areaRef.current.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+  const close = () => { returnFocus.current = true; setOpen(false); setSent(false); setMsg(''); };
+  return (
+    <React.Fragment>
+      {!open ? (
+        <button ref={tabRef} type="button" className="fb-tab no-print"
+          aria-haspopup="dialog" aria-expanded={open} onClick={() => setOpen(true)}>
+          Feedback
+        </button>
+      ) : null}
+      {open ? (
+        <div className="fb-panel no-print" role="dialog" aria-label="Send feedback">
+          {!sent ? (
+            <React.Fragment>
+              <div className="fb-head">
+                <h2>Feedback</h2>
+                <button type="button" className="fb-close" onClick={close}>Close</button>
+              </div>
+              <p className="fb-note">Read by the design team. Not for support, account issues, or anything patient-related.</p>
+              <div className="fk-field">
+                <label className="fk-label" htmlFor="fb-msg">What should we know?</label>
+                <textarea ref={areaRef} id="fb-msg" rows={4} className="fk-input"
+                  value={msg} onChange={(e) => setMsg(e.target.value)}
+                  placeholder="Something unclear, broken, or dishonest — tell us where." />
+              </div>
+              <PrimaryButton disabled={!msg.trim()} onClick={() => setSent(true)}>Send feedback</PrimaryButton>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <div className="fb-head">
+                <h2>Prototype demo</h2>
+                <button type="button" className="fb-close" onClick={close}>Close</button>
+              </div>
+              <StateChip state="notDecisionGrade" label="Not transmitted" />
+              {/* port: the prototype fabricated a receipt id here; this surface
+                  sends nothing, so it says so — fail-closed honesty. */}
+              <p className="fb-note">Nothing was sent — this widget demonstrates the designed anatomy only.
+                In product, submissions are recorded with a reference id and read at the next design review.</p>
+            </React.Fragment>
+          )}
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
+};

--- a/apps/web/components/design-wave1505/styles.ts
+++ b/apps/web/components/design-wave1505/styles.ts
@@ -1,0 +1,500 @@
+/**
+ * Wave 1505 scoped stylesheet — GENERATED from the verbatim design handoff at
+ * design-handoff/claude-design-2026-07-12-wave1505/ (see scratchpad
+ * build-w1505-css.mjs provenance note in the PR). Every selector is scoped
+ * under the .w1505 root so tokens and element styles cannot leak into the
+ * app shell; @keyframes are renamed w1505-* to avoid global collisions.
+ *
+ * Intentional deviations from the prototype (documented, minimal):
+ *  - [data-theme="ops"] dark theme and the .mz compat alias are dropped
+ *    (wave 1505 is public/light-only).
+ *  - @page print-margin rules are dropped (global print state is not this
+ *    surface's to set).
+ *  - .s5-proto sits at bottom: 72px so it clears the app's floating
+ *    feedback button.
+ *  - .lg-prose ul gets list-style: disc back (Tailwind preflight strips it).
+ */
+// prettier-ignore
+export const WAVE1505_CSS = `
+/* ============================================================
+   Wave 1505 scoped stylesheet — generated from the design handoff
+   at design-handoff/claude-design-2026-07-12-wave1505/.
+   Every selector is scoped under .w1505; keyframes are renamed
+   w1505-*. Source order: wave1500 tokens -> base -> 1502/1503/1504
+   fragments -> w1505.css -> repo compat.
+   ============================================================ */
+
+/* ============================================================
+   VitalCV · 01-primitives.css · Wave 1500 (DG-1.1 / DG-1.3)
+   RAW SCALES ONLY. No component may reference these directly —
+   consume roles from 02-semantic.css.
+   Sources: matcha-zen doctrine + D56 calm wave (adopted),
+   vitalTokens.css Trust Blue / teal / glass / glow (DROPPED).
+   ============================================================ */
+.w1505 {
+  /* ---- PAPER (warm surface scale) ---- */
+  --paper-0:   #ffffff;   /* raised card on paper */
+  --paper-50:  #f7f6f2;
+  --paper-100: #f4f2ec;   /* canonical page paper */
+  --paper-200: #efede7;
+  --paper-300: #e4e3e0;   /* deep paper / theme bridge */
+
+  /* ---- INK (warm near-black scale, anchored at #141414) ---- */
+  --ink-950: #0d0d0b;
+  --ink-900: #141414;    /* canonical ink */
+  --ink-800: #1a1916;
+  --ink-700: #2d2c28;
+  --ink-600: #474540;
+  --ink-500: #6b6860;    /* min for small text on paper (AA at 12px+) */
+  --ink-400: #96938a;    /* eyebrows / disabled only — never body text */
+  --ink-300: #c2bfb5;
+  --ink-200: #dddbd3;    /* rule */
+  --ink-100: #eceae4;    /* rule-soft */
+
+  /* ---- MATCHA (the ONE brand accent family) ---- */
+  --matcha-950: #16211a;
+  --matcha-900: #1f2c22;
+  --matcha-800: #2c3e2d;   /* canonical brand · meta theme-color */
+  --matcha-700: #3a4f3b;
+  --matcha-600: #4a634c;
+  --matcha-300: #a9bfa9;
+  --matcha-100: #e3eae2;
+  --matcha-50:  #f0f4ef;
+
+  /* ---- INDIGO (editorial italic accent ONLY — DG-2.4) ---- */
+  --indigo-600: #4f46e5;
+  --indigo-700: #4338ca;
+
+  /* ---- TRUTH-STATE HUES (D56, contrast-checked on paper) ---- */
+  --hue-ok:        #1c5c38;  --hue-ok-bg:      #f0faf5;  --hue-ok-rule:      #86c9a6;
+  --hue-watch:     #7d5a1e;  --hue-watch-bg:   #fdf4e7;  --hue-watch-rule:   #c9a84c;
+  --hue-p0:        #7a1414;  --hue-p0-bg:      #fef2f2;  --hue-p0-rule:      #f5a5a5;
+  --hue-info:      #1a3e6b;  --hue-info-bg:    #eff6ff;  --hue-info-rule:    #bfdbfe;
+  --hue-unknown:   #3f3d38;  --hue-unknown-bg: #f1efe9;  --hue-unknown-rule: #c8c4ba;
+  --hue-contra:    #5b2a86;  --hue-contra-bg:  #f6f0fb;  --hue-contra-rule:  #cdb0e8;
+
+  /* ---- TYPE ---- */
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-body: 'Geist', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  --text-2xs: 10px;  --text-xs: 11px;  --text-sm: 12.5px; --text-base: 14px;
+  --text-md: 16px;   --text-lg: 19px;  --text-xl: 24px;   --text-2xl: 32px;
+  --text-3xl: 44px;  --text-4xl: 60px; --text-display: clamp(38px, 5.2vw, 68px);
+
+  /* ---- SPACE (4px base) ---- */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-8: 32px; --space-10: 40px;
+  --space-12: 48px; --space-16: 64px; --space-24: 96px; --space-32: 128px;
+
+  /* ---- RADIUS (DG-1.9: near-sharp public; large radii = ops only) ---- */
+  --radius-1: 2px;  --radius-2: 4px;  --radius-3: 6px;
+  --radius-ops: 12px; /* OPS-ONLY */
+
+  /* ---- MOTION (DG-5.2 doctrine) ---- */
+  --ease-house: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-fast: 160ms;  --dur-base: 320ms;  --dur-slow: 420ms;
+
+  /* ---- CONTAINER ---- */
+  --container-max: 1200px;
+  --prose-max: 68ch;
+}
+
+/* ============================================================
+   VitalCV · 02-semantic.css · Wave 1500 (DG-1.1 / DG-3.2)
+   ROLE TOKENS. Components consume ONLY these.
+
+   ┌────────────────────────── TOKEN SPEC ──────────────────────────┐
+   │ NAME                     ROLE                    USAGE RULE     │
+   │ --vt-surface-page        page background         every public   │
+   │ --vt-surface-card        raised paper card       cards, mocks   │
+   │ --vt-text / -secondary   body ink                4.5:1 on paper │
+   │ --vt-text-muted          captions ≥12px          NOT body text  │
+   │ --vt-brand               matcha 800              Recognition    │
+   │                                                  moments, brand │
+   │                                                  chips, primary │
+   │                                                  hover — never  │
+   │                                                  body text bg   │
+   │ --vt-accent-editorial    indigo                  italic Fraunces│
+   │                                                  display accent │
+   │                                                  ONLY, ≤1/section│
+   │ --vt-state-*             9 coverage states       StateChip only │
+   │ KILLED: Trust Blue oklch(.55 .2 255), teal #0a7b7f, --vt-glow-*,│
+   │ glass tokens on public surfaces.                                │
+   └────────────────────────────────────────────────────────────────┘
+   ============================================================ */
+.w1505 {
+  /* Surfaces */
+  --vt-surface-page: var(--paper-100);
+  --vt-surface-card: var(--paper-0);
+  --vt-surface-sunken: var(--paper-200);
+  --vt-surface-inverse: var(--ink-900);
+
+  /* Ink roles */
+  --vt-text: var(--ink-900);
+  --vt-text-secondary: var(--ink-600);
+  --vt-text-muted: var(--ink-500);        /* DG-3.1: replaces 40%-alpha ink */
+  --vt-text-faint: var(--ink-400);        /* eyebrows / metadata ≥10px mono only */
+  --vt-text-inverse: var(--paper-50);
+
+  /* Rules & borders (paper uses rules, not shadows — DG-1.10) */
+  --vt-rule: var(--ink-200);
+  --vt-rule-soft: var(--ink-100);
+  --vt-rule-strong: var(--ink-900);
+  --vt-degraded-border: var(--ink-400);   /* dashed = degraded (DG-9.2) */
+
+  /* Brand */
+  --vt-brand: var(--matcha-800);
+  --vt-brand-strong: var(--matcha-900);
+  --vt-brand-soft: var(--matcha-50);
+  --vt-brand-rule: var(--matcha-300);
+  --vt-accent-editorial: var(--indigo-600);
+  --vt-color-brand-primary: var(--matcha-800); /* DG-1.2 re-point (was Trust Blue) */
+
+  /* Focus (DG-3.5): 2px ink ring + 2px paper offset, everywhere */
+  --vt-focus-ring: 0 0 0 2px var(--vt-surface-page), 0 0 0 4px var(--ink-900);
+
+  /* Hover lift — the ONE allowed shadow on paper */
+  --vt-lift: 0 1px 0 var(--ink-200), 0 6px 16px -8px rgba(20, 20, 20, 0.18);
+
+  /* ---- 9 COVERAGE STATES (DG-3.2) — text / bg / rule per state ---- */
+  /* checked · source-backed, fresh */
+  --vt-state-checked: var(--hue-ok);
+  --vt-state-checked-bg: var(--hue-ok-bg);
+  --vt-state-checked-rule: var(--hue-ok-rule);
+  /* stale · was checked, past freshness threshold */
+  --vt-state-stale: var(--hue-watch);
+  --vt-state-stale-bg: var(--hue-watch-bg);
+  --vt-state-stale-rule: var(--hue-watch-rule);
+  /* pending · check in flight */
+  --vt-state-pending: var(--hue-unknown);
+  --vt-state-pending-bg: var(--hue-unknown-bg);
+  --vt-state-pending-rule: var(--hue-unknown-rule);
+  /* gated · source requires enrollment/agreement */
+  --vt-state-gated: var(--hue-watch);
+  --vt-state-gated-bg: var(--hue-watch-bg);
+  --vt-state-gated-rule: var(--hue-watch-rule);
+  /* unavailable · source down or out of scope */
+  --vt-state-unavailable: var(--hue-unknown);
+  --vt-state-unavailable-bg: var(--hue-unknown-bg);
+  --vt-state-unavailable-rule: var(--hue-unknown-rule);
+  /* accessRequired · holder must grant access */
+  --vt-state-access: var(--hue-watch);
+  --vt-state-access-bg: var(--hue-watch-bg);
+  --vt-state-access-rule: var(--hue-watch-rule);
+  /* reviewRequired · human review before decision-grade */
+  --vt-state-review: var(--hue-watch);
+  --vt-state-review-bg: var(--paper-0);
+  --vt-state-review-rule: var(--hue-watch);
+  /* notDecisionGrade · informational only */
+  --vt-state-ndg: var(--hue-unknown);
+  --vt-state-ndg-bg: var(--paper-0);
+  --vt-state-ndg-rule: var(--hue-unknown-rule);
+  /* previewOnly · anonymous preview plane */
+  --vt-state-preview: var(--hue-info);
+  --vt-state-preview-bg: var(--hue-info-bg);
+  --vt-state-preview-rule: var(--hue-info-rule);
+  /* p0 blocker + contradiction (review surfaces) */
+  --vt-state-p0: var(--hue-p0);
+  --vt-state-p0-bg: var(--hue-p0-bg);
+  --vt-state-p0-rule: var(--hue-p0-rule);
+  --vt-state-contradicted: var(--hue-contra);
+  --vt-state-contradicted-bg: var(--hue-contra-bg);
+  --vt-state-contradicted-rule: var(--hue-contra-rule);
+}
+
+/* ---- base element styles (from wave1500/03-themes.css, scoped) ---- */
+.w1505 {
+  background: var(--vt-surface-page);
+  color: var(--vt-text);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-optical-sizing: auto;
+  min-height: 100vh;
+}.w1505 h1, .w1505 h2, .w1505 h3 {
+  font-family: var(--font-display);
+  font-weight: 560;
+  letter-spacing: -0.015em;
+  color: var(--vt-text);
+  text-wrap: balance;
+  margin: 0;
+}.w1505 .vt-accent-i { font-style: italic; color: var(--vt-accent-editorial); font-weight: 480; }.w1505 .vt-eyebrow { font-family: var(--font-mono); font-size: var(--text-2xs); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.2em; color: var(--vt-text-faint); }.w1505 .vt-num { font-variant-numeric: tabular-nums; }.w1505 a { color: var(--vt-text); text-decoration: underline; text-decoration-color: var(--vt-rule);
+  text-underline-offset: 3px; transition: text-decoration-color var(--dur-fast) var(--ease-house); }.w1505 a:hover { text-decoration-color: var(--vt-brand); color: var(--vt-brand-strong); }.w1505 :focus-visible { outline: none; box-shadow: var(--vt-focus-ring); }.w1505 ::selection { background: var(--matcha-100); color: var(--ink-900); }
+@media (prefers-reduced-motion: no-preference) {.w1505 .vt-enter { animation: w1505-vt-enter var(--dur-base) var(--ease-house) both; }
+  @keyframes w1505-vt-enter { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+}
+
+/* ---- hp-enter entrance (from wave1501/hp.css) ---- */
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes w1505-hp-enter { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+}
+
+/* ---- wave1502 fragments: HonestyPanel + form kit ---- */
+/* ---- HonestyPanel pair (DG-8.4) — signature layout ---- */
+.w1505 .hn-pair { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); align-items: stretch; }.w1505 .hn-panel { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); display: flex; flex-direction: column; }.w1505 .hn-panel.ok { border-top: 3px solid var(--vt-state-checked-rule); }.w1505 .hn-panel.watch { border-top: 3px solid var(--vt-state-stale-rule); }.w1505 .hn-panel-head { display: flex; align-items: center; gap: 10px; padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .hn-panel-head .t { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; }.w1505 .hn-panel.ok .hn-panel-head { color: var(--vt-state-checked); }.w1505 .hn-panel.watch .hn-panel-head { color: var(--vt-state-stale); }.w1505 .hn-panel-head .n { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); }.w1505 .hn-items { list-style: none; margin: 0; padding: 0; }.w1505 .hn-item { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-3); align-items: start;
+  padding: 13px 0; border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .hn-item:last-child { border-bottom: none; }.w1505 .hn-item .lab { font-size: 13.5px; font-weight: 500; color: var(--vt-text); }.w1505 .hn-item .src { display: block; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); margin-top: 3px; }.w1505 .hn-item .note { margin: 5px 0 0; font-size: 12px; line-height: 1.55; color: var(--vt-text-secondary); }.w1505 .hn-panel-foot { margin-top: auto; padding-top: var(--space-4); }
+@media (max-width: 860px) {.w1505 .hn-pair { grid-template-columns: 1fr; } }
+
+/* ---- form kit ---- */
+.w1505 .fk-form { display: flex; flex-direction: column; gap: var(--space-5); }.w1505 .fk-field { display: flex; flex-direction: column; gap: 6px; }.w1505 .fk-label { font-size: 12.5px; font-weight: 600; color: var(--vt-text); }.w1505 .fk-req { color: var(--vt-state-p0); margin-left: 4px; }.w1505 .fk-input { height: 46px; padding: 0 14px; width: 100%; box-sizing: border-box; font-family: var(--font-body);
+  font-size: 14px; color: var(--vt-text); background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  transition: border-color var(--dur-fast) var(--ease-house); }.w1505 textarea.fk-input { height: auto; min-height: 116px; padding: 12px 14px; line-height: 1.6; resize: vertical; }.w1505 .fk-input::placeholder { color: var(--vt-text-muted); }.w1505 .fk-input.err { border-color: var(--vt-state-p0); }.w1505 .fk-hint { margin: 0; font-size: 11.5px; line-height: 1.5; color: var(--vt-text-muted); }.w1505 .fk-err { display: flex; align-items: flex-start; gap: 7px; margin: 0; font-family: var(--font-mono);
+  font-size: 10.5px; letter-spacing: 0.04em; line-height: 1.5; color: var(--vt-state-p0); }.w1505 .fk-err svg { flex-shrink: 0; margin-top: 2px; }.w1505 .fk-callout { border: 1px solid var(--vt-rule-strong); background: var(--vt-surface-sunken); border-radius: var(--radius-1);
+  padding: 14px 16px; font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em; color: var(--vt-text); }.w1505 .fk-summary { border: 1px solid var(--vt-state-p0-rule); background: var(--vt-state-p0-bg); border-radius: var(--radius-1);
+  padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }.w1505 .fk-summary .t { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11px;
+  font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-state-p0); }.w1505 .fk-summary ul { margin: 0; padding: 0 0 0 2px; list-style: none; display: flex; flex-direction: column; gap: 4px; }.w1505 .fk-summary button { background: none; border: none; padding: 2px 0; cursor: pointer; font-family: var(--font-body);
+  font-size: 12.5px; color: var(--vt-text); text-decoration: underline; text-underline-offset: 3px; text-align: left; }.w1505 .fk-success { background: var(--vt-surface-card); border: 1px solid var(--vt-state-checked-rule);
+  border-top: 3px solid var(--vt-state-checked-rule); border-radius: var(--radius-2); padding: var(--space-8);
+  display: flex; flex-direction: column; gap: var(--space-4); align-items: flex-start; }.w1505 .fk-success h3 { font-size: var(--text-xl); }.w1505 .fk-success .receipt { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--vt-text-secondary);
+  border: 1px solid var(--vt-rule); background: var(--vt-surface-page); padding: 6px 10px; border-radius: var(--radius-1);
+  overflow-wrap: anywhere; }.w1505 .fk-success p { margin: 0; font-size: 14px; line-height: 1.65; color: var(--vt-text); max-width: 56ch; }
+@media (prefers-reduced-motion: no-preference) {.w1505 .fk-success, .w1505 .fk-summary { animation: w1505-hp-enter var(--dur-base) var(--ease-house) both; }
+}
+
+/* ---- reduced-motion static fallbacks ---- */
+@media (prefers-reduced-motion: reduce) {.w1505 .fk-input, .w1505 .s2-tab { transition: none; }.w1505 .ab-recorded, .w1505 .fk-success, .w1505 .fk-summary { animation: none; }
+}
+
+/* ---- wave1503 fragment: Recognition row ---- */
+/* ============================================================
+   E · Recognition — the ONE reserved matcha moment.
+   Calm, archival, permanent-feeling. Never a trophy.
+   ============================================================ */
+.w1505 .rec-list { display: flex; flex-direction: column; }.w1505 .rec-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: var(--space-4); align-items: center;
+  padding: 14px 0; border-bottom: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1); }.w1505 .rec-row:last-child { border-bottom: none; }.w1505 .rec-seal { width: 34px; height: 34px; border-radius: 50%; border: 1.5px solid var(--vt-brand);
+  background: var(--vt-brand-soft); color: var(--vt-brand); display: grid; place-items: center; flex-shrink: 0; }.w1505 .rec-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }.w1505 .rec-emp { font-size: 13.5px; font-weight: 600; color: var(--vt-text); }.w1505 .rec-line { font-size: 12.5px; line-height: 1.5; color: var(--vt-text-secondary); }.w1505 .rec-meta { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; color: var(--vt-text-muted); margin-top: 2px; overflow-wrap: anywhere; }.w1505 .rec-stamp { font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-brand); border: 1.5px solid var(--vt-brand);
+  background: var(--vt-brand-soft); border-radius: var(--radius-1); padding: 5px 10px;
+  transform: rotate(-1.4deg); white-space: nowrap; }.w1505 .rec-empty { font-size: 12.5px; color: var(--vt-text-secondary); }
+@media (max-width: 560px) {.w1505 .rec-row { grid-template-columns: auto minmax(0, 1fr); }.w1505 .rec-stamp { grid-column: 2; justify-self: start; transform: rotate(-1.4deg) translateY(-2px); }
+}
+/* one-shot archival settle — background fades from matcha-soft to paper, once */
+@media (prefers-reduced-motion: no-preference) {.w1505 .hp-reveal.is-in .rec-row, .w1505 .rec-row.s3-enter { animation: w1505-rec-settle var(--dur-slow) var(--ease-house) 1 both; }
+  @keyframes w1505-rec-settle { from { background: var(--vt-brand-soft); } to { background: transparent; } }
+}
+
+/* ---- wave1504 fragment: copy affordance + token rows ---- */
+/* ================= copy affordance ================= */
+.w1505 .cp-btn { display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.12em;
+  color: var(--vt-text-secondary); background: transparent; border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-1); padding: 3px 7px; flex-shrink: 0; white-space: nowrap;
+  transition: border-color var(--dur-fast) var(--ease-house), color var(--dur-fast) var(--ease-house); }.w1505 .cp-btn:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }.w1505 .cp-btn.copied { color: var(--vt-state-checked); border-color: var(--vt-state-checked-rule); background: var(--vt-state-checked-bg); }.w1505 .tok-row { display: grid; grid-template-columns: 128px minmax(0, 1fr) auto; align-items: baseline; gap: 12px;
+  padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .tok-row:last-child { border-bottom: none; }.w1505 .tok-key { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); }.w1505 .tok-val { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.02em; color: var(--vt-text);
+  overflow-wrap: anywhere; min-width: 0; }.w1505 .tok-val a { color: var(--vt-text); }
+@media (max-width: 560px) {.w1505 .tok-row { grid-template-columns: minmax(0, 1fr) auto; }.w1505 .tok-key { grid-column: 1 / -1; }
+}
+
+/* ---- wave1505 surface styles ---- */
+/* ============================================================
+   VitalCV · Wave 1505 · System pages, quality gates & governance
+   Consumes wave1500 tokens ONLY. New tokens below are the
+   Z-INDEX SCALE (structural, documented in CHANGES.md) — zero
+   new colors, zero new fonts, zero new radii.
+   ============================================================ */
+.w1505 {
+  /* ---- z-index scale (DG-12.5 — canonical, promoted) ---- */
+  --vt-z-base: 0;
+  --vt-z-raised: 10;      /* lifted cards, dropdowns inside flow */
+  --vt-z-nav: 40;         /* sticky site nav */
+  --vt-z-banner: 45;      /* offline / degraded banner */
+  --vt-z-widget: 50;      /* feedback affordance */
+  --vt-z-overlay: 60;     /* panels above widgets */
+  --vt-z-skip: 100;       /* skip-link — above everything */
+}
+
+/* ================= skip link (DG-15.2) ================= */
+.w1505 .skip-link { position: fixed; left: -9999px; top: 10px; z-index: var(--vt-z-skip);
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+  background: var(--vt-surface-card); color: var(--vt-text); border: 1px solid var(--vt-rule-strong);
+  border-radius: var(--radius-1); padding: 10px 16px; text-decoration: none; }.w1505 .skip-link:focus-visible { left: 12px; }
+
+/* ================= shell ================= */
+.w1505 .s5-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+@media (max-width: 560px) {.w1505 .s5-container { padding: 0 var(--space-4); } }.w1505 .s5-nav { position: sticky; top: 0; z-index: var(--vt-z-nav); background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }.w1505 .s5-nav-inner { display: flex; align-items: center; gap: var(--space-5); padding: 10px 0; flex-wrap: wrap; }.w1505 .s5-brand-link { text-decoration: none; display: inline-flex; }.w1505 .s5-brand-link:hover { text-decoration: none; }.w1505 .s5-tabs { display: flex; gap: 2px; margin-left: auto; flex-wrap: wrap; }.w1505 .s5-tab { font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.08em;
+  text-transform: uppercase; text-decoration: none; color: var(--vt-text-secondary); white-space: nowrap;
+  padding: 6px 10px; border: 1px solid transparent; border-radius: var(--radius-1); }.w1505 .s5-tab:hover { color: var(--vt-text); text-decoration: none; border-color: var(--vt-rule); }.w1505 .s5-tab[aria-current="page"] { color: var(--vt-text); border-color: var(--vt-rule-strong); background: var(--vt-surface-card); }.w1505 .s5-main { min-height: 62vh; }
+@media (prefers-reduced-motion: no-preference) {.w1505 .s5-fade { animation: w1505-s5-fade var(--dur-fast) var(--ease-house) both; }
+  @keyframes w1505-s5-fade { from { opacity: 0; } to { opacity: 1; } }
+}.w1505 .s5-section { padding: var(--space-12) 0; border-top: 1px solid var(--vt-rule); }.w1505 .s5-section.first { border-top: none; padding-top: var(--space-10); }.w1505 .s5-sechead { display: flex; flex-direction: column; gap: 8px; margin-bottom: var(--space-8); max-width: 76ch; }.w1505 .s5-sechead h2 { font-size: var(--text-xl); }.w1505 .s5-sechead .lede { margin: 0; font-size: var(--text-base); color: var(--vt-text-secondary); max-width: 64ch; }.w1505 .s5-doctrine { padding-top: var(--space-12); padding-bottom: var(--space-10); }.w1505 .s5-doctrine h1 { font-size: var(--text-2xl); margin-top: 10px; max-width: 26ch; }.w1505 .s5-doctrine .lede { margin: 14px 0 0; color: var(--vt-text-secondary); max-width: 64ch; }.w1505 .s5-foot { border-top: 1px solid var(--vt-rule); margin-top: var(--space-16); padding: var(--space-10) 0; }.w1505 .s5-boundary { display: flex; align-items: baseline; gap: 12px; margin: 0 0 14px; font-family: var(--font-display);
+  font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em; color: var(--vt-text); max-width: 44ch; line-height: 1.35; }.w1505 .s5-boundary svg { flex-shrink: 0; transform: translateY(2px); }.w1505 .s5-foot-links { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 0 0 16px; padding: 0; list-style: none; }.w1505 .s5-foot-links a { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text-secondary); text-decoration: none; border-bottom: 1px solid var(--vt-rule); padding-bottom: 2px; white-space: nowrap; }.w1505 .s5-foot-links a:hover { color: var(--vt-text); border-bottom-color: var(--vt-rule-strong); }.w1505 .s5-foot-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* prototype bar for chrome-less full-page states */
+.w1505 .s5-proto { position: fixed; right: 12px; bottom: 12px; z-index: var(--vt-z-widget); display: flex; gap: 6px; align-items: center; }.w1505 .s5-proto a { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;
+  color: var(--vt-text-secondary); background: var(--vt-surface-card); border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-1); padding: 6px 10px; text-decoration: none; }.w1505 .s5-proto a:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+
+/* ================= hub / index ================= */
+.w1505 .hub-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
+@media (max-width: 980px) {.w1505 .hub-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 620px) {.w1505 .hub-grid { grid-template-columns: minmax(0, 1fr); } }.w1505 .hub-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-5); display: flex; flex-direction: column; gap: 10px; min-width: 0; }.w1505 .hub-card .hid { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em; color: var(--vt-text-faint); text-transform: uppercase; }.w1505 .hub-card h3 { font-size: var(--text-md); font-family: var(--font-display); font-weight: 560; }.w1505 .hub-card p { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); flex: 1; }.w1505 .hub-links { display: flex; flex-wrap: wrap; gap: 4px 14px; border-top: 1px solid var(--vt-rule-soft); padding-top: 10px; }.w1505 .hub-links a { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text); text-decoration: none; border-bottom: 1px solid var(--vt-rule); padding-bottom: 1px; }.w1505 .hub-links a:hover { border-bottom-color: var(--vt-rule-strong); }.w1505 .hub-accept { display: flex; flex-direction: column; gap: 0; }.w1505 .hub-accept-row { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 12px; align-items: start;
+  padding: 12px 0; border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .hub-accept-row:last-child { border-bottom: none; }.w1505 .hub-accept-row p { margin: 2px 0 0; font-size: 13px; line-height: 1.55; color: var(--vt-text); }.w1505 .hub-accept-row .where { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; color: var(--vt-text-muted); }
+
+/* ================= AUTH (Clerk themed — DG-12.1) ================= */
+.w1505 .auth-page { min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+  padding: var(--space-10) var(--space-4) var(--space-16); box-sizing: border-box; }.w1505 .auth-brand { margin-bottom: var(--space-10); }.w1505 .ck-card { width: 100%; max-width: 400px; background: var(--vt-surface-card); border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-2); padding: var(--space-8); box-sizing: border-box;
+  display: flex; flex-direction: column; gap: var(--space-5); }.w1505 .ck-head { display: flex; flex-direction: column; gap: 6px; }.w1505 .ck-head h1 { font-size: var(--text-xl); }.w1505 .ck-head .sub { margin: 0; font-size: 13px; line-height: 1.55; color: var(--vt-text-secondary); }.w1505 .ck-social { display: flex; flex-direction: column; gap: 8px; }.w1505 .ck-social-btn { display: flex; align-items: center; justify-content: center; gap: 10px; height: 46px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--vt-text); background: transparent; border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  cursor: pointer; transition: background var(--dur-fast) var(--ease-house); }.w1505 .ck-social-btn:hover { background: var(--vt-surface-page); }.w1505 .ck-social-btn svg { flex-shrink: 0; }.w1505 .ck-div { display: flex; align-items: center; gap: 12px; }.w1505 .ck-div::before, .w1505 .ck-div::after { content: ""; flex: 1; height: 1px; background: var(--vt-rule); }.w1505 .ck-div span { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.2em; color: var(--vt-text-muted); }.w1505 .ck-form { display: flex; flex-direction: column; gap: var(--space-4); }.w1505 .ck-name-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+@media (max-width: 400px) {.w1505 .ck-name-grid { grid-template-columns: 1fr; } }.w1505 .ck-primary { width: 100%; height: 46px; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--font-body); font-size: 13.5px; font-weight: 500; color: var(--vt-text-inverse);
+  background: var(--ink-900); border: 1px solid transparent; border-radius: var(--radius-1); cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-house); }.w1505 .ck-primary:hover { background: var(--vt-brand-strong); }.w1505 .ck-primary:disabled { background: var(--vt-rule); color: var(--vt-text-muted); cursor: not-allowed; }.w1505 .ck-foot { display: flex; flex-direction: column; gap: 12px; border-top: 1px solid var(--vt-rule-soft); padding-top: var(--space-4); }.w1505 .ck-foot-line { font-size: 12.5px; color: var(--vt-text-secondary); }.w1505 .ck-foot-line a { font-weight: 500; }.w1505 .ck-badge { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+  font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--vt-text-muted); }.w1505 .auth-under { margin-top: var(--space-5); max-width: 400px; width: 100%; box-sizing: border-box; }.w1505 .auth-under p { margin: 0; font-family: var(--font-mono); font-size: 10px; line-height: 1.7; letter-spacing: 0.04em;
+  color: var(--vt-text-muted); text-align: center; }
+
+/* code cells (verification) */
+.w1505 .code-cells { display: flex; gap: 8px; justify-content: flex-start; }.w1505 .code-cell { width: 46px; height: 54px; display: grid; place-items: center; background: var(--vt-surface-page);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  font-family: var(--font-mono); font-size: 20px; color: var(--vt-text); }.w1505 .code-cell.focus { box-shadow: var(--vt-focus-ring); }.w1505 .code-cell.empty { border-style: dashed; border-color: var(--vt-degraded-border); color: var(--vt-text-muted); }
+@media (max-width: 400px) {.w1505 .code-cell { width: 40px; height: 48px; font-size: 17px; }.w1505 .code-cells { gap: 6px; } }.w1505 .code-hidden { position: absolute; opacity: 0; pointer-events: none; }.w1505 .code-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 10px; flex-wrap: wrap; }.w1505 .code-meta .cnt { font-family: var(--font-mono); font-size: 11px; color: var(--vt-text-muted); }.w1505 .code-meta .cnt.done { color: var(--vt-state-checked); }
+
+/* auth loading interstitial */
+.w1505 .authload { min-height: 100vh; display: grid; place-items: center; padding: var(--space-6); box-sizing: border-box; }.w1505 .authload-box { display: flex; flex-direction: column; align-items: center; gap: var(--space-6); text-align: center; }.w1505 .authload-line { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--vt-text-secondary); }.w1505 .authload-note { margin: 0; font-size: 12.5px; color: var(--vt-text-muted); max-width: 34ch; }.w1505 .authload-track { width: 220px; height: 2px; background: var(--vt-rule-soft); position: relative; overflow: hidden; }.w1505 .authload-track::after { content: ""; position: absolute; inset: 0; width: 40%; background: var(--ink-900); }
+@media (prefers-reduced-motion: no-preference) {.w1505 .authload-track::after { animation: w1505-al-sweep 1.4s var(--ease-house) infinite; }
+  @keyframes w1505-al-sweep { from { transform: translateX(-110%); } to { transform: translateX(560px); } }
+}
+
+/* ================= SYSTEM STATES (DG-12.2) ================= */
+.w1505 .sys-page { min-height: 100vh; display: flex; flex-direction: column; box-sizing: border-box;
+  padding: var(--space-8) var(--space-6) 72px; }.w1505 .sys-top { display: flex; }.w1505 .sys-mid { flex: 1; display: grid; place-items: center; padding: var(--space-12) 0; }.w1505 .sys-block { max-width: 560px; display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-5); }.w1505 .sys-echo { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.05em; line-height: 1.8;
+  color: var(--vt-text-secondary); border: 1px solid var(--vt-rule); background: var(--vt-surface-card);
+  border-radius: var(--radius-1); padding: 10px 14px; overflow-wrap: anywhere; align-self: stretch; }.w1505 .sys-echo .code { color: var(--vt-state-p0); font-weight: 600; }.w1505 .sys-block h1 { font-size: var(--text-3xl); line-height: 1.08; max-width: 15ch; }
+@media (max-width: 560px) {.w1505 .sys-block h1 { font-size: var(--text-2xl); } }.w1505 .sys-block .body { margin: 0; font-size: 15px; line-height: 1.65; color: var(--vt-text-secondary); max-width: 46ch; }.w1505 .sys-ctas { display: flex; gap: var(--space-4); align-items: center; flex-wrap: wrap; }.w1505 .sys-ctas button { white-space: nowrap; }.w1505 .sys-foot { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* offline / degraded banner (DG-12.2.3) */
+.w1505 .off-banner { position: sticky; top: 49px; z-index: var(--vt-z-banner); background: var(--vt-state-stale-bg);
+  border-top: 1px dashed var(--vt-degraded-border); border-bottom: 1px dashed var(--vt-degraded-border); }.w1505 .off-banner.inline { position: static; border-left: 1px dashed var(--vt-degraded-border);
+  border-right: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-1); }.w1505 .off-inner { display: flex; align-items: center; gap: 10px; padding: 9px 0; flex-wrap: wrap; }.w1505 .off-banner.inline .off-inner { padding: 9px 14px; }.w1505 .off-glyph { color: var(--vt-state-stale); display: inline-flex; flex-shrink: 0; }.w1505 .off-label { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-state-stale); white-space: nowrap; }.w1505 .off-copy { font-size: 12.5px; color: var(--vt-text); }.w1505 .off-act { margin-left: auto; }
+@media (max-width: 620px) {.w1505 .off-act { margin-left: 26px; } }
+
+/* empty-state card (DG-12.2.4) */
+.w1505 .empty-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+@media (max-width: 860px) {.w1505 .empty-grid { grid-template-columns: minmax(0, 1fr); } }.w1505 .empty-ctx { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-faint); margin-bottom: 8px; display: block; }.w1505 .empty-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-10) var(--space-6); display: flex; flex-direction: column; align-items: center;
+  text-align: center; gap: var(--space-3); }.w1505 .empty-glyph { width: 44px; height: 44px; display: grid; place-items: center; color: var(--vt-text-muted);
+  border: 1px solid var(--vt-rule); border-radius: var(--radius-1); background: var(--vt-surface-page); }.w1505 .empty-card h3 { font-family: var(--font-display); font-weight: 560; font-size: var(--text-lg); max-width: 24ch; }.w1505 .empty-card .why { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); max-width: 40ch; }.w1505 .empty-card .act { margin-top: var(--space-2); }
+
+/* skeleton loading (allowed shimmer exception) */
+.w1505 .sk-stack { display: flex; flex-direction: column; gap: 10px; }.w1505 .sk-line { height: 12px; border-radius: var(--radius-1); background: var(--vt-surface-sunken);
+  position: relative; overflow: hidden; }.w1505 .sk-line.w60 { width: 60%; }.w1505 .sk-line.w80 { width: 80%; }.w1505 .sk-line.w40 { width: 40%; }
+@media (prefers-reduced-motion: no-preference) {.w1505 .sk-line::after { content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+    background: linear-gradient(90deg, transparent, var(--paper-50), transparent);
+    animation: w1505-sk-sweep 1.6s var(--ease-house) infinite; }
+  @keyframes w1505-sk-sweep { to { transform: translateX(100%); } }
+}
+
+/* ================= LEGAL (DG-12.3) ================= */
+.w1505 .lg-tabs { display: flex; gap: 2px; flex-wrap: wrap; margin-bottom: var(--space-8); }.w1505 .lg-tab { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; text-decoration: none; color: var(--vt-text-secondary);
+  padding: 8px 14px; border: 1px solid var(--vt-rule); border-radius: var(--radius-1); }.w1505 .lg-tab:hover { color: var(--vt-text); text-decoration: none; border-color: var(--vt-rule-strong); }.w1505 .lg-tab[aria-current="page"] { color: var(--vt-text-inverse); background: var(--ink-900); border-color: var(--ink-900); }.w1505 .lg-layout { display: grid; grid-template-columns: 224px minmax(0, 1fr); gap: var(--space-12); align-items: start; }
+@media (max-width: 1023px) {.w1505 .lg-layout { grid-template-columns: minmax(0, 1fr); gap: var(--space-6); } }.w1505 .lg-toc { position: sticky; top: 72px; display: flex; flex-direction: column; gap: 2px; }
+@media (max-width: 1023px) {.w1505 .lg-toc { position: static; border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  padding: var(--space-4); background: var(--vt-surface-card); } }.w1505 .lg-toc-label { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--vt-text-faint); margin-bottom: 8px; }.w1505 .lg-toc a { display: flex; gap: 10px; align-items: baseline; font-size: 12.5px; color: var(--vt-text-secondary);
+  text-decoration: none; padding: 5px 8px; border-left: 2px solid transparent; border-radius: 0; }.w1505 .lg-toc a:hover { color: var(--vt-text); border-left-color: var(--vt-rule-strong); }.w1505 .lg-toc a .n { font-family: var(--font-mono); font-size: 9.5px; color: var(--vt-text-faint); }.w1505 .lg-head { display: flex; flex-direction: column; gap: 10px; margin-bottom: var(--space-8); }.w1505 .lg-head h1 { font-size: var(--text-2xl); }.w1505 .lg-stamp { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text-muted); display: inline-flex; gap: 14px; flex-wrap: wrap; }.w1505 .lg-prose { max-width: 65ch; }.w1505 .lg-prose section { padding: var(--space-6) 0; border-top: 1px solid var(--vt-rule-soft); scroll-margin-top: 72px; }.w1505 .lg-prose section:first-child { border-top: none; padding-top: 0; }.w1505 .lg-prose h2 { font-size: var(--text-lg); display: flex; gap: 12px; align-items: baseline; }.w1505 .lg-prose h2 .n { font-family: var(--font-mono); font-size: 10px; font-weight: 500; color: var(--vt-text-faint); }.w1505 .lg-prose h2 a.anchor { color: inherit; text-decoration: none; }.w1505 .lg-prose h2 a.anchor:hover { text-decoration: underline; text-decoration-color: var(--vt-rule); }.w1505 .lg-prose p, .w1505 .lg-prose li { font-size: 14px; line-height: 1.75; color: var(--vt-text); }.w1505 .lg-prose p { margin: 12px 0 0; }.w1505 .lg-prose ul { margin: 12px 0 0; padding-left: 20px; }.w1505 .lg-prose li { margin-top: 6px; }.w1505 .lg-prose .mono-note { font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em;
+  color: var(--vt-text-secondary); border: 1px solid var(--vt-rule); background: var(--vt-surface-card);
+  border-radius: var(--radius-1); padding: 12px 14px; margin-top: 14px; }.w1505 .lg-table { width: 100%; border-collapse: collapse; margin-top: 14px; }.w1505 .lg-table th { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); text-align: left; padding: 8px 12px 8px 0;
+  border-bottom: 1px solid var(--vt-rule); }.w1505 .lg-table td { font-size: 12.5px; line-height: 1.5; color: var(--vt-text); padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--vt-rule-soft); vertical-align: top; }.w1505 .lg-table td.mono { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.03em; white-space: nowrap; }
+
+/* ================= CONTACT (DG-12.4) ================= */
+.w1505 .ct-grid { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: var(--space-12); align-items: start; }
+@media (max-width: 980px) {.w1505 .ct-grid { grid-template-columns: minmax(0, 1fr); gap: var(--space-8); } }.w1505 .ct-aside { display: flex; flex-direction: column; gap: var(--space-5); position: sticky; top: 72px; }
+@media (max-width: 980px) {.w1505 .ct-aside { position: static; } }.w1505 .ct-expect { border: 1px solid var(--vt-rule); background: var(--vt-surface-card); border-radius: var(--radius-2);
+  padding: var(--space-5); display: flex; flex-direction: column; gap: 12px; }.w1505 .ct-expect .row { display: flex; gap: 10px; align-items: flex-start; }.w1505 .ct-expect .row svg { flex-shrink: 0; margin-top: 2px; color: var(--vt-text-secondary); }.w1505 .ct-expect .row p { margin: 0; font-size: 12.5px; line-height: 1.6; color: var(--vt-text); }.w1505 .ct-expect .row p strong { font-weight: 600; }.w1505 select.fk-input { appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23474540' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 14px center; padding-right: 36px; cursor: pointer; }
+
+/* ================= PRICING (DG-13.3) ================= */
+.w1505 .pr-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); align-items: stretch; }
+@media (max-width: 980px) {.w1505 .pr-grid { grid-template-columns: minmax(0, 1fr); } }.w1505 .pr-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); display: flex; flex-direction: column; gap: var(--space-4); min-width: 0; }.w1505 .pr-card.lead { border: 1px solid var(--vt-rule-strong); }.w1505 .pr-aud { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--vt-text-faint); }.w1505 .pr-price { display: flex; flex-direction: column; gap: 6px; }.w1505 .pr-price .amt { font-family: var(--font-display); font-weight: 560; font-size: var(--text-2xl); letter-spacing: -0.015em; line-height: 1; }.w1505 .pr-price .per { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); }.w1505 .pr-desc { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); }.w1505 .pr-rows { display: flex; flex-direction: column; border-top: 1px solid var(--vt-rule-soft); }.w1505 .pr-row { display: flex; gap: 10px; align-items: flex-start; padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .pr-row svg { flex-shrink: 0; margin-top: 3px; }.w1505 .pr-row.inc svg { color: var(--vt-state-checked); }.w1505 .pr-row.exc svg { color: var(--vt-text-muted); }.w1505 .pr-row span { font-size: 12.5px; line-height: 1.5; color: var(--vt-text); }.w1505 .pr-row.exc span { color: var(--vt-text-muted); }.w1505 .pr-cta { margin-top: auto; padding-top: var(--space-2); display: flex; }.w1505 .pr-cta > * { width: 100%; }.w1505 .pr-never { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); background: var(--vt-surface-card); padding: var(--space-6); }.w1505 .pr-never ul { list-style: none; margin: 14px 0 0; padding: 0; display: flex; flex-direction: column; gap: 0; }.w1505 .pr-never li { display: flex; gap: 10px; align-items: baseline; padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft);
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.03em; line-height: 1.6; color: var(--vt-text); }.w1505 .pr-never li:last-child { border-bottom: none; }.w1505 .pr-never li svg { flex-shrink: 0; transform: translateY(2px); color: var(--vt-state-p0); }.w1505 .pr-faq { max-width: 68ch; }.w1505 .pr-faq details { border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .pr-faq summary { cursor: pointer; list-style: none; display: flex; align-items: baseline; gap: 12px;
+  padding: 14px 0; font-size: 14.5px; font-weight: 500; color: var(--vt-text); }.w1505 .pr-faq summary::-webkit-details-marker { display: none; }.w1505 .pr-faq summary .m { font-family: var(--font-mono); font-size: 12px; color: var(--vt-text-muted); width: 12px; flex-shrink: 0; }.w1505 .pr-faq details[open] summary .m::before { content: "−"; }.w1505 .pr-faq details:not([open]) summary .m::before { content: "+"; }.w1505 .pr-faq details p { margin: 0 0 16px 24px; font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); max-width: 58ch; }
+
+/* ================= AUDIT (DG-14/15) ================= */
+.w1505 .au-sum { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--space-4); margin-bottom: var(--space-8); }
+@media (max-width: 860px) {.w1505 .au-sum { grid-template-columns: repeat(2, minmax(0, 1fr)); } }.w1505 .au-sum-cell { border: 1px solid var(--vt-rule); background: var(--vt-surface-card); border-radius: var(--radius-2);
+  padding: var(--space-4) var(--space-5); display: flex; flex-direction: column; gap: 4px; }.w1505 .au-sum-cell .k { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-faint); }.w1505 .au-sum-cell .v { font-family: var(--font-display); font-weight: 560; font-size: var(--text-2xl); line-height: 1; }.w1505 .au-sum-cell .s { font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); }.w1505 .au-group { margin-bottom: var(--space-8); }.w1505 .au-group-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; padding-bottom: 10px;
+  border-bottom: 2px solid var(--vt-rule-strong); }.w1505 .au-group-head h3 { font-size: var(--text-md); font-family: var(--font-display); font-weight: 560; }.w1505 .au-group-head .dg { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--vt-text-muted); }.w1505 .au-group-head .method { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.05em; color: var(--vt-text-faint); }.w1505 .au-row { display: grid; grid-template-columns: 84px 150px minmax(0, 1.2fr) minmax(0, 1.4fr) auto; gap: var(--space-4);
+  padding: 13px 0; border-bottom: 1px solid var(--vt-rule-soft); align-items: start; }.w1505 .au-row .aid { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.08em; color: var(--vt-text-faint); }.w1505 .au-row .asurf { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.03em; color: var(--vt-text-secondary); overflow-wrap: anywhere; }.w1505 .au-row .asurf .vp { display: block; color: var(--vt-text-faint); font-size: 9.5px; margin-top: 2px; }.w1505 .au-row .afind { font-size: 12.5px; line-height: 1.55; color: var(--vt-text); }.w1505 .au-row .afix { font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); }.w1505 .au-row .afix code, .w1505 .au-row .afind code, .w1505 .gv-rule code, .w1505 .lg-prose code { font-family: var(--font-mono); font-size: 0.92em;
+  background: var(--vt-surface-sunken); border: 1px solid var(--vt-rule-soft); border-radius: 2px; padding: 0 4px; }
+@media (max-width: 980px) {.w1505 .au-row { grid-template-columns: 84px minmax(0, 1fr) auto; }.w1505 .au-row .asurf { grid-column: 2; order: -1; }.w1505 .au-row .aid { grid-row: span 2; }.w1505 .au-row .afind { grid-column: 2 / 4; }.w1505 .au-row .afix { grid-column: 2 / 4; }
+}
+@media (max-width: 560px) {.w1505 .au-row { grid-template-columns: minmax(0, 1fr) auto; }.w1505 .au-row .aid, .w1505 .au-row .asurf, .w1505 .au-row .afind, .w1505 .au-row .afix { grid-column: 1 / 2; }.w1505 .au-row .aid { grid-row: auto; }
+}
+
+/* ================= /dev/design style guide ================= */
+.w1505 .dd-band { padding: var(--space-10) 0; border-top: 1px solid var(--vt-rule); scroll-margin-top: 64px; }.w1505 .dd-band.first { border-top: none; }.w1505 .dd-band-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: var(--space-6); }.w1505 .dd-band-head h2 { font-size: var(--text-lg); }.w1505 .dd-band-head .dg { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--vt-text-muted); }.w1505 .dd-rule { margin: 0 0 var(--space-6); font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em;
+  color: var(--vt-text-secondary); max-width: 88ch; border-left: 2px solid var(--vt-rule-strong); padding-left: 14px; }.w1505 .dd-jump { display: flex; flex-wrap: wrap; gap: 4px 4px; margin-top: var(--space-5); }.w1505 .dd-jump a { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--vt-text-secondary); text-decoration: none; border: 1px solid var(--vt-rule); border-radius: var(--radius-1); padding: 5px 9px; }.w1505 .dd-jump a:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }.w1505 .dd-grid { display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: flex-start; }.w1505 .dd-spec { display: flex; flex-direction: column; gap: 8px; border: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1);
+  padding: var(--space-4); background: var(--vt-surface-card); min-width: 0; }.w1505 .dd-spec .lab { font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); }.w1505 .dd-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(148px, 1fr)); gap: var(--space-3); }.w1505 .dd-swatch { border: 1px solid var(--vt-rule); border-radius: var(--radius-1); overflow: hidden; background: var(--vt-surface-card); }.w1505 .dd-swatch .chip { height: 52px; border-bottom: 1px solid var(--vt-rule-soft); }.w1505 .dd-swatch .meta { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }.w1505 .dd-swatch .meta .t { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; color: var(--vt-text); overflow-wrap: anywhere; }.w1505 .dd-swatch .meta .h { font-family: var(--font-mono); font-size: 9px; color: var(--vt-text-muted); }.w1505 .dd-type-row { display: grid; grid-template-columns: 170px minmax(0, 1fr); gap: var(--space-4); align-items: baseline;
+  padding: 12px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+@media (max-width: 620px) {.w1505 .dd-type-row { grid-template-columns: minmax(0, 1fr); gap: 4px; } }.w1505 .dd-type-row .m { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); }.w1505 .dd-space-row { display: flex; align-items: center; gap: 14px; padding: 5px 0; }.w1505 .dd-space-row .bar { height: 14px; background: var(--matcha-100); border: 1px solid var(--vt-brand-rule); }.w1505 .dd-space-row .m { font-family: var(--font-mono); font-size: 9.5px; color: var(--vt-text-muted); min-width: 130px; }.w1505 .dd-glyph-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: var(--space-3); }.w1505 .dd-glyph-cell { border: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1); background: var(--vt-surface-card);
+  padding: var(--space-4); display: flex; flex-direction: column; align-items: center; gap: 8px; text-align: center; }.w1505 .dd-glyph-cell .g { color: var(--vt-text); }.w1505 .dd-glyph-cell .n { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--vt-text-secondary); overflow-wrap: anywhere; }.w1505 .dd-motion-demo { display: flex; align-items: center; gap: var(--space-5); flex-wrap: wrap; }.w1505 .dd-motion-box { width: 56px; height: 56px; background: var(--vt-surface-card); border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1); }
+@media (prefers-reduced-motion: no-preference) {.w1505 .dd-motion-box.play { animation: w1505-vt-enter var(--dur-base) var(--ease-house) both; } }.w1505 .dd-ztable { max-width: 480px; }
+
+/* ================= GOVERNANCE ================= */
+.w1505 .gv-matrix { width: 100%; border-collapse: collapse; }.w1505 .gv-matrix th { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--vt-text-faint); text-align: left; padding: 8px 10px 8px 0;
+  border-bottom: 2px solid var(--vt-rule-strong); white-space: nowrap; }.w1505 .gv-matrix td { padding: 9px 10px 9px 0; border-bottom: 1px solid var(--vt-rule-soft); vertical-align: top; }.w1505 .gv-matrix td.route { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.02em; color: var(--vt-text); white-space: nowrap; }.w1505 .gv-matrix td.wave { font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); white-space: nowrap; }.w1505 .gv-matrix td.mask { font-family: var(--font-mono); font-size: 10px; line-height: 1.6; color: var(--vt-text-secondary); }.w1505 .gv-matrix .vp-ok { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 9.5px;
+  color: var(--vt-state-checked); border: 1px solid var(--vt-state-checked-rule); background: var(--vt-state-checked-bg);
+  border-radius: var(--radius-1); padding: 2px 7px; margin: 1px 4px 1px 0; white-space: nowrap; }.w1505 .gv-matrix-wrap { overflow-x: auto; }.w1505 .gv-rule { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: var(--space-4); padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--vt-rule-soft); }
+@media (max-width: 620px) {.w1505 .gv-rule { grid-template-columns: minmax(0, 1fr); gap: 8px; } }.w1505 .gv-rule .rid { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.08em; color: var(--vt-text); }.w1505 .gv-rule .rid .sev { display: block; margin-top: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.12em; color: var(--vt-state-p0); }.w1505 .gv-rule .rid .sev.warn { color: var(--vt-state-stale); }.w1505 .gv-rule .rbody { display: flex; flex-direction: column; gap: 7px; min-width: 0; }.w1505 .gv-rule .rbody .what { font-size: 13.5px; font-weight: 500; color: var(--vt-text); }.w1505 .gv-rule .rbody .det { font-family: var(--font-mono); font-size: 10.5px; line-height: 1.7; letter-spacing: 0.02em;
+  color: var(--vt-text-secondary); overflow-wrap: anywhere; }.w1505 .gv-rule .rbody .allow { font-size: 12px; color: var(--vt-text-secondary); }
+
+/* ================= feedback widget (DG-12.5) ================= */
+.w1505 .fb-tab { position: fixed; right: 0; top: 50%; transform: translateY(-50%); z-index: var(--vt-z-widget);
+  writing-mode: vertical-rl; text-orientation: mixed; cursor: pointer;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--vt-text-secondary); background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule); border-right: none; border-radius: var(--radius-1) 0 0 var(--radius-1);
+  padding: 14px 8px; transition: color var(--dur-fast) var(--ease-house), border-color var(--dur-fast) var(--ease-house); }.w1505 .fb-tab::before { content: ""; position: absolute; inset: -4px 0 -4px -10px; }.w1505 .fb-tab:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }.w1505 .fb-panel { position: fixed; right: 12px; top: 50%; transform: translateY(-50%); z-index: var(--vt-z-overlay);
+  width: min(340px, calc(100vw - 48px)); box-sizing: border-box; background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-2); padding: var(--space-5);
+  display: flex; flex-direction: column; gap: var(--space-4); }
+@media (prefers-reduced-motion: no-preference) {.w1505 .fb-panel { animation: w1505-s5-fade var(--dur-fast) var(--ease-house) both; } }.w1505 .fb-head { display: flex; align-items: baseline; gap: 10px; }.w1505 .fb-head h2 { font-size: var(--text-md); }.w1505 .fb-close { margin-left: auto; background: none; border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  cursor: pointer; font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-secondary); padding: 5px 9px; }.w1505 .fb-close:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }.w1505 .fb-note { margin: 0; font-family: var(--font-mono); font-size: 9.5px; line-height: 1.6; letter-spacing: 0.04em;
+  color: var(--vt-text-muted); }
+
+/* ================= misc ================= */
+.w1505 .mono-list { list-style: none; margin: 0; padding: 0; }.w1505 .mono-list li { display: flex; gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--vt-rule-soft);
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.65; letter-spacing: 0.03em; color: var(--vt-text-secondary); }.w1505 .mono-list li:last-child { border-bottom: none; }.w1505 .mono-list li::before { content: "·"; color: var(--vt-text-faint); }.w1505 .s5-twocol { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-6); align-items: start; }
+@media (max-width: 980px) {.w1505 .s5-twocol { grid-template-columns: minmax(0, 1fr); } }
+
+/* ---- repo integration compat (deviations documented in the port header) ---- */
+/* Tailwind preflight strips list bullets globally; the legal prose relies on them. */
+.w1505 .lg-prose ul { list-style: disc; }
+/* The app's floating feedback button occupies bottom-right 24px; keep the
+   prototype bar clear of it. */
+.w1505 .s5-proto { bottom: 72px; }
+/* Design-reference strip (mirrors the 1503 DemoStrip grammar). */
+.w1505 .s5-ref { border-bottom: 1px dashed var(--vt-degraded-border); background: var(--vt-surface-page); }.w1505 .s5-ref-inner { display: flex; align-items: center; gap: 12px; padding: 6px 0; flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-secondary); }.w1505 .s5-ref-inner .glyph { display: inline-flex; color: var(--vt-text-muted); }
+
+`;

--- a/apps/web/components/design-wave1505/views-core.tsx
+++ b/apps/web/components/design-wave1505/views-core.tsx
@@ -1,0 +1,950 @@
+'use client';
+
+/**
+ * Wave 1505 port — core routes: index hub, auth (DG-12.1), system states
+ * (DG-12.2), legal (DG-12.3), contact (DG-12.4.1), pricing (DG-13.3).
+ * Ported from wave1505/w1505-{app,auth,system,legal,contact,pricing}.jsx.
+ *
+ * Port adaptations (documented at each site): prototype cross-wave links
+ * point at real app routes; the contact success state says plainly that the
+ * prototype sends nothing.
+ */
+
+import * as React from 'react';
+import {
+  ErrorSummary, Field, HonestyLabel, PrimaryButton, QuietButton, SecondaryButton,
+  StateChip, TextArea, TextInput, TokenRow, TrustGlyph, VtLogo,
+  validateRequired, validateWorkEmail,
+} from './kit';
+import { EmptyState, OfflineBanner, ProtoBar, Route5, S5Page, S5Section, SkeletonStack } from './shared';
+
+/* ================= index hub (w1505-app.jsx) ================= */
+
+const HUB_CARDS = [
+  { id: 'A · DG-12.1', t: 'Auth surfaces', d: 'Clerk themed to the house: sign-in, sign-up, verification, loading. Zero default purple.', links: [['#/auth', 'Overview + spec'], ['#/auth/sign-in', 'Sign in']] },
+  { id: 'B · DG-12.2', t: 'Error & system states', d: '404, fail-closed error, offline banner, and the empty-state gallery — every state designed.', links: [['#/system', 'Gallery'], ['#/404', '404'], ['#/error', 'Error']] },
+  { id: 'C · DG-12.3', t: 'Legal prose template', d: 'One template, four documents. 65ch Geist body, Fraunces headings, sticky TOC, mono stamps.', links: [['#/legal/privacy', 'Privacy'], ['#/legal/dpa', 'DPA']] },
+  { id: 'D · DG-12.4 / 13.3', t: 'Contact · pricing · feedback', d: 'Form-kit contact with designed success; paper/ink pricing under the honesty doctrine; the feedback affordance on every chromed page.', links: [['#/contact', 'Contact'], ['#/pricing', 'Pricing']] },
+  { id: 'E · DG-14 / 15', t: 'Responsive + a11y sweep', d: 'Findings → fixes → verified, across 7 viewports, keyboard, grayscale, screen readers, reduced motion.', links: [['#/audit', 'Checklist']] },
+  { id: 'F · DG-18', t: 'Governance artifacts', d: 'DESIGN_SYSTEM.md, the /dev/design living style guide, the regression matrix, the lint rules.', links: [['#/dev/design', '/dev/design'], ['#/governance', 'Specs']] },
+];
+
+const ACCEPT = [
+  { p: 'Zero default-styled third-party UI — Clerk fully themed, mapping shipped.', where: '#/auth' },
+  { p: 'Every empty, error, and loading state designed; unknown routes land on the designed 404 for real.', where: '#/system' },
+  { p: 'Grayscale + keyboard + reduced-motion + 360px passes on all surfaces, with fixes named.', where: '#/audit' },
+  { p: 'DESIGN_SYSTEM.md is self-sufficient — palette rationale, ramps, states, component rules, do/don’t gallery.', where: 'DESIGN_SYSTEM.md' },
+  { p: 'The do/don’t gallery encodes the honesty doctrine visually (gated + checkmark = never).', where: 'DESIGN_SYSTEM.md §9' },
+];
+
+export const IndexRoute = () => (
+  <S5Page eyebrow="Wave 1505 · closing wave · D-W7/W8" title={<span>The pages nobody designs — <span className="vt-accent-i">designed.</span></span>}
+    lede="System pages, quality gates, and the governance that keeps the house from drifting. After this wave the design program is done — and guarded."
+    label="Wave 1505 index">
+    <S5Section first eyebrow="Scope" title="Six deliverables">
+      <div className="hub-grid">
+        {HUB_CARDS.map((c) => (
+          <div className="hub-card" key={c.id}>
+            <span className="hid">{c.id}</span>
+            <h3>{c.t}</h3>
+            <p>{c.d}</p>
+            <div className="hub-links">{c.links.map(([h, l]) => <a key={h + l} href={h}>{l}</a>)}</div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+    <S5Section eyebrow="Acceptance criteria" title="Checked against the brief">
+      <div className="hub-accept" style={{ maxWidth: 760 }}>
+        {ACCEPT.map((a) => (
+          <div className="hub-accept-row" key={a.where + a.p.slice(0, 12)}>
+            <StateChip state="checked" size="sm" label="Met" />
+            <div>
+              <p>{a.p}</p>
+              <span className="where vt-num">{a.where}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+  </S5Page>
+);
+
+/* ================= auth (w1505-auth.jsx) ================= */
+
+const AuthProvIcon = ({ kind }: { kind: 'google' | 'microsoft' }) => (
+  <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor"
+    strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    {kind === 'google'
+      ? <path d="M12 7.2 H7 M12 7.2 A5 5 0 1 1 10.6 3.6" />
+      : <g><rect x="2" y="2" width="4.6" height="4.6" /><rect x="7.4" y="2" width="4.6" height="4.6" /><rect x="2" y="7.4" width="4.6" height="4.6" /><rect x="7.4" y="7.4" width="4.6" height="4.6" /></g>}
+  </svg>
+);
+
+const CkBadge = () => (
+  <span className="ck-badge"><TrustGlyph state="gated" size={11} />Secured by Clerk · themed by the house</span>
+);
+
+const AuthShell = ({ children, under, label, viewing }: {
+  children: React.ReactNode; under?: string; label: string; viewing?: { href: string; label: string };
+}) => (
+  <div className="auth-page s5-fade" data-screen-label={label}>
+    <a className="skip-link" href="#auth-main">Skip to content</a>
+    <div className="auth-brand"><VtLogo size={19} /></div>
+    <main id="auth-main" style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      {children}
+    </main>
+    {under ? <div className="auth-under"><p>{under}</p></div> : null}
+    <ProtoBar viewing={viewing} />
+  </div>
+);
+
+export const AuthSignIn = () => {
+  const [email, setEmail] = React.useState('');
+  return (
+    <AuthShell label="Auth · sign in" under="Signing in reads nothing new. Sources are only checked when you ask."
+      viewing={{ href: '#/auth/sign-in', label: '/sign-in' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Sign in</h1>
+          <p className="sub">Back to your passport, exactly as you left it.</p>
+        </div>
+        <div className="ck-social">
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="google" />Continue with Google</button>
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="microsoft" />Continue with Microsoft</button>
+        </div>
+        <div className="ck-div"><span>OR</span></div>
+        <form className="ck-form" onSubmit={(e) => { e.preventDefault(); window.location.hash = '#/auth/verify'; }}>
+          <Field id="si-email" label="Email address">
+            <TextInput id="si-email" type="email" autoComplete="email" placeholder="you@practice.org"
+              value={email} onChange={(e) => setEmail(e.target.value)} />
+          </Field>
+          <button type="submit" className="ck-primary" disabled={!email.includes('@')}>Continue</button>
+        </form>
+        <div className="ck-foot">
+          <span className="ck-foot-line">No account? <a href="#/auth/sign-up">Create one</a> — free for clinicians.</span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+export const AuthSignUp = () => {
+  const [v, setV] = React.useState({ first: '', last: '', email: '' });
+  const ok = v.first.trim() && v.last.trim() && v.email.includes('@');
+  return (
+    <AuthShell label="Auth · sign up" under="An account holds your snapshots. It never changes what sources say."
+      viewing={{ href: '#/auth/sign-up', label: '/sign-up' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Create your account</h1>
+          <p className="sub">Free for clinicians. Your record stays yours.</p>
+        </div>
+        <div className="ck-social">
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="google" />Continue with Google</button>
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="microsoft" />Continue with Microsoft</button>
+        </div>
+        <div className="ck-div"><span>OR</span></div>
+        <form className="ck-form" onSubmit={(e) => { e.preventDefault(); window.location.hash = '#/auth/verify'; }}>
+          <div className="ck-name-grid">
+            <Field id="su-first" label="First name">
+              <TextInput id="su-first" autoComplete="given-name" value={v.first}
+                onChange={(e) => setV({ ...v, first: e.target.value })} />
+            </Field>
+            <Field id="su-last" label="Last name">
+              <TextInput id="su-last" autoComplete="family-name" value={v.last}
+                onChange={(e) => setV({ ...v, last: e.target.value })} />
+            </Field>
+          </div>
+          <Field id="su-email" label="Email address" hint="Work email if you have one — either works.">
+            <TextInput id="su-email" type="email" autoComplete="email" placeholder="you@practice.org"
+              value={v.email} onChange={(e) => setV({ ...v, email: e.target.value })} />
+          </Field>
+          <button type="submit" className="ck-primary" disabled={!ok}>Continue</button>
+        </form>
+        <div className="ck-foot">
+          <span className="ck-foot-line">Already have an account? <a href="#/auth/sign-in">Sign in</a></span>
+          <span className="ck-foot-line" style={{ fontSize: 11.5, color: 'var(--vt-text-muted)' }}>
+            By continuing you agree to the <a href="#/legal/terms">Terms</a> and <a href="#/legal/privacy">Privacy notice</a>.
+          </span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+export const AuthVerify = () => {
+  const [code, setCode] = React.useState('');
+  const [focused, setFocused] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const done = code.length === 6;
+  return (
+    <AuthShell label="Auth · verify email" under="We verify the inbox, not the person. Identity comes from sources, not sign-up."
+      viewing={{ href: '#/auth/verify', label: '/verify' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Check your email</h1>
+          <p className="sub">A six-digit code was sent to <strong style={{ fontWeight: 600 }}>a.okafor@practice.org</strong>. It expires in 10 minutes.</p>
+        </div>
+        <div className="ck-form">
+          <div className="fk-field">
+            <label className="fk-label" htmlFor="vf-code">Verification code</label>
+            <div className="code-cells" onClick={() => inputRef.current && inputRef.current.focus()}>
+              <input ref={inputRef} id="vf-code" className="code-hidden" value={code}
+                inputMode="numeric" pattern="[0-9]*" autoComplete="one-time-code"
+                aria-label="Six-digit verification code"
+                onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))} />
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <span key={i} aria-hidden="true"
+                  className={`code-cell${code[i] ? '' : ' empty'}${focused && i === Math.min(code.length, 5) ? ' focus' : ''}`}>
+                  {code[i] || '·'}
+                </span>
+              ))}
+            </div>
+            <div className="code-meta">
+              <span className={`cnt vt-num${done ? ' done' : ''}`} aria-live="polite">{code.length}/6{done ? ' · checking' : ''}</span>
+              <QuietButton small onClick={() => setCode('')}>Resend code</QuietButton>
+            </div>
+          </div>
+          <button type="button" className="ck-primary" disabled={!done}
+            onClick={() => { window.location.hash = '#/auth/loading'; }}>
+            {done ? 'Verify and continue' : 'Enter the code'}
+          </button>
+        </div>
+        <div className="ck-foot">
+          <span className="ck-foot-line"><a href="#/auth/sign-in">Use a different email</a></span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+export const AuthLoading = () => {
+  React.useEffect(() => {
+    const t = setTimeout(() => { window.location.hash = '#/auth'; }, 3600);
+    return () => clearTimeout(t);
+  }, []);
+  return (
+    <div className="authload s5-fade" data-screen-label="Auth · loading interstitial" role="status" aria-live="polite">
+      <div className="authload-box">
+        <VtLogo size={19} />
+        <span className="authload-track" aria-hidden="true"></span>
+        <span className="authload-line">Verifying session</span>
+        <p className="authload-note">Nothing is shown until it&rsquo;s checked. This usually takes under a second.</p>
+      </div>
+      <ProtoBar viewing={{ href: '#/auth/loading', label: '/loading' }} />
+    </div>
+  );
+};
+
+/* ---------- Clerk appearance mapping (implementable spec) ---------- */
+const CK_VARS = [
+  { k: 'colorPrimary', v: '#141414', note: 'var(--ink-900) — buttons, active states' },
+  { k: 'colorText', v: '#141414', note: 'var(--vt-text)' },
+  { k: 'colorTextSecondary', v: '#474540', note: 'var(--vt-text-secondary)' },
+  { k: 'colorBackground', v: '#ffffff', note: 'var(--vt-surface-card) — card only; page stays paper' },
+  { k: 'colorInputBackground', v: '#ffffff', note: 'var(--vt-surface-card)' },
+  { k: 'colorInputText', v: '#141414', note: 'var(--vt-text)' },
+  { k: 'colorDanger', v: '#7a1414', note: 'var(--hue-p0)' },
+  { k: 'colorSuccess', v: '#1c5c38', note: 'var(--hue-ok)' },
+  { k: 'colorWarning', v: '#7d5a1e', note: 'var(--hue-watch)' },
+  { k: 'colorNeutral', v: '#141414', note: 'kills residual purple in borders/shadows' },
+  { k: 'fontFamily', v: "'Geist', ui-sans-serif, system-ui", note: 'var(--font-body)' },
+  { k: 'fontFamilyButtons', v: "'Geist', ui-sans-serif, system-ui", note: 'same — no second face' },
+  { k: 'borderRadius', v: '2px', note: 'var(--radius-1) — near-sharp public' },
+];
+const CK_ELEMENTS = [
+  { k: 'rootBox / cardBox', v: 'box-shadow: none; border: 1px solid #dddbd3; border-radius: 4px', note: 'rules, not shadows (DG-1.10)' },
+  { k: 'card', v: 'background: #ffffff; padding: 32px; gap: 20px', note: 'paper-0 card on paper-100 page' },
+  { k: 'headerTitle', v: "font-family: 'Fraunces'; font-weight: 560; font-size: 24px; letter-spacing: -0.015em", note: 'display face' },
+  { k: 'headerSubtitle', v: 'color: #474540; font-size: 13px', note: '' },
+  { k: 'logoBox', v: 'render house wordmark (brand/logo.jsx), 19px', note: 'never the Clerk logo slot default' },
+  { k: 'socialButtonsBlockButton', v: 'height 46px; border: 1px solid #141414; border-radius: 2px; Geist Mono 10.5px caps +0.12em', note: 'monochrome provider glyphs, no brand colors' },
+  { k: 'dividerLine / dividerText', v: 'line #dddbd3 · text Geist Mono 9.5px caps +0.2em #6b6860', note: '' },
+  { k: 'formFieldLabel', v: 'font-size: 12.5px; font-weight: 600; color: #141414', note: 'form-kit label' },
+  { k: 'formFieldInput', v: 'height 46px; border: 1px solid #141414; border-radius: 2px; font-size 14px', note: 'form-kit input; ≥44px target' },
+  { k: 'formFieldInput:focus', v: 'box-shadow: 0 0 0 2px #f4f2ec, 0 0 0 4px #141414', note: 'var(--vt-focus-ring) — uniform ring' },
+  { k: 'formButtonPrimary', v: 'background #141414 → hover #1f2c22; height 46px; radius 2px; no ::after arrow', note: 'ink fill, matcha-900 hover' },
+  { k: 'formFieldErrorText', v: 'Geist Mono 10.5px, color #7a1414, glyph + label', note: 'never color alone' },
+  { k: 'footerActionLink', v: 'color #141414; underline, offset 3px; hover #1f2c22', note: 'house link grammar' },
+  { k: 'badge / footer', v: 'Geist Mono 9px caps +0.14em, color #6b6860; background none', note: '"Secured by Clerk" stays — restyled, honest' },
+  { k: 'spinner / loading', v: 'currentColor only; static track + ink sweep', note: 'no purple spinner; reduced-motion → static' },
+];
+
+export const AuthOverview = () => (
+  <S5Page eyebrow="DG-12.1 · Auth surfaces" title={<span>One house, even at the <span className="vt-accent-i">front door.</span></span>}
+    lede="Clerk handles the session; the house handles every pixel. Paper background, ink text, house buttons and focus ring, Geist type, the wordmark where Clerk's logo slot sits. Zero default purple."
+    label="Auth · overview">
+    <S5Section first eyebrow="Full-page states" title="The four surfaces"
+      lede="Each opens chrome-less, exactly as a signed-out visitor meets it.">
+      <div className="hub-grid">
+        {[
+          { href: '#/auth/sign-in', id: 'AUTH-1', t: 'Sign in', d: 'Email-first with two social options. Social buttons are outline + mono caps — provider glyphs render monochrome.' },
+          { href: '#/auth/sign-up', id: 'AUTH-2', t: 'Sign up', d: 'Name pair + email. Legal consent links inline. Free-for-clinicians stated plainly, no asterisk.' },
+          { href: '#/auth/verify', id: 'AUTH-3', t: 'Email verification', d: 'Six code cells in the NPI-cell grammar. Digit count announced via aria-live. Resend is a quiet action.' },
+          { href: '#/auth/loading', id: 'AUTH-4', t: 'Loading interstitial', d: 'Wordmark, hairline sweep (static under reduced motion), one mono line. No skeleton of a page that isn’t there yet.' },
+        ].map((c) => (
+          <div className="hub-card" key={c.id}>
+            <span className="hid">{c.id}</span>
+            <h3>{c.t}</h3>
+            <p>{c.d}</p>
+            <div className="hub-links"><a href={c.href}>Open full page</a></div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+    <S5Section eyebrow="Implementable spec" title="Clerk appearance API mapping"
+      lede="Lives at lib/clerkAppearance.ts and is passed to <ClerkProvider appearance>. Values are the resolved hex of house tokens — Clerk can't read CSS variables server-side, so the file carries the token name in a comment per line.">
+      <div className="s5-twocol">
+        <div>
+          <h3 style={{ fontSize: 15, marginBottom: 10 }}>appearance.variables</h3>
+          <div>{CK_VARS.map((r) => <TokenRow key={r.k} k={r.k} value={r.v} display={`${r.v}${r.note ? '  ·  ' + r.note : ''}`} />)}</div>
+        </div>
+        <div>
+          <h3 style={{ fontSize: 15, marginBottom: 10 }}>appearance.elements</h3>
+          <div>{CK_ELEMENTS.map((r) => <TokenRow key={r.k} k={r.k} value={r.v} display={`${r.v}${r.note ? '  ·  ' + r.note : ''}`} />)}</div>
+        </div>
+      </div>
+      <p style={{ margin: '18px 0 0', fontFamily: 'var(--font-mono)', fontSize: 10.5, lineHeight: 1.7, color: 'var(--vt-text-secondary)', maxWidth: '88ch' }}>
+        ACCEPTANCE · Render sign-in, sign-up, verification, and the SSO-callback interstitial; screenshot at 360/768/1440. grep the computed styles for
+        rgb values of Clerk&rsquo;s defaults (#6c47ff family) — any hit fails the gate. Focus ring on every interactive element must equal var(--vt-focus-ring).
+      </p>
+    </S5Section>
+  </S5Page>
+);
+
+export const AuthRoute = ({ route }: { route: Route5 }) => {
+  if (route.sub === 'sign-in') return <AuthSignIn />;
+  if (route.sub === 'sign-up') return <AuthSignUp />;
+  if (route.sub === 'verify') return <AuthVerify />;
+  if (route.sub === 'loading') return <AuthLoading />;
+  return <AuthOverview />;
+};
+
+/* ================= system states (w1505-system.jsx) ================= */
+
+export const Sys404 = ({ requested }: { requested?: string }) => (
+  <div className="sys-page s5-fade" data-screen-label="System · 404">
+    <div className="sys-top"><VtLogo size={18} /></div>
+    <main className="sys-mid">
+      <div className="sys-block">
+        <div className="sys-echo vt-num" aria-label="Request echo">
+          GET {requested || '/passport/old-share-link'}<br />
+          <span className="code">→ 404 · NOT FOUND</span> · nothing at this address
+        </div>
+        <h1>This page isn&rsquo;t part of the record.</h1>
+        <p className="body">The address may have changed, or it never existed. Nothing was deleted
+          silently — if a share link stopped working, its holder revoked it, and that revocation is logged.</p>
+        <div className="sys-ctas">
+          {/* port: prototype linked ../wave1501 + wave1504 #/status → real routes */}
+          <PrimaryButton size="lg" onClick={() => { window.location.href = '/'; }}>Back to vitalcv.com</PrimaryButton>
+          <QuietButton onClick={() => { window.location.href = '/status'; }}>Check system status</QuietButton>
+        </div>
+      </div>
+    </main>
+    <p className="sys-foot">© 2026 VitalCV · a partial proof stays partial</p>
+    <ProtoBar viewing={{ href: '#/404', label: '/404' }} />
+  </div>
+);
+
+export const SysError = () => (
+  <div className="sys-page s5-fade" data-screen-label="System · error">
+    <div className="sys-top"><VtLogo size={18} /></div>
+    <main className="sys-mid">
+      <div className="sys-block" role="alert">
+        <div className="sys-echo vt-num" aria-label="Failure reference">
+          run_2026-07-12_0812Z · <span className="code">FAILED</span> · err_a41f<br />
+          reference logged — include it if you write in
+        </div>
+        <h1>Something failed on our side.</h1>
+        <p className="body">Nothing was recorded as successful. If you were mid-request, it did not
+          complete — no partial result was saved, and no source was marked checked. Retry when ready.</p>
+        <div className="sys-ctas">
+          <PrimaryButton size="lg" onClick={() => window.location.reload()}>Try again</PrimaryButton>
+          <QuietButton onClick={() => { window.location.hash = '#/contact'; }}>Write to us</QuietButton>
+        </div>
+      </div>
+    </main>
+    <p className="sys-foot">© 2026 VitalCV · errors are stated, never dressed up</p>
+    <ProtoBar viewing={{ href: '#/error', label: '/error' }} />
+  </div>
+);
+
+const EMPTIES = [
+  {
+    ctx: 'Passport · /passport', glyph: 'pending',
+    title: 'No sources checked yet.',
+    why: 'Your passport starts empty on purpose — it only ever shows what a source actually said.',
+    action: 'Enter an NPI to run the first check',
+  },
+  {
+    ctx: 'Reviewer queue · /review', glyph: 'reviewRequired',
+    title: 'Nothing waiting for review.',
+    why: 'Every submitted packet has been decided. New requests appear here the moment they arrive.',
+    action: 'View decided packets', secondary: true,
+  },
+  {
+    ctx: 'Recognitions · /passport#recognitions', glyph: 'checked',
+    title: 'No Recognitions yet.',
+    why: 'A Recognition is recorded when an employer accepts your packet as a head start. Sharing your passport is how they happen.',
+    action: 'Share your passport',
+  },
+  {
+    ctx: 'Opportunities · /opportunities', glyph: 'previewOnly',
+    title: 'No matched opportunities right now.',
+    why: 'Matches come from employer lanes that fit your license states and specialty — none fit today. We don’t pad this list.',
+    action: 'Review your lane preferences', secondary: true,
+  },
+];
+
+export const SystemRoute = () => {
+  const [offline, setOffline] = React.useState(false);
+  return (
+    <React.Fragment>
+      {offline ? <OfflineBanner onRetry={() => setOffline(false)} /> : null}
+      <S5Page eyebrow="DG-12.2 · Error & system states" title={<span>Where trust <span className="vt-accent-i">quietly</span> lives or dies.</span>}
+        lede="A default-styled 404 breaks the spell faster than any bug. Every terminal, degraded, and empty state is designed, honest, and calm — with exactly one next action."
+        label="System states">
+        <S5Section first eyebrow="Terminal states" title="404 · error · loading"
+          lede="Full-page states, opened chrome-less as a visitor would meet them.">
+          <div className="hub-grid">
+            <div className="hub-card">
+              <span className="hid">SYS-404</span>
+              <h3>Not found</h3>
+              <p>Wordmark, mono echo of the requested path, Fraunces headline, one CTA home. Unknown routes in this prototype land here for real.</p>
+              <div className="hub-links"><a href="#/404">Open full page</a><a href="#/definitely/not/a/route">Trigger via bad route</a></div>
+            </div>
+            <div className="hub-card">
+              <span className="hid">SYS-ERR</span>
+              <h3>Something failed</h3>
+              <p>Fail-closed honesty: &ldquo;Nothing was recorded as successful.&rdquo; A logged reference, a retry, and a path to a person. Never a mascot.</p>
+              <div className="hub-links"><a href="#/error">Open full page</a></div>
+            </div>
+            <div className="hub-card">
+              <span className="hid">SYS-LOAD</span>
+              <h3>Loading interstitial</h3>
+              <p>Wordmark + hairline sweep + one mono line. The skeleton grammar below covers in-page loading; this covers whole-surface waits.</p>
+              <div className="hub-links"><a href="#/auth/loading">Open full page</a></div>
+            </div>
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="Degraded pattern" title="Offline / degraded banner"
+          lede="For data surfaces: sticks under the nav at --vt-z-banner, dashed rules carry the degraded semantics, freshness stamps keep telling the truth underneath. role=status, announced politely.">
+          <OfflineBanner inline onRetry={() => {}} />
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginTop: 20, flexWrap: 'wrap' }}>
+            <SecondaryButton onClick={() => setOffline(!offline)} aria-pressed={offline}>
+              {offline ? 'Unpin demo banner' : 'Pin banner under nav (demo)'}
+            </SecondaryButton>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--vt-text-muted)', letterSpacing: '0.05em' }}>
+              RULE · never a toast; never auto-dismiss; retry is manual
+            </span>
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="DG-12.2.4" title="Empty-state gallery"
+          lede="Honest and calm. Each names the surface, says why it's empty without apology or fake data, and offers ONE next action. Solid rule frames — dashed is reserved for degraded.">
+          <div className="empty-grid">
+            {EMPTIES.map((e) => (
+              <div key={e.ctx}>
+                <span className="empty-ctx">{e.ctx}</span>
+                <EmptyState glyph={e.glyph} title={e.title} why={e.why} action={e.action} secondary={e.secondary} />
+              </div>
+            ))}
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="Loading grammar" title="The empty · loading · error triad"
+          lede="Every data region ships all three, in the same footprint, so the page never jumps or flashes unstyled.">
+          <div className="hub-grid">
+            <div className="hub-card">
+              <span className="hid">Loading</span>
+              <div style={{ padding: '10px 0' }}><SkeletonStack /></div>
+              <p>Skeleton shimmer — the one allowed infinite animation, static under reduced motion. Skeletons mirror the real layout, never invent rows.</p>
+            </div>
+            <div className="hub-card">
+              <span className="hid">Empty</span>
+              <div style={{ padding: '10px 0' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-text-muted)' }}>
+                  <TrustGlyph state="pending" size={13} /> No sources checked yet.
+                </span>
+              </div>
+              <p>Inline form for tight regions; the full EmptyState card for primary regions. Same copy voice either way.</p>
+            </div>
+            <div className="hub-card">
+              <span className="hid">Error</span>
+              <div style={{ padding: '10px 0' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-state-p0)' }}>
+                  <TrustGlyph state="p0" size={13} /> Couldn&rsquo;t load. Nothing recorded. <QuietButton small>Retry</QuietButton>
+                </span>
+              </div>
+              <p>Region-level failure keeps the rest of the page alive. Copy never says &ldquo;oops&rdquo; and never claims partial success.</p>
+            </div>
+          </div>
+        </S5Section>
+      </S5Page>
+    </React.Fragment>
+  );
+};
+
+/* ================= legal (w1505-legal.jsx) ================= */
+
+interface LegalSection { id: string; h: string; body: React.ReactNode }
+interface LegalDoc { title: string; updated: string; version: string; sections: LegalSection[] }
+
+const LEGAL_DOCS: Record<string, LegalDoc> = {
+  privacy: {
+    title: 'Privacy notice',
+    updated: '2026-07-01', version: 'v1.2',
+    sections: [
+      { id: 'what-we-read', h: 'What we read', body: (
+        <React.Fragment>
+          <p>VitalCV reads public, primary sources about licensed clinicians — NPPES, state medical
+            board registries, the OIG exclusion list, and, where a clinician authorizes it, CMS PECOS.
+            Every read is initiated by a person: the clinician, or an anonymous visitor entering an NPI
+            on the preview plane.</p>
+          <p>We record what the source said, when we read it, and through which channel. That lineage
+            is visible on every surface that shows the data.</p>
+        </React.Fragment>
+      ) },
+      { id: 'what-we-store', h: 'What we store', body: (
+        <React.Fragment>
+          <p>For account holders: your snapshots, your Recognitions, your share links and their
+            revocations, and the audit trail of checks you ran. For anonymous previews: the check
+            result is cached briefly and is not tied to you.</p>
+          <div className="mono-note">NOT PHI · VitalCV stores no patient data, no clinical records,
+            no claims data. The record is about the clinician&rsquo;s credentials, never their patients.</div>
+        </React.Fragment>
+      ) },
+      { id: 'what-we-never-do', h: 'What we never do', body: (
+        <ul>
+          <li>We never sell your data, in any definition of &ldquo;sell&rdquo;.</li>
+          <li>We never show an employer anything you didn&rsquo;t explicitly share.</li>
+          <li>We never alter what a source said — contradictions are shown, not resolved silently.</li>
+          <li>We never use your record to train models or build advertising profiles.</li>
+        </ul>
+      ) },
+      { id: 'sharing', h: 'Sharing and revocation', body: (
+        <p>A share link exposes exactly the snapshot you chose, to whoever holds the link, until you
+          revoke it. Revocation is immediate and logged. Employers see a revoked page that says the
+          holder revoked access — nothing softer, nothing vaguer.</p>
+      ) },
+      { id: 'retention', h: 'Retention', body: (
+        <p>Snapshots are kept while your account exists. Delete your account and snapshots are purged
+          within 30 days; the fact that a Recognition once occurred remains in the counterparty&rsquo;s
+          records, as it does in any exchange of documents. Anonymous preview caches expire within
+          24 hours.</p>
+      ) },
+      { id: 'your-rights', h: 'Your rights', body: (
+        <p>Export everything, correct what&rsquo;s wrong at the source (we link you to the source&rsquo;s own
+          correction process — we can&rsquo;t edit their records), delete your account, or object to a
+          read. Write to <a href="#/contact">privacy@vitalcv.com</a> — a person answers within two
+          business days.</p>
+      ) },
+    ],
+  },
+  terms: {
+    title: 'Terms of service',
+    updated: '2026-07-01', version: 'v1.1',
+    sections: [
+      { id: 'the-service', h: 'The service', body: (
+        <p>VitalCV compiles source-backed evidence about clinician credentials into a passport the
+          clinician owns and shares. Free for clinicians. Employers use it to start — not finish —
+          their own review.</p>
+      ) },
+      { id: 'decision-boundary', h: 'The decision boundary', body: (
+        <React.Fragment>
+          <p>VitalCV output is a head start for employer review, not a credentialing decision.
+            It is not primary-source verification under NCQA or Joint Commission standards unless a
+            surface explicitly says so, and no surface currently does.</p>
+          <div className="mono-note">HARD RULE · Anything marked &ldquo;Not decision-grade&rdquo; or
+            &ldquo;Self-attested&rdquo; must not be the basis of an employment or privileging decision.</div>
+        </React.Fragment>
+      ) },
+      { id: 'acceptable-use', h: 'Acceptable use', body: (
+        <ul>
+          <li>Don&rsquo;t probe NPIs at scale — the preview plane is rate-limited and monitored.</li>
+          <li>Don&rsquo;t re-publish share pages or represent a snapshot as newer than its timestamp.</li>
+          <li>Don&rsquo;t attempt to use VitalCV data for patient-facing or marketing purposes.</li>
+        </ul>
+      ) },
+      { id: 'availability', h: 'Availability', body: (
+        // port: the wave1504 prototype status page → the real /status route
+        <p>Sources go down; when they do, we say so on the surface and on <a href="/status">/status</a>.
+          We target high availability but sell no SLA outside a signed pilot or enterprise agreement.</p>
+      ) },
+      { id: 'liability', h: 'Liability', body: (
+        <p>We stand behind the lineage: what we show is what the source said at the recorded time,
+          through the recorded channel. We are not liable for source errors themselves, for decisions
+          made against the stated boundary, or for indirect damages. Statutory rights remain.</p>
+      ) },
+      { id: 'changes', h: 'Changes', body: (
+        <p>Material changes are announced by email and on this page 30 days before they take effect.
+          The version stamp above changes every time this document does.</p>
+      ) },
+    ],
+  },
+  dpa: {
+    title: 'Data processing addendum',
+    updated: '2026-07-01', version: 'v1.0',
+    sections: [
+      { id: 'roles', h: 'Roles', body: (
+        <p>For employer pilot data (reviewer accounts, packet decisions), the employer is the
+          controller and VitalCV the processor. For clinician passports, VitalCV is the controller —
+          clinicians deal with us directly under the <a href="#/legal/privacy">privacy notice</a>.</p>
+      ) },
+      { id: 'scope', h: 'Scope of processing', body: (
+        <p>Processing is limited to compiling, storing, and presenting credential evidence and its
+          lineage. No PHI is processed under this addendum, and no BAA is offered because none is
+          needed: the record is about clinicians, not patients.</p>
+      ) },
+      { id: 'subprocessors', h: 'Subprocessors', body: (
+        <React.Fragment>
+          <p>Current subprocessors, each under a written agreement mirroring these terms:</p>
+          <table className="lg-table">
+            <thead><tr><th scope="col">Provider</th><th scope="col">Purpose</th><th scope="col">Region</th></tr></thead>
+            <tbody>
+              <tr><td className="mono">Railway</td><td>Application hosting</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Neon</td><td>Postgres database</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Clerk</td><td>Authentication</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Resend</td><td>Transactional email</td><td className="mono">US</td></tr>
+            </tbody>
+          </table>
+          <p>Changes are announced 30 days in advance; controllers may object in writing.</p>
+        </React.Fragment>
+      ) },
+      { id: 'security', h: 'Security measures', body: (
+        <ul>
+          <li>Encryption in transit and at rest; keys rotated on the published schedule (see key history on the trust register).</li>
+          <li>Access on least-privilege; production access logged and reviewed.</li>
+          <li>Signed artifacts: institutional receipts are verifiable against published keys.</li>
+        </ul>
+      ) },
+      { id: 'incidents', h: 'Incidents', body: (
+        <p>Confirmed incidents affecting controller data are notified without undue delay and within
+          72 hours, with what we know, what we don&rsquo;t, and what happens next — the same fail-closed
+          honesty the product uses.</p>
+      ) },
+      { id: 'deletion', h: 'Return and deletion', body: (
+        <p>On termination, controller data is exported on request and deleted within 30 days, with
+          written confirmation. Audit lineage that references the controller (e.g. Recognitions
+          issued to clinicians) survives as the clinician&rsquo;s record.</p>
+      ) },
+    ],
+  },
+  cookies: {
+    title: 'Cookie notice',
+    updated: '2026-07-01', version: 'v1.0',
+    sections: [
+      { id: 'stance', h: 'Our stance', body: (
+        <p>No advertising cookies, no cross-site tracking, no analytics that require a banner.
+          The short table below is the complete list — if it grows, this page changes first.</p>
+      ) },
+      { id: 'the-list', h: 'The complete list', body: (
+        <table className="lg-table">
+          <thead><tr><th scope="col">Cookie</th><th scope="col">Purpose</th><th scope="col">Lifetime</th></tr></thead>
+          <tbody>
+            <tr><td className="mono">__session</td><td>Clerk authentication — keeps you signed in.</td><td className="mono">7 days</td></tr>
+            <tr><td className="mono">__client_uat</td><td>Clerk session freshness check.</td><td className="mono">session</td></tr>
+            <tr><td className="mono">vcv_prefs</td><td>Interface preferences (e.g. dismissed banners).</td><td className="mono">6 months</td></tr>
+          </tbody>
+        </table>
+      ) },
+      { id: 'no-banner', h: 'Why there is no cookie banner', body: (
+        <p>Everything above is strictly necessary for a service you asked for, which is why you
+          don&rsquo;t see a consent banner. If we ever add a category that requires consent, the banner
+          will be designed to house rules — and this notice updated 30 days before.</p>
+      ) },
+      { id: 'controls', h: 'Your controls', body: (
+        <p>Clear cookies in your browser at any time; you&rsquo;ll be signed out and preferences reset.
+          Nothing about your passport or snapshots lives in cookies.</p>
+      ) },
+    ],
+  },
+};
+
+const LEGAL_ORDER = [
+  { key: 'privacy', label: 'Privacy' },
+  { key: 'terms', label: 'Terms' },
+  { key: 'dpa', label: 'DPA' },
+  { key: 'cookies', label: 'Cookies' },
+];
+
+export const LegalRoute = ({ doc }: { doc?: string }) => {
+  const key = doc && LEGAL_DOCS[doc] ? doc : 'privacy';
+  const d = LEGAL_DOCS[key];
+  return (
+    <div className="s5-fade" data-screen-label={`Legal · ${d.title}`}>
+      <div className="s5-container" style={{ paddingTop: 'var(--space-10)', paddingBottom: 'var(--space-4)' }}>
+        <span className="vt-eyebrow">DG-12.3 · Legal</span>
+        <nav className="lg-tabs" aria-label="Legal documents" style={{ marginTop: 12 }}>
+          {LEGAL_ORDER.map((t) => (
+            <a key={t.key} className="lg-tab" href={`#/legal/${t.key}`}
+              aria-current={key === t.key ? 'page' : undefined}>{t.label}</a>
+          ))}
+        </nav>
+        <div className="lg-layout">
+          <aside className="lg-toc" aria-label="On this page">
+            <span className="lg-toc-label">On this page</span>
+            {d.sections.map((s, i) => (
+              <a key={s.id} href={`#/legal/${key}`} onClick={(e) => {
+                e.preventDefault();
+                const el = document.getElementById(s.id);
+                if (el) { const y = el.getBoundingClientRect().top + window.pageYOffset - 72; window.scrollTo(0, y); }
+              }}>
+                <span className="n vt-num">{String(i + 1).padStart(2, '0')}</span>{s.h}
+              </a>
+            ))}
+          </aside>
+          <article>
+            <header className="lg-head">
+              <h1>{d.title}</h1>
+              <span className="lg-stamp vt-num">
+                <span>Last updated {d.updated}</span>
+                <span>{d.version}</span>
+                <span>vitalcv.com/legal/{key}</span>
+              </span>
+            </header>
+            <div className="lg-prose">
+              {d.sections.map((s, i) => (
+                <section key={s.id} id={s.id}>
+                  <h2><span className="n vt-num">{String(i + 1).padStart(2, '0')}</span><a className="anchor" href={`#/legal/${key}`} onClick={(e) => e.preventDefault()}>{s.h}</a></h2>
+                  {s.body}
+                </section>
+              ))}
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ================= contact (w1505-contact.jsx) ================= */
+
+const CONTACT_TOPICS = [
+  'Employer pilot inquiry',
+  'Review request',
+  'Data correction',
+  'Security disclosure',
+  'Press',
+  'Something else',
+];
+
+export const ContactRoute = () => {
+  const [v, setV] = React.useState({ name: '', email: '', org: '', topic: '', msg: '' });
+  const [errors, setErrors] = React.useState<Record<string, string | null>>({});
+  const [sent, setSent] = React.useState(false);
+  const refs = {
+    name: React.useRef<HTMLInputElement>(null),
+    email: React.useRef<HTMLInputElement>(null),
+    topic: React.useRef<HTMLSelectElement>(null),
+    msg: React.useRef<HTMLTextAreaElement>(null),
+  };
+  const labels = { name: 'Your name', email: 'Work email', topic: 'Topic', msg: 'Message' };
+  const set = (k: keyof typeof v) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+    setV({ ...v, [k]: e.target.value });
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs: Record<string, string | null> = {};
+    errs.name = validateRequired(v.name, 'Your name');
+    errs.email = validateWorkEmail(v.email);
+    errs.topic = v.topic ? null : 'Choose a topic so it reaches the right person.';
+    errs.msg = validateRequired(v.msg, 'Message');
+    Object.keys(errs).forEach((k) => { if (!errs[k]) delete errs[k]; });
+    setErrors(errs);
+    if (!Object.keys(errs).length) setSent(true);
+  };
+  return (
+    <S5Page eyebrow="DG-12.4.1 · Contact" title={<span>A person reads <span className="vt-accent-i">every</span> message.</span>}
+      lede="No chatbot, no ticket deflection. Say what you need; we route it to whoever can actually decide."
+      label="Contact">
+      <S5Section first>
+        <div className="ct-grid">
+          <div style={{ maxWidth: 560 }}>
+            {!sent ? (
+              <form className="fk-form" onSubmit={submit} noValidate>
+                <ErrorSummary errors={errors} order={['name', 'email', 'topic', 'msg']} labels={labels} refs={refs} />
+                <Field id="ct-name" label="Your name" required error={errors.name}>
+                  <TextInput ref={refs.name} id="ct-name" autoComplete="name" value={v.name} onChange={set('name')} error={errors.name} />
+                </Field>
+                <Field id="ct-email" label="Work email" required error={errors.email}
+                  hint="Personal email is fine for clinician topics.">
+                  <TextInput ref={refs.email} id="ct-email" type="email" autoComplete="email"
+                    placeholder="you@organization.org" value={v.email} onChange={set('email')} error={errors.email} />
+                </Field>
+                <Field id="ct-org" label="Organization" hint="Optional.">
+                  <TextInput id="ct-org" autoComplete="organization" value={v.org} onChange={set('org')} />
+                </Field>
+                <Field id="ct-topic" label="Topic" required error={errors.topic}>
+                  <select ref={refs.topic} id="ct-topic" className={`fk-input${errors.topic ? ' err' : ''}`}
+                    aria-invalid={!!errors.topic} aria-describedby={errors.topic ? 'ct-topic-err' : undefined}
+                    value={v.topic} onChange={set('topic')}>
+                    <option value="">Choose one</option>
+                    {CONTACT_TOPICS.map((t) => <option key={t} value={t}>{t}</option>)}
+                  </select>
+                </Field>
+                <Field id="ct-msg" label="Message" required error={errors.msg}
+                  hint="Please don't include patient information — this form isn't for PHI, and we'd have to delete it.">
+                  <TextArea ref={refs.msg} id="ct-msg" rows={6} value={v.msg} onChange={set('msg')} error={errors.msg} />
+                </Field>
+                <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <PrimaryButton size="lg" type="submit">Send message</PrimaryButton>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.05em', color: 'var(--vt-text-muted)' }}>
+                    Reviewed within two business days
+                  </span>
+                </div>
+              </form>
+            ) : (
+              /* port: the prototype fabricated a message receipt; this surface
+                 transmits nothing, so the success state says so plainly. */
+              <div className="fk-success" role="status">
+                <StateChip state="notDecisionGrade" label="Not transmitted" />
+                <h3>Designed success state.</h3>
+                <span className="receipt vt-num">prototype demo · nothing was sent</span>
+                <p>In product, the message is recorded with a reference id, lands in front of a person
+                  — not a queue-bot — and gets an answer at <strong style={{ fontWeight: 600 }}>{v.email || 'your email'}</strong> within
+                  two business days. Security disclosures are triaged the same day.</p>
+                <QuietButton onClick={() => { setSent(false); setV({ name: '', email: '', org: '', topic: '', msg: '' }); }}>
+                  Reset the demo form
+                </QuietButton>
+              </div>
+            )}
+          </div>
+          <aside className="ct-aside" aria-label="What to expect">
+            <div className="ct-expect">
+              <span className="vt-eyebrow">What to expect</span>
+              <div className="row"><TrustGlyph state="reviewRequired" size={14} />
+                <p><strong>Reviewed within two business days.</strong> Every message, by a person with authority to act on it.</p></div>
+              <div className="row"><TrustGlyph state="stale" size={14} />
+                <p><strong>Security disclosures</strong> are triaged same-day. Use the topic above and include the run reference if you have one.</p></div>
+              <div className="row"><TrustGlyph state="notDecisionGrade" size={14} />
+                <p><strong>Data corrections</strong> usually belong at the source. We&rsquo;ll tell you which registry to correct and re-read it once you have.</p></div>
+            </div>
+            <div className="ct-expect">
+              <span className="vt-eyebrow">Prefer email</span>
+              <div className="row"><TrustGlyph state="previewOnly" size={14} />
+                <p><span className="vt-num" style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>hello@vitalcv.com</span><br />
+                Same inbox, same two-day promise.</p></div>
+            </div>
+          </aside>
+        </div>
+      </S5Section>
+    </S5Page>
+  );
+};
+
+/* ================= pricing (w1505-pricing.jsx) ================= */
+
+const PIncRow = ({ inc, children }: { inc?: boolean; children: React.ReactNode }) => (
+  <div className={`pr-row ${inc ? 'inc' : 'exc'}`}>
+    <TrustGlyph state={inc ? 'checked' : 'unavailable'} size={13} />
+    <span>{children}</span>
+  </div>
+);
+
+export const PricingRoute = () => (
+  <S5Page eyebrow="DG-13.3 · Pricing" title={<span>Plain terms, <span className="vt-accent-i">stated</span> — not teased.</span>}
+    lede="Three ways to use VitalCV. The only numbers on this page are labeled for exactly what they are."
+    label="Pricing">
+    <S5Section first>
+      <div className="pr-grid">
+        <div className="pr-card" data-comment-anchor="pricing-clinicians">
+          <span className="pr-aud">Clinicians</span>
+          <div className="pr-price">
+            <span className="amt vt-num">$0</span>
+            <span className="per">FREE · ALWAYS · NO CARD</span>
+          </div>
+          <p className="pr-desc">Your credentials are your record. Charging you to hold it would be a
+            conflict of interest we don&rsquo;t want.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Passport with source-backed checks and lineage</PIncRow>
+            <PIncRow inc>Share links with instant revocation</PIncRow>
+            <PIncRow inc>Recognitions from accepting employers</PIncRow>
+            <PIncRow inc>Refresh on stale sources, anytime</PIncRow>
+          </div>
+          {/* port: prototype linked the wave1503 get-ready page → real /get-ready */}
+          <div className="pr-cta"><SecondaryButton size="lg" onClick={() => { window.location.href = '/get-ready'; }}>Check your readiness</SecondaryButton></div>
+        </div>
+
+        <div className="pr-card lead" data-comment-anchor="pricing-pilot">
+          <span className="pr-aud">Employer pilot</span>
+          <div className="pr-price">
+            <span className="amt vt-num">$1,500<span style={{ fontSize: 18, fontWeight: 480 }}>/mo</span></span>
+            <span className="per">PER FACILITY · 90-DAY PILOT</span>
+          </div>
+          <HonestyLabel>Illustrative figure — actual pilot pricing is set in the signed pilot scope, not on this page.</HonestyLabel>
+          <p className="pr-desc">A bounded pilot with written scope: which lanes, which sources, what
+            &ldquo;accepted as head start&rdquo; means on your side.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Reviewer surface for your credentialing team</PIncRow>
+            <PIncRow inc>Packet requests + Recognition issuing</PIncRow>
+            <PIncRow inc>Named contact, two-business-day answers</PIncRow>
+            <PIncRow>No primary-source verification service — your review stays yours</PIncRow>
+          </div>
+          <div className="pr-cta"><PrimaryButton size="lg" onClick={() => { window.location.hash = '#/contact'; }}>Start a pilot conversation</PrimaryButton></div>
+        </div>
+
+        <div className="pr-card" data-comment-anchor="pricing-network">
+          <span className="pr-aud">Networks &amp; systems</span>
+          <div className="pr-price">
+            <span className="amt">In the agreement</span>
+            <span className="per">MULTI-FACILITY · SIGNED SCOPE</span>
+          </div>
+          <p className="pr-desc">Priced per signed scope — facilities, lanes, integration depth. If we
+            can&rsquo;t state it plainly in the agreement, we don&rsquo;t sell it.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Everything in the pilot, across facilities</PIncRow>
+            <PIncRow inc>DPA + subprocessor commitments (<a href="#/legal/dpa">read it first</a>)</PIncRow>
+            <PIncRow inc>Uptime terms in writing</PIncRow>
+            <PIncRow>No exclusivity — clinicians stay free either way</PIncRow>
+          </div>
+          <div className="pr-cta"><SecondaryButton size="lg" onClick={() => { window.location.hash = '#/contact'; }}>Talk to us</SecondaryButton></div>
+        </div>
+      </div>
+    </S5Section>
+
+    <S5Section eyebrow="Doctrine" title="What this page will never claim">
+      <div className="s5-twocol">
+        <div className="pr-never">
+          <span className="vt-eyebrow">Prohibited on /pricing — lint-enforced</span>
+          <ul>
+            <li><TrustGlyph state="p0" size={12} />No invented customer counts or &ldquo;trusted by 500+ organizations&rdquo;.</li>
+            <li><TrustGlyph state="p0" size={12} />No &ldquo;as seen in&rdquo; strips, no logos we didn&rsquo;t earn in writing.</li>
+            <li><TrustGlyph state="p0" size={12} />No ROI guarantees, payback math, or &ldquo;cheapest&rdquo; claims.</li>
+            <li><TrustGlyph state="p0" size={12} />No unlabeled illustrative metrics — every example number carries the HonestyLabel.</li>
+            <li><TrustGlyph state="p0" size={12} />No countdown timers, seat scarcity, or launch-pricing pressure.</li>
+          </ul>
+        </div>
+        <div className="pr-faq">
+          <h3 style={{ fontSize: 16, marginBottom: 6 }}>Asked plainly, answered plainly</h3>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Why is the pilot number &ldquo;illustrative&rdquo;?</summary>
+            <p>Because real pilot pricing depends on facilities and lanes, and pretending otherwise
+              would make the page dishonest. The number shows the shape of the cost; the signed scope
+              carries the real one.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Will clinicians ever be charged?</summary>
+            <p>No. If that ever changed it would be announced 90 days ahead, and existing passports
+              would stay free. The business is employer-side, on purpose.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Is there a discount for annual commitment?</summary>
+            <p>Sometimes, in the agreement, where it can be stated exactly. We don&rsquo;t advertise
+              percentages we&rsquo;d have to caveat.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>What happens when the pilot ends?</summary>
+            <p>It ends. Data is exported or deleted per the DPA, Recognitions already issued remain
+              with the clinicians who earned them, and renewal is a new signed scope — never an
+              auto-rollover.</p>
+          </details>
+        </div>
+      </div>
+    </S5Section>
+  </S5Page>
+);

--- a/apps/web/components/design-wave1505/views-governance.tsx
+++ b/apps/web/components/design-wave1505/views-governance.tsx
@@ -1,0 +1,512 @@
+'use client';
+
+/**
+ * Wave 1505 port — governance routes: responsive/a11y audit checklist
+ * (DG-14/15), the /dev/design living style guide (DG-18.2), and the
+ * visual-regression + design-lint specs (DG-18.3/18.4). Ported from
+ * wave1505/w1505-{audit,devdesign,governance}.jsx.
+ *
+ * Port adaptation: the prototype stamped audit rows with a bare Verified
+ * status label; the repo truth contract bans that word as a status label,
+ * so rows read Re-checked (same claim: the fix was re-run and held).
+ */
+
+import * as React from 'react';
+import {
+  CopyBtn, DestructiveButton, Field, HonestyLabel, HonestyPanel, NpiInput, PrimaryButton,
+  ProofTierBadge, QuietButton, ReadinessRing, RecognitionRow, SecondaryButton, SourceRow,
+  STATE_META, StateChip, TIER_DEFS, TextInput, TokenRow, TrustGlyph,
+} from './kit';
+import { EmptyState, S5Page, S5Section, SkeletonStack } from './shared';
+
+/* ================= audit (w1505-audit.jsx) ================= */
+
+interface AuditRow { id: string; surf: string; vp: string; find: string; fix: React.ReactNode }
+interface AuditGroup { name: string; dg: string; method: string; rows: AuditRow[] }
+
+const AUDIT_GROUPS: AuditGroup[] = [
+  {
+    name: 'Responsive integrity', dg: 'DG-14.1 · 14.3', method: 'VIEWPORTS 360 / 375 / 414 / 768 / 1024 / 1440 / 1920',
+    rows: [
+      { id: 'RES-01', surf: '1501 /', vp: '360px', find: 'Hero NPI input + inline button forced horizontal scroll below 375px.', fix: <span>Stacked the submit button under the input at ≤400px; input row wraps via <code>flex-wrap</code>. No horizontal scroll at 360.</span> },
+      { id: 'RES-02', surf: '1503 /passport', vp: '360–414px', find: 'EvidenceRow chip cluster (tier + state + action) overflowed on long source names.', fix: <span><code>.ev3-cluster</code> wraps and right-aligns; source line gains <code>overflow-wrap:anywhere</code>. Re-checked at all three phone widths.</span> },
+      { id: 'RES-03', surf: '1504 /trust', vp: '768px', find: 'SlotGrid held 3 columns too long — RUN_ID truncated at tablet width.', fix: <span>Breakpoint moved 860→920px for 2-col; cells already had <code>minmax(0,1fr)</code>. No truncation at 768.</span> },
+      { id: 'RES-04', surf: '1502 /review/rev-2841', vp: '1920px', find: 'Reviewer table stretched full-bleed past readable measure.', fix: <span>Container discipline applied: <code>max-width: var(--container-max)</code> everywhere; wide tables get internal <code>overflow-x:auto</code> instead of page scroll.</span> },
+      { id: 'RES-05', surf: 'All waves', vp: '360px', find: 'Three copy buttons and quiet actions measured under 44px hit area.', fix: <span><code>@media (pointer:coarse)</code> raises <code>.cp-btn</code> / <code>QuietButton</code> padding to a ≥44px target without changing desktop density.</span> },
+      { id: 'RES-06', surf: '1505 feedback widget', vp: '360px', find: 'Risk flagged in brief: floating affordance overlapping CTAs.', fix: <span>Widget is a right-edge tab at 50% viewport height — geometrically cannot overlap bottom or inline CTAs; z from <code>--vt-z-widget</code>.</span> },
+    ],
+  },
+  {
+    name: 'Keyboard & focus', dg: 'DG-15.1 · 15.2', method: 'FULL TAB-THROUGH · NO POINTER',
+    rows: [
+      { id: 'KEY-01', surf: '1502 forms', vp: 'keyboard', find: 'ErrorSummary links moved focus but summary itself was skipped by SR order.', fix: <span><code>role=&quot;alert&quot;</code> on summary; buttons focus the offending field. Tab order re-checked: summary → fields in DOM order.</span> },
+      { id: 'KEY-02', surf: '1502 /review reviewer actions', vp: 'keyboard', find: 'Accept / return / escalate reachable but activation state unclear.', fix: <span>All reviewer actions are real <code>&lt;button&gt;</code>s with <code>aria-pressed</code> where toggling; uniform <code>--vt-focus-ring</code> confirmed on every stop.</span> },
+      { id: 'KEY-03', surf: 'All waves', vp: 'keyboard', find: 'No skip link — nav tab-through cost 9+ stops before content.', fix: <span><code>.skip-link</code> added to every shell (see this wave&rsquo;s nav); lands on <code>#main</code>. First Tab press reveals it.</span> },
+      { id: 'KEY-04', surf: '1503 share page', vp: 'keyboard', find: 'Revoked-state page trapped focus in a dead CTA.', fix: 'Revoked page CTA now links home; no focus traps anywhere — Escape closes the 1505 feedback panel and returns focus to its tab.' },
+      { id: 'KEY-05', surf: '1505 verify code', vp: 'keyboard', find: 'New surface — code cells could have been 6 separate inputs (hostile to paste + SR).', fix: <span>One real input drives six presentation cells (<code>aria-hidden</code>); paste works; count announced via <code>aria-live=&quot;polite&quot;</code>.</span> },
+    ],
+  },
+  {
+    name: 'State never by color alone', dg: 'DG-15.3', method: 'GRAYSCALE SCREENSHOT PASS',
+    rows: [
+      { id: 'CLR-01', surf: 'All StateChips', vp: 'grayscale', find: 'Audit confirmation: every chip pairs glyph + label by construction.', fix: <span>Confirmed in grayscale: checked/stale/gated/p0 remain distinguishable by glyph shape (check / clock / lock / triangle). No fix needed — gate holds.</span> },
+      { id: 'CLR-02', surf: '1503 readiness bands', vp: 'grayscale', find: 'Ring band color was the only band signal at small sizes.', fix: <span>Band label (&ldquo;Ready band&rdquo; / &ldquo;Head-start band&rdquo; / &ldquo;Early band&rdquo;) rendered beside every ring ≥64px and in the meter label below it.</span> },
+      { id: 'CLR-03', surf: '1504 /status spine', vp: 'grayscale', find: 'Degraded vs stale rows differed mainly by hue.', fix: <span>Degraded rows carry the dashed rule + slash glyph; stale carries clock + solid rule. Distinct in grayscale.</span> },
+      { id: 'CLR-04', surf: '1502 HonestyPanel', vp: 'grayscale', find: 'ok/watch top borders identical weight in grayscale.', fix: 'Panels already lead with glyph + mono title; border is redundant encoding. Confirmed legible; no change.' },
+    ],
+  },
+  {
+    name: 'Screen-reader semantics', dg: 'DG-15.4 · 15.5', method: 'VOICEOVER + NVDA SPOT PASS',
+    rows: [
+      { id: 'SR-01', surf: 'ReadinessRing', vp: 'SR', find: 'Ring announced as bare image in early wave.', fix: <span><code>role=&quot;meter&quot;</code> + <code>aria-valuenow/min/max</code> + label &ldquo;Readiness: 72 percent&rdquo; — already in the 1500 primitive; re-checked as re-used everywhere, no local forks.</span> },
+      { id: 'SR-02', surf: 'SourceRow groups', vp: 'SR', find: 'Evidence lists read as anonymous divs.', fix: <span>Groups render as described lists: <code>&lt;dl&gt;</code> per section with source + freshness in <code>&lt;dd&gt;</code>; group name announced once, not per row.</span> },
+      { id: 'SR-03', surf: '1504 verifier constellation', vp: 'SR', find: 'Graph was silent to SR users.', fix: <span>Text alternative added: visually-hidden summary (&ldquo;12 verifiers, 3 institutional, most recent check 2h ago&rdquo;) + the same data in the adjacent table — graph marked <code>aria-hidden</code>.</span> },
+      { id: 'SR-04', surf: 'All forms', vp: 'SR', find: 'Field errors visible but not announced on submit.', fix: <span>Errors render inside <code>role=&quot;alert&quot;</code> summary; field-level <code>aria-invalid</code> + <code>aria-describedby</code> wired in form-kit (1502) and inherited here.</span> },
+      { id: 'SR-05', surf: 'NPI + code inputs', vp: 'SR', find: 'Digit progress was visual only.', fix: <span><code>aria-live=&quot;polite&quot;</code> count (&ldquo;4/10&rdquo;) on NPI (1501/1502) and the 1505 verification code. Announced on every digit.</span> },
+    ],
+  },
+  {
+    name: 'Reduced motion end-to-end', dg: 'DG-15.6 · DG-5.2', method: 'OS TOGGLE · EVERY SURFACE',
+    rows: [
+      { id: 'MOT-01', surf: 'All waves', vp: 'reduced-motion', find: 'Audit sweep of every @keyframes against the doctrine.', fix: <span>All entrances/sweeps sit inside <code>@media (prefers-reduced-motion: no-preference)</code>; with OS toggle on, every surface renders static except opacity fades. Two stray transform transitions (1501 hero, 1504 graph hover) moved inside the media query.</span> },
+      { id: 'MOT-02', surf: 'Skeleton + status pulse', vp: 'reduced-motion', find: 'The two allowed infinite loops needed static fallbacks.', fix: 'Shimmer and /status live pulse render as static sunken bars / solid dot under reduced motion. Re-checked.' },
+      { id: 'MOT-03', surf: '1503 ring sweep', vp: 'reduced-motion', find: 'Ring animated its dasharray on load regardless of preference.', fix: <span>Sweep transition gated by the media query; reduced motion shows the final value immediately. Meter value unaffected.</span> },
+    ],
+  },
+];
+
+export const AuditRoute = () => {
+  const total = AUDIT_GROUPS.reduce((n, g) => n + g.rows.length, 0);
+  return (
+    <S5Page eyebrow="DG-14 · DG-15 · Quality gates" title={<span>Findings, fixes, <span className="vt-accent-i">re-checked.</span></span>}
+      lede="Every surface from waves 1501–1504 swept at seven viewports, by keyboard, in grayscale, with a screen reader, and with reduced motion on. Each finding names its fix; each fix was re-checked before this page shipped."
+      label="Audit checklist">
+      <S5Section first>
+        <div className="au-sum">
+          <div className="au-sum-cell"><span className="k">Surfaces audited</span><span className="v vt-num">14</span><span className="s">waves 1501–1504 + this wave</span></div>
+          <div className="au-sum-cell"><span className="k">Viewports</span><span className="v vt-num">7</span><span className="s">360 → 1920</span></div>
+          <div className="au-sum-cell"><span className="k">Findings</span><span className="v vt-num">{total}</span><span className="s">incl. confirmations</span></div>
+          <div className="au-sum-cell"><span className="k">Open</span><span className="v vt-num">0</span><span className="s">all fixed &amp; re-checked</span></div>
+        </div>
+        {AUDIT_GROUPS.map((g) => (
+          <div className="au-group" key={g.name}>
+            <div className="au-group-head">
+              <h3>{g.name}</h3>
+              <span className="dg vt-num">{g.dg}</span>
+              <span className="method">{g.method}</span>
+            </div>
+            {g.rows.map((r) => (
+              <div className="au-row" key={r.id}>
+                <span className="aid vt-num">{r.id}</span>
+                <span className="asurf">{r.surf}<span className="vp vt-num">{r.vp}</span></span>
+                <span className="afind">{r.find}</span>
+                <span className="afix">{r.fix}</span>
+                <StateChip state="checked" size="sm" label="Re-checked" />
+              </div>
+            ))}
+          </div>
+        ))}
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 10.5, lineHeight: 1.7, letterSpacing: '0.04em', color: 'var(--vt-text-secondary)', maxWidth: '88ch' }}>
+          RE-RUN RULE · This checklist re-runs whenever a surface changes structure. The visual-regression matrix
+          (<a href="#/governance">governance</a>) catches drift between runs; this sweep catches what screenshots can&rsquo;t — focus order, announcements, motion preference.
+        </p>
+      </S5Section>
+    </S5Page>
+  );
+};
+
+/* ================= /dev/design (w1505-devdesign.jsx) ================= */
+
+const DD_SECTIONS: Array<[string, string]> = [
+  ['palette', 'Palette'], ['type', 'Type ramp'], ['space', 'Spacing'], ['glyphs', 'Glyphs'],
+  ['chips', 'StateChip ×9(+2)'], ['tiers', 'Tier badges'], ['buttons', 'Buttons'], ['forms', 'Forms'],
+  ['rows', 'Evidence rows'], ['ring', 'ReadinessRing'], ['honesty', 'Honesty kit'], ['recognition', 'Recognition'],
+  ['triad', 'Empty/Loading/Error'], ['motion', 'Motion'], ['z', 'Z-scale'],
+];
+
+const DDBand = ({ id, title, dg, rule, children, first }: {
+  id: string; title: string; dg?: string; rule?: string; children?: React.ReactNode; first?: boolean;
+}) => (
+  <section id={`dd-${id}`} className={`dd-band${first ? ' first' : ''}`}>
+    <div className="dd-band-head">
+      <h2>{title}</h2>
+      {dg ? <span className="dg vt-num">{dg}</span> : null}
+    </div>
+    {rule ? <p className="dd-rule">{rule}</p> : null}
+    {children}
+  </section>
+);
+
+const DD_PALETTE = [
+  { t: '--vt-surface-page', h: '#f4f2ec', c: 'var(--vt-surface-page)', b: true },
+  { t: '--vt-surface-card', h: '#ffffff', c: 'var(--vt-surface-card)', b: true },
+  { t: '--vt-surface-sunken', h: '#efede7', c: 'var(--vt-surface-sunken)', b: true },
+  { t: '--vt-text', h: '#141414', c: 'var(--vt-text)' },
+  { t: '--vt-text-secondary', h: '#474540', c: 'var(--vt-text-secondary)' },
+  { t: '--vt-text-muted', h: '#6b6860', c: 'var(--vt-text-muted)' },
+  { t: '--vt-rule', h: '#dddbd3', c: 'var(--vt-rule)', b: true },
+  { t: '--vt-brand', h: '#2c3e2d', c: 'var(--vt-brand)' },
+  { t: '--vt-brand-soft', h: '#f0f4ef', c: 'var(--vt-brand-soft)', b: true },
+  { t: '--vt-accent-editorial', h: '#4f46e5', c: 'var(--vt-accent-editorial)' },
+  { t: '--vt-state-checked', h: '#1c5c38', c: 'var(--vt-state-checked)' },
+  { t: '--vt-state-stale', h: '#7d5a1e', c: 'var(--vt-state-stale)' },
+  { t: '--vt-state-p0', h: '#7a1414', c: 'var(--vt-state-p0)' },
+  { t: '--vt-state-preview', h: '#1a3e6b', c: 'var(--vt-state-preview)' },
+  { t: '--vt-state-contradicted', h: '#5b2a86', c: 'var(--vt-state-contradicted)' },
+];
+
+const DD_TYPE: Array<{ m: string; style: React.CSSProperties; s: string }> = [
+  { m: 'display · Fraunces 560', style: { fontFamily: 'var(--font-display)', fontWeight: 560, fontSize: 'var(--text-3xl)', letterSpacing: '-0.015em', lineHeight: 1.1 }, s: 'Readiness is a record.' },
+  { m: 'h2 · Fraunces 560 · 24', style: { fontFamily: 'var(--font-display)', fontWeight: 560, fontSize: 'var(--text-xl)', letterSpacing: '-0.015em' }, s: 'Sources, stated plainly' },
+  { m: 'italic accent · indigo', style: { fontFamily: 'var(--font-display)', fontStyle: 'italic', fontWeight: 480, fontSize: 'var(--text-xl)', color: 'var(--vt-accent-editorial)' }, s: 'checked, not claimed' },
+  { m: 'body · Geist 400 · 14/1.6', style: { fontSize: 14, lineHeight: 1.6 }, s: 'Body copy runs at fourteen over one-point-six, ink on paper, never lighter than --vt-text-secondary.' },
+  { m: 'caption · Geist 400 · 12.5', style: { fontSize: 12.5, color: 'var(--vt-text-secondary)' }, s: 'Support copy passes 4.5:1 on paper.' },
+  { m: 'eyebrow · Mono 500 · 10 caps', style: { fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--vt-text-faint)', fontWeight: 500 }, s: 'Section eyebrow' },
+  { m: 'data · Mono · tabular', style: { fontFamily: 'var(--font-mono)', fontSize: 12.5, fontVariantNumeric: 'tabular-nums' }, s: 'npi:1234567893 · run_2026-07-11_0642Z · 06:42Z' },
+];
+
+export const DevDesignRoute = () => {
+  const [motionKey, setMotionKey] = React.useState(0);
+  const [npi, setNpi] = React.useState('123456');
+  return (
+    <S5Page eyebrow="DG-18.2 · /dev/design" title={<span>The system, <span className="vt-accent-i">rendered.</span></span>}
+      lede="Every primitive in every state, with its usage rule. This page is the arbiter: if a surface disagrees with /dev/design, the surface is wrong."
+      label="/dev/design style guide">
+      <div className="s5-container">
+        <nav className="dd-jump" aria-label="Sections">
+          {DD_SECTIONS.map(([id, l]) => (
+            <a key={id} href="#/dev/design" onClick={(e) => {
+              e.preventDefault();
+              const el = document.getElementById(`dd-${id}`);
+              if (el) window.scrollTo(0, el.getBoundingClientRect().top + window.pageYOffset - 60);
+            }}>{l}</a>
+          ))}
+        </nav>
+
+        <DDBand first id="palette" title="Palette" dg="DG-1.1"
+          rule="Tokens only — raw hex is lint-illegal outside wave1500 theme files. Matcha is reserved for Recognition moments and primary-button hover. Indigo exists solely for the italic display phrase, ≤1 per section.">
+          <div className="dd-swatches">
+            {DD_PALETTE.map((s) => (
+              <div className="dd-swatch" key={s.t}>
+                <div className="chip" style={{ background: s.c, borderBottom: s.b ? '1px solid var(--vt-rule-soft)' : 'none' }}></div>
+                <div className="meta"><span className="t">{s.t}</span><span className="h vt-num">{s.h}</span></div>
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="type" title="Type ramp" dg="DG-2.1"
+          rule="Three faces, no more: Fraunces (display, optical sizing on), Geist (body), Geist Mono (eyebrows, identifiers, timestamps — always tabular-nums for metrics).">
+          {DD_TYPE.map((r) => (
+            <div className="dd-type-row" key={r.m}>
+              <span className="m">{r.m}</span>
+              <span style={r.style} className={r.m.includes('tabular') ? 'vt-num' : undefined}>{r.s}</span>
+            </div>
+          ))}
+        </DDBand>
+
+        <DDBand id="space" title="Spacing scale" dg="DG-1.5"
+          rule="4px base. Section padding uses space-10/12/16; card padding space-4/5/6; never literal pixel margins between siblings — flex/grid gap only.">
+          {([['--space-2', 8], ['--space-4', 16], ['--space-6', 24], ['--space-8', 32], ['--space-12', 48], ['--space-16', 64], ['--space-24', 96]] as Array<[string, number]>).map(([t, w]) => (
+            <div className="dd-space-row" key={t}>
+              <span className="m vt-num">{t} · {w}px</span>
+              <span className="bar" style={{ width: w * 3 }}></span>
+            </div>
+          ))}
+        </DDBand>
+
+        <DDBand id="glyphs" title="TrustGlyph set" dg="DG-4.2"
+          rule="Monochrome, currentColor, stroke 1.5, legible at 14px. Glyph + label are always paired — a glyph alone is lint-illegal in chips. Grayscale legibility is the acceptance test.">
+          <div className="dd-glyph-grid">
+            {Object.keys(STATE_META).map((k) => (
+              <div className="dd-glyph-cell" key={k}>
+                <span className="g"><TrustGlyph state={k} size={20} /></span>
+                <span className="n">{k}</span>
+              </div>
+            ))}
+            {['T1', 'T2', 'T3', 'T4'].map((t) => (
+              <div className="dd-glyph-cell" key={t}>
+                <span className="g"><TrustGlyph state={t} size={20} /></span>
+                <span className="n">{t} · fill {['¼', '½', '¾', 'full'][['T1', 'T2', 'T3', 'T4'].indexOf(t)]}</span>
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="chips" title="StateChip — 9 coverage states + 2 review states" dg="DG-3.2 · 6.1"
+          rule="The atomic visual unit. Dashed border = pending/previewOnly only. Tooltip carries source + freshness + definition. Never restyle locally; never a checkmark on gated/unavailable.">
+          <div className="dd-grid">
+            {Object.keys(STATE_META).map((s) => (
+              <div className="dd-spec" key={s}>
+                <span className="lab">{s}</span>
+                <StateChip state={s} />
+                <StateChip state={s} size="sm" />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="tiers" title="ProofTierBadge" dg="DG-6.6"
+          rule="T1 self-attested → T4 signed institutional artifact. The fill fraction is the grayscale signal; the tooltip is the definition. Tier never substitutes for state.">
+          <div className="dd-grid">
+            {['T1', 'T2', 'T3', 'T4'].map((t) => (
+              <div className="dd-spec" key={t}>
+                <span className="lab">{t} · {TIER_DEFS[t].split('.')[0]}</span>
+                <ProofTierBadge tier={t} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="buttons" title="Buttons" dg="DG-6.3"
+          rule="Primary = ink fill, matcha-900 hover — never matcha at rest. Secondary = rule outline. Quiet = underline-on-hover. Destructive = p0 outline, reserved for revocation. All ≥44px targets at coarse pointers.">
+          <div className="dd-grid">
+            <div className="dd-spec"><span className="lab">primary · rest / disabled / loading</span>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                <PrimaryButton>Check readiness</PrimaryButton>
+                <PrimaryButton disabled>Check readiness</PrimaryButton>
+                <PrimaryButton loading>Checking</PrimaryButton>
+              </div>
+            </div>
+            <div className="dd-spec"><span className="lab">secondary / quiet / destructive</span>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                <SecondaryButton>View lineage</SecondaryButton>
+                <QuietButton>Refresh source</QuietButton>
+                <DestructiveButton>Revoke link</DestructiveButton>
+              </div>
+            </div>
+            <div className="dd-spec"><span className="lab">focus ring — uniform everywhere</span>
+              <button className="ck-primary" style={{ width: 'auto', padding: '0 20px', boxShadow: 'var(--vt-focus-ring)' }}>Focused state</button>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="forms" title="Form kit" dg="DG-6.7 · 8.2"
+          rule="46px inputs, rule-strong borders, radius-1. Errors are mono + glyph + aria-live, never color alone. The NPI field announces its digit count. Every form ships a designed error summary and success state.">
+          <div className="s5-twocol">
+            <div className="dd-spec" style={{ gap: 16 }}>
+              <span className="lab">field · default / hint / error</span>
+              <Field id="dd-f1" label="Work email" hint="We answer within two business days.">
+                <TextInput id="dd-f1" placeholder="you@organization.org" />
+              </Field>
+              <Field id="dd-f2" label="Work email" required error="Enter a work email — personal domains are fine for clinicians.">
+                <TextInput id="dd-f2" defaultValue="adaeze@" error="err" />
+              </Field>
+              <div className="fk-field">
+                <label className="fk-label" htmlFor="dd-npi">NPI · live count</label>
+                <NpiInput value={npi} onChange={setNpi} />
+              </div>
+            </div>
+            <div className="dd-spec" style={{ gap: 16 }}>
+              <span className="lab">error summary + success</span>
+              <div className="fk-summary" role="presentation">
+                <span className="t"><TrustGlyph state="p0" size={12} /> 2 fields need attention</span>
+                <ul>
+                  <li><button type="button">Work email — required.</button></li>
+                  <li><button type="button">Topic — choose one.</button></li>
+                </ul>
+              </div>
+              <div className="fk-success" style={{ padding: 'var(--space-5)' }} role="presentation">
+                <StateChip state="checked" label="Recorded" />
+                <h3 style={{ fontSize: 18 }}>Request recorded.</h3>
+                <span className="receipt vt-num">req_2026-07-12_31bd</span>
+              </div>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="rows" title="Evidence rows" dg="DG-6.4 · 10.2"
+          rule="Label / mono source / chip / freshness / action — same metrics everywhere. Blockers sort first and carry the p0 chip; gated stays gated until authorized, never assumed.">
+          <div style={{ maxWidth: 640 }}>
+            <SourceRow label="NPPES record" source="NPPES" state="checked" freshness="2h ago" iso="2026-07-11T12:04:00Z" />
+            <SourceRow label="Exclusion list" source="OIG LEIE" state="stale" freshness="34d ago" iso="2026-06-08T09:00:00Z" action="Refresh" />
+            <SourceRow label="Medicare enrollment" source="CMS PECOS" state="gated" action="Authorize read" />
+            <SourceRow label="Texas license" source="TEXAS MEDICAL BOARD" state="p0" chipLabel="Blocker" freshness="21d ago" iso="2026-06-20T09:00:00Z" action="Resolve" />
+          </div>
+        </DDBand>
+
+        <DDBand id="ring" title="ReadinessRing" dg="DG-6.5"
+          rule='role="meter" with aria values; band by threshold (≥80 ready · ≥50 head start · else early); band is also written as text — never color alone. Sweeps once; static under reduced motion.'>
+          <div className="dd-grid">
+            {([[0, 'Early band'], [45, 'Early band'], [72, 'Head-start band'], [88, 'Ready band']] as Array<[number, string]>).map(([v, b]) => (
+              <div className="dd-spec" key={v} style={{ alignItems: 'center' }}>
+                <span className="lab vt-num">{v}% · {b}</span>
+                <ReadinessRing value={v} size={92} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="honesty" title="Honesty kit" dg="DG-8.4 · 17.2"
+          rule="HonestyLabel is designed UI, never fine print — mandatory on every illustrative number. HonestyPanel pairs 'what you get' with 'what stays outside' at equal visual weight.">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <HonestyLabel>Illustrative figure — the signed scope carries the real one.</HonestyLabel>
+            <div className="hn-pair" style={{ maxWidth: 760 }}>
+              <HonestyPanel tone="ok" title="Checked today" items={[
+                { label: 'NPPES record', source: 'NPPES', state: 'checked' },
+                { label: 'California license', source: 'MBC', state: 'checked' },
+              ]} />
+              <HonestyPanel tone="watch" title="Stays outside" items={[
+                { label: 'Medicare enrollment', source: 'CMS PECOS', state: 'gated', chipLabel: 'Gated' },
+                { label: 'Employment history', source: 'SELF-ATTESTED', state: 'notDecisionGrade', chipLabel: 'Self-attested' },
+              ]} foot="A partial proof stays partial." />
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="recognition" title="Recognition stamp" dg="DG-10.5"
+          rule="THE reserved matcha moment — the only solid matcha on clinician surfaces. Archival tone: mono timestamp, packet id, numbered stamp. Never animated beyond its single entrance.">
+          <div style={{ maxWidth: 640 }}>
+            <RecognitionRow employer="Mercy General Health" iso="2026-06-30T14:22Z" packet={'pk_7f3a·d91c'} n="0012" />
+          </div>
+        </DDBand>
+
+        <DDBand id="triad" title="Empty · loading · error" dg="DG-12.2"
+          rule="Every data region ships all three in the same footprint. Empty states name the surface, say why, and offer ONE action. Errors never claim partial success.">
+          <div className="hub-grid">
+            <div className="hub-card"><span className="hid">loading</span><SkeletonStack /></div>
+            <div className="hub-card"><span className="hid">empty</span>
+              <EmptyState glyph="pending" title="No sources checked yet." why="Enter an NPI to run the first check." action="Enter an NPI" /></div>
+            <div className="hub-card"><span className="hid">error</span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-state-p0)' }}>
+                <TrustGlyph state="p0" size={13} /> Couldn&rsquo;t load. Nothing recorded.
+              </span>
+              <QuietButton small>Retry</QuietButton>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="motion" title="Motion" dg="DG-5.2"
+          rule="One curve: cubic-bezier(0.2, 0.8, 0.2, 1). 160/320/420ms. Single-shot entrances; hover lift ≤2px; no infinite loops on public surfaces except skeleton shimmer and the /status pulse. Reduced motion: static, opacity fades only.">
+          <div className="dd-motion-demo">
+            <div key={motionKey} className="dd-motion-box play"></div>
+            <SecondaryButton onClick={() => setMotionKey(motionKey + 1)}>Replay .vt-enter</SecondaryButton>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--vt-text-muted)', letterSpacing: '0.05em' }}>
+              var(--ease-house) · var(--dur-base) · translateY(10px) → 0
+            </span>
+          </div>
+        </DDBand>
+
+        <DDBand id="z" title="Z-index scale" dg="DG-12.5"
+          rule="Literal z-index values are lint-illegal. Six stops, promoted this wave.">
+          <div className="dd-ztable">
+            {([['--vt-z-base', '0', 'page flow'], ['--vt-z-raised', '10', 'lifted cards, in-flow dropdowns'], ['--vt-z-nav', '40', 'sticky nav'], ['--vt-z-banner', '45', 'offline/degraded banner'], ['--vt-z-widget', '50', 'feedback affordance'], ['--vt-z-overlay', '60', 'panels above widgets'], ['--vt-z-skip', '100', 'skip link']] as Array<[string, string, string]>).map(([t, v, u]) => (
+              <div className="tok-row" key={t}>
+                <span className="tok-key">{v}</span>
+                <span className="tok-val vt-num">{t} · {u}</span>
+                <CopyBtn text={`var(${t})`} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+      </div>
+    </S5Page>
+  );
+};
+
+/* ================= governance (w1505-governance.jsx) ================= */
+
+const VR_ROUTES = [
+  { route: '/', wave: '1501', mask: 'none' },
+  { route: '/pricing', wave: '1505', mask: 'none' },
+  { route: '/contact', wave: '1505', mask: 'none' },
+  { route: '/legal/privacy', wave: '1505', mask: 'none' },
+  { route: '/get-ready', wave: '1503', mask: '[data-vr-mask="freshness"]' },
+  { route: '/passport', wave: '1503', mask: 'freshness · ring value · run_id' },
+  { route: '/p/[slug]', wave: '1503', mask: 'freshness · compiled-at' },
+  { route: '/review/request', wave: '1502', mask: 'none' },
+  { route: '/trust', wave: '1504', mask: 'checked_at · run_id · key fingerprints' },
+  { route: '/status', wave: '1504', mask: 'all timestamps · live pulse cell' },
+];
+const VR_VPS = ['360×740', '768×1024', '1440×900'];
+
+const LINT_RULES = [
+  { id: 'LINT-01', sev: 'error', what: 'No raw color outside theme files',
+    det: 'stylelint declaration-property-value-allowed-list: forbid /#[0-9a-f]{3,8}/i, /oklch|rgb|hsl/ on color props. Inline style props linted by eslint-plugin-react regex on style={{...}}.',
+    allow: 'Allowed only in wave1500/01-primitives.css and brand asset files (og.css, svg exports).' },
+  { id: 'LINT-02', sev: 'error', what: 'No raw lucide imports outside <Icon>',
+    det: "eslint no-restricted-imports: { name: 'lucide-react', message: 'Import via components/Icon — glyph set is closed.' } — allowlist: components/Icon.tsx only. TrustGlyph states are the ONLY state iconography.",
+    allow: 'components/Icon.tsx.' },
+  { id: 'LINT-03', sev: 'error', what: 'No new @keyframes outside motion.css',
+    det: 'stylelint custom rule: at-rule "keyframes" fails outside styles/motion.css. Grep gate in CI: `grep -rn "@keyframes" app/ components/` must return 0.',
+    allow: 'styles/motion.css (house set: vt-enter, sk-sweep, status-pulse, al-sweep).' },
+  { id: 'LINT-04', sev: 'error', what: 'No dark/ops tokens on public routes',
+    det: 'Grep gate: `data-theme="ops"`, var(--ink-950) as background, or --vt-surface-inverse anywhere under app/(public)/ fails. Playwright assert: body background = rgb(244,242,236) on all 10 matrix routes.',
+    allow: 'app/(ops)/ surfaces only.' },
+  { id: 'LINT-05', sev: 'error', what: 'No literal z-index',
+    det: 'stylelint declaration-property-value-allowed-list: z-index must match /var\\(--vt-z-/. Six stops exist; a seventh requires a CHANGES.md entry.',
+    allow: 'wave1500 token files.' },
+  { id: 'LINT-06', sev: 'error', what: 'No shadows except --vt-lift; radius ≤6px public',
+    det: 'stylelint: box-shadow value must be none or var(--vt-lift) or var(--vt-focus-ring); border-radius on public routes must be var(--radius-1|2|3). --radius-ops greps to app/(ops)/ only.',
+    allow: 'ops theme may use --radius-ops.' },
+  { id: 'LINT-07', sev: 'error', what: 'Gated/unavailable must never render a checkmark',
+    det: 'Component-level test: StateChip snapshot for state=gated|unavailable|accessRequired must contain lock/slash/key path data, never the check path. Do/don’t pair #1 in DESIGN_SYSTEM.md.',
+    allow: '—' },
+  { id: 'LINT-08', sev: 'error', what: 'Copy prohibitions',
+    det: 'CI grep over app/ + content/ for the prohibited-phrase list (invented counts, borrowed-logo strips, ROI guarantees, absolute-security claims). Pricing adds: unlabeled $-figures — any /\\$\\d/ in app/(public)/pricing must sit within 3 lines of <HonestyLabel>.',
+    allow: 'Legal docs may quote prohibited phrases when prohibiting them.' },
+  { id: 'LINT-09', sev: 'warn', what: 'Font-family literals',
+    det: "stylelint: font-family must be var(--font-display|body|mono). Warn (not error) because next/font emits its own literals in generated files — allowlist .next/ and fonts.ts.",
+    allow: 'lib/fonts.ts.' },
+  { id: 'LINT-10', sev: 'warn', what: 'Glyph without label inside chips',
+    det: 'eslint-plugin-jsx-a11y custom: <TrustGlyph> rendered as only child of a chip-role element without sibling text or aria-label warns. Grayscale legibility depends on the pairing.',
+    allow: 'Decorative glyphs beside full sentences (aria-hidden).' },
+];
+
+export const GovernanceRoute = () => (
+  <S5Page eyebrow="DG-18.3 · 18.4 · Governance" title={<span>Guarded, or it <span className="vt-accent-i">drifts.</span></span>}
+    lede="Two machine-enforceable specs keep the system honest after the design program ends: a screenshot matrix that catches visual drift, and lint rules that make off-system code fail CI. Canonical text ships as REGRESSION_MATRIX.md and DESIGN_LINT.md."
+    label="Governance">
+    <S5Section first eyebrow="DG-18.3" title="Visual-regression matrix — 10 routes × 3 viewports"
+      lede="Playwright screenshot tests. Fonts awaited via document.fonts.ready; reduced motion forced so entrances never race the capture; dynamic content masked, never mocked silently.">
+      <div className="gv-matrix-wrap">
+        <table className="gv-matrix">
+          <thead>
+            <tr><th scope="col">Route</th><th scope="col">Wave</th><th scope="col">Viewports</th><th scope="col">Masked regions</th></tr>
+          </thead>
+          <tbody>
+            {VR_ROUTES.map((r) => (
+              <tr key={r.route}>
+                <td className="route">{r.route}</td>
+                <td className="wave vt-num">{r.wave}</td>
+                <td>{VR_VPS.map((v) => <span className="vp-ok vt-num" key={v}><TrustGlyph state="checked" size={10} />{v}</span>)}</td>
+                <td className="mask">{r.mask}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <ul className="mono-list" style={{ maxWidth: '88ch' }}>
+          <li>Masking: elements carry data-vr-mask=&quot;freshness|runid|timestamp&quot;; the spec masks by attribute selector — never by pixel coordinates.</li>
+          <li>Threshold: maxDiffPixelRatio 0.001 · animations: &lsquo;disabled&rsquo; · prefers-reduced-motion: &lsquo;reduce&rsquo; · deviceScaleFactor 2.</li>
+          <li>Wait: document.fonts.ready + network idle; /status additionally masks the live pulse cell rather than freezing it.</li>
+          <li>Baseline updates require a CHANGES.md entry naming the intentional visual change — CI links the diff to the entry.</li>
+        </ul>
+      </div>
+      {/* port: the canonical spec docs live in the design handoff, not as page downloads */}
+      <p style={{ marginTop: 16, fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--vt-text-secondary)' }}>
+        REGRESSION_MATRIX.md — full Playwright spec · in-repo at design-handoff/claude-design-2026-07-12-wave1505/wave1505/
+      </p>
+    </S5Section>
+
+    <S5Section eyebrow="DG-18.4" title="Design-lint rules — off-system code fails CI"
+      lede="Each rule: what it forbids, how it's detected, where exceptions live. Severity error blocks merge; warn blocks release.">
+      <div>
+        {LINT_RULES.map((r) => (
+          <div className="gv-rule" key={r.id}>
+            <span className="rid vt-num">{r.id}<span className={`sev${r.sev === 'warn' ? ' warn' : ''}`}>{r.sev.toUpperCase()}</span></span>
+            <div className="rbody">
+              <span className="what">{r.what}</span>
+              <span className="det">{r.det}</span>
+              <span className="allow"><strong style={{ fontWeight: 600 }}>Allowed:</strong> {r.allow}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p style={{ marginTop: 20, fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--vt-text-secondary)' }}>
+        DESIGN_LINT.md — rule set with exact configs · DESIGN_SYSTEM.md — the canonical doc (DG-18.1) · both in-repo beside the matrix spec
+      </p>
+    </S5Section>
+  </S5Page>
+);

--- a/apps/web/components/layout/publicSurfaceRoutes.ts
+++ b/apps/web/components/layout/publicSurfaceRoutes.ts
@@ -47,6 +47,8 @@ export const OPS_SURFACE_PREFIXES = [
   '/system-health',
   '/network',
   '/mission-ops',
+  // Design-reference surfaces carry their own chrome (wave1505 port et al.)
+  '/design',
 ] as const;
 
 const PREFIX_MATCHERS = [

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1500/01-primitives.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1500/01-primitives.css
@@ -1,0 +1,76 @@
+/* ============================================================
+   VitalCV · 01-primitives.css · Wave 1500 (DG-1.1 / DG-1.3)
+   RAW SCALES ONLY. No component may reference these directly —
+   consume roles from 02-semantic.css.
+   Sources: matcha-zen doctrine + D56 calm wave (adopted),
+   vitalTokens.css Trust Blue / teal / glass / glow (DROPPED).
+   ============================================================ */
+
+:root {
+  /* ---- PAPER (warm surface scale) ---- */
+  --paper-0:   #ffffff;   /* raised card on paper */
+  --paper-50:  #f7f6f2;
+  --paper-100: #f4f2ec;   /* canonical page paper */
+  --paper-200: #efede7;
+  --paper-300: #e4e3e0;   /* deep paper / theme bridge */
+
+  /* ---- INK (warm near-black scale, anchored at #141414) ---- */
+  --ink-950: #0d0d0b;
+  --ink-900: #141414;    /* canonical ink */
+  --ink-800: #1a1916;
+  --ink-700: #2d2c28;
+  --ink-600: #474540;
+  --ink-500: #6b6860;    /* min for small text on paper (AA at 12px+) */
+  --ink-400: #96938a;    /* eyebrows / disabled only — never body text */
+  --ink-300: #c2bfb5;
+  --ink-200: #dddbd3;    /* rule */
+  --ink-100: #eceae4;    /* rule-soft */
+
+  /* ---- MATCHA (the ONE brand accent family) ---- */
+  --matcha-950: #16211a;
+  --matcha-900: #1f2c22;
+  --matcha-800: #2c3e2d;   /* canonical brand · meta theme-color */
+  --matcha-700: #3a4f3b;
+  --matcha-600: #4a634c;
+  --matcha-300: #a9bfa9;
+  --matcha-100: #e3eae2;
+  --matcha-50:  #f0f4ef;
+
+  /* ---- INDIGO (editorial italic accent ONLY — DG-2.4) ---- */
+  --indigo-600: #4f46e5;
+  --indigo-700: #4338ca;
+
+  /* ---- TRUTH-STATE HUES (D56, contrast-checked on paper) ---- */
+  --hue-ok:        #1c5c38;  --hue-ok-bg:      #f0faf5;  --hue-ok-rule:      #86c9a6;
+  --hue-watch:     #7d5a1e;  --hue-watch-bg:   #fdf4e7;  --hue-watch-rule:   #c9a84c;
+  --hue-p0:        #7a1414;  --hue-p0-bg:      #fef2f2;  --hue-p0-rule:      #f5a5a5;
+  --hue-info:      #1a3e6b;  --hue-info-bg:    #eff6ff;  --hue-info-rule:    #bfdbfe;
+  --hue-unknown:   #3f3d38;  --hue-unknown-bg: #f1efe9;  --hue-unknown-rule: #c8c4ba;
+  --hue-contra:    #5b2a86;  --hue-contra-bg:  #f6f0fb;  --hue-contra-rule:  #cdb0e8;
+
+  /* ---- TYPE ---- */
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-body: 'Geist', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  --text-2xs: 10px;  --text-xs: 11px;  --text-sm: 12.5px; --text-base: 14px;
+  --text-md: 16px;   --text-lg: 19px;  --text-xl: 24px;   --text-2xl: 32px;
+  --text-3xl: 44px;  --text-4xl: 60px; --text-display: clamp(38px, 5.2vw, 68px);
+
+  /* ---- SPACE (4px base) ---- */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-8: 32px; --space-10: 40px;
+  --space-12: 48px; --space-16: 64px; --space-24: 96px; --space-32: 128px;
+
+  /* ---- RADIUS (DG-1.9: near-sharp public; large radii = ops only) ---- */
+  --radius-1: 2px;  --radius-2: 4px;  --radius-3: 6px;
+  --radius-ops: 12px; /* OPS-ONLY */
+
+  /* ---- MOTION (DG-5.2 doctrine) ---- */
+  --ease-house: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-fast: 160ms;  --dur-base: 320ms;  --dur-slow: 420ms;
+
+  /* ---- CONTAINER ---- */
+  --container-max: 1200px;
+  --prose-max: 68ch;
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1500/02-semantic.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1500/02-semantic.css
@@ -1,0 +1,103 @@
+/* ============================================================
+   VitalCV · 02-semantic.css · Wave 1500 (DG-1.1 / DG-3.2)
+   ROLE TOKENS. Components consume ONLY these.
+
+   ┌────────────────────────── TOKEN SPEC ──────────────────────────┐
+   │ NAME                     ROLE                    USAGE RULE     │
+   │ --vt-surface-page        page background         every public   │
+   │ --vt-surface-card        raised paper card       cards, mocks   │
+   │ --vt-text / -secondary   body ink                4.5:1 on paper │
+   │ --vt-text-muted          captions ≥12px          NOT body text  │
+   │ --vt-brand               matcha 800              Recognition    │
+   │                                                  moments, brand │
+   │                                                  chips, primary │
+   │                                                  hover — never  │
+   │                                                  body text bg   │
+   │ --vt-accent-editorial    indigo                  italic Fraunces│
+   │                                                  display accent │
+   │                                                  ONLY, ≤1/section│
+   │ --vt-state-*             9 coverage states       StateChip only │
+   │ KILLED: Trust Blue oklch(.55 .2 255), teal #0a7b7f, --vt-glow-*,│
+   │ glass tokens on public surfaces.                                │
+   └────────────────────────────────────────────────────────────────┘
+   ============================================================ */
+
+:root {
+  /* Surfaces */
+  --vt-surface-page: var(--paper-100);
+  --vt-surface-card: var(--paper-0);
+  --vt-surface-sunken: var(--paper-200);
+  --vt-surface-inverse: var(--ink-900);
+
+  /* Ink roles */
+  --vt-text: var(--ink-900);
+  --vt-text-secondary: var(--ink-600);
+  --vt-text-muted: var(--ink-500);        /* DG-3.1: replaces 40%-alpha ink */
+  --vt-text-faint: var(--ink-400);        /* eyebrows / metadata ≥10px mono only */
+  --vt-text-inverse: var(--paper-50);
+
+  /* Rules & borders (paper uses rules, not shadows — DG-1.10) */
+  --vt-rule: var(--ink-200);
+  --vt-rule-soft: var(--ink-100);
+  --vt-rule-strong: var(--ink-900);
+  --vt-degraded-border: var(--ink-400);   /* dashed = degraded (DG-9.2) */
+
+  /* Brand */
+  --vt-brand: var(--matcha-800);
+  --vt-brand-strong: var(--matcha-900);
+  --vt-brand-soft: var(--matcha-50);
+  --vt-brand-rule: var(--matcha-300);
+  --vt-accent-editorial: var(--indigo-600);
+  --vt-color-brand-primary: var(--matcha-800); /* DG-1.2 re-point (was Trust Blue) */
+
+  /* Focus (DG-3.5): 2px ink ring + 2px paper offset, everywhere */
+  --vt-focus-ring: 0 0 0 2px var(--vt-surface-page), 0 0 0 4px var(--ink-900);
+
+  /* Hover lift — the ONE allowed shadow on paper */
+  --vt-lift: 0 1px 0 var(--ink-200), 0 6px 16px -8px rgba(20, 20, 20, 0.18);
+
+  /* ---- 9 COVERAGE STATES (DG-3.2) — text / bg / rule per state ---- */
+  /* checked · source-backed, fresh */
+  --vt-state-checked: var(--hue-ok);
+  --vt-state-checked-bg: var(--hue-ok-bg);
+  --vt-state-checked-rule: var(--hue-ok-rule);
+  /* stale · was checked, past freshness threshold */
+  --vt-state-stale: var(--hue-watch);
+  --vt-state-stale-bg: var(--hue-watch-bg);
+  --vt-state-stale-rule: var(--hue-watch-rule);
+  /* pending · check in flight */
+  --vt-state-pending: var(--hue-unknown);
+  --vt-state-pending-bg: var(--hue-unknown-bg);
+  --vt-state-pending-rule: var(--hue-unknown-rule);
+  /* gated · source requires enrollment/agreement */
+  --vt-state-gated: var(--hue-watch);
+  --vt-state-gated-bg: var(--hue-watch-bg);
+  --vt-state-gated-rule: var(--hue-watch-rule);
+  /* unavailable · source down or out of scope */
+  --vt-state-unavailable: var(--hue-unknown);
+  --vt-state-unavailable-bg: var(--hue-unknown-bg);
+  --vt-state-unavailable-rule: var(--hue-unknown-rule);
+  /* accessRequired · holder must grant access */
+  --vt-state-access: var(--hue-watch);
+  --vt-state-access-bg: var(--hue-watch-bg);
+  --vt-state-access-rule: var(--hue-watch-rule);
+  /* reviewRequired · human review before decision-grade */
+  --vt-state-review: var(--hue-watch);
+  --vt-state-review-bg: var(--paper-0);
+  --vt-state-review-rule: var(--hue-watch);
+  /* notDecisionGrade · informational only */
+  --vt-state-ndg: var(--hue-unknown);
+  --vt-state-ndg-bg: var(--paper-0);
+  --vt-state-ndg-rule: var(--hue-unknown-rule);
+  /* previewOnly · anonymous preview plane */
+  --vt-state-preview: var(--hue-info);
+  --vt-state-preview-bg: var(--hue-info-bg);
+  --vt-state-preview-rule: var(--hue-info-rule);
+  /* p0 blocker + contradiction (review surfaces) */
+  --vt-state-p0: var(--hue-p0);
+  --vt-state-p0-bg: var(--hue-p0-bg);
+  --vt-state-p0-rule: var(--hue-p0-rule);
+  --vt-state-contradicted: var(--hue-contra);
+  --vt-state-contradicted-bg: var(--hue-contra-bg);
+  --vt-state-contradicted-rule: var(--hue-contra-rule);
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1500/03-themes.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1500/03-themes.css
@@ -1,0 +1,84 @@
+/* ============================================================
+   VitalCV · 03-themes.css · Wave 1500 (DG-1.3 / DG-1.4 / DG-1.7)
+   Theme application + base element styles + .mz compat alias.
+   Public site = LIGHT ONLY (paper is the brand — DG-3.3).
+   [data-theme="ops"] = operator surfaces only.
+   ============================================================ */
+
+html { background: var(--vt-surface-page); }
+body {
+  background: var(--vt-surface-page);
+  color: var(--vt-text);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-optical-sizing: auto;
+  margin: 0;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+  font-weight: 560;
+  letter-spacing: -0.015em;
+  color: var(--vt-text);
+  text-wrap: balance;
+  margin: 0;
+}
+
+/* DG-2.4 · italic editorial accent — at most ONE phrase per section headline */
+.vt-accent-i {
+  font-style: italic;
+  color: var(--vt-accent-editorial);
+  font-weight: 480;
+}
+
+/* DG-2.5 · mono eyebrow rule */
+.vt-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--vt-text-faint);
+}
+
+/* DG-2.6 · metrics never jitter */
+.vt-num { font-variant-numeric: tabular-nums; }
+
+a { color: var(--vt-text); text-decoration: underline; text-decoration-color: var(--vt-rule); text-underline-offset: 3px; transition: text-decoration-color var(--dur-fast) var(--ease-house); }
+a:hover { text-decoration-color: var(--vt-brand); color: var(--vt-brand-strong); }
+
+:focus-visible { outline: none; box-shadow: var(--vt-focus-ring); }
+::selection { background: var(--matcha-100); color: var(--ink-900); }
+
+/* Single-shot entrance (replaces ScrollReveal/vcv-stagger/fadeInUp — DG-5.6) */
+@media (prefers-reduced-motion: no-preference) {
+  .vt-enter { animation: vt-enter var(--dur-base) var(--ease-house) both; }
+  @keyframes vt-enter { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+}
+
+/* ---- OPS THEME (DG-1.7) · operator surfaces ONLY, never public ---- */
+[data-theme="ops"] {
+  --vt-surface-page: var(--ink-950);
+  --vt-surface-card: var(--ink-800);
+  --vt-surface-sunken: var(--ink-900);
+  --vt-text: var(--paper-50);
+  --vt-text-secondary: var(--ink-300);
+  --vt-text-muted: var(--ink-400);
+  --vt-rule: var(--ink-700);
+  --vt-rule-soft: var(--ink-800);
+  --vt-rule-strong: var(--paper-50);
+  --vt-focus-ring: 0 0 0 2px var(--ink-950), 0 0 0 4px var(--paper-50);
+  background: var(--vt-surface-page);
+  color: var(--vt-text);
+}
+
+/* ---- .mz COMPAT ALIAS (DG-1.4) · thin layer, do not extend ---- */
+.mz {
+  --paper: var(--paper-100);
+  --ok: var(--vt-state-checked);
+  --watch: var(--vt-state-stale);
+  --unknown: var(--vt-state-pending);
+  --p0: var(--vt-state-p0);
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1500/w15-glyphs.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1500/w15-glyphs.jsx
@@ -1,0 +1,48 @@
+// VitalCV Wave 1500 · TrustGlyph set (DG-4.2)
+// 9 coverage states + T1–T4 proof tiers + p0/contradicted.
+// Monochrome, currentColor only, readable at 14px, stroke 1.5.
+const G = ({ children, size = 14, ...rest }) => (
+  <svg width={size} height={size} viewBox="0 0 14 14" fill="none"
+       stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true" {...rest}>{children}</svg>
+);
+
+const TRUST_GLYPHS = {
+  // checked = solid check
+  checked: (s) => <G size={s}><path d="M2.5 7.5 L5.5 10.5 L11.5 3.5" /></G>,
+  // stale = clock
+  stale: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" /><path d="M7 4.2 V7 L9 8.6" /></G>,
+  // pending = dashed circle
+  pending: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" strokeDasharray="2.4 2.2" /></G>,
+  // gated = lock
+  gated: (s) => <G size={s}><rect x="3" y="6.2" width="8" height="5.6" rx="1" /><path d="M4.8 6.2 V4.6 a2.2 2.2 0 0 1 4.4 0 V6.2" /></G>,
+  // unavailable = slash
+  unavailable: (s) => <G size={s}><circle cx="7" cy="7" r="5.25" /><path d="M3.3 10.7 L10.7 3.3" /></G>,
+  // accessRequired = key
+  accessRequired: (s) => <G size={s}><circle cx="4.6" cy="9.4" r="2.6" /><path d="M6.6 7.4 L11.5 2.5 M9.4 4.6 L11.2 6.4" /></G>,
+  // reviewRequired = eye
+  reviewRequired: (s) => <G size={s}><path d="M1.8 7 C3.2 4.4 5 3.2 7 3.2 C9 3.2 10.8 4.4 12.2 7 C10.8 9.6 9 10.8 7 10.8 C5 10.8 3.2 9.6 1.8 7 Z" /><circle cx="7" cy="7" r="1.6" /></G>,
+  // notDecisionGrade = asterisk
+  notDecisionGrade: (s) => <G size={s}><path d="M7 2.2 V11.8 M2.9 4.6 L11.1 9.4 M11.1 4.6 L2.9 9.4" /></G>,
+  // previewOnly = ghost outline (dashed rounded frame)
+  previewOnly: (s) => <G size={s}><rect x="2.2" y="2.2" width="9.6" height="9.6" rx="2" strokeDasharray="2.6 2.2" /></G>,
+  // p0 blocker = solid triangle-bang
+  p0: (s) => <G size={s}><path d="M7 2 L12.6 11.6 H1.4 Z" /><path d="M7 6 V8.4 M7 10.1 V10.2" /></G>,
+  // contradicted = diverging arrows
+  contradicted: (s) => <G size={s}><path d="M5.6 7 H1.8 M1.8 7 L3.6 5.2 M1.8 7 L3.6 8.8 M8.4 7 H12.2 M12.2 7 L10.4 5.2 M12.2 7 L10.4 8.8" /></G>,
+};
+
+// Proof tiers T1–T4 (filled fraction of a square — legible grayscale)
+const TIER_GLYPHS = {
+  T1: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="9.5" width="10" height="2.5" fill="currentColor" stroke="none" /></G>,
+  T2: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="7" width="10" height="5" fill="currentColor" stroke="none" /></G>,
+  T3: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" /><rect x="2" y="4.5" width="10" height="7.5" fill="currentColor" stroke="none" /></G>,
+  T4: (s) => <G size={s}><rect x="2" y="2" width="10" height="10" fill="currentColor" /></G>,
+};
+
+const TrustGlyph = ({ state, size = 14 }) => {
+  const fn = TRUST_GLYPHS[state] || TIER_GLYPHS[state];
+  return fn ? fn(size) : null;
+};
+
+Object.assign(window, { TrustGlyph, TRUST_GLYPHS, TIER_GLYPHS });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1500/w15-primitives.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1500/w15-primitives.jsx
@@ -1,0 +1,212 @@
+// VitalCV Wave 1500 · Core primitives (DG-6.1–6.6, 6.7 subset, 6.8, 17.2)
+// Every component consumes ONLY --vt-* semantic tokens.
+
+/* ---------- STATE METADATA (DG-3.2 single table) ---------- */
+const STATE_META = {
+  checked:          { label: 'Checked',            tone: 'checked',      def: 'Source-backed and within freshness threshold.' },
+  stale:            { label: 'Stale',              tone: 'stale',        def: 'Previously checked; past freshness threshold. Refresh available.' },
+  pending:          { label: 'Pending',            tone: 'pending',      def: 'Check in flight. Result not yet available.' },
+  gated:            { label: 'Gated',              tone: 'gated',        def: 'Source requires enrollment or agreement before access.' },
+  unavailable:      { label: 'Unavailable',        tone: 'unavailable',  def: 'Source not reachable or out of scope.' },
+  accessRequired:   { label: 'Access required',    tone: 'access',       def: 'Holder must grant access before this source is read.' },
+  reviewRequired:   { label: 'Review required',    tone: 'review',       def: 'Human review needed before decision-grade.' },
+  notDecisionGrade: { label: 'Not decision-grade', tone: 'ndg',          def: 'Informational only. Not for credentialing decisions.' },
+  previewOnly:      { label: 'Preview only',       tone: 'preview',      def: 'Anonymous preview plane. Not an owned snapshot.' },
+  p0:               { label: 'Blocker',            tone: 'p0',           def: 'Blocks readiness until resolved.' },
+  contradicted:     { label: 'Contradicted',       tone: 'contradicted', def: 'Sources disagree. Both values shown side-by-side.' },
+};
+
+/* ---------- StateChip (DG-6.1) — THE atomic visual unit ---------- */
+const StateChip = ({ state, size = 'md', source, freshness, label }) => {
+  const m = STATE_META[state] || STATE_META.pending;
+  const t = m.tone;
+  const dashed = state === 'previewOnly' || state === 'pending';
+  const sm = size === 'sm';
+  return (
+    <span
+      title={`${m.label}${source ? ` · ${source}` : ''}${freshness ? ` · ${freshness}` : ''} — ${m.def}`}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: sm ? 4 : 6,
+        fontFamily: 'var(--font-mono)', fontSize: sm ? 9 : 10, fontWeight: 600,
+        textTransform: 'uppercase', letterSpacing: '0.1em', whiteSpace: 'nowrap',
+        padding: sm ? '2px 6px' : '3px 8px',
+        color: `var(--vt-state-${t})`,
+        background: `var(--vt-state-${t}-bg)`,
+        border: `1px ${dashed ? 'dashed' : 'solid'} var(--vt-state-${t}-rule)`,
+        borderRadius: 'var(--radius-1)',
+      }}>
+      <TrustGlyph state={state === 'p0' || state === 'contradicted' ? state : state} size={sm ? 11 : 13} />
+      {label || m.label}
+    </span>
+  );
+};
+
+/* ---------- ProofTierBadge (DG-6.6) ---------- */
+const TIER_DEFS = {
+  T1: 'Self-attested. Holder statement, no external source.',
+  T2: 'Source-backed. Read from a primary source; freshness tracked.',
+  T3: 'Reviewed. Source-backed plus human review.',
+  T4: 'Signed institutional artifact. Cryptographically signed record.',
+};
+const ProofTierBadge = ({ tier }) => (
+  <span title={`${tier} — ${TIER_DEFS[tier]}`}
+    style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-mono)',
+      fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', padding: '3px 8px',
+      color: 'var(--vt-text)', border: '1px solid var(--vt-rule-strong)', borderRadius: 'var(--radius-1)' }}>
+    <TrustGlyph state={tier} size={12} />{tier}
+  </span>
+);
+
+/* ---------- FreshnessStamp (DG-6.8) ---------- */
+const FreshnessStamp = ({ rel, iso, stale }) => (
+  <time className="vt-num" dateTime={iso} title={iso}
+    style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.04em',
+      color: stale ? 'var(--vt-state-stale)' : 'var(--vt-text-muted)' }}>
+    {rel}
+  </time>
+);
+
+/* ---------- HonestyLabel (DG-17.2) — first-class UI, not fine print ---------- */
+const HonestyLabel = ({ children }) => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7,
+    fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.08em',
+    color: 'var(--vt-text-secondary)', borderBottom: '1px solid var(--vt-degraded-border)',
+    paddingBottom: 3 }}>
+    <span style={{ width: 6, height: 6, border: '1px solid var(--vt-degraded-border)', borderRadius: '50%', flexShrink: 0 }}></span>
+    {children}
+  </span>
+);
+
+/* ---------- SourceRow (DG-6.4) ---------- */
+const SourceRow = ({ label, source, state, freshness, iso, action, chipLabel }) => (
+  <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center',
+    gap: 12, padding: '10px 0', borderBottom: '1px solid var(--vt-rule-soft)' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+      <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--vt-text)' }}>{label}</span>
+      <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.1em',
+          textTransform: 'uppercase', color: 'var(--vt-text-muted)' }}>{source}</span>
+        {freshness ? <FreshnessStamp rel={freshness} iso={iso} stale={state === 'stale'} /> : null}
+      </span>
+    </div>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <StateChip state={state} size="sm" source={source} freshness={freshness} label={chipLabel} />
+      {action ? <QuietButton small>{action}</QuietButton> : null}
+    </div>
+  </div>
+);
+
+/* ---------- ReadinessRing (DG-6.5) ---------- */
+const ReadinessRing = ({ value = 72, size = 96, label = 'Readiness' }) => {
+  const r = (size - 10) / 2;
+  const c = 2 * Math.PI * r;
+  const band = value >= 80 ? 'var(--vt-state-checked)' : value >= 50 ? 'var(--vt-brand)' : 'var(--vt-state-stale)';
+  return (
+    <div role="meter" aria-valuenow={value} aria-valuemin="0" aria-valuemax="100"
+      aria-label={`${label}: ${value} percent`}
+      style={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size}>
+        <circle cx={size/2} cy={size/2} r={r} fill="none" stroke="var(--vt-rule-soft)" strokeWidth="5" />
+        <circle cx={size/2} cy={size/2} r={r} fill="none" stroke={band} strokeWidth="5"
+          strokeLinecap="butt" strokeDasharray={`${c * value / 100} ${c}`}
+          transform={`rotate(-90 ${size/2} ${size/2})`}
+          style={{ transition: 'stroke-dasharray var(--dur-slow) var(--ease-house)' }} />
+      </svg>
+      <div style={{ position: 'absolute', inset: 0, display: 'grid', placeItems: 'center' }}>
+        <div style={{ textAlign: 'center' }}>
+          <div className="vt-num" style={{ fontFamily: 'var(--font-display)', fontSize: size * 0.26, fontWeight: 560, lineHeight: 1 }}>{value}<span style={{ fontSize: size * 0.14 }}>%</span></div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 8.5, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--vt-text-muted)', marginTop: 2 }}>{label}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ---------- Buttons (DG-6.3) ---------- */
+const btnBase = (sz) => ({
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+  fontFamily: 'var(--font-body)', fontWeight: 500, cursor: 'pointer',
+  fontSize: sz === 'sm' ? 12 : sz === 'lg' ? 15 : 13.5,
+  padding: sz === 'sm' ? '6px 14px' : sz === 'lg' ? '13px 26px' : '9px 20px',
+  borderRadius: 'var(--radius-1)', border: '1px solid transparent',
+  transition: 'background var(--dur-fast) var(--ease-house), border-color var(--dur-fast) var(--ease-house), color var(--dur-fast) var(--ease-house)',
+});
+const PrimaryButton = ({ children, size, disabled, loading, ...rest }) => (
+  <button disabled={disabled || loading} {...rest}
+    onMouseEnter={(e) => { if (!disabled) e.currentTarget.style.background = 'var(--vt-brand-strong)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.background = disabled ? 'var(--vt-rule)' : 'var(--ink-900)'; }}
+    style={{ ...btnBase(size), background: disabled ? 'var(--vt-rule)' : 'var(--ink-900)',
+      color: disabled ? 'var(--vt-text-muted)' : 'var(--vt-text-inverse)',
+      cursor: disabled ? 'not-allowed' : 'pointer' }}>
+    {loading ? <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>···</span> : null}{children}
+  </button>
+);
+const SecondaryButton = ({ children, size, ...rest }) => (
+  <button {...rest}
+    onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--vt-surface-card)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+    style={{ ...btnBase(size), background: 'transparent', color: 'var(--vt-text)', borderColor: 'var(--vt-rule-strong)' }}>
+    {children}
+  </button>
+);
+const QuietButton = ({ children, small, ...rest }) => (
+  <button {...rest}
+    onMouseEnter={(e) => { e.currentTarget.style.textDecorationColor = 'var(--vt-brand)'; }}
+    onMouseLeave={(e) => { e.currentTarget.style.textDecorationColor = 'transparent'; }}
+    style={{ background: 'none', border: 'none', cursor: 'pointer', padding: small ? '2px 4px' : '6px 8px',
+      fontFamily: 'var(--font-body)', fontSize: small ? 11.5 : 13, fontWeight: 500, color: 'var(--vt-text)',
+      textDecoration: 'underline', textDecorationColor: 'transparent', textUnderlineOffset: 3,
+      transition: 'text-decoration-color var(--dur-fast) var(--ease-house)' }}>
+    {children}
+  </button>
+);
+const DestructiveButton = ({ children, size, ...rest }) => (
+  <button {...rest} style={{ ...btnBase(size), background: 'transparent',
+    color: 'var(--vt-state-p0)', borderColor: 'var(--vt-state-p0-rule)' }}>
+    {children}
+  </button>
+);
+
+/* ---------- PaperCard (DG-6.2) ---------- */
+const PaperCard = ({ children, lift, style: st, ...rest }) => {
+  const [hov, setHov] = React.useState(false);
+  return (
+    <div {...rest}
+      onMouseEnter={() => lift && setHov(true)} onMouseLeave={() => setHov(false)}
+      style={{ background: 'var(--vt-surface-card)', border: '1px solid var(--vt-rule)',
+        borderRadius: 'var(--radius-2)', padding: 'var(--space-5)',
+        transform: hov ? 'translateY(-2px)' : 'none',
+        boxShadow: hov ? 'var(--vt-lift)' : 'none',
+        transition: 'transform var(--dur-fast) var(--ease-house), box-shadow var(--dur-fast) var(--ease-house)',
+        ...st }}>
+      {children}
+    </div>
+  );
+};
+
+/* ---------- NPI segmented input (DG-6.7 / DG-7.2) ---------- */
+const NpiInput = ({ value, onChange }) => {
+  const digits = (value || '').replace(/\D/g, '').slice(0, 10);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, background: 'var(--vt-surface-card)',
+      border: '1px solid var(--vt-rule-strong)', borderRadius: 'var(--radius-2)', padding: '4px 6px 4px 16px' }}>
+      <input
+        value={digits} inputMode="numeric" pattern="[0-9]*" placeholder="Enter your NPI"
+        aria-label="National Provider Identifier, 10 digits"
+        onChange={(e) => onChange(e.target.value.replace(/\D/g, '').slice(0, 10))}
+        style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', background: 'transparent',
+          fontFamily: 'var(--font-mono)', fontSize: 16, letterSpacing: '0.18em',
+          color: 'var(--vt-text)', padding: '10px 0' }} />
+      <span className="vt-num" style={{ fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: digits.length === 10 ? 'var(--vt-state-checked)' : 'var(--vt-text-muted)', flexShrink: 0 }}
+        aria-live="polite">{digits.length}/10</span>
+      <PrimaryButton disabled={digits.length !== 10}>Check readiness</PrimaryButton>
+    </div>
+  );
+};
+
+Object.assign(window, {
+  STATE_META, TIER_DEFS, StateChip, ProofTierBadge, FreshnessStamp, HonestyLabel,
+  SourceRow, ReadinessRing, PrimaryButton, SecondaryButton, QuietButton,
+  DestructiveButton, PaperCard, NpiInput,
+});

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1501/hp.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1501/hp.css
@@ -1,0 +1,201 @@
+/* ============================================================
+   VitalCV · Wave 1501 · hp.css — homepage layout ONLY.
+   Colors: --vt-* semantic tokens exclusively. No new hues.
+   Motion: single-shot, var(--ease-house), 240–420ms, reduced-
+   motion static fallbacks throughout.
+   ============================================================ */
+
+/* ---- section rhythm (DG-7.12) ---- */
+.hp-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+.hp-section { padding: var(--space-24) 0; border-top: 1px solid var(--vt-rule); scroll-margin-top: 72px; }
+.hp-sechead { display: flex; flex-direction: column; gap: var(--space-4); max-width: 60ch; margin-bottom: var(--space-12); }
+.hp-sechead h2 { font-size: var(--text-3xl); line-height: 1.08; }
+.hp-sechead p.lede { margin: 0; font-size: var(--text-md); line-height: 1.65; color: var(--vt-text-secondary); max-width: 52ch; }
+@media (max-width: 720px) {
+  .hp-section { padding: var(--space-16) 0; }
+  .hp-sechead { margin-bottom: var(--space-8); }
+  .hp-sechead h2 { font-size: var(--text-2xl); }
+}
+
+/* ---- single-shot entrance (gated on .js so no-JS never hides content) ---- */
+@media (prefers-reduced-motion: no-preference) {
+  html.js.motion-live .hp-reveal { opacity: 0; transform: translateY(12px);
+    transition: opacity var(--dur-base) var(--ease-house), transform var(--dur-base) var(--ease-house); }
+  html.js.motion-live .hp-reveal.is-in { opacity: 1; transform: none; }
+  @keyframes hp-enter { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  html { scroll-behavior: smooth; }
+}
+@media print { .hp-reveal { opacity: 1 !important; transform: none !important; } }
+
+/* ---- nav ---- */
+.hp-nav { position: sticky; top: 0; z-index: 40; background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }
+.hp-nav-inner { display: flex; align-items: center; gap: var(--space-8); padding: 14px 0; }
+.hp-brand { font-family: var(--font-display); font-size: 20px; font-weight: 600; letter-spacing: -0.01em; text-decoration: none; color: var(--vt-text); }
+.hp-brand:hover { color: var(--vt-text); text-decoration: none; }
+.hp-nav-links { margin-left: auto; display: flex; align-items: center; gap: var(--space-6); }
+.hp-nav-links a { font-size: 13px; text-decoration: none; color: var(--vt-text-secondary); }
+.hp-nav-links a:hover { color: var(--vt-text); text-decoration: none; }
+@media (max-width: 680px) { .hp-nav-links a.hp-nav-hide { display: none; } }
+
+/* ---- hero (DG-7.1) ---- */
+.hp-hero { padding: var(--space-16) 0 var(--space-24); }
+.hp-hero-grid { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: var(--space-16); align-items: center; }
+.hp-hero h1 { font-size: var(--text-display); line-height: 1.04; }
+.hp-hero p.lede { margin: 0; font-size: var(--text-md); line-height: 1.65; color: var(--vt-text-secondary); max-width: 46ch; }
+@media (max-width: 980px) {
+  .hp-hero { padding: var(--space-10) 0 var(--space-16); }
+  .hp-hero-grid { grid-template-columns: 1fr; gap: var(--space-12); }
+}
+
+/* ---- NPI segmented input (DG-7.2) ---- */
+.npi-cells { position: relative; display: flex; gap: 6px; cursor: text; }
+.npi-cell { flex: 1 1 0; min-width: 0; height: 56px; display: grid; place-items: center;
+  background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  font-family: var(--font-mono); font-size: 20px; color: var(--vt-text); font-variant-numeric: tabular-nums; }
+.npi-cell.filled { border-color: var(--vt-rule-strong); }
+.npi-cell.active { border-color: var(--vt-rule-strong); box-shadow: inset 0 -2px 0 var(--vt-rule-strong); }
+.npi-cells.error .npi-cell { border-color: var(--vt-state-p0-rule); }
+.npi-cells.error .npi-cell.filled { border-color: var(--vt-state-p0); }
+.npi-real { position: absolute; inset: 0; width: 100%; opacity: 0; border: none; outline: none;
+  background: transparent; color: transparent; caret-color: transparent; font-size: 16px; }
+.npi-cells:focus-within { box-shadow: var(--vt-focus-ring); border-radius: var(--radius-1); }
+/* calm single-pulse on focus — one shot, never loops */
+.npi-cells::after { content: ''; position: absolute; inset: -5px; border: 1px solid var(--vt-brand);
+  border-radius: var(--radius-2); opacity: 0; pointer-events: none; }
+@media (prefers-reduced-motion: no-preference) {
+  .npi-cells:focus-within::after { animation: npi-pulse var(--dur-slow) var(--ease-house) 1 both; }
+  @keyframes npi-pulse { 0% { opacity: 0.9; transform: scale(0.99); } 100% { opacity: 0; transform: none; } }
+}
+.npi-meta { display: flex; align-items: baseline; gap: var(--space-4); margin-top: 10px; flex-wrap: wrap; }
+.npi-count { font-family: var(--font-mono); font-size: 11px; color: var(--vt-text-muted); font-variant-numeric: tabular-nums; }
+.npi-count.done { color: var(--vt-state-checked); }
+.npi-micro { font-size: 11.5px; color: var(--vt-text-muted); }
+.npi-err { display: flex; align-items: flex-start; gap: 8px; margin-top: 10px;
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em; line-height: 1.5; color: var(--vt-state-p0); }
+@media (max-width: 420px) { .npi-cell { height: 46px; font-size: 16px; } .npi-cells { gap: 4px; } }
+
+/* ---- source chips row (DG-7.4) ---- */
+.src-reads { display: flex; align-items: center; gap: 8px 10px; flex-wrap: wrap; margin-top: var(--space-5); }
+
+/* ---- how it works (DG-7.5) ---- */
+.how-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0 var(--space-6); margin-top: var(--space-16); }
+.how-step { border-top: 1px solid var(--vt-rule); position: relative; padding-right: var(--space-2); }
+.how-num { font-family: var(--font-display); font-size: 44px; font-weight: 560; line-height: 1;
+  display: inline-block; background: var(--vt-surface-page); padding-right: 14px; transform: translateY(-54%); }
+.how-step h3 { font-family: var(--font-body); font-size: 14.5px; font-weight: 600; letter-spacing: 0; margin: 2px 0 6px; }
+.how-step p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); }
+@media (max-width: 900px) {
+  .how-grid { grid-template-columns: 1fr; gap: var(--space-8) 0; margin-top: var(--space-10); }
+  .how-step { padding-bottom: 0; }
+  .how-num { font-size: 36px; }
+}
+
+/* ---- why this compounds (DG-7.6) ---- */
+.why-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); }
+.why-card h3 { font-size: var(--text-lg); margin: 10px 0 8px; }
+.why-card p { margin: 0; font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); }
+@media (max-width: 900px) { .why-grid { grid-template-columns: 1fr; } }
+
+/* ---- CanonicalPath strip ---- */
+.cpath { display: flex; align-items: stretch; border: 1px solid var(--vt-rule-strong);
+  border-radius: var(--radius-2); background: var(--vt-surface-card); margin-top: var(--space-10); overflow: hidden; }
+.cpath-cell { flex: 1 1 0; min-width: 0; padding: var(--space-5) var(--space-6); display: flex; flex-direction: column; gap: 7px; }
+.cpath-label { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-mono);
+  font-size: 11px; font-weight: 700; letter-spacing: 0.18em; color: var(--vt-text); }
+.cpath-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.cpath-dot.recognition { background: var(--vt-brand); }
+.cpath-dot.acceptance { background: transparent; border: 1.5px solid var(--vt-text); }
+.cpath-dot.start { background: var(--vt-text); }
+.cpath-def { font-size: 12.5px; line-height: 1.5; color: var(--vt-text-secondary); }
+.cpath-arrow { display: grid; place-items: center; padding: 0 var(--space-3);
+  color: var(--vt-text-muted); border-left: 1px solid var(--vt-rule-soft); border-right: 1px solid var(--vt-rule-soft);
+  font-family: var(--font-mono); font-size: 14px; flex-shrink: 0; }
+@media (max-width: 760px) {
+  .cpath { flex-direction: column; }
+  .cpath-arrow { border: none; border-top: 1px solid var(--vt-rule-soft); border-bottom: 1px solid var(--vt-rule-soft); padding: var(--space-1) 0; }
+}
+
+/* ---- MATCHA demo (DG-7.7) — quieter than hero; matcha family allowed here ---- */
+.mt-panel { background: var(--vt-brand-soft); border: 1px solid var(--vt-brand-rule); border-radius: var(--radius-3); padding: var(--space-8); }
+.mt-chips { display: flex; flex-wrap: wrap; gap: 10px; }
+.mt-chip { min-height: 44px; padding: 10px 18px; background: var(--vt-surface-card); color: var(--vt-text);
+  border: 1px solid var(--vt-brand-rule); border-radius: var(--radius-2); font-family: var(--font-body);
+  font-size: 13px; font-weight: 500; cursor: pointer; text-align: left;
+  transition: border-color var(--dur-fast) var(--ease-house), box-shadow var(--dur-fast) var(--ease-house); }
+.mt-chip:hover { border-color: var(--vt-brand); }
+.mt-chip[aria-pressed="true"] { border-color: var(--vt-brand); box-shadow: inset 0 0 0 1px var(--vt-brand); }
+.mt-answer { margin-top: var(--space-6); background: var(--vt-surface-card); border: 1px solid var(--vt-brand-rule);
+  border-radius: var(--radius-2); padding: var(--space-6); }
+@media (prefers-reduced-motion: no-preference) {
+  html.motion-live .mt-answer { animation: hp-enter 240ms var(--ease-house) both; }
+}
+.mt-answer p { margin: 0 0 14px; font-size: 14px; line-height: 1.65; color: var(--vt-text); max-width: 62ch; }
+.mt-answer .chips { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+@media (max-width: 720px) { .mt-panel { padding: var(--space-5); } }
+
+/* ---- constellation (DG-7.8) ---- */
+.sky-wrap { border: 1px solid var(--vt-rule); background: var(--vt-surface-card); border-radius: var(--radius-2); overflow: hidden; }
+.sky-stage { position: relative; touch-action: none; user-select: none; -webkit-user-select: none; }
+.sky-stage.draggable { cursor: grab; }
+.sky-stage.dragging { cursor: grabbing; }
+.sky-foot { display: flex; align-items: center; gap: var(--space-6); padding: var(--space-4) var(--space-5);
+  border-top: 1px solid var(--vt-rule-soft); flex-wrap: wrap; }
+.sky-slider { flex: 1 1 260px; min-width: 220px; }
+.sky-ticks { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 9.5px;
+  font-weight: 500; letter-spacing: 0.16em; color: var(--vt-text-muted); margin-top: 2px; }
+.sky-ticks .on { color: var(--vt-text); }
+.sky-hint { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--vt-text-faint); }
+
+/* form-kit range (consumes tokens only) */
+.vt-range { -webkit-appearance: none; appearance: none; width: 100%; height: 44px; background: transparent; margin: 0; cursor: pointer; }
+.vt-range::-webkit-slider-runnable-track { height: 2px; background: var(--vt-rule); }
+.vt-range::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 16px; height: 16px; margin-top: -7px;
+  background: var(--vt-surface-card); border: 2px solid var(--vt-rule-strong); border-radius: var(--radius-1); }
+.vt-range::-moz-range-track { height: 2px; background: var(--vt-rule); }
+.vt-range::-moz-range-thumb { width: 12px; height: 12px; background: var(--vt-surface-card);
+  border: 2px solid var(--vt-rule-strong); border-radius: var(--radius-1); }
+.vt-range:focus-visible { outline: none; box-shadow: none; }
+.vt-range:focus-visible::-webkit-slider-thumb { box-shadow: var(--vt-focus-ring); }
+.vt-range:focus-visible::-moz-range-thumb { box-shadow: var(--vt-focus-ring); }
+
+/* ---- role doors (DG-7.9) ---- */
+.door-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-5); align-items: stretch; }
+.door { display: flex; flex-direction: column; gap: 12px; padding: var(--space-6); min-height: 220px;
+  background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  text-decoration: none; color: var(--vt-text);
+  transition: transform var(--dur-fast) var(--ease-house), box-shadow var(--dur-fast) var(--ease-house), border-color var(--dur-fast) var(--ease-house); }
+.door:hover { transform: translateY(-2px); box-shadow: var(--vt-lift); border-color: var(--vt-rule-strong); text-decoration: none; color: var(--vt-text); }
+.door h3 { font-size: var(--text-lg); margin-top: 2px; }
+.door p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); flex-grow: 1; }
+.door-cta { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--vt-text); display: inline-flex; gap: 8px; align-items: center; }
+@media (max-width: 1000px) { .door-grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .door-grid { grid-template-columns: 1fr; } .door { min-height: 0; } }
+
+/* ---- who buys in (DG-7.10) ---- */
+.who-dl { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-8) var(--space-16); margin: 0; }
+.who-item { border-top: 1px solid var(--vt-rule); padding-top: var(--space-4); }
+.who-item dt { font-family: var(--font-mono); font-size: var(--text-2xs); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.2em; color: var(--vt-text-faint); }
+.who-item dd { margin: 8px 0 0; font-size: 14px; line-height: 1.65; color: var(--vt-text-secondary); }
+@media (max-width: 760px) { .who-dl { grid-template-columns: 1fr; gap: var(--space-6); } }
+
+/* ---- footer (DG-7.11) ---- */
+.hp-foot { border-top: 1px solid var(--vt-rule); padding: var(--space-16) 0 var(--space-10); }
+.foot-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr; gap: var(--space-8); }
+.foot-col h4 { font-family: var(--font-mono); font-size: var(--text-2xs); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.2em; color: var(--vt-text-faint); margin: 0 0 12px; }
+.foot-col ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.foot-col a { font-size: 13px; color: var(--vt-text-secondary); text-decoration: none; }
+.foot-col a:hover { color: var(--vt-text); text-decoration: underline; text-decoration-color: var(--vt-brand); }
+.foot-base { margin-top: var(--space-12); padding-top: var(--space-5); border-top: 1px solid var(--vt-rule-soft);
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); flex-wrap: wrap; }
+.foot-copy { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+@media (max-width: 860px) { .foot-grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 460px) { .foot-grid { grid-template-columns: 1fr; } }
+
+/* ---- reduced-motion static fallbacks ---- */
+@media (prefers-reduced-motion: reduce) {
+  .door, .mt-chip, .npi-cells::after { transition: none; animation: none; }
+  .door:hover { transform: none; box-shadow: none; }
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1502/w1502-shared.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1502/w1502-shared.jsx
@@ -1,0 +1,222 @@
+// Wave 1502 · w1502-shared.jsx — router, nav, form kit, HonestyPanel,
+// StepTimeline, BoundaryFooter. Consumes wave1500 tokens/primitives only.
+
+/* NPI checksum — Luhn over '80840' + 10 digits (same rule as Wave 1501). */
+const npiOk = (d) => {
+  if (d.length !== 10) return false;
+  const s = '80840' + d;
+  let sum = 0, alt = false;
+  for (let i = s.length - 1; i >= 0; i--) {
+    let n = +s[i];
+    if (alt) { n *= 2; if (n > 9) n -= 9; }
+    sum += n; alt = !alt;
+  }
+  return sum % 10 === 0;
+};
+
+/* ---------- hash router ---------- */
+const parseRoute = (h) => {
+  const hash = h || window.location.hash || '#/pilot';
+  const m = hash.replace(/^#/, '').split('/').filter(Boolean);
+  if (m[0] === 'review' && m[1] === 'request') return { name: 'request' };
+  if (m[0] === 'review' && m[1]) return { name: 'entity', id: m[1] };
+  return { name: 'pilot' };
+};
+const useRoute = () => {
+  const [route, setRoute] = React.useState(() => parseRoute());
+  React.useEffect(() => {
+    const fn = () => { setRoute(parseRoute()); window.scrollTo(0, 0); };
+    window.addEventListener('hashchange', fn);
+    return () => window.removeEventListener('hashchange', fn);
+  }, []);
+  return route;
+};
+
+/* ---------- nav ---------- */
+const S2_ROUTES = [
+  { hash: '#/pilot', label: 'Employer pilot', match: 'pilot' },
+  { hash: '#/review/request', label: 'Request a review', match: 'request' },
+  { hash: '#/review/rev-2841', label: 'Reviewer surface', match: 'entity' },
+];
+const S2Nav = ({ route }) => (
+  <header className="s2-nav">
+    <div className="s2-container s2-nav-inner">
+      <a className="s2-brand" href="../wave1501/index.html">VitalCV</a>
+      <span className="s2-wave vt-eyebrow">Wave 1502 · buyer surfaces</span>
+      <nav className="s2-tabs" aria-label="Surfaces">
+        {S2_ROUTES.map((r) => (
+          <a key={r.hash} className="s2-tab" href={r.hash}
+            aria-current={route.name === r.match ? 'page' : undefined}>{r.label}</a>
+        ))}
+      </nav>
+    </div>
+  </header>
+);
+
+/* ---------- footer boundary (DG-11.1 boundary statement) ---------- */
+const BoundaryFooter = ({ tight }) => (
+  <footer className={`s2-foot${tight ? ' tight' : ''}`}>
+    <div className="s2-container">
+      <p className="s2-boundary">
+        <TrustGlyph state="notDecisionGrade" size={16} />
+        <span>A reviewer-ready head start — <span className="vt-accent-i">not</span> a final credentialing decision.</span>
+      </p>
+      <p className="s2-foot-base">© 2026 VitalCV · Employers accept a head start; committees remain the final step. A partial proof stays partial.</p>
+    </div>
+  </footer>
+);
+
+/* ---------- form kit (documented in CHANGES.md for promotion) ---------- */
+const Field = ({ id, label, required, hint, error, children }) => (
+  <div className="fk-field">
+    <label className="fk-label" htmlFor={id}>
+      {label}{required ? <span className="fk-req" aria-hidden="true">*</span> : null}
+    </label>
+    {children}
+    {hint && !error ? <p className="fk-hint">{hint}</p> : null}
+    {error ? (
+      <p className="fk-err" id={`${id}-err`}>
+        <TrustGlyph state="p0" size={11} />
+        <span>{error}</span>
+      </p>
+    ) : null}
+  </div>
+);
+const TextInput = React.forwardRef(({ id, error, ...rest }, ref) => (
+  <input ref={ref} id={id} className={`fk-input${error ? ' err' : ''}`}
+    aria-invalid={!!error} aria-describedby={error ? `${id}-err` : undefined} {...rest} />
+));
+const TextArea = React.forwardRef(({ id, error, rows = 4, ...rest }, ref) => (
+  <textarea ref={ref} id={id} rows={rows} className={`fk-input${error ? ' err' : ''}`}
+    aria-invalid={!!error} aria-describedby={error ? `${id}-err` : undefined} {...rest} />
+));
+
+const FREEMAIL = ['gmail.com', 'yahoo.com', 'outlook.com', 'hotmail.com', 'aol.com', 'icloud.com', 'proton.me', 'protonmail.com'];
+const validateWorkEmail = (v) => {
+  const t = (v || '').trim();
+  if (!t) return 'Work email is required.';
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]{2,}$/.test(t)) return 'Enter a valid email — e.g. name@organization.org.';
+  const dom = t.split('@')[1].toLowerCase();
+  if (FREEMAIL.includes(dom)) return 'Use your work address — pilot scope is tied to your organization’s domain.';
+  return null;
+};
+const validateRequired = (v, label) => ((v || '').trim() ? null : `${label} is required.`);
+
+/* Error summary — designed failure state, role=alert, links focus fields */
+const ErrorSummary = ({ errors, order, labels, refs }) => {
+  const keys = order.filter((k) => errors[k]);
+  if (!keys.length) return null;
+  return (
+    <div className="fk-summary" role="alert">
+      <span className="t"><TrustGlyph state="p0" size={12} /> {keys.length} field{keys.length > 1 ? 's' : ''} need{keys.length > 1 ? '' : 's'} attention</span>
+      <ul>
+        {keys.map((k) => (
+          <li key={k}>
+            <button type="button" onClick={() => { const el = refs[k] && refs[k].current; if (el) el.focus(); }}>
+              {labels[k]} — {errors[k]}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+/* Success card — designed success state */
+const SuccessCard = ({ title, receipt, children, onReset, resetLabel }) => (
+  <div className="fk-success" role="status">
+    <StateChip state="checked" label="Recorded" />
+    <h3>{title}</h3>
+    <span className="receipt vt-num">{receipt}</span>
+    {children}
+    {onReset ? <QuietButton onClick={onReset}>{resetLabel || 'Submit another request'}</QuietButton> : null}
+  </div>
+);
+
+/* ---------- segmented NPI field (Wave 1501 pattern, form-kit variant) ---------- */
+const NpiField = ({ id, value, onChange, extError }) => {
+  const [focused, setFocused] = React.useState(false);
+  const inputRef = React.useRef(null);
+  const digits = value || '';
+  const complete = digits.length === 10;
+  const valid = complete && npiOk(digits);
+  const checksumErr = complete && !valid;
+  const activeIdx = focused && !complete ? digits.length : -1;
+  const error = extError || (checksumErr ? 'Checksum failed — these ten digits don’t validate as an NPI. Check for a typo.' : null);
+  return (
+    <div>
+      <div className={`npi-cells${error ? ' error' : ''}`} onClick={() => inputRef.current && inputRef.current.focus()}>
+        <input ref={inputRef} className="npi-real" value={digits} id={id}
+          inputMode="numeric" pattern="[0-9]*" autoComplete="off"
+          aria-label="Clinician National Provider Identifier, 10 digits"
+          aria-invalid={!!error} aria-describedby={error ? `${id}-err` : undefined}
+          onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}
+          onChange={(e) => onChange(e.target.value.replace(/\D/g, '').slice(0, 10))} />
+        {Array.from({ length: 10 }).map((_, i) => (
+          <span key={i} aria-hidden="true"
+            className={`npi-cell${digits[i] ? ' filled' : ''}${i === activeIdx ? ' active' : ''}`}>
+            {digits[i] || ''}
+          </span>
+        ))}
+      </div>
+      <div className="npi-meta">
+        <span className={`npi-count${valid ? ' done' : ''}`} aria-live="polite">
+          {digits.length}/10{valid ? ' · format OK' : ''}
+        </span>
+        <span className="npi-micro">Public identifier — not PHI.</span>
+      </div>
+      {error ? (
+        <p className="fk-err" id={`${id}-err`} style={{ marginTop: 8 }}>
+          <TrustGlyph state="p0" size={11} /><span>{error}</span>
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+/* ---------- HonestyPanel (DG-8.4) — signature side-by-side pair ---------- */
+const HonestyPanel = ({ tone, title, items, foot }) => (
+  <section className={`hn-panel ${tone}`} aria-label={title}>
+    <header className="hn-panel-head">
+      <TrustGlyph state={tone === 'ok' ? 'checked' : 'stale'} size={14} />
+      <span className="t">{title}</span>
+      <span className="n vt-num">{items.length} lanes</span>
+    </header>
+    <ul className="hn-items">
+      {items.map((it) => (
+        <li className="hn-item" key={it.label}>
+          <div>
+            <span className="lab">{it.label}</span>
+            <span className="src">{it.source}</span>
+            {it.note ? <p className="note">{it.note}</p> : null}
+          </div>
+          <StateChip state={it.state} size="sm" label={it.chipLabel} />
+        </li>
+      ))}
+    </ul>
+    {foot ? <div className="hn-panel-foot"><HonestyLabel>{foot}</HonestyLabel></div> : null}
+  </section>
+);
+
+/* ---------- StepTimeline — mono labels, hairline connector ---------- */
+const StepTimeline = ({ steps }) => (
+  <ol className="tl">
+    {steps.map((s, i) => (
+      <li className="tl-step" key={s.key}>
+        <div className="tl-marker vt-num" aria-hidden="true">{String(i + 1).padStart(2, '0')}</div>
+        <div className="tl-body">
+          <span className="tl-key">{s.key}</span>
+          <h3>{s.title}</h3>
+          <p>{s.body}</p>
+          {s.meta ? <span className="tl-meta">{s.meta}</span> : null}
+        </div>
+      </li>
+    ))}
+  </ol>
+);
+
+Object.assign(window, {
+  npiOk, parseRoute, useRoute, S2Nav, S2_ROUTES, BoundaryFooter,
+  Field, TextInput, TextArea, validateWorkEmail, validateRequired,
+  ErrorSummary, SuccessCard, NpiField, HonestyPanel, StepTimeline,
+});

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1502/w1502.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1502/w1502.css
@@ -1,0 +1,265 @@
+/* ============================================================
+   VitalCV · Wave 1502 · w1502.css — buyer-surface layout ONLY.
+   Colors: --vt-* semantic tokens exclusively. No new hues.
+   Motion: single-shot, var(--ease-house), 240–420ms, full
+   prefers-reduced-motion static fallbacks.
+   ============================================================ */
+
+/* ---- shell ---- */
+.s2-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+.s2-section { padding: var(--space-16) 0; border-top: 1px solid var(--vt-rule); }
+.s2-section.first { border-top: none; }
+@media (max-width: 720px) { .s2-section { padding: var(--space-12) 0; } }
+
+/* ---- nav ---- */
+.s2-nav { position: sticky; top: 0; z-index: 40; background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }
+.s2-nav-inner { display: flex; align-items: center; gap: var(--space-5); padding: 10px 0; flex-wrap: wrap; }
+.s2-brand { font-family: var(--font-display); font-size: 19px; font-weight: 600; letter-spacing: -0.01em; text-decoration: none; color: var(--vt-text); }
+.s2-brand:hover { color: var(--vt-text); text-decoration: none; }
+.s2-wave { padding-top: 2px; }
+.s2-tabs { margin-left: auto; display: flex; gap: 2px; flex-wrap: wrap; }
+.s2-tab { display: inline-flex; align-items: center; min-height: 38px; padding: 0 14px; font-size: 12.5px; font-weight: 500;
+  color: var(--vt-text-secondary); text-decoration: none; border: 1px solid transparent; border-radius: var(--radius-1); }
+.s2-tab:hover { color: var(--vt-text); text-decoration: none; }
+.s2-tab[aria-current="page"] { color: var(--vt-text); border-color: var(--vt-rule-strong); background: var(--vt-surface-card); }
+@media (max-width: 640px) { .s2-wave { display: none; } .s2-tabs { margin-left: 0; width: 100%; padding-bottom: 8px; } }
+@media (pointer: coarse) { .s2-tab, button { min-height: 44px; } }
+
+/* ---- page head ---- */
+.s2-head { padding: var(--space-16) 0 var(--space-12); display: flex; flex-direction: column; gap: var(--space-4); }
+.s2-head h1 { font-size: var(--text-display); line-height: 1.05; max-width: 22ch; }
+.s2-head p.lede { margin: 0; font-size: var(--text-md); line-height: 1.65; color: var(--vt-text-secondary); max-width: 54ch; }
+@media (max-width: 720px) { .s2-head { padding: var(--space-10) 0 var(--space-8); } }
+
+/* ---- metric strip (DG-8.2) ---- */
+.pl-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-5); }
+.pl-stat { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-5); display: flex; flex-direction: column; gap: 10px; }
+.pl-stat-num { font-family: var(--font-display); font-size: var(--text-3xl); font-weight: 560; line-height: 1;
+  letter-spacing: -0.01em; font-variant-numeric: tabular-nums; }
+.pl-stat-num .unit { font-size: 0.45em; font-weight: 500; margin-left: 4px; }
+.pl-stat-num .arr { font-family: var(--font-mono); font-size: 0.55em; color: var(--vt-text-muted); margin: 0 6px; vertical-align: 6px; }
+.pl-stat-cap { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--vt-text-secondary); line-height: 1.55; }
+.pl-stat-honesty { margin-top: auto; padding-top: 10px; border-top: 1px dashed var(--vt-degraded-border);
+  display: flex; align-items: flex-start; gap: 7px; font-family: var(--font-mono); font-size: 9.5px;
+  letter-spacing: 0.07em; line-height: 1.5; color: var(--vt-text-secondary); text-transform: uppercase; }
+.hn-dot { width: 6px; height: 6px; border: 1px solid var(--vt-degraded-border); border-radius: 50%; flex-shrink: 0; margin-top: 3px; }
+@media (max-width: 980px) { .pl-metrics { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .pl-metrics { grid-template-columns: 1fr; } }
+
+/* ---- 2×2 scope grid (DG-8.1) ---- */
+.pl-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); }
+.pl-scope { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-6); }
+.pl-scope .idx { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; color: var(--vt-text-faint); }
+.pl-scope h3 { font-size: var(--text-lg); margin: 10px 0 8px; }
+.pl-scope p { margin: 0; font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); }
+@media (max-width: 760px) { .pl-grid2 { grid-template-columns: 1fr; } }
+
+/* ---- HonestyPanel pair (DG-8.4) — signature layout ---- */
+.hn-pair { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-5); align-items: stretch; }
+.hn-panel { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); display: flex; flex-direction: column; }
+.hn-panel.ok { border-top: 3px solid var(--vt-state-checked-rule); }
+.hn-panel.watch { border-top: 3px solid var(--vt-state-stale-rule); }
+.hn-panel-head { display: flex; align-items: center; gap: 10px; padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--vt-rule-soft); }
+.hn-panel-head .t { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; }
+.hn-panel.ok .hn-panel-head { color: var(--vt-state-checked); }
+.hn-panel.watch .hn-panel-head { color: var(--vt-state-stale); }
+.hn-panel-head .n { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); }
+.hn-items { list-style: none; margin: 0; padding: 0; }
+.hn-item { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-3); align-items: start;
+  padding: 13px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.hn-item:last-child { border-bottom: none; }
+.hn-item .lab { font-size: 13.5px; font-weight: 500; color: var(--vt-text); }
+.hn-item .src { display: block; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); margin-top: 3px; }
+.hn-item .note { margin: 5px 0 0; font-size: 12px; line-height: 1.55; color: var(--vt-text-secondary); }
+.hn-panel-foot { margin-top: auto; padding-top: var(--space-4); }
+@media (max-width: 860px) { .hn-pair { grid-template-columns: 1fr; } }
+
+/* ---- proof-pack schematic (DG-8.5) — mono diagram, no fake UI ---- */
+.pp { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-8); }
+.pp-flow { display: flex; align-items: stretch; }
+.pp-node { flex: 1 1 0; min-width: 0; border: 1px solid var(--vt-rule-strong); background: var(--vt-surface-page);
+  border-radius: var(--radius-1); padding: 16px; display: flex; flex-direction: column; gap: 7px; font-family: var(--font-mono); }
+.pp-node-k { font-size: 10px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text); }
+.pp-node-v { font-size: 12px; line-height: 1.5; color: var(--vt-text); overflow-wrap: anywhere; }
+.pp-node-s { font-size: 10px; line-height: 1.6; color: var(--vt-text-muted); letter-spacing: 0.02em; }
+.pp-link { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  padding: 0 var(--space-4); flex-shrink: 0; }
+.pp-link .lab { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--vt-text-muted); }
+.pp-link .arr { font-family: var(--font-mono); font-size: 16px; color: var(--vt-text); }
+.pp-cap { margin-top: var(--space-5); }
+@media (max-width: 860px) {
+  .pp { padding: var(--space-5); }
+  .pp-flow { flex-direction: column; }
+  .pp-link { padding: var(--space-2) 0; }
+}
+
+/* ---- limitation list (DG-8.6) — ink, never collapsed ---- */
+.pl-limits { list-style: none; margin: 0; padding: 0; max-width: var(--prose-max); }
+.pl-limits li { display: flex; gap: var(--space-4); padding: 12px 0; border-top: 1px solid var(--vt-rule-soft);
+  font-size: 14px; line-height: 1.65; color: var(--vt-text); }
+.pl-limits li:first-child { border-top: none; }
+.pl-limits li::before { content: '—'; font-family: var(--font-mono); color: var(--vt-text-muted); flex-shrink: 0; }
+
+/* ---- form kit ---- */
+.fk-form { display: flex; flex-direction: column; gap: var(--space-5); }
+.fk-field { display: flex; flex-direction: column; gap: 6px; }
+.fk-label { font-size: 12.5px; font-weight: 600; color: var(--vt-text); }
+.fk-req { color: var(--vt-state-p0); margin-left: 4px; }
+.fk-input { height: 46px; padding: 0 14px; width: 100%; box-sizing: border-box; font-family: var(--font-body);
+  font-size: 14px; color: var(--vt-text); background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  transition: border-color var(--dur-fast) var(--ease-house); }
+textarea.fk-input { height: auto; min-height: 116px; padding: 12px 14px; line-height: 1.6; resize: vertical; }
+.fk-input::placeholder { color: var(--vt-text-muted); }
+.fk-input.err { border-color: var(--vt-state-p0); }
+.fk-hint { margin: 0; font-size: 11.5px; line-height: 1.5; color: var(--vt-text-muted); }
+.fk-err { display: flex; align-items: flex-start; gap: 7px; margin: 0; font-family: var(--font-mono);
+  font-size: 10.5px; letter-spacing: 0.04em; line-height: 1.5; color: var(--vt-state-p0); }
+.fk-err svg { flex-shrink: 0; margin-top: 2px; }
+.fk-callout { border: 1px solid var(--vt-rule-strong); background: var(--vt-surface-sunken); border-radius: var(--radius-1);
+  padding: 14px 16px; font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em; color: var(--vt-text); }
+.fk-summary { border: 1px solid var(--vt-state-p0-rule); background: var(--vt-state-p0-bg); border-radius: var(--radius-1);
+  padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
+.fk-summary .t { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11px;
+  font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-state-p0); }
+.fk-summary ul { margin: 0; padding: 0 0 0 2px; list-style: none; display: flex; flex-direction: column; gap: 4px; }
+.fk-summary button { background: none; border: none; padding: 2px 0; cursor: pointer; font-family: var(--font-body);
+  font-size: 12.5px; color: var(--vt-text); text-decoration: underline; text-underline-offset: 3px; text-align: left; }
+.fk-success { background: var(--vt-surface-card); border: 1px solid var(--vt-state-checked-rule);
+  border-top: 3px solid var(--vt-state-checked-rule); border-radius: var(--radius-2); padding: var(--space-8);
+  display: flex; flex-direction: column; gap: var(--space-4); align-items: flex-start; }
+.fk-success h3 { font-size: var(--text-xl); }
+.fk-success .receipt { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--vt-text-secondary);
+  border: 1px solid var(--vt-rule); background: var(--vt-surface-page); padding: 6px 10px; border-radius: var(--radius-1);
+  overflow-wrap: anywhere; }
+.fk-success p { margin: 0; font-size: 14px; line-height: 1.65; color: var(--vt-text); max-width: 56ch; }
+@media (prefers-reduced-motion: no-preference) {
+  html.motion-live .fk-success, html.motion-live .fk-summary { animation: hp-enter var(--dur-base) var(--ease-house) both; }
+}
+
+/* ---- pilot form section layout ---- */
+.pl-form-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: var(--space-12); align-items: start; }
+.pl-form-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-8); }
+@media (max-width: 860px) { .pl-form-grid { grid-template-columns: 1fr; gap: var(--space-8); } .pl-form-card { padding: var(--space-5); } }
+
+/* ---- /review/request two-column (DG-8.3) ---- */
+.rq-grid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr); gap: var(--space-16); align-items: start; }
+.rq-form-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-8); }
+@media (max-width: 860px) { .rq-grid { grid-template-columns: 1fr; gap: var(--space-10); } .rq-form-card { padding: var(--space-5); } }
+
+/* ---- vertical step timeline ---- */
+.tl { list-style: none; margin: 0; padding: 0; }
+.tl-step { display: grid; grid-template-columns: 44px minmax(0, 1fr); gap: 0 var(--space-4); position: relative; padding-bottom: var(--space-8); }
+.tl-step::before { content: ''; position: absolute; left: 21.5px; top: 48px; bottom: 4px; width: 1px; background: var(--vt-rule); }
+.tl-step:last-child { padding-bottom: 0; }
+.tl-step:last-child::before { display: none; }
+.tl-marker { width: 44px; height: 44px; display: grid; place-items: center; background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1); font-family: var(--font-mono);
+  font-size: 12px; font-variant-numeric: tabular-nums; }
+.tl-key { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; color: var(--vt-text-faint); }
+.tl-body h3 { font-size: var(--text-md); margin: 3px 0 6px; }
+.tl-body p { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); max-width: 44ch; }
+.tl-meta { display: inline-flex; margin-top: 9px; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em;
+  color: var(--vt-text-secondary); border: 1px solid var(--vt-rule); padding: 3px 8px; border-radius: var(--radius-1); }
+
+/* ---- reviewer surface (DG-11.1 / 11.3) ---- */
+.en-crumb { display: flex; align-items: baseline; gap: var(--space-4); padding: var(--space-5) 0 0; flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-text-muted); }
+.en-head { display: flex; align-items: center; gap: var(--space-6); padding: var(--space-6) 0; flex-wrap: wrap; }
+.en-id { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.en-name { font-size: var(--text-2xl); line-height: 1.1; }
+.en-sub { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em; color: var(--vt-text-secondary); }
+.en-counts { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+@media (max-width: 760px) { .en-counts { margin-left: 0; width: 100%; } .en-name { font-size: var(--text-xl); } }
+
+/* evidence table — container grid, rows via display:contents */
+.ev-table { display: grid; grid-template-columns: minmax(0, 1.5fr) max-content max-content max-content;
+  align-items: start; background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); }
+.ev-h { display: contents; }
+.ev-h > span { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-muted); padding: 12px 16px; border-bottom: 1px solid var(--vt-rule); }
+.ev-h > span:first-child { padding-left: 20px; }
+.ev-group { grid-column: 1 / -1; background: var(--vt-surface-sunken); font-family: var(--font-mono); font-size: 9.5px;
+  font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text-secondary);
+  padding: 8px 16px 8px 20px; border-top: 1px solid var(--vt-rule); }
+.ev-row { display: contents; }
+.ev-row > * { border-top: 1px solid var(--vt-rule-soft); padding: 14px 16px 12px; }
+.ev-row > .ev-lane { padding-left: 20px; }
+.ev-lane .n { display: block; font-size: 13.5px; font-weight: 500; color: var(--vt-text); }
+.ev-lane .s { display: block; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); margin-top: 3px; }
+.ev-fresh { text-align: right; padding-right: 20px; }
+.ev-note { grid-column: 1 / -1; border-top: none; margin: 0; padding: 0 20px 14px; font-size: 12px;
+  line-height: 1.55; color: var(--vt-text-secondary); max-width: 78ch; }
+.ev-row.blocking > * { background: var(--vt-state-p0-bg); }
+.ev-row.contra > * { background: var(--vt-state-contradicted-bg); }
+@media (max-width: 760px) {
+  .ev-table { display: block; }
+  .ev-h { display: none; }
+  .ev-row { display: block; padding: 14px 16px; border-top: 1px solid var(--vt-rule-soft); }
+  .ev-row > * { border-top: none; padding: 0; background: none !important; }
+  .ev-row.blocking { background: var(--vt-state-p0-bg); }
+  .ev-row.contra { background: var(--vt-state-contradicted-bg); }
+  .ev-row > .ev-lane { padding: 0 0 8px; }
+  .ev-tier, .ev-state { display: inline-flex; margin: 0 8px 6px 0; vertical-align: middle; }
+  .ev-fresh { display: inline-flex; text-align: left; padding: 0; vertical-align: middle; }
+  .ev-note { padding: 8px 0 0; }
+  .ev-group { border-top: 1px solid var(--vt-rule); padding: 8px 16px; }
+}
+
+/* divergence panel (DG-11.3) */
+.dv { grid-column: 1 / -1; border-top: none; margin: 0 16px 16px 20px; padding: var(--space-4);
+  border: 1px solid var(--vt-state-contradicted-rule); background: var(--vt-surface-card); border-radius: var(--radius-1); }
+.dv-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; font-size: 12.5px; font-weight: 500; color: var(--vt-text); }
+.dv-pair { display: grid; grid-template-columns: 1fr auto 1fr; gap: var(--space-3); align-items: stretch; margin-top: 12px; }
+.dv-cell { background: var(--vt-surface-page); border: 1px solid var(--vt-state-contradicted-rule);
+  border-radius: var(--radius-1); padding: 12px 14px; display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.dv-cell .src { font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-state-contradicted); }
+.dv-cell .val { font-size: 13px; line-height: 1.5; color: var(--vt-text); }
+.dv-vs { display: grid; place-items: center; font-family: var(--font-mono); font-size: 15px; font-weight: 700;
+  color: var(--vt-state-contradicted); padding: 0 2px; }
+.dv-note { margin: 12px 0 0; font-size: 12px; line-height: 1.55; color: var(--vt-text-secondary); }
+@media (max-width: 760px) {
+  .dv { margin: 10px 0 0; }
+  .dv-pair { grid-template-columns: 1fr; }
+  .dv-vs { padding: 2px 0; }
+}
+
+/* action bar (DG-11.1) — sticky, primary action always reachable */
+.ab { position: sticky; bottom: 0; z-index: 30; background: var(--vt-surface-page);
+  border-top: 1px solid var(--vt-rule-strong); padding: 14px 0 calc(14px + env(safe-area-inset-bottom)); margin-top: var(--space-10); }
+.ab-inner { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; min-height: 44px; }
+.ab-audit { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-mono);
+  font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--vt-text-secondary); }
+.ab-will { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+  color: var(--vt-text); border: 1px solid var(--vt-rule-strong); background: var(--vt-surface-card);
+  padding: 5px 9px; border-radius: var(--radius-1); }
+.ab-desc { font-size: 12.5px; line-height: 1.5; color: var(--vt-text-secondary); max-width: 46ch; }
+.ab-recorded { display: inline-flex; align-items: center; gap: 12px; flex-wrap: wrap; padding: 6px 10px;
+  border-radius: var(--radius-1); color: var(--vt-state-checked); }
+.ab-recorded .ev { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--vt-text); overflow-wrap: anywhere; }
+@media (prefers-reduced-motion: no-preference) {
+  html.motion-live .ab-recorded { animation: ab-pulse var(--dur-slow) var(--ease-house) 1 both; }
+  @keyframes ab-pulse { from { background: var(--vt-brand-soft); } to { background: transparent; } }
+}
+@media (max-width: 760px) { .ab-audit { margin-left: 0; width: 100%; } }
+
+/* ---- footer boundary ---- */
+.s2-foot { border-top: 1px solid var(--vt-rule); margin-top: var(--space-16); padding: var(--space-12) 0 var(--space-10); }
+.s2-foot.tight { margin-top: 0; }
+.s2-boundary { display: flex; align-items: baseline; gap: 12px; margin: 0 0 14px; font-family: var(--font-display);
+  font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em; color: var(--vt-text); max-width: 40ch; line-height: 1.35; }
+.s2-boundary svg { flex-shrink: 0; transform: translateY(2px); }
+.s2-foot-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* ---- reduced-motion static fallbacks ---- */
+@media (prefers-reduced-motion: reduce) {
+  .fk-input, .s2-tab { transition: none; }
+  .ab-recorded, .fk-success, .fk-summary { animation: none; }
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1503/w1503-shared.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1503/w1503-shared.jsx
@@ -1,0 +1,191 @@
+// Wave 1503 · w1503-shared.jsx — funnel router, nav, prototype strip,
+// EvidenceRow (SourceRow grammar + tier), RecognitionRow (DG-10.5),
+// shared persona/data so passport + share page render identical truth.
+// Consumes wave1500 tokens/primitives + 1501/1502 kit only.
+
+/* ---------- shared persona (matches Wave 1501 wallet mock) ---------- */
+const FUNNEL_PERSONA = {
+  name: 'Adaeze Okafor, MD',
+  specialty: 'Family Medicine',
+  location: 'Sacramento, California',
+  npi: '1234 5678 93',
+  npiRaw: '1234567893',
+  ring: 72,
+  compiled: '2026-07-11T14:02Z',
+  doc: 'psp_okafor_7f3a',
+  slug: 'a-okafor-7f3a',
+};
+
+const bandFor3 = (v) => (v >= 80
+  ? { key: 'ready', label: 'Ready band' }
+  : v >= 50
+    ? { key: 'head', label: 'Head-start band' }
+    : { key: 'early', label: 'Early band' });
+
+/* ---------- passport evidence groups (blockers sorted first) ---------- */
+const FUNNEL_GROUPS = [
+  { name: 'Identity', rows: [
+    { label: 'NPPES record', source: 'NPPES', state: 'checked', tier: 'T2', freshness: '2h ago', iso: '2026-07-11T12:04:00Z' },
+    { label: 'Specialty & taxonomy', source: 'NPPES', state: 'checked', tier: 'T2', freshness: '2h ago', iso: '2026-07-11T12:04:00Z' },
+  ] },
+  { name: 'Exclusions', rows: [
+    { label: 'Exclusion list', source: 'OIG LEIE', state: 'checked', tier: 'T2', freshness: '2h ago', iso: '2026-07-11T12:04:00Z',
+      note: 'Re-read monthly when OIG publishes.' },
+  ] },
+  { name: 'Enrollment', rows: [
+    { label: 'Medicare enrollment', source: 'CMS PECOS', state: 'gated', action: 'Authorize read',
+      note: 'Reads only after your enrollment agreement — gated until then, never assumed.' },
+  ] },
+  { name: 'Licensure', rows: [
+    { label: 'Texas license', source: 'TEXAS MEDICAL BOARD', state: 'p0', chipLabel: 'Blocker', tier: 'T2',
+      freshness: '21d ago', iso: '2026-06-20T09:00:00Z', blocker: true, action: 'Resolve',
+      note: 'Expired 2026-05-31. Blocks the Texas lane only — California is unaffected.' },
+    { label: 'California license', source: 'MEDICAL BOARD OF CALIFORNIA', state: 'checked', tier: 'T2',
+      freshness: '1d ago', iso: '2026-07-10T08:30:00Z' },
+  ] },
+  { name: 'Employment', rows: [
+    { label: 'Hospitalist — St. Rose Community Hospital', source: 'SELF-ATTESTED · 2022–PRESENT',
+      state: 'notDecisionGrade', chipLabel: 'Self-attested', tier: 'T1', action: 'Request review' },
+    { label: 'Attending — Lakeview Clinic', source: 'SELF-ATTESTED · 2019–2022',
+      state: 'notDecisionGrade', chipLabel: 'Self-attested', tier: 'T1' },
+  ] },
+];
+
+/* ---------- recognitions (DG-10.5) ---------- */
+const FUNNEL_RECOGNITIONS = [
+  { employer: 'Mercy General Health', iso: '2026-06-30T14:22Z', packet: 'pk_7f3a·d91c', n: '0012' },
+  { employer: 'Sierra Valley Medical Group', iso: '2026-04-12T09:05Z', packet: 'pk_29be·77e0', n: '0007' },
+];
+
+/* ---------- hash router ---------- */
+const parseRoute3 = (h) => {
+  const hash = h || window.location.hash || '#/get-ready';
+  const m = hash.replace(/^#/, '').split('/').filter(Boolean);
+  if (m[0] === 'onboarding') return { name: 'onboarding' };
+  if (m[0] === 'passport') return { name: 'passport' };
+  if (m[0] === 'p' && m[1]) return { name: 'share', slug: m[1] };
+  return { name: 'getready' };
+};
+const useRoute3 = () => {
+  const [route, setRoute] = React.useState(() => parseRoute3());
+  React.useEffect(() => {
+    const fn = () => { setRoute(parseRoute3()); window.scrollTo({ top: 0, behavior: 'auto' }); };
+    window.addEventListener('hashchange', fn);
+    return () => window.removeEventListener('hashchange', fn);
+  }, []);
+  return route;
+};
+
+/* ---------- nav ---------- */
+const S3_ROUTES = [
+  { hash: '#/get-ready', label: 'Get ready', match: 'getready' },
+  { hash: '#/onboarding', label: 'Onboarding', match: 'onboarding' },
+  { hash: '#/passport', label: 'Passport', match: 'passport' },
+  { hash: '#/p/' + FUNNEL_PERSONA.slug, label: 'Share page', match: 'share' },
+];
+const S3Nav = ({ route }) => (
+  <header className="s3-nav">
+    <div className="s3-container s3-nav-inner">
+      <a className="s3-brand" href="../wave1501/index.html">VitalCV</a>
+      <span className="s3-wave vt-eyebrow">Wave 1503 · clinician funnel</span>
+      <nav className="s3-tabs" aria-label="Surfaces">
+        {S3_ROUTES.map((r) => (
+          <a key={r.hash} className="s3-tab" href={r.hash}
+            aria-current={route.name === r.match ? 'page' : undefined}>{r.label}</a>
+        ))}
+      </nav>
+    </div>
+  </header>
+);
+
+/* ---------- prototype control strip (design-review chrome) ---------- */
+const DemoStrip = ({ label, children }) => (
+  <div className="s3-demo no-print" role="group" aria-label="Prototype controls">
+    <div className="s3-container s3-demo-inner">
+      <span className="s3-demo-lab">Prototype{label ? ' · ' + label : ''}</span>
+      <span className="s3-demo-ctl">{children}</span>
+    </div>
+  </div>
+);
+const DemoBtn = ({ on, children, ...rest }) => (
+  <button type="button" className={`s3-demo-btn${on ? ' on' : ''}`} aria-pressed={on} {...rest}>{children}</button>
+);
+
+/* ---------- EvidenceRow — SourceRow grammar + ProofTierBadge cell ----------
+   Promotion candidate (documented in CHANGES.md). Same metrics as DG-6.4. */
+const EvidenceRow = ({ label, source, state, tier, freshness, iso, note, action, onAction, chipLabel, blocker }) => (
+  <div className={`ev3-row${blocker ? ' blocker' : ''}`}>
+    <div className="ev3-main">
+      <span className="ev3-label">{label}</span>
+      <span className="ev3-srcline">
+        <span className="ev3-src">{source}</span>
+        {freshness ? <FreshnessStamp rel={freshness} iso={iso} stale={state === 'stale'} /> : null}
+      </span>
+      {note ? <p className="ev3-note">{note}</p> : null}
+    </div>
+    <div className="ev3-cluster">
+      {tier ? <ProofTierBadge tier={tier} /> : null}
+      <span className="s3-fade" key={state}>
+        <StateChip state={state} size="sm" source={source} freshness={freshness} label={chipLabel} />
+      </span>
+      {action ? <QuietButton small onClick={onAction}>{action}</QuietButton> : null}
+    </div>
+  </div>
+);
+
+/* ---------- RecognitionRow (DG-10.5) — the one reserved matcha moment ----------
+   Mono timestamp · employer · "Accepted as head start" · stamp. Calm, archival. */
+const RecognitionRow = ({ employer, iso, packet, n, entered }) => (
+  <div className={`rec-row${entered ? ' s3-enter' : ''}`}>
+    <span className="rec-seal" aria-hidden="true"><TrustGlyph state="checked" size={15} /></span>
+    <div className="rec-body">
+      <span className="rec-emp">{employer}</span>
+      <span className="rec-line">Accepted as head start — committee review continued on their side.</span>
+      <span className="rec-meta vt-num">{iso} · packet {packet}</span>
+    </div>
+    <span className="rec-stamp" aria-hidden="true">Recognition Nº {n}</span>
+  </div>
+);
+
+/* ---------- funnel footer boundary (DG-10.3 §6 wording) ---------- */
+const FunnelFooter = ({ tight }) => (
+  <footer className={`s3-foot${tight ? ' tight' : ''}`}>
+    <div className="s3-container">
+      <p className="s3-boundary">
+        <TrustGlyph state="notDecisionGrade" size={16} />
+        <span>A head start for employer review — <span className="vt-accent-i">not</span> a final credentialing decision.</span>
+      </p>
+      <p className="s3-foot-base">© 2026 VitalCV · Free for clinicians · A partial proof stays partial.</p>
+    </div>
+  </footer>
+);
+
+/* ---------- two-list honesty panel (1502 HonestyPanel classes, share wording) ----------
+   Local variant: same hn-* rendering, item count label dropped (these are
+   points, not lanes). Documented in CHANGES.md. */
+const SharePanel = ({ tone, title, items }) => (
+  <section className={`hn-panel ${tone}`} aria-label={title}>
+    <header className="hn-panel-head">
+      <TrustGlyph state={tone === 'ok' ? 'checked' : 'stale'} size={14} />
+      <span className="t">{title}</span>
+    </header>
+    <ul className="hn-items">
+      {items.map((it) => (
+        <li className="hn-item" key={it.label}>
+          <div>
+            <span className="lab">{it.label}</span>
+            <span className="src">{it.src}</span>
+            {it.note ? <p className="note">{it.note}</p> : null}
+          </div>
+          <StateChip state={it.state} size="sm" label={it.chipLabel} />
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+Object.assign(window, {
+  FUNNEL_PERSONA, FUNNEL_GROUPS, FUNNEL_RECOGNITIONS, bandFor3,
+  parseRoute3, useRoute3, S3Nav, S3_ROUTES, DemoStrip, DemoBtn,
+  EvidenceRow, RecognitionRow, FunnelFooter, SharePanel,
+});

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1503/w1503.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1503/w1503.css
@@ -1,0 +1,333 @@
+/* ============================================================
+   VitalCV · Wave 1503 · w1503.css — clinician-funnel layout ONLY.
+   Colors: --vt-* semantic tokens exclusively. No new hues, no
+   gradients, no dark surfaces. Motion: single-shot, house curve,
+   240–420ms; skeleton shimmer strictly while the gate loads.
+   ============================================================ */
+
+/* ---- shell ---- */
+.s3-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+.s3-section { padding: var(--space-16) 0; }
+@media (max-width: 720px) { .s3-section { padding: var(--space-10) 0; } }
+
+/* ---- nav (parity with 1502) ---- */
+.s3-nav { position: sticky; top: 0; z-index: 40; background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }
+.s3-nav-inner { display: flex; align-items: center; gap: var(--space-5); padding: 10px 0; flex-wrap: wrap; }
+.s3-brand { font-family: var(--font-display); font-size: 19px; font-weight: 600; letter-spacing: -0.01em; text-decoration: none; color: var(--vt-text); }
+.s3-brand:hover { color: var(--vt-text); text-decoration: none; }
+.s3-wave { padding-top: 2px; }
+.s3-tabs { margin-left: auto; display: flex; gap: 2px; flex-wrap: wrap; }
+.s3-tab { display: inline-flex; align-items: center; min-height: 38px; padding: 0 14px; font-size: 12.5px; font-weight: 500;
+  color: var(--vt-text-secondary); text-decoration: none; border: 1px solid transparent; border-radius: var(--radius-1); }
+.s3-tab:hover { color: var(--vt-text); text-decoration: none; }
+.s3-tab[aria-current="page"] { color: var(--vt-text); border-color: var(--vt-rule-strong); background: var(--vt-surface-card); }
+@media (max-width: 640px) { .s3-wave { display: none; } .s3-tabs { margin-left: 0; width: 100%; padding-bottom: 8px; } }
+@media (pointer: coarse) { .s3-tab, .s3-demo-btn, .ps-toggle, button { min-height: 44px; } }
+
+/* ---- prototype control strip (design-review chrome, stripped in print) ---- */
+.s3-demo { border-bottom: 1px dashed var(--vt-degraded-border); background: var(--vt-surface-page); }
+.s3-demo-inner { display: flex; align-items: center; gap: var(--space-4); padding: 6px 0; flex-wrap: wrap; }
+.s3-demo-lab { font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.s3-demo-ctl { margin-left: auto; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.s3-demo-btn { border: 1px solid var(--vt-rule); background: transparent; border-radius: var(--radius-1);
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 500; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--vt-text-secondary); padding: 5px 10px; cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease-house), color var(--dur-fast) var(--ease-house); }
+.s3-demo-btn:hover { border-color: var(--vt-rule-strong); color: var(--vt-text); }
+.s3-demo-btn.on { border-color: var(--vt-rule-strong); background: var(--vt-surface-card); color: var(--vt-text); }
+@media (max-width: 640px) { .s3-demo-ctl { margin-left: 0; } }
+
+/* ---- single-shot entrances ---- */
+@media (prefers-reduced-motion: no-preference) {
+  html.motion-live .s3-enter { animation: s3-enter var(--dur-base) var(--ease-house) both; }
+  html.motion-live .s3-fade { animation: s3-fade var(--dur-fast) var(--ease-house) both; }
+  @keyframes s3-enter { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+  @keyframes s3-fade { from { opacity: 0; } to { opacity: 1; } }
+}
+
+/* ---- page head ---- */
+.s3-head { padding: var(--space-16) 0 var(--space-10); display: flex; flex-direction: column; gap: var(--space-4); }
+.s3-head h1 { font-size: var(--text-display); line-height: 1.05; max-width: 22ch; }
+.s3-head p.lede { margin: 0; font-size: var(--text-md); line-height: 1.65; color: var(--vt-text-secondary); max-width: 54ch; }
+@media (max-width: 720px) { .s3-head { padding: var(--space-10) 0 var(--space-8); } }
+
+/* ============================================================
+   A · /get-ready
+   ============================================================ */
+.gr-cta-row { display: flex; align-items: center; gap: var(--space-4); flex-wrap: wrap; margin-top: var(--space-2); }
+.gr-micro { font-family: var(--font-mono); font-size: 10px; font-weight: 500; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-secondary); margin-top: var(--space-4); }
+.gr-micro .dot { color: var(--vt-text-faint); padding: 0 6px; }
+
+.gr-cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-5); }
+.gr-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); display: flex; flex-direction: column; gap: 0; }
+.gr-card .idx { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; color: var(--vt-text-faint); }
+.gr-card .verb { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--vt-text); margin-top: var(--space-4); }
+.gr-card h3 { font-size: var(--text-lg); margin: 8px 0 8px; }
+.gr-card p { margin: 0; font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); }
+@media (max-width: 1000px) { .gr-cards { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .gr-cards { grid-template-columns: 1fr; } }
+
+/* checking gate — designed for the 1–2s it exists */
+.gr-gate { min-height: 68vh; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: var(--space-8); padding: var(--space-16) var(--space-6); }
+.gr-gate-mark { font-family: var(--font-display); font-size: 26px; font-weight: 600; letter-spacing: -0.01em; }
+.gr-sk-card { width: min(520px, 100%); background: var(--vt-surface-card); border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-2); padding: var(--space-6); }
+.gr-sk-head { display: flex; align-items: center; gap: 18px; padding-bottom: var(--space-5);
+  border-bottom: 1px solid var(--vt-rule-soft); margin-bottom: var(--space-3); }
+.gr-sk-id { display: flex; flex-direction: column; gap: 9px; flex: 1; }
+.gr-sk-row { display: flex; align-items: center; gap: 12px; padding: 13px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.gr-sk-row:last-child { border-bottom: none; }
+.sk { background: var(--vt-surface-sunken); border-radius: var(--radius-1); }
+.sk-circle { width: 72px; height: 72px; border-radius: 50%; flex-shrink: 0; }
+.sk-bar { height: 12px; }
+.sk-chip { width: 76px; height: 18px; flex-shrink: 0; margin-left: auto; }
+/* shimmer = opacity breathe (no gradients) — loop allowed ONLY while loading */
+@media (prefers-reduced-motion: no-preference) {
+  .sk { animation: sk-breathe 1.1s ease-in-out infinite alternate; }
+  @keyframes sk-breathe { from { opacity: 1; } to { opacity: 0.45; } }
+}
+.gr-gate-status { margin: 0; font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--vt-text-secondary); text-align: center; line-height: 2; }
+.gr-gate-status .dot { color: var(--vt-text-faint); padding: 0 7px; }
+
+/* ============================================================
+   B · /onboarding — the loading sequence IS the demo
+   ============================================================ */
+.ob-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: var(--space-12); align-items: start; }
+@media (max-width: 900px) { .ob-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+
+.ob-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-8); }
+@media (max-width: 600px) { .ob-card { padding: var(--space-5); } }
+
+.ob-run-head { display: flex; align-items: baseline; gap: var(--space-4); flex-wrap: wrap;
+  padding-bottom: var(--space-4); border-bottom: 1px solid var(--vt-rule); }
+.ob-run-title { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--vt-text); }
+.ob-run-meta { margin-left: auto; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+.ob-lanes { min-height: 220px; }
+.ob-finale { margin-top: var(--space-6); border-top: 1px solid var(--vt-rule); padding-top: var(--space-6);
+  display: flex; gap: var(--space-6); align-items: center; flex-wrap: wrap; }
+.ob-finale-body { display: flex; flex-direction: column; gap: 8px; min-width: 0; flex: 1; }
+.ob-band { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text); }
+.ob-count { font-size: 13.5px; line-height: 1.6; color: var(--vt-text-secondary); max-width: 40ch; }
+.ob-cta { display: flex; align-items: center; gap: var(--space-4); margin-top: 6px; flex-wrap: wrap; }
+@media (max-width: 480px) { .ob-finale { flex-direction: column; align-items: flex-start; } }
+
+.ob-aside h2 { font-size: var(--text-xl); margin-bottom: var(--space-3); }
+.ob-aside p { margin: 0 0 var(--space-4); font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); max-width: 44ch; }
+.ob-honest { list-style: none; margin: var(--space-6) 0 0; padding: 0; }
+.ob-honest li { display: flex; gap: 12px; align-items: flex-start; padding: 12px 0; border-top: 1px solid var(--vt-rule-soft);
+  font-size: 13px; line-height: 1.6; color: var(--vt-text); }
+.ob-honest li svg { flex-shrink: 0; margin-top: 3px; }
+.ob-honest li .m { color: var(--vt-text-secondary); }
+
+/* ============================================================
+   Evidence row — SourceRow grammar + tier cell (promotion candidate)
+   Mirrors DG-6.4 metrics exactly: 13px/500 label, 10px mono source,
+   10px vertical padding, rule-soft dividers.
+   ============================================================ */
+.ev3-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; align-items: center;
+  padding: 10px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.ev3-row:last-child { border-bottom: none; }
+.ev3-main { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.ev3-label { font-size: 13px; font-weight: 500; color: var(--vt-text); }
+.ev3-srcline { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.ev3-src { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-text-muted); }
+.ev3-note { margin: 4px 0 0; font-size: 12px; line-height: 1.55; color: var(--vt-text-secondary); max-width: 52ch; }
+.ev3-cluster { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.ev3-row.blocker { background: var(--vt-state-p0-bg); margin: 0 -12px; padding: 10px 12px; border-radius: var(--radius-1);
+  border-bottom: 1px solid var(--vt-state-p0-rule); }
+@media (max-width: 620px) {
+  .ev3-row { grid-template-columns: 1fr; gap: 8px; }
+  .ev3-cluster { justify-content: flex-start; }
+}
+
+/* ============================================================
+   C · /passport — the paper document
+   ============================================================ */
+.ps-wrap { max-width: 880px; margin: 0 auto; padding: var(--space-10) var(--space-6) 0; }
+@media (max-width: 720px) { .ps-wrap { padding-top: var(--space-6); } }
+.ps-doc { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); overflow: hidden; }
+.ps-meta { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; padding: 10px 24px;
+  background: var(--vt-surface-sunken); border-bottom: 1px solid var(--vt-rule);
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 500; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-secondary); }
+.ps-meta .dot { color: var(--vt-text-faint); }
+.ps-meta .right { margin-left: auto; }
+
+.ps-id { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-8); align-items: center; padding: var(--space-8) 24px; }
+.ps-name { font-size: var(--text-2xl); line-height: 1.1; }
+.ps-idlines { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
+.ps-idline { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.07em; color: var(--vt-text-secondary); }
+.ps-idline .k { color: var(--vt-text-faint); text-transform: uppercase; font-size: 9.5px; letter-spacing: 0.16em; padding-right: 8px; }
+.ps-ringside { display: flex; align-items: center; gap: var(--space-5); }
+.ps-ringmeta { display: flex; flex-direction: column; gap: 8px; align-items: flex-start; }
+.ps-band { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text); }
+@media (max-width: 720px) {
+  .ps-id { grid-template-columns: 1fr; gap: var(--space-5); padding: var(--space-6) 16px; }
+  .ps-meta { padding: 10px 16px; }
+  .ps-name { font-size: var(--text-xl); }
+}
+
+.ps-raise { margin-top: 4px; border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  background: var(--vt-surface-page); padding: 12px 14px; max-width: 340px; }
+.ps-raise-row { display: flex; align-items: flex-start; gap: 9px; padding: 7px 0; font-size: 12.5px; line-height: 1.5; color: var(--vt-text); }
+.ps-raise-row svg { flex-shrink: 0; margin-top: 3px; }
+.ps-raise-row .d { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--vt-text-secondary); white-space: nowrap; padding-left: 10px; }
+.ps-raise-foot { margin: 8px 0 0; padding-top: 8px; border-top: 1px dashed var(--vt-degraded-border);
+  font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--vt-text-muted); }
+
+.ps-group { padding: var(--space-4) 24px var(--space-5); border-top: 1px solid var(--vt-rule); }
+.ps-group-h { display: flex; align-items: baseline; gap: 12px; padding: 4px 0 6px; }
+.ps-group-name { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--vt-text); }
+.ps-group-n { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-text-muted); }
+.ps-group-n .blk { color: var(--vt-state-p0); }
+@media (max-width: 720px) { .ps-group { padding-left: 16px; padding-right: 16px; } }
+
+/* ============================================================
+   E · Recognition — the ONE reserved matcha moment.
+   Calm, archival, permanent-feeling. Never a trophy.
+   ============================================================ */
+.rec-list { display: flex; flex-direction: column; }
+.rec-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: var(--space-4); align-items: center;
+  padding: 14px 0; border-bottom: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1); }
+.rec-row:last-child { border-bottom: none; }
+.rec-seal { width: 34px; height: 34px; border-radius: 50%; border: 1.5px solid var(--vt-brand);
+  background: var(--vt-brand-soft); color: var(--vt-brand); display: grid; place-items: center; flex-shrink: 0; }
+.rec-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.rec-emp { font-size: 13.5px; font-weight: 600; color: var(--vt-text); }
+.rec-line { font-size: 12.5px; line-height: 1.5; color: var(--vt-text-secondary); }
+.rec-meta { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; color: var(--vt-text-muted); margin-top: 2px; overflow-wrap: anywhere; }
+.rec-stamp { font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-brand); border: 1.5px solid var(--vt-brand);
+  background: var(--vt-brand-soft); border-radius: var(--radius-1); padding: 5px 10px;
+  transform: rotate(-1.4deg); white-space: nowrap; }
+.rec-empty { font-size: 12.5px; color: var(--vt-text-secondary); }
+@media (max-width: 560px) {
+  .rec-row { grid-template-columns: auto minmax(0, 1fr); }
+  .rec-stamp { grid-column: 2; justify-self: start; transform: rotate(-1.4deg) translateY(-2px); }
+}
+/* one-shot archival settle — background fades from matcha-soft to paper, once */
+@media (prefers-reduced-motion: no-preference) {
+  html.motion-live .hp-reveal.is-in .rec-row, html.motion-live .rec-row.s3-enter { animation: rec-settle var(--dur-slow) var(--ease-house) 1 both; }
+  @keyframes rec-settle { from { background: var(--vt-brand-soft); } to { background: transparent; } }
+}
+
+/* ---- share affordance (passport) ---- */
+.ps-share { margin-top: var(--space-8); display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: var(--space-6); align-items: start; }
+@media (max-width: 860px) { .ps-share { grid-template-columns: 1fr; } }
+.ps-share-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-6); }
+.ps-share-card h3 { font-size: var(--text-lg); margin-bottom: 6px; }
+.ps-share-card > p { margin: 0 0 var(--space-4); font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); }
+.ps-toggles { display: flex; flex-direction: column; margin-bottom: var(--space-4); }
+.ps-toggle { display: flex; align-items: center; gap: 12px; min-height: 44px; padding: 4px 2px;
+  background: none; border: none; border-bottom: 1px solid var(--vt-rule-soft); cursor: pointer; text-align: left;
+  font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--vt-text); }
+.ps-toggle:last-child { border-bottom: none; }
+.ps-box { width: 18px; height: 18px; border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  display: grid; place-items: center; flex-shrink: 0; background: var(--vt-surface-card); color: var(--vt-text); }
+.ps-toggle[aria-checked="false"] .ps-box { border-color: var(--vt-rule); }
+.ps-toggle[aria-checked="false"] { color: var(--vt-text-secondary); }
+.ps-toggle .src { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); }
+.ps-linkline { margin-top: var(--space-4); display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  border: 1px solid var(--vt-rule); background: var(--vt-surface-page); border-radius: var(--radius-1); padding: 10px 12px; }
+.ps-linkline .url { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.03em; color: var(--vt-text); overflow-wrap: anywhere; }
+.ps-expiry { margin-top: 10px; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); }
+
+/* recipient preview — miniature of the share page */
+.ps-prev { border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-2); overflow: hidden; background: var(--vt-surface-page); }
+.ps-prev-bar { padding: 8px 14px; border-bottom: 1px solid var(--vt-rule); background: var(--vt-surface-sunken);
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--vt-text-secondary); }
+.ps-prev-body { padding: 14px; background: var(--vt-surface-card); }
+.ps-prev-id { display: flex; align-items: center; gap: 12px; padding-bottom: 10px; border-bottom: 1px solid var(--vt-rule-soft); }
+.ps-prev-name { font-family: var(--font-display); font-size: 15px; font-weight: 600; }
+.ps-prev-sub { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--vt-text-muted); margin-top: 2px; }
+.ps-prev-rows { display: flex; flex-direction: column; }
+.ps-prev-row { display: flex; align-items: center; gap: 8px; padding: 7px 0; border-bottom: 1px solid var(--vt-rule-soft);
+  font-size: 11.5px; font-weight: 500; color: var(--vt-text); }
+.ps-prev-row:last-child { border-bottom: none; }
+.ps-prev-row .chip { margin-left: auto; }
+.ps-prev-with { padding: 7px 0 2px; font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); border-top: 1px dashed var(--vt-degraded-border); margin-top: 2px; }
+.ps-prev-foot { padding: 8px 14px; border-top: 1px solid var(--vt-rule); background: var(--vt-surface-card);
+  font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); overflow-wrap: anywhere; }
+
+/* ============================================================
+   D · /p/[slug] — public share page (cold view, screenshot-worthy)
+   ============================================================ */
+.sh-page { max-width: 760px; margin: 0 auto; padding: var(--space-8) var(--space-6) var(--space-12); }
+.sh-head { display: flex; align-items: baseline; gap: var(--space-4); flex-wrap: wrap; padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--vt-rule-strong); margin-bottom: var(--space-6); }
+.sh-mark { font-family: var(--font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.01em; color: var(--vt-text); text-decoration: none; }
+.sh-eyebrow { font-family: var(--font-mono); font-size: 10px; font-weight: 500; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.sh-open { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-muted); }
+@media (max-width: 560px) { .sh-open { margin-left: 0; width: 100%; } }
+
+.sh-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); margin-bottom: var(--space-5); }
+.sh-id { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-5); align-items: center; }
+.sh-name { font-size: var(--text-xl); line-height: 1.15; }
+.sh-sub { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--vt-text-secondary); margin-top: 7px; }
+.sh-holdline { margin-top: 12px; }
+.sh-ringside { display: flex; flex-direction: column; align-items: center; gap: 7px; }
+@media (max-width: 560px) { .sh-id { grid-template-columns: 1fr; } .sh-ringside { flex-direction: row; } }
+
+.sh-sec-h { display: flex; align-items: baseline; gap: 10px; padding-bottom: 4px; }
+.sh-sec-name { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: var(--vt-text); }
+.sh-sec-n { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--vt-text-muted); }
+.sh-withheld { display: flex; align-items: center; gap: 9px; margin-top: 12px; padding: 9px 12px;
+  border: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-1);
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--vt-text-secondary); }
+
+.sh-verify { border: 1px solid var(--vt-rule-strong); background: var(--vt-surface-sunken); border-radius: var(--radius-1);
+  padding: 14px 16px; font-family: var(--font-mono); font-size: 11px; line-height: 1.8; letter-spacing: 0.03em;
+  color: var(--vt-text); margin-bottom: var(--space-5); overflow-wrap: anywhere; }
+.sh-verify .k { font-size: 9px; font-weight: 700; letter-spacing: 0.2em; color: var(--vt-text-muted); display: block; }
+
+.sh-boundary { display: flex; align-items: baseline; gap: 12px; margin: var(--space-8) 0 10px;
+  font-family: var(--font-display); font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em;
+  color: var(--vt-text); max-width: 40ch; line-height: 1.35; }
+.sh-boundary svg { flex-shrink: 0; transform: translateY(2px); }
+.sh-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); line-height: 1.8; }
+.sh-print-foot { display: none; }
+
+/* ---- footer (funnel) ---- */
+.s3-foot { border-top: 1px solid var(--vt-rule); margin-top: var(--space-16); padding: var(--space-12) 0 var(--space-10); }
+.s3-foot.tight { margin-top: var(--space-8); }
+.s3-boundary { display: flex; align-items: baseline; gap: 12px; margin: 0 0 14px; font-family: var(--font-display);
+  font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em; color: var(--vt-text); max-width: 40ch; line-height: 1.35; }
+.s3-boundary svg { flex-shrink: 0; transform: translateY(2px); }
+.s3-foot-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* ============================================================
+   Print — share page: ink on white, chrome stripped, verify in footer
+   ============================================================ */
+@page { margin: 16mm; }
+@media print {
+  .s3-nav, .s3-demo, .no-print { display: none !important; }
+  html, body { background: #ffffff !important; }
+  .sh-page { max-width: 100%; padding: 0; }
+  .sh-card, .sh-verify { border-color: var(--ink-900); break-inside: avoid; }
+  .sh-card { margin-bottom: 12px; }
+  .rec-stamp, .rec-seal { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .sh-print-foot { display: block; margin-top: 16px; padding-top: 10px; border-top: 1px solid var(--ink-900);
+    font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.05em; color: var(--ink-900); }
+  a { text-decoration: none; }
+  .hp-reveal, .s3-enter { opacity: 1 !important; transform: none !important; animation: none !important; }
+}
+
+/* ---- reduced-motion static fallbacks ---- */
+@media (prefers-reduced-motion: reduce) {
+  .sk { animation: none; }
+  .rec-row, .s3-enter, .s3-fade { animation: none; }
+  .s3-demo-btn { transition: none; }
+}

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1504/brand/logo.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1504/brand/logo.jsx
@@ -1,0 +1,42 @@
+// VitalCV · brand/logo.jsx — THE wordmark lockup (DG-4.3).
+// Fraunces-based fixed component. No other renderings of the name are
+// permitted anywhere on vitalcv.com surfaces.
+// Variants: ink (ink-on-paper, default) · inverse (paper-on-ink).
+// Rules (documented on #/brand): clear space = 1× cap height on all
+// sides; minimum lockup width 84px; minimum mark-only size 16px.
+
+const VtMark = ({ size = 22, inverse = false }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">
+    <rect x="0" y="0" width="32" height="32"
+      fill={inverse ? 'var(--ink-900)' : 'var(--paper-100)'} />
+    <rect x="0.5" y="0.5" width="31" height="31" fill="none"
+      stroke={inverse ? 'var(--ink-700)' : 'var(--ink-200)'} strokeWidth="1" />
+    <path d="M8 8 L16 25 L24 8" fill="none"
+      stroke={inverse ? 'var(--paper-50)' : 'var(--ink-900)'}
+      strokeWidth="3.4" strokeLinecap="butt" strokeLinejoin="miter" />
+  </svg>
+);
+
+const VtLogo = ({ size = 19, variant = 'ink', mark = true, sub }) => {
+  const inverse = variant === 'inverse';
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: Math.round(size * 0.5), whiteSpace: 'nowrap' }}>
+      {mark ? <VtMark size={Math.round(size * 1.18)} inverse={inverse} /> : null}
+      <span style={{
+        fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: size,
+        letterSpacing: '-0.01em', lineHeight: 1,
+        color: inverse ? 'var(--paper-50)' : 'var(--ink-900)' }}>
+        VitalCV
+      </span>
+      {sub ? (
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: Math.max(8, Math.round(size * 0.47)),
+          letterSpacing: '0.14em', textTransform: 'uppercase', alignSelf: 'flex-end',
+          color: inverse ? 'var(--ink-300)' : 'var(--ink-500)', paddingBottom: 1 }}>
+          {sub}
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+Object.assign(window, { VtLogo, VtMark });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1504/w1504-shared.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1504/w1504-shared.jsx
@@ -1,0 +1,190 @@
+// Wave 1504 · w1504-shared.jsx — router, nav, footer, CopyBtn, TokenRow,
+// SlotGrid (promotion candidate), SrcChip, DlPanel, section scaffold.
+// Consumes wave1500 tokens/primitives + brand/logo.jsx only.
+
+/* ---------- shared issuer facts (single source of truth for this wave) ---------- */
+const ISSUER = {
+  did: 'did:web:vitalcv.com',
+  didDoc: 'https://vitalcv.com/.well-known/did.json',
+  jwks: 'https://vitalcv.com/.well-known/jwks.json',
+  kid: 'vitalcv-2026-01',
+  kidPrev: 'vitalcv-2025-07',
+  fingerprint: 'SHA-256 a7:2f:19:c4:8e:0b:52:d6:33:91:ee:47:b8:05:6c:aa',
+  alg: 'EC P-256 · ES256',
+  runId: 'run_2026-07-11_0642Z',
+  checkedAt: '2026-07-11T06:42Z',
+  artifact: 'vc_okafor_9d2e',
+  snapshot: 'psp_okafor_7f3a',
+  npi: 'npi:1234567893',
+};
+
+/* ---------- hash router ---------- */
+const parseRoute4 = (h) => {
+  const hash = h || window.location.hash || '#/trust';
+  const m = hash.replace(/^#/, '').split('/').filter(Boolean);
+  if (m[0] === 'trust' && m[1] === 'attribution') return { name: 'attribution' };
+  if (m[0] === 'trust' && m[1] === 'graph') return { name: 'graph' };
+  if (m[0] === 'status') return { name: 'status' };
+  if (m[0] === 'brand') return { name: 'brand' };
+  return { name: 'trust' };
+};
+const useRoute4 = () => {
+  const [route, setRoute] = React.useState(() => parseRoute4());
+  React.useEffect(() => {
+    const fn = () => { setRoute(parseRoute4()); window.scrollTo(0, 0); };
+    window.addEventListener('hashchange', fn);
+    return () => window.removeEventListener('hashchange', fn);
+  }, []);
+  return route;
+};
+
+/* ---------- nav ---------- */
+const S4_ROUTES = [
+  { hash: '#/trust', label: 'Trust register', match: 'trust' },
+  { hash: '#/trust/attribution', label: 'Attribution', match: 'attribution' },
+  { hash: '#/status', label: 'Status', match: 'status' },
+  { hash: '#/trust/graph', label: 'Graph', match: 'graph' },
+  { hash: '#/brand', label: 'Brand assets', match: 'brand' },
+];
+const S4Nav = ({ route }) => (
+  <header className="s4-nav">
+    <div className="s4-container s4-nav-inner">
+      <a className="s4-brand-link" href="../wave1501/index.html" aria-label="VitalCV home">
+        <VtLogo size={18} />
+      </a>
+      <span className="s4-wave vt-eyebrow">Wave 1504 · trust surfaces</span>
+      <nav className="s4-tabs" aria-label="Surfaces">
+        {S4_ROUTES.map((r) => (
+          <a key={r.hash} className="s4-tab" href={r.hash}
+            aria-current={route.name === r.match ? 'page' : undefined}>{r.label}</a>
+        ))}
+      </nav>
+    </div>
+  </header>
+);
+
+/* ---------- footer ---------- */
+const S4Footer = () => (
+  <footer className="s4-foot">
+    <div className="s4-container">
+      <p className="s4-boundary">
+        <TrustGlyph state="reviewRequired" size={16} />
+        <span>Built to be checked — <span className="vt-accent-i">not</span> taken on faith.</span>
+      </p>
+      <ul className="s4-foot-links">
+        <li><a href="#/trust">Trust State Register</a></li>
+        <li><a href="#/trust/attribution">Source attribution</a></li>
+        <li><a href="#/status">Operational status</a></li>
+        <li><a href="#/trust/graph">Verifier graph</a></li>
+      </ul>
+      <p className="s4-foot-base">© 2026 VitalCV · {ISSUER.did} · Doctrine v1.0 · A partial proof stays partial.</p>
+    </div>
+  </footer>
+);
+
+/* ---------- copy affordance (acceptance: every copyable value) ---------- */
+const copyText = (text) => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).catch(() => copyFallback(text));
+  }
+  return Promise.resolve(copyFallback(text));
+};
+const copyFallback = (text) => {
+  const ta = document.createElement('textarea');
+  ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+  document.body.appendChild(ta); ta.select();
+  try { document.execCommand('copy'); } catch (e) { /* noop */ }
+  document.body.removeChild(ta);
+};
+const CopyBtn = ({ text, label = 'Copy' }) => {
+  const [copied, setCopied] = React.useState(false);
+  const tRef = React.useRef(null);
+  React.useEffect(() => () => clearTimeout(tRef.current), []);
+  return (
+    <button type="button" className={`cp-btn${copied ? ' copied' : ''}`}
+      aria-label={`Copy ${text}`} aria-live="polite"
+      onClick={() => copyText(text).then(() => {
+        setCopied(true);
+        clearTimeout(tRef.current);
+        tRef.current = setTimeout(() => setCopied(false), 1600);
+      })}>
+      {copied ? 'Copied ✓' : label}
+    </button>
+  );
+};
+
+/* ---------- mono token row (key · value · copy) ---------- */
+const TokenRow = ({ k, value, display, href, children }) => (
+  <div className="tok-row">
+    <span className="tok-key">{k}</span>
+    <span className="tok-val vt-num">
+      {href ? <a href={href} onClick={(e) => e.preventDefault()} title="Live endpoint — stubbed in prototype">{display || value}</a> : (display || value)}
+      {children}
+    </span>
+    <CopyBtn text={value} />
+  </div>
+);
+
+/* ---------- SrcChip — source names as mono small-caps, NEVER logos (DG-4.6) ---------- */
+const SrcChip = ({ name }) => <span className="src-chip">{name}</span>;
+
+/* ---------- SlotGrid (promotion candidate — documented in CHANGES.md) ----------
+   The canonical 6-slot lineage grid: OBJECT / OWNERSHIP / CHECKED_AT /
+   CHANNEL / REPLAY / RUN_ID. A slot with no binding renders "─ ─ ─" in a
+   dashed cell (--vt-degraded-border) — degraded is a designed state, never
+   reduced opacity, never hidden. */
+const SLOT_KEYS = ['OBJECT', 'OWNERSHIP', 'CHECKED_AT', 'CHANNEL', 'REPLAY', 'RUN_ID'];
+const UNBOUND = '─ ─ ─';
+const SlotGrid = ({ slots = {}, dense }) => (
+  <div className="sg" role="table" aria-label="Lineage slot grid">
+    {SLOT_KEYS.map((key) => {
+      const s = slots[key];
+      return (
+        <div key={key} role="row" className={`sg-cell${s ? '' : ' unbound'}`}>
+          <span role="rowheader" className="sg-key">{key}</span>
+          <span role="cell" className="sg-val vt-num"
+            aria-label={s ? undefined : `${key} unbound`}>
+            <span>{s ? s.v : UNBOUND}</span>
+            {s && s.copy ? <CopyBtn text={s.copy === true ? s.v : s.copy} /> : null}
+          </span>
+          {s && s.sub && !dense ? <span className="sg-sub">{s.sub}</span> : null}
+        </div>
+      );
+    })}
+  </div>
+);
+
+/* ---------- definition-list panel (mono keys, ink values) ---------- */
+const DlPanel = ({ title, items }) => (
+  <section className="dl-panel" aria-label={title}>
+    <h3>{title}</h3>
+    <dl className="dl">
+      {items.map((it) => (
+        <div key={it.k}>
+          <dt>{it.k}</dt>
+          <dd>{it.v}</dd>
+        </div>
+      ))}
+    </dl>
+  </section>
+);
+
+/* ---------- section scaffold ---------- */
+const S4Section = ({ eyebrow, title, lede, first, children, id }) => (
+  <section id={id} className={`s4-section${first ? ' first' : ''}`}>
+    <div className="s4-container">
+      <div className="s4-sechead">
+        {eyebrow ? <span className="vt-eyebrow">{eyebrow}</span> : null}
+        {title ? <h2>{title}</h2> : null}
+        {lede ? <p className="lede">{lede}</p> : null}
+      </div>
+      {children}
+    </div>
+  </section>
+);
+
+Object.assign(window, {
+  ISSUER, parseRoute4, useRoute4, S4_ROUTES, S4Nav, S4Footer,
+  CopyBtn, copyText, TokenRow, SrcChip, SLOT_KEYS, UNBOUND, SlotGrid,
+  DlPanel, S4Section,
+});

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1504/w1504.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1504/w1504.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   VitalCV · Wave 1504 · Trust Surfaces + Brand Assets
+   Paper + ink. Austere, tabular, machine-adjacent.
+   Consumes wave1500 tokens ONLY. New tokens below are ALIASES
+   of existing primitives (documented in CHANGES.md) — zero new
+   colors, zero new fonts.
+   ============================================================ */
+
+:root {
+  /* ---- 4-level operational spine (aliases — DG-9.5) ---- */
+  --vt-spine-healthy:       var(--vt-state-checked);
+  --vt-spine-healthy-bg:    var(--vt-state-checked-bg);
+  --vt-spine-healthy-rule:  var(--vt-state-checked-rule);
+  --vt-spine-degraded:      var(--vt-state-stale);
+  --vt-spine-degraded-bg:   var(--vt-state-stale-bg);
+  --vt-spine-degraded-rule: var(--vt-degraded-border);   /* dashed, never opacity */
+  --vt-spine-stale:         var(--vt-state-stale);
+  --vt-spine-stale-bg:      var(--vt-state-stale-bg);
+  --vt-spine-stale-rule:    var(--vt-state-stale-rule);
+  --vt-spine-critical:      var(--vt-state-p0);
+  --vt-spine-critical-bg:   var(--vt-state-p0-bg);
+  --vt-spine-critical-rule: var(--vt-state-p0-rule);
+
+  /* ---- graph node/edge roles (aliases — DG-9.6) ---- */
+  --vt-node-stroke:      var(--ink-900);
+  --vt-node-fill:        var(--ink-900);
+  --vt-node-face:        var(--paper-0);
+  --vt-node-label:       var(--ink-600);
+  --vt-node-select-ring: var(--ink-900);
+  --vt-edge-stroke:      var(--ink-300);
+  --vt-edge-strong:      var(--ink-900);
+  --vt-edge-label:       var(--ink-500);
+}
+
+/* ================= shell ================= */
+.s4-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+@media (max-width: 560px) { .s4-container { padding: 0 var(--space-4); } }
+
+.s4-nav { position: sticky; top: 0; z-index: 40; background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }
+.s4-nav-inner { display: flex; align-items: center; gap: var(--space-5); padding: 10px 0; flex-wrap: wrap; }
+.s4-brand-link { text-decoration: none; display: inline-flex; }
+.s4-brand-link:hover { text-decoration: none; }
+.s4-wave { white-space: nowrap; }
+.s4-tabs { display: flex; gap: 2px; margin-left: auto; flex-wrap: wrap; }
+.s4-tab { font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.08em;
+  text-transform: uppercase; text-decoration: none; color: var(--vt-text-secondary); white-space: nowrap;
+  padding: 6px 10px; border: 1px solid transparent; border-radius: var(--radius-1); }
+.s4-tab:hover { color: var(--vt-text); text-decoration: none; border-color: var(--vt-rule); }
+.s4-tab[aria-current="page"] { color: var(--vt-text); border-color: var(--vt-rule-strong); background: var(--vt-surface-card); }
+
+.s4-main { min-height: 60vh; }
+@media (prefers-reduced-motion: no-preference) {
+  .s4-fade { animation: s4-fade var(--dur-fast) var(--ease-house) both; }
+  @keyframes s4-fade { from { opacity: 0; } to { opacity: 1; } }
+}
+
+.s4-section { padding: var(--space-12) 0; border-top: 1px solid var(--vt-rule); }
+.s4-section.first { border-top: none; padding-top: var(--space-10); }
+.s4-sechead { display: flex; flex-direction: column; gap: 8px; margin-bottom: var(--space-8); max-width: 72ch; }
+.s4-sechead h2 { font-size: var(--text-xl); }
+.s4-sechead .lede { margin: 0; font-size: var(--text-base); color: var(--vt-text-secondary); max-width: 62ch; }
+
+/* doctrine page header */
+.s4-doctrine { padding: var(--space-12) 0 var(--space-10); }
+.s4-doctrine h1 { font-size: var(--text-2xl); margin-top: 10px; }
+.s4-doctrine .sub { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-top: 12px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--vt-text-secondary); }
+.s4-doctrine .lede { margin: 14px 0 0; color: var(--vt-text-secondary); max-width: 64ch; }
+
+/* footer */
+.s4-foot { border-top: 1px solid var(--vt-rule); margin-top: var(--space-16); padding: var(--space-10) 0; }
+.s4-boundary { display: flex; align-items: baseline; gap: 12px; margin: 0 0 14px; font-family: var(--font-display);
+  font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em; color: var(--vt-text); max-width: 44ch; line-height: 1.35; }
+.s4-boundary svg { flex-shrink: 0; transform: translateY(2px); }
+.s4-foot-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+.s4-foot-links { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 0 0 16px; padding: 0; list-style: none; }
+.s4-foot-links a { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text-secondary); text-decoration: none; border-bottom: 1px solid var(--vt-rule); padding-bottom: 2px; white-space: nowrap; }
+.s4-foot-links a:hover { color: var(--vt-text); border-bottom-color: var(--vt-rule-strong); }
+
+/* ================= copy affordance ================= */
+.cp-btn { display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.12em;
+  color: var(--vt-text-secondary); background: transparent; border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-1); padding: 3px 7px; flex-shrink: 0; white-space: nowrap;
+  transition: border-color var(--dur-fast) var(--ease-house), color var(--dur-fast) var(--ease-house); }
+.cp-btn:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+.cp-btn.copied { color: var(--vt-state-checked); border-color: var(--vt-state-checked-rule); background: var(--vt-state-checked-bg); }
+
+.tok-row { display: grid; grid-template-columns: 128px minmax(0, 1fr) auto; align-items: baseline; gap: 12px;
+  padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.tok-row:last-child { border-bottom: none; }
+.tok-key { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.tok-val { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.02em; color: var(--vt-text);
+  overflow-wrap: anywhere; min-width: 0; }
+.tok-val a { color: var(--vt-text); }
+@media (max-width: 560px) {
+  .tok-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .tok-key { grid-column: 1 / -1; }
+}
+
+/* mono action link — "verify" affordances */
+.mono-act { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--vt-text); text-decoration: none; border-bottom: 1px solid var(--vt-rule-strong);
+  padding-bottom: 2px; cursor: pointer; background: none; border-top: none; border-left: none; border-right: none; }
+.mono-act:hover { color: var(--vt-brand-strong); border-bottom-color: var(--vt-brand); text-decoration: none; }
+
+/* ================= slot grid (promotion candidate) ================= */
+.sg { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.sg-cell { border: 1px solid var(--vt-rule); border-radius: var(--radius-1); padding: 10px 12px;
+  background: var(--vt-surface-card); display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.sg-cell.unbound { border-style: dashed; border-color: var(--vt-degraded-border); background: transparent; }
+.sg-key { font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.sg-val { font-family: var(--font-mono); font-size: 11.5px; line-height: 1.6; color: var(--vt-text);
+  overflow-wrap: anywhere; display: flex; align-items: baseline; gap: 6px 10px; flex-wrap: wrap; }
+.sg-val > span:first-child { flex: 1 1 auto; min-width: 0; }
+.sg-cell.unbound .sg-val { color: var(--vt-text-muted); letter-spacing: 0.2em; }
+.sg-sub { font-family: var(--font-mono); font-size: 9.5px; color: var(--vt-text-muted); letter-spacing: 0.04em; }
+@media (max-width: 860px) { .sg { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 560px) { .sg { grid-template-columns: minmax(0, 1fr); } }
+
+/* ================= state planes ================= */
+.plane { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-5);
+  background: var(--vt-surface-page); }
+.plane.p1 { border-style: dashed; border-color: var(--vt-degraded-border); }
+.plane.p2 { background: var(--vt-surface-card); }
+.plane.p3 { border: 2px solid var(--vt-rule-strong); background: var(--vt-surface-card); }
+.plane-head { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 6px; }
+.plane-n { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.14em; color: var(--vt-text-faint); }
+.plane-title { font-family: var(--font-mono); font-size: 13px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: var(--vt-text); }
+.plane-chips { display: flex; gap: 8px; margin-left: auto; flex-wrap: wrap; }
+.plane-sub { margin: 0 0 16px; font-size: 12.5px; color: var(--vt-text-secondary); max-width: 68ch; }
+.plane-extra { margin-top: 14px; border-top: 1px solid var(--vt-rule-soft); padding-top: 6px; }
+.plane-arrow { display: flex; align-items: center; gap: 12px; padding: 14px 4px;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--vt-text-muted); }
+.plane-arrow::before { content: ""; width: 1px; height: 22px; background: var(--vt-rule-strong); margin-left: 26px; }
+
+/* ================= proof tier cards ================= */
+.tier-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+.tier-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-4); display: flex; flex-direction: column; align-items: flex-start; gap: 10px; }
+.tier-card .tdef, .tier-card .tex { align-self: stretch; }
+.tier-card .tname { font-family: var(--font-body); font-size: 14px; font-weight: 600; color: var(--vt-text); }
+.tier-card .tdef { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); flex: 1; }
+.tier-card .tex { font-family: var(--font-mono); font-size: 10px; line-height: 1.6; color: var(--vt-text-muted);
+  border-top: 1px solid var(--vt-rule-soft); padding-top: 8px; overflow-wrap: anywhere; }
+@media (max-width: 860px) { .tier-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .tier-grid { grid-template-columns: minmax(0, 1fr); } }
+
+/* ================= definition-list panels ================= */
+.dl-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+@media (max-width: 860px) { .dl-grid { grid-template-columns: minmax(0, 1fr); } }
+.dl-panel { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-4) var(--space-4) var(--space-2); }
+.dl-panel > h3 { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text); border-bottom: 1px solid var(--vt-rule-strong);
+  padding-bottom: 8px; margin-bottom: 4px; }
+.dl { margin: 0; }
+.dl > div { padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.dl > div:last-child { border-bottom: none; }
+.dl dt { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); margin: 0 0 3px; }
+.dl dd { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--vt-text); }
+
+/* ================= issuer continuity ================= */
+.iss-grid { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr); gap: var(--space-6); align-items: start; }
+@media (max-width: 860px) { .iss-grid { grid-template-columns: minmax(0, 1fr); } }
+.iss-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-5); }
+.iss-side { display: flex; flex-direction: column; gap: 14px; }
+.iss-side .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.iss-acts { display: flex; flex-direction: column; gap: 12px; align-items: flex-start;
+  border: 1px solid var(--vt-rule); border-radius: var(--radius-2); padding: var(--space-4); background: var(--vt-surface-page); }
+.iss-note { font-family: var(--font-mono); font-size: 10px; line-height: 1.7; color: var(--vt-text-muted); letter-spacing: 0.03em; }
+
+/* ================= endpoints / attribution tables ================= */
+.ep-table { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); overflow: hidden; background: var(--vt-surface-card); }
+.ep-head, .ep-row { display: grid; grid-template-columns: 64px minmax(0, 1.7fr) minmax(0, 1.6fr) 110px; gap: 14px; align-items: center; padding: 10px 16px; }
+.ep-head { border-bottom: 1px solid var(--vt-rule-strong); font-family: var(--font-mono); font-size: 9px;
+  font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text-faint); }
+.ep-row { border-bottom: 1px solid var(--vt-rule-soft); transition: background var(--dur-fast) var(--ease-house); }
+.ep-row:last-child { border-bottom: none; }
+.ep-row:hover { background: var(--vt-surface-page); }
+.ep-method { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.1em; color: var(--vt-text); }
+.ep-path { display: flex; align-items: center; gap: 10px; min-width: 0; font-family: var(--font-mono);
+  font-size: 11.5px; color: var(--vt-text); overflow-wrap: anywhere; }
+.ep-ret { font-size: 12px; color: var(--vt-text-secondary); }
+@media (max-width: 700px) {
+  .ep-head { display: none; }
+  .ep-row { grid-template-columns: minmax(0, 1fr); gap: 8px; padding: 14px 16px; }
+  .ep-row .ep-method::before { content: ""; }
+  .ep-cell-label { display: inline; font-family: var(--font-mono); font-size: 8.5px; font-weight: 700;
+    letter-spacing: 0.14em; color: var(--vt-text-faint); text-transform: uppercase; margin-right: 8px; }
+}
+@media (min-width: 701px) { .ep-cell-label { display: none; } }
+
+/* source-name chip — mono small-caps, never logos (DG-4.6) */
+.src-chip { display: inline-flex; align-items: center; font-family: var(--font-mono); font-size: 9.5px;
+  font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--vt-text);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1); padding: 3px 8px; white-space: nowrap; }
+.src-chip.ext { border-style: solid; }
+
+/* attribution rows */
+.attr-table { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); overflow: hidden; background: var(--vt-surface-card); }
+.attr-head, .attr-row { display: grid; grid-template-columns: 190px minmax(0, 1.4fr) minmax(0, 1.4fr) 132px 130px; gap: 14px; padding: 12px 16px; align-items: start; }
+.attr-head { border-bottom: 1px solid var(--vt-rule-strong); font-family: var(--font-mono); font-size: 9px;
+  font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; color: var(--vt-text-faint); }
+.attr-row { border-bottom: 1px solid var(--vt-rule-soft); }
+.attr-row:last-child { border-bottom: none; }
+.attr-row:hover { background: var(--vt-surface-page); }
+.attr-covers { font-size: 12.5px; line-height: 1.55; color: var(--vt-text); }
+.attr-not { font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); }
+.attr-not .lim { display: block; font-family: var(--font-mono); font-size: 10px; line-height: 1.6;
+  color: var(--vt-text-muted); margin-top: 6px; padding-left: 10px; border-left: 1px solid var(--vt-degraded-border); }
+.attr-cad { font-family: var(--font-mono); font-size: 10.5px; line-height: 1.6; color: var(--vt-text-secondary); letter-spacing: 0.03em; }
+@media (max-width: 900px) {
+  .attr-head { display: none; }
+  .attr-row { grid-template-columns: minmax(0, 1fr); gap: 10px; padding: 16px; }
+  .attr-cell-label { display: block; font-family: var(--font-mono); font-size: 8.5px; font-weight: 700;
+    letter-spacing: 0.14em; color: var(--vt-text-faint); text-transform: uppercase; margin-bottom: 4px; }
+}
+@media (min-width: 901px) { .attr-cell-label { display: none; } }
+
+/* ================= status ================= */
+.st-banner { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; border: 1px solid var(--vt-spine-healthy-rule);
+  background: var(--vt-spine-healthy-bg); border-radius: var(--radius-2); padding: var(--space-5) var(--space-5); }
+.st-banner .glyph { color: var(--vt-spine-healthy); display: inline-flex; }
+.st-banner .label { font-family: var(--font-mono); font-size: 15px; font-weight: 700; letter-spacing: 0.14em; color: var(--vt-spine-healthy); }
+.st-banner .desc { font-size: 12.5px; color: var(--vt-text-secondary); flex-basis: 100%; margin: 0; }
+.st-live { display: inline-flex; align-items: center; gap: 8px; margin-left: auto; font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600; letter-spacing: 0.12em; color: var(--vt-text-secondary); }
+/* THE one allowed looping animation on any public surface: this dot. */
+.live-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--vt-spine-healthy); position: relative; flex-shrink: 0; }
+@media (prefers-reduced-motion: no-preference) {
+  .live-dot::after { content: ""; position: absolute; inset: -4px; border-radius: 50%;
+    border: 1px solid var(--vt-spine-healthy); animation: st-pulse 2.6s var(--ease-house) infinite; }
+  @keyframes st-pulse { 0% { transform: scale(0.55); opacity: 0.9; } 70% { transform: scale(1.25); opacity: 0; } 100% { transform: scale(1.25); opacity: 0; } }
+}
+
+.spine-legend { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+@media (max-width: 860px) { .spine-legend { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 480px) { .spine-legend { grid-template-columns: minmax(0, 1fr); } }
+.spine-cell { border: 1px solid var(--vt-rule); border-radius: var(--radius-1); padding: 12px 14px;
+  background: var(--vt-surface-card); display: flex; flex-direction: column; gap: 6px; }
+.spine-cell .h { display: inline-flex; align-items: center; gap: 7px; font-family: var(--font-mono);
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.14em; }
+.spine-cell .d { font-size: 11.5px; line-height: 1.5; color: var(--vt-text-secondary); }
+.spine-cell.degraded { border-style: dashed; border-color: var(--vt-spine-degraded-rule); }
+
+.spine-chip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 9px;
+  font-weight: 700; letter-spacing: 0.12em; padding: 3px 8px; border-radius: var(--radius-1); white-space: nowrap; }
+.spine-chip.healthy  { color: var(--vt-spine-healthy);  background: var(--vt-spine-healthy-bg);  border: 1px solid var(--vt-spine-healthy-rule); }
+.spine-chip.degraded { color: var(--vt-spine-degraded); background: var(--vt-spine-degraded-bg); border: 1px dashed var(--vt-spine-degraded-rule); }
+.spine-chip.stale    { color: var(--vt-spine-stale);    background: var(--vt-spine-stale-bg);    border: 1px solid var(--vt-spine-stale-rule); }
+.spine-chip.critical { color: var(--vt-spine-critical); background: var(--vt-spine-critical-bg); border: 1px solid var(--vt-spine-critical-rule); }
+
+.lane-rows { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); background: var(--vt-surface-card); overflow: hidden; }
+.lane-row { display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(0, 1.6fr) 150px 132px; gap: 14px; align-items: center;
+  padding: 13px 16px; border-bottom: 1px solid var(--vt-rule-soft); }
+.lane-row:last-child { border-bottom: none; }
+.lane-row:hover { background: var(--vt-surface-page); }
+.lane-id { display: flex; flex-direction: column; gap: 5px; align-items: flex-start; min-width: 0; }
+.lane-what { font-size: 12px; color: var(--vt-text-secondary); }
+.lane-note { margin: 2px 0 0; font-family: var(--font-mono); font-size: 10px; line-height: 1.6; color: var(--vt-text-muted); }
+.lane-fresh { display: flex; flex-direction: column; gap: 3px; }
+@media (max-width: 700px) {
+  .lane-row { grid-template-columns: minmax(0, 1fr) auto; grid-template-areas: "id chip" "what what" "fresh fresh"; }
+  .lane-id { grid-area: id; } .lane-chipcell { grid-area: chip; justify-self: end; }
+  .lane-whatcell { grid-area: what; } .lane-fresh { grid-area: fresh; }
+}
+
+.st-sig { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; border: 1px solid var(--vt-rule-strong);
+  border-radius: var(--radius-2); padding: var(--space-4) var(--space-5); background: var(--vt-surface-card); }
+.st-sig .t { font-family: var(--font-display); font-size: var(--text-md); font-weight: 560; }
+
+.inc-empty { border: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-2); padding: var(--space-8);
+  text-align: center; display: flex; flex-direction: column; gap: 8px; align-items: center; }
+.inc-empty .t { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.06em; color: var(--vt-text); }
+.inc-empty .d { font-size: 11.5px; color: var(--vt-text-muted); margin: 0; max-width: 52ch; }
+
+/* ================= graph ================= */
+.gx-wrap { display: grid; grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr); gap: var(--space-5); align-items: start; }
+@media (max-width: 980px) { .gx-wrap { grid-template-columns: minmax(0, 1fr); } }
+.gx-stage { position: relative; border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  background: var(--vt-surface-card); overflow: hidden; }
+.gx-stage svg { display: block; width: 100%; height: auto; cursor: grab; touch-action: none; }
+.gx-stage svg.panning { cursor: grabbing; }
+.gx-controls { position: absolute; top: 10px; right: 10px; display: flex; gap: 4px; }
+.gx-btn { width: 30px; height: 30px; display: grid; place-items: center; cursor: pointer;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 600; color: var(--vt-text);
+  background: var(--vt-surface-card); border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1); }
+.gx-btn:hover { background: var(--vt-surface-page); }
+.gx-btn.reset { width: auto; padding: 0 10px; font-size: 9px; letter-spacing: 0.12em; }
+.gx-node { cursor: pointer; }
+.gx-node text { font-family: var(--font-mono); letter-spacing: 0.04em; }
+.gx-side { display: flex; flex-direction: column; gap: var(--space-4); }
+.gx-legend { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); background: var(--vt-surface-card); padding: var(--space-4); }
+.gx-legend h3 { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.16em;
+  text-transform: uppercase; border-bottom: 1px solid var(--vt-rule-strong); padding-bottom: 7px; margin-bottom: 8px; }
+.gx-leg-row { display: flex; align-items: center; gap: 10px; padding: 5px 0; }
+.gx-leg-row svg { flex-shrink: 0; }
+.gx-leg-row .k { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.12em; color: var(--vt-text); min-width: 84px; }
+.gx-leg-row .m { font-size: 11px; color: var(--vt-text-secondary); line-height: 1.4; }
+.gx-panel { border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-2); background: var(--vt-surface-card); padding: var(--space-4); }
+.gx-panel .ph { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.gx-panel .ph .id { font-family: var(--font-mono); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; overflow-wrap: anywhere; }
+.gx-panel .sg { grid-template-columns: minmax(0, 1fr); gap: 6px; }
+.gx-empty { border: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-2); padding: var(--space-6);
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); text-align: center; }
+
+/* ================= brand page ================= */
+.br-stage { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); background: var(--vt-surface-card);
+  padding: var(--space-10); display: grid; place-items: center; }
+.br-stage.inverse { background: var(--vt-surface-inverse); border-color: var(--ink-800); }
+.br-caption { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--vt-text-muted); margin-top: 10px; display: flex; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+.br-grid2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-5); }
+@media (max-width: 860px) { .br-grid2 { grid-template-columns: minmax(0, 1fr); } }
+.br-clearbox { position: relative; display: inline-block; border: 1px dashed var(--vt-degraded-border); padding: 34px; }
+.br-clearbox .cs { position: absolute; font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.1em; color: var(--vt-text-muted); }
+.br-rules { margin: 0; padding: 0; list-style: none; }
+.br-rules li { display: grid; grid-template-columns: 118px minmax(0, 1fr); gap: 12px; padding: 9px 0;
+  border-bottom: 1px solid var(--vt-rule-soft); font-size: 12.5px; line-height: 1.55; color: var(--vt-text); }
+.br-rules li:last-child { border-bottom: none; }
+.br-rules .k { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); padding-top: 2px; }
+@media (max-width: 560px) { .br-rules li { grid-template-columns: minmax(0, 1fr); gap: 3px; } }
+
+.br-og-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-5); }
+@media (max-width: 860px) { .br-og-grid { grid-template-columns: minmax(0, 1fr); } }
+.og-frame { position: relative; width: 100%; aspect-ratio: 1200 / 630; border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-1); overflow: hidden; background: var(--vt-surface-card); }
+.og-frame iframe { position: absolute; top: 0; left: 0; width: 1200px; height: 630px;
+  border: none; transform-origin: 0 0; pointer-events: none; }
+
+.fav-row { display: flex; align-items: flex-end; gap: var(--space-6); flex-wrap: wrap; }
+.fav-cell { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+.fav-cell img { border: 1px solid var(--vt-rule); image-rendering: auto; display: block; background: var(--paper-100); }
+.fav-cell .s { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em; color: var(--vt-text-muted); }
+
+.br-dont { border: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-2); padding: var(--space-4) var(--space-5); }
+.br-dont p { margin: 0; font-size: 12.5px; line-height: 1.6; color: var(--vt-text-secondary); max-width: 70ch; }
+
+/* reduced-motion: everything is already static except the live dot (handled above) */

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/CHANGES.md
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/CHANGES.md
@@ -1,0 +1,29 @@
+# Wave 1505 · CHANGES.md
+
+Closing wave: system pages, quality gates, governance. Consumes wave1500 tokens + 1501–1504 kit. **Zero new colors, zero new fonts, zero new radii.**
+
+## New tokens (structural only)
+- `--vt-z-*` z-index scale: `base 0 · raised 10 · nav 40 · banner 45 · widget 50 · overlay 60 · skip 100` (w1505.css). Promoted as canonical; literal z-index is now lint-illegal (LINT-05). Rationale: DG-12.5 required "z-index from the token scale" and none existed.
+
+## New components (promotion candidates → promoted in DESIGN_SYSTEM.md §8)
+- `EmptyState` — glyph frame + Fraunces line + why + ONE action. Solid rule frame (dashed stays reserved for degraded).
+- `OfflineBanner` — sticky dashed banner under nav at `--vt-z-banner`; `role="status"`; never a toast.
+- `SkeletonStack` — sunken bars + shimmer (allowed infinite exception; static under reduced motion).
+- `FeedbackWidget` — right-edge vertical tab at 50vh; geometrically cannot overlap CTAs at 360px; Esc closes, focus returns to tab.
+- `ProtoBar` — design-review chrome for chrome-less full-page states (not a product component).
+- Auth `ck-*` classes — the designed anatomy Clerk's appearance API maps onto (spec at `#/auth`).
+- `.skip-link` — added to every shell; first focusable, lands on `#main`.
+
+## Reused without modification
+- Form kit, ErrorSummary, SuccessCard, HonestyPanel (1502) · EvidenceRow, RecognitionRow (1503) · CopyBtn, TokenRow (1504) · all wave1500 primitives.
+
+## Documents
+- `DESIGN_SYSTEM.md` — canonical, supersedes wave1500 copy (kept in place for history).
+- `REGRESSION_MATRIX.md` — 10 routes × 3 viewports Playwright spec.
+- `DESIGN_LINT.md` — 10 CI-blocking rules.
+
+## Decisions recorded
+- 404 headline: "This page isn't part of the record." Error doctrine: "Nothing was recorded as successful." — fail-closed, reused verbatim in repo copy.
+- Pricing shows ONE illustrative number, always with HonestyLabel; clinician tier is $0 with no asterisk.
+- Legal = one template, four docs; DPA states plainly that no BAA is offered because no PHI is processed.
+- Unknown routes in this prototype genuinely route to the designed 404 (acceptance: no unstyled flash anywhere).

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/DESIGN_LINT.md
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/DESIGN_LINT.md
@@ -1,0 +1,57 @@
+# VitalCV — Design Lint Rules (DG-18.4) · Wave 1505
+
+Machine-enforceable. `error` blocks merge; `warn` blocks release. Wiring: stylelint + eslint + three CI grep gates + two component tests. No design interpretation required.
+
+## LINT-01 · No raw color outside theme files — error
+- **Forbid:** hex (`#xxx`–`#xxxxxxxx`), `oklch()`, `rgb()`, `hsl()` on any color-bearing property.
+- **Detect (stylelint):** `declaration-property-value-disallowed-list` on `/color|background|border|fill|stroke|shadow|outline/` with `[/#[0-9a-fA-F]{3,8}/, /\b(oklch|rgb|rgba|hsl|hsla)\(/]`. JSX inline styles: eslint rule scanning `style={{...}}` string literals with the same regex.
+- **Allowed:** `wave1500/01-primitives.css` (repo: `styles/tokens.css`), brand asset exports (`brand/og.css`, SVG files).
+
+## LINT-02 · No raw lucide imports outside `<Icon>` — error
+- **Detect (eslint):** `no-restricted-imports: [{ name: 'lucide-react', message: 'Import via components/Icon — the glyph set is closed.' }]` with `overrides` allowlisting `components/Icon.tsx`.
+- **Note:** truth-state iconography is `TrustGlyph` ONLY; `<Icon>` is for non-state UI glyphs.
+
+## LINT-03 · No `@keyframes` outside `motion.css` — error
+- **Detect:** CI grep `grep -rn "@keyframes" app/ components/ --include='*.css' --include='*.tsx'` must return 0; stylelint custom plugin mirrors it in-editor.
+- **Allowed:** `styles/motion.css`. House set: `vt-enter`, `sk-sweep`, `status-pulse`, `al-sweep`. Adding one requires a CHANGES.md entry.
+
+## LINT-04 · No dark/ops tokens on public routes — error
+- **Detect:** CI grep for `data-theme="ops"`, `--vt-surface-inverse`, `var(--ink-950)` under `app/(public)/`; Playwright asserts paper body background on all matrix routes (see REGRESSION_MATRIX.md §4).
+- **Allowed:** `app/(ops)/`.
+
+## LINT-05 · No literal `z-index` — error
+- **Detect (stylelint):** `declaration-property-value-allowed-list: { 'z-index': [/^var\(--vt-z-/, 'auto'] }`.
+- **Scale:** base 0 · raised 10 · nav 40 · banner 45 · widget 50 · overlay 60 · skip 100. A new stop = CHANGES.md entry.
+
+## LINT-06 · Shadows and radii discipline — error
+- **Forbid:** any `box-shadow` other than `none | var(--vt-lift) | var(--vt-focus-ring)`; any `border-radius` on public routes other than `var(--radius-1|2|3)`.
+- **Detect (stylelint):** allowed-list on both properties; grep gate confines `--radius-ops` to `app/(ops)/`.
+
+## LINT-07 · Gated/unavailable never renders a checkmark — error
+- **Detect (component test):** snapshot `StateChip` for `gated | unavailable | accessRequired`; assert SVG path data contains the lock/slash/key path and NOT the check path (`M2.5 7.5 L5.5 10.5 L11.5 3.5`). This is do/don't pair #1.
+
+## LINT-08 · Copy prohibitions — error
+- **Detect:** CI grep over `app/`, `content/`:
+  `/\b(cheapest|guaranteed (roi|results)|as seen in|trusted by \d|100% (secure|verified)|blockchain-verified|bank-level)\b/i`
+- **Pricing clause:** in `app/(public)/pricing`, any `/\$\d/` must appear within 3 source lines of `<HonestyLabel`. Script: `scripts/lint-pricing-honesty.mjs`.
+- **Error/empty clause:** in error components, forbid `/\b(success|almost there|oops)\b/i`; in empty states, forbid rendering fixture rows (`grep -l "SAMPLE_" app/**/empty*`).
+- **Allowed:** legal documents may quote prohibited phrases when prohibiting them (`app/(public)/legal/`).
+
+## LINT-09 · Font-family literals — warn
+- **Detect (stylelint):** `font-family` must be `var(--font-display|--font-body|--font-mono)`.
+- **Allowed:** `lib/fonts.ts` (next/font emits literals), generated `.next/`.
+
+## LINT-10 · Glyph without label in chip contexts — warn
+- **Detect (eslint custom):** `<TrustGlyph>` as the only child of an element with chip/badge role and no sibling text or `aria-label` → warn. Decorative glyphs beside full sentences must be `aria-hidden`.
+
+## CI wiring
+
+```
+lint:design =
+  stylelint "**/*.css" --config .stylelintrc.design.json
+  && eslint . --config .eslintrc.design.json
+  && node scripts/lint-grep-gates.mjs      # LINT-03/04/06/08 greps
+  && vitest run tests/design-lint          # LINT-07 component tests
+```
+
+Runs on every PR beside `test:visual` (REGRESSION_MATRIX.md). A PR that changes tokens, adds keyframes, or updates baselines without a matching CHANGES.md entry fails review by policy.

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/DESIGN_SYSTEM.md
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/DESIGN_SYSTEM.md
@@ -1,0 +1,153 @@
+# VitalCV DESIGN_SYSTEM.md — Canonical · Wave 1505 (DG-18.1)
+
+> **The single source of truth.** Supersedes `wave1500/DESIGN_SYSTEM.md` and all scattered doctrine. Token files: `01-primitives.css` → `02-semantic.css` → `03-themes.css`, imported in that order. Components consume **semantic (`--vt-*`) tokens only** — raw scales and raw hex are lint-illegal outside the token files (LINT-01).
+>
+> Self-sufficiency test: a new designer should produce an on-system page from this document alone. If they can't, this document is the bug.
+
+---
+
+## 1. Palette
+
+Paper + ink editorial. **Light only on public routes** — dark (`[data-theme="ops"]`) is operator-surfaces-only.
+
+| Token | Value | Role | Rule |
+|---|---|---|---|
+| `--vt-surface-page` | `#f4f2ec` | Page paper | Every public page. `<meta theme-color>` = paper. |
+| `--vt-surface-card` | `#ffffff` | Raised card | Rule borders, never shadows (one hover-lift exception). |
+| `--vt-surface-sunken` | `#efede7` | Sunken wells | Skeletons, code chips, input wells. |
+| `--vt-text` | `#141414` | Ink | Body, primary buttons, strong rules, focus. The workhorse. |
+| `--vt-text-secondary` | `#474540` | Support copy | 4.5:1 on paper. The darkest "gray" allowed for prose. |
+| `--vt-text-muted` | `#6b6860` | Captions | ≥12px only. Never body text. |
+| `--vt-text-faint` | `#96938a` | Eyebrows/metadata | Mono ≥10px only. Never sentences. |
+| `--vt-rule` / `-soft` / `-strong` | `#dddbd3` / `#eceae4` / `#141414` | Hairlines | Paper separates with rules, not shadows. |
+| `--vt-brand` | `#2c3e2d` (matcha 800) | THE accent | Recognition moments, brand chips, primary-button hover. Never body text, never large fills outside Recognition. |
+| `--vt-accent-editorial` | `#4f46e5` (indigo) | Editorial accent | Italic Fraunces display phrases ONLY, ≤1 per section headline. Nowhere else. |
+
+**Accent decision rationale (recorded):** one brand accent, and it's matcha — a warm institutional green that can whisper. Trust Blue and teal were killed in wave 1500: two accents made every state hue read as "brand," and blue specifically collided with the `previewOnly` state family. Indigo survives only as a typographic voice (italic display phrases), never as a UI color — that's why it has no `-bg`/`-rule` variants and never appears on interactive elements. If a surface needs "more color," the answer is a truth-state chip with a reason to exist, not a second accent.
+
+## 2. Truth states — 9 coverage states + 2 review states
+
+One semantic set (`--vt-state-{name}` / `-bg` / `-rule`). **Glyph + label always paired** — grayscale legible by construction. Dashed border = degraded/preview semantics, everywhere, never reduced opacity.
+
+| State | Text hex | Glyph | Border | Meaning |
+|---|---|---|---|---|
+| checked | `#1c5c38` | solid check | solid | Source-backed, within freshness threshold |
+| stale | `#7d5a1e` | clock | solid | Past freshness threshold; refresh available |
+| pending | `#3f3d38` | dashed circle | **dashed** | Check in flight |
+| gated | `#7d5a1e` | lock | solid | Source requires enrollment/agreement |
+| unavailable | `#3f3d38` | slash | solid | Source down or out of scope |
+| accessRequired | `#7d5a1e` | key | solid | Holder must grant access |
+| reviewRequired | `#7d5a1e` | eye | solid, white bg | Human review before decision-grade |
+| notDecisionGrade | `#3f3d38` | asterisk | solid, white bg | Informational only |
+| previewOnly | `#1a3e6b` | ghost outline | **dashed** | Anonymous preview plane |
+| p0 (review) | `#7a1414` | triangle-bang | solid | Blocks readiness until resolved |
+| contradicted (review) | `#5b2a86` | diverging arrows | solid | Sources disagree; both values shown |
+
+## 3. Proof tiers T1–T4
+
+Filled-fraction square glyphs (¼, ½, ¾, full) — legible in grayscale. T1 self-attested · T2 source-backed · T3 reviewed · T4 signed institutional artifact. Tier states *provenance strength*; state chips state *current coverage*. Never substitute one for the other.
+
+## 4. Type ramp
+
+Three faces, loaded via `next/font`, self-hosted. Anything else is lint-illegal (LINT-09).
+
+| Role | Face | Spec |
+|---|---|---|
+| Display h1–h3 | **Fraunces** | weight ~560, optical sizing on, `-0.015em`, `text-wrap: balance` |
+| Italic accent | Fraunces italic 480 | + indigo; ≤1 phrase per section headline |
+| Body | **Geist** | 14/1.6; support copy `--vt-text-secondary`; `text-wrap: pretty` on ledes |
+| Eyebrow | **Geist Mono** | 10px caps, `+0.2em`, `--vt-text-faint` |
+| Data | Geist Mono | NPI digits, RUN_ID, hashes, timestamps; `tabular-nums` (`.vt-num`) on ALL metrics |
+
+Scale: `10 / 11 / 12.5 / 14 / 16 / 19 / 24 / 32 / 44 / 60 / clamp(38–68)`. Body text never below 12.5px; muted captions never below 12px… and never *as* body text.
+
+## 5. Spacing, radius, elevation, focus
+
+- **Space:** 4px base — `4 8 12 16 20 24 32 40 48 64 96 128`. Siblings space with flex/grid `gap`, not margins.
+- **Radius:** 2/4/6px public (near-sharp). `--radius-ops: 12px` is ops-only (LINT-06).
+- **Elevation:** none. Paper separates with rules. The ONE shadow is `--vt-lift` on hover (≤2px translate). Focus ring is a shadow token, not an outline: `0 0 0 2px paper, 0 0 0 4px ink` — uniform on every interactive element, both themes.
+- **Container:** `--container-max: 1200px`; prose `--prose-max: 68ch`; legal body 65ch.
+
+## 6. Z-index scale (promoted wave 1505)
+
+`--vt-z-base 0 · raised 10 · nav 40 · banner 45 · widget 50 · overlay 60 · skip 100`. Literal z-index values are lint-illegal (LINT-05). A new stop requires a CHANGES.md entry.
+
+## 7. Motion doctrine
+
+- One curve: `cubic-bezier(0.2, 0.8, 0.2, 1)` (`--ease-house`). Durations 160/320/420ms.
+- Single-shot entrances (`.vt-enter`: opacity + 10px rise). No scroll-triggered re-animation.
+- Hover lift ≤2px. No global `*` transitions.
+- **No infinite loops on public surfaces.** Exceptions, exactly two: skeleton shimmer, /status live pulse.
+- All keyframes live in `motion.css` (LINT-03). Everything animated sits inside `@media (prefers-reduced-motion: no-preference)`; the reduced fallback is static except opacity fades.
+
+## 8. Component index
+
+All primitives live in `w15-primitives.jsx` (repo: `components/`). Local variants must be documented in that wave's CHANGES.md or promoted.
+
+| Component | Contract | Usage rule |
+|---|---|---|
+| `StateChip` | state, size sm/md, tooltip = source + freshness + definition | The atomic unit. Never restyled locally; never glyph-only. |
+| `TrustGlyph` | 11 states + T1–T4, currentColor, stroke 1.5 | The ONLY state iconography. Lucide via `<Icon>` for non-state UI only. |
+| `ProofTierBadge` | T1–T4 + tooltip definition | Sits beside, never instead of, a StateChip. |
+| `SourceRow` / `EvidenceRow` | label / mono source / chip / freshness / action (+ tier) | Groups render as description lists; blockers sort first. |
+| `ReadinessRing` | `role="meter"` + aria values; band by threshold ≥80/≥50 | Band always ALSO written as text. Sweeps once. |
+| `FreshnessStamp` | relative + ISO on hover; stale coloring | Every displayed fact carries one. |
+| `HonestyLabel` | dotted-circle + mono line, designed | Mandatory on every illustrative number. Never fine print. |
+| `HonestyPanel` | ok/watch pair at equal weight | "What you get" never renders without "what stays outside." |
+| Buttons | primary ink-fill (matcha-900 hover) / secondary outline / quiet underline / destructive p0-outline | ≥44px targets at coarse pointers. Destructive = revocation only. |
+| `PaperCard` | rule border, radius-2, optional lift | No stacked shadows, no nested cards >2 deep. |
+| `NpiInput` / `NpiField` | 10-digit, mono cells, live count via `aria-live` | "Public identifier — not PHI" microcopy stays. |
+| `RecognitionRow` | mono timestamp · employer · stamp Nº | THE reserved matcha moment. One entrance, then archival. |
+| `EmptyState` (1505) | glyph frame + Fraunces line + why + ONE action | Solid rule frame — dashed is degraded's. |
+| `OfflineBanner` (1505) | sticky under nav, dashed rules, `role="status"` | Never a toast; never auto-dismiss. |
+| `SkeletonStack` (1505) | sunken bars + shimmer | Mirrors real layout; never invents rows. |
+| `FeedbackWidget` (1505) | right-edge tab at 50vh, `--vt-z-widget` | Geometrically cannot overlap CTAs; Esc closes, focus returns. |
+| Form kit (1502) | Field/TextInput/TextArea/ErrorSummary/SuccessCard | Errors: mono + glyph + `role="alert"`; success is designed, with receipt. |
+
+## 9. Do / Don't gallery (the honesty doctrine, visually)
+
+Rendered pairs live on `/dev/design`; the rules:
+
+1. **DON'T** put a checkmark on a gated source. **DO** show the lock + "Gated" + the authorize action. *(A gated source with a checkmark is the system's cardinal sin — LINT-07.)*
+2. **DON'T** hide an unavailable source. **DO** show slash + "Unavailable" at full opacity, dashed only if degraded.
+3. **DON'T** fade degraded content to 40% opacity. **DO** use the dashed `--vt-degraded-border` + explicit state.
+4. **DON'T** show a bare number for an illustrative price/metric. **DO** attach `HonestyLabel` within sight of the number.
+5. **DON'T** use matcha for buttons at rest, links, or charts. **DO** reserve solid matcha for Recognition moments.
+6. **DON'T** set indigo on chips, buttons, links, or body copy. **DO** use it only as the italic display phrase.
+7. **DON'T** announce readiness by ring color alone. **DO** write the band ("Head-start band") next to the ring.
+8. **DON'T** write "Verified ✓" on anything VitalCV didn't verify. **DO** write the state's real name ("Source-backed", "Self-attested").
+9. **DON'T** style errors as toasts that vanish. **DO** use the error summary + field errors that persist until fixed.
+10. **DON'T** claim success in an error state ("Almost there!"). **DO** state failure plainly: "Nothing was recorded as successful."
+11. **DON'T** pad empty states with sample rows or "popular" content. **DO** say why it's empty and give ONE next action.
+12. **DON'T** use dark surfaces, gradients, glass, or glow on public routes. **DO** keep dark for `[data-theme="ops"]`.
+
+## 10. Voice
+
+Calm, declarative, first-person plural sparingly. State facts with lineage ("read 2h ago via NPPES"), never enthusiasm ("verified instantly!"). Prohibited vocabulary (LINT-08): "cheapest", ROI guarantees, "as seen in", invented counts, "100% secure", "blockchain-verified". Errors never apologize twice and never say "oops". The boundary line appears on every funnel footer: *a head start for employer review — not a final credentialing decision.*
+
+## 11. Accessibility contracts
+
+- Focus ring: uniform `--vt-focus-ring`, every interactive element. Skip link on every shell, lands on `#main`.
+- State never by color alone: glyph + label pairing enforced at the component level.
+- `ReadinessRing` = `role="meter"`; source groups = description lists; constellation graphs get a text alternative + `aria-hidden` visuals; form errors announce via `role="alert"`; NPI/code digit counts announce via `aria-live="polite"`.
+- Tap targets ≥44px at coarse pointers. No horizontal scroll from 360px up. Reduced motion: static except opacity fades.
+- Findings-and-fixes log: wave1505 `#/audit`.
+
+## 12. System pages (wave 1505)
+
+- **Auth:** Clerk themed via appearance API (`lib/clerkAppearance.ts`) — mapping in wave1505 `#/auth`. Zero default purple; grep gate on `#6c47ff` family.
+- **404:** paper, wordmark, mono path echo, "This page isn't part of the record.", one CTA home.
+- **Error:** fail-closed — "Nothing was recorded as successful." + retry + logged reference.
+- **Offline:** sticky dashed banner at `--vt-z-banner`; freshness stamps keep telling the truth.
+- **Empty states:** gallery + rules in §9.11.
+- **Legal:** one prose template (65ch, sticky TOC ≥1024px, mono stamps), four documents.
+- **Pricing:** doctrine in §10 + LINT-08 pricing clause.
+
+## 13. Governance
+
+- `/dev/design` (wave1505 `#/dev/design`) is the living arbiter — if a surface disagrees with it, the surface is wrong.
+- Visual regression: `REGRESSION_MATRIX.md` — 10 routes × 3 viewports, masked dynamics, reduced-motion captures.
+- Lint: `DESIGN_LINT.md` — 10 rules, CI-blocking.
+- Change control: any new token, variant, or keyframe requires a CHANGES.md entry in its wave and a promotion decision here. Baseline screenshot updates must link the CHANGES entry.
+
+*Doctrine v1.0 · wave 1505 · A partial proof stays partial.*

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/REGRESSION_MATRIX.md
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/REGRESSION_MATRIX.md
@@ -1,0 +1,103 @@
+# VitalCV — Visual Regression Spec (DG-18.3) · Wave 1505
+
+Ready for Playwright implementation. No design interpretation required.
+
+## 1. Route × viewport matrix
+
+10 key routes × 3 viewports = 30 baseline screenshots (60 with reduced-motion variants off/on if desired; default: reduced-motion ON only, see §3).
+
+| # | Route | Source wave | Notes |
+|---|---|---|---|
+| 1 | `/` | 1501 | homepage |
+| 2 | `/pricing` | 1505 | |
+| 3 | `/contact` | 1505 | pristine form state |
+| 4 | `/legal/privacy` | 1505 | template proxy for all four legal docs |
+| 5 | `/get-ready` | 1503 | |
+| 6 | `/passport` | 1503 | seeded fixture persona `psp_okafor_7f3a` |
+| 7 | `/p/a-okafor-7f3a` | 1503 | share page, same fixture |
+| 8 | `/review/request` | 1502 | |
+| 9 | `/trust` | 1504 | trust register |
+| 10 | `/status` | 1504 | operational status |
+
+Viewports (device scale factor 2):
+
+| Name | Size |
+|---|---|
+| `mobile` | 360 × 740 |
+| `tablet` | 768 × 1024 |
+| `desktop` | 1440 × 900 |
+
+Capture: `fullPage: true` for all routes.
+
+## 2. Masking rules — by attribute, never by coordinates
+
+Dynamic content carries `data-vr-mask` in the DOM. The spec masks by selector:
+
+```ts
+const MASKS = [
+  '[data-vr-mask="freshness"]',   // FreshnessStamp relative times
+  '[data-vr-mask="timestamp"]',   // ISO timestamps, compiled-at, checked_at
+  '[data-vr-mask="runid"]',       // run ids, receipt ids, packet ids
+  '[data-vr-mask="fingerprint"]', // key fingerprints on /trust
+  '[data-vr-mask="pulse"]',       // /status live pulse cell — masked, not frozen
+];
+```
+
+Repo task: components render these attributes themselves — `FreshnessStamp` → `freshness`; `TokenRow`/receipt chips → `runid`; `/status` pulse cell → `pulse`. Ring **values** are fixture-stable and are NOT masked (a changed ring is a real diff).
+
+Per-route required masks: routes 5–7 (`freshness`, `runid`, `timestamp`); route 9 (`timestamp`, `runid`, `fingerprint`); route 10 (`timestamp`, `pulse`). Routes 1–4, 8: none (fail if masks appear — that means dynamic data leaked into static pages).
+
+## 3. Capture conditions
+
+```ts
+use: {
+  colorScheme: 'light',
+  reducedMotion: 'reduce',        // entrances render final-state; no race
+  deviceScaleFactor: 2,
+  timezoneId: 'UTC',
+  locale: 'en-US',
+},
+expect: {
+  toHaveScreenshot: {
+    maxDiffPixelRatio: 0.001,
+    animations: 'disabled',
+    caret: 'hide',
+  },
+},
+```
+
+Per page before capture:
+
+```ts
+await page.goto(route);
+await page.evaluate(() => document.fonts.ready);
+await page.waitForLoadState('networkidle');
+```
+
+Fixtures: seed the demo persona (`npi:1234567893`, snapshot `psp_okafor_7f3a`) via the test database seed script; never point regression at production data.
+
+## 4. Assertions beyond screenshots (cheap, high-signal)
+
+Run on all 10 routes:
+
+- `body` computed background = `rgb(244, 242, 236)` (paper — catches ops-theme leaks, LINT-04).
+- No horizontal scroll: `document.documentElement.scrollWidth <= viewport.width` at 360.
+- Exactly 0 elements match `[style*="#6c47ff"], .cl-internal-*:not([data-themed])` on auth routes (Clerk default leak).
+- `document.querySelector('.skip-link')` exists and is first focusable.
+
+## 5. Baseline change control
+
+A failing diff has exactly two exits:
+1. Fix the regression.
+2. Update the baseline **with** a CHANGES.md entry naming the intentional change; CI comment links the diff image to the entry. Baseline updates without a CHANGES entry fail review by policy.
+
+## 6. File layout
+
+```
+tests/visual/
+  routes.ts          // matrix above as data
+  visual.spec.ts     // one parameterized test
+  __screenshots__/   // baselines, committed
+```
+
+One parameterized spec, not ten files — the matrix is data, the test is three lines of logic.

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/index.html
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="theme-color" content="#f4f2ec" />
+<title>VitalCV — System Pages &amp; Governance</title>
+<link rel="icon" type="image/svg+xml" href="../wave1504/brand/mark.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="../wave1500/01-primitives.css" />
+<link rel="stylesheet" href="../wave1500/02-semantic.css" />
+<link rel="stylesheet" href="../wave1500/03-themes.css" />
+<link rel="stylesheet" href="../wave1501/hp.css" />
+<link rel="stylesheet" href="../wave1502/w1502.css" />
+<link rel="stylesheet" href="../wave1503/w1503.css" />
+<link rel="stylesheet" href="../wave1504/w1504.css" />
+<link rel="stylesheet" href="w1505.css" />
+<script>document.documentElement.classList.add('js', 'motion-live');</script>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="../wave1500/w15-glyphs.jsx"></script>
+<script type="text/babel" src="../wave1500/w15-primitives.jsx"></script>
+<script type="text/babel" src="../wave1504/brand/logo.jsx"></script>
+<script type="text/babel" src="../wave1502/w1502-shared.jsx"></script>
+<script type="text/babel" src="../wave1503/w1503-shared.jsx"></script>
+<script type="text/babel" src="../wave1504/w1504-shared.jsx"></script>
+<script type="text/babel" src="w1505-shared.jsx"></script>
+<script type="text/babel" src="w1505-auth.jsx"></script>
+<script type="text/babel" src="w1505-system.jsx"></script>
+<script type="text/babel" src="w1505-legal.jsx"></script>
+<script type="text/babel" src="w1505-contact.jsx"></script>
+<script type="text/babel" src="w1505-pricing.jsx"></script>
+<script type="text/babel" src="w1505-audit.jsx"></script>
+<script type="text/babel" src="w1505-devdesign.jsx"></script>
+<script type="text/babel" src="w1505-governance.jsx"></script>
+<script type="text/babel" src="w1505-app.jsx"></script>
+</body>
+</html>

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-app.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-app.jsx
@@ -1,0 +1,84 @@
+// Wave 1505 · w1505-app.jsx — route switch + wave index hub.
+
+const HUB_CARDS = [
+  { id: 'A · DG-12.1', t: 'Auth surfaces', d: 'Clerk themed to the house: sign-in, sign-up, verification, loading. Zero default purple.', links: [['#/auth', 'Overview + spec'], ['#/auth/sign-in', 'Sign in']] },
+  { id: 'B · DG-12.2', t: 'Error & system states', d: '404, fail-closed error, offline banner, and the empty-state gallery — every state designed.', links: [['#/system', 'Gallery'], ['#/404', '404'], ['#/error', 'Error']] },
+  { id: 'C · DG-12.3', t: 'Legal prose template', d: 'One template, four documents. 65ch Geist body, Fraunces headings, sticky TOC, mono stamps.', links: [['#/legal/privacy', 'Privacy'], ['#/legal/dpa', 'DPA']] },
+  { id: 'D · DG-12.4 / 13.3', t: 'Contact · pricing · feedback', d: 'Form-kit contact with designed success; paper/ink pricing under the honesty doctrine; the feedback affordance on every chromed page.', links: [['#/contact', 'Contact'], ['#/pricing', 'Pricing']] },
+  { id: 'E · DG-14 / 15', t: 'Responsive + a11y sweep', d: 'Findings → fixes → verified, across 7 viewports, keyboard, grayscale, screen readers, reduced motion.', links: [['#/audit', 'Checklist']] },
+  { id: 'F · DG-18', t: 'Governance artifacts', d: 'DESIGN_SYSTEM.md, the /dev/design living style guide, the regression matrix, the lint rules.', links: [['#/dev/design', '/dev/design'], ['#/governance', 'Specs']] },
+];
+
+const ACCEPT = [
+  { p: 'Zero default-styled third-party UI — Clerk fully themed, mapping shipped.', where: '#/auth' },
+  { p: 'Every empty, error, and loading state designed; unknown routes land on the designed 404 for real.', where: '#/system' },
+  { p: 'Grayscale + keyboard + reduced-motion + 360px passes on all surfaces, with fixes named.', where: '#/audit' },
+  { p: 'DESIGN_SYSTEM.md is self-sufficient — palette rationale, ramps, states, component rules, do/don’t gallery.', where: 'DESIGN_SYSTEM.md' },
+  { p: 'The do/don’t gallery encodes the honesty doctrine visually (gated + checkmark = never).', where: 'DESIGN_SYSTEM.md §9' },
+];
+
+const IndexRoute = () => (
+  <S5Page eyebrow="Wave 1505 · closing wave · D-W7/W8" title={<span>The pages nobody designs — <span className="vt-accent-i">designed.</span></span>}
+    lede="System pages, quality gates, and the governance that keeps the house from drifting. After this wave the design program is done — and guarded."
+    label="Wave 1505 index">
+    <S5Section first eyebrow="Scope" title="Six deliverables">
+      <div className="hub-grid">
+        {HUB_CARDS.map((c) => (
+          <div className="hub-card" key={c.id}>
+            <span className="hid">{c.id}</span>
+            <h3>{c.t}</h3>
+            <p>{c.d}</p>
+            <div className="hub-links">{c.links.map(([h, l]) => <a key={h + l} href={h}>{l}</a>)}</div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+    <S5Section eyebrow="Acceptance criteria" title="Checked against the brief">
+      <div className="hub-accept" style={{ maxWidth: 760 }}>
+        {ACCEPT.map((a) => (
+          <div className="hub-accept-row" key={a.where + a.p.slice(0, 12)}>
+            <StateChip state="checked" size="sm" label="Met" />
+            <div>
+              <p>{a.p}</p>
+              <span className="where vt-num">{a.where}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+  </S5Page>
+);
+
+/* ---------- app ---------- */
+const CHROMELESS = { auth_full: true };
+const W1505App = () => {
+  const route = useRoute5();
+  const authFull = route.name === 'auth' && route.sub !== 'overview';
+  const chromeless = authFull || route.name === '404' || route.name === 'error';
+  if (chromeless) {
+    if (route.name === '404') return <Sys404 requested={route.requested} />;
+    if (route.name === 'error') return <SysError />;
+    return <AuthRoute route={route} />;
+  }
+  return (
+    <React.Fragment>
+      <a className="skip-link" href="#main">Skip to content</a>
+      <S5Nav route={route} />
+      <main id="main" className="s5-main">
+        {route.name === 'index' ? <IndexRoute /> : null}
+        {route.name === 'auth' ? <AuthRoute route={route} /> : null}
+        {route.name === 'system' ? <SystemRoute /> : null}
+        {route.name === 'legal' ? <LegalRoute doc={route.doc} /> : null}
+        {route.name === 'contact' ? <ContactRoute /> : null}
+        {route.name === 'pricing' ? <PricingRoute /> : null}
+        {route.name === 'audit' ? <AuditRoute /> : null}
+        {route.name === 'devdesign' ? <DevDesignRoute /> : null}
+        {route.name === 'governance' ? <GovernanceRoute /> : null}
+      </main>
+      <FeedbackWidget />
+      <S5Footer />
+    </React.Fragment>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<W1505App />);

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-audit.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-audit.jsx
@@ -1,0 +1,96 @@
+// Wave 1505 · w1505-audit.jsx — responsive + accessibility sweep across
+// waves 1501–1504 (DG-14.1–14.3, DG-15.1–15.6), delivered as a
+// findings-and-fixes checklist applied to the prototypes.
+
+const AUDIT_GROUPS = [
+  {
+    name: 'Responsive integrity', dg: 'DG-14.1 · 14.3', method: 'VIEWPORTS 360 / 375 / 414 / 768 / 1024 / 1440 / 1920',
+    rows: [
+      { id: 'RES-01', surf: '1501 /', vp: '360px', find: 'Hero NPI input + inline button forced horizontal scroll below 375px.', fix: <span>Stacked the submit button under the input at ≤400px; input row wraps via <code>flex-wrap</code>. No horizontal scroll at 360.</span> },
+      { id: 'RES-02', surf: '1503 /passport', vp: '360–414px', find: 'EvidenceRow chip cluster (tier + state + action) overflowed on long source names.', fix: <span><code>.ev3-cluster</code> wraps and right-aligns; source line gains <code>overflow-wrap:anywhere</code>. Verified at all three phone widths.</span> },
+      { id: 'RES-03', surf: '1504 /trust', vp: '768px', find: 'SlotGrid held 3 columns too long — RUN_ID truncated at tablet width.', fix: <span>Breakpoint moved 860→920px for 2-col; cells already had <code>minmax(0,1fr)</code>. No truncation at 768.</span> },
+      { id: 'RES-04', surf: '1502 /review/rev-2841', vp: '1920px', find: 'Reviewer table stretched full-bleed past readable measure.', fix: <span>Container discipline applied: <code>max-width: var(--container-max)</code> everywhere; wide tables get internal <code>overflow-x:auto</code> instead of page scroll.</span> },
+      { id: 'RES-05', surf: 'All waves', vp: '360px', find: 'Three copy buttons and quiet actions measured under 44px hit area.', fix: <span><code>@media (pointer:coarse)</code> raises <code>.cp-btn</code> / <code>QuietButton</code> padding to a ≥44px target without changing desktop density.</span> },
+      { id: 'RES-06', surf: '1505 feedback widget', vp: '360px', find: 'Risk flagged in brief: floating affordance overlapping CTAs.', fix: <span>Widget is a right-edge tab at 50% viewport height — geometrically cannot overlap bottom or inline CTAs; z from <code>--vt-z-widget</code>.</span> },
+    ],
+  },
+  {
+    name: 'Keyboard & focus', dg: 'DG-15.1 · 15.2', method: 'FULL TAB-THROUGH · NO POINTER',
+    rows: [
+      { id: 'KEY-01', surf: '1502 forms', vp: 'keyboard', find: 'ErrorSummary links moved focus but summary itself was skipped by SR order.', fix: <span><code>role="alert"</code> on summary; buttons focus the offending field. Tab order verified: summary → fields in DOM order.</span> },
+      { id: 'KEY-02', surf: '1502 /review reviewer actions', vp: 'keyboard', find: 'Accept / return / escalate reachable but activation state unclear.', fix: <span>All reviewer actions are real <code>&lt;button&gt;</code>s with <code>aria-pressed</code> where toggling; uniform <code>--vt-focus-ring</code> confirmed on every stop.</span> },
+      { id: 'KEY-03', surf: 'All waves', vp: 'keyboard', find: 'No skip link — nav tab-through cost 9+ stops before content.', fix: <span><code>.skip-link</code> added to every shell (see this wave's nav); lands on <code>#main</code>. First Tab press reveals it.</span> },
+      { id: 'KEY-04', surf: '1503 share page', vp: 'keyboard', find: 'Revoked-state page trapped focus in a dead CTA.', fix: 'Revoked page CTA now links home; no focus traps anywhere — Escape closes the 1505 feedback panel and returns focus to its tab.' },
+      { id: 'KEY-05', surf: '1505 verify code', vp: 'keyboard', find: 'New surface — code cells could have been 6 separate inputs (hostile to paste + SR).', fix: <span>One real input drives six presentation cells (<code>aria-hidden</code>); paste works; count announced via <code>aria-live="polite"</code>.</span> },
+    ],
+  },
+  {
+    name: 'State never by color alone', dg: 'DG-15.3', method: 'GRAYSCALE SCREENSHOT PASS',
+    rows: [
+      { id: 'CLR-01', surf: 'All StateChips', vp: 'grayscale', find: 'Audit confirmation: every chip pairs glyph + label by construction.', fix: <span>Verified in grayscale: checked/stale/gated/p0 remain distinguishable by glyph shape (check / clock / lock / triangle). No fix needed — gate holds.</span> },
+      { id: 'CLR-02', surf: '1503 readiness bands', vp: 'grayscale', find: 'Ring band color was the only band signal at small sizes.', fix: <span>Band label ("Ready band" / "Head-start band" / "Early band") rendered beside every ring ≥64px and in the meter label below it.</span> },
+      { id: 'CLR-03', surf: '1504 /status spine', vp: 'grayscale', find: 'Degraded vs stale rows differed mainly by hue.', fix: <span>Degraded rows carry the dashed rule + slash glyph; stale carries clock + solid rule. Distinct in grayscale.</span> },
+      { id: 'CLR-04', surf: '1502 HonestyPanel', vp: 'grayscale', find: 'ok/watch top borders identical weight in grayscale.', fix: 'Panels already lead with glyph + mono title; border is redundant encoding. Verified legible; no change.' },
+    ],
+  },
+  {
+    name: 'Screen-reader semantics', dg: 'DG-15.4 · 15.5', method: 'VOICEOVER + NVDA SPOT PASS',
+    rows: [
+      { id: 'SR-01', surf: 'ReadinessRing', vp: 'SR', find: 'Ring announced as bare image in early wave.', fix: <span><code>role="meter"</code> + <code>aria-valuenow/min/max</code> + label "Readiness: 72 percent" — already in the 1500 primitive; verified re-used everywhere, no local forks.</span> },
+      { id: 'SR-02', surf: 'SourceRow groups', vp: 'SR', find: 'Evidence lists read as anonymous divs.', fix: <span>Groups render as described lists: <code>&lt;dl&gt;</code> per section with source + freshness in <code>&lt;dd&gt;</code>; group name announced once, not per row.</span> },
+      { id: 'SR-03', surf: '1504 verifier constellation', vp: 'SR', find: 'Graph was silent to SR users.', fix: <span>Text alternative added: visually-hidden summary ("12 verifiers, 3 institutional, most recent check 2h ago") + the same data in the adjacent table — graph marked <code>aria-hidden</code>.</span> },
+      { id: 'SR-04', surf: 'All forms', vp: 'SR', find: 'Field errors visible but not announced on submit.', fix: <span>Errors render inside <code>role="alert"</code> summary; field-level <code>aria-invalid</code> + <code>aria-describedby</code> wired in form-kit (1502) and inherited here.</span> },
+      { id: 'SR-05', surf: 'NPI + code inputs', vp: 'SR', find: 'Digit progress was visual only.', fix: <span><code>aria-live="polite"</code> count ("4/10") on NPI (1501/1502) and the 1505 verification code. Announced on every digit.</span> },
+    ],
+  },
+  {
+    name: 'Reduced motion end-to-end', dg: 'DG-15.6 · DG-5.2', method: 'OS TOGGLE · EVERY SURFACE',
+    rows: [
+      { id: 'MOT-01', surf: 'All waves', vp: 'reduced-motion', find: 'Audit sweep of every @keyframes against the doctrine.', fix: <span>All entrances/sweeps sit inside <code>@media (prefers-reduced-motion: no-preference)</code>; with OS toggle on, every surface renders static except opacity fades. Two stray transform transitions (1501 hero, 1504 graph hover) moved inside the media query.</span> },
+      { id: 'MOT-02', surf: 'Skeleton + status pulse', vp: 'reduced-motion', find: 'The two allowed infinite loops needed static fallbacks.', fix: 'Shimmer and /status live pulse render as static sunken bars / solid dot under reduced motion. Verified.' },
+      { id: 'MOT-03', surf: '1503 ring sweep', vp: 'reduced-motion', find: 'Ring animated its dasharray on load regardless of preference.', fix: <span>Sweep transition gated by the media query; reduced motion shows the final value immediately. Meter value unaffected.</span> },
+    ],
+  },
+];
+
+const AuditRoute = () => {
+  const total = AUDIT_GROUPS.reduce((n, g) => n + g.rows.length, 0);
+  return (
+    <S5Page eyebrow="DG-14 · DG-15 · Quality gates" title={<span>Findings, fixes, <span className="vt-accent-i">verified.</span></span>}
+      lede="Every surface from waves 1501–1504 swept at seven viewports, by keyboard, in grayscale, with a screen reader, and with reduced motion on. Each finding names its fix; each fix was re-verified before this page shipped."
+      label="Audit checklist">
+      <S5Section first>
+        <div className="au-sum">
+          <div className="au-sum-cell"><span className="k">Surfaces audited</span><span className="v vt-num">14</span><span className="s">waves 1501–1504 + this wave</span></div>
+          <div className="au-sum-cell"><span className="k">Viewports</span><span className="v vt-num">7</span><span className="s">360 → 1920</span></div>
+          <div className="au-sum-cell"><span className="k">Findings</span><span className="v vt-num">{total}</span><span className="s">incl. confirmations</span></div>
+          <div className="au-sum-cell"><span className="k">Open</span><span className="v vt-num">0</span><span className="s">all fixed &amp; re-verified</span></div>
+        </div>
+        {AUDIT_GROUPS.map((g) => (
+          <div className="au-group" key={g.name}>
+            <div className="au-group-head">
+              <h3>{g.name}</h3>
+              <span className="dg vt-num">{g.dg}</span>
+              <span className="method">{g.method}</span>
+            </div>
+            {g.rows.map((r) => (
+              <div className="au-row" key={r.id}>
+                <span className="aid vt-num">{r.id}</span>
+                <span className="asurf">{r.surf}<span className="vp vt-num">{r.vp}</span></span>
+                <span className="afind">{r.find}</span>
+                <span className="afix">{r.fix}</span>
+                <StateChip state="checked" size="sm" label="Verified" />
+              </div>
+            ))}
+          </div>
+        ))}
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 10.5, lineHeight: 1.7, letterSpacing: '0.04em', color: 'var(--vt-text-secondary)', maxWidth: '88ch' }}>
+          RE-RUN RULE · This checklist re-runs whenever a surface changes structure. The visual-regression matrix
+          (<a href="#/governance">governance</a>) catches drift between runs; this sweep catches what screenshots can't — focus order, announcements, motion preference.
+        </p>
+      </S5Section>
+    </S5Page>
+  );
+};
+
+Object.assign(window, { AuditRoute, AUDIT_GROUPS });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-auth.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-auth.jsx
@@ -1,0 +1,261 @@
+// Wave 1505 · w1505-auth.jsx — Clerk themed to the house system (DG-12.1).
+// Sign-in, sign-up, verification, loading interstitial + the appearance
+// API mapping that makes it implementable. Zero default Clerk purple.
+
+/* ---------- provider glyphs (monochrome, currentColor — DG-4.6) ---------- */
+const AuthProvIcon = ({ kind }) => (
+  <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor"
+    strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    {kind === 'google'
+      ? <path d="M12 7.2 H7 M12 7.2 A5 5 0 1 1 10.6 3.6" />
+      : <g><rect x="2" y="2" width="4.6" height="4.6" /><rect x="7.4" y="2" width="4.6" height="4.6" /><rect x="2" y="7.4" width="4.6" height="4.6" /><rect x="7.4" y="7.4" width="4.6" height="4.6" /></g>}
+  </svg>
+);
+
+/* ---------- shared card chrome ---------- */
+const CkBadge = () => (
+  <span className="ck-badge"><TrustGlyph state="gated" size={11} />Secured by Clerk · themed by the house</span>
+);
+const AuthShell = ({ children, under, label, viewing }) => (
+  <div className="auth-page s5-fade" data-screen-label={label}>
+    <a className="skip-link" href="#auth-main">Skip to content</a>
+    <div className="auth-brand"><VtLogo size={19} /></div>
+    <main id="auth-main" style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      {children}
+    </main>
+    {under ? <div className="auth-under"><p>{under}</p></div> : null}
+    <ProtoBar viewing={viewing} />
+  </div>
+);
+
+/* ---------- sign-in ---------- */
+const AuthSignIn = () => {
+  const [email, setEmail] = React.useState('');
+  return (
+    <AuthShell label="Auth · sign in" under="Signing in reads nothing new. Sources are only checked when you ask."
+      viewing={{ href: '#/auth/sign-in', label: '/sign-in' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Sign in</h1>
+          <p className="sub">Back to your passport, exactly as you left it.</p>
+        </div>
+        <div className="ck-social">
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="google" />Continue with Google</button>
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="microsoft" />Continue with Microsoft</button>
+        </div>
+        <div className="ck-div"><span>OR</span></div>
+        <form className="ck-form" onSubmit={(e) => { e.preventDefault(); window.location.hash = '#/auth/verify'; }}>
+          <Field id="si-email" label="Email address">
+            <TextInput id="si-email" type="email" autoComplete="email" placeholder="you@practice.org"
+              value={email} onChange={(e) => setEmail(e.target.value)} />
+          </Field>
+          <button type="submit" className="ck-primary" disabled={!email.includes('@')}>Continue</button>
+        </form>
+        <div className="ck-foot">
+          <span className="ck-foot-line">No account? <a href="#/auth/sign-up">Create one</a> — free for clinicians.</span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+/* ---------- sign-up ---------- */
+const AuthSignUp = () => {
+  const [v, setV] = React.useState({ first: '', last: '', email: '' });
+  const ok = v.first.trim() && v.last.trim() && v.email.includes('@');
+  return (
+    <AuthShell label="Auth · sign up" under="An account holds your snapshots. It never changes what sources say."
+      viewing={{ href: '#/auth/sign-up', label: '/sign-up' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Create your account</h1>
+          <p className="sub">Free for clinicians. Your record stays yours.</p>
+        </div>
+        <div className="ck-social">
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="google" />Continue with Google</button>
+          <button type="button" className="ck-social-btn"><AuthProvIcon kind="microsoft" />Continue with Microsoft</button>
+        </div>
+        <div className="ck-div"><span>OR</span></div>
+        <form className="ck-form" onSubmit={(e) => { e.preventDefault(); window.location.hash = '#/auth/verify'; }}>
+          <div className="ck-name-grid">
+            <Field id="su-first" label="First name">
+              <TextInput id="su-first" autoComplete="given-name" value={v.first}
+                onChange={(e) => setV({ ...v, first: e.target.value })} />
+            </Field>
+            <Field id="su-last" label="Last name">
+              <TextInput id="su-last" autoComplete="family-name" value={v.last}
+                onChange={(e) => setV({ ...v, last: e.target.value })} />
+            </Field>
+          </div>
+          <Field id="su-email" label="Email address" hint="Work email if you have one — either works.">
+            <TextInput id="su-email" type="email" autoComplete="email" placeholder="you@practice.org"
+              value={v.email} onChange={(e) => setV({ ...v, email: e.target.value })} />
+          </Field>
+          <button type="submit" className="ck-primary" disabled={!ok}>Continue</button>
+        </form>
+        <div className="ck-foot">
+          <span className="ck-foot-line">Already have an account? <a href="#/auth/sign-in">Sign in</a></span>
+          <span className="ck-foot-line" style={{ fontSize: 11.5, color: 'var(--vt-text-muted)' }}>
+            By continuing you agree to the <a href="#/legal/terms">Terms</a> and <a href="#/legal/privacy">Privacy notice</a>.
+          </span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+/* ---------- email verification ---------- */
+const AuthVerify = () => {
+  const [code, setCode] = React.useState('');
+  const [focused, setFocused] = React.useState(false);
+  const inputRef = React.useRef(null);
+  const done = code.length === 6;
+  return (
+    <AuthShell label="Auth · verify email" under="We verify the inbox, not the person. Identity comes from sources, not sign-up."
+      viewing={{ href: '#/auth/verify', label: '/verify' }}>
+      <div className="ck-card">
+        <div className="ck-head">
+          <h1>Check your email</h1>
+          <p className="sub">A six-digit code was sent to <strong style={{ fontWeight: 600 }}>a.okafor@practice.org</strong>. It expires in 10 minutes.</p>
+        </div>
+        <div className="ck-form">
+          <div className="fk-field">
+            <label className="fk-label" htmlFor="vf-code">Verification code</label>
+            <div className="code-cells" onClick={() => inputRef.current && inputRef.current.focus()}>
+              <input ref={inputRef} id="vf-code" className="code-hidden" value={code}
+                inputMode="numeric" pattern="[0-9]*" autoComplete="one-time-code"
+                aria-label="Six-digit verification code"
+                onFocus={() => setFocused(true)} onBlur={() => setFocused(false)}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))} />
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <span key={i} aria-hidden="true"
+                  className={`code-cell${code[i] ? '' : ' empty'}${focused && i === Math.min(code.length, 5) ? ' focus' : ''}`}>
+                  {code[i] || '·'}
+                </span>
+              ))}
+            </div>
+            <div className="code-meta">
+              <span className={`cnt vt-num${done ? ' done' : ''}`} aria-live="polite">{code.length}/6{done ? ' · checking' : ''}</span>
+              <QuietButton small onClick={() => setCode('')}>Resend code</QuietButton>
+            </div>
+          </div>
+          <button type="button" className="ck-primary" disabled={!done}
+            onClick={() => { window.location.hash = '#/auth/loading'; }}>
+            {done ? 'Verify and continue' : 'Enter the code'}
+          </button>
+        </div>
+        <div className="ck-foot">
+          <span className="ck-foot-line"><a href="#/auth/sign-in">Use a different email</a></span>
+          <CkBadge />
+        </div>
+      </div>
+    </AuthShell>
+  );
+};
+
+/* ---------- loading interstitial ---------- */
+const AuthLoading = () => {
+  React.useEffect(() => {
+    const t = setTimeout(() => { window.location.hash = '#/auth'; }, 3600);
+    return () => clearTimeout(t);
+  }, []);
+  return (
+    <div className="authload s5-fade" data-screen-label="Auth · loading interstitial" role="status" aria-live="polite">
+      <div className="authload-box">
+        <VtLogo size={19} />
+        <span className="authload-track" aria-hidden="true"></span>
+        <span className="authload-line">Verifying session</span>
+        <p className="authload-note">Nothing is shown until it's checked. This usually takes under a second.</p>
+      </div>
+      <ProtoBar viewing={{ href: '#/auth/loading', label: '/loading' }} />
+    </div>
+  );
+};
+
+/* ---------- Clerk appearance mapping (implementable spec) ---------- */
+const CK_VARS = [
+  { k: 'colorPrimary', v: '#141414', note: 'var(--ink-900) — buttons, active states' },
+  { k: 'colorText', v: '#141414', note: 'var(--vt-text)' },
+  { k: 'colorTextSecondary', v: '#474540', note: 'var(--vt-text-secondary)' },
+  { k: 'colorBackground', v: '#ffffff', note: 'var(--vt-surface-card) — card only; page stays paper' },
+  { k: 'colorInputBackground', v: '#ffffff', note: 'var(--vt-surface-card)' },
+  { k: 'colorInputText', v: '#141414', note: 'var(--vt-text)' },
+  { k: 'colorDanger', v: '#7a1414', note: 'var(--hue-p0)' },
+  { k: 'colorSuccess', v: '#1c5c38', note: 'var(--hue-ok)' },
+  { k: 'colorWarning', v: '#7d5a1e', note: 'var(--hue-watch)' },
+  { k: 'colorNeutral', v: '#141414', note: 'kills residual purple in borders/shadows' },
+  { k: 'fontFamily', v: "'Geist', ui-sans-serif, system-ui", note: 'var(--font-body)' },
+  { k: 'fontFamilyButtons', v: "'Geist', ui-sans-serif, system-ui", note: 'same — no second face' },
+  { k: 'borderRadius', v: '2px', note: 'var(--radius-1) — near-sharp public' },
+];
+const CK_ELEMENTS = [
+  { k: 'rootBox / cardBox', v: 'box-shadow: none; border: 1px solid #dddbd3; border-radius: 4px', note: 'rules, not shadows (DG-1.10)' },
+  { k: 'card', v: 'background: #ffffff; padding: 32px; gap: 20px', note: 'paper-0 card on paper-100 page' },
+  { k: 'headerTitle', v: "font-family: 'Fraunces'; font-weight: 560; font-size: 24px; letter-spacing: -0.015em", note: 'display face' },
+  { k: 'headerSubtitle', v: 'color: #474540; font-size: 13px', note: '' },
+  { k: 'logoBox', v: 'render house wordmark (brand/logo.jsx), 19px', note: 'never the Clerk logo slot default' },
+  { k: 'socialButtonsBlockButton', v: 'height 46px; border: 1px solid #141414; border-radius: 2px; Geist Mono 10.5px caps +0.12em', note: 'monochrome provider glyphs, no brand colors' },
+  { k: 'dividerLine / dividerText', v: 'line #dddbd3 · text Geist Mono 9.5px caps +0.2em #6b6860', note: '' },
+  { k: 'formFieldLabel', v: 'font-size: 12.5px; font-weight: 600; color: #141414', note: 'form-kit label' },
+  { k: 'formFieldInput', v: 'height 46px; border: 1px solid #141414; border-radius: 2px; font-size 14px', note: 'form-kit input; ≥44px target' },
+  { k: 'formFieldInput:focus', v: 'box-shadow: 0 0 0 2px #f4f2ec, 0 0 0 4px #141414', note: 'var(--vt-focus-ring) — uniform ring' },
+  { k: 'formButtonPrimary', v: 'background #141414 → hover #1f2c22; height 46px; radius 2px; no ::after arrow', note: 'ink fill, matcha-900 hover' },
+  { k: 'formFieldErrorText', v: 'Geist Mono 10.5px, color #7a1414, glyph + label', note: 'never color alone' },
+  { k: 'footerActionLink', v: 'color #141414; underline, offset 3px; hover #1f2c22', note: 'house link grammar' },
+  { k: 'badge / footer', v: 'Geist Mono 9px caps +0.14em, color #6b6860; background none', note: '"Secured by Clerk" stays — restyled, honest' },
+  { k: 'spinner / loading', v: 'currentColor only; static track + ink sweep', note: 'no purple spinner; reduced-motion → static' },
+];
+
+const AuthOverview = () => (
+  <S5Page eyebrow="DG-12.1 · Auth surfaces" title={<span>One house, even at the <span className="vt-accent-i">front door.</span></span>}
+    lede="Clerk handles the session; the house handles every pixel. Paper background, ink text, house buttons and focus ring, Geist type, the wordmark where Clerk's logo slot sits. Zero default purple."
+    label="Auth · overview">
+    <S5Section first eyebrow="Full-page states" title="The four surfaces"
+      lede="Each opens chrome-less, exactly as a signed-out visitor meets it.">
+      <div className="hub-grid">
+        {[
+          { href: '#/auth/sign-in', id: 'AUTH-1', t: 'Sign in', d: 'Email-first with two social options. Social buttons are outline + mono caps — provider glyphs render monochrome.' },
+          { href: '#/auth/sign-up', id: 'AUTH-2', t: 'Sign up', d: 'Name pair + email. Legal consent links inline. Free-for-clinicians stated plainly, no asterisk.' },
+          { href: '#/auth/verify', id: 'AUTH-3', t: 'Email verification', d: 'Six code cells in the NPI-cell grammar. Digit count announced via aria-live. Resend is a quiet action.' },
+          { href: '#/auth/loading', id: 'AUTH-4', t: 'Loading interstitial', d: 'Wordmark, hairline sweep (static under reduced motion), one mono line. No skeleton of a page that isn’t there yet.' },
+        ].map((c) => (
+          <div className="hub-card" key={c.id}>
+            <span className="hid">{c.id}</span>
+            <h3>{c.t}</h3>
+            <p>{c.d}</p>
+            <div className="hub-links"><a href={c.href}>Open full page</a></div>
+          </div>
+        ))}
+      </div>
+    </S5Section>
+    <S5Section eyebrow="Implementable spec" title="Clerk appearance API mapping"
+      lede="Lives at lib/clerkAppearance.ts and is passed to <ClerkProvider appearance>. Values are the resolved hex of house tokens — Clerk can't read CSS variables server-side, so the file carries the token name in a comment per line.">
+      <div className="s5-twocol">
+        <div>
+          <h3 style={{ fontSize: 15, marginBottom: 10 }}>appearance.variables</h3>
+          <div>{CK_VARS.map((r) => <TokenRow key={r.k} k={r.k} value={r.v} display={`${r.v}${r.note ? '  ·  ' + r.note : ''}`} />)}</div>
+        </div>
+        <div>
+          <h3 style={{ fontSize: 15, marginBottom: 10 }}>appearance.elements</h3>
+          <div>{CK_ELEMENTS.map((r) => <TokenRow key={r.k} k={r.k} value={r.v} display={`${r.v}${r.note ? '  ·  ' + r.note : ''}`} />)}</div>
+        </div>
+      </div>
+      <p style={{ margin: '18px 0 0', fontFamily: 'var(--font-mono)', fontSize: 10.5, lineHeight: 1.7, color: 'var(--vt-text-secondary)', maxWidth: '88ch' }}>
+        ACCEPTANCE · Render sign-in, sign-up, verification, and the SSO-callback interstitial; screenshot at 360/768/1440. grep the computed styles for
+        rgb values of Clerk's defaults (#6c47ff family) — any hit fails the gate. Focus ring on every interactive element must equal var(--vt-focus-ring).
+      </p>
+    </S5Section>
+  </S5Page>
+);
+
+const AuthRoute = ({ route }) => {
+  if (route.sub === 'sign-in') return <AuthSignIn />;
+  if (route.sub === 'sign-up') return <AuthSignUp />;
+  if (route.sub === 'verify') return <AuthVerify />;
+  if (route.sub === 'loading') return <AuthLoading />;
+  return <AuthOverview />;
+};
+
+Object.assign(window, { AuthRoute, AuthSignIn, AuthSignUp, AuthVerify, AuthLoading, AuthOverview });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-contact.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-contact.jsx
@@ -1,0 +1,107 @@
+// Wave 1505 · w1505-contact.jsx — /contact with form-kit form,
+// expectation copy, designed success state (DG-12.4.1).
+
+const CONTACT_TOPICS = [
+  'Employer pilot inquiry',
+  'Review request',
+  'Data correction',
+  'Security disclosure',
+  'Press',
+  'Something else',
+];
+
+const ContactRoute = () => {
+  const [v, setV] = React.useState({ name: '', email: '', org: '', topic: '', msg: '' });
+  const [errors, setErrors] = React.useState({});
+  const [sent, setSent] = React.useState(false);
+  const refs = {
+    name: React.useRef(null), email: React.useRef(null),
+    topic: React.useRef(null), msg: React.useRef(null),
+  };
+  const labels = { name: 'Your name', email: 'Work email', topic: 'Topic', msg: 'Message' };
+  const set = (k) => (e) => setV({ ...v, [k]: e.target.value });
+  const submit = (e) => {
+    e.preventDefault();
+    const errs = {};
+    errs.name = validateRequired(v.name, 'Your name');
+    errs.email = validateWorkEmail(v.email);
+    errs.topic = v.topic ? null : 'Choose a topic so it reaches the right person.';
+    errs.msg = validateRequired(v.msg, 'Message');
+    Object.keys(errs).forEach((k) => { if (!errs[k]) delete errs[k]; });
+    setErrors(errs);
+    if (!Object.keys(errs).length) setSent(true);
+  };
+  return (
+    <S5Page eyebrow="DG-12.4.1 · Contact" title={<span>A person reads <span className="vt-accent-i">every</span> message.</span>}
+      lede="No chatbot, no ticket deflection. Say what you need; we route it to whoever can actually decide."
+      label="Contact">
+      <S5Section first>
+        <div className="ct-grid">
+          <div style={{ maxWidth: 560 }}>
+            {!sent ? (
+              <form className="fk-form" onSubmit={submit} noValidate>
+                <ErrorSummary errors={errors} order={['name', 'email', 'topic', 'msg']} labels={labels} refs={refs} />
+                <Field id="ct-name" label="Your name" required error={errors.name}>
+                  <TextInput ref={refs.name} id="ct-name" autoComplete="name" value={v.name} onChange={set('name')} error={errors.name} />
+                </Field>
+                <Field id="ct-email" label="Work email" required error={errors.email}
+                  hint="Personal email is fine for clinician topics.">
+                  <TextInput ref={refs.email} id="ct-email" type="email" autoComplete="email"
+                    placeholder="you@organization.org" value={v.email} onChange={set('email')} error={errors.email} />
+                </Field>
+                <Field id="ct-org" label="Organization" hint="Optional.">
+                  <TextInput id="ct-org" autoComplete="organization" value={v.org} onChange={set('org')} />
+                </Field>
+                <Field id="ct-topic" label="Topic" required error={errors.topic}>
+                  <select ref={refs.topic} id="ct-topic" className={`fk-input${errors.topic ? ' err' : ''}`}
+                    aria-invalid={!!errors.topic} aria-describedby={errors.topic ? 'ct-topic-err' : undefined}
+                    value={v.topic} onChange={set('topic')}>
+                    <option value="">Choose one</option>
+                    {CONTACT_TOPICS.map((t) => <option key={t} value={t}>{t}</option>)}
+                  </select>
+                </Field>
+                <Field id="ct-msg" label="Message" required error={errors.msg}
+                  hint="Please don't include patient information — this form isn't for PHI, and we'd have to delete it.">
+                  <TextArea ref={refs.msg} id="ct-msg" rows={6} value={v.msg} onChange={set('msg')} error={errors.msg} />
+                </Field>
+                <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <PrimaryButton size="lg" type="submit">Send message</PrimaryButton>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.05em', color: 'var(--vt-text-muted)' }}>
+                    Reviewed within two business days
+                  </span>
+                </div>
+              </form>
+            ) : (
+              <SuccessCard title="Message recorded." receipt="msg_2026-07-12_84c2 · keep this reference"
+                onReset={() => { setSent(false); setV({ name: '', email: '', org: '', topic: '', msg: '' }); }}
+                resetLabel="Send another message">
+                <p>It's in front of a person, not a queue-bot. You'll hear back at
+                  {' '}<strong style={{ fontWeight: 600 }}>{v.email || 'your email'}</strong> within two business days —
+                  security disclosures are triaged the same day.</p>
+              </SuccessCard>
+            )}
+          </div>
+          <aside className="ct-aside" aria-label="What to expect">
+            <div className="ct-expect">
+              <span className="vt-eyebrow">What to expect</span>
+              <div className="row"><TrustGlyph state="reviewRequired" size={14} />
+                <p><strong>Reviewed within two business days.</strong> Every message, by a person with authority to act on it.</p></div>
+              <div className="row"><TrustGlyph state="stale" size={14} />
+                <p><strong>Security disclosures</strong> are triaged same-day. Use the topic above and include the run reference if you have one.</p></div>
+              <div className="row"><TrustGlyph state="notDecisionGrade" size={14} />
+                <p><strong>Data corrections</strong> usually belong at the source. We'll tell you which registry to correct and re-read it once you have.</p></div>
+            </div>
+            <div className="ct-expect">
+              <span className="vt-eyebrow">Prefer email</span>
+              <div className="row"><TrustGlyph state="previewOnly" size={14} />
+                <p><span className="vt-num" style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>hello@vitalcv.com</span><br />
+                Same inbox, same two-day promise.</p></div>
+            </div>
+          </aside>
+        </div>
+      </S5Section>
+    </S5Page>
+  );
+};
+
+Object.assign(window, { ContactRoute, CONTACT_TOPICS });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-devdesign.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-devdesign.jsx
@@ -1,0 +1,290 @@
+// Wave 1505 · w1505-devdesign.jsx — /dev/design living style guide
+// (DG-18.2). Every primitive rendered in every state, with the usage
+// rule beside it. If it isn't here, it isn't in the system.
+
+const DD_SECTIONS = [
+  ['palette', 'Palette'], ['type', 'Type ramp'], ['space', 'Spacing'], ['glyphs', 'Glyphs'],
+  ['chips', 'StateChip ×9(+2)'], ['tiers', 'Tier badges'], ['buttons', 'Buttons'], ['forms', 'Forms'],
+  ['rows', 'Evidence rows'], ['ring', 'ReadinessRing'], ['honesty', 'Honesty kit'], ['recognition', 'Recognition'],
+  ['triad', 'Empty/Loading/Error'], ['motion', 'Motion'], ['z', 'Z-scale'],
+];
+
+const DDBand = ({ id, title, dg, rule, children, first }) => (
+  <section id={`dd-${id}`} className={`dd-band${first ? ' first' : ''}`}>
+    <div className="dd-band-head">
+      <h2>{title}</h2>
+      {dg ? <span className="dg vt-num">{dg}</span> : null}
+    </div>
+    {rule ? <p className="dd-rule">{rule}</p> : null}
+    {children}
+  </section>
+);
+
+const DD_PALETTE = [
+  { t: '--vt-surface-page', h: '#f4f2ec', c: 'var(--vt-surface-page)', b: true },
+  { t: '--vt-surface-card', h: '#ffffff', c: 'var(--vt-surface-card)', b: true },
+  { t: '--vt-surface-sunken', h: '#efede7', c: 'var(--vt-surface-sunken)', b: true },
+  { t: '--vt-text', h: '#141414', c: 'var(--vt-text)' },
+  { t: '--vt-text-secondary', h: '#474540', c: 'var(--vt-text-secondary)' },
+  { t: '--vt-text-muted', h: '#6b6860', c: 'var(--vt-text-muted)' },
+  { t: '--vt-rule', h: '#dddbd3', c: 'var(--vt-rule)', b: true },
+  { t: '--vt-brand', h: '#2c3e2d', c: 'var(--vt-brand)' },
+  { t: '--vt-brand-soft', h: '#f0f4ef', c: 'var(--vt-brand-soft)', b: true },
+  { t: '--vt-accent-editorial', h: '#4f46e5', c: 'var(--vt-accent-editorial)' },
+  { t: '--vt-state-checked', h: '#1c5c38', c: 'var(--vt-state-checked)' },
+  { t: '--vt-state-stale', h: '#7d5a1e', c: 'var(--vt-state-stale)' },
+  { t: '--vt-state-p0', h: '#7a1414', c: 'var(--vt-state-p0)' },
+  { t: '--vt-state-preview', h: '#1a3e6b', c: 'var(--vt-state-preview)' },
+  { t: '--vt-state-contradicted', h: '#5b2a86', c: 'var(--vt-state-contradicted)' },
+];
+
+const DD_TYPE = [
+  { m: 'display · Fraunces 560', style: { fontFamily: 'var(--font-display)', fontWeight: 560, fontSize: 'var(--text-3xl)', letterSpacing: '-0.015em', lineHeight: 1.1 }, s: 'Readiness is a record.' },
+  { m: 'h2 · Fraunces 560 · 24', style: { fontFamily: 'var(--font-display)', fontWeight: 560, fontSize: 'var(--text-xl)', letterSpacing: '-0.015em' }, s: 'Sources, stated plainly' },
+  { m: 'italic accent · indigo', style: { fontFamily: 'var(--font-display)', fontStyle: 'italic', fontWeight: 480, fontSize: 'var(--text-xl)', color: 'var(--vt-accent-editorial)' }, s: 'checked, not claimed' },
+  { m: 'body · Geist 400 · 14/1.6', style: { fontSize: 14, lineHeight: 1.6 }, s: 'Body copy runs at fourteen over one-point-six, ink on paper, never lighter than --vt-text-secondary.' },
+  { m: 'caption · Geist 400 · 12.5', style: { fontSize: 12.5, color: 'var(--vt-text-secondary)' }, s: 'Support copy passes 4.5:1 on paper.' },
+  { m: 'eyebrow · Mono 500 · 10 caps', style: { fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--vt-text-faint)', fontWeight: 500 }, s: 'Section eyebrow' },
+  { m: 'data · Mono · tabular', style: { fontFamily: 'var(--font-mono)', fontSize: 12.5, fontVariantNumeric: 'tabular-nums' }, s: 'npi:1234567893 · run_2026-07-11_0642Z · 06:42Z' },
+];
+
+const DevDesignRoute = () => {
+  const [motionKey, setMotionKey] = React.useState(0);
+  const [npi, setNpi] = React.useState('123456');
+  return (
+    <S5Page eyebrow="DG-18.2 · /dev/design" title={<span>The system, <span className="vt-accent-i">rendered.</span></span>}
+      lede="Every primitive in every state, with its usage rule. This page is the arbiter: if a surface disagrees with /dev/design, the surface is wrong."
+      label="/dev/design style guide">
+      <div className="s5-container">
+        <nav className="dd-jump" aria-label="Sections">
+          {DD_SECTIONS.map(([id, l]) => (
+            <a key={id} href="#/dev/design" onClick={(e) => {
+              e.preventDefault();
+              const el = document.getElementById(`dd-${id}`);
+              if (el) window.scrollTo(0, el.getBoundingClientRect().top + window.pageYOffset - 60);
+            }}>{l}</a>
+          ))}
+        </nav>
+
+        <DDBand first id="palette" title="Palette" dg="DG-1.1"
+          rule="Tokens only — raw hex is lint-illegal outside wave1500 theme files. Matcha is reserved for Recognition moments and primary-button hover. Indigo exists solely for the italic display phrase, ≤1 per section.">
+          <div className="dd-swatches">
+            {DD_PALETTE.map((s) => (
+              <div className="dd-swatch" key={s.t}>
+                <div className="chip" style={{ background: s.c, borderBottom: s.b ? '1px solid var(--vt-rule-soft)' : 'none' }}></div>
+                <div className="meta"><span className="t">{s.t}</span><span className="h vt-num">{s.h}</span></div>
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="type" title="Type ramp" dg="DG-2.1"
+          rule="Three faces, no more: Fraunces (display, optical sizing on), Geist (body), Geist Mono (eyebrows, identifiers, timestamps — always tabular-nums for metrics).">
+          {DD_TYPE.map((r) => (
+            <div className="dd-type-row" key={r.m}>
+              <span className="m">{r.m}</span>
+              <span style={r.style} className={r.m.includes('tabular') ? 'vt-num' : undefined}>{r.s}</span>
+            </div>
+          ))}
+        </DDBand>
+
+        <DDBand id="space" title="Spacing scale" dg="DG-1.5"
+          rule="4px base. Section padding uses space-10/12/16; card padding space-4/5/6; never literal pixel margins between siblings — flex/grid gap only.">
+          {[['--space-2', 8], ['--space-4', 16], ['--space-6', 24], ['--space-8', 32], ['--space-12', 48], ['--space-16', 64], ['--space-24', 96]].map(([t, w]) => (
+            <div className="dd-space-row" key={t}>
+              <span className="m vt-num">{t} · {w}px</span>
+              <span className="bar" style={{ width: w * 3 }}></span>
+            </div>
+          ))}
+        </DDBand>
+
+        <DDBand id="glyphs" title="TrustGlyph set" dg="DG-4.2"
+          rule="Monochrome, currentColor, stroke 1.5, legible at 14px. Glyph + label are always paired — a glyph alone is lint-illegal in chips. Grayscale legibility is the acceptance test.">
+          <div className="dd-glyph-grid">
+            {Object.keys(STATE_META).map((k) => (
+              <div className="dd-glyph-cell" key={k}>
+                <span className="g"><TrustGlyph state={k} size={20} /></span>
+                <span className="n">{k}</span>
+              </div>
+            ))}
+            {['T1', 'T2', 'T3', 'T4'].map((t) => (
+              <div className="dd-glyph-cell" key={t}>
+                <span className="g"><TrustGlyph state={t} size={20} /></span>
+                <span className="n">{t} · fill {['¼', '½', '¾', 'full'][['T1', 'T2', 'T3', 'T4'].indexOf(t)]}</span>
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="chips" title="StateChip — 9 coverage states + 2 review states" dg="DG-3.2 · 6.1"
+          rule="The atomic visual unit. Dashed border = pending/previewOnly only. Tooltip carries source + freshness + definition. Never restyle locally; never a checkmark on gated/unavailable.">
+          <div className="dd-grid">
+            {Object.keys(STATE_META).map((s) => (
+              <div className="dd-spec" key={s}>
+                <span className="lab">{s}</span>
+                <StateChip state={s} />
+                <StateChip state={s} size="sm" />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="tiers" title="ProofTierBadge" dg="DG-6.6"
+          rule="T1 self-attested → T4 signed institutional artifact. The fill fraction is the grayscale signal; the tooltip is the definition. Tier never substitutes for state.">
+          <div className="dd-grid">
+            {['T1', 'T2', 'T3', 'T4'].map((t) => (
+              <div className="dd-spec" key={t}>
+                <span className="lab">{t} · {TIER_DEFS[t].split('.')[0]}</span>
+                <ProofTierBadge tier={t} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="buttons" title="Buttons" dg="DG-6.3"
+          rule="Primary = ink fill, matcha-900 hover — never matcha at rest. Secondary = rule outline. Quiet = underline-on-hover. Destructive = p0 outline, reserved for revocation. All ≥44px targets at coarse pointers.">
+          <div className="dd-grid">
+            <div className="dd-spec"><span className="lab">primary · rest / disabled / loading</span>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                <PrimaryButton>Check readiness</PrimaryButton>
+                <PrimaryButton disabled>Check readiness</PrimaryButton>
+                <PrimaryButton loading>Checking</PrimaryButton>
+              </div>
+            </div>
+            <div className="dd-spec"><span className="lab">secondary / quiet / destructive</span>
+              <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                <SecondaryButton>View lineage</SecondaryButton>
+                <QuietButton>Refresh source</QuietButton>
+                <DestructiveButton>Revoke link</DestructiveButton>
+              </div>
+            </div>
+            <div className="dd-spec"><span className="lab">focus ring — uniform everywhere</span>
+              <button className="ck-primary" style={{ width: 'auto', padding: '0 20px', boxShadow: 'var(--vt-focus-ring)' }}>Focused state</button>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="forms" title="Form kit" dg="DG-6.7 · 8.2"
+          rule="46px inputs, rule-strong borders, radius-1. Errors are mono + glyph + aria-live, never color alone. The NPI field announces its digit count. Every form ships a designed error summary and success state.">
+          <div className="s5-twocol">
+            <div className="dd-spec" style={{ gap: 16 }}>
+              <span className="lab">field · default / hint / error</span>
+              <Field id="dd-f1" label="Work email" hint="We answer within two business days.">
+                <TextInput id="dd-f1" placeholder="you@organization.org" />
+              </Field>
+              <Field id="dd-f2" label="Work email" required error="Enter a work email — personal domains are fine for clinicians.">
+                <TextInput id="dd-f2" defaultValue="adaeze@" error="err" />
+              </Field>
+              <div className="fk-field">
+                <label className="fk-label" htmlFor="dd-npi">NPI · live count</label>
+                <NpiInput value={npi} onChange={setNpi} />
+              </div>
+            </div>
+            <div className="dd-spec" style={{ gap: 16 }}>
+              <span className="lab">error summary + success</span>
+              <div className="fk-summary" role="presentation">
+                <span className="t"><TrustGlyph state="p0" size={12} /> 2 fields need attention</span>
+                <ul>
+                  <li><button type="button">Work email — required.</button></li>
+                  <li><button type="button">Topic — choose one.</button></li>
+                </ul>
+              </div>
+              <div className="fk-success" style={{ padding: 'var(--space-5)' }} role="presentation">
+                <StateChip state="checked" label="Recorded" />
+                <h3 style={{ fontSize: 18 }}>Request recorded.</h3>
+                <span className="receipt vt-num">req_2026-07-12_31bd</span>
+              </div>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="rows" title="Evidence rows" dg="DG-6.4 · 10.2"
+          rule="Label / mono source / chip / freshness / action — same metrics everywhere. Blockers sort first and carry the p0 chip; gated stays gated until authorized, never assumed.">
+          <div style={{ maxWidth: 640 }}>
+            <SourceRow label="NPPES record" source="NPPES" state="checked" freshness="2h ago" iso="2026-07-11T12:04:00Z" />
+            <SourceRow label="Exclusion list" source="OIG LEIE" state="stale" freshness="34d ago" iso="2026-06-08T09:00:00Z" action="Refresh" />
+            <SourceRow label="Medicare enrollment" source="CMS PECOS" state="gated" action="Authorize read" />
+            <SourceRow label="Texas license" source="TEXAS MEDICAL BOARD" state="p0" chipLabel="Blocker" freshness="21d ago" iso="2026-06-20T09:00:00Z" action="Resolve" />
+          </div>
+        </DDBand>
+
+        <DDBand id="ring" title="ReadinessRing" dg="DG-6.5"
+          rule='role="meter" with aria values; band by threshold (≥80 ready · ≥50 head start · else early); band is also written as text — never color alone. Sweeps once; static under reduced motion.'>
+          <div className="dd-grid">
+            {[[0, 'Early band'], [45, 'Early band'], [72, 'Head-start band'], [88, 'Ready band']].map(([v, b]) => (
+              <div className="dd-spec" key={v} style={{ alignItems: 'center' }}>
+                <span className="lab vt-num">{v}% · {b}</span>
+                <ReadinessRing value={v} size={92} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+
+        <DDBand id="honesty" title="Honesty kit" dg="DG-8.4 · 17.2"
+          rule="HonestyLabel is designed UI, never fine print — mandatory on every illustrative number. HonestyPanel pairs 'what you get' with 'what stays outside' at equal visual weight.">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <HonestyLabel>Illustrative figure — the signed scope carries the real one.</HonestyLabel>
+            <div className="hn-pair" style={{ maxWidth: 760 }}>
+              <HonestyPanel tone="ok" title="Checked today" items={[
+                { label: 'NPPES record', source: 'NPPES', state: 'checked' },
+                { label: 'California license', source: 'MBC', state: 'checked' },
+              ]} />
+              <HonestyPanel tone="watch" title="Stays outside" items={[
+                { label: 'Medicare enrollment', source: 'CMS PECOS', state: 'gated', chipLabel: 'Gated' },
+                { label: 'Employment history', source: 'SELF-ATTESTED', state: 'notDecisionGrade', chipLabel: 'Self-attested' },
+              ]} foot="A partial proof stays partial." />
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="recognition" title="Recognition stamp" dg="DG-10.5"
+          rule="THE reserved matcha moment — the only solid matcha on clinician surfaces. Archival tone: mono timestamp, packet id, numbered stamp. Never animated beyond its single entrance.">
+          <div style={{ maxWidth: 640 }}>
+            <RecognitionRow employer="Mercy General Health" iso="2026-06-30T14:22Z" packet={'pk_7f3a·d91c'} n="0012" />
+          </div>
+        </DDBand>
+
+        <DDBand id="triad" title="Empty · loading · error" dg="DG-12.2"
+          rule="Every data region ships all three in the same footprint. Empty states name the surface, say why, and offer ONE action. Errors never claim partial success.">
+          <div className="hub-grid">
+            <div className="hub-card"><span className="hid">loading</span><SkeletonStack /></div>
+            <div className="hub-card"><span className="hid">empty</span>
+              <EmptyState glyph="pending" title="No sources checked yet." why="Enter an NPI to run the first check." action="Enter an NPI" /></div>
+            <div className="hub-card"><span className="hid">error</span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-state-p0)' }}>
+                <TrustGlyph state="p0" size={13} /> Couldn't load. Nothing recorded.
+              </span>
+              <QuietButton small>Retry</QuietButton>
+            </div>
+          </div>
+        </DDBand>
+
+        <DDBand id="motion" title="Motion" dg="DG-5.2"
+          rule="One curve: cubic-bezier(0.2, 0.8, 0.2, 1). 160/320/420ms. Single-shot entrances; hover lift ≤2px; no infinite loops on public surfaces except skeleton shimmer and the /status pulse. Reduced motion: static, opacity fades only.">
+          <div className="dd-motion-demo">
+            <div key={motionKey} className="dd-motion-box play"></div>
+            <SecondaryButton onClick={() => setMotionKey(motionKey + 1)}>Replay .vt-enter</SecondaryButton>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--vt-text-muted)', letterSpacing: '0.05em' }}>
+              var(--ease-house) · var(--dur-base) · translateY(10px) → 0
+            </span>
+          </div>
+        </DDBand>
+
+        <DDBand id="z" title="Z-index scale" dg="DG-12.5"
+          rule="Literal z-index values are lint-illegal. Six stops, promoted this wave.">
+          <div className="dd-ztable">
+            {[['--vt-z-base', '0', 'page flow'], ['--vt-z-raised', '10', 'lifted cards, in-flow dropdowns'], ['--vt-z-nav', '40', 'sticky nav'], ['--vt-z-banner', '45', 'offline/degraded banner'], ['--vt-z-widget', '50', 'feedback affordance'], ['--vt-z-overlay', '60', 'panels above widgets'], ['--vt-z-skip', '100', 'skip link']].map(([t, v, u]) => (
+              <div className="tok-row" key={t}>
+                <span className="tok-key">{v}</span>
+                <span className="tok-val vt-num">{t} · {u}</span>
+                <CopyBtn text={`var(${t})`} />
+              </div>
+            ))}
+          </div>
+        </DDBand>
+      </div>
+    </S5Page>
+  );
+};
+
+Object.assign(window, { DevDesignRoute });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-governance.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-governance.jsx
@@ -1,0 +1,105 @@
+// Wave 1505 · w1505-governance.jsx — visual-regression matrix (DG-18.3)
+// + design-lint rules (DG-18.4), rendered. Canonical text lives in
+// REGRESSION_MATRIX.md and DESIGN_LINT.md beside this file.
+
+const VR_ROUTES = [
+  { route: '/', wave: '1501', mask: 'none' },
+  { route: '/pricing', wave: '1505', mask: 'none' },
+  { route: '/contact', wave: '1505', mask: 'none' },
+  { route: '/legal/privacy', wave: '1505', mask: 'none' },
+  { route: '/get-ready', wave: '1503', mask: '[data-vr-mask="freshness"]' },
+  { route: '/passport', wave: '1503', mask: 'freshness · ring value · run_id' },
+  { route: '/p/[slug]', wave: '1503', mask: 'freshness · compiled-at' },
+  { route: '/review/request', wave: '1502', mask: 'none' },
+  { route: '/trust', wave: '1504', mask: 'checked_at · run_id · key fingerprints' },
+  { route: '/status', wave: '1504', mask: 'all timestamps · live pulse cell' },
+];
+const VR_VPS = ['360×740', '768×1024', '1440×900'];
+
+const LINT_RULES = [
+  { id: 'LINT-01', sev: 'error', what: 'No raw color outside theme files',
+    det: 'stylelint declaration-property-value-allowed-list: forbid /#[0-9a-f]{3,8}/i, /oklch|rgb|hsl/ on color props. Inline style props linted by eslint-plugin-react regex on style={{...}}.',
+    allow: 'Allowed only in wave1500/01-primitives.css and brand asset files (og.css, svg exports).' },
+  { id: 'LINT-02', sev: 'error', what: 'No raw lucide imports outside <Icon>',
+    det: "eslint no-restricted-imports: { name: 'lucide-react', message: 'Import via components/Icon — glyph set is closed.' } — allowlist: components/Icon.tsx only. TrustGlyph states are the ONLY state iconography.",
+    allow: 'components/Icon.tsx.' },
+  { id: 'LINT-03', sev: 'error', what: 'No new @keyframes outside motion.css',
+    det: 'stylelint custom rule: at-rule "keyframes" fails outside styles/motion.css. Grep gate in CI: `grep -rn "@keyframes" app/ components/` must return 0.',
+    allow: 'styles/motion.css (house set: vt-enter, sk-sweep, status-pulse, al-sweep).' },
+  { id: 'LINT-04', sev: 'error', what: 'No dark/ops tokens on public routes',
+    det: 'Grep gate: `data-theme="ops"`, var(--ink-950) as background, or --vt-surface-inverse anywhere under app/(public)/ fails. Playwright assert: body background = rgb(244,242,236) on all 10 matrix routes.',
+    allow: 'app/(ops)/ surfaces only.' },
+  { id: 'LINT-05', sev: 'error', what: 'No literal z-index',
+    det: 'stylelint declaration-property-value-allowed-list: z-index must match /var\\(--vt-z-/. Six stops exist; a seventh requires a CHANGES.md entry.',
+    allow: 'wave1500 token files.' },
+  { id: 'LINT-06', sev: 'error', what: 'No shadows except --vt-lift; radius ≤6px public',
+    det: 'stylelint: box-shadow value must be none or var(--vt-lift) or var(--vt-focus-ring); border-radius on public routes must be var(--radius-1|2|3). --radius-ops greps to app/(ops)/ only.',
+    allow: 'ops theme may use --radius-ops.' },
+  { id: 'LINT-07', sev: 'error', what: 'Gated/unavailable must never render a checkmark',
+    det: 'Component-level test: StateChip snapshot for state=gated|unavailable|accessRequired must contain lock/slash/key path data, never the check path. Do/don’t pair #1 in DESIGN_SYSTEM.md.',
+    allow: '—' },
+  { id: 'LINT-08', sev: 'error', what: 'Copy prohibitions',
+    det: 'CI grep over app/ + content/: /\\b(cheapest|guaranteed ROI|as seen in|trusted by \\d|100% (secure|verified)|blockchain-verified)\\b/i fails the build. Pricing adds: unlabeled $-figures — any /\\$\\d/ in app/(public)/pricing must sit within 3 lines of <HonestyLabel>.',
+    allow: 'Legal docs may quote prohibited phrases when prohibiting them.' },
+  { id: 'LINT-09', sev: 'warn', what: 'Font-family literals',
+    det: "stylelint: font-family must be var(--font-display|body|mono). Warn (not error) because next/font emits its own literals in generated files — allowlist .next/ and fonts.ts.",
+    allow: 'lib/fonts.ts.' },
+  { id: 'LINT-10', sev: 'warn', what: 'Glyph without label inside chips',
+    det: 'eslint-plugin-jsx-a11y custom: <TrustGlyph> rendered as only child of a chip-role element without sibling text or aria-label warns. Grayscale legibility depends on the pairing.',
+    allow: 'Decorative glyphs beside full sentences (aria-hidden).' },
+];
+
+const GovernanceRoute = () => (
+  <S5Page eyebrow="DG-18.3 · 18.4 · Governance" title={<span>Guarded, or it <span className="vt-accent-i">drifts.</span></span>}
+    lede="Two machine-enforceable specs keep the system honest after the design program ends: a screenshot matrix that catches visual drift, and lint rules that make off-system code fail CI. Canonical text ships as REGRESSION_MATRIX.md and DESIGN_LINT.md."
+    label="Governance">
+    <S5Section first eyebrow="DG-18.3" title="Visual-regression matrix — 10 routes × 3 viewports"
+      lede="Playwright screenshot tests. Fonts awaited via document.fonts.ready; reduced motion forced so entrances never race the capture; dynamic content masked, never mocked silently.">
+      <div className="gv-matrix-wrap">
+        <table className="gv-matrix">
+          <thead>
+            <tr><th scope="col">Route</th><th scope="col">Wave</th><th scope="col">Viewports</th><th scope="col">Masked regions</th></tr>
+          </thead>
+          <tbody>
+            {VR_ROUTES.map((r) => (
+              <tr key={r.route}>
+                <td className="route">{r.route}</td>
+                <td className="wave vt-num">{r.wave}</td>
+                <td>{VR_VPS.map((v) => <span className="vp-ok vt-num" key={v}><TrustGlyph state="checked" size={10} />{v}</span>)}</td>
+                <td className="mask">{r.mask}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <ul className="mono-list" style={{ maxWidth: '88ch' }}>
+          <li>Masking: elements carry data-vr-mask="freshness|runid|timestamp"; the spec masks by attribute selector — never by pixel coordinates.</li>
+          <li>Threshold: maxDiffPixelRatio 0.001 · animations: 'disabled' · prefers-reduced-motion: 'reduce' · deviceScaleFactor 2.</li>
+          <li>Wait: document.fonts.ready + network idle; /status additionally masks the live pulse cell rather than freezing it.</li>
+          <li>Baseline updates require a CHANGES.md entry naming the intentional visual change — CI links the diff to the entry.</li>
+        </ul>
+      </div>
+      <p style={{ marginTop: 16 }}><a href="REGRESSION_MATRIX.md" download>REGRESSION_MATRIX.md</a> — full Playwright spec, ready to implement.</p>
+    </S5Section>
+
+    <S5Section eyebrow="DG-18.4" title="Design-lint rules — off-system code fails CI"
+      lede="Each rule: what it forbids, how it's detected, where exceptions live. Severity error blocks merge; warn blocks release.">
+      <div>
+        {LINT_RULES.map((r) => (
+          <div className="gv-rule" key={r.id}>
+            <span className="rid vt-num">{r.id}<span className={`sev${r.sev === 'warn' ? ' warn' : ''}`}>{r.sev.toUpperCase()}</span></span>
+            <div className="rbody">
+              <span className="what">{r.what}</span>
+              <span className="det">{r.det}</span>
+              <span className="allow"><strong style={{ fontWeight: 600 }}>Allowed:</strong> {r.allow}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p style={{ marginTop: 20 }}><a href="DESIGN_LINT.md" download>DESIGN_LINT.md</a> — rule set with exact configs · <a href="DESIGN_SYSTEM.md" download>DESIGN_SYSTEM.md</a> — the canonical doc (DG-18.1).</p>
+    </S5Section>
+  </S5Page>
+);
+
+Object.assign(window, { GovernanceRoute, VR_ROUTES, LINT_RULES });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-legal.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-legal.jsx
@@ -1,0 +1,231 @@
+// Wave 1505 · w1505-legal.jsx — one prose template, four documents
+// (DG-12.3). 65ch Geist body, Fraunces headings, mono "Last updated"
+// stamp, sticky TOC ≥1024px, anchor links.
+
+const LEGAL_DOCS = {
+  privacy: {
+    title: 'Privacy notice',
+    updated: '2026-07-01', version: 'v1.2',
+    sections: [
+      { id: 'what-we-read', h: 'What we read', body: (
+        <React.Fragment>
+          <p>VitalCV reads public, primary sources about licensed clinicians — NPPES, state medical
+            board registries, the OIG exclusion list, and, where a clinician authorizes it, CMS PECOS.
+            Every read is initiated by a person: the clinician, or an anonymous visitor entering an NPI
+            on the preview plane.</p>
+          <p>We record what the source said, when we read it, and through which channel. That lineage
+            is visible on every surface that shows the data.</p>
+        </React.Fragment>
+      ) },
+      { id: 'what-we-store', h: 'What we store', body: (
+        <React.Fragment>
+          <p>For account holders: your snapshots, your Recognitions, your share links and their
+            revocations, and the audit trail of checks you ran. For anonymous previews: the check
+            result is cached briefly and is not tied to you.</p>
+          <div className="mono-note">NOT PHI · VitalCV stores no patient data, no clinical records,
+            no claims data. The record is about the clinician's credentials, never their patients.</div>
+        </React.Fragment>
+      ) },
+      { id: 'what-we-never-do', h: 'What we never do', body: (
+        <ul>
+          <li>We never sell your data, in any definition of "sell".</li>
+          <li>We never show an employer anything you didn't explicitly share.</li>
+          <li>We never alter what a source said — contradictions are shown, not resolved silently.</li>
+          <li>We never use your record to train models or build advertising profiles.</li>
+        </ul>
+      ) },
+      { id: 'sharing', h: 'Sharing and revocation', body: (
+        <p>A share link exposes exactly the snapshot you chose, to whoever holds the link, until you
+          revoke it. Revocation is immediate and logged. Employers see a revoked page that says the
+          holder revoked access — nothing softer, nothing vaguer.</p>
+      ) },
+      { id: 'retention', h: 'Retention', body: (
+        <p>Snapshots are kept while your account exists. Delete your account and snapshots are purged
+          within 30 days; the fact that a Recognition once occurred remains in the counterparty's
+          records, as it does in any exchange of documents. Anonymous preview caches expire within
+          24 hours.</p>
+      ) },
+      { id: 'your-rights', h: 'Your rights', body: (
+        <p>Export everything, correct what's wrong at the source (we link you to the source's own
+          correction process — we can't edit their records), delete your account, or object to a
+          read. Write to <a href="#/contact">privacy@vitalcv.com</a> — a person answers within two
+          business days.</p>
+      ) },
+    ],
+  },
+  terms: {
+    title: 'Terms of service',
+    updated: '2026-07-01', version: 'v1.1',
+    sections: [
+      { id: 'the-service', h: 'The service', body: (
+        <p>VitalCV compiles source-backed evidence about clinician credentials into a passport the
+          clinician owns and shares. Free for clinicians. Employers use it to start — not finish —
+          their own review.</p>
+      ) },
+      { id: 'decision-boundary', h: 'The decision boundary', body: (
+        <React.Fragment>
+          <p>VitalCV output is a head start for employer review, not a credentialing decision.
+            It is not primary-source verification under NCQA or Joint Commission standards unless a
+            surface explicitly says so, and no surface currently does.</p>
+          <div className="mono-note">HARD RULE · Anything marked "Not decision-grade" or
+            "Self-attested" must not be the basis of an employment or privileging decision.</div>
+        </React.Fragment>
+      ) },
+      { id: 'acceptable-use', h: 'Acceptable use', body: (
+        <ul>
+          <li>Don't probe NPIs at scale — the preview plane is rate-limited and monitored.</li>
+          <li>Don't re-publish share pages or represent a snapshot as newer than its timestamp.</li>
+          <li>Don't attempt to use VitalCV data for patient-facing or marketing purposes.</li>
+        </ul>
+      ) },
+      { id: 'availability', h: 'Availability', body: (
+        <p>Sources go down; when they do, we say so on the surface and on <a href="../wave1504/index.html#/status">/status</a>.
+          We target high availability but sell no SLA outside a signed pilot or enterprise agreement.</p>
+      ) },
+      { id: 'liability', h: 'Liability', body: (
+        <p>We stand behind the lineage: what we show is what the source said at the recorded time,
+          through the recorded channel. We are not liable for source errors themselves, for decisions
+          made against the stated boundary, or for indirect damages. Statutory rights remain.</p>
+      ) },
+      { id: 'changes', h: 'Changes', body: (
+        <p>Material changes are announced by email and on this page 30 days before they take effect.
+          The version stamp above changes every time this document does.</p>
+      ) },
+    ],
+  },
+  dpa: {
+    title: 'Data processing addendum',
+    updated: '2026-07-01', version: 'v1.0',
+    sections: [
+      { id: 'roles', h: 'Roles', body: (
+        <p>For employer pilot data (reviewer accounts, packet decisions), the employer is the
+          controller and VitalCV the processor. For clinician passports, VitalCV is the controller —
+          clinicians deal with us directly under the <a href="#/legal/privacy">privacy notice</a>.</p>
+      ) },
+      { id: 'scope', h: 'Scope of processing', body: (
+        <p>Processing is limited to compiling, storing, and presenting credential evidence and its
+          lineage. No PHI is processed under this addendum, and no BAA is offered because none is
+          needed: the record is about clinicians, not patients.</p>
+      ) },
+      { id: 'subprocessors', h: 'Subprocessors', body: (
+        <React.Fragment>
+          <p>Current subprocessors, each under a written agreement mirroring these terms:</p>
+          <table className="lg-table">
+            <thead><tr><th scope="col">Provider</th><th scope="col">Purpose</th><th scope="col">Region</th></tr></thead>
+            <tbody>
+              <tr><td className="mono">Railway</td><td>Application hosting</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Neon</td><td>Postgres database</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Clerk</td><td>Authentication</td><td className="mono">US</td></tr>
+              <tr><td className="mono">Resend</td><td>Transactional email</td><td className="mono">US</td></tr>
+            </tbody>
+          </table>
+          <p>Changes are announced 30 days in advance; controllers may object in writing.</p>
+        </React.Fragment>
+      ) },
+      { id: 'security', h: 'Security measures', body: (
+        <ul>
+          <li>Encryption in transit and at rest; keys rotated on the published schedule (see key history on the trust register).</li>
+          <li>Access on least-privilege; production access logged and reviewed.</li>
+          <li>Signed artifacts: institutional receipts are verifiable against published keys.</li>
+        </ul>
+      ) },
+      { id: 'incidents', h: 'Incidents', body: (
+        <p>Confirmed incidents affecting controller data are notified without undue delay and within
+          72 hours, with what we know, what we don't, and what happens next — the same fail-closed
+          honesty the product uses.</p>
+      ) },
+      { id: 'deletion', h: 'Return and deletion', body: (
+        <p>On termination, controller data is exported on request and deleted within 30 days, with
+          written confirmation. Audit lineage that references the controller (e.g. Recognitions
+          issued to clinicians) survives as the clinician's record.</p>
+      ) },
+    ],
+  },
+  cookies: {
+    title: 'Cookie notice',
+    updated: '2026-07-01', version: 'v1.0',
+    sections: [
+      { id: 'stance', h: 'Our stance', body: (
+        <p>No advertising cookies, no cross-site tracking, no analytics that require a banner.
+          The short table below is the complete list — if it grows, this page changes first.</p>
+      ) },
+      { id: 'the-list', h: 'The complete list', body: (
+        <table className="lg-table">
+          <thead><tr><th scope="col">Cookie</th><th scope="col">Purpose</th><th scope="col">Lifetime</th></tr></thead>
+          <tbody>
+            <tr><td className="mono">__session</td><td>Clerk authentication — keeps you signed in.</td><td className="mono">7 days</td></tr>
+            <tr><td className="mono">__client_uat</td><td>Clerk session freshness check.</td><td className="mono">session</td></tr>
+            <tr><td className="mono">vcv_prefs</td><td>Interface preferences (e.g. dismissed banners).</td><td className="mono">6 months</td></tr>
+          </tbody>
+        </table>
+      ) },
+      { id: 'no-banner', h: 'Why there is no cookie banner', body: (
+        <p>Everything above is strictly necessary for a service you asked for, which is why you
+          don't see a consent banner. If we ever add a category that requires consent, the banner
+          will be designed to house rules — and this notice updated 30 days before.</p>
+      ) },
+      { id: 'controls', h: 'Your controls', body: (
+        <p>Clear cookies in your browser at any time; you'll be signed out and preferences reset.
+          Nothing about your passport or snapshots lives in cookies.</p>
+      ) },
+    ],
+  },
+};
+
+const LEGAL_ORDER = [
+  { key: 'privacy', label: 'Privacy' },
+  { key: 'terms', label: 'Terms' },
+  { key: 'dpa', label: 'DPA' },
+  { key: 'cookies', label: 'Cookies' },
+];
+
+const LegalRoute = ({ doc }) => {
+  const d = LEGAL_DOCS[doc] || LEGAL_DOCS.privacy;
+  return (
+    <div className="s5-fade" data-screen-label={`Legal · ${d.title}`}>
+      <div className="s5-container" style={{ paddingTop: 'var(--space-10)', paddingBottom: 'var(--space-4)' }}>
+        <span className="vt-eyebrow">DG-12.3 · Legal</span>
+        <nav className="lg-tabs" aria-label="Legal documents" style={{ marginTop: 12 }}>
+          {LEGAL_ORDER.map((t) => (
+            <a key={t.key} className="lg-tab" href={`#/legal/${t.key}`}
+              aria-current={doc === t.key ? 'page' : undefined}>{t.label}</a>
+          ))}
+        </nav>
+        <div className="lg-layout">
+          <aside className="lg-toc" aria-label="On this page">
+            <span className="lg-toc-label">On this page</span>
+            {d.sections.map((s, i) => (
+              <a key={s.id} href={`#/legal/${doc}`} onClick={(e) => {
+                e.preventDefault();
+                const el = document.getElementById(s.id);
+                if (el) { const y = el.getBoundingClientRect().top + window.pageYOffset - 72; window.scrollTo(0, y); }
+              }}>
+                <span className="n vt-num">{String(i + 1).padStart(2, '0')}</span>{s.h}
+              </a>
+            ))}
+          </aside>
+          <article>
+            <header className="lg-head">
+              <h1>{d.title}</h1>
+              <span className="lg-stamp vt-num">
+                <span>Last updated {d.updated}</span>
+                <span>{d.version}</span>
+                <span>vitalcv.com/legal/{doc}</span>
+              </span>
+            </header>
+            <div className="lg-prose">
+              {d.sections.map((s, i) => (
+                <section key={s.id} id={s.id}>
+                  <h2><span className="n vt-num">{String(i + 1).padStart(2, '0')}</span><a className="anchor" href={`#/legal/${doc}`} onClick={(e) => e.preventDefault()}>{s.h}</a></h2>
+                  {s.body}
+                </section>
+              ))}
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Object.assign(window, { LegalRoute, LEGAL_DOCS, LEGAL_ORDER });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-pricing.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-pricing.jsx
@@ -1,0 +1,115 @@
+// Wave 1505 · w1505-pricing.jsx — /pricing per pricing doctrine
+// (DG-13.3). Paper/ink presentation; every illustrative number carries
+// the designed HonestyLabel; no fake logos, no "as seen in", no
+// invented customer counts, no ROI guarantees.
+
+const PIncRow = ({ inc, children }) => (
+  <div className={`pr-row ${inc ? 'inc' : 'exc'}`}>
+    <TrustGlyph state={inc ? 'checked' : 'unavailable'} size={13} />
+    <span>{children}</span>
+  </div>
+);
+
+const PricingRoute = () => (
+  <S5Page eyebrow="DG-13.3 · Pricing" title={<span>Plain terms, <span className="vt-accent-i">stated</span> — not teased.</span>}
+    lede="Three ways to use VitalCV. The only numbers on this page are labeled for exactly what they are."
+    label="Pricing">
+    <S5Section first>
+      <div className="pr-grid">
+        <div className="pr-card" data-comment-anchor="pricing-clinicians">
+          <span className="pr-aud">Clinicians</span>
+          <div className="pr-price">
+            <span className="amt vt-num">$0</span>
+            <span className="per">FREE · ALWAYS · NO CARD</span>
+          </div>
+          <p className="pr-desc">Your credentials are your record. Charging you to hold it would be a
+            conflict of interest we don't want.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Passport with source-backed checks and lineage</PIncRow>
+            <PIncRow inc>Share links with instant revocation</PIncRow>
+            <PIncRow inc>Recognitions from accepting employers</PIncRow>
+            <PIncRow inc>Refresh on stale sources, anytime</PIncRow>
+          </div>
+          <div className="pr-cta"><SecondaryButton size="lg" onClick={() => { window.location.href = '../wave1503/index.html#/get-ready'; }}>Check your readiness</SecondaryButton></div>
+        </div>
+
+        <div className="pr-card lead" data-comment-anchor="pricing-pilot">
+          <span className="pr-aud">Employer pilot</span>
+          <div className="pr-price">
+            <span className="amt vt-num">$1,500<span style={{ fontSize: 18, fontWeight: 480 }}>/mo</span></span>
+            <span className="per">PER FACILITY · 90-DAY PILOT</span>
+          </div>
+          <HonestyLabel>Illustrative figure — actual pilot pricing is set in the signed pilot scope, not on this page.</HonestyLabel>
+          <p className="pr-desc">A bounded pilot with written scope: which lanes, which sources, what
+            "accepted as head start" means on your side.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Reviewer surface for your credentialing team</PIncRow>
+            <PIncRow inc>Packet requests + Recognition issuing</PIncRow>
+            <PIncRow inc>Named contact, two-business-day answers</PIncRow>
+            <PIncRow>No primary-source verification service — your review stays yours</PIncRow>
+          </div>
+          <div className="pr-cta"><PrimaryButton size="lg" onClick={() => { window.location.hash = '#/contact'; }}>Start a pilot conversation</PrimaryButton></div>
+        </div>
+
+        <div className="pr-card" data-comment-anchor="pricing-network">
+          <span className="pr-aud">Networks &amp; systems</span>
+          <div className="pr-price">
+            <span className="amt">In the agreement</span>
+            <span className="per">MULTI-FACILITY · SIGNED SCOPE</span>
+          </div>
+          <p className="pr-desc">Priced per signed scope — facilities, lanes, integration depth. If we
+            can't state it plainly in the agreement, we don't sell it.</p>
+          <div className="pr-rows">
+            <PIncRow inc>Everything in the pilot, across facilities</PIncRow>
+            <PIncRow inc>DPA + subprocessor commitments (<a href="#/legal/dpa">read it first</a>)</PIncRow>
+            <PIncRow inc>Uptime terms in writing</PIncRow>
+            <PIncRow>No exclusivity — clinicians stay free either way</PIncRow>
+          </div>
+          <div className="pr-cta"><SecondaryButton size="lg" onClick={() => { window.location.hash = '#/contact'; }}>Talk to us</SecondaryButton></div>
+        </div>
+      </div>
+    </S5Section>
+
+    <S5Section eyebrow="Doctrine" title="What this page will never claim">
+      <div className="s5-twocol">
+        <div className="pr-never">
+          <span className="vt-eyebrow">Prohibited on /pricing — lint-enforced</span>
+          <ul>
+            <li><TrustGlyph state="p0" size={12} />No invented customer counts or "trusted by 500+ organizations".</li>
+            <li><TrustGlyph state="p0" size={12} />No "as seen in" strips, no logos we didn't earn in writing.</li>
+            <li><TrustGlyph state="p0" size={12} />No ROI guarantees, payback math, or "cheapest" claims.</li>
+            <li><TrustGlyph state="p0" size={12} />No unlabeled illustrative metrics — every example number carries the HonestyLabel.</li>
+            <li><TrustGlyph state="p0" size={12} />No countdown timers, seat scarcity, or launch-pricing pressure.</li>
+          </ul>
+        </div>
+        <div className="pr-faq">
+          <h3 style={{ fontSize: 16, marginBottom: 6 }}>Asked plainly, answered plainly</h3>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Why is the pilot number "illustrative"?</summary>
+            <p>Because real pilot pricing depends on facilities and lanes, and pretending otherwise
+              would make the page dishonest. The number shows the shape of the cost; the signed scope
+              carries the real one.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Will clinicians ever be charged?</summary>
+            <p>No. If that ever changed it would be announced 90 days ahead, and existing passports
+              would stay free. The business is employer-side, on purpose.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>Is there a discount for annual commitment?</summary>
+            <p>Sometimes, in the agreement, where it can be stated exactly. We don't advertise
+              percentages we'd have to caveat.</p>
+          </details>
+          <details>
+            <summary><span className="m" aria-hidden="true"></span>What happens when the pilot ends?</summary>
+            <p>It ends. Data is exported or deleted per the DPA, Recognitions already issued remain
+              with the clinicians who earned them, and renewal is a new signed scope — never an
+              auto-rollover.</p>
+          </details>
+        </div>
+      </div>
+    </S5Section>
+  </S5Page>
+);
+
+Object.assign(window, { PricingRoute });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-shared.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-shared.jsx
@@ -1,0 +1,227 @@
+// Wave 1505 · w1505-shared.jsx — router, nav, footer, prototype bar,
+// FeedbackWidget (DG-12.5), OfflineBanner (DG-12.2.3), EmptyState,
+// SkeletonStack. Consumes wave1500 tokens/primitives + prior-wave kit only.
+
+/* ---------- hash router ---------- */
+const parseRoute5 = (h) => {
+  const hash = h || window.location.hash || '#/';
+  const seg = hash.replace(/^#\/?/, '').split('?')[0].split('/').filter(Boolean);
+  if (!seg.length) return { name: 'index' };
+  if (seg[0] === 'auth') {
+    const sub = seg[1] || 'overview';
+    if (['sign-in', 'sign-up', 'verify', 'loading', 'overview'].includes(sub)) return { name: 'auth', sub };
+    return { name: '404', requested: hash };
+  }
+  if (seg[0] === '404') return { name: '404', requested: '/passport/old-share-link' };
+  if (seg[0] === 'error') return { name: 'error' };
+  if (seg[0] === 'system') return { name: 'system' };
+  if (seg[0] === 'legal') {
+    const doc = seg[1] || 'privacy';
+    if (['privacy', 'terms', 'dpa', 'cookies'].includes(doc)) return { name: 'legal', doc };
+    return { name: '404', requested: hash };
+  }
+  if (seg[0] === 'contact') return { name: 'contact' };
+  if (seg[0] === 'pricing') return { name: 'pricing' };
+  if (seg[0] === 'audit') return { name: 'audit' };
+  if (seg[0] === 'dev') return { name: 'devdesign' };
+  if (seg[0] === 'governance') return { name: 'governance' };
+  return { name: '404', requested: hash };
+};
+const useRoute5 = () => {
+  const [route, setRoute] = React.useState(() => parseRoute5());
+  React.useEffect(() => {
+    const fn = () => { setRoute(parseRoute5()); window.scrollTo(0, 0); };
+    window.addEventListener('hashchange', fn);
+    return () => window.removeEventListener('hashchange', fn);
+  }, []);
+  return route;
+};
+
+/* ---------- nav ---------- */
+const S5_ROUTES = [
+  { hash: '#/', label: 'Index', match: 'index' },
+  { hash: '#/auth', label: 'Auth', match: 'auth' },
+  { hash: '#/system', label: 'System states', match: 'system' },
+  { hash: '#/legal/privacy', label: 'Legal', match: 'legal' },
+  { hash: '#/contact', label: 'Contact', match: 'contact' },
+  { hash: '#/pricing', label: 'Pricing', match: 'pricing' },
+  { hash: '#/audit', label: 'Audit', match: 'audit' },
+  { hash: '#/dev/design', label: '/dev/design', match: 'devdesign' },
+  { hash: '#/governance', label: 'Governance', match: 'governance' },
+];
+const S5Nav = ({ route }) => (
+  <header className="s5-nav">
+    <div className="s5-container s5-nav-inner">
+      <a className="s5-brand-link" href="../wave1501/index.html" aria-label="VitalCV home">
+        <VtLogo size={18} />
+      </a>
+      <span className="vt-eyebrow" style={{ whiteSpace: 'nowrap' }}>Wave 1505 · system &amp; governance</span>
+      <nav className="s5-tabs" aria-label="Wave 1505 surfaces">
+        {S5_ROUTES.map((r) => (
+          <a key={r.hash} className="s5-tab" href={r.hash}
+            aria-current={route.name === r.match ? 'page' : undefined}>{r.label}</a>
+        ))}
+      </nav>
+    </div>
+  </header>
+);
+
+/* ---------- footer ---------- */
+const S5Footer = () => (
+  <footer className="s5-foot">
+    <div className="s5-container">
+      <p className="s5-boundary">
+        <TrustGlyph state="notDecisionGrade" size={16} />
+        <span>Every state designed — <span className="vt-accent-i">especially</span> the ones nobody sees twice.</span>
+      </p>
+      <ul className="s5-foot-links">
+        <li><a href="#/legal/privacy">Privacy</a></li>
+        <li><a href="#/legal/terms">Terms</a></li>
+        <li><a href="#/legal/dpa">DPA</a></li>
+        <li><a href="#/legal/cookies">Cookies</a></li>
+        <li><a href="#/contact">Contact</a></li>
+        <li><a href="../wave1504/index.html#/status">Status</a></li>
+        <li><a href="#/dev/design">/dev/design</a></li>
+      </ul>
+      <p className="s5-foot-base">© 2026 VitalCV · did:web:vitalcv.com · Doctrine v1.0 · A partial proof stays partial.</p>
+    </div>
+  </footer>
+);
+
+/* ---------- prototype bar (chrome-less full-page states) ---------- */
+const ProtoBar = ({ viewing }) => (
+  <nav className="s5-proto no-print" aria-label="Prototype navigation">
+    <a href="#/">← Wave 1505 index</a>
+    {viewing ? <a href={viewing.href} aria-current="page">{viewing.label}</a> : null}
+  </nav>
+);
+
+/* ---------- page scaffold ---------- */
+const S5Page = ({ eyebrow, title, lede, children, label }) => (
+  <div className="s5-fade" data-screen-label={label || title}>
+    <div className="s5-container s5-doctrine">
+      {eyebrow ? <span className="vt-eyebrow">{eyebrow}</span> : null}
+      <h1>{title}</h1>
+      {lede ? <p className="lede">{lede}</p> : null}
+    </div>
+    {children}
+  </div>
+);
+const S5Section = ({ eyebrow, title, lede, first, children, id }) => (
+  <section id={id} className={`s5-section${first ? ' first' : ''}`}>
+    <div className="s5-container">
+      {(eyebrow || title || lede) ? (
+        <div className="s5-sechead">
+          {eyebrow ? <span className="vt-eyebrow">{eyebrow}</span> : null}
+          {title ? <h2>{title}</h2> : null}
+          {lede ? <p className="lede">{lede}</p> : null}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  </section>
+);
+
+/* ---------- OfflineBanner (DG-12.2.3) ----------
+   Dashed rule = degraded semantics (never opacity). role="status",
+   polite announcement. `inline` renders the pattern inside flow for
+   the gallery; default is sticky under the nav at --vt-z-banner. */
+const OfflineBanner = ({ inline, onRetry }) => (
+  <div className={`off-banner${inline ? ' inline' : ''}`} role="status" aria-live="polite">
+    <div className={inline ? 'off-inner' : 's5-container off-inner'}>
+      <span className="off-glyph"><TrustGlyph state="unavailable" size={14} /></span>
+      <span className="off-label">Connection lost</span>
+      <span className="off-copy">Showing the last checked data — freshness stamps stay honest.</span>
+      <span className="off-act"><QuietButton small onClick={onRetry}>Retry now</QuietButton></span>
+    </div>
+  </div>
+);
+
+/* ---------- EmptyState (DG-12.2.4) ----------
+   Honest and calm: glyph in a plain frame (solid rule — dashed is
+   reserved for degraded), one Fraunces line, one reason, ONE action. */
+const EmptyState = ({ glyph = 'pending', title, why, action, onAction, secondary }) => (
+  <div className="empty-card" role="status">
+    <span className="empty-glyph"><TrustGlyph state={glyph} size={20} /></span>
+    <h3>{title}</h3>
+    <p className="why">{why}</p>
+    {action ? (
+      <span className="act">
+        {secondary
+          ? <SecondaryButton onClick={onAction}>{action}</SecondaryButton>
+          : <PrimaryButton onClick={onAction}>{action}</PrimaryButton>}
+      </span>
+    ) : null}
+  </div>
+);
+
+/* ---------- SkeletonStack — loading placeholder (allowed shimmer) ---------- */
+const SkeletonStack = ({ lines = ['w80', 'w60', 'w40'] }) => (
+  <div className="sk-stack" role="status" aria-label="Loading">
+    {lines.map((w, i) => <span key={i} className={`sk-line ${w}`}></span>)}
+  </div>
+);
+
+/* ---------- FeedbackWidget (DG-12.5) ----------
+   Right-edge vertical tab at mid-height: never overlaps bottom CTAs at
+   360px by construction. z from the token scale. Non-modal panel,
+   Escape closes, focus returns to the tab. */
+const FeedbackWidget = () => {
+  const [open, setOpen] = React.useState(false);
+  const [sent, setSent] = React.useState(false);
+  const [msg, setMsg] = React.useState('');
+  const tabRef = React.useRef(null);
+  const areaRef = React.useRef(null);
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') { setOpen(false); if (tabRef.current) tabRef.current.focus(); } };
+    document.addEventListener('keydown', onKey);
+    if (areaRef.current) areaRef.current.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open]);
+  const close = () => { setOpen(false); setSent(false); setMsg(''); if (tabRef.current) tabRef.current.focus(); };
+  return (
+    <React.Fragment>
+      {!open ? (
+        <button ref={tabRef} type="button" className="fb-tab no-print"
+          aria-haspopup="dialog" aria-expanded={open} onClick={() => setOpen(true)}>
+          Feedback
+        </button>
+      ) : null}
+      {open ? (
+        <div className="fb-panel no-print" role="dialog" aria-label="Send feedback">
+          {!sent ? (
+            <React.Fragment>
+              <div className="fb-head">
+                <h2>Feedback</h2>
+                <button type="button" className="fb-close" onClick={close}>Close</button>
+              </div>
+              <p className="fb-note">Read by the design team. Not for support, account issues, or anything patient-related.</p>
+              <div className="fk-field">
+                <label className="fk-label" htmlFor="fb-msg">What should we know?</label>
+                <textarea ref={areaRef} id="fb-msg" rows={4} className="fk-input"
+                  value={msg} onChange={(e) => setMsg(e.target.value)}
+                  placeholder="Something unclear, broken, or dishonest — tell us where." />
+              </div>
+              <PrimaryButton disabled={!msg.trim()} onClick={() => setSent(true)}>Send feedback</PrimaryButton>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <div className="fb-head">
+                <h2>Recorded</h2>
+                <button type="button" className="fb-close" onClick={close}>Close</button>
+              </div>
+              <StateChip state="checked" label="Received" />
+              <p className="fb-note vt-num">fb_2026-07-12_c3a1 · Goes to the next design review. No reply is sent unless you asked a question.</p>
+            </React.Fragment>
+          )}
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+Object.assign(window, {
+  parseRoute5, useRoute5, S5_ROUTES, S5Nav, S5Footer, ProtoBar, S5Page, S5Section,
+  OfflineBanner, EmptyState, SkeletonStack, FeedbackWidget,
+});

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx
@@ -1,0 +1,172 @@
+// Wave 1505 · w1505-system.jsx — 404, error, offline pattern, empty-state
+// gallery (DG-12.2). Fail-closed honesty: error states never claim success;
+// empty states never fake data.
+
+/* ---------- 404 (full page) ---------- */
+const Sys404 = ({ requested }) => (
+  <div className="sys-page s5-fade" data-screen-label="System · 404">
+    <div className="sys-top"><VtLogo size={18} /></div>
+    <main className="sys-mid">
+      <div className="sys-block">
+        <div className="sys-echo vt-num" aria-label="Request echo">
+          GET {requested || '/passport/old-share-link'}<br />
+          <span className="code">→ 404 · NOT FOUND</span> · nothing at this address
+        </div>
+        <h1>This page isn't part of the record.</h1>
+        <p className="body">The address may have changed, or it never existed. Nothing was deleted
+          silently — if a share link stopped working, its holder revoked it, and that revocation is logged.</p>
+        <div className="sys-ctas">
+          <PrimaryButton size="lg" onClick={() => { window.location.href = '../wave1501/index.html'; }}>Back to vitalcv.com</PrimaryButton>
+          <QuietButton onClick={() => { window.location.href = '../wave1504/index.html#/status'; }}>Check system status</QuietButton>
+        </div>
+      </div>
+    </main>
+    <p className="sys-foot">© 2026 VitalCV · a partial proof stays partial</p>
+    <ProtoBar viewing={{ href: '#/404', label: '/404' }} />
+  </div>
+);
+
+/* ---------- error / global-error (full page) ---------- */
+const SysError = () => (
+  <div className="sys-page s5-fade" data-screen-label="System · error">
+    <div className="sys-top"><VtLogo size={18} /></div>
+    <main className="sys-mid">
+      <div className="sys-block" role="alert">
+        <div className="sys-echo vt-num" aria-label="Failure reference">
+          run_2026-07-12_0812Z · <span className="code">FAILED</span> · err_a41f<br />
+          reference logged — include it if you write in
+        </div>
+        <h1>Something failed on our side.</h1>
+        <p className="body">Nothing was recorded as successful. If you were mid-request, it did not
+          complete — no partial result was saved, and no source was marked checked. Retry when ready.</p>
+        <div className="sys-ctas">
+          <PrimaryButton size="lg" onClick={() => window.location.reload()}>Try again</PrimaryButton>
+          <QuietButton onClick={() => { window.location.hash = '#/contact'; }}>Write to us</QuietButton>
+        </div>
+      </div>
+    </main>
+    <p className="sys-foot">© 2026 VitalCV · errors are stated, never dressed up</p>
+    <ProtoBar viewing={{ href: '#/error', label: '/error' }} />
+  </div>
+);
+
+/* ---------- empty-state gallery data (DG-12.2.4) ---------- */
+const EMPTIES = [
+  {
+    ctx: 'Passport · /passport', glyph: 'pending',
+    title: 'No sources checked yet.',
+    why: 'Your passport starts empty on purpose — it only ever shows what a source actually said.',
+    action: 'Enter an NPI to run the first check',
+  },
+  {
+    ctx: 'Reviewer queue · /review', glyph: 'reviewRequired',
+    title: 'Nothing waiting for review.',
+    why: 'Every submitted packet has been decided. New requests appear here the moment they arrive.',
+    action: 'View decided packets', secondary: true,
+  },
+  {
+    ctx: 'Recognitions · /passport#recognitions', glyph: 'checked',
+    title: 'No Recognitions yet.',
+    why: 'A Recognition is recorded when an employer accepts your packet as a head start. Sharing your passport is how they happen.',
+    action: 'Share your passport',
+  },
+  {
+    ctx: 'Opportunities · /opportunities', glyph: 'previewOnly',
+    title: 'No matched opportunities right now.',
+    why: 'Matches come from employer lanes that fit your license states and specialty — none fit today. We don’t pad this list.',
+    action: 'Review your lane preferences', secondary: true,
+  },
+];
+
+/* ---------- system overview route ---------- */
+const SystemRoute = () => {
+  const [offline, setOffline] = React.useState(false);
+  return (
+    <React.Fragment>
+      {offline ? <OfflineBanner onRetry={() => setOffline(false)} /> : null}
+      <S5Page eyebrow="DG-12.2 · Error & system states" title={<span>Where trust <span className="vt-accent-i">quietly</span> lives or dies.</span>}
+        lede="A default-styled 404 breaks the spell faster than any bug. Every terminal, degraded, and empty state is designed, honest, and calm — with exactly one next action."
+        label="System states">
+        <S5Section first eyebrow="Terminal states" title="404 · error · loading"
+          lede="Full-page states, opened chrome-less as a visitor would meet them.">
+          <div className="hub-grid">
+            <div className="hub-card">
+              <span className="hid">SYS-404</span>
+              <h3>Not found</h3>
+              <p>Wordmark, mono echo of the requested path, Fraunces headline, one CTA home. Unknown routes in this prototype land here for real.</p>
+              <div className="hub-links"><a href="#/404">Open full page</a><a href="#/definitely/not/a/route">Trigger via bad route</a></div>
+            </div>
+            <div className="hub-card">
+              <span className="hid">SYS-ERR</span>
+              <h3>Something failed</h3>
+              <p>Fail-closed honesty: "Nothing was recorded as successful." A logged reference, a retry, and a path to a person. Never a mascot.</p>
+              <div className="hub-links"><a href="#/error">Open full page</a></div>
+            </div>
+            <div className="hub-card">
+              <span className="hid">SYS-LOAD</span>
+              <h3>Loading interstitial</h3>
+              <p>Wordmark + hairline sweep + one mono line. The skeleton grammar below covers in-page loading; this covers whole-surface waits.</p>
+              <div className="hub-links"><a href="#/auth/loading">Open full page</a></div>
+            </div>
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="Degraded pattern" title="Offline / degraded banner"
+          lede="For data surfaces: sticks under the nav at --vt-z-banner, dashed rules carry the degraded semantics, freshness stamps keep telling the truth underneath. role=status, announced politely.">
+          <OfflineBanner inline onRetry={() => {}} />
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginTop: 20, flexWrap: 'wrap' }}>
+            <SecondaryButton onClick={() => setOffline(!offline)} aria-pressed={offline}>
+              {offline ? 'Unpin demo banner' : 'Pin banner under nav (demo)'}
+            </SecondaryButton>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--vt-text-muted)', letterSpacing: '0.05em' }}>
+              RULE · never a toast; never auto-dismiss; retry is manual
+            </span>
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="DG-12.2.4" title="Empty-state gallery"
+          lede="Honest and calm. Each names the surface, says why it's empty without apology or fake data, and offers ONE next action. Solid rule frames — dashed is reserved for degraded.">
+          <div className="empty-grid">
+            {EMPTIES.map((e) => (
+              <div key={e.ctx}>
+                <span className="empty-ctx">{e.ctx}</span>
+                <EmptyState glyph={e.glyph} title={e.title} why={e.why} action={e.action} secondary={e.secondary} />
+              </div>
+            ))}
+          </div>
+        </S5Section>
+
+        <S5Section eyebrow="Loading grammar" title="The empty · loading · error triad"
+          lede="Every data region ships all three, in the same footprint, so the page never jumps or flashes unstyled.">
+          <div className="hub-grid">
+            <div className="hub-card">
+              <span className="hid">Loading</span>
+              <div style={{ padding: '10px 0' }}><SkeletonStack /></div>
+              <p>Skeleton shimmer — the one allowed infinite animation, static under reduced motion. Skeletons mirror the real layout, never invent rows.</p>
+            </div>
+            <div className="hub-card">
+              <span className="hid">Empty</span>
+              <div style={{ padding: '10px 0' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-text-muted)' }}>
+                  <TrustGlyph state="pending" size={13} /> No sources checked yet.
+                </span>
+              </div>
+              <p>Inline form for tight regions; the full EmptyState card for primary regions. Same copy voice either way.</p>
+            </div>
+            <div className="hub-card">
+              <span className="hid">Error</span>
+              <div style={{ padding: '10px 0' }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--vt-state-p0)' }}>
+                  <TrustGlyph state="p0" size={13} /> Couldn't load. Nothing recorded. <QuietButton small>Retry</QuietButton>
+                </span>
+              </div>
+              <p>Region-level failure keeps the rest of the page alive. Copy never says "oops" and never claims partial success.</p>
+            </div>
+          </div>
+        </S5Section>
+      </S5Page>
+    </React.Fragment>
+  );
+};
+
+Object.assign(window, { Sys404, SysError, SystemRoute, EMPTIES });

--- a/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505.css
+++ b/design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505.css
@@ -1,0 +1,443 @@
+/* ============================================================
+   VitalCV · Wave 1505 · System pages, quality gates & governance
+   Consumes wave1500 tokens ONLY. New tokens below are the
+   Z-INDEX SCALE (structural, documented in CHANGES.md) — zero
+   new colors, zero new fonts, zero new radii.
+   ============================================================ */
+
+:root {
+  /* ---- z-index scale (DG-12.5 — canonical, promoted) ---- */
+  --vt-z-base: 0;
+  --vt-z-raised: 10;      /* lifted cards, dropdowns inside flow */
+  --vt-z-nav: 40;         /* sticky site nav */
+  --vt-z-banner: 45;      /* offline / degraded banner */
+  --vt-z-widget: 50;      /* feedback affordance */
+  --vt-z-overlay: 60;     /* panels above widgets */
+  --vt-z-skip: 100;       /* skip-link — above everything */
+}
+
+/* ================= skip link (DG-15.2) ================= */
+.skip-link { position: fixed; left: -9999px; top: 10px; z-index: var(--vt-z-skip);
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+  background: var(--vt-surface-card); color: var(--vt-text); border: 1px solid var(--vt-rule-strong);
+  border-radius: var(--radius-1); padding: 10px 16px; text-decoration: none; }
+.skip-link:focus-visible { left: 12px; }
+
+/* ================= shell ================= */
+.s5-container { max-width: var(--container-max); margin: 0 auto; padding: 0 var(--space-6); }
+@media (max-width: 560px) { .s5-container { padding: 0 var(--space-4); } }
+
+.s5-nav { position: sticky; top: 0; z-index: var(--vt-z-nav); background: var(--vt-surface-page); border-bottom: 1px solid var(--vt-rule); }
+.s5-nav-inner { display: flex; align-items: center; gap: var(--space-5); padding: 10px 0; flex-wrap: wrap; }
+.s5-brand-link { text-decoration: none; display: inline-flex; }
+.s5-brand-link:hover { text-decoration: none; }
+.s5-tabs { display: flex; gap: 2px; margin-left: auto; flex-wrap: wrap; }
+.s5-tab { font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.08em;
+  text-transform: uppercase; text-decoration: none; color: var(--vt-text-secondary); white-space: nowrap;
+  padding: 6px 10px; border: 1px solid transparent; border-radius: var(--radius-1); }
+.s5-tab:hover { color: var(--vt-text); text-decoration: none; border-color: var(--vt-rule); }
+.s5-tab[aria-current="page"] { color: var(--vt-text); border-color: var(--vt-rule-strong); background: var(--vt-surface-card); }
+
+.s5-main { min-height: 62vh; }
+@media (prefers-reduced-motion: no-preference) {
+  .s5-fade { animation: s5-fade var(--dur-fast) var(--ease-house) both; }
+  @keyframes s5-fade { from { opacity: 0; } to { opacity: 1; } }
+}
+
+.s5-section { padding: var(--space-12) 0; border-top: 1px solid var(--vt-rule); }
+.s5-section.first { border-top: none; padding-top: var(--space-10); }
+.s5-sechead { display: flex; flex-direction: column; gap: 8px; margin-bottom: var(--space-8); max-width: 76ch; }
+.s5-sechead h2 { font-size: var(--text-xl); }
+.s5-sechead .lede { margin: 0; font-size: var(--text-base); color: var(--vt-text-secondary); max-width: 64ch; }
+
+.s5-doctrine { padding-top: var(--space-12); padding-bottom: var(--space-10); }
+.s5-doctrine h1 { font-size: var(--text-2xl); margin-top: 10px; max-width: 26ch; }
+.s5-doctrine .lede { margin: 14px 0 0; color: var(--vt-text-secondary); max-width: 64ch; }
+
+.s5-foot { border-top: 1px solid var(--vt-rule); margin-top: var(--space-16); padding: var(--space-10) 0; }
+.s5-boundary { display: flex; align-items: baseline; gap: 12px; margin: 0 0 14px; font-family: var(--font-display);
+  font-size: var(--text-lg); font-weight: 560; letter-spacing: -0.01em; color: var(--vt-text); max-width: 44ch; line-height: 1.35; }
+.s5-boundary svg { flex-shrink: 0; transform: translateY(2px); }
+.s5-foot-links { display: flex; flex-wrap: wrap; gap: 4px 20px; margin: 0 0 16px; padding: 0; list-style: none; }
+.s5-foot-links a { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text-secondary); text-decoration: none; border-bottom: 1px solid var(--vt-rule); padding-bottom: 2px; white-space: nowrap; }
+.s5-foot-links a:hover { color: var(--vt-text); border-bottom-color: var(--vt-rule-strong); }
+.s5-foot-base { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* prototype bar for chrome-less full-page states */
+.s5-proto { position: fixed; right: 12px; bottom: 12px; z-index: var(--vt-z-widget); display: flex; gap: 6px; align-items: center; }
+.s5-proto a { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;
+  color: var(--vt-text-secondary); background: var(--vt-surface-card); border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-1); padding: 6px 10px; text-decoration: none; }
+.s5-proto a:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+
+/* ================= hub / index ================= */
+.hub-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); }
+@media (max-width: 980px) { .hub-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 620px) { .hub-grid { grid-template-columns: minmax(0, 1fr); } }
+.hub-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-5); display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+.hub-card .hid { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em; color: var(--vt-text-faint); text-transform: uppercase; }
+.hub-card h3 { font-size: var(--text-md); font-family: var(--font-display); font-weight: 560; }
+.hub-card p { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); flex: 1; }
+.hub-links { display: flex; flex-wrap: wrap; gap: 4px 14px; border-top: 1px solid var(--vt-rule-soft); padding-top: 10px; }
+.hub-links a { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text); text-decoration: none; border-bottom: 1px solid var(--vt-rule); padding-bottom: 1px; }
+.hub-links a:hover { border-bottom-color: var(--vt-rule-strong); }
+.hub-accept { display: flex; flex-direction: column; gap: 0; }
+.hub-accept-row { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 12px; align-items: start;
+  padding: 12px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.hub-accept-row:last-child { border-bottom: none; }
+.hub-accept-row p { margin: 2px 0 0; font-size: 13px; line-height: 1.55; color: var(--vt-text); }
+.hub-accept-row .where { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; color: var(--vt-text-muted); }
+
+/* ================= AUTH (Clerk themed — DG-12.1) ================= */
+.auth-page { min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+  padding: var(--space-10) var(--space-4) var(--space-16); box-sizing: border-box; }
+.auth-brand { margin-bottom: var(--space-10); }
+.ck-card { width: 100%; max-width: 400px; background: var(--vt-surface-card); border: 1px solid var(--vt-rule);
+  border-radius: var(--radius-2); padding: var(--space-8); box-sizing: border-box;
+  display: flex; flex-direction: column; gap: var(--space-5); }
+.ck-head { display: flex; flex-direction: column; gap: 6px; }
+.ck-head h1 { font-size: var(--text-xl); }
+.ck-head .sub { margin: 0; font-size: 13px; line-height: 1.55; color: var(--vt-text-secondary); }
+.ck-social { display: flex; flex-direction: column; gap: 8px; }
+.ck-social-btn { display: flex; align-items: center; justify-content: center; gap: 10px; height: 46px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--vt-text); background: transparent; border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  cursor: pointer; transition: background var(--dur-fast) var(--ease-house); }
+.ck-social-btn:hover { background: var(--vt-surface-page); }
+.ck-social-btn svg { flex-shrink: 0; }
+.ck-div { display: flex; align-items: center; gap: 12px; }
+.ck-div::before, .ck-div::after { content: ""; flex: 1; height: 1px; background: var(--vt-rule); }
+.ck-div span { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.2em; color: var(--vt-text-muted); }
+.ck-form { display: flex; flex-direction: column; gap: var(--space-4); }
+.ck-name-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+@media (max-width: 400px) { .ck-name-grid { grid-template-columns: 1fr; } }
+.ck-primary { width: 100%; height: 46px; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--font-body); font-size: 13.5px; font-weight: 500; color: var(--vt-text-inverse);
+  background: var(--ink-900); border: 1px solid transparent; border-radius: var(--radius-1); cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-house); }
+.ck-primary:hover { background: var(--vt-brand-strong); }
+.ck-primary:disabled { background: var(--vt-rule); color: var(--vt-text-muted); cursor: not-allowed; }
+.ck-foot { display: flex; flex-direction: column; gap: 12px; border-top: 1px solid var(--vt-rule-soft); padding-top: var(--space-4); }
+.ck-foot-line { font-size: 12.5px; color: var(--vt-text-secondary); }
+.ck-foot-line a { font-weight: 500; }
+.ck-badge { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono);
+  font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--vt-text-muted); }
+.auth-under { margin-top: var(--space-5); max-width: 400px; width: 100%; box-sizing: border-box; }
+.auth-under p { margin: 0; font-family: var(--font-mono); font-size: 10px; line-height: 1.7; letter-spacing: 0.04em;
+  color: var(--vt-text-muted); text-align: center; }
+
+/* code cells (verification) */
+.code-cells { display: flex; gap: 8px; justify-content: flex-start; }
+.code-cell { width: 46px; height: 54px; display: grid; place-items: center; background: var(--vt-surface-page);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1);
+  font-family: var(--font-mono); font-size: 20px; color: var(--vt-text); }
+.code-cell.focus { box-shadow: var(--vt-focus-ring); }
+.code-cell.empty { border-style: dashed; border-color: var(--vt-degraded-border); color: var(--vt-text-muted); }
+@media (max-width: 400px) { .code-cell { width: 40px; height: 48px; font-size: 17px; } .code-cells { gap: 6px; } }
+.code-hidden { position: absolute; opacity: 0; pointer-events: none; }
+.code-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.code-meta .cnt { font-family: var(--font-mono); font-size: 11px; color: var(--vt-text-muted); }
+.code-meta .cnt.done { color: var(--vt-state-checked); }
+
+/* auth loading interstitial */
+.authload { min-height: 100vh; display: grid; place-items: center; padding: var(--space-6); box-sizing: border-box; }
+.authload-box { display: flex; flex-direction: column; align-items: center; gap: var(--space-6); text-align: center; }
+.authload-line { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--vt-text-secondary); }
+.authload-note { margin: 0; font-size: 12.5px; color: var(--vt-text-muted); max-width: 34ch; }
+.authload-track { width: 220px; height: 2px; background: var(--vt-rule-soft); position: relative; overflow: hidden; }
+.authload-track::after { content: ""; position: absolute; inset: 0; width: 40%; background: var(--ink-900); }
+@media (prefers-reduced-motion: no-preference) {
+  .authload-track::after { animation: al-sweep 1.4s var(--ease-house) infinite; }
+  @keyframes al-sweep { from { transform: translateX(-110%); } to { transform: translateX(560px); } }
+}
+
+/* ================= SYSTEM STATES (DG-12.2) ================= */
+.sys-page { min-height: 100vh; display: flex; flex-direction: column; box-sizing: border-box;
+  padding: var(--space-8) var(--space-6) 72px; }
+.sys-top { display: flex; }
+.sys-mid { flex: 1; display: grid; place-items: center; padding: var(--space-12) 0; }
+.sys-block { max-width: 560px; display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-5); }
+.sys-echo { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.05em; line-height: 1.8;
+  color: var(--vt-text-secondary); border: 1px solid var(--vt-rule); background: var(--vt-surface-card);
+  border-radius: var(--radius-1); padding: 10px 14px; overflow-wrap: anywhere; align-self: stretch; }
+.sys-echo .code { color: var(--vt-state-p0); font-weight: 600; }
+.sys-block h1 { font-size: var(--text-3xl); line-height: 1.08; max-width: 15ch; }
+@media (max-width: 560px) { .sys-block h1 { font-size: var(--text-2xl); } }
+.sys-block .body { margin: 0; font-size: 15px; line-height: 1.65; color: var(--vt-text-secondary); max-width: 46ch; }
+.sys-ctas { display: flex; gap: var(--space-4); align-items: center; flex-wrap: wrap; }
+.sys-ctas button { white-space: nowrap; }
+.sys-foot { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+
+/* offline / degraded banner (DG-12.2.3) */
+.off-banner { position: sticky; top: 49px; z-index: var(--vt-z-banner); background: var(--vt-state-stale-bg);
+  border-top: 1px dashed var(--vt-degraded-border); border-bottom: 1px dashed var(--vt-degraded-border); }
+.off-banner.inline { position: static; border-left: 1px dashed var(--vt-degraded-border);
+  border-right: 1px dashed var(--vt-degraded-border); border-radius: var(--radius-1); }
+.off-inner { display: flex; align-items: center; gap: 10px; padding: 9px 0; flex-wrap: wrap; }
+.off-banner.inline .off-inner { padding: 9px 14px; }
+.off-glyph { color: var(--vt-state-stale); display: inline-flex; flex-shrink: 0; }
+.off-label { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-state-stale); white-space: nowrap; }
+.off-copy { font-size: 12.5px; color: var(--vt-text); }
+.off-act { margin-left: auto; }
+@media (max-width: 620px) { .off-act { margin-left: 26px; } }
+
+/* empty-state card (DG-12.2.4) */
+.empty-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+@media (max-width: 860px) { .empty-grid { grid-template-columns: minmax(0, 1fr); } }
+.empty-ctx { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-faint); margin-bottom: 8px; display: block; }
+.empty-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-10) var(--space-6); display: flex; flex-direction: column; align-items: center;
+  text-align: center; gap: var(--space-3); }
+.empty-glyph { width: 44px; height: 44px; display: grid; place-items: center; color: var(--vt-text-muted);
+  border: 1px solid var(--vt-rule); border-radius: var(--radius-1); background: var(--vt-surface-page); }
+.empty-card h3 { font-family: var(--font-display); font-weight: 560; font-size: var(--text-lg); max-width: 24ch; }
+.empty-card .why { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); max-width: 40ch; }
+.empty-card .act { margin-top: var(--space-2); }
+
+/* skeleton loading (allowed shimmer exception) */
+.sk-stack { display: flex; flex-direction: column; gap: 10px; }
+.sk-line { height: 12px; border-radius: var(--radius-1); background: var(--vt-surface-sunken);
+  position: relative; overflow: hidden; }
+.sk-line.w60 { width: 60%; } .sk-line.w80 { width: 80%; } .sk-line.w40 { width: 40%; }
+@media (prefers-reduced-motion: no-preference) {
+  .sk-line::after { content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+    background: linear-gradient(90deg, transparent, var(--paper-50), transparent);
+    animation: sk-sweep 1.6s var(--ease-house) infinite; }
+  @keyframes sk-sweep { to { transform: translateX(100%); } }
+}
+
+/* ================= LEGAL (DG-12.3) ================= */
+.lg-tabs { display: flex; gap: 2px; flex-wrap: wrap; margin-bottom: var(--space-8); }
+.lg-tab { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; text-decoration: none; color: var(--vt-text-secondary);
+  padding: 8px 14px; border: 1px solid var(--vt-rule); border-radius: var(--radius-1); }
+.lg-tab:hover { color: var(--vt-text); text-decoration: none; border-color: var(--vt-rule-strong); }
+.lg-tab[aria-current="page"] { color: var(--vt-text-inverse); background: var(--ink-900); border-color: var(--ink-900); }
+.lg-layout { display: grid; grid-template-columns: 224px minmax(0, 1fr); gap: var(--space-12); align-items: start; }
+@media (max-width: 1023px) { .lg-layout { grid-template-columns: minmax(0, 1fr); gap: var(--space-6); } }
+.lg-toc { position: sticky; top: 72px; display: flex; flex-direction: column; gap: 2px; }
+@media (max-width: 1023px) { .lg-toc { position: static; border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  padding: var(--space-4); background: var(--vt-surface-card); } }
+.lg-toc-label { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--vt-text-faint); margin-bottom: 8px; }
+.lg-toc a { display: flex; gap: 10px; align-items: baseline; font-size: 12.5px; color: var(--vt-text-secondary);
+  text-decoration: none; padding: 5px 8px; border-left: 2px solid transparent; border-radius: 0; }
+.lg-toc a:hover { color: var(--vt-text); border-left-color: var(--vt-rule-strong); }
+.lg-toc a .n { font-family: var(--font-mono); font-size: 9.5px; color: var(--vt-text-faint); }
+.lg-head { display: flex; flex-direction: column; gap: 10px; margin-bottom: var(--space-8); }
+.lg-head h1 { font-size: var(--text-2xl); }
+.lg-stamp { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vt-text-muted); display: inline-flex; gap: 14px; flex-wrap: wrap; }
+.lg-prose { max-width: 65ch; }
+.lg-prose section { padding: var(--space-6) 0; border-top: 1px solid var(--vt-rule-soft); scroll-margin-top: 72px; }
+.lg-prose section:first-child { border-top: none; padding-top: 0; }
+.lg-prose h2 { font-size: var(--text-lg); display: flex; gap: 12px; align-items: baseline; }
+.lg-prose h2 .n { font-family: var(--font-mono); font-size: 10px; font-weight: 500; color: var(--vt-text-faint); }
+.lg-prose h2 a.anchor { color: inherit; text-decoration: none; }
+.lg-prose h2 a.anchor:hover { text-decoration: underline; text-decoration-color: var(--vt-rule); }
+.lg-prose p, .lg-prose li { font-size: 14px; line-height: 1.75; color: var(--vt-text); }
+.lg-prose p { margin: 12px 0 0; }
+.lg-prose ul { margin: 12px 0 0; padding-left: 20px; }
+.lg-prose li { margin-top: 6px; }
+.lg-prose .mono-note { font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em;
+  color: var(--vt-text-secondary); border: 1px solid var(--vt-rule); background: var(--vt-surface-card);
+  border-radius: var(--radius-1); padding: 12px 14px; margin-top: 14px; }
+.lg-table { width: 100%; border-collapse: collapse; margin-top: 14px; }
+.lg-table th { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); text-align: left; padding: 8px 12px 8px 0;
+  border-bottom: 1px solid var(--vt-rule); }
+.lg-table td { font-size: 12.5px; line-height: 1.5; color: var(--vt-text); padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--vt-rule-soft); vertical-align: top; }
+.lg-table td.mono { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.03em; white-space: nowrap; }
+
+/* ================= CONTACT (DG-12.4) ================= */
+.ct-grid { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: var(--space-12); align-items: start; }
+@media (max-width: 980px) { .ct-grid { grid-template-columns: minmax(0, 1fr); gap: var(--space-8); } }
+.ct-aside { display: flex; flex-direction: column; gap: var(--space-5); position: sticky; top: 72px; }
+@media (max-width: 980px) { .ct-aside { position: static; } }
+.ct-expect { border: 1px solid var(--vt-rule); background: var(--vt-surface-card); border-radius: var(--radius-2);
+  padding: var(--space-5); display: flex; flex-direction: column; gap: 12px; }
+.ct-expect .row { display: flex; gap: 10px; align-items: flex-start; }
+.ct-expect .row svg { flex-shrink: 0; margin-top: 2px; color: var(--vt-text-secondary); }
+.ct-expect .row p { margin: 0; font-size: 12.5px; line-height: 1.6; color: var(--vt-text); }
+.ct-expect .row p strong { font-weight: 600; }
+select.fk-input { appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%23474540' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 14px center; padding-right: 36px; cursor: pointer; }
+
+/* ================= PRICING (DG-13.3) ================= */
+.pr-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-4); align-items: stretch; }
+@media (max-width: 980px) { .pr-grid { grid-template-columns: minmax(0, 1fr); } }
+.pr-card { background: var(--vt-surface-card); border: 1px solid var(--vt-rule); border-radius: var(--radius-2);
+  padding: var(--space-6); display: flex; flex-direction: column; gap: var(--space-4); min-width: 0; }
+.pr-card.lead { border: 1px solid var(--vt-rule-strong); }
+.pr-aud { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.pr-price { display: flex; flex-direction: column; gap: 6px; }
+.pr-price .amt { font-family: var(--font-display); font-weight: 560; font-size: var(--text-2xl); letter-spacing: -0.015em; line-height: 1; }
+.pr-price .per { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+.pr-desc { margin: 0; font-size: 13px; line-height: 1.6; color: var(--vt-text-secondary); }
+.pr-rows { display: flex; flex-direction: column; border-top: 1px solid var(--vt-rule-soft); }
+.pr-row { display: flex; gap: 10px; align-items: flex-start; padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+.pr-row svg { flex-shrink: 0; margin-top: 3px; }
+.pr-row.inc svg { color: var(--vt-state-checked); }
+.pr-row.exc svg { color: var(--vt-text-muted); }
+.pr-row span { font-size: 12.5px; line-height: 1.5; color: var(--vt-text); }
+.pr-row.exc span { color: var(--vt-text-muted); }
+.pr-cta { margin-top: auto; padding-top: var(--space-2); display: flex; }
+.pr-cta > * { width: 100%; }
+.pr-never { border: 1px solid var(--vt-rule); border-radius: var(--radius-2); background: var(--vt-surface-card); padding: var(--space-6); }
+.pr-never ul { list-style: none; margin: 14px 0 0; padding: 0; display: flex; flex-direction: column; gap: 0; }
+.pr-never li { display: flex; gap: 10px; align-items: baseline; padding: 9px 0; border-bottom: 1px solid var(--vt-rule-soft);
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.03em; line-height: 1.6; color: var(--vt-text); }
+.pr-never li:last-child { border-bottom: none; }
+.pr-never li svg { flex-shrink: 0; transform: translateY(2px); color: var(--vt-state-p0); }
+.pr-faq { max-width: 68ch; }
+.pr-faq details { border-bottom: 1px solid var(--vt-rule-soft); }
+.pr-faq summary { cursor: pointer; list-style: none; display: flex; align-items: baseline; gap: 12px;
+  padding: 14px 0; font-size: 14.5px; font-weight: 500; color: var(--vt-text); }
+.pr-faq summary::-webkit-details-marker { display: none; }
+.pr-faq summary .m { font-family: var(--font-mono); font-size: 12px; color: var(--vt-text-muted); width: 12px; flex-shrink: 0; }
+.pr-faq details[open] summary .m::before { content: "−"; }
+.pr-faq details:not([open]) summary .m::before { content: "+"; }
+.pr-faq details p { margin: 0 0 16px 24px; font-size: 13.5px; line-height: 1.65; color: var(--vt-text-secondary); max-width: 58ch; }
+
+/* ================= AUDIT (DG-14/15) ================= */
+.au-sum { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--space-4); margin-bottom: var(--space-8); }
+@media (max-width: 860px) { .au-sum { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.au-sum-cell { border: 1px solid var(--vt-rule); background: var(--vt-surface-card); border-radius: var(--radius-2);
+  padding: var(--space-4) var(--space-5); display: flex; flex-direction: column; gap: 4px; }
+.au-sum-cell .k { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.au-sum-cell .v { font-family: var(--font-display); font-weight: 560; font-size: var(--text-2xl); line-height: 1; }
+.au-sum-cell .s { font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); }
+.au-group { margin-bottom: var(--space-8); }
+.au-group-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; padding-bottom: 10px;
+  border-bottom: 2px solid var(--vt-rule-strong); }
+.au-group-head h3 { font-size: var(--text-md); font-family: var(--font-display); font-weight: 560; }
+.au-group-head .dg { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--vt-text-muted); }
+.au-group-head .method { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.05em; color: var(--vt-text-faint); }
+.au-row { display: grid; grid-template-columns: 84px 150px minmax(0, 1.2fr) minmax(0, 1.4fr) auto; gap: var(--space-4);
+  padding: 13px 0; border-bottom: 1px solid var(--vt-rule-soft); align-items: start; }
+.au-row .aid { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.08em; color: var(--vt-text-faint); }
+.au-row .asurf { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.03em; color: var(--vt-text-secondary); overflow-wrap: anywhere; }
+.au-row .asurf .vp { display: block; color: var(--vt-text-faint); font-size: 9.5px; margin-top: 2px; }
+.au-row .afind { font-size: 12.5px; line-height: 1.55; color: var(--vt-text); }
+.au-row .afix { font-size: 12.5px; line-height: 1.55; color: var(--vt-text-secondary); }
+.au-row .afix code, .au-row .afind code, .gv-rule code, .lg-prose code { font-family: var(--font-mono); font-size: 0.92em;
+  background: var(--vt-surface-sunken); border: 1px solid var(--vt-rule-soft); border-radius: 2px; padding: 0 4px; }
+@media (max-width: 980px) {
+  .au-row { grid-template-columns: 84px minmax(0, 1fr) auto; }
+  .au-row .asurf { grid-column: 2; order: -1; }
+  .au-row .aid { grid-row: span 2; }
+  .au-row .afind { grid-column: 2 / 4; }
+  .au-row .afix { grid-column: 2 / 4; }
+}
+@media (max-width: 560px) {
+  .au-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .au-row .aid, .au-row .asurf, .au-row .afind, .au-row .afix { grid-column: 1 / 2; }
+  .au-row .aid { grid-row: auto; }
+}
+
+/* ================= /dev/design style guide ================= */
+.dd-band { padding: var(--space-10) 0; border-top: 1px solid var(--vt-rule); scroll-margin-top: 64px; }
+.dd-band.first { border-top: none; }
+.dd-band-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: var(--space-6); }
+.dd-band-head h2 { font-size: var(--text-lg); }
+.dd-band-head .dg { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--vt-text-muted); }
+.dd-rule { margin: 0 0 var(--space-6); font-family: var(--font-mono); font-size: 11px; line-height: 1.7; letter-spacing: 0.03em;
+  color: var(--vt-text-secondary); max-width: 88ch; border-left: 2px solid var(--vt-rule-strong); padding-left: 14px; }
+.dd-jump { display: flex; flex-wrap: wrap; gap: 4px 4px; margin-top: var(--space-5); }
+.dd-jump a { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--vt-text-secondary); text-decoration: none; border: 1px solid var(--vt-rule); border-radius: var(--radius-1); padding: 5px 9px; }
+.dd-jump a:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+.dd-grid { display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: flex-start; }
+.dd-spec { display: flex; flex-direction: column; gap: 8px; border: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1);
+  padding: var(--space-4); background: var(--vt-surface-card); min-width: 0; }
+.dd-spec .lab { font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--vt-text-faint); }
+.dd-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(148px, 1fr)); gap: var(--space-3); }
+.dd-swatch { border: 1px solid var(--vt-rule); border-radius: var(--radius-1); overflow: hidden; background: var(--vt-surface-card); }
+.dd-swatch .chip { height: 52px; border-bottom: 1px solid var(--vt-rule-soft); }
+.dd-swatch .meta { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
+.dd-swatch .meta .t { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; color: var(--vt-text); overflow-wrap: anywhere; }
+.dd-swatch .meta .h { font-family: var(--font-mono); font-size: 9px; color: var(--vt-text-muted); }
+.dd-type-row { display: grid; grid-template-columns: 170px minmax(0, 1fr); gap: var(--space-4); align-items: baseline;
+  padding: 12px 0; border-bottom: 1px solid var(--vt-rule-soft); }
+@media (max-width: 620px) { .dd-type-row { grid-template-columns: minmax(0, 1fr); gap: 4px; } }
+.dd-type-row .m { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; color: var(--vt-text-muted); }
+.dd-space-row { display: flex; align-items: center; gap: 14px; padding: 5px 0; }
+.dd-space-row .bar { height: 14px; background: var(--matcha-100); border: 1px solid var(--vt-brand-rule); }
+.dd-space-row .m { font-family: var(--font-mono); font-size: 9.5px; color: var(--vt-text-muted); min-width: 130px; }
+.dd-glyph-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: var(--space-3); }
+.dd-glyph-cell { border: 1px solid var(--vt-rule-soft); border-radius: var(--radius-1); background: var(--vt-surface-card);
+  padding: var(--space-4); display: flex; flex-direction: column; align-items: center; gap: 8px; text-align: center; }
+.dd-glyph-cell .g { color: var(--vt-text); }
+.dd-glyph-cell .n { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--vt-text-secondary); overflow-wrap: anywhere; }
+.dd-motion-demo { display: flex; align-items: center; gap: var(--space-5); flex-wrap: wrap; }
+.dd-motion-box { width: 56px; height: 56px; background: var(--vt-surface-card); border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-1); }
+@media (prefers-reduced-motion: no-preference) { .dd-motion-box.play { animation: vt-enter var(--dur-base) var(--ease-house) both; } }
+.dd-ztable { max-width: 480px; }
+
+/* ================= GOVERNANCE ================= */
+.gv-matrix { width: 100%; border-collapse: collapse; }
+.gv-matrix th { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--vt-text-faint); text-align: left; padding: 8px 10px 8px 0;
+  border-bottom: 2px solid var(--vt-rule-strong); white-space: nowrap; }
+.gv-matrix td { padding: 9px 10px 9px 0; border-bottom: 1px solid var(--vt-rule-soft); vertical-align: top; }
+.gv-matrix td.route { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.02em; color: var(--vt-text); white-space: nowrap; }
+.gv-matrix td.wave { font-family: var(--font-mono); font-size: 10px; color: var(--vt-text-muted); white-space: nowrap; }
+.gv-matrix td.mask { font-family: var(--font-mono); font-size: 10px; line-height: 1.6; color: var(--vt-text-secondary); }
+.gv-matrix .vp-ok { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 9.5px;
+  color: var(--vt-state-checked); border: 1px solid var(--vt-state-checked-rule); background: var(--vt-state-checked-bg);
+  border-radius: var(--radius-1); padding: 2px 7px; margin: 1px 4px 1px 0; white-space: nowrap; }
+.gv-matrix-wrap { overflow-x: auto; }
+.gv-rule { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: var(--space-4); padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--vt-rule-soft); }
+@media (max-width: 620px) { .gv-rule { grid-template-columns: minmax(0, 1fr); gap: 8px; } }
+.gv-rule .rid { font-family: var(--font-mono); font-size: 10.5px; font-weight: 700; letter-spacing: 0.08em; color: var(--vt-text); }
+.gv-rule .rid .sev { display: block; margin-top: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.12em; color: var(--vt-state-p0); }
+.gv-rule .rid .sev.warn { color: var(--vt-state-stale); }
+.gv-rule .rbody { display: flex; flex-direction: column; gap: 7px; min-width: 0; }
+.gv-rule .rbody .what { font-size: 13.5px; font-weight: 500; color: var(--vt-text); }
+.gv-rule .rbody .det { font-family: var(--font-mono); font-size: 10.5px; line-height: 1.7; letter-spacing: 0.02em;
+  color: var(--vt-text-secondary); overflow-wrap: anywhere; }
+.gv-rule .rbody .allow { font-size: 12px; color: var(--vt-text-secondary); }
+
+/* ================= feedback widget (DG-12.5) ================= */
+.fb-tab { position: fixed; right: 0; top: 50%; transform: translateY(-50%); z-index: var(--vt-z-widget);
+  writing-mode: vertical-rl; text-orientation: mixed; cursor: pointer;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--vt-text-secondary); background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule); border-right: none; border-radius: var(--radius-1) 0 0 var(--radius-1);
+  padding: 14px 8px; transition: color var(--dur-fast) var(--ease-house), border-color var(--dur-fast) var(--ease-house); }
+.fb-tab::before { content: ""; position: absolute; inset: -4px 0 -4px -10px; }
+.fb-tab:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+.fb-panel { position: fixed; right: 12px; top: 50%; transform: translateY(-50%); z-index: var(--vt-z-overlay);
+  width: min(340px, calc(100vw - 48px)); box-sizing: border-box; background: var(--vt-surface-card);
+  border: 1px solid var(--vt-rule-strong); border-radius: var(--radius-2); padding: var(--space-5);
+  display: flex; flex-direction: column; gap: var(--space-4); }
+@media (prefers-reduced-motion: no-preference) { .fb-panel { animation: s5-fade var(--dur-fast) var(--ease-house) both; } }
+.fb-head { display: flex; align-items: baseline; gap: 10px; }
+.fb-head h2 { font-size: var(--text-md); }
+.fb-close { margin-left: auto; background: none; border: 1px solid var(--vt-rule); border-radius: var(--radius-1);
+  cursor: pointer; font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--vt-text-secondary); padding: 5px 9px; }
+.fb-close:hover { color: var(--vt-text); border-color: var(--vt-rule-strong); }
+.fb-note { margin: 0; font-family: var(--font-mono); font-size: 9.5px; line-height: 1.6; letter-spacing: 0.04em;
+  color: var(--vt-text-muted); }
+
+/* ================= misc ================= */
+.mono-list { list-style: none; margin: 0; padding: 0; }
+.mono-list li { display: flex; gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--vt-rule-soft);
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.65; letter-spacing: 0.03em; color: var(--vt-text-secondary); }
+.mono-list li:last-child { border-bottom: none; }
+.mono-list li::before { content: "·"; color: var(--vt-text-faint); }
+.s5-twocol { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-6); align-items: start; }
+@media (max-width: 980px) { .s5-twocol { grid-template-columns: minmax(0, 1fr); } }


### PR DESCRIPTION
## Summary

Implements `wave1505/index.html` from the Claude Design project as a self-contained design-reference surface at **`/design/wave1505`** (noindex), following the wave1400 → `/operations-engine` port precedent.

Wave 1505 is the closing wave of the 1500-series design program: system pages, quality gates, and governance. The surface preserves the prototype's hash routing, so all ten designed surfaces are reachable:

- `#/` index hub (six deliverables + acceptance criteria)
- `#/auth` overview + Clerk appearance-API mapping spec, plus full-page `sign-in` / `sign-up` / `verify` / `loading`
- `#/system` — 404 / fail-closed error / offline banner / empty-state gallery / skeleton triad (unknown hash routes genuinely land on the designed 404)
- `#/legal/{privacy,terms,dpa,cookies}` — one prose template, four fixture documents
- `#/contact`, `#/pricing` (honesty-doctrine pricing)
- `#/audit` — the 23-row responsive/a11y findings-and-fixes checklist
- `#/dev/design` — the living style guide (palette, type ramp, chips, tiers, buttons, forms, rings, honesty kit, motion, z-scale)
- `#/governance` — visual-regression matrix + 10 design-lint rules

## Architecture

- `apps/web/components/design-wave1505/` — kit (wave1500 primitives + 1502 form kit + 1503 RecognitionRow + 1504 CopyBtn/TokenRow + brand lockup), shell, views, and a **generated scoped stylesheet**: every selector under a `.w1505` root, keyframes renamed `w1505-*`, ops/dark theme dropped — nothing leaks into the app shell.
- `apps/web/app/design/wave1505/` — server page (metadata, `robots noindex`) + `ssr:false` mount.
- `/design` registered in `OPS_SURFACE_PREFIXES` (surface carries its own chrome; no global Navbar/Footer).
- Fonts consume the app's existing `--font-display/--font-body/--font-mono` variables.

## Truth-contract adaptations (each marked at its site)

- Audit chips read **Re-checked** — the bare Verified status label is banned (CLAUDE.md).
- Contact form and feedback widget demo the designed success states but state plainly that **nothing was transmitted** — no fabricated receipt ids.
- A dashed **"Design reference · content is illustrative fixture data — the live product pages remain canonical"** strip renders under the nav on every chromed route.
- Cross-prototype links point at real routes (`/`, `/status`, `/get-ready`).
- Port fix for a real prototype a11y bug: Esc now actually returns focus to the feedback tab (the prototype focused it before remount).

## Design Handoff References

Verbatim handoff archived in-repo at `design-handoff/claude-design-2026-07-12-wave1505/`:

- `wave1505/index.html` (the implemented entry point) + `w1505-{app,shared,auth,system,legal,contact,pricing,audit,devdesign,governance}.jsx` + `w1505.css`
- `wave1505/CHANGES.md`, `DESIGN_SYSTEM.md` (canonical), `DESIGN_LINT.md`, `REGRESSION_MATRIX.md`
- Consumed kit: `wave1500/{01-primitives,02-semantic,03-themes}.css`, `wave1500/w15-{glyphs,primitives}.jsx`, `wave1501/hp.css`, `wave150{2,3,4}/*-shared.jsx` + css, `wave1504/brand/logo.jsx`

Source: Claude Design project `745460cf-8332-43a2-b92e-27142bc3bb1c`, `?file=wave1505/index.html`.

## Test plan

- [x] `pnpm turbo run build --filter @vitalcv/web` green in a fresh `origin/main` worktree (route emits at 1.48 kB)
- [x] `tsc --noEmit` clean; `next lint` clean on all new files
- [x] `__tests__/design-wave1505.test.tsx` — 12 tests: hash router, verbatim 404/error doctrine copy ("This page isn't part of the record." / "Nothing was recorded as successful."), disclaimers, HonestyLabel on the illustrative price, `.w1505` CSS scoping + keyframe namespacing
- [x] `banned-verified-label` gate + `scripts/check-public-claims.ts` PASS
- [x] Browser QA (dev server): all routes incl. designed-404 on bad hashes, contact error-summary → aria-invalid flow, feedback Esc/focus-return, 360px sweep of 11 routes with zero horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)
