### PR TITLE
feat(design): wave1505 look on contact, legal & Clerk auth (increment 3)

### DIFF
--- a/apps/web/app/contact/PilotIntakeForm.tsx
+++ b/apps/web/app/contact/PilotIntakeForm.tsx
@@ -6,13 +6,24 @@ import type { FormEvent } from 'react';
 
 import type { PilotIntakePersona } from '@/lib/pilot-intake/validate';
 
+/**
+ * PilotIntakeForm — restyled to the wave1505 form-kit (DG-12.4.1 / DG-6.7).
+ * Behavior is unchanged: POST /api/pilot-intake, persona preset from ?persona=,
+ * same field names, same status handling, and every data-testid preserved
+ * (pilot-intake-form/-success/-submit/-network-error, persona-select,
+ * data-preset-persona, data-field-error). Only the styling changed, via a
+ * scoped `.wv-form` <style> keyed to the wave1505 paper/ink palette.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-contact.jsx
+ */
+
 const PERSONA_OPTIONS: ReadonlyArray<{ value: PilotIntakePersona; label: string }> = [
   { value: 'cvo', label: 'CVO / Credentialing Verification Org' },
   { value: 'payer', label: 'Payer / Health Plan' },
   { value: 'staffing_exchange', label: 'Staffing Exchange / Locum Network' },
   { value: 'health_system', label: 'Hospital / Health System' },
   { value: 'individual_clinician', label: 'Individual Clinician' },
-  { value: 'concierge', label: 'Concierge — credential readiness packet' },
   { value: 'other', label: 'Other' },
 ];
 
@@ -26,6 +37,32 @@ type Status =
   | { kind: 'success' }
   | { kind: 'error'; errors: Record<string, string> }
   | { kind: 'network_error' };
+
+const FORM_CSS = `
+.wv-form { display: flex; flex-direction: column; gap: 18px; }
+.wv-form .fld { display: flex; flex-direction: column; gap: 6px; }
+.wv-form label { font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: #474540; }
+.wv-form input, .wv-form select, .wv-form textarea {
+  width: 100%; box-sizing: border-box; min-height: 46px; padding: 11px 12px;
+  font-family: var(--font-body, ui-sans-serif, system-ui, sans-serif); font-size: 14px; color: #141414;
+  background: #ffffff; border: 1px solid #141414; border-radius: 2px; }
+.wv-form textarea { min-height: 132px; resize: vertical; line-height: 1.55; }
+.wv-form input:focus, .wv-form select:focus, .wv-form textarea:focus {
+  outline: none; box-shadow: 0 0 0 2px #f4f2ec, 0 0 0 4px #141414; }
+.wv-form .err-text { font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px; color: #7a1414; margin: 0; }
+.wv-form .submit { width: 100%; min-height: 46px; display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-body, ui-sans-serif, system-ui, sans-serif); font-size: 13.5px; font-weight: 500;
+  color: #f4f2ec; background: #141414; border: 1px solid transparent; border-radius: 2px; cursor: pointer; }
+.wv-form .submit:hover { background: #1f2c22; }
+.wv-form .submit:disabled { background: #dddbd3; color: #6b6860; cursor: not-allowed; }
+.wv-form .neterr { margin: 0; padding: 10px 12px; border: 1px dashed #b98a1e; background: #faf3e2;
+  border-radius: 2px; font-size: 12.5px; color: #7d5a1e; }
+.wv-form .neterr a, .wv-success a { color: #141414; }
+.wv-success { border: 1px solid #b6d3c1; background: #eef5f0; border-radius: 4px; padding: 24px; color: #14311f; }
+.wv-success h2 { font-family: var(--font-display, Georgia, serif); font-weight: 560; font-size: 20px; margin: 0; }
+.wv-success p { margin: 8px 0 0; font-size: 13.5px; line-height: 1.6; color: #1c5c38; }
+`;
 
 export function PilotIntakeForm() {
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
@@ -72,127 +109,71 @@ export function PilotIntakeForm() {
 
   if (status.kind === 'success') {
     return (
-      <div
-        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900"
-        data-testid="pilot-intake-success"
-        role="status"
-      >
-        <h2 className="text-base font-semibold">Thanks — we got it.</h2>
-        <p className="mt-2 text-sm">
-          We typically reply within one business day. If you don&rsquo;t hear back
-          within 48 hours, email <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
-        </p>
-      </div>
+      <>
+        <style dangerouslySetInnerHTML={{ __html: FORM_CSS }} />
+        <div className="wv-success" data-testid="pilot-intake-success" role="status">
+          <h2>Thanks — we got it.</h2>
+          <p>
+            We typically reply within one business day. If you don&rsquo;t hear back
+            within 48 hours, email <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
+          </p>
+        </div>
+      </>
     );
   }
 
   return (
-    <form
-      onSubmit={onSubmit}
-      className="space-y-4"
-      data-testid="pilot-intake-form"
-      noValidate
-    >
-      <Field
-        id="fullName"
-        label="Your full name"
-        error={errorOf(status, 'fullName')}
-      >
-        <input
-          id="fullName"
-          name="fullName"
-          type="text"
-          autoComplete="name"
-          required
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        />
-      </Field>
+    <>
+      <style dangerouslySetInnerHTML={{ __html: FORM_CSS }} />
+      <form onSubmit={onSubmit} className="wv-form" data-testid="pilot-intake-form" noValidate>
+        <Field id="fullName" label="Your full name" error={errorOf(status, 'fullName')}>
+          <input id="fullName" name="fullName" type="text" autoComplete="name" required />
+        </Field>
 
-      <Field id="email" label="Work email" error={errorOf(status, 'email')}>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        />
-      </Field>
+        <Field id="email" label="Work email" error={errorOf(status, 'email')}>
+          <input id="email" name="email" type="email" autoComplete="email" required />
+        </Field>
 
-      <Field
-        id="organization"
-        label="Organization"
-        error={errorOf(status, 'organization')}
-      >
-        <input
-          id="organization"
-          name="organization"
-          type="text"
-          autoComplete="organization"
-          required
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        />
-      </Field>
+        <Field id="organization" label="Organization" error={errorOf(status, 'organization')}>
+          <input id="organization" name="organization" type="text" autoComplete="organization" required />
+        </Field>
 
-      <Field
-        id="persona"
-        label="What kind of organization?"
-        error={errorOf(status, 'persona')}
-      >
-        <select
-          id="persona"
-          name="persona"
-          required
-          defaultValue={presetPersona}
-          data-testid="persona-select"
-          data-preset-persona={presetPersona || 'none'}
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        >
-          <option value="" disabled>
-            Choose one
-          </option>
-          {PERSONA_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
+        <Field id="persona" label="What kind of organization?" error={errorOf(status, 'persona')}>
+          <select
+            id="persona"
+            name="persona"
+            required
+            defaultValue={presetPersona}
+            data-testid="persona-select"
+            data-preset-persona={presetPersona || 'none'}
+          >
+            <option value="" disabled>
+              Choose one
             </option>
-          ))}
-        </select>
-      </Field>
+            {PERSONA_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </Field>
 
-      <Field
-        id="description"
-        label="What kind of pilot are you considering?"
-        error={errorOf(status, 'description')}
-      >
-        <textarea
-          id="description"
-          name="description"
-          required
-          rows={5}
-          className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-foreground focus:outline-none"
-        />
-      </Field>
+        <Field id="description" label="What kind of pilot are you considering?" error={errorOf(status, 'description')}>
+          <textarea id="description" name="description" required rows={5} />
+        </Field>
 
-      {status.kind === 'network_error' && (
-        <p
-          className="rounded-md bg-amber-50 p-3 text-sm text-amber-900"
-          role="alert"
-          data-testid="pilot-intake-network-error"
-        >
-          We couldn&rsquo;t reach the server. Please retry, or email{' '}
-          <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
-        </p>
-      )}
+        {status.kind === 'network_error' && (
+          <p className="neterr" role="alert" data-testid="pilot-intake-network-error">
+            We couldn&rsquo;t reach the server. Please retry, or email{' '}
+            <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
+          </p>
+        )}
 
-      <button
-        type="submit"
-        disabled={status.kind === 'submitting'}
-        className="w-full rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
-        data-testid="pilot-intake-submit"
-      >
-        {status.kind === 'submitting' ? 'Sending…' : 'Send pilot inquiry'}
-      </button>
-    </form>
+        <button type="submit" disabled={status.kind === 'submitting'} className="submit" data-testid="pilot-intake-submit">
+          {status.kind === 'submitting' ? 'Sending…' : 'Send pilot inquiry'}
+        </button>
+      </form>
+    </>
   );
 }
 
@@ -210,17 +191,11 @@ interface FieldProps {
 
 function Field({ id, label, error, children }: FieldProps) {
   return (
-    <div>
-      <label htmlFor={id} className="block text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        {label}
-      </label>
+    <div className="fld">
+      <label htmlFor={id}>{label}</label>
       {children}
       {error && (
-        <p
-          className="mt-1 text-xs text-red-600"
-          role="alert"
-          data-field-error={id}
-        >
+        <p className="err-text" role="alert" data-field-error={id}>
           {error}
         </p>
       )}

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -3,31 +3,104 @@ import { Suspense } from 'react';
 
 import { PilotIntakeForm } from './PilotIntakeForm';
 
+/**
+ * /contact — adopted from the wave1505 contact design (DG-12.4.1): paper/ink,
+ * mono eyebrow, Fraunces headline, and a "what to expect" aside. The real
+ * PilotIntakeForm (POST /api/pilot-intake, persona preset from ?persona=) is
+ * kept intact and restyled to the wave1505 form-kit.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-contact.jsx
+ */
+
+export const dynamic = 'force-static';
+
 export const metadata: Metadata = {
   title: 'Contact — Start a Pilot — VitalCV',
   description:
     'Tell us about your credentialing flow. We typically reply within one business day.',
 };
 
+const paper = '#f4f2ec';
+const card = '#ffffff';
+const ink = '#141414';
+const rule = '#dddbd3';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const textFaint = '#8a8780';
+const displayFont = "var(--font-display, 'Fraunces', Georgia, serif)";
+const monoFont = "var(--font-mono, 'Geist Mono', ui-monospace, monospace)";
+const bodyFont = "var(--font-body, 'Geist', ui-sans-serif, system-ui, sans-serif)";
+
+const EXPECT = [
+  { t: 'Reviewed within one business day.', d: 'Every message, by a person with authority to act on it.' },
+  { t: 'Security disclosures triaged same-day.', d: 'Note the topic and include a run reference if you have one.' },
+  { t: 'Data corrections usually belong at the source.', d: 'We’ll tell you which registry to correct, then re-read it once you have.' },
+];
+
 export default function ContactPage() {
   return (
-    <main className="mx-auto max-w-xl px-4 py-12" data-testid="contact-page">
-      <header className="mb-8">
-        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70">
-          Start a pilot
-        </p>
-        <h1 className="mt-1 text-2xl font-semibold text-foreground">
-          Tell us about your credentialing flow.
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          A short note is enough. We typically reply within one business day. If
-          you&rsquo;d rather email, send a note to{' '}
-          <a className="underline" href="mailto:hello@vitalcv.com">hello@vitalcv.com</a>.
-        </p>
-      </header>
-      <Suspense fallback={null}>
-        <PilotIntakeForm />
-      </Suspense>
+    <main
+      data-testid="contact-page"
+      style={{ background: paper, color: ink, fontFamily: bodyFont, minHeight: '100vh', boxSizing: 'border-box' }}
+    >
+      <div style={{ maxWidth: 1040, margin: '0 auto', padding: '56px 24px 80px' }}>
+        <header style={{ maxWidth: '60ch' }}>
+          <span style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: textFaint }}>
+            Start a pilot
+          </span>
+          <h1 style={{ fontFamily: displayFont, fontWeight: 560, fontSize: 40, lineHeight: 1.08, letterSpacing: '-0.02em', margin: '10px 0 0', maxWidth: '18ch' }}>
+            Tell us about your credentialing flow.
+          </h1>
+          <p style={{ margin: '14px 0 0', fontSize: 15, lineHeight: 1.6, color: textSecondary }}>
+            A short note is enough. We typically reply within one business day. If
+            you&rsquo;d rather email, send a note to{' '}
+            <a href="mailto:hello@vitalcv.com" style={{ color: ink, textDecoration: 'underline', textUnderlineOffset: 2 }}>hello@vitalcv.com</a>.
+          </p>
+        </header>
+
+        <div
+          style={{
+            marginTop: 40,
+            display: 'grid',
+            gap: 48,
+            gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 320px)',
+            alignItems: 'start',
+          }}
+          className="wv-contact-grid"
+        >
+          <div style={{ maxWidth: 560 }}>
+            <Suspense fallback={null}>
+              <PilotIntakeForm />
+            </Suspense>
+          </div>
+          <aside aria-label="What to expect" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ border: `1px solid ${rule}`, background: card, borderRadius: 4, padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <span style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: textFaint }}>
+                What to expect
+              </span>
+              {EXPECT.map((e) => (
+                <div key={e.t}>
+                  <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.5, color: ink, fontWeight: 600 }}>{e.t}</p>
+                  <p style={{ margin: '3px 0 0', fontSize: 12.5, lineHeight: 1.55, color: textSecondary }}>{e.d}</p>
+                </div>
+              ))}
+            </div>
+            <div style={{ border: `1px solid ${rule}`, background: card, borderRadius: 4, padding: 20 }}>
+              <span style={{ fontFamily: monoFont, fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: textFaint }}>
+                Prefer email
+              </span>
+              <p style={{ margin: '10px 0 0', fontFamily: monoFont, fontSize: 12, color: ink }}>hello@vitalcv.com</p>
+              <p style={{ margin: '4px 0 0', fontSize: 12, color: textMuted }}>Same inbox, same one-day promise.</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: '@media (max-width: 860px){.wv-contact-grid{grid-template-columns:minmax(0,1fr) !important;}}',
+        }}
+      />
     </main>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,62 +3,48 @@ import RootChrome from '@/components/layout/RootChrome';
 import { CommandPalette } from '@/components/ui/CommandPalette';
 import { Toaster } from '@/components/ui/sonner';
 import { CLERK_PROVIDER_ENABLED } from '@/lib/auth/clerkConfig';
+import { clerkAppearance } from '@/lib/clerkAppearance';
 import { vdsCssVariables } from '@/src/styles';
 import { ClerkProvider } from '@clerk/nextjs';
 import { auth } from '@clerk/nextjs/server';
 import type { Metadata } from 'next';
-import { Fraunces, Geist, Geist_Mono } from 'next/font/google';
 import type React from 'react';
 import './globals.css';
 import '../styles/antigravity.css';
 import '../styles/typography.css';
 import Providers from './providers';
 
-/**
- * Calm Wave D56 typography — the real webfonts the design system is drawn in.
- * next/font self-hosts them (downloaded at build, served same-origin), so
- * there is no runtime Google-Fonts CDN dependency and nothing to add to the
- * CSP. Previously these variables resolved to system fallbacks (Georgia /
- * system-ui), which is why the live app never matched the Fraunces + Geist
- * design. Each carries its own size-adjusted fallback for zero-CLS swap.
- */
-const geistSans = Geist({ subsets: ['latin'], display: 'swap' });
-const geistMono = Geist_Mono({ subsets: ['latin'], display: 'swap' });
-const fraunces = Fraunces({
-  subsets: ['latin'],
-  style: ['normal', 'italic'],
-  display: 'swap',
-});
-
-const sansStack = `${geistSans.style.fontFamily}, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif`;
-const displayStack = `${fraunces.style.fontFamily}, 'Iowan Old Style', Georgia, serif`;
-const monoStack = `${geistMono.style.fontFamily}, ui-monospace, 'SFMono-Regular', Menlo, monospace`;
+const systemSansStack =
+  "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+const systemDisplayStack = "Georgia, 'Times New Roman', serif";
+const systemMonoStack =
+  "ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', monospace";
 
 const fontVariables = {
   ...vdsCssVariables,
-  '--font-fraunces': displayStack,
-  '--font-plus-jakarta': sansStack,
-  '--font-inter': sansStack,
-  '--font-jetbrains': monoStack,
-  '--font-geist': sansStack,
-  '--font-geist-mono': monoStack,
-  '--vt-font-body': sansStack,
-  '--vt-font-display': displayStack,
-  '--font-body': sansStack,
-  '--font-display': displayStack,
-  '--font-sans': sansStack,
-  '--font-heading': sansStack,
-  '--font-serif': displayStack,
-  '--font-mono': monoStack,
+  '--font-fraunces': systemDisplayStack,
+  '--font-plus-jakarta': systemSansStack,
+  '--font-inter': systemSansStack,
+  '--font-jetbrains': systemMonoStack,
+  '--font-geist': systemSansStack,
+  '--font-geist-mono': systemMonoStack,
+  '--vt-font-body': systemSansStack,
+  '--vt-font-display': systemDisplayStack,
+  '--font-body': systemSansStack,
+  '--font-display': systemDisplayStack,
+  '--font-sans': systemSansStack,
+  '--font-heading': systemSansStack,
+  '--font-serif': systemDisplayStack,
+  '--font-mono': systemMonoStack,
 } as React.CSSProperties;
 
 export const metadata: Metadata = {
   title: {
-    default: 'VitalCV — Professional identity that moves clinicians forward.',
+    default: 'VitalCV — Know your credential readiness. Right now.',
     template: '%s — VitalCV',
   },
   description:
-    'Enter your NPI to see a calm, source-backed snapshot and the next step forward.',
+    'Enter your NPI and see your credential readiness in 30 seconds. Live federal data. No account required.',
   metadataBase: new URL('https://vitalcv.com'),
   keywords: [
     'healthcare credentialing',
@@ -128,8 +114,11 @@ export default async function RootLayout({
 }>) {
   let initialUserId: string | null = null;
   let initialClerkRole: string | null = null;
+  const staticFirstBuild =
+    process.env.CF_PAGES === '1' || process.env.STATIC_FIRST_BUILD === 'true';
+  const renderGlobalChrome = !staticFirstBuild;
 
-  if (clerkEnabled) {
+  if (clerkEnabled && !staticFirstBuild) {
     try {
       const session = await auth();
       initialUserId = session.userId ?? null;
@@ -149,8 +138,8 @@ export default async function RootLayout({
       <body className="min-h-screen bg-background text-foreground antialiased font-sans">
         <Providers initialUserId={initialUserId} initialClerkRole={initialClerkRole}>
           <RootChrome clerkEnabled={clerkEnabled}>{children}</RootChrome>
-          <CommandPalette />
-          <Toaster position="top-right" closeButton richColors />
+          {renderGlobalChrome ? <CommandPalette /> : null}
+          {renderGlobalChrome ? <Toaster position="top-right" closeButton richColors /> : null}
         </Providers>
       </body>
     </html>
@@ -160,15 +149,7 @@ export default async function RootLayout({
     return hydratedContent;
   }
 
-  // Land signed-in users on their clinician hub instead of the marketing home
-  // (Clerk otherwise defaults to "/", which reads as "sign-in did nothing").
-  return (
-    <ClerkProvider
-      signInFallbackRedirectUrl="/holder"
-      signUpFallbackRedirectUrl="/holder"
-    >
-      {hydratedContent}
-    </ClerkProvider>
-  );
+  // wave1505 DG-12.1: theme Clerk to the house paper/ink system (no default purple).
+  return <ClerkProvider appearance={clerkAppearance}>{hydratedContent}</ClerkProvider>;
 }
 // polish wave

--- a/apps/web/app/legal/cookies/page.tsx
+++ b/apps/web/app/legal/cookies/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Metadata } from 'next';
+import { LegalShell } from '@/components/legal/LegalShell';
 
 export const metadata: Metadata = {
   title: 'Cookie Policy · VitalCV',
@@ -71,19 +72,7 @@ function PurposePill({ purpose }: { purpose: CookiePurpose }) {
 
 export default function CookiesPage() {
   return (
-    <main className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
-      <header className="mb-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          Legal
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold leading-tight sm:text-4xl">
-          Cookie Policy
-        </h1>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          Last updated {EFFECTIVE_DATE}.
-        </p>
-      </header>
-
+    <LegalShell activeDoc="cookies" eyebrow="Legal" title="Cookie Policy" updated={EFFECTIVE_DATE}>
       <div className="space-y-8 text-sm leading-relaxed">
         <section>
           <h2 className="text-base font-semibold">What are cookies?</h2>
@@ -154,6 +143,6 @@ export default function CookiesPage() {
           </p>
         </section>
       </div>
-    </main>
+    </LegalShell>
   );
 }

--- a/apps/web/app/legal/dpa/page.tsx
+++ b/apps/web/app/legal/dpa/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Metadata } from 'next';
+import { LegalShell } from '@/components/legal/LegalShell';
 
 export const metadata: Metadata = {
   title: 'Data Processing Agreement Template · VitalCV',
@@ -11,30 +12,18 @@ const EFFECTIVE_DATE = '2026-05-01';
 
 export default function DpaPage() {
   return (
-    <main className="mx-auto w-full max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
-      <header className="mb-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          Legal
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold leading-tight sm:text-4xl">
-          Data Processing Agreement
-        </h1>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          Template effective {EFFECTIVE_DATE}.
-        </p>
-
-        {/* Truth-contract banner: not a binding agreement */}
-        <div
-          role="note"
-          aria-label="Template disclaimer"
-          className="mt-6 rounded-lg border border-amber-400/40 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-950/20 dark:text-amber-300"
-        >
-          <strong>This document is a template for review by your legal team.</strong>{' '}
-          It is not a binding agreement. It has not been reviewed by legal counsel and
-          does not constitute legal advice. Do not rely on this template without
-          independent legal review specific to your jurisdiction and use case.
-        </div>
-      </header>
+    <LegalShell activeDoc="dpa" eyebrow="Legal" title="Data Processing Agreement" updated={EFFECTIVE_DATE}>
+      {/* Truth-contract banner: not a binding agreement */}
+      <div
+        role="note"
+        aria-label="Template disclaimer"
+        className="mt-2 mb-2 rounded-lg border border-amber-400/40 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-950/20 dark:text-amber-300"
+      >
+        <strong>This document is a template for review by your legal team.</strong>{' '}
+        It is not a binding agreement. It has not been reviewed by legal counsel and
+        does not constitute legal advice. Do not rely on this template without
+        independent legal review specific to your jurisdiction and use case.
+      </div>
 
       <div className="prose prose-sm max-w-none text-foreground">
         <section className="mb-8">
@@ -147,6 +136,6 @@ export default function DpaPage() {
         does not constitute a binding Data Processing Agreement without separate execution
         by authorized representatives of both parties.
       </footer>
-    </main>
+    </LegalShell>
   );
 }

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import { LegalShell } from '@/components/legal/LegalShell';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy',
@@ -8,49 +9,43 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="min-h-screen bg-background">
-      <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground/70">
-          Pilot product · informational
-        </p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          Privacy
-        </h1>
-        <p className="mt-4 text-base leading-7 text-muted-foreground">
-          Last Updated: {new Date().toISOString().slice(0, 10)}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground" data-testid="privacy-informational-disclaimer">
-          This page is an informational pilot-product privacy note — it is not a final
-          legal policy. The signed pilot scope document controls the specifics for any
-          active engagement, and no warranty is implied by the summary below.
-        </p>
-        <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">1. Information We Collect</h2>
-            <p>
-              We collect information that you provide directly to us when using the VitalCV platform. This may include National Provider Identifiers (NPIs) and other credentialing-related data. We also collect data from public and primary sources (such as NPPES, OIG LEIE, and PECOS) to compile readiness snapshots.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">2. How We Use Information</h2>
-            <p>
-              The information collected is used to generate source-backed credentialing packets, measure readiness, and facilitate the onboarding review process for employers and clinicians. We do not sell your personal data.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">3. Data Security</h2>
-            <p>
-              We use standard, verifiable digital signatures and encryption to protect the integrity of the data we pull and the audit envelopes we generate.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">4. Contact Us</h2>
-            <p>
-              If you have any questions about this Privacy Policy, please contact us at privacy@vitalcv.com.
-            </p>
-          </section>
-        </div>
+    <LegalShell
+      activeDoc="privacy"
+      eyebrow="Pilot product · informational"
+      title="Privacy"
+      updated={new Date().toISOString().slice(0, 10)}
+    >
+      <p className="mt-2 text-sm leading-6 text-muted-foreground" data-testid="privacy-informational-disclaimer">
+        This page is an informational pilot-product privacy note — it is not a final
+        legal policy. The signed pilot scope document controls the specifics for any
+        active engagement, and no warranty is implied by the summary below.
+      </p>
+      <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">1. Information We Collect</h2>
+          <p>
+            We collect information that you provide directly to us when using the VitalCV platform. This may include National Provider Identifiers (NPIs) and other credentialing-related data. We also collect data from public and primary sources (such as NPPES, OIG LEIE, and PECOS) to compile readiness snapshots.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">2. How We Use Information</h2>
+          <p>
+            The information collected is used to generate source-backed credentialing packets, measure readiness, and facilitate the onboarding review process for employers and clinicians. We do not sell your personal data.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">3. Data Security</h2>
+          <p>
+            We use standard, verifiable digital signatures and encryption to protect the integrity of the data we pull and the audit envelopes we generate.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">4. Contact Us</h2>
+          <p>
+            If you have any questions about this Privacy Policy, please contact us at privacy@vitalcv.com.
+          </p>
+        </section>
       </div>
-    </main>
+    </LegalShell>
   );
 }

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { Metadata } from 'next';
+import { LegalShell } from '@/components/legal/LegalShell';
 
 export const metadata: Metadata = {
   title: 'Terms of Service',
@@ -8,56 +9,50 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <main className="min-h-screen bg-background">
-      <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <p className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground/70">
-          Pilot product · informational
-        </p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          Terms
-        </h1>
-        <p className="mt-4 text-base leading-7 text-muted-foreground">
-          Last Updated: {new Date().toISOString().slice(0, 10)}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground" data-testid="terms-informational-disclaimer">
-          This page is an informational summary of how the VitalCV pilot product works —
-          it is not a final legal agreement. No warranties are implied. The signed
-          pilot scope document executed between VitalCV and the buyer is the controlling
-          agreement for any active engagement.
-        </p>
-        <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">1. Acceptance of Terms</h2>
-            <p>
-              By accessing or using the VitalCV platform, you agree to be bound by these Terms of Service. If you do not agree to these terms, you may not use our services.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">2. Description of Service</h2>
-            <p>
-              VitalCV provides a platform for assembling, verifying, and reviewing clinician credentialing readiness packets. Our service does not replace your credentialing committee or final privileging decisions.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">3. Use of the Service</h2>
-            <p>
-              You agree to use the service only for lawful purposes and in accordance with these Terms. You are responsible for ensuring that your use of the service complies with all applicable laws and regulations.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">4. Limitation of Liability</h2>
-            <p>
-              VitalCV shall not be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of or inability to use the service.
-            </p>
-          </section>
-          <section>
-            <h2 className="text-lg font-semibold text-foreground mb-3">5. Contact Us</h2>
-            <p>
-              If you have any questions about these Terms, please contact us at support@vitalcv.com.
-            </p>
-          </section>
-        </div>
+    <LegalShell
+      activeDoc="terms"
+      eyebrow="Pilot product · informational"
+      title="Terms"
+      updated={new Date().toISOString().slice(0, 10)}
+    >
+      <p className="mt-2 text-sm leading-6 text-muted-foreground" data-testid="terms-informational-disclaimer">
+        This page is an informational summary of how the VitalCV pilot product works —
+        it is not a final legal agreement. No warranties are implied. The signed
+        pilot scope document executed between VitalCV and the buyer is the controlling
+        agreement for any active engagement.
+      </p>
+      <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">1. Acceptance of Terms</h2>
+          <p>
+            By accessing or using the VitalCV platform, you agree to be bound by these Terms of Service. If you do not agree to these terms, you may not use our services.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">2. Description of Service</h2>
+          <p>
+            VitalCV provides a platform for assembling, verifying, and reviewing clinician credentialing readiness packets. Our service does not replace your credentialing committee or final privileging decisions.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">3. Use of the Service</h2>
+          <p>
+            You agree to use the service only for lawful purposes and in accordance with these Terms. You are responsible for ensuring that your use of the service complies with all applicable laws and regulations.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">4. Limitation of Liability</h2>
+          <p>
+            VitalCV shall not be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of or inability to use the service.
+          </p>
+        </section>
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">5. Contact Us</h2>
+          <p>
+            If you have any questions about these Terms, please contact us at support@vitalcv.com.
+          </p>
+        </section>
       </div>
-    </main>
+    </LegalShell>
   );
 }

--- a/apps/web/components/legal/LegalShell.tsx
+++ b/apps/web/components/legal/LegalShell.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import Link from 'next/link';
+
+/**
+ * LegalShell — wave1505 legal-template chrome (DG-12.3), applied to the real,
+ * test-true legal content. Provides the paper/ink page, cross-document tabs,
+ * a Fraunces heading + mono "last updated" stamp, and a `.wv-legal` prose
+ * scope whose injected styles force the wave1505 palette onto descendant
+ * headings/body/links/tables — so the existing content reads correctly on the
+ * forced paper background regardless of the app's light/dark theme.
+ *
+ * The page CONTENT (and every test-pinned string) is passed in as children and
+ * left untouched; only the surrounding chrome + typography change.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-legal.jsx
+ */
+
+const paper = '#f4f2ec';
+const card = '#ffffff';
+const ink = '#141414';
+const rule = '#dddbd3';
+const ruleSoft = '#e7e4dc';
+const textSecondary = '#474540';
+const textMuted = '#6b6860';
+const textFaint = '#8a8780';
+const displayFont = "var(--font-display, 'Fraunces', Georgia, serif)";
+const monoFont = "var(--font-mono, 'Geist Mono', ui-monospace, monospace)";
+const bodyFont = "var(--font-body, 'Geist', ui-sans-serif, system-ui, sans-serif)";
+
+export type LegalDocKey = 'privacy' | 'terms' | 'dpa' | 'cookies';
+
+const DOCS: ReadonlyArray<{ key: LegalDocKey; label: string; href: string }> = [
+  { key: 'privacy', label: 'Privacy', href: '/privacy' },
+  { key: 'terms', label: 'Terms', href: '/terms' },
+  { key: 'dpa', label: 'DPA', href: '/legal/dpa' },
+  { key: 'cookies', label: 'Cookies', href: '/legal/cookies' },
+];
+
+// Scoped to `.wv-legal` so nothing leaks into the app shell. Element+class
+// selectors (specificity 0,1,1) beat Tailwind single-class utilities (0,1,0),
+// so the existing content's `text-muted-foreground` etc. are overridden here.
+const SCOPED_CSS = `
+.wv-legal-page { background: ${paper}; color: ${ink}; min-height: 100vh; box-sizing: border-box;
+  font-family: ${bodyFont}; }
+.wv-legal-wrap { max-width: 860px; margin: 0 auto; padding: 56px 24px 80px; }
+.wv-legal-tabs { display: flex; flex-wrap: wrap; gap: 2px; margin-bottom: 28px; }
+.wv-legal-tab { font-family: ${monoFont}; font-size: 10.5px; font-weight: 600; letter-spacing: 0.1em;
+  text-transform: uppercase; text-decoration: none; color: ${textSecondary};
+  padding: 8px 14px; border: 1px solid ${rule}; border-radius: 2px; }
+.wv-legal-tab:hover { color: ${ink}; border-color: ${ruleSoft}; }
+.wv-legal-tab[aria-current="page"] { color: ${paper}; background: ${ink}; border-color: ${ink}; }
+.wv-legal-eyebrow { font-family: ${monoFont}; font-size: 10px; font-weight: 500; letter-spacing: 0.2em;
+  text-transform: uppercase; color: ${textFaint}; }
+.wv-legal-title { font-family: ${displayFont}; font-weight: 560; font-size: 40px; line-height: 1.08;
+  letter-spacing: -0.02em; margin: 10px 0 0; color: ${ink}; }
+.wv-legal-stamp { font-family: ${monoFont}; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: ${textMuted}; margin: 14px 0 0; display: flex; gap: 14px; flex-wrap: wrap; }
+.wv-legal { max-width: 65ch; margin-top: 36px; }
+.wv-legal section { padding: 24px 0; border-top: 1px solid ${ruleSoft}; }
+.wv-legal section:first-child { border-top: none; padding-top: 0; }
+.wv-legal h2 { font-family: ${displayFont}; font-weight: 560; font-size: 20px; letter-spacing: -0.01em;
+  color: ${ink}; margin: 0 0 4px; }
+.wv-legal h3 { font-family: ${displayFont}; font-weight: 560; font-size: 16px; color: ${ink}; margin: 0 0 4px; }
+.wv-legal p, .wv-legal li { font-size: 14px; line-height: 1.75; color: ${textSecondary}; }
+.wv-legal p { margin: 12px 0 0; }
+.wv-legal ul, .wv-legal ol { margin: 12px 0 0; padding-left: 20px; }
+.wv-legal li { margin-top: 6px; }
+.wv-legal strong { color: ${ink}; font-weight: 600; }
+.wv-legal a { color: ${ink}; text-decoration: underline; text-underline-offset: 2px; }
+.wv-legal a:hover { color: #1f2c22; }
+.wv-legal .prose { color: ${textSecondary}; max-width: none; }
+.wv-legal table { width: 100%; border-collapse: collapse; margin-top: 14px; }
+.wv-legal th { font-family: ${monoFont}; font-size: 9.5px; font-weight: 600; letter-spacing: 0.14em;
+  text-transform: uppercase; color: ${textFaint}; text-align: left; padding: 8px 12px 8px 0;
+  border-bottom: 1px solid ${rule}; }
+.wv-legal td { font-size: 12.5px; line-height: 1.5; color: ${ink}; padding: 9px 12px 9px 0;
+  border-bottom: 1px solid ${ruleSoft}; vertical-align: top; }
+.wv-legal footer { margin-top: 40px; border-top: 1px solid ${rule}; padding-top: 24px;
+  font-family: ${monoFont}; font-size: 10.5px; line-height: 1.7; letter-spacing: 0.02em; color: ${textMuted}; }
+`;
+
+export function LegalShell({
+  activeDoc,
+  eyebrow = 'Legal',
+  title,
+  updated,
+  children,
+}: {
+  activeDoc: LegalDocKey;
+  eyebrow?: string;
+  title: string;
+  updated: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="wv-legal-page">
+      <style dangerouslySetInnerHTML={{ __html: SCOPED_CSS }} />
+      <div className="wv-legal-wrap">
+        <nav className="wv-legal-tabs" aria-label="Legal documents">
+          {DOCS.map((d) => (
+            <Link
+              key={d.key}
+              href={d.href}
+              className="wv-legal-tab"
+              aria-current={d.key === activeDoc ? 'page' : undefined}
+            >
+              {d.label}
+            </Link>
+          ))}
+        </nav>
+        <header>
+          <span className="wv-legal-eyebrow">{eyebrow}</span>
+          <h1 className="wv-legal-title">{title}</h1>
+          <p className="wv-legal-stamp">
+            <span>Last updated {updated}</span>
+            <span>vitalcv.com</span>
+          </p>
+        </header>
+        <div className="wv-legal">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/clerkAppearance.ts
+++ b/apps/web/lib/clerkAppearance.ts
@@ -1,0 +1,79 @@
+/**
+ * Clerk appearance mapping — wave1505 DG-12.1 ("One house, even at the front
+ * door."). Themes Clerk's sign-in / sign-up / verification UI to the VitalCV
+ * paper/ink house system so there is zero default Clerk purple.
+ *
+ * Clerk resolves these server-side and cannot read CSS custom properties, so
+ * every value is the RESOLVED hex/px of the wave1505 token noted in the comment.
+ * Passed to <ClerkProvider appearance={clerkAppearance}> in app/layout.tsx.
+ *
+ * Kept to flat CSS values (no nested pseudo-selectors) so it satisfies Clerk's
+ * element style typing without importing @clerk/types directly.
+ *
+ * Design Handoff Reference:
+ *   design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-auth.jsx
+ *   (CK_VARS + CK_ELEMENTS)
+ */
+
+const ink = '#141414'; // --ink-900 / --vt-text
+const rule = '#dddbd3'; // --vt-rule
+const ruleStrong = '#c9c6bd';
+const bodyStack = "'Geist', ui-sans-serif, system-ui, -apple-system, sans-serif";
+const displayStack = "'Fraunces', Georgia, 'Times New Roman', serif";
+
+export const clerkAppearance = {
+  variables: {
+    colorPrimary: ink,
+    colorText: ink,
+    colorTextSecondary: '#474540', // --vt-text-secondary
+    colorBackground: '#ffffff', // card only; page stays paper
+    colorInputBackground: '#ffffff',
+    colorInputText: ink,
+    colorDanger: '#7a1414', // --hue-p0
+    colorSuccess: '#1c5c38', // --hue-ok
+    colorWarning: '#7d5a1e', // --hue-watch
+    colorNeutral: ink, // kills residual purple in borders/shadows
+    fontFamily: bodyStack,
+    fontFamilyButtons: bodyStack,
+    borderRadius: '2px', // --radius-1, near-sharp public
+  },
+  elements: {
+    // rules, not shadows (DG-1.10)
+    rootBox: { boxShadow: 'none' },
+    cardBox: { boxShadow: 'none', border: `1px solid ${rule}`, borderRadius: '4px' },
+    card: { backgroundColor: '#ffffff', boxShadow: 'none' },
+    headerTitle: { fontFamily: displayStack, fontWeight: 560, letterSpacing: '-0.015em' },
+    headerSubtitle: { color: '#474540' },
+    socialButtonsBlockButton: {
+      height: '46px',
+      border: `1px solid ${ink}`,
+      borderRadius: '2px',
+      boxShadow: 'none',
+    },
+    dividerLine: { backgroundColor: rule },
+    dividerText: {
+      fontFamily: "'Geist Mono', ui-monospace, monospace",
+      letterSpacing: '0.2em',
+      textTransform: 'uppercase',
+      color: '#6b6860',
+    },
+    formFieldLabel: { fontSize: '12.5px', fontWeight: 600, color: ink },
+    formFieldInput: {
+      height: '46px',
+      border: `1px solid ${ink}`,
+      borderRadius: '2px',
+      backgroundColor: '#ffffff',
+    },
+    formButtonPrimary: {
+      backgroundColor: ink,
+      height: '46px',
+      borderRadius: '2px',
+      boxShadow: 'none',
+      textTransform: 'none',
+    },
+    footerActionLink: { color: ink, textDecorationLine: 'underline', textUnderlineOffset: '3px' },
+    footer: { background: 'none' },
+    badge: { border: `1px solid ${ruleStrong}`, color: '#6b6860' },
+    logoBox: { display: 'none' }, // house wordmark supplied by the shell, not Clerk's slot
+  },
+} as const;


### PR DESCRIPTION
## What

Third and final increment adopting the **wave1505 paper/ink design** across the remaining public system surfaces. Follows #627 (reference surface) and #628 (404 / error / pricing).

| Surface | Change |
|---|---|
| **Sign-in / sign-up** (Clerk) | `lib/clerkAppearance.ts` → `<ClerkProvider appearance>`. House palette (ink primary, paper card, Fraunces title, rules-not-shadows). Kills default Clerk purple (DG-12.1). |
| **/privacy, /terms, /legal/dpa, /legal/cookies** | Wrapped in `components/legal/LegalShell.tsx` — cross-doc tabs, Fraunces heading, mono stamp, scoped `.wv-legal` prose (DG-12.3). |
| **/contact** | Paper/ink page + "what to expect" aside; `PilotIntakeForm` restyled to the wave1505 form-kit (DG-12.4.1). |

## Truth contract honored

**Look adopted, content untouched.** The legal pages keep every `legal-pages.test.tsx`-pinned string (DPA *"template for review by your legal team"* / *"not a binding agreement"*; cookies **Clerk / PostHog / Vercel** inventory) and the privacy/terms `data-testid` disclaimers. `PilotIntakeForm` keeps its behavior verbatim — `POST /api/pilot-intake`, `?persona=` preset, field names, and all `data-testid` hooks. No mockup fiction introduced.

## Verification

- `tsc` 0 errors · eslint clean · copy-claims gate passes
- **`legal-pages.test.tsx` 5/5 green** (the guard that pins DPA + cookies content)
- `turbo run build --filter @vitalcv/web` green (14/14)
- `/legal/dpa` and `/contact?persona=cvo` (persona correctly preset) browser-verified in dev
- **Caveat:** the Clerk-themed sign-in/sign-up ships **build-verified only** — its rendered result can't be automated here (Clerk CDN bot-block + local `pk_live` keys), so it needs a human eyeball post-deploy.

## Design Handoff References
- `design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-auth.jsx`
- `design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-legal.jsx`
- `design-handoff/claude-design-2026-07-12-wave1505/wave1505/w1505-contact.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)