### PR TITLE
feat(design): wave1505 look on real routes — 404, error, /pricing

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -6,6 +6,28 @@ import { PilotFailureSignal } from '@/components/pilot-ops/PilotFailureSignal';
 import { SupportActionButton } from '@/components/pilot-ops/SupportActionButton';
 import { trackPilotEvent } from '@/lib/pilot-ops/client';
 
+/**
+ * Route error boundary — adopted from the wave1505 system-states design
+ * (DG-12.2). Fail-closed doctrine copy recorded in the wave1505 CHANGES.md
+ * ("Nothing was recorded as successful." — reused verbatim). Paper/ink,
+ * self-contained inline styles; preserves the pilot failure signal, telemetry,
+ * reset(), and support-contact behavior.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx (SysError)
+ */
+
+const paper = '#f4f2ec';
+const ink = '#141414';
+const rule = '#dddbd3';
+const ruleStrong = '#c9c6bd';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const stateP0 = '#7a1414';
+const displayFont = "var(--font-display, 'Fraunces', Georgia, serif)";
+const monoFont = "var(--font-mono, 'Geist Mono', ui-monospace, monospace)";
+const bodyFont = "var(--font-body, 'Geist', ui-sans-serif, system-ui, sans-serif)";
+
 export default function Error({
   error,
   reset,
@@ -19,45 +41,109 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background text-foreground">
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        boxSizing: 'border-box',
+        padding: '32px 24px 72px',
+        background: paper,
+        color: ink,
+        fontFamily: bodyFont,
+      }}
+    >
       <PilotFailureSignal
         title="Page could not load"
         message={error.digest ?? 'runtime_error'}
         queueItem={{ source: 'route_failure' }}
-        details={{
-          digest: error.digest ?? null,
-        }}
+        details={{ digest: error.digest ?? null }}
         dedupeKey={`app-error:${error.digest ?? 'unknown'}`}
       />
-      <div className="max-w-md animate-fade-in-up px-6 text-center">
-        <h1 className="text-2xl font-semibold mb-3 text-foreground">
-          Something went wrong
-        </h1>
-        <p className="text-muted-foreground mb-8 text-sm leading-relaxed">
-          This page couldn&apos;t load. Your data is safe — try reloading, or
-          return to the homepage and continue from there.
-        </p>
-        <div className="flex flex-col gap-3">
-          <button
-            onClick={reset}
-            className="rounded-full bg-foreground px-6 py-2.5 text-sm font-semibold text-background hover:opacity-90 transition"
-          >
-            Try again
-          </button>
-          <Link
-            href="/"
-            className="rounded-full border border-border px-6 py-2.5 text-sm font-semibold text-foreground/85 transition hover:border-border hover:text-foreground"
-          >
-            Return home
-          </Link>
-          <SupportActionButton
-            label="Contact support"
-            title="Page could not load"
-            messagePrefill={error.digest ?? 'An error occurred'}
-            className="rounded-full border border-border px-6 py-2.5 text-sm font-semibold text-foreground/85 transition hover:border-border hover:text-foreground"
-          />
-        </div>
+      <div style={{ display: 'flex' }}>
+        <span style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 18, letterSpacing: '-0.01em' }}>
+          VitalCV
+        </span>
       </div>
+      <main style={{ flex: 1, display: 'grid', placeItems: 'center', padding: '48px 0' }}>
+        <div role="alert" style={{ maxWidth: 560, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 20 }}>
+          <div
+            aria-label="Failure reference"
+            style={{
+              alignSelf: 'stretch',
+              fontFamily: monoFont,
+              fontSize: 11,
+              letterSpacing: '0.05em',
+              lineHeight: 1.8,
+              color: textSecondary,
+              border: `1px solid ${rule}`,
+              background: '#ffffff',
+              borderRadius: 2,
+              padding: '10px 14px',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            <span style={{ color: stateP0, fontWeight: 600 }}>FAILED</span>
+            {error.digest ? <> · ref {error.digest}</> : null}
+            <br />
+            reference logged — include it if you write in
+          </div>
+          <h1 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 40, lineHeight: 1.08, letterSpacing: '-0.02em', margin: 0, maxWidth: '15ch' }}>
+            Something failed on our side.
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, lineHeight: 1.65, color: textSecondary, maxWidth: '46ch' }}>
+            Nothing was recorded as successful. If you were mid-request, it did not complete — no partial
+            result was saved, and no source was marked checked. Retry when ready.
+          </p>
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 }}>
+            <button
+              onClick={reset}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                height: 46,
+                padding: '0 22px',
+                fontFamily: bodyFont,
+                fontSize: 13.5,
+                fontWeight: 500,
+                color: paper,
+                background: ink,
+                border: '1px solid transparent',
+                borderRadius: 2,
+                cursor: 'pointer',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Try again
+            </button>
+            <style>{`
+              .wv-quiet-cta {
+                font-family: ${monoFont};
+                font-size: 11px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: ${ink};
+                background: transparent;
+                border: none;
+                border-bottom: 1px solid ${ruleStrong};
+                padding: 0 0 2px;
+                cursor: pointer;
+                white-space: nowrap;
+              }
+              .wv-quiet-cta:hover { border-bottom-color: ${ink}; }
+            `}</style>
+            <SupportActionButton
+              label="Write to us"
+              title="Page could not load"
+              messagePrefill={error.digest ?? 'An error occurred'}
+              className="wv-quiet-cta"
+            />
+          </div>
+        </div>
+      </main>
+      <p style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.06em', color: textMuted, margin: 0 }}>
+        © 2026 VitalCV · errors are stated, never dressed up
+      </p>
     </div>
   );
 }

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,10 +1,31 @@
 'use client';
 
 import { useEffect } from 'react';
-import { AlertTriangle, RefreshCw } from 'lucide-react';
-import Link from 'next/link';
 import { PilotFailureSignal } from '@/components/pilot-ops/PilotFailureSignal';
 import { SupportActionButton } from '@/components/pilot-ops/SupportActionButton';
+
+/**
+ * Global error boundary — adopted from the wave1505 system-states design
+ * (DG-12.2). This renders its own <html>/<body> and fires when the root layout
+ * itself fails, so it can rely on NO app CSS: every style here is literal
+ * (paper/ink palette, literal font stacks). Fail-closed doctrine copy reused
+ * from the wave1505 CHANGES.md. Preserves the pilot failure signal, reset(),
+ * support-contact, and the technical digest.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx (SysError)
+ */
+
+const paper = '#f4f2ec';
+const ink = '#141414';
+const rule = '#dddbd3';
+const ruleStrong = '#c9c6bd';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const stateP0 = '#7a1414';
+const displayFont = "'Fraunces', Georgia, 'Times New Roman', serif";
+const monoFont = "'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace";
+const bodyFont = "'Geist', ui-sans-serif, system-ui, -apple-system, sans-serif";
 
 export default function GlobalError({
   error,
@@ -19,61 +40,110 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body className="min-h-screen flex items-center justify-center bg-zinc-950 font-sans">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          boxSizing: 'border-box',
+          padding: '32px 24px 72px',
+          background: paper,
+          color: ink,
+          fontFamily: bodyFont,
+        }}
+      >
+        <style>{`
+          .wv-quiet-cta {
+            font-family: ${monoFont};
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: ${ink};
+            background: transparent;
+            border: none;
+            border-bottom: 1px solid ${ruleStrong};
+            padding: 0 0 2px;
+            cursor: pointer;
+            white-space: nowrap;
+          }
+          .wv-quiet-cta:hover { border-bottom-color: ${ink}; }
+        `}</style>
         <PilotFailureSignal
           title="System interruption"
           message={error.message}
           queueItem={{ source: 'route_failure' }}
-          details={{
-            digest: error.digest ?? null,
-          }}
+          details={{ digest: error.digest ?? null }}
           dedupeKey={`global-error:${error.digest ?? error.message}`}
         />
-        <main className="max-w-xl w-full mx-4">
-          <div className="rounded-2xl border border-border bg-white/[0.04] p-8 space-y-5">
-            <div className="flex items-center gap-2 text-foreground">
-              <AlertTriangle className="h-5 w-5 text-amber-300" />
-              <h1 className="text-2xl font-semibold">System Interruption</h1>
+        <div style={{ display: 'flex' }}>
+          <span style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 18, letterSpacing: '-0.01em' }}>
+            VitalCV
+          </span>
+        </div>
+        <main style={{ flex: 1, display: 'grid', placeItems: 'center', padding: '48px 0' }}>
+          <div role="alert" style={{ maxWidth: 560, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 20 }}>
+            <div
+              aria-label="Failure reference"
+              style={{
+                alignSelf: 'stretch',
+                fontFamily: monoFont,
+                fontSize: 11,
+                letterSpacing: '0.05em',
+                lineHeight: 1.8,
+                color: textSecondary,
+                border: `1px solid ${rule}`,
+                background: '#ffffff',
+                borderRadius: 2,
+                padding: '10px 14px',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              <span style={{ color: stateP0, fontWeight: 600 }}>FAILED</span>
+              {error.digest ? <> · ref {error.digest}</> : null}
+              <br />
+              reference logged — include it if you write in
             </div>
-            <p className="text-sm text-foreground/70">
-              The platform encountered a temporary issue. Your data is safe. Please refresh to continue.
+            <h1 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 40, lineHeight: 1.08, letterSpacing: '-0.02em', margin: 0, maxWidth: '15ch' }}>
+              Something failed on our side.
+            </h1>
+            <p style={{ margin: 0, fontSize: 15, lineHeight: 1.65, color: textSecondary, maxWidth: '46ch' }}>
+              Nothing was recorded as successful. The platform hit a temporary interruption — your data
+              is untouched. Refresh to continue; if it persists, include the reference above.
             </p>
-            <p className="text-sm text-foreground/70">
-              If this persists, share the reference below in a support request.
-            </p>
-
-            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 }}>
               <button
                 onClick={reset}
-                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-4 py-2 text-zinc-950 transition-colors hover:bg-zinc-200"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  height: 46,
+                  padding: '0 22px',
+                  fontFamily: bodyFont,
+                  fontSize: 13.5,
+                  fontWeight: 500,
+                  color: paper,
+                  background: ink,
+                  border: '1px solid transparent',
+                  borderRadius: 2,
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                }}
               >
-                <RefreshCw className="h-4 w-4" />
-                Refresh View
+                Refresh view
               </button>
-              <Link
-                href="/"
-                className="inline-flex items-center justify-center gap-2 rounded-md border border-border px-4 py-2 text-foreground/80 transition hover:border-border hover:text-foreground"
-              >
-                Return home
-              </Link>
               <SupportActionButton
-                label="Contact support"
+                label="Write to us"
                 title="System interruption"
                 messagePrefill={error.message}
-                className="inline-flex items-center justify-center gap-2 rounded-md border border-border px-4 py-2 text-foreground/80 transition hover:border-border hover:text-foreground"
+                className="wv-quiet-cta"
               />
             </div>
-
-            {error.digest && (
-              <details className="rounded-md border border-border bg-white/[0.03] p-3 text-xs text-foreground/70">
-                <summary className="font-medium text-foreground cursor-pointer">
-                  Technical Reference
-                </summary>
-                <p className="mt-2 break-all font-mono">Digest: {error.digest}</p>
-              </details>
-            )}
           </div>
         </main>
+        <p style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.06em', color: textMuted, margin: 0 }}>
+          © 2026 VitalCV · errors are stated, never dressed up
+        </p>
       </body>
     </html>
   );

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -2,30 +2,120 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { NotFoundTracker } from '@/lib/analytics/not-found-tracker';
 
+/**
+ * 404 — adopted from the wave1505 system-states design (DG-12.2).
+ * Paper/ink, fail-closed doctrine copy recorded in the wave1505 CHANGES.md
+ * ("This page isn't part of the record." — reused verbatim). Self-contained
+ * inline styles keyed to the wave1505 palette with --font-* fallbacks, so the
+ * page needs no global stylesheet and picks up real Fraunces/Geist when present.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx (Sys404)
+ */
+
 export const metadata: Metadata = {
   title: { absolute: 'Page Not Found — VitalCV' },
 };
 
+const paper = '#f4f2ec';
+const ink = '#141414';
+const rule = '#dddbd3';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const stateP0 = '#7a1414';
+const displayFont = "var(--font-display, 'Fraunces', Georgia, serif)";
+const monoFont = "var(--font-mono, 'Geist Mono', ui-monospace, monospace)";
+const bodyFont = "var(--font-body, 'Geist', ui-sans-serif, system-ui, sans-serif)";
+
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-vt-surface-ops-base text-slate-200">
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        boxSizing: 'border-box',
+        padding: '32px 24px 72px',
+        background: paper,
+        color: ink,
+        fontFamily: bodyFont,
+      }}
+    >
       <NotFoundTracker />
-      <div className="max-w-md animate-fade-in-up px-6 text-center">
-        <div className="text-6xl font-bold mb-4 text-muted-foreground/40">404</div>
-        <h1 className="text-2xl font-semibold mb-3 text-foreground">
-          Page not found
-        </h1>
-        <p className="text-slate-400 mb-8 text-sm leading-relaxed">
-          This page doesn&apos;t exist or may have been moved. Head back to
-          explore VitalCV.
-        </p>
-        <Link
-          href="/"
-          className="rounded-full bg-white px-6 py-2.5 text-sm font-semibold text-[#080e1a] hover:bg-white/90 transition"
-        >
-          Go home
-        </Link>
+      <div style={{ display: 'flex' }}>
+        <span style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 18, letterSpacing: '-0.01em' }}>
+          VitalCV
+        </span>
       </div>
+      <main style={{ flex: 1, display: 'grid', placeItems: 'center', padding: '48px 0' }}>
+        <div style={{ maxWidth: 560, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 20 }}>
+          <div
+            aria-label="Request status"
+            style={{
+              alignSelf: 'stretch',
+              fontFamily: monoFont,
+              fontSize: 11,
+              letterSpacing: '0.05em',
+              lineHeight: 1.8,
+              color: textSecondary,
+              border: `1px solid ${rule}`,
+              background: '#ffffff',
+              borderRadius: 2,
+              padding: '10px 14px',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            <span style={{ color: stateP0, fontWeight: 600 }}>404 · NOT FOUND</span> · nothing at this address
+          </div>
+          <h1 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 40, lineHeight: 1.08, letterSpacing: '-0.02em', margin: 0, maxWidth: '15ch' }}>
+            This page isn&rsquo;t part of the record.
+          </h1>
+          <p style={{ margin: 0, fontSize: 15, lineHeight: 1.65, color: textSecondary, maxWidth: '46ch' }}>
+            The address may have changed, or it never existed. Nothing was deleted silently — if a share
+            link stopped working, its holder revoked it, and that revocation is logged.
+          </p>
+          <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 }}>
+            <Link
+              href="/"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                height: 46,
+                padding: '0 22px',
+                fontFamily: bodyFont,
+                fontSize: 13.5,
+                fontWeight: 500,
+                color: paper,
+                background: ink,
+                borderRadius: 2,
+                textDecoration: 'none',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Back to vitalcv.com
+            </Link>
+            <Link
+              href="/status"
+              style={{
+                fontFamily: monoFont,
+                fontSize: 11,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: ink,
+                textDecoration: 'none',
+                borderBottom: `1px solid ${rule}`,
+                paddingBottom: 2,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Check system status
+            </Link>
+          </div>
+        </div>
+      </main>
+      <p style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.06em', color: textMuted, margin: 0 }}>
+        © 2026 VitalCV · a partial proof stays partial
+      </p>
     </div>
   );
 }

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -10,72 +10,220 @@ import {
 import { ctaForPricingPlan } from '@/lib/commercial/pricingCta';
 import { CalendarBookingEmbed } from '@/components/pricing/CalendarBookingEmbed';
 
+/**
+ * /pricing — visual design adopted from the wave1505 pricing doctrine
+ * (DG-13.3): paper/ink cards, Fraunces headings, mono eyebrows, the
+ * HonestyLabel treatment, and the "what this page will never claim" doctrine
+ * block. The CONTENT stays real and test-true: plans come from the canonical
+ * buildPricingFoundationPlan() helper, CTAs from ctaForPricingPlan() (with the
+ * data-* test hooks preserved), and the "Payments are not collected" honesty
+ * copy is unchanged. No mockup pricing fiction is introduced.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-pricing.jsx
+ */
+
 export const metadata: Metadata = {
   title: 'Pricing Foundation | VitalCV',
   description: 'Pricing is a foundation preview. Payments are not collected in this build.',
 };
 
-const STATUS_CLASS: Record<PricingPlanStatus, string> = {
-  foundation_preview: 'border-amber-500/40 bg-amber-500/10 text-amber-700',
-  pilot_ready: 'border-sky-500/40 bg-sky-500/10 text-sky-700',
-  planned: 'border-slate-400/40 bg-slate-500/10 text-slate-600',
+const paper = '#f4f2ec';
+const card = '#ffffff';
+const ink = '#141414';
+const rule = '#dddbd3';
+const ruleSoft = '#e7e4dc';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const textFaint = '#8a8780';
+const stateP0 = '#7a1414';
+const stateChecked = '#1c5c38';
+const stateStale = '#7d5a1e';
+const statePreview = '#1a3e6b';
+const displayFont = "var(--font-display, 'Fraunces', Georgia, serif)";
+const monoFont = "var(--font-mono, 'Geist Mono', ui-monospace, monospace)";
+const bodyFont = "var(--font-body, 'Geist', ui-sans-serif, system-ui, sans-serif)";
+
+const STATUS_COLOR: Record<PricingPlanStatus, string> = {
+  foundation_preview: statePreview,
+  pilot_ready: stateChecked,
+  planned: stateStale,
 };
 
 export default function PricingFoundationPage() {
   const plans = buildPricingFoundationPlan();
 
   return (
-    <main className="mx-auto w-full max-w-4xl px-4 py-8 sm:py-12">
-      <header className="mb-8 sm:mb-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          Pricing foundation
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">
-          Commercial plan preview
-        </h1>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          <strong>{`Pricing is a foundation preview. Payments are not collected in this build.`}</strong>{' '}
-          Plan cards describe launch scaffolding only and do not activate paid access.
-        </p>
-      </header>
+    <main
+      style={{
+        background: paper,
+        color: ink,
+        fontFamily: bodyFont,
+        minHeight: '100vh',
+        boxSizing: 'border-box',
+      }}
+    >
+      <div style={{ maxWidth: 1120, margin: '0 auto', padding: '64px 24px 40px' }}>
+        <header style={{ maxWidth: '64ch' }}>
+          <span style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: textFaint }}>
+            Pricing foundation
+          </span>
+          <h1 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 40, lineHeight: 1.08, letterSpacing: '-0.02em', margin: '10px 0 0', maxWidth: '18ch' }}>
+            Plain terms, stated — not teased.
+          </h1>
+          <p style={{ margin: '14px 0 0', fontSize: 15, lineHeight: 1.6, color: textSecondary }}>
+            <strong style={{ fontWeight: 600, color: ink }}>Pricing is a foundation preview. Payments are not collected in this build.</strong>{' '}
+            Plan cards describe launch scaffolding only and do not activate paid access.
+          </p>
+          <p
+            style={{
+              margin: '18px 0 0',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              fontFamily: monoFont,
+              fontSize: 10.5,
+              letterSpacing: '0.04em',
+              lineHeight: 1.6,
+              color: textSecondary,
+              border: `1px solid ${rule}`,
+              background: card,
+              borderRadius: 2,
+              padding: '8px 12px',
+            }}
+          >
+            <span aria-hidden="true" style={{ color: stateStale, fontWeight: 700 }}>◆</span>
+            Any figure shown is illustrative — real pricing is set in a signed scope, never on this page.
+          </p>
+        </header>
 
-      <section aria-labelledby="plans-heading">
-        <h2 id="plans-heading" className="sr-only">
-          Foundation pricing plans
-        </h2>
-        <ul className="grid gap-3 sm:grid-cols-2">
-          {plans.map((plan) => (
-            <li
-              key={plan.kind}
-              className="rounded-xl border border-[var(--vt-border,_rgba(0,0,0,0.08))] bg-[var(--vt-surface,_white)] p-4 sm:p-5"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                  <h3 className="text-base font-semibold">{plan.label}</h3>
-                  <p className="mt-1 text-xs text-muted-foreground">{plan.audience}</p>
+        <section aria-labelledby="plans-heading" style={{ marginTop: 40 }}>
+          <h2 id="plans-heading" style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}>
+            Foundation pricing plans
+          </h2>
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+              display: 'grid',
+              gap: 16,
+              gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 300px), 1fr))',
+            }}
+          >
+            {plans.map((plan) => (
+              <li
+                key={plan.kind}
+                style={{
+                  background: card,
+                  border: `1px solid ${plan.status === 'pilot_ready' ? '#c9c6bd' : rule}`,
+                  borderRadius: 4,
+                  padding: 24,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 16,
+                  minWidth: 0,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 10 }}>
+                  <span style={{ fontFamily: monoFont, fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: textFaint }}>
+                    {plan.audience}
+                  </span>
+                  <span
+                    aria-label={`Status: ${plan.status.replace(/_/g, ' ')}`}
+                    title={explainPricingPlanStatus(plan.status)}
+                    style={{
+                      fontFamily: monoFont,
+                      fontSize: 9,
+                      fontWeight: 600,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      color: STATUS_COLOR[plan.status],
+                      border: `1px solid ${STATUS_COLOR[plan.status]}33`,
+                      borderRadius: 2,
+                      padding: '3px 7px',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {plan.status.replace(/_/g, ' ')}
+                  </span>
                 </div>
-                <span
-                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${STATUS_CLASS[plan.status]}`}
-                  aria-label={`Status: ${plan.status}`}
-                  title={explainPricingPlanStatus(plan.status)}
-                >
-                  {plan.status.replace(/_/g, ' ')}
-                </span>
-              </div>
-              <p className="mt-4 text-lg font-semibold">{plan.priceLabel}</p>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{plan.description}</p>
-              <p className="mt-3 text-xs text-muted-foreground">
-                Payments collected: {String(plan.collectsPayment)}. Checkout live:{' '}
-                {String(plan.checkoutIntegrationLive)}. Subscription active:{' '}
-                {String(plan.subscriptionActive)}.
-              </p>
-              <PlanCta planKind={plan.kind} />
-            </li>
-          ))}
-        </ul>
-      </section>
 
-      <CalendarBookingEmbed />
+                <div>
+                  <h3 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 22, letterSpacing: '-0.01em', margin: 0 }}>
+                    {plan.label}
+                  </h3>
+                  <p style={{ fontFamily: monoFont, fontSize: 11, letterSpacing: '0.04em', color: textMuted, margin: '6px 0 0' }}>
+                    {plan.priceLabel}
+                  </p>
+                </div>
+
+                <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: textSecondary, flex: 1 }}>
+                  {plan.description}
+                </p>
+
+                <p
+                  style={{
+                    margin: 0,
+                    paddingTop: 12,
+                    borderTop: `1px solid ${ruleSoft}`,
+                    fontFamily: monoFont,
+                    fontSize: 10,
+                    letterSpacing: '0.03em',
+                    lineHeight: 1.7,
+                    color: textMuted,
+                  }}
+                >
+                  Payments collected: {String(plan.collectsPayment)} · Checkout live:{' '}
+                  {String(plan.checkoutIntegrationLive)} · Subscription active:{' '}
+                  {String(plan.subscriptionActive)}
+                </p>
+
+                <PlanCta planKind={plan.kind} />
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section style={{ marginTop: 56, borderTop: `1px solid ${rule}`, paddingTop: 40 }}>
+          <span style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: textFaint }}>
+            Doctrine
+          </span>
+          <h2 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 24, letterSpacing: '-0.015em', margin: '8px 0 0' }}>
+            What this page will never claim
+          </h2>
+          <ul style={{ listStyle: 'none', margin: '18px 0 0', padding: 0, maxWidth: '72ch', display: 'flex', flexDirection: 'column' }}>
+            {[
+              'No invented customer counts or borrowed authority.',
+              'No borrowed-logo strips or credentials we did not earn in writing.',
+              'No payback guarantees, ROI math, or lowest-price claims.',
+              'No unlabeled illustrative metrics — every example figure is marked as illustrative.',
+              'No countdown timers, seat scarcity, or launch-pricing pressure.',
+            ].map((line) => (
+              <li
+                key={line}
+                style={{
+                  display: 'flex',
+                  gap: 10,
+                  alignItems: 'baseline',
+                  padding: '9px 0',
+                  borderBottom: `1px solid ${ruleSoft}`,
+                  fontFamily: monoFont,
+                  fontSize: 11.5,
+                  letterSpacing: '0.03em',
+                  lineHeight: 1.6,
+                  color: ink,
+                }}
+              >
+                <span aria-hidden="true" style={{ color: stateP0, flexShrink: 0 }}>—</span>
+                {line}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <CalendarBookingEmbed />
+      </div>
     </main>
   );
 }
@@ -92,7 +240,7 @@ function PlanCta({
   if (cta.href === null) {
     return (
       <p
-        className="mt-4 text-xs text-muted-foreground"
+        style={{ margin: 0, fontSize: 11.5, lineHeight: 1.6, color: textMuted }}
         data-testid="plan-cta"
         data-cta-kind={cta.kind}
         data-opens-paid-checkout={String(cta.opensPaidCheckout)}
@@ -104,7 +252,6 @@ function PlanCta({
 
   return (
     <div
-      className="mt-4"
       data-testid="plan-cta"
       data-cta-kind={cta.kind}
       data-cta-href={cta.href}
@@ -112,11 +259,23 @@ function PlanCta({
     >
       <Link
         href={cta.href}
-        className="inline-flex items-center justify-center rounded-md border border-foreground bg-foreground px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          height: 42,
+          padding: '0 18px',
+          fontFamily: bodyFont,
+          fontSize: 13,
+          fontWeight: 500,
+          color: paper,
+          background: ink,
+          borderRadius: 2,
+          textDecoration: 'none',
+        }}
       >
         {cta.label} →
       </Link>
-      <p className="mt-2 text-[11px] text-muted-foreground">{cta.rationale}</p>
+      <p style={{ margin: '10px 0 0', fontSize: 11, lineHeight: 1.6, color: textMuted }}>{cta.rationale}</p>
     </div>
   );
 }


### PR DESCRIPTION
## What

Adopts the **wave1505 paper/ink system-page design** onto the production surfaces a real visitor actually meets — not just the `/design/wave1505` reference surface shipped in #627.

| Surface | Change |
|---|---|
| `app/not-found.tsx` | 404 in the wave1505 system-state design; fail-closed doctrine headline *"This page isn't part of the record."* Keeps `NotFoundTracker`. |
| `app/error.tsx` | Route error boundary; doctrine copy *"Nothing was recorded as successful."* Keeps `PilotFailureSignal`, telemetry, `reset()`, support-contact. |
| `app/global-error.tsx` | Same look, **fully self-contained** (own `<html>`, literal styles) since it fires when the root layout itself fails — no app CSS available. |
| `app/pricing/page.tsx` | Restyled to the wave1505 pricing doctrine (paper cards, Fraunces headings, illustrative-figure honesty callout, "what this page will never claim"). |

## Truth contract honored

The **look** is adopted; the **content stays real**. `/pricing` keeps `buildPricingFoundationPlan()`, `ctaForPricingPlan()` (with the `data-*` test hooks), and the "Payments are not collected in this build" honesty copy — no mockup pricing fiction. Styling is self-contained inline styles keyed to the wave1505 palette with `--font-*` fallbacks (picks up real Fraunces/Geist where present).

## Verification

- `tsc` 0 errors · eslint clean · copy-claims gate passes (pricing route is scanned)
- `pricing-cta` + commercial-foundation helper tests unaffected (the 2 red rows in `foundation-sweep-6-commercial` are **pre-existing** on `main` — signup/onboarding copy, confirmed by stashing this diff)
- `turbo run build --filter @vitalcv/web` green (14/14)
- 404 and `/pricing` browser-verified in dev (screenshots in session)

## Design Handoff References
- `design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-system.jsx`
- `design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-pricing.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)